### PR TITLE
Fixes gradle build daemon disappearing unexpectedly

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx1g
+org.gradle.daemon=false


### PR DESCRIPTION
## PR description
Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed) while building another PR. This PR attempts to fix the underlying issue