### PR TITLE
Remove `validator_registry_exit_count`

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/BeaconState.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/BeaconState.java
@@ -64,7 +64,6 @@ public class BeaconState {
   private Validators validator_registry;
   private ArrayList<Double> validator_balances;
   private long validator_registry_latest_change_slot;
-  private long validator_registry_exit_count;
   private Bytes32 validator_registry_delta_chain_tip;
 
   // Randomness and committees
@@ -112,7 +111,6 @@ public class BeaconState {
       Validators validator_registry,
       ArrayList<Double> validator_balances,
       long validator_registry_latest_change_slot,
-      long validator_registry_exit_count,
       Bytes32 validator_registry_delta_chain_tip,
       // Randomness and committees
       ArrayList<Bytes32> latest_randao_mixes,
@@ -141,7 +139,6 @@ public class BeaconState {
     this.validator_registry = validator_registry;
     this.validator_balances = validator_balances;
     this.validator_registry_latest_change_slot = validator_registry_latest_change_slot;
-    this.validator_registry_exit_count = validator_registry_exit_count;
     this.validator_registry_delta_chain_tip = validator_registry_delta_chain_tip;
 
     // Randomness and committees
@@ -194,7 +191,6 @@ public class BeaconState {
             new Validators(),
             new ArrayList<>(),
             INITIAL_SLOT_NUMBER,
-            0,
             Bytes32.ZERO,
 
             // Randomness and committees
@@ -719,14 +715,6 @@ public class BeaconState {
 
   public void setValidator_balances(ArrayList<Double> validator_balances) {
     this.validator_balances = validator_balances;
-  }
-
-  public long getValidator_registry_exit_count() {
-    return validator_registry_exit_count;
-  }
-
-  public void setValidator_registry_exit_count(long validator_registry_exit_count) {
-    this.validator_registry_exit_count = validator_registry_exit_count;
   }
 
   public Bytes32 getValidator_registry_delta_chain_tip() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/BeaconStateTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/BeaconStateTest.java
@@ -57,7 +57,6 @@ class BeaconStateTest {
             new Validators(),
             new ArrayList<>(),
             0,
-            0,
             Bytes32.ZERO,
             new ArrayList<>(),
             new ArrayList<>(),
@@ -328,14 +327,12 @@ class BeaconStateTest {
     BeaconState state = newState();
     int validator_index = 3;
 
-    long before_exit_count = state.getValidator_registry_exit_count();
     double before_balance = state.getValidator_balances().get(validator_index);
     //    Hash before_tip = state.validator_registry_delta_chain_tip;
 
     exit_validator(state, validator_index);
 
     // TODO: update for 0.1
-    // assertThat(before_exit_count).isEqualTo(state.getValidator_registry_exit_count());
     // assertThat(state.getValidator_balances().get(validator_index)).isLessThan(before_balance);
     // TODO: Uncomment this when tree_root_hash is working.
     //    assertThat(before_tip).isNotEqualTo(state.validator_registry_delta_chain_tip);
@@ -348,13 +345,11 @@ class BeaconStateTest {
     /*
     int validator_index = 2;
 
-    long before_exit_count = state.getValidator_registry_exit_count();
     double before_balance = state.getValidator_balances().get(validator_index);
     //    Hash before_tip = state.validator_registry_delta_chain_tip;
 
     exit_validator(state, validator_index);
 
-    assertThat(before_exit_count).isEqualTo(state.getValidator_registry_exit_count() - 1);
     assertThat(state.getValidator_balances().get(validator_index)).isLessThan(before_balance);
     // TODO: Uncomment this when tree_root_hash is working.
     //    assertThat(before_tip).isNotEqualTo(state.validator_registry_delta_chain_tip);
@@ -375,7 +370,6 @@ class BeaconStateTest {
     initiate_validator_exit(state, validator_index);
     exit_validator(state, validator_index);
 
-    assertThat(before_exit_count).isEqualTo(state.getValidator_registry_exit_count() - 1);
     assertThat(state.getPersistent_committees().get(validator_index).size())
         .isEqualTo(before_persistent_committees_size - 1);
     // TODO: Uncomment this when tree_root_hash is working.


### PR DESCRIPTION
Implements https://github.com/ethereum/eth2.0-specs/pull/525
Addresses some of #235

Note that some of the BeaconStateTests still need fixing up.
