### PR TITLE
Shuffle and split accept ArrayList of generic type objects

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/state/BeaconState.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/state/BeaconState.java
@@ -49,7 +49,6 @@ import tech.pegasys.artemis.util.uint.UInt384;
 import tech.pegasys.artemis.util.uint.UInt64;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
@@ -498,7 +497,6 @@ public class BeaconState {
     this.latest_vdf_outputs = latest_vdf_outputs;
   }
 
-
   static class BeaconStateHelperFunctions {
 
     /**
@@ -526,9 +524,8 @@ public class BeaconState {
      * @return          The shuffled array.
      */
     @VisibleForTesting
-    static Object[] shuffle(Object[] values, Hash seed) {
-
-      int values_count = values.length;
+    static <T> ArrayList<T> shuffle(ArrayList<T> values, Hash seed) {
+      int values_count = values.size();
 
       // Entropy is consumed from the seed in 3-byte (24 bit) chunks.
       int rand_bytes = 3;
@@ -539,16 +536,17 @@ public class BeaconState {
       // may be shuffled. It is a logic error to supply an oversized list.
       assert values_count < rand_max;
 
-      Object[] output = values.clone();
+      ArrayList<T>  output = new ArrayList<>();
+      output.addAll(values);
+
       Hash source = seed;
       int index = 0;
-
       while (index < values_count - 1) {
         // Re-hash the `source` to obtain a new pattern of bytes.
         source = Hash.hash(source);
 
         // List to hold values for swap below.
-        Object tmp;
+        T tmp;
 
         // Iterate through the `source` bytes in 3-byte chunks
         for (int position = 0; position < (32 - (32 % rand_bytes)); position += rand_bytes) {
@@ -564,15 +562,14 @@ public class BeaconState {
           // Sample values greater than or equal to `sample_max` will cause
           // modulo bias when mapped into the `remaining` range.
           int sample_max = rand_max - rand_max % remaining;
-
           // Perform a swap if the consumed entropy will not cause modulo bias.
           if (sample_from_source < sample_max) {
             // Select a replacement index for the current index
             int replacement_position = (sample_from_source % remaining) + index;
             // Swap the current index with the replacement index.
-            tmp = output[index];
-            output[index] = output[replacement_position];
-            output[replacement_position] = tmp;
+            tmp = output.get(index);
+            output.set(index, output.get(replacement_position));
+            output.set(replacement_position, tmp);
             index += 1;
           }
 
@@ -591,20 +588,21 @@ public class BeaconState {
      * @param split_count     The number of pieces to split the array into.
      * @return                The list of validators split into N pieces.
      */
-    static Object[] split(Object[] values, int split_count) {
+    static <T> ArrayList<ArrayList<T>> split(ArrayList<T> values, int split_count) {
       checkArgument(split_count > 0, "Expected positive split_count but got %s", split_count);
 
-      int list_length = values.length;
-
-      Object[] split_arr = new Object[split_count];
+      int list_length = values.size();
+      ArrayList<ArrayList<T>> split_arr = new ArrayList<>(split_count);
 
       for (int i = 0; i < split_count; i++) {
         int startIndex = list_length * i / split_count;
         int endIndex = list_length * (i + 1) / split_count;
-        Object[] new_split = Arrays.copyOfRange(values, startIndex, endIndex);
-        split_arr[i] = new_split;
+        ArrayList<T> new_split = new ArrayList<>();
+        for (int j = startIndex; j < endIndex; j++) {
+          new_split.add(values.get(j));
+        }
+        split_arr.add(new_split);
       }
-
       return split_arr;
 
     }
@@ -619,8 +617,6 @@ public class BeaconState {
     }
 
   }
-
-
 
   public long getGenesis_time() {
     return genesis_time;

--- a/artemis/src/test/java/tech/pegasys/artemis/state/BeaconStateTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/state/BeaconStateTest.java
@@ -36,7 +36,9 @@ import tech.pegasys.artemis.util.bytes.BytesValue;
 import tech.pegasys.artemis.util.uint.UInt64;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import com.google.gson.Gson;
 import org.junit.Test;
@@ -303,34 +305,74 @@ public class BeaconStateTest {
 
   @Test
   public void testShuffle() {
-    Object[] actual = shuffle(new Object[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, hashSrc());
-    Object[] expected = {2, 4, 10, 7, 5, 6, 9, 8, 1, 3};
+    List<Integer> input = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    ArrayList<Integer> sample = new ArrayList<>(input);
+
+    ArrayList<Integer> actual = shuffle(sample, hashSrc());
+    List<Integer> expected_input = Arrays.asList(2, 4, 10, 7, 5, 6, 9, 8, 1, 3);
+    ArrayList<Integer> expected = new ArrayList<>(expected_input);
     assertThat(actual).isEqualTo(expected);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void failsWhenInvalidArgumentTestSplit() {
-    split(new Object[]{0, 1, 2, 3, 4, 5, 6, 7}, -1);
+    List<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7);
+    ArrayList<Integer> sample = new ArrayList<>(input);
+
+    split(sample, -1);
   }
 
   @Test
   public void splitReturnsOneSmallerSizedSplit() {
-    Object[] actual = split(new Object[]{0, 1, 2, 3, 4, 5, 6, 7}, 3);
-    Object[][] expected = {{0, 1}, {2, 3, 4}, {5, 6, 7}};
+    List<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7);
+    ArrayList<Integer> sample = new ArrayList<>(input);
+
+    ArrayList<ArrayList<Integer>> actual = split(sample, 3);
+
+    ArrayList<ArrayList<Integer>> expected = new ArrayList<>();
+    List<Integer> one = Arrays.asList(0, 1);
+    expected.add(new ArrayList<>(one));
+    List<Integer> two = Arrays.asList(2, 3, 4);
+    expected.add(new ArrayList<>(two));
+    List<Integer> three = Arrays.asList(5, 6, 7);
+    expected.add(new ArrayList<>(three));
+
     assertThat(actual).isEqualTo(expected);
   }
 
   @Test
   public void splitReturnsTwoSmallerSizedSplits() {
-    Object[] actual = split(new Object[]{0, 1, 2, 3, 4, 5, 6}, 3);
-    Object[][] expected = {{0, 1}, {2, 3}, {4, 5, 6}};
+    List<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5, 6);
+    ArrayList<Integer> sample = new ArrayList<>(input);
+
+    ArrayList<ArrayList<Integer>> actual = split(sample, 3);
+
+    ArrayList<ArrayList<Integer>> expected = new ArrayList<>();
+    List<Integer> one = Arrays.asList(0, 1);
+    expected.add(new ArrayList<>(one));
+    List<Integer> two = Arrays.asList(2, 3);
+    expected.add(new ArrayList<>(two));
+    List<Integer> three = Arrays.asList(4, 5, 6);
+    expected.add(new ArrayList<>(three));
+
     assertThat(actual).isEqualTo(expected);
   }
 
   @Test
   public void splitReturnsEquallySizedSplits() {
-    Object[] actual = split(new Object[]{0, 1, 2, 3, 4, 5, 6, 7, 8}, 3);
-    Object[][] expected = {{0, 1, 2}, {3, 4, 5}, {6, 7, 8}};
+    List<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8);
+    ArrayList<Integer> sample = new ArrayList<>(input);
+
+    ArrayList<ArrayList<Integer>> actual = split(sample, 3);
+
+    ArrayList<ArrayList<Integer>> expected = new ArrayList<>();
+    List<Integer> one = Arrays.asList(0, 1, 2);
+    expected.add(new ArrayList<>(one));
+    List<Integer> two = Arrays.asList(3, 4, 5);
+    expected.add(new ArrayList<>(two));
+    List<Integer> three = Arrays.asList(6, 7, 8);
+    expected.add(new ArrayList<>(three));
+
     assertThat(actual).isEqualTo(expected);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR description
Previously, shuffle and split only accepted Object arrays. Now, they accept ArrayLists that contain generic type objects.

## Fixed issues
Resolves #105.