### PR TITLE
Moved Beacon Chain event handling to StateTreeManager

### DIFF
--- a/ethereum/beaconchain/build.gradle
+++ b/ethereum/beaconchain/build.gradle
@@ -7,6 +7,7 @@ jar {
 }
 
 dependencies {
+  implementation project(':pow')
   implementation project(':util')
 
   implementation 'net.consensys.cava:cava-crypto'

--- a/ethereum/beaconchain/src/main/java/tech/pegasys/artemis/state/StateTreeManager.java
+++ b/ethereum/beaconchain/src/main/java/tech/pegasys/artemis/state/StateTreeManager.java
@@ -23,6 +23,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.artemis.datastructures.beaconchainblocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.beaconchainoperations.Attestation;
+import tech.pegasys.artemis.pow.api.ChainStartEvent;
+import tech.pegasys.artemis.pow.api.ValidatorRegistrationEvent;
 
 public class StateTreeManager {
 
@@ -41,6 +43,17 @@ public class StateTreeManager {
     this.unprocessedAttestations = new LinkedBlockingQueue<Attestation>();
 
     this.eventBus.register(this);
+  }
+
+  @Subscribe
+  public void onChainStarted(ChainStartEvent event) {
+    LOG.info("ChainStart Event Detected");
+  }
+
+  @Subscribe
+  public void onValidatorRegistered(ValidatorRegistrationEvent event) {
+    LOG.info("Validator Registration Event detected");
+    // LOG.info("   Validator Number: " + validatorRegisteredEvent.getInfo());
   }
 
   @Subscribe

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainService.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainService.java
@@ -14,25 +14,17 @@
 package tech.pegasys.artemis.services.beaconchain;
 
 import com.google.common.eventbus.EventBus;
-import com.google.common.eventbus.Subscribe;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.artemis.Constants;
-import tech.pegasys.artemis.pow.api.ChainStartEvent;
-import tech.pegasys.artemis.pow.api.ValidatorRegistrationEvent;
 import tech.pegasys.artemis.services.ServiceInterface;
 import tech.pegasys.artemis.state.SlotScheduler;
-import tech.pegasys.artemis.state.StateTreeManager;
 
 public class BeaconChainService implements ServiceInterface {
 
   private EventBus eventBus;
   private ScheduledExecutorService scheduler;
-  private static final Logger LOG = LogManager.getLogger();
-  private StateTreeManager stateTreeManager;
 
   public BeaconChainService() {}
 
@@ -40,7 +32,6 @@ public class BeaconChainService implements ServiceInterface {
   public void init(EventBus eventBus) {
     this.eventBus = eventBus;
     this.scheduler = Executors.newScheduledThreadPool(1);
-    this.stateTreeManager = new StateTreeManager(this.eventBus);
     this.eventBus.register(this);
   }
 
@@ -56,16 +47,5 @@ public class BeaconChainService implements ServiceInterface {
   public void stop() {
     this.scheduler.shutdown();
     this.eventBus.unregister(this);
-  }
-
-  @Subscribe
-  public void onChainStarted(ChainStartEvent event) {
-    LOG.info("ChainStart Event Detected");
-  }
-
-  @Subscribe
-  public void onValidatorRegistered(ValidatorRegistrationEvent event) {
-    LOG.info("Validator Registration Event detected");
-    // LOG.info("   Validator Number: " + validatorRegisteredEvent.getInfo());
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainService.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainService.java
@@ -20,11 +20,13 @@ import java.util.concurrent.TimeUnit;
 import tech.pegasys.artemis.Constants;
 import tech.pegasys.artemis.services.ServiceInterface;
 import tech.pegasys.artemis.state.SlotScheduler;
+import tech.pegasys.artemis.state.StateTreeManager;
 
 public class BeaconChainService implements ServiceInterface {
 
   private EventBus eventBus;
   private ScheduledExecutorService scheduler;
+  private StateTreeManager stateTreeManager;
 
   public BeaconChainService() {}
 
@@ -32,6 +34,7 @@ public class BeaconChainService implements ServiceInterface {
   public void init(EventBus eventBus) {
     this.eventBus = eventBus;
     this.scheduler = Executors.newScheduledThreadPool(1);
+    this.stateTreeManager = new StateTreeManager(this.eventBus);
     this.eventBus.register(this);
   }
 


### PR DESCRIPTION
## PR Description

Moved beacon chain event handling to the StateTreeManager instead of housing that logic in the BeaconChainService.

## Fixed Issue(s)

fixes #200 