### PR TITLE
Add UTF-8 support to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@
 #FROM openjdk:8-jre-alpine
 FROM openjdk:8-jdk
 
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 # copy application (with libraries inside)
 ADD build/install/artemis /opt/artemis/
 ADD integration-tests/src/test/resources/net/consensys/artemis/tests/cluster/docker/geth/genesis.json /opt/artemis/genesis.json


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Adds Unicode/UTF-8 support to Dockerfile in an attempt to debug failing gradle builds initiated from Jenkins when non-ASCII chars are in env vars.

## Fixed Issue(s)
(Hopefully) Fixes #189
