### PR TITLE
UInt64 to long

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/datastructures/beaconchainblocks/BeaconBlock.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/datastructures/beaconchainblocks/BeaconBlock.java
@@ -15,12 +15,11 @@ package tech.pegasys.artemis.datastructures.beaconchainblocks;
 
 import tech.pegasys.artemis.ethereum.core.Hash;
 import tech.pegasys.artemis.util.uint.UInt384;
-import tech.pegasys.artemis.util.uint.UInt64;
 
 public class BeaconBlock {
 
   // Header
-  private UInt64 slot;
+  private long slot;
   private Hash[] ancestor_hashes;
   private Hash state_root;
   private Hash randao_reveal;
@@ -122,14 +121,14 @@ public class BeaconBlock {
   /**
    * @return the slot
    */
-  public UInt64 getSlot() {
+  public long getSlot() {
     return slot;
   }
 
   /**
    * @param slot the slot to set
    */
-  public void setSlot(UInt64 slot) {
+  public void setSlot(long slot) {
     this.slot = slot;
   }
 }

--- a/artemis/src/main/java/tech/pegasys/artemis/services/beaconchain/StateTransition.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/services/beaconchain/StateTransition.java
@@ -16,7 +16,6 @@ package tech.pegasys.artemis.services.beaconchain;
 import tech.pegasys.artemis.Constants;
 import tech.pegasys.artemis.datastructures.beaconchainblocks.BeaconBlock;
 import tech.pegasys.artemis.state.BeaconState;
-import tech.pegasys.artemis.util.uint.UInt64;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,11 +41,8 @@ public class StateTransition{
         blockProcessor(state, block);
         //}
 
-        //TODO: constants either need to be in UINT64 or this needs to be implemented the idiomatic way.
-        long epoch_length = Integer.toUnsignedLong(Constants.EPOCH_LENGTH);
-        long zero = Integer.toUnsignedLong(0);
         // per-epoch processing
-        if( state.getSlot().modulo(epoch_length).equals(UInt64.valueOf(zero)) ){
+        if( state.getSlot() % Constants.EPOCH_LENGTH == 0){
             epochProcessor(state);
         }
 

--- a/artemis/src/test/java/tech/pegasys/artemis/state/BeaconStateTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/state/BeaconStateTest.java
@@ -44,25 +44,25 @@ public class BeaconStateTest {
 
   private BeaconState newState() {
     // Initialize state
-    BeaconState state = new BeaconState(UInt64.MIN_VALUE, UInt64.MIN_VALUE, new ForkData(UInt64.MIN_VALUE,
+    BeaconState state = new BeaconState(0, 0, new ForkData(UInt64.MIN_VALUE,
         UInt64.MIN_VALUE, UInt64.MIN_VALUE), new ArrayList<ValidatorRecord>(), new ArrayList<Double>(),
-        UInt64.MIN_VALUE, UInt64.MIN_VALUE, hash(Bytes32.TRUE), new ArrayList<Hash>(), new ArrayList<Hash>(),
-        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), UInt64.MIN_VALUE, UInt64.MIN_VALUE, UInt64.MIN_VALUE,
-        UInt64.MIN_VALUE,  new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+       0, 0, hash(Bytes32.TRUE), new ArrayList<Hash>(), new ArrayList<Hash>(),
+        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), 0, 0, 0,
+        0,  new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
         new ArrayList<>(), hash(Bytes32.TRUE), new ArrayList<>());
 
     // Add validator records
     ArrayList<ValidatorRecord> validators = new ArrayList<ValidatorRecord>();
     validators.add(new ValidatorRecord(0, Hash.ZERO, Hash.ZERO, UInt64.MIN_VALUE,
-        UInt64.valueOf(PENDING_ACTIVATION), state.getSlot(), UInt64.MIN_VALUE, UInt64.MIN_VALUE, UInt64.MIN_VALUE));
+        UInt64.valueOf(PENDING_ACTIVATION), UInt64.valueOf(state.getSlot()), UInt64.MIN_VALUE, UInt64.MIN_VALUE, UInt64.MIN_VALUE));
     validators.add(new ValidatorRecord(100, Hash.ZERO, Hash.ZERO, UInt64.MIN_VALUE,
-        UInt64.valueOf(ACTIVE), state.getSlot(), UInt64.MIN_VALUE, UInt64.MIN_VALUE, UInt64.MIN_VALUE));
+        UInt64.valueOf(ACTIVE), UInt64.valueOf(state.getSlot()), UInt64.MIN_VALUE, UInt64.MIN_VALUE, UInt64.MIN_VALUE));
     validators.add(new ValidatorRecord(200, Hash.ZERO, Hash.ZERO, UInt64.MIN_VALUE,
-        UInt64.valueOf(ACTIVE_PENDING_EXIT), state.getSlot(), UInt64.MIN_VALUE, UInt64.MIN_VALUE, UInt64.MIN_VALUE));
+        UInt64.valueOf(ACTIVE_PENDING_EXIT), UInt64.valueOf(state.getSlot()), UInt64.MIN_VALUE, UInt64.MIN_VALUE, UInt64.MIN_VALUE));
     validators.add(new ValidatorRecord(0, Hash.ZERO, Hash.ZERO, UInt64.MIN_VALUE,
-        UInt64.valueOf(EXITED_WITHOUT_PENALTY), state.getSlot(), UInt64.MIN_VALUE, UInt64.MIN_VALUE, UInt64.MIN_VALUE));
+        UInt64.valueOf(EXITED_WITHOUT_PENALTY), UInt64.valueOf(state.getSlot()), UInt64.MIN_VALUE, UInt64.MIN_VALUE, UInt64.MIN_VALUE));
     validators.add(new ValidatorRecord(0, Hash.ZERO, Hash.ZERO, UInt64.MIN_VALUE,
-        UInt64.valueOf(EXITED_WITH_PENALTY), state.getSlot(), UInt64.MIN_VALUE, UInt64.MIN_VALUE, UInt64.MIN_VALUE));
+        UInt64.valueOf(EXITED_WITH_PENALTY), UInt64.valueOf(state.getSlot()), UInt64.MIN_VALUE, UInt64.MIN_VALUE, UInt64.MIN_VALUE));
     state.setValidator_registry(validators);
 
     // Add validator balances
@@ -150,7 +150,7 @@ public class BeaconStateTest {
     assertThat(state.getValidator_registry().get(validator_index).getStatus().getValue()).isEqualTo(PENDING_ACTIVATION);
     state.activate_validator(validator_index);
     assertThat(state.getValidator_registry().get(validator_index).getStatus().getValue()).isEqualTo(ACTIVE);
-    assertThat(state.getValidator_registry().get(validator_index).getLatest_status_change_slot())
+    assertThat(state.getValidator_registry().get(validator_index).getLatest_status_change_slot().getValue())
         .isEqualTo(state.getSlot());
   }
 
@@ -172,7 +172,7 @@ public class BeaconStateTest {
     assertThat(state.getValidator_registry().get(validator_index).
         getStatus().getValue()).isEqualTo(ACTIVE_PENDING_EXIT);
     assertThat(state.getValidator_registry().get(validator_index).
-        getLatest_status_change_slot()).isEqualTo(state.getSlot());
+        getLatest_status_change_slot().getValue()).isEqualTo(state.getSlot());
   }
 
   @Test
@@ -193,7 +193,7 @@ public class BeaconStateTest {
     assertThat(state.getValidator_registry().get(validator_index).
         getStatus().getValue()).isEqualTo(EXITED_WITHOUT_PENALTY);
     assertThat(state.getValidator_registry().get(validator_index).
-        getLatest_status_change_slot()).isEqualTo(state.getSlot());
+        getLatest_status_change_slot().getValue()).isEqualTo(state.getSlot());
   }
 
   @Test
@@ -201,13 +201,13 @@ public class BeaconStateTest {
     BeaconState state = newState();
     int validator_index = 3;
 
-    long before_exit_count = state.getValidator_registry_exit_count().getValue();
+    long before_exit_count = state.getValidator_registry_exit_count();
     double before_balance = state.getValidator_balances().get(validator_index);
 //    Hash before_tip = state.validator_registry_delta_chain_tip;
 
     state.exit_validator(state, validator_index, EXITED_WITH_PENALTY);
 
-    assertThat(before_exit_count).isEqualTo(state.getValidator_registry_exit_count().getValue());
+    assertThat(before_exit_count).isEqualTo(state.getValidator_registry_exit_count());
     assertThat(state.getValidator_balances().get(validator_index)).isLessThan(before_balance);
     // TODO: Uncomment this when tree_root_hash is working.
 //    assertThat(before_tip).isNotEqualTo(state.validator_registry_delta_chain_tip);
@@ -218,13 +218,13 @@ public class BeaconStateTest {
     BeaconState state = newState();
     int validator_index = 2;
 
-    long before_exit_count = state.getValidator_registry_exit_count().getValue();
+    long before_exit_count = state.getValidator_registry_exit_count();
     double before_balance = state.getValidator_balances().get(validator_index);
 //    Hash before_tip = state.validator_registry_delta_chain_tip;
 
     state.exit_validator(state, validator_index, EXITED_WITH_PENALTY);
 
-    assertThat(before_exit_count).isEqualTo(state.getValidator_registry_exit_count().getValue() - 1);
+    assertThat(before_exit_count).isEqualTo(state.getValidator_registry_exit_count() - 1);
     assertThat(state.getValidator_balances().get(validator_index)).isLessThan(before_balance);
     // TODO: Uncomment this when tree_root_hash is working.
 //    assertThat(before_tip).isNotEqualTo(state.validator_registry_delta_chain_tip);
@@ -235,13 +235,13 @@ public class BeaconStateTest {
     BeaconState state = newState();
     int validator_index = 0;
 
-    long before_exit_count = state.getValidator_registry_exit_count().getValue();
+    long before_exit_count = state.getValidator_registry_exit_count();
     int before_persistent_committees_size = state.getPersistent_committees().get(validator_index).size();
 //    Hash before_tip = state.validator_registry_delta_chain_tip;
 
     state.exit_validator(state, validator_index, EXITED_WITHOUT_PENALTY);
 
-    assertThat(before_exit_count).isEqualTo(state.getValidator_registry_exit_count().getValue() - 1);
+    assertThat(before_exit_count).isEqualTo(state.getValidator_registry_exit_count() - 1);
     assertThat(state.getPersistent_committees().get(validator_index).size())
         .isEqualTo(before_persistent_committees_size - 1);
     // TODO: Uncomment this when tree_root_hash is working.

--- a/artemis/src/test/java/tech/pegasys/artemis/state/BeaconStateTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/state/BeaconStateTest.java
@@ -91,11 +91,11 @@ public class BeaconStateTest {
   private BeaconState processDepositSetup() {
     BeaconState state = newState();
     ValidatorRecord validator1 = new ValidatorRecord(0, Hash.ZERO, Hash.ZERO, UInt64.valueOf(0), UInt64.valueOf(0),
-        UInt64.valueOf(PENDING_ACTIVATION), state.getSlot(), UInt64.valueOf(0), UInt64.valueOf(0));
+        UInt64.valueOf(PENDING_ACTIVATION), UInt64.valueOf(state.getSlot()), UInt64.valueOf(0), UInt64.valueOf(0));
     ValidatorRecord validator2 = new ValidatorRecord(100, Hash.ZERO, Hash.ZERO, UInt64.valueOf(0), UInt64.valueOf(0),
-        UInt64.valueOf(PENDING_ACTIVATION), state.getSlot(), UInt64.valueOf(0), UInt64.valueOf(0));
+        UInt64.valueOf(PENDING_ACTIVATION), UInt64.valueOf(state.getSlot()), UInt64.valueOf(0), UInt64.valueOf(0));
     ValidatorRecord validator3 = new ValidatorRecord(200, Hash.ZERO, Hash.ZERO, UInt64.valueOf(0), UInt64.valueOf(0),
-        UInt64.valueOf(PENDING_ACTIVATION), state.getSlot(), UInt64.valueOf(0), UInt64.valueOf(0));
+        UInt64.valueOf(PENDING_ACTIVATION), UInt64.valueOf(state.getSlot()), UInt64.valueOf(0), UInt64.valueOf(0));
     ArrayList<ValidatorRecord> validators = new ArrayList<ValidatorRecord>();
     validators.add(validator1);
     validators.add(validator2);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR description
- Attempt to make the minimal viable code change needed to switch slot representation to long in the places that the StateTransition logic will be affected.  I am working under the following assumptions:
- The changes should be limited to: 
    - BeaconState.java
    - BeaconBlock.java
    - StateTransition.java
- Methods in BeaconState.java like `get_shard_committees_at_slot(BeaconState state, int slot)` that specifically a slot of type int are written that way for a good reason.  If this is incorrect and need to be modified to be longs, then that is outside the scope of this PR.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
resolves #145 
