### PR TITLE
Fix bug in BeaconState:bytes3ToInt, add more unit test coverage.

### DIFF
--- a/ethereum/beaconchain/src/main/java/tech/pegasys/artemis/state/BeaconState.java
+++ b/ethereum/beaconchain/src/main/java/tech/pegasys/artemis/state/BeaconState.java
@@ -862,17 +862,17 @@ public class BeaconState {
   static class BeaconStateHelperFunctions {
 
     /**
-     * Converts byte[] to int.
+     * Converts byte[] (wrapped by BytesValue) to int.
      *
-     * @param src byte[]
+     * @param src byte[] (wrapped by BytesValue)
      * @param pos Index in Byte[] array
      * @return converted int
      * @throws IllegalArgumentException if pos is a negative value.
      */
     @VisibleForTesting
-    static int bytes3ToInt(Hash src, int pos) {
+    static int bytes3ToInt(BytesValue src, int pos) {
       checkArgument(pos >= 0, "Expected positive pos but got %s", pos);
-      return ((src.extractArray()[pos] & 0xF) << 16)
+      return ((src.extractArray()[pos] & 0xFF) << 16)
           | ((src.extractArray()[pos + 1] & 0xFF) << 8)
           | (src.extractArray()[pos + 2] & 0xFF);
     }

--- a/ethereum/beaconchain/src/test/java/tech/pegasys/artemis/state/BeaconStateTest.java
+++ b/ethereum/beaconchain/src/test/java/tech/pegasys/artemis/state/BeaconStateTest.java
@@ -455,14 +455,35 @@ public class BeaconStateTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void failsWhenInvalidArgumentsBytes3ToInt() {
-    bytes3ToInt(hashSrc(), -1);
+    bytes3ToInt(BytesValue.wrap(new byte[] {(byte) 0, (byte) 0, (byte) 0}), -1);
   }
 
   @Test
   public void convertBytes3ToInt() {
-    int expected = 817593;
-    int actual = bytes3ToInt(hashSrc(), 0);
-    assertThat(actual).isEqualTo(expected);
+    // Smoke Tests
+    // Test that MSB [00000001][00000000][11110000] LSB == 65656
+    assertThat(bytes3ToInt(BytesValue.wrap(new byte[] {(byte) 1, (byte) 0, (byte) 120}), 0))
+        .isEqualTo(65656);
+
+    // Boundary Tests
+    // Test that MSB [00000000][00000000][00000000] LSB == 0
+    assertThat(bytes3ToInt(BytesValue.wrap(new byte[] {(byte) 0, (byte) 0, (byte) 0}), 0))
+        .isEqualTo(0);
+    // Test that MSB [00000000][00000000][11111111] LSB == 255
+    assertThat(bytes3ToInt(BytesValue.wrap(new byte[] {(byte) 0, (byte) 0, (byte) 255}), 0))
+        .isEqualTo(255);
+    // Test that MSB [00000000][00000001][00000000] LSB == 256
+    assertThat(bytes3ToInt(BytesValue.wrap(new byte[] {(byte) 0, (byte) 1, (byte) 0}), 0))
+        .isEqualTo(256);
+    // Test that MSB [00000000][11111111][11111111] LSB == 65535
+    assertThat(bytes3ToInt(BytesValue.wrap(new byte[] {(byte) 0, (byte) 255, (byte) 255}), 0))
+        .isEqualTo(65535);
+    // Test that MSB [00000001][00000000][00000000] LSB == 65536
+    assertThat(bytes3ToInt(BytesValue.wrap(new byte[] {(byte) 1, (byte) 0, (byte) 0}), 0))
+        .isEqualTo(65536);
+    // Test that MSB [11111111][11111111][11111111] LSB == 16777215
+    assertThat(bytes3ToInt(BytesValue.wrap(new byte[] {(byte) 255, (byte) 255, (byte) 255}), 0))
+        .isEqualTo(16777215);
   }
 
   @Test
@@ -471,7 +492,7 @@ public class BeaconStateTest {
     ArrayList<Integer> sample = new ArrayList<>(input);
 
     ArrayList<Integer> actual = shuffle(sample, hashSrc());
-    List<Integer> expected_input = Arrays.asList(2, 4, 10, 7, 5, 6, 9, 8, 1, 3);
+    List<Integer> expected_input = Arrays.asList(4, 7, 2, 1, 5, 10, 3, 6, 8, 9);
     ArrayList<Integer> expected = new ArrayList<>(expected_input);
     assertThat(actual).isEqualTo(expected);
   }


### PR DESCRIPTION
## PR Description
- Fixes bug described in #180 where typo in bit mask accidentally truncates size of most significant byte.
- Changes input type from Hash (probably only used as a convenient way to wrap a byte[] array) to BytesValue.
- Adds additional unit test coverage around byte boundaries.
- Changes behavior of existing smoke test - unsure why we were hashing a byte array then converting the hash to an int.

## Fixed Issue(s)
Fixes #180 
