### PR TITLE
Log4j error message on start

### DIFF
--- a/artemis/build.gradle
+++ b/artemis/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   implementation 'io.vertx:vertx-core'
   implementation 'io.vertx:vertx-web'
   implementation 'org.apache.logging.log4j:log4j-api'
+  implementation 'org.slf4j:slf4j-nop:1.7.25' 
 
   runtime 'org.apache.logging.log4j:log4j-core'
 


### PR DESCRIPTION
Log4j error message on start is no longer shown. SLF4J needs another dependency.

Fixes #142

