### PR TITLE
Implement SSZ and test round-trip for blocks and operations datastructures.

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlock.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlock.java
@@ -14,6 +14,8 @@
 package tech.pegasys.artemis.datastructures.blocks;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.bytes.Bytes48;
@@ -32,8 +34,6 @@ public final class BeaconBlock {
   // Body
   private BeaconBlockBody body;
 
-  public BeaconBlock() {}
-
   public BeaconBlock(
       long slot,
       List<Bytes32> ancestor_hashes,
@@ -51,17 +51,60 @@ public final class BeaconBlock {
     this.body = body;
   }
 
+  public static BeaconBlock fromBytes(Bytes bytes) {
+    return SSZ.decode(
+        bytes,
+        reader ->
+            new BeaconBlock(
+                reader.readUInt64(),
+                reader.readBytesList().stream().map(Bytes32::wrap).collect(Collectors.toList()),
+                Bytes32.wrap(reader.readBytes()),
+                reader.readBytesList().stream().map(Bytes48::wrap).collect(Collectors.toList()),
+                Eth1Data.fromBytes(reader.readBytes()),
+                reader.readBytesList().stream().map(Bytes48::wrap).collect(Collectors.toList()),
+                BeaconBlockBody.fromBytes(reader.readBytes())));
+  }
+
   public Bytes toBytes() {
     return SSZ.encode(
         writer -> {
-          writer.writeUInt64(0l);
-          writer.writeBytesList(ancestor_hashes.toArray(new Bytes32[0]));
+          writer.writeUInt64(slot);
+          writer.writeBytesList(ancestor_hashes);
           writer.writeBytes(state_root);
-          writer.writeBytesList(randao_reveal.toArray(new Bytes48[0]));
+          writer.writeBytesList(randao_reveal);
           writer.writeBytes(eth1_data.toBytes());
-          writer.writeBytesList(signature.toArray(new Bytes48[0]));
+          writer.writeBytesList(signature);
           writer.writeBytes(body.toBytes());
         });
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(slot, ancestor_hashes, state_root, randao_reveal, eth1_data, signature);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (Objects.isNull(obj)) {
+      return false;
+    }
+
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof BeaconBlock)) {
+      return false;
+    }
+
+    BeaconBlock other = (BeaconBlock) obj;
+    return slot == other.getSlot()
+        && Objects.equals(this.getAncestor_hashes(), other.getAncestor_hashes())
+        && Objects.equals(this.getState_root(), other.getState_root())
+        && Objects.equals(this.getRandao_reveal(), other.getRandao_reveal())
+        && Objects.equals(this.getEth1_data(), other.getEth1_data())
+        && Objects.equals(this.getSignature(), other.getSignature())
+        && Objects.equals(this.getBody(), other.getBody());
   }
 
   /** ******************* * GETTERS & SETTERS * * ******************* */

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlock.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlock.java
@@ -25,7 +25,7 @@ public final class BeaconBlock {
 
   // Header
   private long slot;
-  private List<Bytes32> ancestor_hashes;
+  private Bytes32 parent_root;
   private Bytes32 state_root;
   private List<Bytes48> randao_reveal;
   private Eth1Data eth1_data;
@@ -36,14 +36,14 @@ public final class BeaconBlock {
 
   public BeaconBlock(
       long slot,
-      List<Bytes32> ancestor_hashes,
+      Bytes32 parent_root,
       Bytes32 state_root,
       List<Bytes48> randao_reveal,
       Eth1Data eth1_data,
       List<Bytes48> signature,
       BeaconBlockBody body) {
     this.slot = slot;
-    this.ancestor_hashes = ancestor_hashes;
+    this.parent_root = parent_root;
     this.state_root = state_root;
     this.randao_reveal = randao_reveal;
     this.eth1_data = eth1_data;
@@ -57,7 +57,7 @@ public final class BeaconBlock {
         reader ->
             new BeaconBlock(
                 reader.readUInt64(),
-                reader.readBytesList().stream().map(Bytes32::wrap).collect(Collectors.toList()),
+                Bytes32.wrap(reader.readBytes()),
                 Bytes32.wrap(reader.readBytes()),
                 reader.readBytesList().stream().map(Bytes48::wrap).collect(Collectors.toList()),
                 Eth1Data.fromBytes(reader.readBytes()),
@@ -69,7 +69,7 @@ public final class BeaconBlock {
     return SSZ.encode(
         writer -> {
           writer.writeUInt64(slot);
-          writer.writeBytesList(ancestor_hashes);
+          writer.writeBytes(parent_root);
           writer.writeBytes(state_root);
           writer.writeBytesList(randao_reveal);
           writer.writeBytes(eth1_data.toBytes());
@@ -80,7 +80,7 @@ public final class BeaconBlock {
 
   @Override
   public int hashCode() {
-    return Objects.hash(slot, ancestor_hashes, state_root, randao_reveal, eth1_data, signature);
+    return Objects.hash(slot, parent_root, state_root, randao_reveal, eth1_data, signature);
   }
 
   @Override
@@ -99,7 +99,7 @@ public final class BeaconBlock {
 
     BeaconBlock other = (BeaconBlock) obj;
     return slot == other.getSlot()
-        && Objects.equals(this.getAncestor_hashes(), other.getAncestor_hashes())
+        && Objects.equals(this.getParent_root(), other.getParent_root())
         && Objects.equals(this.getState_root(), other.getState_root())
         && Objects.equals(this.getRandao_reveal(), other.getRandao_reveal())
         && Objects.equals(this.getEth1_data(), other.getEth1_data())
@@ -148,12 +148,12 @@ public final class BeaconBlock {
     this.state_root = state_root;
   }
 
-  public List<Bytes32> getAncestor_hashes() {
-    return ancestor_hashes;
+  public Bytes32 getParent_root() {
+    return parent_root;
   }
 
-  public void setAncestor_hashes(List<Bytes32> ancestor_hashes) {
-    this.ancestor_hashes = ancestor_hashes;
+  public void setParent_root(Bytes32 parent_root) {
+    this.parent_root = parent_root;
   }
 
   public long getSlot() {

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockBody.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockBody.java
@@ -29,9 +29,9 @@ import tech.pegasys.artemis.datastructures.operations.ProposerSlashing;
 
 /** A Beacon block body */
 public class BeaconBlockBody {
-  private List<Attestation> attestations;
   private List<ProposerSlashing> proposer_slashings;
   private List<CasperSlashing> casper_slashings;
+  private List<Attestation> attestations;
   private List<Deposit> deposits;
   private List<Exit> exits;
 
@@ -42,9 +42,9 @@ public class BeaconBlockBody {
   private List<ProofOfCustodyResponse> poc_responses;
 
   public BeaconBlockBody(
-      List<Attestation> attestations,
       List<ProposerSlashing> proposer_slashings,
       List<CasperSlashing> casper_slashings,
+      List<Attestation> attestations,
       List<Deposit> deposits,
       List<Exit> exits) {
     this.attestations = attestations;
@@ -62,11 +62,6 @@ public class BeaconBlockBody {
                 reader
                     .readBytesList()
                     .stream()
-                    .map(Attestation::fromBytes)
-                    .collect(Collectors.toList()),
-                reader
-                    .readBytesList()
-                    .stream()
                     .map(ProposerSlashing::fromBytes)
                     .collect(Collectors.toList()),
                 reader
@@ -77,27 +72,32 @@ public class BeaconBlockBody {
                 reader
                     .readBytesList()
                     .stream()
+                    .map(Attestation::fromBytes)
+                    .collect(Collectors.toList()),
+                reader
+                    .readBytesList()
+                    .stream()
                     .map(Deposit::fromBytes)
                     .collect(Collectors.toList()),
                 reader.readBytesList().stream().map(Exit::fromBytes).collect(Collectors.toList())));
   }
 
   public Bytes toBytes() {
-    List<Bytes> attestationsBytes =
-        attestations.stream().map(item -> item.toBytes()).collect(Collectors.toList());
     List<Bytes> proposerSlashingsBytes =
         proposer_slashings.stream().map(item -> item.toBytes()).collect(Collectors.toList());
     List<Bytes> casperSlashingsBytes =
         casper_slashings.stream().map(item -> item.toBytes()).collect(Collectors.toList());
+    List<Bytes> attestationsBytes =
+        attestations.stream().map(item -> item.toBytes()).collect(Collectors.toList());
     List<Bytes> depositsBytes =
         deposits.stream().map(item -> item.toBytes()).collect(Collectors.toList());
     List<Bytes> exitsBytes =
         exits.stream().map(item -> item.toBytes()).collect(Collectors.toList());
     return SSZ.encode(
         writer -> {
-          writer.writeBytesList(attestationsBytes);
           writer.writeBytesList(proposerSlashingsBytes);
           writer.writeBytesList(casperSlashingsBytes);
+          writer.writeBytesList(attestationsBytes);
           writer.writeBytesList(depositsBytes);
           writer.writeBytesList(exitsBytes);
         });

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/blocks/Eth1Data.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/blocks/Eth1Data.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.artemis.datastructures.blocks;
 
+import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.ssz.SSZ;
@@ -27,12 +28,42 @@ public final class Eth1Data {
     this.block_hash = block_hash;
   }
 
+  public static Eth1Data fromBytes(Bytes bytes) {
+    return SSZ.decode(
+        bytes,
+        reader -> new Eth1Data(Bytes32.wrap(reader.readBytes()), Bytes32.wrap(reader.readBytes())));
+  }
+
   public Bytes toBytes() {
     return SSZ.encode(
         writer -> {
           writer.writeBytes(deposit_root);
           writer.writeBytes(block_hash);
         });
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(deposit_root, block_hash);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (Objects.isNull(obj)) {
+      return false;
+    }
+
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof Eth1Data)) {
+      return false;
+    }
+
+    Eth1Data other = (Eth1Data) obj;
+    return Objects.equals(this.getDeposit_root(), other.getDeposit_root())
+        && Objects.equals(this.getBlock_hash(), other.getBlock_hash());
   }
 
   /** @return the deposit_root */

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/blocks/ProposalSignedData.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/blocks/ProposalSignedData.java
@@ -14,6 +14,7 @@
 package tech.pegasys.artemis.datastructures.blocks;
 
 import com.google.common.primitives.UnsignedLong;
+import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.ssz.SSZ;
@@ -30,6 +31,16 @@ public class ProposalSignedData {
     this.block_hash = block_hash;
   }
 
+  public static ProposalSignedData fromBytes(Bytes bytes) {
+    return SSZ.decode(
+        bytes,
+        reader ->
+            new ProposalSignedData(
+                UnsignedLong.fromLongBits(reader.readUInt64()),
+                UnsignedLong.fromLongBits(reader.readUInt64()),
+                Bytes32.wrap(reader.readBytes())));
+  }
+
   public Bytes toBytes() {
     return SSZ.encode(
         writer -> {
@@ -37,6 +48,31 @@ public class ProposalSignedData {
           writer.writeUInt64(shard.longValue());
           writer.writeBytes(block_hash);
         });
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(slot, shard, block_hash);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (Objects.isNull(obj)) {
+      return false;
+    }
+
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof ProposalSignedData)) {
+      return false;
+    }
+
+    ProposalSignedData other = (ProposalSignedData) obj;
+    return Objects.equals(this.getSlot(), other.getSlot())
+        && Objects.equals(this.getShard(), other.getShard())
+        && Objects.equals(this.getBlock_hash(), other.getBlock_hash());
   }
 
   /** ******************* * GETTERS & SETTERS * * ******************* */

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/Attestation.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/Attestation.java
@@ -14,6 +14,8 @@
 package tech.pegasys.artemis.datastructures.operations;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.bytes.Bytes48;
@@ -37,14 +39,51 @@ public class Attestation {
     this.aggregate_signature = aggregate_signature;
   }
 
+  public static Attestation fromBytes(Bytes bytes) {
+    return SSZ.decode(
+        bytes,
+        reader ->
+            new Attestation(
+                AttestationData.fromBytes(reader.readBytes()),
+                Bytes32.wrap(reader.readBytes()),
+                Bytes32.wrap(reader.readBytes()),
+                reader.readBytesList().stream().map(Bytes48::wrap).collect(Collectors.toList())));
+  }
+
   public Bytes toBytes() {
     return SSZ.encode(
         writer -> {
           writer.writeBytes(data.toBytes());
           writer.writeBytes(participation_bitfield);
           writer.writeBytes(custody_bitfield);
-          writer.writeBytesList(aggregate_signature.toArray(new Bytes48[0]));
+          writer.writeBytesList(aggregate_signature);
         });
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(data, participation_bitfield, custody_bitfield, aggregate_signature);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (Objects.isNull(obj)) {
+      return false;
+    }
+
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof Attestation)) {
+      return false;
+    }
+
+    Attestation other = (Attestation) obj;
+    return Objects.equals(this.getData(), other.getData())
+        && Objects.equals(this.getParticipation_bitfield(), other.getParticipation_bitfield())
+        && Objects.equals(this.getCustody_bitfield(), other.getCustody_bitfield())
+        && Objects.equals(this.getAggregate_signature(), other.getAggregate_signature());
   }
 
   /** ******************* * GETTERS & SETTERS * * ******************* */

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/AttestationData.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/AttestationData.java
@@ -14,6 +14,7 @@
 package tech.pegasys.artemis.datastructures.operations;
 
 import com.google.common.primitives.UnsignedLong;
+import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.ssz.SSZ;
@@ -48,6 +49,21 @@ public class AttestationData {
     this.justified_block_hash = justified_block_hash;
   }
 
+  public static AttestationData fromBytes(Bytes bytes) {
+    return SSZ.decode(
+        bytes,
+        reader ->
+            new AttestationData(
+                reader.readUInt64(),
+                UnsignedLong.valueOf(reader.readUInt64()),
+                Bytes32.wrap(reader.readBytes()),
+                Bytes32.wrap(reader.readBytes()),
+                Bytes32.wrap(reader.readBytes()),
+                Bytes32.wrap(reader.readBytes()),
+                UnsignedLong.valueOf(reader.readUInt64()),
+                Bytes32.wrap(reader.readBytes())));
+  }
+
   public Bytes toBytes() {
     return SSZ.encode(
         writer -> {
@@ -60,6 +76,44 @@ public class AttestationData {
           writer.writeUInt64(justified_slot.longValue());
           writer.writeBytes(justified_block_hash);
         });
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        slot,
+        shard,
+        beacon_block_hash,
+        epoch_boundary_hash,
+        shard_block_hash,
+        last_crosslink_hash,
+        justified_slot,
+        justified_block_hash);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (Objects.isNull(obj)) {
+      return false;
+    }
+
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof AttestationData)) {
+      return false;
+    }
+
+    AttestationData other = (AttestationData) obj;
+    return Objects.equals(this.getSlot(), other.getSlot())
+        && Objects.equals(this.getShard(), other.getShard())
+        && Objects.equals(this.getBeacon_block_hash(), other.getBeacon_block_hash())
+        && Objects.equals(this.getEpoch_boundary_hash(), other.getEpoch_boundary_hash())
+        && Objects.equals(this.getShard_block_hash(), other.getShard_block_hash())
+        && Objects.equals(this.getLast_crosslink_hash(), other.getLast_crosslink_hash())
+        && Objects.equals(this.getJustified_slot(), other.getJustified_slot())
+        && Objects.equals(this.getJustified_block_hash(), other.getJustified_block_hash());
   }
 
   /** ******************* * GETTERS & SETTERS * * ******************* */

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/CasperSlashing.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/CasperSlashing.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.artemis.datastructures.operations;
 
+import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.ssz.SSZ;
 
@@ -26,12 +27,45 @@ public class CasperSlashing {
     this.votes_2 = votes_2;
   }
 
+  public static CasperSlashing fromBytes(Bytes bytes) {
+    return SSZ.decode(
+        bytes,
+        reader ->
+            new CasperSlashing(
+                SlashableVoteData.fromBytes(reader.readBytes()),
+                SlashableVoteData.fromBytes(reader.readBytes())));
+  }
+
   public Bytes toBytes() {
     return SSZ.encode(
         writer -> {
           writer.writeBytes(votes_1.toBytes());
           writer.writeBytes(votes_2.toBytes());
         });
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(votes_1, votes_2);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (Objects.isNull(obj)) {
+      return false;
+    }
+
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof CasperSlashing)) {
+      return false;
+    }
+
+    CasperSlashing other = (CasperSlashing) obj;
+    return Objects.equals(this.getVotes_1(), other.getVotes_1())
+        && Objects.equals(this.getVotes_2(), other.getVotes_2());
   }
 
   /** ******************* * GETTERS & SETTERS * * ******************* */

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/Deposit.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/Deposit.java
@@ -15,6 +15,8 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.ssz.SSZ;
@@ -32,13 +34,48 @@ public class Deposit {
     this.deposit_data = deposit_data;
   }
 
+  public static Deposit fromBytes(Bytes bytes) {
+    return SSZ.decode(
+        bytes,
+        reader ->
+            new Deposit(
+                reader.readBytesList().stream().map(Bytes32::wrap).collect(Collectors.toList()),
+                UnsignedLong.fromLongBits(reader.readUInt64()),
+                DepositData.fromBytes(reader.readBytes())));
+  }
+
   public Bytes toBytes() {
     return SSZ.encode(
         writer -> {
-          writer.writeBytesList(merkle_branch.toArray(new Bytes32[0]));
+          writer.writeBytesList(merkle_branch);
           writer.writeUInt64(merkle_tree_index.longValue());
           writer.writeBytes(deposit_data.toBytes());
         });
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(merkle_branch, merkle_tree_index, deposit_data);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (Objects.isNull(obj)) {
+      return false;
+    }
+
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof Deposit)) {
+      return false;
+    }
+
+    Deposit other = (Deposit) obj;
+    return Objects.equals(this.getMerkle_branch(), other.getMerkle_branch())
+        && Objects.equals(this.getMerkle_tree_index(), other.getMerkle_tree_index())
+        && Objects.equals(this.getDeposit_data(), other.getDeposit_data());
   }
 
   /** ******************* * GETTERS & SETTERS * * ******************* */

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/DepositData.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/DepositData.java
@@ -14,6 +14,7 @@
 package tech.pegasys.artemis.datastructures.operations;
 
 import com.google.common.primitives.UnsignedLong;
+import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.ssz.SSZ;
 
@@ -29,13 +30,48 @@ public class DepositData {
     this.timestamp = timestamp;
   }
 
+  public static DepositData fromBytes(Bytes bytes) {
+    return SSZ.decode(
+        bytes,
+        reader ->
+            new DepositData(
+                DepositInput.fromBytes(reader.readBytes()),
+                UnsignedLong.fromLongBits(reader.readUInt64()),
+                UnsignedLong.fromLongBits(reader.readUInt64())));
+  }
+
   public Bytes toBytes() {
     return SSZ.encode(
         writer -> {
           writer.writeBytes(deposit_input.toBytes());
           writer.writeUInt64(value.longValue());
-          writer.writeUInt64(value.longValue());
+          writer.writeUInt64(timestamp.longValue());
         });
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(deposit_input, value, timestamp);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (Objects.isNull(obj)) {
+      return false;
+    }
+
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof DepositData)) {
+      return false;
+    }
+
+    DepositData other = (DepositData) obj;
+    return Objects.equals(this.getDeposit_input(), other.getDeposit_input())
+        && Objects.equals(this.getValue(), other.getValue())
+        && Objects.equals(this.getTimestamp(), other.getTimestamp());
   }
 
   /** ******************* * GETTERS & SETTERS * * ******************* */

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/DepositInput.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/DepositInput.java
@@ -24,15 +24,6 @@ import net.consensys.cava.ssz.SSZ;
 
 public final class DepositInput {
 
-  public static DepositInput fromBytes(Bytes bytes) {
-    return SSZ.decode(
-        bytes,
-        reader ->
-            new DepositInput(
-                Bytes48.wrap(reader.readBytes()),
-                Bytes32.wrap(reader.readBytes()),
-                reader.readBytesList().stream().map(Bytes48::wrap).collect(Collectors.toList())));
-  }
   // BLS pubkey
   Bytes48 pubkey;
   // Withdrawal credentials
@@ -45,6 +36,16 @@ public final class DepositInput {
     this.pubkey = pubkey;
     this.withdrawal_credentials = withdrawal_credentials;
     this.proof_of_possession = proof_of_possession;
+  }
+
+  public static DepositInput fromBytes(Bytes bytes) {
+    return SSZ.decode(
+        bytes,
+        reader ->
+            new DepositInput(
+                Bytes48.wrap(reader.readBytes()),
+                Bytes32.wrap(reader.readBytes()),
+                reader.readBytesList().stream().map(Bytes48::wrap).collect(Collectors.toList())));
   }
 
   /** ******************* * GETTERS & SETTERS * * ******************* */
@@ -84,17 +85,15 @@ public final class DepositInput {
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(pubkey, withdrawal_credentials);
-    result = 31 * result + proof_of_possession.hashCode();
-    return result;
+    return Objects.hash(pubkey, withdrawal_credentials, proof_of_possession);
   }
 
   public Bytes toBytes() {
     return SSZ.encode(
         writer -> {
-          writer.writeBytesList(proof_of_possession.toArray(new Bytes48[0]));
           writer.writeBytes(pubkey);
           writer.writeBytes(withdrawal_credentials);
+          writer.writeBytesList(proof_of_possession);
         });
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/Exit.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/Exit.java
@@ -15,6 +15,8 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.ssz.SSZ;
@@ -31,13 +33,48 @@ public class Exit {
     this.signature = signature;
   }
 
+  public static Exit fromBytes(Bytes bytes) {
+    return SSZ.decode(
+        bytes,
+        reader ->
+            new Exit(
+                UnsignedLong.fromLongBits(reader.readUInt64()),
+                UnsignedLong.fromLongBits(reader.readUInt64()),
+                reader.readBytesList().stream().map(Bytes48::wrap).collect(Collectors.toList())));
+  }
+
   public Bytes toBytes() {
     return SSZ.encode(
         writer -> {
           writer.writeUInt64(slot.longValue());
           writer.writeUInt64(validator_index.longValue());
-          writer.writeBytesList(signature.toArray(new Bytes48[0]));
+          writer.writeBytesList(signature);
         });
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(slot, validator_index, signature);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (Objects.isNull(obj)) {
+      return false;
+    }
+
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof Exit)) {
+      return false;
+    }
+
+    Exit other = (Exit) obj;
+    return Objects.equals(this.getSlot(), other.getSlot())
+        && Objects.equals(this.getValidator_index(), other.getValidator_index())
+        && Objects.equals(this.getSignature(), other.getSignature());
   }
 
   /** ******************* * GETTERS & SETTERS * * ******************* */

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/ProposerSlashing.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/ProposerSlashing.java
@@ -14,6 +14,8 @@
 package tech.pegasys.artemis.datastructures.operations;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.ssz.SSZ;
@@ -40,15 +42,59 @@ public class ProposerSlashing {
     this.proposal_signature_2 = proposal_signature_2;
   }
 
+  public static ProposerSlashing fromBytes(Bytes bytes) {
+    return SSZ.decode(
+        bytes,
+        reader ->
+            new ProposerSlashing(
+                reader.readInt(24),
+                ProposalSignedData.fromBytes(reader.readBytes()),
+                reader.readBytesList().stream().map(Bytes48::wrap).collect(Collectors.toList()),
+                ProposalSignedData.fromBytes(reader.readBytes()),
+                reader.readBytesList().stream().map(Bytes48::wrap).collect(Collectors.toList())));
+  }
+
   public Bytes toBytes() {
     return SSZ.encode(
         writer -> {
           writer.writeInt(proposer_index, 24);
           writer.writeBytes(proposal_data_1.toBytes());
-          writer.writeBytesList(proposal_signature_1.toArray(new Bytes48[0]));
+          writer.writeBytesList(proposal_signature_1);
           writer.writeBytes(proposal_data_2.toBytes());
-          writer.writeBytesList(proposal_signature_2.toArray(new Bytes48[0]));
+          writer.writeBytesList(proposal_signature_2);
         });
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        proposer_index,
+        proposal_data_1,
+        proposal_signature_1,
+        proposal_data_2,
+        proposal_signature_2);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (Objects.isNull(obj)) {
+      return false;
+    }
+
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof ProposerSlashing)) {
+      return false;
+    }
+
+    ProposerSlashing other = (ProposerSlashing) obj;
+    return Objects.equals(this.getProposer_index(), other.getProposer_index())
+        && Objects.equals(this.getProposal_data_1(), other.getProposal_data_1())
+        && Objects.equals(this.getProposal_signature_1(), other.getProposal_signature_1())
+        && Objects.equals(this.getProposal_data_2(), other.getProposal_data_2())
+        && Objects.equals(this.getProposal_signature_2(), other.getProposal_signature_2());
   }
 
   /** ******************* * GETTERS & SETTERS * * ******************* */

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/SlashableVoteData.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/SlashableVoteData.java
@@ -14,6 +14,8 @@
 package tech.pegasys.artemis.datastructures.operations;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.ssz.SSZ;
@@ -36,18 +38,51 @@ public class SlashableVoteData {
     this.aggregate_signature = aggregate_signature;
   }
 
+  public static SlashableVoteData fromBytes(Bytes bytes) {
+    return SSZ.decode(
+        bytes,
+        reader ->
+            new SlashableVoteData(
+                reader.readIntList(24),
+                reader.readIntList(24),
+                AttestationData.fromBytes(reader.readBytes()),
+                reader.readBytesList().stream().map(Bytes48::wrap).collect(Collectors.toList())));
+  }
+
   public Bytes toBytes() {
     return SSZ.encode(
         writer -> {
-          for (Integer item : custody_bit_0_indices) {
-            writer.writeInt(item, 24);
-          }
-          for (Integer item : custody_bit_1_indices) {
-            writer.writeInt(item, 24);
-          }
+          writer.writeIntList(24, custody_bit_0_indices);
+          writer.writeIntList(24, custody_bit_1_indices);
           writer.writeBytes(data.toBytes());
-          writer.writeBytesList(aggregate_signature.toArray(new Bytes48[0]));
+          writer.writeBytesList(aggregate_signature);
         });
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(custody_bit_0_indices, custody_bit_1_indices, data, aggregate_signature);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (Objects.isNull(obj)) {
+      return false;
+    }
+
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof SlashableVoteData)) {
+      return false;
+    }
+
+    SlashableVoteData other = (SlashableVoteData) obj;
+    return Objects.equals(this.getCustody_bit_0_indices(), other.getCustody_bit_0_indices())
+        && Objects.equals(this.getCustody_bit_1_indices(), other.getCustody_bit_1_indices())
+        && Objects.equals(this.getData(), other.getData())
+        && Objects.equals(this.getAggregate_signature(), other.getAggregate_signature());
   }
 
   /** ******************* * GETTERS & SETTERS * * ******************* */

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.util;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.Arrays;
+import net.consensys.cava.bytes.Bytes32;
+import net.consensys.cava.bytes.Bytes48;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlockBody;
+import tech.pegasys.artemis.datastructures.blocks.Eth1Data;
+import tech.pegasys.artemis.datastructures.blocks.ProposalSignedData;
+import tech.pegasys.artemis.datastructures.operations.Attestation;
+import tech.pegasys.artemis.datastructures.operations.AttestationData;
+import tech.pegasys.artemis.datastructures.operations.CasperSlashing;
+import tech.pegasys.artemis.datastructures.operations.Deposit;
+import tech.pegasys.artemis.datastructures.operations.DepositData;
+import tech.pegasys.artemis.datastructures.operations.DepositInput;
+import tech.pegasys.artemis.datastructures.operations.Exit;
+import tech.pegasys.artemis.datastructures.operations.ProposerSlashing;
+import tech.pegasys.artemis.datastructures.operations.SlashableVoteData;
+
+public final class DataStructureUtil {
+
+  public static int randomInt() {
+    return (int) (Math.random() * 1000000);
+  }
+
+  public static long randomLong() {
+    return Math.round(Math.random() * 1000000);
+  }
+
+  public static UnsignedLong randomUnsignedLong() {
+    return UnsignedLong.fromLongBits(randomLong());
+  }
+
+  public static Eth1Data randomEth1Data() {
+    return new Eth1Data(Bytes32.random(), Bytes32.random());
+  }
+
+  public static AttestationData randomAttestationData(long slotNum) {
+    return new AttestationData(
+        slotNum,
+        randomUnsignedLong(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Bytes32.random(),
+        randomUnsignedLong(),
+        Bytes32.random());
+  }
+
+  public static AttestationData randomAttestationData() {
+    return new AttestationData(
+        randomLong(),
+        randomUnsignedLong(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Bytes32.random(),
+        randomUnsignedLong(),
+        Bytes32.random());
+  }
+
+  public static Attestation randomAttestation(long slotNum) {
+    return new Attestation(
+        randomAttestationData(slotNum),
+        Bytes32.random(),
+        Bytes32.random(),
+        Arrays.asList(Bytes48.random(), Bytes48.random()));
+  }
+
+  public static Attestation randomAttestation() {
+    return new Attestation(
+        randomAttestationData(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Arrays.asList(Bytes48.random(), Bytes48.random()));
+  }
+
+  public static ProposalSignedData randomProposalSignedData() {
+    return new ProposalSignedData(randomUnsignedLong(), randomUnsignedLong(), Bytes32.random());
+  }
+
+  public static ProposerSlashing randomProposerSlashing() {
+    return new ProposerSlashing(
+        randomInt(),
+        randomProposalSignedData(),
+        Arrays.asList(Bytes48.random(), Bytes48.random()),
+        randomProposalSignedData(),
+        Arrays.asList(Bytes48.random(), Bytes48.random()));
+  }
+
+  public static SlashableVoteData randomSlashableVoteData() {
+    return new SlashableVoteData(
+        Arrays.asList(randomInt(), randomInt(), randomInt()),
+        Arrays.asList(randomInt(), randomInt(), randomInt()),
+        randomAttestationData(),
+        Arrays.asList(Bytes48.random(), Bytes48.random()));
+  }
+
+  public static CasperSlashing randomCasperSlashing() {
+    return new CasperSlashing(randomSlashableVoteData(), randomSlashableVoteData());
+  }
+
+  public static DepositInput randomDepositInput() {
+    return new DepositInput(
+        Bytes48.random(), Bytes32.random(), Arrays.asList(Bytes48.random(), Bytes48.random()));
+  }
+
+  public static DepositData randomDepositData() {
+    return new DepositData(randomDepositInput(), randomUnsignedLong(), randomUnsignedLong());
+  }
+
+  public static Deposit randomDeposit() {
+    return new Deposit(
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random()),
+        randomUnsignedLong(),
+        randomDepositData());
+  }
+
+  public static Exit randomExit() {
+    return new Exit(
+        randomUnsignedLong(),
+        randomUnsignedLong(),
+        Arrays.asList(Bytes48.random(), Bytes48.random()));
+  }
+
+  public static BeaconBlockBody randomBeaconBlockBody() {
+    return new BeaconBlockBody(
+        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing()),
+        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing()),
+        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation()),
+        Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit()),
+        Arrays.asList(randomExit(), randomExit(), randomExit()));
+  }
+
+  public static BeaconBlock randomBeaconBlock(long slotNum) {
+    return new BeaconBlock(
+        slotNum,
+        Bytes32.random(),
+        Bytes32.random(),
+        Arrays.asList(Bytes48.random(), Bytes48.random()),
+        randomEth1Data(),
+        Arrays.asList(Bytes48.random(), Bytes48.random()),
+        randomBeaconBlockBody());
+  }
+
+  public static BeaconBlock randomBeaconBlock() {
+    return new BeaconBlock(
+        randomLong(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Arrays.asList(Bytes48.random(), Bytes48.random()),
+        randomEth1Data(),
+        Arrays.asList(Bytes48.random(), Bytes48.random()),
+        randomBeaconBlockBody());
+  }
+}

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockBodyTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockBodyTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.blocks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.bytes.Bytes32;
+import net.consensys.cava.bytes.Bytes48;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.operations.Attestation;
+import tech.pegasys.artemis.datastructures.operations.AttestationData;
+import tech.pegasys.artemis.datastructures.operations.CasperSlashing;
+import tech.pegasys.artemis.datastructures.operations.Deposit;
+import tech.pegasys.artemis.datastructures.operations.DepositData;
+import tech.pegasys.artemis.datastructures.operations.DepositInput;
+import tech.pegasys.artemis.datastructures.operations.Exit;
+import tech.pegasys.artemis.datastructures.operations.ProposerSlashing;
+import tech.pegasys.artemis.datastructures.operations.SlashableVoteData;
+
+class BeaconBlockBodyTest {
+
+  @Test
+  void equalsReturnsTrueWhenObjectAreSame() {
+    List<Attestation> attestations =
+        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
+    List<ProposerSlashing> proposerSlashings =
+        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
+    List<CasperSlashing> casperSlashings =
+        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
+    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
+    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
+
+    BeaconBlockBody bbb1 =
+        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
+    BeaconBlockBody bbb2 = bbb1;
+
+    assertEquals(bbb1, bbb2);
+  }
+
+  @Test
+  void equalsReturnsTrueWhenObjectFieldsAreEqual() {
+    List<Attestation> attestations =
+        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
+    List<ProposerSlashing> proposerSlashings =
+        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
+    List<CasperSlashing> casperSlashings =
+        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
+    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
+    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
+
+    BeaconBlockBody bbb1 =
+        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
+    BeaconBlockBody bbb2 =
+        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
+
+    assertEquals(bbb1, bbb2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenAttestationsAreDifferent() {
+    List<Attestation> attestations =
+        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
+    List<ProposerSlashing> proposerSlashings =
+        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
+    List<CasperSlashing> casperSlashings =
+        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
+    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
+    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
+
+    // Create copy of attestations and reverse to ensure it is different.
+    List<Attestation> reverseAttestations = new ArrayList<Attestation>(attestations);
+    Collections.reverse(reverseAttestations);
+
+    BeaconBlockBody bbb1 =
+        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
+    BeaconBlockBody bbb2 =
+        new BeaconBlockBody(
+            reverseAttestations, proposerSlashings, casperSlashings, deposits, exits);
+
+    assertNotEquals(bbb1, bbb2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenProposerSlashingsAreDifferent() {
+    List<Attestation> attestations =
+        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
+    List<ProposerSlashing> proposerSlashings =
+        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
+    List<CasperSlashing> casperSlashings =
+        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
+    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
+    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
+
+    // Create copy of proposerSlashings and reverse to ensure it is different.
+    List<ProposerSlashing> reverseProposerSlashings =
+        new ArrayList<ProposerSlashing>(proposerSlashings);
+    Collections.reverse(reverseProposerSlashings);
+
+    BeaconBlockBody bbb1 =
+        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
+    BeaconBlockBody bbb2 =
+        new BeaconBlockBody(
+            attestations, reverseProposerSlashings, casperSlashings, deposits, exits);
+
+    assertNotEquals(bbb1, bbb2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenCasperSlashingsAreDifferent() {
+    List<Attestation> attestations =
+        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
+    List<ProposerSlashing> proposerSlashings =
+        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
+    List<CasperSlashing> casperSlashings =
+        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
+    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
+    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
+
+    // Create copy of casperSlashings and reverse to ensure it is different.
+    List<CasperSlashing> reverseCasperSlashings = new ArrayList<CasperSlashing>(casperSlashings);
+    Collections.reverse(reverseCasperSlashings);
+
+    BeaconBlockBody bbb1 =
+        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
+    BeaconBlockBody bbb2 =
+        new BeaconBlockBody(
+            attestations, proposerSlashings, reverseCasperSlashings, deposits, exits);
+
+    assertNotEquals(bbb1, bbb2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenDepositsAreDifferent() {
+    List<Attestation> attestations =
+        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
+    List<ProposerSlashing> proposerSlashings =
+        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
+    List<CasperSlashing> casperSlashings =
+        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
+    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
+    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
+
+    // Create copy of deposits and reverse to ensure it is different.
+    List<Deposit> reverseDeposits = new ArrayList<Deposit>(deposits);
+    Collections.reverse(reverseDeposits);
+
+    BeaconBlockBody bbb1 =
+        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
+    BeaconBlockBody bbb2 =
+        new BeaconBlockBody(
+            attestations, proposerSlashings, casperSlashings, reverseDeposits, exits);
+
+    assertNotEquals(bbb1, bbb2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenExitsAreDifferent() {
+    List<Attestation> attestations =
+        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
+    List<ProposerSlashing> proposerSlashings =
+        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
+    List<CasperSlashing> casperSlashings =
+        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
+    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
+    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
+
+    // Create copy of exits and reverse to ensure it is different.
+    List<Exit> reverseExits = new ArrayList<Exit>(exits);
+    Collections.reverse(reverseExits);
+
+    BeaconBlockBody bbb1 =
+        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
+    BeaconBlockBody bbb2 =
+        new BeaconBlockBody(
+            attestations, proposerSlashings, casperSlashings, deposits, reverseExits);
+
+    assertNotEquals(bbb1, bbb2);
+  }
+
+  @Test
+  void rountripSSZ() {
+    BeaconBlockBody beaconBlockBody =
+        new BeaconBlockBody(
+            Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation()),
+            Arrays.asList(
+                randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing()),
+            Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing()),
+            Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit()),
+            Arrays.asList(randomExit(), randomExit(), randomExit()));
+    Bytes sszBeaconBlockBodyBytes = beaconBlockBody.toBytes();
+    assertEquals(beaconBlockBody, BeaconBlockBody.fromBytes(sszBeaconBlockBodyBytes));
+  }
+
+  private int randomInt() {
+    return (int) (Math.random() * 1000000);
+  }
+
+  private long randomLong() {
+    return Math.round(Math.random() * 1000000);
+  }
+
+  private UnsignedLong randomUnsignedLong() {
+    return UnsignedLong.fromLongBits(randomLong());
+  }
+
+  private List<Bytes48> randomSignature() {
+    return Arrays.asList(Bytes48.random(), Bytes48.random());
+  }
+
+  private AttestationData randomAttestationData() {
+    return new AttestationData(
+        randomLong(),
+        randomUnsignedLong(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Bytes32.random(),
+        randomUnsignedLong(),
+        Bytes32.random());
+  }
+
+  private Attestation randomAttestation() {
+    return new Attestation(
+        randomAttestationData(), Bytes32.random(), Bytes32.random(), randomSignature());
+  }
+
+  private ProposalSignedData randomProposalSignedData() {
+    return new ProposalSignedData(randomUnsignedLong(), randomUnsignedLong(), Bytes32.random());
+  }
+
+  private ProposerSlashing randomProposerSlashing() {
+    return new ProposerSlashing(
+        randomInt(),
+        randomProposalSignedData(),
+        randomSignature(),
+        randomProposalSignedData(),
+        randomSignature());
+  }
+
+  private SlashableVoteData randomSlashableVoteData() {
+    return new SlashableVoteData(
+        Arrays.asList(randomInt(), randomInt(), randomInt()),
+        Arrays.asList(randomInt(), randomInt(), randomInt()),
+        randomAttestationData(),
+        randomSignature());
+  }
+
+  private CasperSlashing randomCasperSlashing() {
+    return new CasperSlashing(randomSlashableVoteData(), randomSlashableVoteData());
+  }
+
+  private DepositInput randomDepositInput() {
+    return new DepositInput(Bytes48.random(), Bytes32.random(), randomSignature());
+  }
+
+  private DepositData randomDepositData() {
+    return new DepositData(randomDepositInput(), randomUnsignedLong(), randomUnsignedLong());
+  }
+
+  private Deposit randomDeposit() {
+    return new Deposit(
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random()),
+        randomUnsignedLong(),
+        randomDepositData());
+  }
+
+  private Exit randomExit() {
+    return new Exit(randomUnsignedLong(), randomUnsignedLong(), randomSignature());
+  }
+}

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockBodyTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockBodyTest.java
@@ -15,25 +15,23 @@ package tech.pegasys.artemis.datastructures.blocks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomAttestation;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomCasperSlashing;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomDeposit;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomExit;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomProposerSlashing;
 
-import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import net.consensys.cava.bytes.Bytes;
-import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.operations.Attestation;
-import tech.pegasys.artemis.datastructures.operations.AttestationData;
 import tech.pegasys.artemis.datastructures.operations.CasperSlashing;
 import tech.pegasys.artemis.datastructures.operations.Deposit;
-import tech.pegasys.artemis.datastructures.operations.DepositData;
-import tech.pegasys.artemis.datastructures.operations.DepositInput;
 import tech.pegasys.artemis.datastructures.operations.Exit;
 import tech.pegasys.artemis.datastructures.operations.ProposerSlashing;
-import tech.pegasys.artemis.datastructures.operations.SlashableVoteData;
 
 class BeaconBlockBodyTest {
 
@@ -49,7 +47,7 @@ class BeaconBlockBodyTest {
     List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
 
     BeaconBlockBody bbb1 =
-        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
+        new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
     BeaconBlockBody bbb2 = bbb1;
 
     assertEquals(bbb1, bbb2);
@@ -67,35 +65,11 @@ class BeaconBlockBodyTest {
     List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
 
     BeaconBlockBody bbb1 =
-        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
+        new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
     BeaconBlockBody bbb2 =
-        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
+        new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
 
     assertEquals(bbb1, bbb2);
-  }
-
-  @Test
-  void equalsReturnsFalseWhenAttestationsAreDifferent() {
-    List<Attestation> attestations =
-        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
-    List<ProposerSlashing> proposerSlashings =
-        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
-    List<CasperSlashing> casperSlashings =
-        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
-    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
-    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
-
-    // Create copy of attestations and reverse to ensure it is different.
-    List<Attestation> reverseAttestations = new ArrayList<Attestation>(attestations);
-    Collections.reverse(reverseAttestations);
-
-    BeaconBlockBody bbb1 =
-        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
-    BeaconBlockBody bbb2 =
-        new BeaconBlockBody(
-            reverseAttestations, proposerSlashings, casperSlashings, deposits, exits);
-
-    assertNotEquals(bbb1, bbb2);
   }
 
   @Test
@@ -115,10 +89,10 @@ class BeaconBlockBodyTest {
     Collections.reverse(reverseProposerSlashings);
 
     BeaconBlockBody bbb1 =
-        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
+        new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
     BeaconBlockBody bbb2 =
         new BeaconBlockBody(
-            attestations, reverseProposerSlashings, casperSlashings, deposits, exits);
+            reverseProposerSlashings, casperSlashings, attestations, deposits, exits);
 
     assertNotEquals(bbb1, bbb2);
   }
@@ -139,10 +113,34 @@ class BeaconBlockBodyTest {
     Collections.reverse(reverseCasperSlashings);
 
     BeaconBlockBody bbb1 =
-        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
+        new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
     BeaconBlockBody bbb2 =
         new BeaconBlockBody(
-            attestations, proposerSlashings, reverseCasperSlashings, deposits, exits);
+            proposerSlashings, reverseCasperSlashings, attestations, deposits, exits);
+
+    assertNotEquals(bbb1, bbb2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenAttestationsAreDifferent() {
+    List<Attestation> attestations =
+        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
+    List<ProposerSlashing> proposerSlashings =
+        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
+    List<CasperSlashing> casperSlashings =
+        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
+    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
+    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
+
+    // Create copy of attestations and reverse to ensure it is different.
+    List<Attestation> reverseAttestations = new ArrayList<Attestation>(attestations);
+    Collections.reverse(reverseAttestations);
+
+    BeaconBlockBody bbb1 =
+        new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
+    BeaconBlockBody bbb2 =
+        new BeaconBlockBody(
+            proposerSlashings, casperSlashings, reverseAttestations, deposits, exits);
 
     assertNotEquals(bbb1, bbb2);
   }
@@ -163,10 +161,10 @@ class BeaconBlockBodyTest {
     Collections.reverse(reverseDeposits);
 
     BeaconBlockBody bbb1 =
-        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
+        new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
     BeaconBlockBody bbb2 =
         new BeaconBlockBody(
-            attestations, proposerSlashings, casperSlashings, reverseDeposits, exits);
+            proposerSlashings, casperSlashings, attestations, reverseDeposits, exits);
 
     assertNotEquals(bbb1, bbb2);
   }
@@ -187,10 +185,10 @@ class BeaconBlockBodyTest {
     Collections.reverse(reverseExits);
 
     BeaconBlockBody bbb1 =
-        new BeaconBlockBody(attestations, proposerSlashings, casperSlashings, deposits, exits);
+        new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
     BeaconBlockBody bbb2 =
         new BeaconBlockBody(
-            attestations, proposerSlashings, casperSlashings, deposits, reverseExits);
+            proposerSlashings, casperSlashings, attestations, deposits, reverseExits);
 
     assertNotEquals(bbb1, bbb2);
   }
@@ -199,90 +197,13 @@ class BeaconBlockBodyTest {
   void rountripSSZ() {
     BeaconBlockBody beaconBlockBody =
         new BeaconBlockBody(
-            Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation()),
             Arrays.asList(
                 randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing()),
             Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing()),
+            Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation()),
             Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit()),
             Arrays.asList(randomExit(), randomExit(), randomExit()));
     Bytes sszBeaconBlockBodyBytes = beaconBlockBody.toBytes();
     assertEquals(beaconBlockBody, BeaconBlockBody.fromBytes(sszBeaconBlockBodyBytes));
-  }
-
-  private int randomInt() {
-    return (int) (Math.random() * 1000000);
-  }
-
-  private long randomLong() {
-    return Math.round(Math.random() * 1000000);
-  }
-
-  private UnsignedLong randomUnsignedLong() {
-    return UnsignedLong.fromLongBits(randomLong());
-  }
-
-  private List<Bytes48> randomSignature() {
-    return Arrays.asList(Bytes48.random(), Bytes48.random());
-  }
-
-  private AttestationData randomAttestationData() {
-    return new AttestationData(
-        randomLong(),
-        randomUnsignedLong(),
-        Bytes32.random(),
-        Bytes32.random(),
-        Bytes32.random(),
-        Bytes32.random(),
-        randomUnsignedLong(),
-        Bytes32.random());
-  }
-
-  private Attestation randomAttestation() {
-    return new Attestation(
-        randomAttestationData(), Bytes32.random(), Bytes32.random(), randomSignature());
-  }
-
-  private ProposalSignedData randomProposalSignedData() {
-    return new ProposalSignedData(randomUnsignedLong(), randomUnsignedLong(), Bytes32.random());
-  }
-
-  private ProposerSlashing randomProposerSlashing() {
-    return new ProposerSlashing(
-        randomInt(),
-        randomProposalSignedData(),
-        randomSignature(),
-        randomProposalSignedData(),
-        randomSignature());
-  }
-
-  private SlashableVoteData randomSlashableVoteData() {
-    return new SlashableVoteData(
-        Arrays.asList(randomInt(), randomInt(), randomInt()),
-        Arrays.asList(randomInt(), randomInt(), randomInt()),
-        randomAttestationData(),
-        randomSignature());
-  }
-
-  private CasperSlashing randomCasperSlashing() {
-    return new CasperSlashing(randomSlashableVoteData(), randomSlashableVoteData());
-  }
-
-  private DepositInput randomDepositInput() {
-    return new DepositInput(Bytes48.random(), Bytes32.random(), randomSignature());
-  }
-
-  private DepositData randomDepositData() {
-    return new DepositData(randomDepositInput(), randomUnsignedLong(), randomUnsignedLong());
-  }
-
-  private Deposit randomDeposit() {
-    return new Deposit(
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random()),
-        randomUnsignedLong(),
-        randomDepositData());
-  }
-
-  private Exit randomExit() {
-    return new Exit(randomUnsignedLong(), randomUnsignedLong(), randomSignature());
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockBodyTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockBodyTest.java
@@ -35,174 +35,101 @@ import tech.pegasys.artemis.datastructures.operations.ProposerSlashing;
 
 class BeaconBlockBodyTest {
 
+  List<Attestation> attestations =
+      Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
+  List<ProposerSlashing> proposerSlashings =
+      Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
+  List<CasperSlashing> casperSlashings =
+      Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
+  List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
+  List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
+
+  BeaconBlockBody beaconBlockBody =
+      new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
+
   @Test
   void equalsReturnsTrueWhenObjectAreSame() {
-    List<Attestation> attestations =
-        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
-    List<ProposerSlashing> proposerSlashings =
-        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
-    List<CasperSlashing> casperSlashings =
-        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
-    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
-    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
+    BeaconBlockBody testBeaconBlockBody = beaconBlockBody;
 
-    BeaconBlockBody bbb1 =
-        new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
-    BeaconBlockBody bbb2 = bbb1;
-
-    assertEquals(bbb1, bbb2);
+    assertEquals(beaconBlockBody, testBeaconBlockBody);
   }
 
   @Test
   void equalsReturnsTrueWhenObjectFieldsAreEqual() {
-    List<Attestation> attestations =
-        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
-    List<ProposerSlashing> proposerSlashings =
-        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
-    List<CasperSlashing> casperSlashings =
-        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
-    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
-    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
-
-    BeaconBlockBody bbb1 =
-        new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
-    BeaconBlockBody bbb2 =
+    BeaconBlockBody testBeaconBlockBody =
         new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
 
-    assertEquals(bbb1, bbb2);
+    assertEquals(beaconBlockBody, testBeaconBlockBody);
   }
 
   @Test
   void equalsReturnsFalseWhenProposerSlashingsAreDifferent() {
-    List<Attestation> attestations =
-        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
-    List<ProposerSlashing> proposerSlashings =
-        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
-    List<CasperSlashing> casperSlashings =
-        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
-    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
-    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
-
     // Create copy of proposerSlashings and reverse to ensure it is different.
     List<ProposerSlashing> reverseProposerSlashings =
         new ArrayList<ProposerSlashing>(proposerSlashings);
     Collections.reverse(reverseProposerSlashings);
 
-    BeaconBlockBody bbb1 =
-        new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
-    BeaconBlockBody bbb2 =
+    BeaconBlockBody testBeaconBlockBody =
         new BeaconBlockBody(
             reverseProposerSlashings, casperSlashings, attestations, deposits, exits);
 
-    assertNotEquals(bbb1, bbb2);
+    assertNotEquals(beaconBlockBody, testBeaconBlockBody);
   }
 
   @Test
   void equalsReturnsFalseWhenCasperSlashingsAreDifferent() {
-    List<Attestation> attestations =
-        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
-    List<ProposerSlashing> proposerSlashings =
-        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
-    List<CasperSlashing> casperSlashings =
-        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
-    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
-    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
-
     // Create copy of casperSlashings and reverse to ensure it is different.
     List<CasperSlashing> reverseCasperSlashings = new ArrayList<CasperSlashing>(casperSlashings);
     Collections.reverse(reverseCasperSlashings);
 
-    BeaconBlockBody bbb1 =
-        new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
-    BeaconBlockBody bbb2 =
+    BeaconBlockBody testBeaconBlockBody =
         new BeaconBlockBody(
             proposerSlashings, reverseCasperSlashings, attestations, deposits, exits);
 
-    assertNotEquals(bbb1, bbb2);
+    assertNotEquals(beaconBlockBody, testBeaconBlockBody);
   }
 
   @Test
   void equalsReturnsFalseWhenAttestationsAreDifferent() {
-    List<Attestation> attestations =
-        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
-    List<ProposerSlashing> proposerSlashings =
-        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
-    List<CasperSlashing> casperSlashings =
-        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
-    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
-    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
-
     // Create copy of attestations and reverse to ensure it is different.
     List<Attestation> reverseAttestations = new ArrayList<Attestation>(attestations);
     Collections.reverse(reverseAttestations);
 
-    BeaconBlockBody bbb1 =
-        new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
-    BeaconBlockBody bbb2 =
+    BeaconBlockBody testBeaconBlockBody =
         new BeaconBlockBody(
             proposerSlashings, casperSlashings, reverseAttestations, deposits, exits);
 
-    assertNotEquals(bbb1, bbb2);
+    assertNotEquals(beaconBlockBody, testBeaconBlockBody);
   }
 
   @Test
   void equalsReturnsFalseWhenDepositsAreDifferent() {
-    List<Attestation> attestations =
-        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
-    List<ProposerSlashing> proposerSlashings =
-        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
-    List<CasperSlashing> casperSlashings =
-        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
-    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
-    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
-
     // Create copy of deposits and reverse to ensure it is different.
     List<Deposit> reverseDeposits = new ArrayList<Deposit>(deposits);
     Collections.reverse(reverseDeposits);
 
-    BeaconBlockBody bbb1 =
-        new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
-    BeaconBlockBody bbb2 =
+    BeaconBlockBody testBeaconBlockBody =
         new BeaconBlockBody(
             proposerSlashings, casperSlashings, attestations, reverseDeposits, exits);
 
-    assertNotEquals(bbb1, bbb2);
+    assertNotEquals(beaconBlockBody, testBeaconBlockBody);
   }
 
   @Test
   void equalsReturnsFalseWhenExitsAreDifferent() {
-    List<Attestation> attestations =
-        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation());
-    List<ProposerSlashing> proposerSlashings =
-        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing());
-    List<CasperSlashing> casperSlashings =
-        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing());
-    List<Deposit> deposits = Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit());
-    List<Exit> exits = Arrays.asList(randomExit(), randomExit(), randomExit());
-
     // Create copy of exits and reverse to ensure it is different.
     List<Exit> reverseExits = new ArrayList<Exit>(exits);
     Collections.reverse(reverseExits);
 
-    BeaconBlockBody bbb1 =
-        new BeaconBlockBody(proposerSlashings, casperSlashings, attestations, deposits, exits);
-    BeaconBlockBody bbb2 =
+    BeaconBlockBody testBeaconBlockBody =
         new BeaconBlockBody(
             proposerSlashings, casperSlashings, attestations, deposits, reverseExits);
 
-    assertNotEquals(bbb1, bbb2);
+    assertNotEquals(beaconBlockBody, testBeaconBlockBody);
   }
 
   @Test
   void rountripSSZ() {
-    BeaconBlockBody beaconBlockBody =
-        new BeaconBlockBody(
-            Arrays.asList(
-                randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing()),
-            Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing()),
-            Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation()),
-            Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit()),
-            Arrays.asList(randomExit(), randomExit(), randomExit()));
     Bytes sszBeaconBlockBodyBytes = beaconBlockBody.toBytes();
     assertEquals(beaconBlockBody, BeaconBlockBody.fromBytes(sszBeaconBlockBodyBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockTest.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.blocks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.bytes.Bytes32;
+import net.consensys.cava.bytes.Bytes48;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.operations.Attestation;
+import tech.pegasys.artemis.datastructures.operations.AttestationData;
+import tech.pegasys.artemis.datastructures.operations.CasperSlashing;
+import tech.pegasys.artemis.datastructures.operations.Deposit;
+import tech.pegasys.artemis.datastructures.operations.DepositData;
+import tech.pegasys.artemis.datastructures.operations.DepositInput;
+import tech.pegasys.artemis.datastructures.operations.Exit;
+import tech.pegasys.artemis.datastructures.operations.ProposerSlashing;
+import tech.pegasys.artemis.datastructures.operations.SlashableVoteData;
+
+class BeaconBlockTest {
+
+  @Test
+  void equalsReturnsTrueWhenObjectAreSame() {
+    long slot = randomLong();
+    List<Bytes32> ancestorHashes =
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 stateRoot = Bytes32.random();
+    List<Bytes48> randaoReveal = randomSignature();
+    Eth1Data eth1Data = randomEth1Data();
+    List<Bytes48> signature = randomSignature();
+    BeaconBlockBody body = randomBeaconBlockBody();
+
+    BeaconBlock b1 =
+        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+    BeaconBlock b2 = b1;
+
+    assertEquals(b1, b2);
+  }
+
+  @Test
+  void equalsReturnsTrueWhenObjectFieldsAreEqual() {
+    long slot = randomLong();
+    List<Bytes32> ancestorHashes =
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 stateRoot = Bytes32.random();
+    List<Bytes48> randaoReveal = randomSignature();
+    Eth1Data eth1Data = randomEth1Data();
+    List<Bytes48> signature = randomSignature();
+    BeaconBlockBody body = randomBeaconBlockBody();
+
+    BeaconBlock b1 =
+        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+    BeaconBlock b2 =
+        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+
+    assertEquals(b1, b2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenSlotsAreDifferent() {
+    long slot = randomLong();
+    List<Bytes32> ancestorHashes =
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 stateRoot = Bytes32.random();
+    List<Bytes48> randaoReveal = randomSignature();
+    Eth1Data eth1Data = randomEth1Data();
+    List<Bytes48> signature = randomSignature();
+    BeaconBlockBody body = randomBeaconBlockBody();
+
+    BeaconBlock b1 =
+        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+    BeaconBlock b2 =
+        new BeaconBlock(
+            slot + randomLong(),
+            ancestorHashes,
+            stateRoot,
+            randaoReveal,
+            eth1Data,
+            signature,
+            body);
+
+    assertNotEquals(b1, b2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenAncestorHashesAreDifferent() {
+    long slot = randomLong();
+    List<Bytes32> ancestorHashes =
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 stateRoot = Bytes32.random();
+    List<Bytes48> randaoReveal = randomSignature();
+    Eth1Data eth1Data = randomEth1Data();
+    List<Bytes48> signature = randomSignature();
+    BeaconBlockBody body = randomBeaconBlockBody();
+
+    // Create copy of ancestorHashes and reverse to ensure it is different.
+    List<Bytes32> reverseAncestorHashes = new ArrayList<Bytes32>(ancestorHashes);
+    Collections.reverse(reverseAncestorHashes);
+
+    BeaconBlock b1 =
+        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+    BeaconBlock b2 =
+        new BeaconBlock(
+            slot, reverseAncestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+
+    assertNotEquals(b1, b2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenStateRootsAreDifferent() {
+    long slot = randomLong();
+    List<Bytes32> ancestorHashes =
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 stateRoot = Bytes32.random();
+    List<Bytes48> randaoReveal = randomSignature();
+    Eth1Data eth1Data = randomEth1Data();
+    List<Bytes48> signature = randomSignature();
+    BeaconBlockBody body = randomBeaconBlockBody();
+
+    BeaconBlock b1 =
+        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+    BeaconBlock b2 =
+        new BeaconBlock(
+            slot, ancestorHashes, stateRoot.not(), randaoReveal, eth1Data, signature, body);
+
+    assertNotEquals(b1, b2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenRandaoRevealsAreDifferent() {
+    long slot = randomLong();
+    List<Bytes32> ancestorHashes =
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 stateRoot = Bytes32.random();
+    List<Bytes48> randaoReveal = randomSignature();
+    Eth1Data eth1Data = randomEth1Data();
+    List<Bytes48> signature = randomSignature();
+    BeaconBlockBody body = randomBeaconBlockBody();
+
+    // Create copy of randaoReveal and reverse to ensure it is different.
+    List<Bytes48> reverseRandaoReveal = new ArrayList<Bytes48>(randaoReveal);
+    Collections.reverse(reverseRandaoReveal);
+
+    BeaconBlock b1 =
+        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+
+    BeaconBlock b2 =
+        new BeaconBlock(
+            slot, ancestorHashes, stateRoot, reverseRandaoReveal, eth1Data, signature, body);
+
+    assertNotEquals(b1, b2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenEth1DataIsDifferent() {
+    long slot = randomLong();
+    List<Bytes32> ancestorHashes =
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 stateRoot = Bytes32.random();
+    List<Bytes48> randaoReveal = randomSignature();
+    Eth1Data eth1Data = randomEth1Data();
+    List<Bytes48> signature = randomSignature();
+    BeaconBlockBody body = randomBeaconBlockBody();
+
+    BeaconBlock b1 =
+        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+    BeaconBlock b2 =
+        new BeaconBlock(
+            slot,
+            ancestorHashes,
+            stateRoot,
+            randaoReveal,
+            new Eth1Data(eth1Data.getDeposit_root().not(), eth1Data.getBlock_hash().not()),
+            signature,
+            body);
+
+    assertNotEquals(b1, b2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenSignaturesAreDifferent() {
+    long slot = randomLong();
+    List<Bytes32> ancestorHashes =
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 stateRoot = Bytes32.random();
+    List<Bytes48> randaoReveal = randomSignature();
+    Eth1Data eth1Data = randomEth1Data();
+    List<Bytes48> signature = randomSignature();
+    BeaconBlockBody body = randomBeaconBlockBody();
+
+    // Create copy of signature and reverse to ensure it is different.
+    List<Bytes48> reverseSignature = new ArrayList<Bytes48>(signature);
+    Collections.reverse(reverseSignature);
+
+    BeaconBlock b1 =
+        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+
+    BeaconBlock b2 =
+        new BeaconBlock(
+            slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, reverseSignature, body);
+
+    assertNotEquals(b1, b2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenBeaconBlockBodiesAreDifferent() {
+    long slot = randomLong();
+    List<Bytes32> ancestorHashes =
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 stateRoot = Bytes32.random();
+    List<Bytes48> randaoReveal = randomSignature();
+    Eth1Data eth1Data = randomEth1Data();
+    List<Bytes48> signature = randomSignature();
+    BeaconBlockBody body = randomBeaconBlockBody();
+
+    // BeaconBlock is rather involved to create. Just create a random one until it is not the same
+    // as the original.
+    BeaconBlockBody otherBody = randomBeaconBlockBody();
+    while (Objects.equals(otherBody, body)) {
+      otherBody = randomBeaconBlockBody();
+    }
+
+    BeaconBlock b1 =
+        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+
+    BeaconBlock b2 =
+        new BeaconBlock(
+            slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, otherBody);
+
+    assertNotEquals(b1, b2);
+  }
+
+  @Test
+  void rountripSSZ() {
+    BeaconBlock beaconBlock =
+        new BeaconBlock(
+            randomLong(),
+            Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random()),
+            Bytes32.random(),
+            randomSignature(),
+            randomEth1Data(),
+            randomSignature(),
+            randomBeaconBlockBody());
+    Bytes sszBeaconBlockBytes = beaconBlock.toBytes();
+    assertEquals(beaconBlock, BeaconBlock.fromBytes(sszBeaconBlockBytes));
+  }
+
+  private int randomInt() {
+    return (int) (Math.random() * 1000000);
+  }
+
+  private long randomLong() {
+    return Math.round(Math.random() * 1000000);
+  }
+
+  private UnsignedLong randomUnsignedLong() {
+    return UnsignedLong.fromLongBits(randomLong());
+  }
+
+  private List<Bytes48> randomSignature() {
+    return Arrays.asList(Bytes48.random(), Bytes48.random());
+  }
+
+  private Eth1Data randomEth1Data() {
+    return new Eth1Data(Bytes32.random(), Bytes32.random());
+  }
+
+  private AttestationData randomAttestationData() {
+    return new AttestationData(
+        randomLong(),
+        randomUnsignedLong(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Bytes32.random(),
+        randomUnsignedLong(),
+        Bytes32.random());
+  }
+
+  private Attestation randomAttestation() {
+    return new Attestation(
+        randomAttestationData(), Bytes32.random(), Bytes32.random(), randomSignature());
+  }
+
+  private ProposalSignedData randomProposalSignedData() {
+    return new ProposalSignedData(randomUnsignedLong(), randomUnsignedLong(), Bytes32.random());
+  }
+
+  private ProposerSlashing randomProposerSlashing() {
+    return new ProposerSlashing(
+        randomInt(),
+        randomProposalSignedData(),
+        randomSignature(),
+        randomProposalSignedData(),
+        randomSignature());
+  }
+
+  private SlashableVoteData randomSlashableVoteData() {
+    return new SlashableVoteData(
+        Arrays.asList(randomInt(), randomInt(), randomInt()),
+        Arrays.asList(randomInt(), randomInt(), randomInt()),
+        randomAttestationData(),
+        randomSignature());
+  }
+
+  private CasperSlashing randomCasperSlashing() {
+    return new CasperSlashing(randomSlashableVoteData(), randomSlashableVoteData());
+  }
+
+  private DepositInput randomDepositInput() {
+    return new DepositInput(Bytes48.random(), Bytes32.random(), randomSignature());
+  }
+
+  private DepositData randomDepositData() {
+    return new DepositData(randomDepositInput(), randomUnsignedLong(), randomUnsignedLong());
+  }
+
+  private Deposit randomDeposit() {
+    return new Deposit(
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random()),
+        randomUnsignedLong(),
+        randomDepositData());
+  }
+
+  private Exit randomExit() {
+    return new Exit(randomUnsignedLong(), randomUnsignedLong(), randomSignature());
+  }
+
+  private BeaconBlockBody randomBeaconBlockBody() {
+    return new BeaconBlockBody(
+        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation()),
+        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing()),
+        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing()),
+        Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit()),
+        Arrays.asList(randomExit(), randomExit(), randomExit()));
+  }
+}

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockTest.java
@@ -15,8 +15,10 @@ package tech.pegasys.artemis.datastructures.blocks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBeaconBlockBody;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomEth1Data;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomLong;
 
-import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -26,31 +28,21 @@ import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.artemis.datastructures.operations.Attestation;
-import tech.pegasys.artemis.datastructures.operations.AttestationData;
-import tech.pegasys.artemis.datastructures.operations.CasperSlashing;
-import tech.pegasys.artemis.datastructures.operations.Deposit;
-import tech.pegasys.artemis.datastructures.operations.DepositData;
-import tech.pegasys.artemis.datastructures.operations.DepositInput;
-import tech.pegasys.artemis.datastructures.operations.Exit;
-import tech.pegasys.artemis.datastructures.operations.ProposerSlashing;
-import tech.pegasys.artemis.datastructures.operations.SlashableVoteData;
 
 class BeaconBlockTest {
 
   @Test
   void equalsReturnsTrueWhenObjectAreSame() {
     long slot = randomLong();
-    List<Bytes32> ancestorHashes =
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 parentRoot = Bytes32.random();
     Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = randomSignature();
+    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
     Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = randomSignature();
+    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
     BeaconBlockBody body = randomBeaconBlockBody();
 
     BeaconBlock b1 =
-        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
     BeaconBlock b2 = b1;
 
     assertEquals(b1, b2);
@@ -59,18 +51,17 @@ class BeaconBlockTest {
   @Test
   void equalsReturnsTrueWhenObjectFieldsAreEqual() {
     long slot = randomLong();
-    List<Bytes32> ancestorHashes =
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 parentRoot = Bytes32.random();
     Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = randomSignature();
+    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
     Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = randomSignature();
+    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
     BeaconBlockBody body = randomBeaconBlockBody();
 
     BeaconBlock b1 =
-        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
     BeaconBlock b2 =
-        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
 
     assertEquals(b1, b2);
   }
@@ -78,25 +69,18 @@ class BeaconBlockTest {
   @Test
   void equalsReturnsFalseWhenSlotsAreDifferent() {
     long slot = randomLong();
-    List<Bytes32> ancestorHashes =
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 parentRoot = Bytes32.random();
     Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = randomSignature();
+    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
     Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = randomSignature();
+    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
     BeaconBlockBody body = randomBeaconBlockBody();
 
     BeaconBlock b1 =
-        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
     BeaconBlock b2 =
         new BeaconBlock(
-            slot + randomLong(),
-            ancestorHashes,
-            stateRoot,
-            randaoReveal,
-            eth1Data,
-            signature,
-            body);
+            slot + randomLong(), parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
 
     assertNotEquals(b1, b2);
   }
@@ -104,23 +88,17 @@ class BeaconBlockTest {
   @Test
   void equalsReturnsFalseWhenAncestorHashesAreDifferent() {
     long slot = randomLong();
-    List<Bytes32> ancestorHashes =
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 parentRoot = Bytes32.random();
     Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = randomSignature();
+    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
     Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = randomSignature();
+    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
     BeaconBlockBody body = randomBeaconBlockBody();
 
-    // Create copy of ancestorHashes and reverse to ensure it is different.
-    List<Bytes32> reverseAncestorHashes = new ArrayList<Bytes32>(ancestorHashes);
-    Collections.reverse(reverseAncestorHashes);
-
     BeaconBlock b1 =
-        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
     BeaconBlock b2 =
-        new BeaconBlock(
-            slot, reverseAncestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+        new BeaconBlock(slot, parentRoot.not(), stateRoot, randaoReveal, eth1Data, signature, body);
 
     assertNotEquals(b1, b2);
   }
@@ -128,19 +106,17 @@ class BeaconBlockTest {
   @Test
   void equalsReturnsFalseWhenStateRootsAreDifferent() {
     long slot = randomLong();
-    List<Bytes32> ancestorHashes =
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 parentRoot = Bytes32.random();
     Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = randomSignature();
+    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
     Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = randomSignature();
+    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
     BeaconBlockBody body = randomBeaconBlockBody();
 
     BeaconBlock b1 =
-        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
     BeaconBlock b2 =
-        new BeaconBlock(
-            slot, ancestorHashes, stateRoot.not(), randaoReveal, eth1Data, signature, body);
+        new BeaconBlock(slot, parentRoot, stateRoot.not(), randaoReveal, eth1Data, signature, body);
 
     assertNotEquals(b1, b2);
   }
@@ -148,12 +124,11 @@ class BeaconBlockTest {
   @Test
   void equalsReturnsFalseWhenRandaoRevealsAreDifferent() {
     long slot = randomLong();
-    List<Bytes32> ancestorHashes =
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 parentRoot = Bytes32.random();
     Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = randomSignature();
+    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
     Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = randomSignature();
+    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
     BeaconBlockBody body = randomBeaconBlockBody();
 
     // Create copy of randaoReveal and reverse to ensure it is different.
@@ -161,11 +136,10 @@ class BeaconBlockTest {
     Collections.reverse(reverseRandaoReveal);
 
     BeaconBlock b1 =
-        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
-
+        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
     BeaconBlock b2 =
         new BeaconBlock(
-            slot, ancestorHashes, stateRoot, reverseRandaoReveal, eth1Data, signature, body);
+            slot, parentRoot, stateRoot, reverseRandaoReveal, eth1Data, signature, body);
 
     assertNotEquals(b1, b2);
   }
@@ -173,20 +147,19 @@ class BeaconBlockTest {
   @Test
   void equalsReturnsFalseWhenEth1DataIsDifferent() {
     long slot = randomLong();
-    List<Bytes32> ancestorHashes =
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 parentRoot = Bytes32.random();
     Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = randomSignature();
+    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
     Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = randomSignature();
+    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
     BeaconBlockBody body = randomBeaconBlockBody();
 
     BeaconBlock b1 =
-        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
+        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
     BeaconBlock b2 =
         new BeaconBlock(
             slot,
-            ancestorHashes,
+            parentRoot,
             stateRoot,
             randaoReveal,
             new Eth1Data(eth1Data.getDeposit_root().not(), eth1Data.getBlock_hash().not()),
@@ -199,12 +172,11 @@ class BeaconBlockTest {
   @Test
   void equalsReturnsFalseWhenSignaturesAreDifferent() {
     long slot = randomLong();
-    List<Bytes32> ancestorHashes =
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 parentRoot = Bytes32.random();
     Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = randomSignature();
+    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
     Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = randomSignature();
+    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
     BeaconBlockBody body = randomBeaconBlockBody();
 
     // Create copy of signature and reverse to ensure it is different.
@@ -212,11 +184,10 @@ class BeaconBlockTest {
     Collections.reverse(reverseSignature);
 
     BeaconBlock b1 =
-        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
-
+        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
     BeaconBlock b2 =
         new BeaconBlock(
-            slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, reverseSignature, body);
+            slot, parentRoot, stateRoot, randaoReveal, eth1Data, reverseSignature, body);
 
     assertNotEquals(b1, b2);
   }
@@ -224,12 +195,11 @@ class BeaconBlockTest {
   @Test
   void equalsReturnsFalseWhenBeaconBlockBodiesAreDifferent() {
     long slot = randomLong();
-    List<Bytes32> ancestorHashes =
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes32 parentRoot = Bytes32.random();
     Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = randomSignature();
+    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
     Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = randomSignature();
+    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
     BeaconBlockBody body = randomBeaconBlockBody();
 
     // BeaconBlock is rather involved to create. Just create a random one until it is not the same
@@ -240,11 +210,9 @@ class BeaconBlockTest {
     }
 
     BeaconBlock b1 =
-        new BeaconBlock(slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, body);
-
+        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
     BeaconBlock b2 =
-        new BeaconBlock(
-            slot, ancestorHashes, stateRoot, randaoReveal, eth1Data, signature, otherBody);
+        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, otherBody);
 
     assertNotEquals(b1, b2);
   }
@@ -254,103 +222,13 @@ class BeaconBlockTest {
     BeaconBlock beaconBlock =
         new BeaconBlock(
             randomLong(),
-            Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random()),
             Bytes32.random(),
-            randomSignature(),
+            Bytes32.random(),
+            Arrays.asList(Bytes48.random(), Bytes48.random()),
             randomEth1Data(),
-            randomSignature(),
+            Arrays.asList(Bytes48.random(), Bytes48.random()),
             randomBeaconBlockBody());
     Bytes sszBeaconBlockBytes = beaconBlock.toBytes();
     assertEquals(beaconBlock, BeaconBlock.fromBytes(sszBeaconBlockBytes));
-  }
-
-  private int randomInt() {
-    return (int) (Math.random() * 1000000);
-  }
-
-  private long randomLong() {
-    return Math.round(Math.random() * 1000000);
-  }
-
-  private UnsignedLong randomUnsignedLong() {
-    return UnsignedLong.fromLongBits(randomLong());
-  }
-
-  private List<Bytes48> randomSignature() {
-    return Arrays.asList(Bytes48.random(), Bytes48.random());
-  }
-
-  private Eth1Data randomEth1Data() {
-    return new Eth1Data(Bytes32.random(), Bytes32.random());
-  }
-
-  private AttestationData randomAttestationData() {
-    return new AttestationData(
-        randomLong(),
-        randomUnsignedLong(),
-        Bytes32.random(),
-        Bytes32.random(),
-        Bytes32.random(),
-        Bytes32.random(),
-        randomUnsignedLong(),
-        Bytes32.random());
-  }
-
-  private Attestation randomAttestation() {
-    return new Attestation(
-        randomAttestationData(), Bytes32.random(), Bytes32.random(), randomSignature());
-  }
-
-  private ProposalSignedData randomProposalSignedData() {
-    return new ProposalSignedData(randomUnsignedLong(), randomUnsignedLong(), Bytes32.random());
-  }
-
-  private ProposerSlashing randomProposerSlashing() {
-    return new ProposerSlashing(
-        randomInt(),
-        randomProposalSignedData(),
-        randomSignature(),
-        randomProposalSignedData(),
-        randomSignature());
-  }
-
-  private SlashableVoteData randomSlashableVoteData() {
-    return new SlashableVoteData(
-        Arrays.asList(randomInt(), randomInt(), randomInt()),
-        Arrays.asList(randomInt(), randomInt(), randomInt()),
-        randomAttestationData(),
-        randomSignature());
-  }
-
-  private CasperSlashing randomCasperSlashing() {
-    return new CasperSlashing(randomSlashableVoteData(), randomSlashableVoteData());
-  }
-
-  private DepositInput randomDepositInput() {
-    return new DepositInput(Bytes48.random(), Bytes32.random(), randomSignature());
-  }
-
-  private DepositData randomDepositData() {
-    return new DepositData(randomDepositInput(), randomUnsignedLong(), randomUnsignedLong());
-  }
-
-  private Deposit randomDeposit() {
-    return new Deposit(
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random()),
-        randomUnsignedLong(),
-        randomDepositData());
-  }
-
-  private Exit randomExit() {
-    return new Exit(randomUnsignedLong(), randomUnsignedLong(), randomSignature());
-  }
-
-  private BeaconBlockBody randomBeaconBlockBody() {
-    return new BeaconBlockBody(
-        Arrays.asList(randomAttestation(), randomAttestation(), randomAttestation()),
-        Arrays.asList(randomProposerSlashing(), randomProposerSlashing(), randomProposerSlashing()),
-        Arrays.asList(randomCasperSlashing(), randomCasperSlashing(), randomCasperSlashing()),
-        Arrays.asList(randomDeposit(), randomDeposit(), randomDeposit()),
-        Arrays.asList(randomExit(), randomExit(), randomExit()));
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockTest.java
@@ -31,132 +31,73 @@ import org.junit.jupiter.api.Test;
 
 class BeaconBlockTest {
 
+  long slot = randomLong();
+  Bytes32 parentRoot = Bytes32.random();
+  Bytes32 stateRoot = Bytes32.random();
+  List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
+  Eth1Data eth1Data = randomEth1Data();
+  List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
+  BeaconBlockBody body = randomBeaconBlockBody();
+
+  BeaconBlock beaconBlock =
+      new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
+
   @Test
   void equalsReturnsTrueWhenObjectAreSame() {
-    long slot = randomLong();
-    Bytes32 parentRoot = Bytes32.random();
-    Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
-    Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
-    BeaconBlockBody body = randomBeaconBlockBody();
+    BeaconBlock testBeaconBlock = beaconBlock;
 
-    BeaconBlock b1 =
-        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
-    BeaconBlock b2 = b1;
-
-    assertEquals(b1, b2);
+    assertEquals(beaconBlock, testBeaconBlock);
   }
 
   @Test
   void equalsReturnsTrueWhenObjectFieldsAreEqual() {
-    long slot = randomLong();
-    Bytes32 parentRoot = Bytes32.random();
-    Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
-    Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
-    BeaconBlockBody body = randomBeaconBlockBody();
-
-    BeaconBlock b1 =
-        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
-    BeaconBlock b2 =
+    BeaconBlock testBeaconBlock =
         new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
 
-    assertEquals(b1, b2);
+    assertEquals(beaconBlock, testBeaconBlock);
   }
 
   @Test
   void equalsReturnsFalseWhenSlotsAreDifferent() {
-    long slot = randomLong();
-    Bytes32 parentRoot = Bytes32.random();
-    Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
-    Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
-    BeaconBlockBody body = randomBeaconBlockBody();
-
-    BeaconBlock b1 =
-        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
-    BeaconBlock b2 =
+    BeaconBlock testBeaconBlock =
         new BeaconBlock(
             slot + randomLong(), parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
 
-    assertNotEquals(b1, b2);
+    assertNotEquals(beaconBlock, testBeaconBlock);
   }
 
   @Test
   void equalsReturnsFalseWhenAncestorHashesAreDifferent() {
-    long slot = randomLong();
-    Bytes32 parentRoot = Bytes32.random();
-    Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
-    Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
-    BeaconBlockBody body = randomBeaconBlockBody();
-
-    BeaconBlock b1 =
-        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
-    BeaconBlock b2 =
+    BeaconBlock testBeaconBlock =
         new BeaconBlock(slot, parentRoot.not(), stateRoot, randaoReveal, eth1Data, signature, body);
 
-    assertNotEquals(b1, b2);
+    assertNotEquals(beaconBlock, testBeaconBlock);
   }
 
   @Test
   void equalsReturnsFalseWhenStateRootsAreDifferent() {
-    long slot = randomLong();
-    Bytes32 parentRoot = Bytes32.random();
-    Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
-    Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
-    BeaconBlockBody body = randomBeaconBlockBody();
-
-    BeaconBlock b1 =
-        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
-    BeaconBlock b2 =
+    BeaconBlock testBeaconBlock =
         new BeaconBlock(slot, parentRoot, stateRoot.not(), randaoReveal, eth1Data, signature, body);
 
-    assertNotEquals(b1, b2);
+    assertNotEquals(beaconBlock, testBeaconBlock);
   }
 
   @Test
   void equalsReturnsFalseWhenRandaoRevealsAreDifferent() {
-    long slot = randomLong();
-    Bytes32 parentRoot = Bytes32.random();
-    Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
-    Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
-    BeaconBlockBody body = randomBeaconBlockBody();
-
     // Create copy of randaoReveal and reverse to ensure it is different.
     List<Bytes48> reverseRandaoReveal = new ArrayList<Bytes48>(randaoReveal);
     Collections.reverse(reverseRandaoReveal);
 
-    BeaconBlock b1 =
-        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
-    BeaconBlock b2 =
+    BeaconBlock testBeaconBlock =
         new BeaconBlock(
             slot, parentRoot, stateRoot, reverseRandaoReveal, eth1Data, signature, body);
 
-    assertNotEquals(b1, b2);
+    assertNotEquals(beaconBlock, testBeaconBlock);
   }
 
   @Test
   void equalsReturnsFalseWhenEth1DataIsDifferent() {
-    long slot = randomLong();
-    Bytes32 parentRoot = Bytes32.random();
-    Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
-    Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
-    BeaconBlockBody body = randomBeaconBlockBody();
-
-    BeaconBlock b1 =
-        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
-    BeaconBlock b2 =
+    BeaconBlock testBeaconBlock =
         new BeaconBlock(
             slot,
             parentRoot,
@@ -166,42 +107,24 @@ class BeaconBlockTest {
             signature,
             body);
 
-    assertNotEquals(b1, b2);
+    assertNotEquals(beaconBlock, testBeaconBlock);
   }
 
   @Test
   void equalsReturnsFalseWhenSignaturesAreDifferent() {
-    long slot = randomLong();
-    Bytes32 parentRoot = Bytes32.random();
-    Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
-    Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
-    BeaconBlockBody body = randomBeaconBlockBody();
-
     // Create copy of signature and reverse to ensure it is different.
     List<Bytes48> reverseSignature = new ArrayList<Bytes48>(signature);
     Collections.reverse(reverseSignature);
 
-    BeaconBlock b1 =
-        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
-    BeaconBlock b2 =
+    BeaconBlock testBeaconBlock =
         new BeaconBlock(
             slot, parentRoot, stateRoot, randaoReveal, eth1Data, reverseSignature, body);
 
-    assertNotEquals(b1, b2);
+    assertNotEquals(beaconBlock, testBeaconBlock);
   }
 
   @Test
   void equalsReturnsFalseWhenBeaconBlockBodiesAreDifferent() {
-    long slot = randomLong();
-    Bytes32 parentRoot = Bytes32.random();
-    Bytes32 stateRoot = Bytes32.random();
-    List<Bytes48> randaoReveal = Arrays.asList(Bytes48.random(), Bytes48.random());
-    Eth1Data eth1Data = randomEth1Data();
-    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
-    BeaconBlockBody body = randomBeaconBlockBody();
-
     // BeaconBlock is rather involved to create. Just create a random one until it is not the same
     // as the original.
     BeaconBlockBody otherBody = randomBeaconBlockBody();
@@ -209,25 +132,14 @@ class BeaconBlockTest {
       otherBody = randomBeaconBlockBody();
     }
 
-    BeaconBlock b1 =
-        new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
-    BeaconBlock b2 =
+    BeaconBlock testBeaconBlock =
         new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, otherBody);
 
-    assertNotEquals(b1, b2);
+    assertNotEquals(beaconBlock, testBeaconBlock);
   }
 
   @Test
   void rountripSSZ() {
-    BeaconBlock beaconBlock =
-        new BeaconBlock(
-            randomLong(),
-            Bytes32.random(),
-            Bytes32.random(),
-            Arrays.asList(Bytes48.random(), Bytes48.random()),
-            randomEth1Data(),
-            Arrays.asList(Bytes48.random(), Bytes48.random()),
-            randomBeaconBlockBody());
     Bytes sszBeaconBlockBytes = beaconBlock.toBytes();
     assertEquals(beaconBlock, BeaconBlock.fromBytes(sszBeaconBlockBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/Eth1DataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/Eth1DataTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.blocks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+
+class Eth1DataTest {
+
+  @Test
+  void equalsReturnsTrueWhenObjectAreSame() {
+    Bytes32 depositRoot = Bytes32.random();
+    Bytes32 blockHash = Bytes32.random();
+
+    Eth1Data ed1 = new Eth1Data(depositRoot, blockHash);
+    Eth1Data ed2 = ed1;
+
+    assertEquals(ed1, ed2);
+  }
+
+  @Test
+  void equalsReturnsTrueWhenObjectFieldsAreEqual() {
+    Bytes32 depositRoot = Bytes32.random();
+    Bytes32 blockHash = Bytes32.random();
+
+    Eth1Data ed1 = new Eth1Data(depositRoot, blockHash);
+    Eth1Data ed2 = new Eth1Data(depositRoot, blockHash);
+
+    assertEquals(ed1, ed2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenDepositRootsAreDifferent() {
+    Bytes32 depositRoot = Bytes32.random();
+    Bytes32 blockHash = Bytes32.random();
+
+    Eth1Data ed1 = new Eth1Data(depositRoot, blockHash);
+    Eth1Data ed2 = new Eth1Data(depositRoot.not(), blockHash);
+
+    assertNotEquals(ed1, ed2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenBlockHashesAreDifferent() {
+    Bytes32 depositRoot = Bytes32.random();
+    Bytes32 blockHash = Bytes32.random();
+
+    Eth1Data ed1 = new Eth1Data(depositRoot, blockHash);
+    Eth1Data ed2 = new Eth1Data(depositRoot, blockHash.not());
+
+    assertNotEquals(ed1, ed2);
+  }
+
+  @Test
+  void rountripSSZ() {
+    Eth1Data eth1Data = new Eth1Data(Bytes32.random(), Bytes32.random());
+    Bytes sszEth1DataBytes = eth1Data.toBytes();
+    assertEquals(eth1Data, Eth1Data.fromBytes(sszEth1DataBytes));
+  }
+}

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/Eth1DataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/Eth1DataTest.java
@@ -22,53 +22,41 @@ import org.junit.jupiter.api.Test;
 
 class Eth1DataTest {
 
+  Bytes32 depositRoot = Bytes32.random();
+  Bytes32 blockHash = Bytes32.random();
+
+  Eth1Data eth1Data = new Eth1Data(depositRoot, blockHash);
+
   @Test
   void equalsReturnsTrueWhenObjectAreSame() {
-    Bytes32 depositRoot = Bytes32.random();
-    Bytes32 blockHash = Bytes32.random();
+    Eth1Data testEth1Data = eth1Data;
 
-    Eth1Data ed1 = new Eth1Data(depositRoot, blockHash);
-    Eth1Data ed2 = ed1;
-
-    assertEquals(ed1, ed2);
+    assertEquals(eth1Data, testEth1Data);
   }
 
   @Test
   void equalsReturnsTrueWhenObjectFieldsAreEqual() {
-    Bytes32 depositRoot = Bytes32.random();
-    Bytes32 blockHash = Bytes32.random();
+    Eth1Data testEth1Data = new Eth1Data(depositRoot, blockHash);
 
-    Eth1Data ed1 = new Eth1Data(depositRoot, blockHash);
-    Eth1Data ed2 = new Eth1Data(depositRoot, blockHash);
-
-    assertEquals(ed1, ed2);
+    assertEquals(eth1Data, testEth1Data);
   }
 
   @Test
   void equalsReturnsFalseWhenDepositRootsAreDifferent() {
-    Bytes32 depositRoot = Bytes32.random();
-    Bytes32 blockHash = Bytes32.random();
+    Eth1Data testEth1Data = new Eth1Data(depositRoot.not(), blockHash);
 
-    Eth1Data ed1 = new Eth1Data(depositRoot, blockHash);
-    Eth1Data ed2 = new Eth1Data(depositRoot.not(), blockHash);
-
-    assertNotEquals(ed1, ed2);
+    assertNotEquals(eth1Data, testEth1Data);
   }
 
   @Test
   void equalsReturnsFalseWhenBlockHashesAreDifferent() {
-    Bytes32 depositRoot = Bytes32.random();
-    Bytes32 blockHash = Bytes32.random();
+    Eth1Data testEth1Data = new Eth1Data(depositRoot, blockHash.not());
 
-    Eth1Data ed1 = new Eth1Data(depositRoot, blockHash);
-    Eth1Data ed2 = new Eth1Data(depositRoot, blockHash.not());
-
-    assertNotEquals(ed1, ed2);
+    assertNotEquals(eth1Data, testEth1Data);
   }
 
   @Test
   void rountripSSZ() {
-    Eth1Data eth1Data = new Eth1Data(Bytes32.random(), Bytes32.random());
     Bytes sszEth1DataBytes = eth1Data.toBytes();
     assertEquals(eth1Data, Eth1Data.fromBytes(sszEth1DataBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/ProposalSignedDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/ProposalSignedDataTest.java
@@ -24,72 +24,52 @@ import org.junit.jupiter.api.Test;
 
 class ProposalSignedDataTest {
 
+  UnsignedLong slot = randomUnsignedLong();
+  UnsignedLong shard = randomUnsignedLong();
+  Bytes32 blockHash = Bytes32.random();
+
+  ProposalSignedData proposalSignedData = new ProposalSignedData(slot, shard, blockHash);
+
   @Test
   void equalsReturnsTrueWhenObjectAreSame() {
-    UnsignedLong slot = randomUnsignedLong();
-    UnsignedLong shard = randomUnsignedLong();
-    Bytes32 blockHash = Bytes32.random();
+    ProposalSignedData testProposalSignedData = proposalSignedData;
 
-    ProposalSignedData psd1 = new ProposalSignedData(slot, shard, blockHash);
-    ProposalSignedData psd2 = psd1;
-
-    assertEquals(psd1, psd2);
+    assertEquals(proposalSignedData, testProposalSignedData);
   }
 
   @Test
   void equalsReturnsTrueWhenObjectFieldsAreEqual() {
-    UnsignedLong slot = randomUnsignedLong();
-    UnsignedLong shard = randomUnsignedLong();
-    Bytes32 blockHash = Bytes32.random();
+    ProposalSignedData testProposalSignedData = new ProposalSignedData(slot, shard, blockHash);
 
-    ProposalSignedData psd1 = new ProposalSignedData(slot, shard, blockHash);
-    ProposalSignedData psd2 = new ProposalSignedData(slot, shard, blockHash);
-
-    assertEquals(psd1, psd2);
+    assertEquals(proposalSignedData, testProposalSignedData);
   }
 
   @Test
   void equalsReturnsFalseWhenSlotsAreDifferent() {
-    UnsignedLong slot = randomUnsignedLong();
-    UnsignedLong shard = randomUnsignedLong();
-    Bytes32 blockHash = Bytes32.random();
-
-    ProposalSignedData psd1 = new ProposalSignedData(slot, shard, blockHash);
-    ProposalSignedData psd2 =
+    ProposalSignedData testProposalSignedData =
         new ProposalSignedData(slot.plus(randomUnsignedLong()), shard, blockHash);
 
-    assertNotEquals(psd1, psd2);
+    assertNotEquals(proposalSignedData, testProposalSignedData);
   }
 
   @Test
   void equalsReturnsFalseWhenShardsAreDifferent() {
-    UnsignedLong slot = randomUnsignedLong();
-    UnsignedLong shard = randomUnsignedLong();
-    Bytes32 blockHash = Bytes32.random();
-
-    ProposalSignedData psd1 = new ProposalSignedData(slot, shard, blockHash);
-    ProposalSignedData psd2 =
+    ProposalSignedData testProposalSignedData =
         new ProposalSignedData(slot, shard.plus(randomUnsignedLong()), blockHash);
 
-    assertNotEquals(psd1, psd2);
+    assertNotEquals(proposalSignedData, testProposalSignedData);
   }
 
   @Test
   void equalsReturnsFalseWhenBlockHashesAreDifferent() {
-    UnsignedLong slot = randomUnsignedLong();
-    UnsignedLong shard = randomUnsignedLong();
-    Bytes32 blockHash = Bytes32.random();
+    ProposalSignedData testProposalSignedData =
+        new ProposalSignedData(slot, shard, blockHash.not());
 
-    ProposalSignedData psd1 = new ProposalSignedData(slot, shard, blockHash);
-    ProposalSignedData psd2 = new ProposalSignedData(slot, shard, blockHash.not());
-
-    assertNotEquals(psd1, psd2);
+    assertNotEquals(proposalSignedData, testProposalSignedData);
   }
 
   @Test
   void rountripSSZ() {
-    ProposalSignedData proposalSignedData =
-        new ProposalSignedData(randomUnsignedLong(), randomUnsignedLong(), Bytes32.random());
     Bytes sszProposalSignedDataBytes = proposalSignedData.toBytes();
     assertEquals(proposalSignedData, ProposalSignedData.fromBytes(sszProposalSignedDataBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/ProposalSignedDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/ProposalSignedDataTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.blocks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.google.common.primitives.UnsignedLong;
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+
+class ProposalSignedDataTest {
+
+  @Test
+  void equalsReturnsTrueWhenObjectAreSame() {
+    UnsignedLong slot = randomUnsignedLong();
+    UnsignedLong shard = randomUnsignedLong();
+    Bytes32 blockHash = Bytes32.random();
+
+    ProposalSignedData psd1 = new ProposalSignedData(slot, shard, blockHash);
+    ProposalSignedData psd2 = psd1;
+
+    assertEquals(psd1, psd2);
+  }
+
+  @Test
+  void equalsReturnsTrueWhenObjectFieldsAreEqual() {
+    UnsignedLong slot = randomUnsignedLong();
+    UnsignedLong shard = randomUnsignedLong();
+    Bytes32 blockHash = Bytes32.random();
+
+    ProposalSignedData psd1 = new ProposalSignedData(slot, shard, blockHash);
+    ProposalSignedData psd2 = new ProposalSignedData(slot, shard, blockHash);
+
+    assertEquals(psd1, psd2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenSlotsAreDifferent() {
+    UnsignedLong slot = randomUnsignedLong();
+    UnsignedLong shard = randomUnsignedLong();
+    Bytes32 blockHash = Bytes32.random();
+
+    ProposalSignedData psd1 = new ProposalSignedData(slot, shard, blockHash);
+    ProposalSignedData psd2 =
+        new ProposalSignedData(slot.plus(randomUnsignedLong()), shard, blockHash);
+
+    assertNotEquals(psd1, psd2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenShardsAreDifferent() {
+    UnsignedLong slot = randomUnsignedLong();
+    UnsignedLong shard = randomUnsignedLong();
+    Bytes32 blockHash = Bytes32.random();
+
+    ProposalSignedData psd1 = new ProposalSignedData(slot, shard, blockHash);
+    ProposalSignedData psd2 =
+        new ProposalSignedData(slot, shard.plus(randomUnsignedLong()), blockHash);
+
+    assertNotEquals(psd1, psd2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenBlockHashesAreDifferent() {
+    UnsignedLong slot = randomUnsignedLong();
+    UnsignedLong shard = randomUnsignedLong();
+    Bytes32 blockHash = Bytes32.random();
+
+    ProposalSignedData psd1 = new ProposalSignedData(slot, shard, blockHash);
+    ProposalSignedData psd2 = new ProposalSignedData(slot, shard, blockHash.not());
+
+    assertNotEquals(psd1, psd2);
+  }
+
+  @Test
+  void rountripSSZ() {
+    ProposalSignedData proposalSignedData =
+        new ProposalSignedData(randomUnsignedLong(), randomUnsignedLong(), Bytes32.random());
+    Bytes sszProposalSignedDataBytes = proposalSignedData.toBytes();
+    assertEquals(proposalSignedData, ProposalSignedData.fromBytes(sszProposalSignedDataBytes));
+  }
+
+  private long randomLong() {
+    return Math.round(Math.random() * 1000000);
+  }
+
+  private UnsignedLong randomUnsignedLong() {
+    return UnsignedLong.fromLongBits(randomLong());
+  }
+}

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/ProposalSignedDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/ProposalSignedDataTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.artemis.datastructures.blocks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import net.consensys.cava.bytes.Bytes;
@@ -91,13 +92,5 @@ class ProposalSignedDataTest {
         new ProposalSignedData(randomUnsignedLong(), randomUnsignedLong(), Bytes32.random());
     Bytes sszProposalSignedDataBytes = proposalSignedData.toBytes();
     assertEquals(proposalSignedData, ProposalSignedData.fromBytes(sszProposalSignedDataBytes));
-  }
-
-  private long randomLong() {
-    return Math.round(Math.random() * 1000000);
-  }
-
-  private UnsignedLong randomUnsignedLong() {
-    return UnsignedLong.fromLongBits(randomLong());
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationDataTest.java
@@ -25,54 +25,36 @@ import org.junit.jupiter.api.Test;
 
 class AttestationDataTest {
 
+  long slot = randomLong();
+  UnsignedLong shard = randomUnsignedLong();
+  Bytes32 beaconBlockHash = Bytes32.random();
+  Bytes32 epochBoundaryHash = Bytes32.random();
+  Bytes32 shardBlockHash = Bytes32.random();
+  Bytes32 lastCrosslinkHash = Bytes32.random();
+  UnsignedLong justifiedSlot = randomUnsignedLong();
+  Bytes32 justifiedBlockHash = Bytes32.random();
+
+  AttestationData attestationData =
+      new AttestationData(
+          slot,
+          shard,
+          beaconBlockHash,
+          epochBoundaryHash,
+          shardBlockHash,
+          lastCrosslinkHash,
+          justifiedSlot,
+          justifiedBlockHash);
+
   @Test
   void equalsReturnsTrueWhenObjectAreSame() {
-    long slot = randomLong();
-    UnsignedLong shard = randomUnsignedLong();
-    Bytes32 beaconBlockHash = Bytes32.random();
-    Bytes32 epochBoundaryHash = Bytes32.random();
-    Bytes32 shardBlockHash = Bytes32.random();
-    Bytes32 lastCrosslinkHash = Bytes32.random();
-    UnsignedLong justifiedSlot = randomUnsignedLong();
-    Bytes32 justifiedBlockHash = Bytes32.random();
+    AttestationData testAttestationData = attestationData;
 
-    AttestationData ad1 =
-        new AttestationData(
-            slot,
-            shard,
-            beaconBlockHash,
-            epochBoundaryHash,
-            shardBlockHash,
-            lastCrosslinkHash,
-            justifiedSlot,
-            justifiedBlockHash);
-    AttestationData ad2 = ad1;
-
-    assertEquals(ad1, ad2);
+    assertEquals(attestationData, testAttestationData);
   }
 
   @Test
   void equalsReturnsTrueWhenObjectFieldsAreEqual() {
-    long slot = randomLong();
-    UnsignedLong shard = randomUnsignedLong();
-    Bytes32 beaconBlockHash = Bytes32.random();
-    Bytes32 epochBoundaryHash = Bytes32.random();
-    Bytes32 shardBlockHash = Bytes32.random();
-    Bytes32 lastCrosslinkHash = Bytes32.random();
-    UnsignedLong justifiedSlot = randomUnsignedLong();
-    Bytes32 justifiedBlockHash = Bytes32.random();
-
-    AttestationData ad1 =
-        new AttestationData(
-            slot,
-            shard,
-            beaconBlockHash,
-            epochBoundaryHash,
-            shardBlockHash,
-            lastCrosslinkHash,
-            justifiedSlot,
-            justifiedBlockHash);
-    AttestationData ad2 =
+    AttestationData testAttestationData =
         new AttestationData(
             slot,
             shard,
@@ -83,31 +65,12 @@ class AttestationDataTest {
             justifiedSlot,
             justifiedBlockHash);
 
-    assertEquals(ad1, ad2);
+    assertEquals(attestationData, testAttestationData);
   }
 
   @Test
   void equalsReturnsFalseWhenSlotsAreDifferent() {
-    long slot = randomLong();
-    UnsignedLong shard = randomUnsignedLong();
-    Bytes32 beaconBlockHash = Bytes32.random();
-    Bytes32 epochBoundaryHash = Bytes32.random();
-    Bytes32 shardBlockHash = Bytes32.random();
-    Bytes32 lastCrosslinkHash = Bytes32.random();
-    UnsignedLong justifiedSlot = randomUnsignedLong();
-    Bytes32 justifiedBlockHash = Bytes32.random();
-
-    AttestationData ad1 =
-        new AttestationData(
-            slot,
-            shard,
-            beaconBlockHash,
-            epochBoundaryHash,
-            shardBlockHash,
-            lastCrosslinkHash,
-            justifiedSlot,
-            justifiedBlockHash);
-    AttestationData ad2 =
+    AttestationData testAttestationData =
         new AttestationData(
             slot + randomLong(),
             shard,
@@ -118,31 +81,12 @@ class AttestationDataTest {
             justifiedSlot,
             justifiedBlockHash);
 
-    assertNotEquals(ad1, ad2);
+    assertNotEquals(attestationData, testAttestationData);
   }
 
   @Test
   void equalsReturnsFalseWhenShardsAreDifferent() {
-    long slot = randomLong();
-    UnsignedLong shard = randomUnsignedLong();
-    Bytes32 beaconBlockHash = Bytes32.random();
-    Bytes32 epochBoundaryHash = Bytes32.random();
-    Bytes32 shardBlockHash = Bytes32.random();
-    Bytes32 lastCrosslinkHash = Bytes32.random();
-    UnsignedLong justifiedSlot = randomUnsignedLong();
-    Bytes32 justifiedBlockHash = Bytes32.random();
-
-    AttestationData ad1 =
-        new AttestationData(
-            slot,
-            shard,
-            beaconBlockHash,
-            epochBoundaryHash,
-            shardBlockHash,
-            lastCrosslinkHash,
-            justifiedSlot,
-            justifiedBlockHash);
-    AttestationData ad2 =
+    AttestationData testAttestationData =
         new AttestationData(
             slot,
             shard.plus(randomUnsignedLong()),
@@ -153,31 +97,12 @@ class AttestationDataTest {
             justifiedSlot,
             justifiedBlockHash);
 
-    assertNotEquals(ad1, ad2);
+    assertNotEquals(attestationData, testAttestationData);
   }
 
   @Test
   void equalsReturnsFalseWhenBeaconBlockHashesAreDifferent() {
-    long slot = randomLong();
-    UnsignedLong shard = randomUnsignedLong();
-    Bytes32 beaconBlockHash = Bytes32.random();
-    Bytes32 epochBoundaryHash = Bytes32.random();
-    Bytes32 shardBlockHash = Bytes32.random();
-    Bytes32 lastCrosslinkHash = Bytes32.random();
-    UnsignedLong justifiedSlot = randomUnsignedLong();
-    Bytes32 justifiedBlockHash = Bytes32.random();
-
-    AttestationData ad1 =
-        new AttestationData(
-            slot,
-            shard,
-            beaconBlockHash,
-            epochBoundaryHash,
-            shardBlockHash,
-            lastCrosslinkHash,
-            justifiedSlot,
-            justifiedBlockHash);
-    AttestationData ad2 =
+    AttestationData testAttestationData =
         new AttestationData(
             slot,
             shard,
@@ -188,31 +113,12 @@ class AttestationDataTest {
             justifiedSlot,
             justifiedBlockHash);
 
-    assertNotEquals(ad1, ad2);
+    assertNotEquals(attestationData, testAttestationData);
   }
 
   @Test
   void equalsReturnsFalseWhenEpochBoundaryHashesAreDifferent() {
-    long slot = randomLong();
-    UnsignedLong shard = randomUnsignedLong();
-    Bytes32 beaconBlockHash = Bytes32.random();
-    Bytes32 epochBoundaryHash = Bytes32.random();
-    Bytes32 shardBlockHash = Bytes32.random();
-    Bytes32 lastCrosslinkHash = Bytes32.random();
-    UnsignedLong justifiedSlot = randomUnsignedLong();
-    Bytes32 justifiedBlockHash = Bytes32.random();
-
-    AttestationData ad1 =
-        new AttestationData(
-            slot,
-            shard,
-            beaconBlockHash,
-            epochBoundaryHash,
-            shardBlockHash,
-            lastCrosslinkHash,
-            justifiedSlot,
-            justifiedBlockHash);
-    AttestationData ad2 =
+    AttestationData testAttestationData =
         new AttestationData(
             slot,
             shard,
@@ -223,31 +129,12 @@ class AttestationDataTest {
             justifiedSlot,
             justifiedBlockHash);
 
-    assertNotEquals(ad1, ad2);
+    assertNotEquals(attestationData, testAttestationData);
   }
 
   @Test
   void equalsReturnsFalseWhenShardBlockHashesAreDifferent() {
-    long slot = randomLong();
-    UnsignedLong shard = randomUnsignedLong();
-    Bytes32 beaconBlockHash = Bytes32.random();
-    Bytes32 epochBoundaryHash = Bytes32.random();
-    Bytes32 shardBlockHash = Bytes32.random();
-    Bytes32 lastCrosslinkHash = Bytes32.random();
-    UnsignedLong justifiedSlot = randomUnsignedLong();
-    Bytes32 justifiedBlockHash = Bytes32.random();
-
-    AttestationData ad1 =
-        new AttestationData(
-            slot,
-            shard,
-            beaconBlockHash,
-            epochBoundaryHash,
-            shardBlockHash,
-            lastCrosslinkHash,
-            justifiedSlot,
-            justifiedBlockHash);
-    AttestationData ad2 =
+    AttestationData testAttestationData =
         new AttestationData(
             slot,
             shard,
@@ -258,31 +145,12 @@ class AttestationDataTest {
             justifiedSlot,
             justifiedBlockHash);
 
-    assertNotEquals(ad1, ad2);
+    assertNotEquals(attestationData, testAttestationData);
   }
 
   @Test
   void equalsReturnsFalseWhenLastCrosslinkHashesAreDifferent() {
-    long slot = randomLong();
-    UnsignedLong shard = randomUnsignedLong();
-    Bytes32 beaconBlockHash = Bytes32.random();
-    Bytes32 epochBoundaryHash = Bytes32.random();
-    Bytes32 shardBlockHash = Bytes32.random();
-    Bytes32 lastCrosslinkHash = Bytes32.random();
-    UnsignedLong justifiedSlot = randomUnsignedLong();
-    Bytes32 justifiedBlockHash = Bytes32.random();
-
-    AttestationData ad1 =
-        new AttestationData(
-            slot,
-            shard,
-            beaconBlockHash,
-            epochBoundaryHash,
-            shardBlockHash,
-            lastCrosslinkHash,
-            justifiedSlot,
-            justifiedBlockHash);
-    AttestationData ad2 =
+    AttestationData testAttestationData =
         new AttestationData(
             slot,
             shard,
@@ -293,31 +161,12 @@ class AttestationDataTest {
             justifiedSlot,
             justifiedBlockHash);
 
-    assertNotEquals(ad1, ad2);
+    assertNotEquals(attestationData, testAttestationData);
   }
 
   @Test
   void equalsReturnsFalseWhenJustifiedSlotsAreDifferent() {
-    long slot = randomLong();
-    UnsignedLong shard = randomUnsignedLong();
-    Bytes32 beaconBlockHash = Bytes32.random();
-    Bytes32 epochBoundaryHash = Bytes32.random();
-    Bytes32 shardBlockHash = Bytes32.random();
-    Bytes32 lastCrosslinkHash = Bytes32.random();
-    UnsignedLong justifiedSlot = randomUnsignedLong();
-    Bytes32 justifiedBlockHash = Bytes32.random();
-
-    AttestationData ad1 =
-        new AttestationData(
-            slot,
-            shard,
-            beaconBlockHash,
-            epochBoundaryHash,
-            shardBlockHash,
-            lastCrosslinkHash,
-            justifiedSlot,
-            justifiedBlockHash);
-    AttestationData ad2 =
+    AttestationData testAttestationData =
         new AttestationData(
             slot,
             shard,
@@ -328,31 +177,12 @@ class AttestationDataTest {
             justifiedSlot.plus(randomUnsignedLong()),
             justifiedBlockHash);
 
-    assertNotEquals(ad1, ad2);
+    assertNotEquals(attestationData, testAttestationData);
   }
 
   @Test
   void equalsReturnsFalseWhenJustifiedBlockHashesAreDifferent() {
-    long slot = randomLong();
-    UnsignedLong shard = randomUnsignedLong();
-    Bytes32 beaconBlockHash = Bytes32.random();
-    Bytes32 epochBoundaryHash = Bytes32.random();
-    Bytes32 shardBlockHash = Bytes32.random();
-    Bytes32 lastCrosslinkHash = Bytes32.random();
-    UnsignedLong justifiedSlot = randomUnsignedLong();
-    Bytes32 justifiedBlockHash = Bytes32.random();
-
-    AttestationData ad1 =
-        new AttestationData(
-            slot,
-            shard,
-            beaconBlockHash,
-            epochBoundaryHash,
-            shardBlockHash,
-            lastCrosslinkHash,
-            justifiedSlot,
-            justifiedBlockHash);
-    AttestationData ad2 =
+    AttestationData testAttestationData =
         new AttestationData(
             slot,
             shard,
@@ -363,21 +193,11 @@ class AttestationDataTest {
             justifiedSlot,
             justifiedBlockHash.not());
 
-    assertNotEquals(ad1, ad2);
+    assertNotEquals(attestationData, testAttestationData);
   }
 
   @Test
   void rountripSSZ() {
-    AttestationData attestationData =
-        new AttestationData(
-            randomLong(),
-            randomUnsignedLong(),
-            Bytes32.random(),
-            Bytes32.random(),
-            Bytes32.random(),
-            Bytes32.random(),
-            randomUnsignedLong(),
-            Bytes32.random());
     Bytes sszAttestationDataBytes = attestationData.toBytes();
     assertEquals(attestationData, AttestationData.fromBytes(sszAttestationDataBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationDataTest.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.operations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.google.common.primitives.UnsignedLong;
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+
+class AttestationDataTest {
+
+  @Test
+  void equalsReturnsTrueWhenObjectAreSame() {
+    long slot = randomLong();
+    UnsignedLong shard = randomUnsignedLong();
+    Bytes32 beaconBlockHash = Bytes32.random();
+    Bytes32 epochBoundaryHash = Bytes32.random();
+    Bytes32 shardBlockHash = Bytes32.random();
+    Bytes32 lastCrosslinkHash = Bytes32.random();
+    UnsignedLong justifiedSlot = randomUnsignedLong();
+    Bytes32 justifiedBlockHash = Bytes32.random();
+
+    AttestationData ad1 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+    AttestationData ad2 = ad1;
+
+    assertEquals(ad1, ad2);
+  }
+
+  @Test
+  void equalsReturnsTrueWhenObjectFieldsAreEqual() {
+    long slot = randomLong();
+    UnsignedLong shard = randomUnsignedLong();
+    Bytes32 beaconBlockHash = Bytes32.random();
+    Bytes32 epochBoundaryHash = Bytes32.random();
+    Bytes32 shardBlockHash = Bytes32.random();
+    Bytes32 lastCrosslinkHash = Bytes32.random();
+    UnsignedLong justifiedSlot = randomUnsignedLong();
+    Bytes32 justifiedBlockHash = Bytes32.random();
+
+    AttestationData ad1 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+    AttestationData ad2 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+
+    assertEquals(ad1, ad2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenSlotsAreDifferent() {
+    long slot = randomLong();
+    UnsignedLong shard = randomUnsignedLong();
+    Bytes32 beaconBlockHash = Bytes32.random();
+    Bytes32 epochBoundaryHash = Bytes32.random();
+    Bytes32 shardBlockHash = Bytes32.random();
+    Bytes32 lastCrosslinkHash = Bytes32.random();
+    UnsignedLong justifiedSlot = randomUnsignedLong();
+    Bytes32 justifiedBlockHash = Bytes32.random();
+
+    AttestationData ad1 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+    AttestationData ad2 =
+        new AttestationData(
+            slot + randomLong(),
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+
+    assertNotEquals(ad1, ad2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenShardsAreDifferent() {
+    long slot = randomLong();
+    UnsignedLong shard = randomUnsignedLong();
+    Bytes32 beaconBlockHash = Bytes32.random();
+    Bytes32 epochBoundaryHash = Bytes32.random();
+    Bytes32 shardBlockHash = Bytes32.random();
+    Bytes32 lastCrosslinkHash = Bytes32.random();
+    UnsignedLong justifiedSlot = randomUnsignedLong();
+    Bytes32 justifiedBlockHash = Bytes32.random();
+
+    AttestationData ad1 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+    AttestationData ad2 =
+        new AttestationData(
+            slot,
+            shard.plus(randomUnsignedLong()),
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+
+    assertNotEquals(ad1, ad2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenBeaconBlockHashesAreDifferent() {
+    long slot = randomLong();
+    UnsignedLong shard = randomUnsignedLong();
+    Bytes32 beaconBlockHash = Bytes32.random();
+    Bytes32 epochBoundaryHash = Bytes32.random();
+    Bytes32 shardBlockHash = Bytes32.random();
+    Bytes32 lastCrosslinkHash = Bytes32.random();
+    UnsignedLong justifiedSlot = randomUnsignedLong();
+    Bytes32 justifiedBlockHash = Bytes32.random();
+
+    AttestationData ad1 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+    AttestationData ad2 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash.not(),
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+
+    assertNotEquals(ad1, ad2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenEpochBoundaryHashesAreDifferent() {
+    long slot = randomLong();
+    UnsignedLong shard = randomUnsignedLong();
+    Bytes32 beaconBlockHash = Bytes32.random();
+    Bytes32 epochBoundaryHash = Bytes32.random();
+    Bytes32 shardBlockHash = Bytes32.random();
+    Bytes32 lastCrosslinkHash = Bytes32.random();
+    UnsignedLong justifiedSlot = randomUnsignedLong();
+    Bytes32 justifiedBlockHash = Bytes32.random();
+
+    AttestationData ad1 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+    AttestationData ad2 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash.not(),
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+
+    assertNotEquals(ad1, ad2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenShardBlockHashesAreDifferent() {
+    long slot = randomLong();
+    UnsignedLong shard = randomUnsignedLong();
+    Bytes32 beaconBlockHash = Bytes32.random();
+    Bytes32 epochBoundaryHash = Bytes32.random();
+    Bytes32 shardBlockHash = Bytes32.random();
+    Bytes32 lastCrosslinkHash = Bytes32.random();
+    UnsignedLong justifiedSlot = randomUnsignedLong();
+    Bytes32 justifiedBlockHash = Bytes32.random();
+
+    AttestationData ad1 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+    AttestationData ad2 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash.not(),
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+
+    assertNotEquals(ad1, ad2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenLastCrosslinkHashesAreDifferent() {
+    long slot = randomLong();
+    UnsignedLong shard = randomUnsignedLong();
+    Bytes32 beaconBlockHash = Bytes32.random();
+    Bytes32 epochBoundaryHash = Bytes32.random();
+    Bytes32 shardBlockHash = Bytes32.random();
+    Bytes32 lastCrosslinkHash = Bytes32.random();
+    UnsignedLong justifiedSlot = randomUnsignedLong();
+    Bytes32 justifiedBlockHash = Bytes32.random();
+
+    AttestationData ad1 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+    AttestationData ad2 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash.not(),
+            justifiedSlot,
+            justifiedBlockHash);
+
+    assertNotEquals(ad1, ad2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenJustifiedSlotsAreDifferent() {
+    long slot = randomLong();
+    UnsignedLong shard = randomUnsignedLong();
+    Bytes32 beaconBlockHash = Bytes32.random();
+    Bytes32 epochBoundaryHash = Bytes32.random();
+    Bytes32 shardBlockHash = Bytes32.random();
+    Bytes32 lastCrosslinkHash = Bytes32.random();
+    UnsignedLong justifiedSlot = randomUnsignedLong();
+    Bytes32 justifiedBlockHash = Bytes32.random();
+
+    AttestationData ad1 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+    AttestationData ad2 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot.plus(randomUnsignedLong()),
+            justifiedBlockHash);
+
+    assertNotEquals(ad1, ad2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenJustifiedBlockHashesAreDifferent() {
+    long slot = randomLong();
+    UnsignedLong shard = randomUnsignedLong();
+    Bytes32 beaconBlockHash = Bytes32.random();
+    Bytes32 epochBoundaryHash = Bytes32.random();
+    Bytes32 shardBlockHash = Bytes32.random();
+    Bytes32 lastCrosslinkHash = Bytes32.random();
+    UnsignedLong justifiedSlot = randomUnsignedLong();
+    Bytes32 justifiedBlockHash = Bytes32.random();
+
+    AttestationData ad1 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash);
+    AttestationData ad2 =
+        new AttestationData(
+            slot,
+            shard,
+            beaconBlockHash,
+            epochBoundaryHash,
+            shardBlockHash,
+            lastCrosslinkHash,
+            justifiedSlot,
+            justifiedBlockHash.not());
+
+    assertNotEquals(ad1, ad2);
+  }
+
+  @Test
+  void rountripSSZ() {
+    AttestationData attestationData =
+        new AttestationData(
+            randomLong(),
+            randomUnsignedLong(),
+            Bytes32.random(),
+            Bytes32.random(),
+            Bytes32.random(),
+            Bytes32.random(),
+            randomUnsignedLong(),
+            Bytes32.random());
+    Bytes sszAttestationDataBytes = attestationData.toBytes();
+    assertEquals(attestationData, AttestationData.fromBytes(sszAttestationDataBytes));
+  }
+
+  private long randomLong() {
+    return Math.round(Math.random() * 1000000);
+  }
+
+  private UnsignedLong randomUnsignedLong() {
+    return UnsignedLong.fromLongBits(randomLong());
+  }
+}

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationDataTest.java
@@ -15,6 +15,8 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomLong;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import net.consensys.cava.bytes.Bytes;
@@ -378,13 +380,5 @@ class AttestationDataTest {
             Bytes32.random());
     Bytes sszAttestationDataBytes = attestationData.toBytes();
     assertEquals(attestationData, AttestationData.fromBytes(sszAttestationDataBytes));
-  }
-
-  private long randomLong() {
-    return Math.round(Math.random() * 1000000);
-  }
-
-  private UnsignedLong randomUnsignedLong() {
-    return UnsignedLong.fromLongBits(randomLong());
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationTest.java
@@ -15,8 +15,8 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomAttestationData;
 
-import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -139,25 +139,5 @@ class AttestationTest {
             Arrays.asList(Bytes48.random(), Bytes48.random()));
     Bytes sszAttestationBytes = attestation.toBytes();
     assertEquals(attestation, Attestation.fromBytes(sszAttestationBytes));
-  }
-
-  private long randomLong() {
-    return Math.round(Math.random() * 1000000);
-  }
-
-  private UnsignedLong randomUnsignedLong() {
-    return UnsignedLong.fromLongBits(randomLong());
-  }
-
-  private AttestationData randomAttestationData() {
-    return new AttestationData(
-        randomLong(),
-        randomUnsignedLong(),
-        Bytes32.random(),
-        Bytes32.random(),
-        Bytes32.random(),
-        Bytes32.random(),
-        randomUnsignedLong(),
-        Bytes32.random());
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationTest.java
@@ -29,42 +29,31 @@ import org.junit.jupiter.api.Test;
 
 class AttestationTest {
 
+  AttestationData data = randomAttestationData();
+  Bytes32 participationBitfield = Bytes32.random();
+  Bytes32 custodyBitfield = Bytes32.random();
+  List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+  Attestation attestation =
+      new Attestation(data, participationBitfield, custodyBitfield, aggregateSignature);
+
   @Test
   void equalsReturnsTrueWhenObjectAreSame() {
-    AttestationData data = randomAttestationData();
-    Bytes32 participationBitfield = Bytes32.random();
-    Bytes32 custodyBitfield = Bytes32.random();
-    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+    Attestation testAttestation = attestation;
 
-    Attestation a1 =
-        new Attestation(data, participationBitfield, custodyBitfield, aggregateSignature);
-    Attestation a2 = a1;
-
-    assertEquals(a1, a2);
+    assertEquals(attestation, testAttestation);
   }
 
   @Test
   void equalsReturnsTrueWhenObjectFieldsAreEqual() {
-    AttestationData data = randomAttestationData();
-    Bytes32 participationBitfield = Bytes32.random();
-    Bytes32 custodyBitfield = Bytes32.random();
-    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
-
-    Attestation a1 =
-        new Attestation(data, participationBitfield, custodyBitfield, aggregateSignature);
-    Attestation a2 =
+    Attestation testAttestation =
         new Attestation(data, participationBitfield, custodyBitfield, aggregateSignature);
 
-    assertEquals(a1, a2);
+    assertEquals(attestation, testAttestation);
   }
 
   @Test
   void equalsReturnsFalseWhenAttestationDataIsDifferent() {
-    AttestationData data = randomAttestationData();
-    Bytes32 participationBitfield = Bytes32.random();
-    Bytes32 custodyBitfield = Bytes32.random();
-    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
-
     // AttestationData is rather involved to create. Just create a random one until it is not the
     // same as the original.
     AttestationData otherData = randomAttestationData();
@@ -72,71 +61,42 @@ class AttestationTest {
       otherData = randomAttestationData();
     }
 
-    Attestation a1 =
-        new Attestation(data, participationBitfield, custodyBitfield, aggregateSignature);
-    Attestation a2 =
+    Attestation testAttestation =
         new Attestation(otherData, participationBitfield, custodyBitfield, aggregateSignature);
 
-    assertNotEquals(a1, a2);
+    assertNotEquals(attestation, testAttestation);
   }
 
   @Test
   void equalsReturnsFalseWhenParticipationBitfieldsAreDifferent() {
-    AttestationData data = randomAttestationData();
-    Bytes32 participationBitfield = Bytes32.random();
-    Bytes32 custodyBitfield = Bytes32.random();
-    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
-
-    Attestation a1 =
-        new Attestation(data, participationBitfield, custodyBitfield, aggregateSignature);
-    Attestation a2 =
+    Attestation testAttestation =
         new Attestation(data, participationBitfield.not(), custodyBitfield, aggregateSignature);
 
-    assertNotEquals(a1, a2);
+    assertNotEquals(attestation, testAttestation);
   }
 
   @Test
   void equalsReturnsFalseWhenCustodyBitfieldsAreDifferent() {
-    AttestationData data = randomAttestationData();
-    Bytes32 participationBitfield = Bytes32.random();
-    Bytes32 custodyBitfield = Bytes32.random();
-    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
-
-    Attestation a1 =
-        new Attestation(data, participationBitfield, custodyBitfield, aggregateSignature);
-    Attestation a2 =
+    Attestation testAttestation =
         new Attestation(data, participationBitfield, custodyBitfield.not(), aggregateSignature);
 
-    assertNotEquals(a1, a2);
+    assertNotEquals(attestation, testAttestation);
   }
 
   @Test
   void equalsReturnsFalseWhenAggregrateSignaturesAreDifferent() {
-    AttestationData data = randomAttestationData();
-    Bytes32 participationBitfield = Bytes32.random();
-    Bytes32 custodyBitfield = Bytes32.random();
-    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
-
     // Create copy of aggregateSignature and reverse to ensure it is different.
     List<Bytes48> reverseAggregateSignature = new ArrayList<Bytes48>(aggregateSignature);
     Collections.reverse(reverseAggregateSignature);
 
-    Attestation a1 =
-        new Attestation(data, participationBitfield, custodyBitfield, aggregateSignature);
-    Attestation a2 =
+    Attestation testAttestation =
         new Attestation(data, participationBitfield, custodyBitfield, reverseAggregateSignature);
 
-    assertNotEquals(a1, a2);
+    assertNotEquals(attestation, testAttestation);
   }
 
   @Test
   void rountripSSZ() {
-    Attestation attestation =
-        new Attestation(
-            randomAttestationData(),
-            Bytes32.random(),
-            Bytes32.random(),
-            Arrays.asList(Bytes48.random(), Bytes48.random()));
     Bytes sszAttestationBytes = attestation.toBytes();
     assertEquals(attestation, Attestation.fromBytes(sszAttestationBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.operations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.bytes.Bytes32;
+import net.consensys.cava.bytes.Bytes48;
+import org.junit.jupiter.api.Test;
+
+class AttestationTest {
+
+  @Test
+  void equalsReturnsTrueWhenObjectAreSame() {
+    AttestationData data = randomAttestationData();
+    Bytes32 participationBitfield = Bytes32.random();
+    Bytes32 custodyBitfield = Bytes32.random();
+    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    Attestation a1 =
+        new Attestation(data, participationBitfield, custodyBitfield, aggregateSignature);
+    Attestation a2 = a1;
+
+    assertEquals(a1, a2);
+  }
+
+  @Test
+  void equalsReturnsTrueWhenObjectFieldsAreEqual() {
+    AttestationData data = randomAttestationData();
+    Bytes32 participationBitfield = Bytes32.random();
+    Bytes32 custodyBitfield = Bytes32.random();
+    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    Attestation a1 =
+        new Attestation(data, participationBitfield, custodyBitfield, aggregateSignature);
+    Attestation a2 =
+        new Attestation(data, participationBitfield, custodyBitfield, aggregateSignature);
+
+    assertEquals(a1, a2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenAttestationDataIsDifferent() {
+    AttestationData data = randomAttestationData();
+    Bytes32 participationBitfield = Bytes32.random();
+    Bytes32 custodyBitfield = Bytes32.random();
+    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    // AttestationData is rather involved to create. Just create a random one until it is not the
+    // same as the original.
+    AttestationData otherData = randomAttestationData();
+    while (Objects.equals(otherData, data)) {
+      otherData = randomAttestationData();
+    }
+
+    Attestation a1 =
+        new Attestation(data, participationBitfield, custodyBitfield, aggregateSignature);
+    Attestation a2 =
+        new Attestation(otherData, participationBitfield, custodyBitfield, aggregateSignature);
+
+    assertNotEquals(a1, a2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenParticipationBitfieldsAreDifferent() {
+    AttestationData data = randomAttestationData();
+    Bytes32 participationBitfield = Bytes32.random();
+    Bytes32 custodyBitfield = Bytes32.random();
+    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    Attestation a1 =
+        new Attestation(data, participationBitfield, custodyBitfield, aggregateSignature);
+    Attestation a2 =
+        new Attestation(data, participationBitfield.not(), custodyBitfield, aggregateSignature);
+
+    assertNotEquals(a1, a2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenCustodyBitfieldsAreDifferent() {
+    AttestationData data = randomAttestationData();
+    Bytes32 participationBitfield = Bytes32.random();
+    Bytes32 custodyBitfield = Bytes32.random();
+    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    Attestation a1 =
+        new Attestation(data, participationBitfield, custodyBitfield, aggregateSignature);
+    Attestation a2 =
+        new Attestation(data, participationBitfield, custodyBitfield.not(), aggregateSignature);
+
+    assertNotEquals(a1, a2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenAggregrateSignaturesAreDifferent() {
+    AttestationData data = randomAttestationData();
+    Bytes32 participationBitfield = Bytes32.random();
+    Bytes32 custodyBitfield = Bytes32.random();
+    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    // Create copy of aggregateSignature and reverse to ensure it is different.
+    List<Bytes48> reverseAggregateSignature = new ArrayList<Bytes48>(aggregateSignature);
+    Collections.reverse(reverseAggregateSignature);
+
+    Attestation a1 =
+        new Attestation(data, participationBitfield, custodyBitfield, aggregateSignature);
+    Attestation a2 =
+        new Attestation(data, participationBitfield, custodyBitfield, reverseAggregateSignature);
+
+    assertNotEquals(a1, a2);
+  }
+
+  @Test
+  void rountripSSZ() {
+    Attestation attestation =
+        new Attestation(
+            randomAttestationData(),
+            Bytes32.random(),
+            Bytes32.random(),
+            Arrays.asList(Bytes48.random(), Bytes48.random()));
+    Bytes sszAttestationBytes = attestation.toBytes();
+    assertEquals(attestation, Attestation.fromBytes(sszAttestationBytes));
+  }
+
+  private long randomLong() {
+    return Math.round(Math.random() * 1000000);
+  }
+
+  private UnsignedLong randomUnsignedLong() {
+    return UnsignedLong.fromLongBits(randomLong());
+  }
+
+  private AttestationData randomAttestationData() {
+    return new AttestationData(
+        randomLong(),
+        randomUnsignedLong(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Bytes32.random(),
+        randomUnsignedLong(),
+        Bytes32.random());
+  }
+}

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/CasperSlashingTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/CasperSlashingTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.operations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.Arrays;
+import java.util.Objects;
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.bytes.Bytes32;
+import net.consensys.cava.bytes.Bytes48;
+import org.junit.jupiter.api.Test;
+
+class CasperSlashingTest {
+
+  @Test
+  void equalsReturnsTrueWhenObjectAreSame() {
+    SlashableVoteData votes1 = randomSlashableVoteData();
+    SlashableVoteData votes2 = randomSlashableVoteData();
+
+    CasperSlashing cs1 = new CasperSlashing(votes1, votes2);
+    CasperSlashing cs2 = cs1;
+
+    assertEquals(cs1, cs2);
+  }
+
+  @Test
+  void equalsReturnsTrueWhenObjectFieldsAreEqual() {
+    SlashableVoteData votes1 = randomSlashableVoteData();
+    SlashableVoteData votes2 = randomSlashableVoteData();
+
+    CasperSlashing cs1 = new CasperSlashing(votes1, votes2);
+    CasperSlashing cs2 = new CasperSlashing(votes1, votes2);
+
+    assertEquals(cs1, cs2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenVotes1IsDifferent() {
+    SlashableVoteData votes1 = randomSlashableVoteData();
+    SlashableVoteData votes2 = randomSlashableVoteData();
+
+    // SlashableVoteData is rather involved to create. Just create a random one until it is not the
+    // same as the original.
+    SlashableVoteData otherVotes1 = randomSlashableVoteData();
+    while (Objects.equals(otherVotes1, votes1)) {
+      otherVotes1 = randomSlashableVoteData();
+    }
+
+    CasperSlashing cs1 = new CasperSlashing(votes1, votes2);
+    CasperSlashing cs2 = new CasperSlashing(otherVotes1, votes2);
+
+    assertNotEquals(cs1, cs2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenVotes2IsDifferent() {
+    SlashableVoteData votes1 = randomSlashableVoteData();
+    SlashableVoteData votes2 = randomSlashableVoteData();
+
+    // SlashableVoteData is rather involved to create. Just create a random one until it is not the
+    // same as the original.
+    SlashableVoteData otherVotes2 = randomSlashableVoteData();
+    while (Objects.equals(otherVotes2, votes2)) {
+      otherVotes2 = randomSlashableVoteData();
+    }
+
+    CasperSlashing cs1 = new CasperSlashing(votes1, votes2);
+    CasperSlashing cs2 = new CasperSlashing(votes1, otherVotes2);
+
+    assertNotEquals(cs1, cs2);
+  }
+
+  @Test
+  void rountripSSZ() {
+    CasperSlashing casperSlashing =
+        new CasperSlashing(randomSlashableVoteData(), randomSlashableVoteData());
+    Bytes sszCasperSlashingBytes = casperSlashing.toBytes();
+    assertEquals(casperSlashing, CasperSlashing.fromBytes(sszCasperSlashingBytes));
+  }
+
+  private int randomInt() {
+    return (int) (Math.random() * 1000000);
+  }
+
+  private long randomLong() {
+    return Math.round(Math.random() * 1000000);
+  }
+
+  private UnsignedLong randomUnsignedLong() {
+    return UnsignedLong.fromLongBits(randomLong());
+  }
+
+  private AttestationData randomAttestationData() {
+    return new AttestationData(
+        randomLong(),
+        randomUnsignedLong(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Bytes32.random(),
+        randomUnsignedLong(),
+        Bytes32.random());
+  }
+
+  private SlashableVoteData randomSlashableVoteData() {
+    return new SlashableVoteData(
+        Arrays.asList(randomInt(), randomInt(), randomInt()),
+        Arrays.asList(randomInt(), randomInt(), randomInt()),
+        randomAttestationData(),
+        Arrays.asList(Bytes48.random(), Bytes48.random()));
+  }
+}

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/CasperSlashingTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/CasperSlashingTest.java
@@ -23,33 +23,27 @@ import org.junit.jupiter.api.Test;
 
 class CasperSlashingTest {
 
+  SlashableVoteData votes1 = randomSlashableVoteData();
+  SlashableVoteData votes2 = randomSlashableVoteData();
+
+  CasperSlashing casperSlashing = new CasperSlashing(votes1, votes2);
+
   @Test
   void equalsReturnsTrueWhenObjectAreSame() {
-    SlashableVoteData votes1 = randomSlashableVoteData();
-    SlashableVoteData votes2 = randomSlashableVoteData();
+    CasperSlashing testCasperSlashing = casperSlashing;
 
-    CasperSlashing cs1 = new CasperSlashing(votes1, votes2);
-    CasperSlashing cs2 = cs1;
-
-    assertEquals(cs1, cs2);
+    assertEquals(casperSlashing, testCasperSlashing);
   }
 
   @Test
   void equalsReturnsTrueWhenObjectFieldsAreEqual() {
-    SlashableVoteData votes1 = randomSlashableVoteData();
-    SlashableVoteData votes2 = randomSlashableVoteData();
+    CasperSlashing testCasperSlashing = new CasperSlashing(votes1, votes2);
 
-    CasperSlashing cs1 = new CasperSlashing(votes1, votes2);
-    CasperSlashing cs2 = new CasperSlashing(votes1, votes2);
-
-    assertEquals(cs1, cs2);
+    assertEquals(casperSlashing, testCasperSlashing);
   }
 
   @Test
   void equalsReturnsFalseWhenVotes1IsDifferent() {
-    SlashableVoteData votes1 = randomSlashableVoteData();
-    SlashableVoteData votes2 = randomSlashableVoteData();
-
     // SlashableVoteData is rather involved to create. Just create a random one until it is not the
     // same as the original.
     SlashableVoteData otherVotes1 = randomSlashableVoteData();
@@ -57,17 +51,13 @@ class CasperSlashingTest {
       otherVotes1 = randomSlashableVoteData();
     }
 
-    CasperSlashing cs1 = new CasperSlashing(votes1, votes2);
-    CasperSlashing cs2 = new CasperSlashing(otherVotes1, votes2);
+    CasperSlashing testCasperSlashing = new CasperSlashing(otherVotes1, votes2);
 
-    assertNotEquals(cs1, cs2);
+    assertNotEquals(casperSlashing, testCasperSlashing);
   }
 
   @Test
   void equalsReturnsFalseWhenVotes2IsDifferent() {
-    SlashableVoteData votes1 = randomSlashableVoteData();
-    SlashableVoteData votes2 = randomSlashableVoteData();
-
     // SlashableVoteData is rather involved to create. Just create a random one until it is not the
     // same as the original.
     SlashableVoteData otherVotes2 = randomSlashableVoteData();
@@ -75,16 +65,13 @@ class CasperSlashingTest {
       otherVotes2 = randomSlashableVoteData();
     }
 
-    CasperSlashing cs1 = new CasperSlashing(votes1, votes2);
-    CasperSlashing cs2 = new CasperSlashing(votes1, otherVotes2);
+    CasperSlashing testCasperSlashing = new CasperSlashing(votes1, otherVotes2);
 
-    assertNotEquals(cs1, cs2);
+    assertNotEquals(casperSlashing, testCasperSlashing);
   }
 
   @Test
   void rountripSSZ() {
-    CasperSlashing casperSlashing =
-        new CasperSlashing(randomSlashableVoteData(), randomSlashableVoteData());
     Bytes sszCasperSlashingBytes = casperSlashing.toBytes();
     assertEquals(casperSlashing, CasperSlashing.fromBytes(sszCasperSlashingBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/CasperSlashingTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/CasperSlashingTest.java
@@ -15,13 +15,10 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomSlashableVoteData;
 
-import com.google.common.primitives.UnsignedLong;
-import java.util.Arrays;
 import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
-import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
 
 class CasperSlashingTest {
@@ -90,37 +87,5 @@ class CasperSlashingTest {
         new CasperSlashing(randomSlashableVoteData(), randomSlashableVoteData());
     Bytes sszCasperSlashingBytes = casperSlashing.toBytes();
     assertEquals(casperSlashing, CasperSlashing.fromBytes(sszCasperSlashingBytes));
-  }
-
-  private int randomInt() {
-    return (int) (Math.random() * 1000000);
-  }
-
-  private long randomLong() {
-    return Math.round(Math.random() * 1000000);
-  }
-
-  private UnsignedLong randomUnsignedLong() {
-    return UnsignedLong.fromLongBits(randomLong());
-  }
-
-  private AttestationData randomAttestationData() {
-    return new AttestationData(
-        randomLong(),
-        randomUnsignedLong(),
-        Bytes32.random(),
-        Bytes32.random(),
-        Bytes32.random(),
-        Bytes32.random(),
-        randomUnsignedLong(),
-        Bytes32.random());
-  }
-
-  private SlashableVoteData randomSlashableVoteData() {
-    return new SlashableVoteData(
-        Arrays.asList(randomInt(), randomInt(), randomInt()),
-        Arrays.asList(randomInt(), randomInt(), randomInt()),
-        randomAttestationData(),
-        Arrays.asList(Bytes48.random(), Bytes48.random()));
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositDataTest.java
@@ -25,36 +25,28 @@ import org.junit.jupiter.api.Test;
 
 class DepositDataTest {
 
+  DepositInput depositInput = randomDepositInput();
+  UnsignedLong value = randomUnsignedLong();
+  UnsignedLong timestamp = randomUnsignedLong();
+
+  DepositData depositData = new DepositData(depositInput, value, timestamp);
+
   @Test
   void equalsReturnsTrueWhenObjectAreSame() {
-    DepositInput depositInput = randomDepositInput();
-    UnsignedLong value = randomUnsignedLong();
-    UnsignedLong timestamp = randomUnsignedLong();
+    DepositData testDepositData = depositData;
 
-    DepositData dd1 = new DepositData(depositInput, value, timestamp);
-    DepositData dd2 = dd1;
-
-    assertEquals(dd1, dd2);
+    assertEquals(depositData, testDepositData);
   }
 
   @Test
   void equalsReturnsTrueWhenObjectFieldsAreEqual() {
-    DepositInput depositInput = randomDepositInput();
-    UnsignedLong value = randomUnsignedLong();
-    UnsignedLong timestamp = randomUnsignedLong();
+    DepositData testDepositData = new DepositData(depositInput, value, timestamp);
 
-    DepositData dd1 = new DepositData(depositInput, value, timestamp);
-    DepositData dd2 = new DepositData(depositInput, value, timestamp);
-
-    assertEquals(dd1, dd2);
+    assertEquals(depositData, testDepositData);
   }
 
   @Test
   void equalsReturnsFalseWhenDepositInputsAreDifferent() {
-    DepositInput depositInput = randomDepositInput();
-    UnsignedLong value = randomUnsignedLong();
-    UnsignedLong timestamp = randomUnsignedLong();
-
     // DepositInput is rather involved to create. Just create a random one until it is not the same
     // as the original.
     DepositInput otherDepositInput = randomDepositInput();
@@ -62,40 +54,29 @@ class DepositDataTest {
       otherDepositInput = randomDepositInput();
     }
 
-    DepositData dd1 = new DepositData(depositInput, value, timestamp);
-    DepositData dd2 = new DepositData(otherDepositInput, value, timestamp);
+    DepositData testDepositData = new DepositData(otherDepositInput, value, timestamp);
 
-    assertNotEquals(dd1, dd2);
+    assertNotEquals(depositData, testDepositData);
   }
 
   @Test
   void equalsReturnsFalseWhenValuesAreDifferent() {
-    DepositInput depositInput = randomDepositInput();
-    UnsignedLong value = randomUnsignedLong();
-    UnsignedLong timestamp = randomUnsignedLong();
+    DepositData testDepositData =
+        new DepositData(depositInput, value.plus(randomUnsignedLong()), timestamp);
 
-    DepositData dd1 = new DepositData(depositInput, value, timestamp);
-    DepositData dd2 = new DepositData(depositInput, value.plus(randomUnsignedLong()), timestamp);
-
-    assertNotEquals(dd1, dd2);
+    assertNotEquals(depositData, testDepositData);
   }
 
   @Test
   void equalsReturnsFalseWhenTimestampsAreDifferent() {
-    DepositInput depositInput = randomDepositInput();
-    UnsignedLong value = randomUnsignedLong();
-    UnsignedLong timestamp = randomUnsignedLong();
+    DepositData testDepositData =
+        new DepositData(depositInput, value, timestamp.plus(randomUnsignedLong()));
 
-    DepositData dd1 = new DepositData(depositInput, value, timestamp);
-    DepositData dd2 = new DepositData(depositInput, value, timestamp.plus(randomUnsignedLong()));
-
-    assertNotEquals(dd1, dd2);
+    assertNotEquals(depositData, testDepositData);
   }
 
   @Test
   void rountripSSZ() {
-    DepositData depositData =
-        new DepositData(randomDepositInput(), randomUnsignedLong(), randomUnsignedLong());
     Bytes sszDepositDataBytes = depositData.toBytes();
     assertEquals(depositData, DepositData.fromBytes(sszDepositDataBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositDataTest.java
@@ -15,13 +15,12 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomDepositInput;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
-import java.util.Arrays;
 import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
-import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
 
 class DepositDataTest {
@@ -99,18 +98,5 @@ class DepositDataTest {
         new DepositData(randomDepositInput(), randomUnsignedLong(), randomUnsignedLong());
     Bytes sszDepositDataBytes = depositData.toBytes();
     assertEquals(depositData, DepositData.fromBytes(sszDepositDataBytes));
-  }
-
-  private long randomLong() {
-    return Math.round(Math.random() * 1000000);
-  }
-
-  private UnsignedLong randomUnsignedLong() {
-    return UnsignedLong.fromLongBits(randomLong());
-  }
-
-  private DepositInput randomDepositInput() {
-    return new DepositInput(
-        Bytes48.random(), Bytes32.random(), Arrays.asList(Bytes48.random(), Bytes48.random()));
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositDataTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.operations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.Arrays;
+import java.util.Objects;
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.bytes.Bytes32;
+import net.consensys.cava.bytes.Bytes48;
+import org.junit.jupiter.api.Test;
+
+class DepositDataTest {
+
+  @Test
+  void equalsReturnsTrueWhenObjectAreSame() {
+    DepositInput depositInput = randomDepositInput();
+    UnsignedLong value = randomUnsignedLong();
+    UnsignedLong timestamp = randomUnsignedLong();
+
+    DepositData dd1 = new DepositData(depositInput, value, timestamp);
+    DepositData dd2 = dd1;
+
+    assertEquals(dd1, dd2);
+  }
+
+  @Test
+  void equalsReturnsTrueWhenObjectFieldsAreEqual() {
+    DepositInput depositInput = randomDepositInput();
+    UnsignedLong value = randomUnsignedLong();
+    UnsignedLong timestamp = randomUnsignedLong();
+
+    DepositData dd1 = new DepositData(depositInput, value, timestamp);
+    DepositData dd2 = new DepositData(depositInput, value, timestamp);
+
+    assertEquals(dd1, dd2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenDepositInputsAreDifferent() {
+    DepositInput depositInput = randomDepositInput();
+    UnsignedLong value = randomUnsignedLong();
+    UnsignedLong timestamp = randomUnsignedLong();
+
+    // DepositInput is rather involved to create. Just create a random one until it is not the same
+    // as the original.
+    DepositInput otherDepositInput = randomDepositInput();
+    while (Objects.equals(otherDepositInput, depositInput)) {
+      otherDepositInput = randomDepositInput();
+    }
+
+    DepositData dd1 = new DepositData(depositInput, value, timestamp);
+    DepositData dd2 = new DepositData(otherDepositInput, value, timestamp);
+
+    assertNotEquals(dd1, dd2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenValuesAreDifferent() {
+    DepositInput depositInput = randomDepositInput();
+    UnsignedLong value = randomUnsignedLong();
+    UnsignedLong timestamp = randomUnsignedLong();
+
+    DepositData dd1 = new DepositData(depositInput, value, timestamp);
+    DepositData dd2 = new DepositData(depositInput, value.plus(randomUnsignedLong()), timestamp);
+
+    assertNotEquals(dd1, dd2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenTimestampsAreDifferent() {
+    DepositInput depositInput = randomDepositInput();
+    UnsignedLong value = randomUnsignedLong();
+    UnsignedLong timestamp = randomUnsignedLong();
+
+    DepositData dd1 = new DepositData(depositInput, value, timestamp);
+    DepositData dd2 = new DepositData(depositInput, value, timestamp.plus(randomUnsignedLong()));
+
+    assertNotEquals(dd1, dd2);
+  }
+
+  @Test
+  void rountripSSZ() {
+    DepositData depositData =
+        new DepositData(randomDepositInput(), randomUnsignedLong(), randomUnsignedLong());
+    Bytes sszDepositDataBytes = depositData.toBytes();
+    assertEquals(depositData, DepositData.fromBytes(sszDepositDataBytes));
+  }
+
+  private long randomLong() {
+    return Math.round(Math.random() * 1000000);
+  }
+
+  private UnsignedLong randomUnsignedLong() {
+    return UnsignedLong.fromLongBits(randomLong());
+  }
+
+  private DepositInput randomDepositInput() {
+    return new DepositInput(
+        Bytes48.random(), Bytes32.random(), Arrays.asList(Bytes48.random(), Bytes48.random()));
+  }
+}

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositInputTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositInputTest.java
@@ -27,77 +27,57 @@ import org.junit.jupiter.api.Test;
 
 class DepositInputTest {
 
+  Bytes48 pubkey = Bytes48.random();
+  Bytes32 withdrawalCredentials = Bytes32.random();
+  List<Bytes48> proofOfPossession = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+  DepositInput depositInput = new DepositInput(pubkey, withdrawalCredentials, proofOfPossession);
+
   @Test
   void equalsReturnsTrueWhenObjectAreSame() {
-    Bytes48 pubkey = Bytes48.random();
-    Bytes32 withdrawalCredentials = Bytes32.random();
-    List<Bytes48> proofOfPossession = Arrays.asList(Bytes48.random(), Bytes48.random());
+    DepositInput testDepositInput = depositInput;
 
-    DepositInput di1 = new DepositInput(pubkey, withdrawalCredentials, proofOfPossession);
-    DepositInput di2 = di1;
-
-    assertEquals(di1, di2);
+    assertEquals(depositInput, testDepositInput);
   }
 
   @Test
   void equalsReturnsTrueWhenObjectFieldsAreEqual() {
-    Bytes48 pubkey = Bytes48.random();
-    Bytes32 withdrawalCredentials = Bytes32.random();
-    List<Bytes48> proofOfPossession = Arrays.asList(Bytes48.random(), Bytes48.random());
+    DepositInput testDepositInput =
+        new DepositInput(pubkey, withdrawalCredentials, proofOfPossession);
 
-    DepositInput di1 = new DepositInput(pubkey, withdrawalCredentials, proofOfPossession);
-    DepositInput di2 = new DepositInput(pubkey, withdrawalCredentials, proofOfPossession);
-
-    assertEquals(di1, di2);
+    assertEquals(depositInput, testDepositInput);
   }
 
   @Test
   void equalsReturnsFalseWhenPubkeysAreDifferent() {
-    Bytes48 pubkey = Bytes48.random();
-    Bytes32 withdrawalCredentials = Bytes32.random();
-    List<Bytes48> proofOfPossession = Arrays.asList(Bytes48.random(), Bytes48.random());
+    DepositInput testDepositInput =
+        new DepositInput(pubkey.not(), withdrawalCredentials, proofOfPossession);
 
-    DepositInput di1 = new DepositInput(pubkey, withdrawalCredentials, proofOfPossession);
-    DepositInput di2 = new DepositInput(pubkey.not(), withdrawalCredentials, proofOfPossession);
-
-    assertNotEquals(di1, di2);
+    assertNotEquals(depositInput, testDepositInput);
   }
 
   @Test
   void equalsReturnsFalseWhenWithdrawalCredentialsAreDifferent() {
-    Bytes48 pubkey = Bytes48.random();
-    Bytes32 withdrawalCredentials = Bytes32.random();
-    List<Bytes48> proofOfPossession = Arrays.asList(Bytes48.random(), Bytes48.random());
+    DepositInput testDepositInput =
+        new DepositInput(pubkey, withdrawalCredentials.not(), proofOfPossession);
 
-    DepositInput di1 = new DepositInput(pubkey, withdrawalCredentials, proofOfPossession);
-    DepositInput di2 = new DepositInput(pubkey, withdrawalCredentials.not(), proofOfPossession);
-
-    assertNotEquals(di1, di2);
+    assertNotEquals(depositInput, testDepositInput);
   }
 
   @Test
   void equalsReturnsFalseWhenProofsOfPosessionAreDifferent() {
-    Bytes48 pubkey = Bytes48.random();
-    Bytes32 withdrawalCredentials = Bytes32.random();
-    List<Bytes48> proofOfPossession = Arrays.asList(Bytes48.random(), Bytes48.random());
-
     // Create copy of signature and reverse to ensure it is different.
     List<Bytes48> reverseProofOfPossession = new ArrayList<Bytes48>(proofOfPossession);
     Collections.reverse(reverseProofOfPossession);
 
-    DepositInput di1 = new DepositInput(pubkey, withdrawalCredentials, proofOfPossession);
-    DepositInput di2 = new DepositInput(pubkey, withdrawalCredentials, reverseProofOfPossession);
+    DepositInput testDepositInput =
+        new DepositInput(pubkey, withdrawalCredentials, reverseProofOfPossession);
 
-    assertNotEquals(di1, di2);
+    assertNotEquals(depositInput, testDepositInput);
   }
 
   @Test
   void rountripSSZ() {
-    DepositInput depositInput =
-        new DepositInput(
-            Bytes48.random(),
-            Bytes32.random(),
-            Arrays.asList(Bytes48.random(), Bytes48.random(), Bytes48.random()));
     Bytes sszDepositInputBytes = depositInput.toBytes();
     assertEquals(depositInput, DepositInput.fromBytes(sszDepositInputBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositInputTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositInputTest.java
@@ -13,7 +13,13 @@
 
 package tech.pegasys.artemis.datastructures.operations;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.bytes.Bytes48;
@@ -22,14 +28,77 @@ import org.junit.jupiter.api.Test;
 class DepositInputTest {
 
   @Test
+  void equalsReturnsTrueWhenObjectAreSame() {
+    Bytes48 pubkey = Bytes48.random();
+    Bytes32 withdrawalCredentials = Bytes32.random();
+    List<Bytes48> proofOfPossession = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    DepositInput di1 = new DepositInput(pubkey, withdrawalCredentials, proofOfPossession);
+    DepositInput di2 = di1;
+
+    assertEquals(di1, di2);
+  }
+
+  @Test
+  void equalsReturnsTrueWhenObjectFieldsAreEqual() {
+    Bytes48 pubkey = Bytes48.random();
+    Bytes32 withdrawalCredentials = Bytes32.random();
+    List<Bytes48> proofOfPossession = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    DepositInput di1 = new DepositInput(pubkey, withdrawalCredentials, proofOfPossession);
+    DepositInput di2 = new DepositInput(pubkey, withdrawalCredentials, proofOfPossession);
+
+    assertEquals(di1, di2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenPubkeysAreDifferent() {
+    Bytes48 pubkey = Bytes48.random();
+    Bytes32 withdrawalCredentials = Bytes32.random();
+    List<Bytes48> proofOfPossession = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    DepositInput di1 = new DepositInput(pubkey, withdrawalCredentials, proofOfPossession);
+    DepositInput di2 = new DepositInput(pubkey.not(), withdrawalCredentials, proofOfPossession);
+
+    assertNotEquals(di1, di2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenWithdrawalCredentialsAreDifferent() {
+    Bytes48 pubkey = Bytes48.random();
+    Bytes32 withdrawalCredentials = Bytes32.random();
+    List<Bytes48> proofOfPossession = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    DepositInput di1 = new DepositInput(pubkey, withdrawalCredentials, proofOfPossession);
+    DepositInput di2 = new DepositInput(pubkey, withdrawalCredentials.not(), proofOfPossession);
+
+    assertNotEquals(di1, di2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenProofsOfPosessionAreDifferent() {
+    Bytes48 pubkey = Bytes48.random();
+    Bytes32 withdrawalCredentials = Bytes32.random();
+    List<Bytes48> proofOfPossession = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    // Create copy of signature and reverse to ensure it is different.
+    List<Bytes48> reverseProofOfPossession = new ArrayList<Bytes48>(proofOfPossession);
+    Collections.reverse(reverseProofOfPossession);
+
+    DepositInput di1 = new DepositInput(pubkey, withdrawalCredentials, proofOfPossession);
+    DepositInput di2 = new DepositInput(pubkey, withdrawalCredentials, reverseProofOfPossession);
+
+    assertNotEquals(di1, di2);
+  }
+
+  @Test
   void rountripSSZ() {
-    DepositInput di =
+    DepositInput depositInput =
         new DepositInput(
             Bytes48.random(),
             Bytes32.random(),
             Arrays.asList(Bytes48.random(), Bytes48.random(), Bytes48.random()));
-    Bytes sszBytes = di.toBytes();
-    // TODO: SSZ testing needs fix after v0.01
-    // assertEquals(di, DepositInput.fromBytes(sszBytes));
+    Bytes sszDepositInputBytes = depositInput.toBytes();
+    assertEquals(depositInput, DepositInput.fromBytes(sszDepositInputBytes));
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositTest.java
@@ -15,6 +15,8 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomDepositData;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;
@@ -24,7 +26,6 @@ import java.util.List;
 import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
 
 class DepositTest {
@@ -114,22 +115,5 @@ class DepositTest {
             randomDepositData());
     Bytes sszDepositBytes = deposit.toBytes();
     assertEquals(deposit, Deposit.fromBytes(sszDepositBytes));
-  }
-
-  private long randomLong() {
-    return Math.round(Math.random() * 1000000);
-  }
-
-  private UnsignedLong randomUnsignedLong() {
-    return UnsignedLong.fromLongBits(randomLong());
-  }
-
-  private DepositInput randomDepositInput() {
-    return new DepositInput(
-        Bytes48.random(), Bytes32.random(), Arrays.asList(Bytes48.random(), Bytes48.random()));
-  }
-
-  private DepositData randomDepositData() {
-    return new DepositData(randomDepositInput(), randomUnsignedLong(), randomUnsignedLong());
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.operations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.bytes.Bytes32;
+import net.consensys.cava.bytes.Bytes48;
+import org.junit.jupiter.api.Test;
+
+class DepositTest {
+
+  @Test
+  void equalsReturnsTrueWhenObjectAreSame() {
+    List<Bytes32> merkleBranch =
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    UnsignedLong merkleTreeIndex = randomUnsignedLong();
+    DepositData depositData = randomDepositData();
+
+    Deposit d1 = new Deposit(merkleBranch, merkleTreeIndex, depositData);
+    Deposit d2 = d1;
+
+    assertEquals(d1, d2);
+  }
+
+  @Test
+  void equalsReturnsTrueWhenObjectFieldsAreEqual() {
+    List<Bytes32> merkleBranch =
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    UnsignedLong merkleTreeIndex = randomUnsignedLong();
+    DepositData depositData = randomDepositData();
+
+    Deposit d1 = new Deposit(merkleBranch, merkleTreeIndex, depositData);
+    Deposit d2 = new Deposit(merkleBranch, merkleTreeIndex, depositData);
+
+    assertEquals(d1, d2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenMerkleBranchesAreDifferent() {
+    List<Bytes32> merkleBranch =
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    UnsignedLong merkleTreeIndex = randomUnsignedLong();
+    DepositData depositData = randomDepositData();
+
+    // Create copy of signature and reverse to ensure it is different.
+    List<Bytes32> reversemerkleBranch = new ArrayList<Bytes32>(merkleBranch);
+    Collections.reverse(reversemerkleBranch);
+
+    Deposit d1 = new Deposit(merkleBranch, merkleTreeIndex, depositData);
+    Deposit d2 = new Deposit(reversemerkleBranch, merkleTreeIndex, depositData);
+
+    assertNotEquals(d1, d2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenMerkleTreeIndicesAreDifferent() {
+    List<Bytes32> merkleBranch =
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    UnsignedLong merkleTreeIndex = randomUnsignedLong();
+    DepositData depositData = randomDepositData();
+
+    Deposit d1 = new Deposit(merkleBranch, merkleTreeIndex, depositData);
+    Deposit d2 = new Deposit(merkleBranch, merkleTreeIndex.plus(randomUnsignedLong()), depositData);
+
+    assertNotEquals(d1, d2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenDepositDataIsDifferent() {
+    List<Bytes32> merkleBranch =
+        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    UnsignedLong merkleTreeIndex = randomUnsignedLong();
+    DepositData depositData = randomDepositData();
+
+    // DepositData is rather involved to create. Just create a random one until it is not the same
+    // as the original.
+    DepositData otherDepositData = randomDepositData();
+    while (Objects.equals(otherDepositData, depositData)) {
+      otherDepositData = randomDepositData();
+    }
+
+    Deposit d1 = new Deposit(merkleBranch, merkleTreeIndex, depositData);
+    Deposit d2 = new Deposit(merkleBranch, merkleTreeIndex, otherDepositData);
+
+    assertNotEquals(d1, d2);
+  }
+
+  @Test
+  void rountripSSZ() {
+    Deposit deposit =
+        new Deposit(
+            Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random()),
+            randomUnsignedLong(),
+            randomDepositData());
+    Bytes sszDepositBytes = deposit.toBytes();
+    assertEquals(deposit, Deposit.fromBytes(sszDepositBytes));
+  }
+
+  private long randomLong() {
+    return Math.round(Math.random() * 1000000);
+  }
+
+  private UnsignedLong randomUnsignedLong() {
+    return UnsignedLong.fromLongBits(randomLong());
+  }
+
+  private DepositInput randomDepositInput() {
+    return new DepositInput(
+        Bytes48.random(), Bytes32.random(), Arrays.asList(Bytes48.random(), Bytes48.random()));
+  }
+
+  private DepositData randomDepositData() {
+    return new DepositData(randomDepositInput(), randomUnsignedLong(), randomUnsignedLong());
+  }
+}

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositTest.java
@@ -30,69 +30,47 @@ import org.junit.jupiter.api.Test;
 
 class DepositTest {
 
+  List<Bytes32> merkleBranch = Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+  UnsignedLong merkleTreeIndex = randomUnsignedLong();
+  DepositData depositData = randomDepositData();
+
+  Deposit deposit = new Deposit(merkleBranch, merkleTreeIndex, depositData);
+
   @Test
   void equalsReturnsTrueWhenObjectAreSame() {
-    List<Bytes32> merkleBranch =
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
-    UnsignedLong merkleTreeIndex = randomUnsignedLong();
-    DepositData depositData = randomDepositData();
+    Deposit testDeposit = deposit;
 
-    Deposit d1 = new Deposit(merkleBranch, merkleTreeIndex, depositData);
-    Deposit d2 = d1;
-
-    assertEquals(d1, d2);
+    assertEquals(deposit, testDeposit);
   }
 
   @Test
   void equalsReturnsTrueWhenObjectFieldsAreEqual() {
-    List<Bytes32> merkleBranch =
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
-    UnsignedLong merkleTreeIndex = randomUnsignedLong();
-    DepositData depositData = randomDepositData();
+    Deposit testDeposit = new Deposit(merkleBranch, merkleTreeIndex, depositData);
 
-    Deposit d1 = new Deposit(merkleBranch, merkleTreeIndex, depositData);
-    Deposit d2 = new Deposit(merkleBranch, merkleTreeIndex, depositData);
-
-    assertEquals(d1, d2);
+    assertEquals(deposit, testDeposit);
   }
 
   @Test
   void equalsReturnsFalseWhenMerkleBranchesAreDifferent() {
-    List<Bytes32> merkleBranch =
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
-    UnsignedLong merkleTreeIndex = randomUnsignedLong();
-    DepositData depositData = randomDepositData();
-
     // Create copy of signature and reverse to ensure it is different.
     List<Bytes32> reversemerkleBranch = new ArrayList<Bytes32>(merkleBranch);
     Collections.reverse(reversemerkleBranch);
 
-    Deposit d1 = new Deposit(merkleBranch, merkleTreeIndex, depositData);
-    Deposit d2 = new Deposit(reversemerkleBranch, merkleTreeIndex, depositData);
+    Deposit testDeposit = new Deposit(reversemerkleBranch, merkleTreeIndex, depositData);
 
-    assertNotEquals(d1, d2);
+    assertNotEquals(deposit, testDeposit);
   }
 
   @Test
   void equalsReturnsFalseWhenMerkleTreeIndicesAreDifferent() {
-    List<Bytes32> merkleBranch =
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
-    UnsignedLong merkleTreeIndex = randomUnsignedLong();
-    DepositData depositData = randomDepositData();
+    Deposit testDeposit =
+        new Deposit(merkleBranch, merkleTreeIndex.plus(randomUnsignedLong()), depositData);
 
-    Deposit d1 = new Deposit(merkleBranch, merkleTreeIndex, depositData);
-    Deposit d2 = new Deposit(merkleBranch, merkleTreeIndex.plus(randomUnsignedLong()), depositData);
-
-    assertNotEquals(d1, d2);
+    assertNotEquals(deposit, testDeposit);
   }
 
   @Test
   void equalsReturnsFalseWhenDepositDataIsDifferent() {
-    List<Bytes32> merkleBranch =
-        Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
-    UnsignedLong merkleTreeIndex = randomUnsignedLong();
-    DepositData depositData = randomDepositData();
-
     // DepositData is rather involved to create. Just create a random one until it is not the same
     // as the original.
     DepositData otherDepositData = randomDepositData();
@@ -100,19 +78,13 @@ class DepositTest {
       otherDepositData = randomDepositData();
     }
 
-    Deposit d1 = new Deposit(merkleBranch, merkleTreeIndex, depositData);
-    Deposit d2 = new Deposit(merkleBranch, merkleTreeIndex, otherDepositData);
+    Deposit testDeposit = new Deposit(merkleBranch, merkleTreeIndex, otherDepositData);
 
-    assertNotEquals(d1, d2);
+    assertNotEquals(deposit, testDeposit);
   }
 
   @Test
   void rountripSSZ() {
-    Deposit deposit =
-        new Deposit(
-            Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random()),
-            randomUnsignedLong(),
-            randomDepositData());
     Bytes sszDepositBytes = deposit.toBytes();
     assertEquals(deposit, Deposit.fromBytes(sszDepositBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ExitTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ExitTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.operations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.bytes.Bytes48;
+import org.junit.jupiter.api.Test;
+
+class ExitTest {
+
+  @Test
+  void equalsReturnsTrueWhenObjectAreSame() {
+    UnsignedLong slot = randomUnsignedLong();
+    UnsignedLong validatorIndex = randomUnsignedLong();
+    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    Exit e1 = new Exit(slot, validatorIndex, signature);
+    Exit e2 = e1;
+
+    assertEquals(e1, e2);
+  }
+
+  @Test
+  void equalsReturnsTrueWhenObjectFieldsAreEqual() {
+    UnsignedLong slot = randomUnsignedLong();
+    UnsignedLong validatorIndex = randomUnsignedLong();
+    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    Exit e1 = new Exit(slot, validatorIndex, signature);
+    Exit e2 = new Exit(slot, validatorIndex, signature);
+
+    assertEquals(e1, e2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenSlotsAreDifferent() {
+    UnsignedLong slot = randomUnsignedLong();
+    UnsignedLong validatorIndex = randomUnsignedLong();
+    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    Exit e1 = new Exit(slot, validatorIndex, signature);
+    Exit e2 = new Exit(slot.plus(randomUnsignedLong()), validatorIndex, signature);
+
+    assertNotEquals(e1, e2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenValidatorIndicesAreDifferent() {
+    UnsignedLong slot = randomUnsignedLong();
+    UnsignedLong validatorIndex = randomUnsignedLong();
+    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    Exit e1 = new Exit(slot, validatorIndex, signature);
+    Exit e2 = new Exit(slot, validatorIndex.plus(randomUnsignedLong()), signature);
+
+    assertNotEquals(e1, e2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenSignaturesAreDifferent() {
+    UnsignedLong slot = randomUnsignedLong();
+    UnsignedLong validatorIndex = randomUnsignedLong();
+    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    // Create copy of signature and reverse to ensure it is different.
+    List<Bytes48> reverseSignature = new ArrayList<Bytes48>(signature);
+    Collections.reverse(reverseSignature);
+
+    Exit e1 = new Exit(slot, validatorIndex, signature);
+    Exit e2 = new Exit(slot, validatorIndex, reverseSignature);
+
+    assertNotEquals(e1, e2);
+  }
+
+  @Test
+  void rountripSSZ() {
+    Exit exit =
+        new Exit(
+            randomUnsignedLong(),
+            randomUnsignedLong(),
+            Arrays.asList(Bytes48.random(), Bytes48.random()));
+    Bytes sszExitBytes = exit.toBytes();
+    assertEquals(exit, Exit.fromBytes(sszExitBytes));
+  }
+
+  private long randomLong() {
+    return Math.round(Math.random() * 1000000);
+  }
+
+  private UnsignedLong randomUnsignedLong() {
+    return UnsignedLong.fromLongBits(randomLong());
+  }
+}

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ExitTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ExitTest.java
@@ -28,77 +28,53 @@ import org.junit.jupiter.api.Test;
 
 class ExitTest {
 
+  UnsignedLong slot = randomUnsignedLong();
+  UnsignedLong validatorIndex = randomUnsignedLong();
+  List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+  Exit exit = new Exit(slot, validatorIndex, signature);
+
   @Test
   void equalsReturnsTrueWhenObjectAreSame() {
-    UnsignedLong slot = randomUnsignedLong();
-    UnsignedLong validatorIndex = randomUnsignedLong();
-    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
+    Exit testExit = exit;
 
-    Exit e1 = new Exit(slot, validatorIndex, signature);
-    Exit e2 = e1;
-
-    assertEquals(e1, e2);
+    assertEquals(exit, testExit);
   }
 
   @Test
   void equalsReturnsTrueWhenObjectFieldsAreEqual() {
-    UnsignedLong slot = randomUnsignedLong();
-    UnsignedLong validatorIndex = randomUnsignedLong();
-    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
+    Exit testExit = new Exit(slot, validatorIndex, signature);
 
-    Exit e1 = new Exit(slot, validatorIndex, signature);
-    Exit e2 = new Exit(slot, validatorIndex, signature);
-
-    assertEquals(e1, e2);
+    assertEquals(exit, testExit);
   }
 
   @Test
   void equalsReturnsFalseWhenSlotsAreDifferent() {
-    UnsignedLong slot = randomUnsignedLong();
-    UnsignedLong validatorIndex = randomUnsignedLong();
-    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
+    Exit testExit = new Exit(slot.plus(randomUnsignedLong()), validatorIndex, signature);
 
-    Exit e1 = new Exit(slot, validatorIndex, signature);
-    Exit e2 = new Exit(slot.plus(randomUnsignedLong()), validatorIndex, signature);
-
-    assertNotEquals(e1, e2);
+    assertNotEquals(exit, testExit);
   }
 
   @Test
   void equalsReturnsFalseWhenValidatorIndicesAreDifferent() {
-    UnsignedLong slot = randomUnsignedLong();
-    UnsignedLong validatorIndex = randomUnsignedLong();
-    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
+    Exit testExit = new Exit(slot, validatorIndex.plus(randomUnsignedLong()), signature);
 
-    Exit e1 = new Exit(slot, validatorIndex, signature);
-    Exit e2 = new Exit(slot, validatorIndex.plus(randomUnsignedLong()), signature);
-
-    assertNotEquals(e1, e2);
+    assertNotEquals(exit, testExit);
   }
 
   @Test
   void equalsReturnsFalseWhenSignaturesAreDifferent() {
-    UnsignedLong slot = randomUnsignedLong();
-    UnsignedLong validatorIndex = randomUnsignedLong();
-    List<Bytes48> signature = Arrays.asList(Bytes48.random(), Bytes48.random());
-
     // Create copy of signature and reverse to ensure it is different.
     List<Bytes48> reverseSignature = new ArrayList<Bytes48>(signature);
     Collections.reverse(reverseSignature);
 
-    Exit e1 = new Exit(slot, validatorIndex, signature);
-    Exit e2 = new Exit(slot, validatorIndex, reverseSignature);
+    Exit testExit = new Exit(slot, validatorIndex, reverseSignature);
 
-    assertNotEquals(e1, e2);
+    assertNotEquals(exit, testExit);
   }
 
   @Test
   void rountripSSZ() {
-    Exit exit =
-        new Exit(
-            randomUnsignedLong(),
-            randomUnsignedLong(),
-            Arrays.asList(Bytes48.random(), Bytes48.random()));
     Bytes sszExitBytes = exit.toBytes();
     assertEquals(exit, Exit.fromBytes(sszExitBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ExitTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ExitTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;
@@ -100,13 +101,5 @@ class ExitTest {
             Arrays.asList(Bytes48.random(), Bytes48.random()));
     Bytes sszExitBytes = exit.toBytes();
     assertEquals(exit, Exit.fromBytes(sszExitBytes));
-  }
-
-  private long randomLong() {
-    return Math.round(Math.random() * 1000000);
-  }
-
-  private UnsignedLong randomUnsignedLong() {
-    return UnsignedLong.fromLongBits(randomLong());
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ProposerSlashingTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ProposerSlashingTest.java
@@ -15,15 +15,15 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomInt;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomProposalSignedData;
 
-import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
-import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.blocks.ProposalSignedData;
@@ -207,21 +207,5 @@ class ProposerSlashingTest {
             Arrays.asList(Bytes48.random(), Bytes48.random()));
     Bytes sszProposerSlashingBytes = proposerSlashing.toBytes();
     assertEquals(proposerSlashing, ProposerSlashing.fromBytes(sszProposerSlashingBytes));
-  }
-
-  private int randomInt() {
-    return (int) (Math.random() * 1000000);
-  }
-
-  private long randomLong() {
-    return Math.round(Math.random() * 1000000);
-  }
-
-  private UnsignedLong randomUnsignedLong() {
-    return UnsignedLong.fromLongBits(randomLong());
-  }
-
-  private ProposalSignedData randomProposalSignedData() {
-    return new ProposalSignedData(randomUnsignedLong(), randomUnsignedLong(), Bytes32.random());
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ProposerSlashingTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ProposerSlashingTest.java
@@ -30,52 +30,35 @@ import tech.pegasys.artemis.datastructures.blocks.ProposalSignedData;
 
 class ProposerSlashingTest {
 
+  int proposerIndex = randomInt();
+  ProposalSignedData proposalData1 = randomProposalSignedData();
+  List<Bytes48> proposalSignature1 = Arrays.asList(Bytes48.random(), Bytes48.random());
+  ProposalSignedData proposalData2 = randomProposalSignedData();
+  List<Bytes48> proposalSignature2 = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+  ProposerSlashing proposerSlashing =
+      new ProposerSlashing(
+          proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
+
   @Test
   void equalsReturnsTrueWhenObjectAreSame() {
-    int proposerIndex = randomInt();
-    ProposalSignedData proposalData1 = randomProposalSignedData();
-    List<Bytes48> proposalSignature1 = Arrays.asList(Bytes48.random(), Bytes48.random());
-    ProposalSignedData proposalData2 = randomProposalSignedData();
-    List<Bytes48> proposalSignature2 = Arrays.asList(Bytes48.random(), Bytes48.random());
+    ProposerSlashing testProposerSlashing = proposerSlashing;
 
-    ProposerSlashing ps1 =
-        new ProposerSlashing(
-            proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
-    ProposerSlashing ps2 = ps1;
-
-    assertEquals(ps1, ps2);
+    assertEquals(proposerSlashing, testProposerSlashing);
   }
 
   @Test
   void equalsReturnsTrueWhenObjectFieldsAreEqual() {
-    int proposerIndex = randomInt();
-    ProposalSignedData proposalData1 = randomProposalSignedData();
-    List<Bytes48> proposalSignature1 = Arrays.asList(Bytes48.random(), Bytes48.random());
-    ProposalSignedData proposalData2 = randomProposalSignedData();
-    List<Bytes48> proposalSignature2 = Arrays.asList(Bytes48.random(), Bytes48.random());
-
-    ProposerSlashing ps1 =
-        new ProposerSlashing(
-            proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
-    ProposerSlashing ps2 =
+    ProposerSlashing testProposerSlashing =
         new ProposerSlashing(
             proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
 
-    assertEquals(ps1, ps2);
+    assertEquals(proposerSlashing, testProposerSlashing);
   }
 
   @Test
   void equalsReturnsFalseWhenProposerIndicesAreDifferent() {
-    int proposerIndex = randomInt();
-    ProposalSignedData proposalData1 = randomProposalSignedData();
-    List<Bytes48> proposalSignature1 = Arrays.asList(Bytes48.random(), Bytes48.random());
-    ProposalSignedData proposalData2 = randomProposalSignedData();
-    List<Bytes48> proposalSignature2 = Arrays.asList(Bytes48.random(), Bytes48.random());
-
-    ProposerSlashing ps1 =
-        new ProposerSlashing(
-            proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
-    ProposerSlashing ps2 =
+    ProposerSlashing testProposerSlashing =
         new ProposerSlashing(
             proposerIndex + randomInt(),
             proposalData1,
@@ -83,17 +66,11 @@ class ProposerSlashingTest {
             proposalData2,
             proposalSignature2);
 
-    assertNotEquals(ps1, ps2);
+    assertNotEquals(proposerSlashing, testProposerSlashing);
   }
 
   @Test
   void equalsReturnsFalseWhenProposalData1IsDifferent() {
-    int proposerIndex = randomInt();
-    ProposalSignedData proposalData1 = randomProposalSignedData();
-    List<Bytes48> proposalSignature1 = Arrays.asList(Bytes48.random(), Bytes48.random());
-    ProposalSignedData proposalData2 = randomProposalSignedData();
-    List<Bytes48> proposalSignature2 = Arrays.asList(Bytes48.random(), Bytes48.random());
-
     // ProposalSignedData is rather involved to create. Just create a random one until it is not the
     // same as the original.
     ProposalSignedData otherProposalData1 = randomProposalSignedData();
@@ -101,10 +78,7 @@ class ProposerSlashingTest {
       otherProposalData1 = randomProposalSignedData();
     }
 
-    ProposerSlashing ps1 =
-        new ProposerSlashing(
-            proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
-    ProposerSlashing ps2 =
+    ProposerSlashing testProposerSlashing =
         new ProposerSlashing(
             proposerIndex,
             otherProposalData1,
@@ -112,25 +86,16 @@ class ProposerSlashingTest {
             proposalData2,
             proposalSignature2);
 
-    assertNotEquals(ps1, ps2);
+    assertNotEquals(proposerSlashing, testProposerSlashing);
   }
 
   @Test
   void equalsReturnsFalseWhenProposalSignature1sAreDifferent() {
-    int proposerIndex = randomInt();
-    ProposalSignedData proposalData1 = randomProposalSignedData();
-    List<Bytes48> proposalSignature1 = Arrays.asList(Bytes48.random(), Bytes48.random());
-    ProposalSignedData proposalData2 = randomProposalSignedData();
-    List<Bytes48> proposalSignature2 = Arrays.asList(Bytes48.random(), Bytes48.random());
-
     // Create copy of proposalSignature1 and reverse to ensure it is different.
     List<Bytes48> reverseProposalSignature1 = new ArrayList<Bytes48>(proposalSignature1);
     Collections.reverse(reverseProposalSignature1);
 
-    ProposerSlashing ps1 =
-        new ProposerSlashing(
-            proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
-    ProposerSlashing ps2 =
+    ProposerSlashing testProposerSlashing =
         new ProposerSlashing(
             proposerIndex,
             proposalData1,
@@ -138,17 +103,11 @@ class ProposerSlashingTest {
             proposalData2,
             proposalSignature2);
 
-    assertNotEquals(ps1, ps2);
+    assertNotEquals(proposerSlashing, testProposerSlashing);
   }
 
   @Test
   void equalsReturnsFalseWhenProposalData2IsDifferent() {
-    int proposerIndex = randomInt();
-    ProposalSignedData proposalData1 = randomProposalSignedData();
-    List<Bytes48> proposalSignature1 = Arrays.asList(Bytes48.random(), Bytes48.random());
-    ProposalSignedData proposalData2 = randomProposalSignedData();
-    List<Bytes48> proposalSignature2 = Arrays.asList(Bytes48.random(), Bytes48.random());
-
     // ProposalSignedData is rather involved to create. Just create a random one until it is not the
     // same as the original.
     ProposalSignedData otherProposalData2 = randomProposalSignedData();
@@ -156,10 +115,7 @@ class ProposerSlashingTest {
       otherProposalData2 = randomProposalSignedData();
     }
 
-    ProposerSlashing ps1 =
-        new ProposerSlashing(
-            proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
-    ProposerSlashing ps2 =
+    ProposerSlashing testProposerSlashing =
         new ProposerSlashing(
             proposerIndex,
             proposalData1,
@@ -167,25 +123,16 @@ class ProposerSlashingTest {
             otherProposalData2,
             proposalSignature2);
 
-    assertNotEquals(ps1, ps2);
+    assertNotEquals(proposerSlashing, testProposerSlashing);
   }
 
   @Test
   void equalsReturnsFalseWhenProposalSignature2sAreDifferent() {
-    int proposerIndex = randomInt();
-    ProposalSignedData proposalData1 = randomProposalSignedData();
-    List<Bytes48> proposalSignature1 = Arrays.asList(Bytes48.random(), Bytes48.random());
-    ProposalSignedData proposalData2 = randomProposalSignedData();
-    List<Bytes48> proposalSignature2 = Arrays.asList(Bytes48.random(), Bytes48.random());
-
     // Create copy of proposalSignature1 and reverse to ensure it is different.
     List<Bytes48> reverseProposalSignature2 = new ArrayList<Bytes48>(proposalSignature2);
     Collections.reverse(reverseProposalSignature2);
 
-    ProposerSlashing ps1 =
-        new ProposerSlashing(
-            proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
-    ProposerSlashing ps2 =
+    ProposerSlashing testProposerSlashing =
         new ProposerSlashing(
             proposerIndex,
             proposalData1,
@@ -193,18 +140,11 @@ class ProposerSlashingTest {
             proposalData2,
             reverseProposalSignature2);
 
-    assertNotEquals(ps1, ps2);
+    assertNotEquals(proposerSlashing, testProposerSlashing);
   }
 
   @Test
   void rountripSSZ() {
-    ProposerSlashing proposerSlashing =
-        new ProposerSlashing(
-            randomInt(),
-            randomProposalSignedData(),
-            Arrays.asList(Bytes48.random(), Bytes48.random()),
-            randomProposalSignedData(),
-            Arrays.asList(Bytes48.random(), Bytes48.random()));
     Bytes sszProposerSlashingBytes = proposerSlashing.toBytes();
     assertEquals(proposerSlashing, ProposerSlashing.fromBytes(sszProposerSlashingBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ProposerSlashingTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ProposerSlashingTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.operations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.bytes.Bytes32;
+import net.consensys.cava.bytes.Bytes48;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.blocks.ProposalSignedData;
+
+class ProposerSlashingTest {
+
+  @Test
+  void equalsReturnsTrueWhenObjectAreSame() {
+    int proposerIndex = randomInt();
+    ProposalSignedData proposalData1 = randomProposalSignedData();
+    List<Bytes48> proposalSignature1 = Arrays.asList(Bytes48.random(), Bytes48.random());
+    ProposalSignedData proposalData2 = randomProposalSignedData();
+    List<Bytes48> proposalSignature2 = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    ProposerSlashing ps1 =
+        new ProposerSlashing(
+            proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
+    ProposerSlashing ps2 = ps1;
+
+    assertEquals(ps1, ps2);
+  }
+
+  @Test
+  void equalsReturnsTrueWhenObjectFieldsAreEqual() {
+    int proposerIndex = randomInt();
+    ProposalSignedData proposalData1 = randomProposalSignedData();
+    List<Bytes48> proposalSignature1 = Arrays.asList(Bytes48.random(), Bytes48.random());
+    ProposalSignedData proposalData2 = randomProposalSignedData();
+    List<Bytes48> proposalSignature2 = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    ProposerSlashing ps1 =
+        new ProposerSlashing(
+            proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
+    ProposerSlashing ps2 =
+        new ProposerSlashing(
+            proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
+
+    assertEquals(ps1, ps2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenProposerIndicesAreDifferent() {
+    int proposerIndex = randomInt();
+    ProposalSignedData proposalData1 = randomProposalSignedData();
+    List<Bytes48> proposalSignature1 = Arrays.asList(Bytes48.random(), Bytes48.random());
+    ProposalSignedData proposalData2 = randomProposalSignedData();
+    List<Bytes48> proposalSignature2 = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    ProposerSlashing ps1 =
+        new ProposerSlashing(
+            proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
+    ProposerSlashing ps2 =
+        new ProposerSlashing(
+            proposerIndex + randomInt(),
+            proposalData1,
+            proposalSignature1,
+            proposalData2,
+            proposalSignature2);
+
+    assertNotEquals(ps1, ps2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenProposalData1IsDifferent() {
+    int proposerIndex = randomInt();
+    ProposalSignedData proposalData1 = randomProposalSignedData();
+    List<Bytes48> proposalSignature1 = Arrays.asList(Bytes48.random(), Bytes48.random());
+    ProposalSignedData proposalData2 = randomProposalSignedData();
+    List<Bytes48> proposalSignature2 = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    // ProposalSignedData is rather involved to create. Just create a random one until it is not the
+    // same as the original.
+    ProposalSignedData otherProposalData1 = randomProposalSignedData();
+    while (Objects.equals(otherProposalData1, proposalData1)) {
+      otherProposalData1 = randomProposalSignedData();
+    }
+
+    ProposerSlashing ps1 =
+        new ProposerSlashing(
+            proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
+    ProposerSlashing ps2 =
+        new ProposerSlashing(
+            proposerIndex,
+            otherProposalData1,
+            proposalSignature1,
+            proposalData2,
+            proposalSignature2);
+
+    assertNotEquals(ps1, ps2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenProposalSignature1sAreDifferent() {
+    int proposerIndex = randomInt();
+    ProposalSignedData proposalData1 = randomProposalSignedData();
+    List<Bytes48> proposalSignature1 = Arrays.asList(Bytes48.random(), Bytes48.random());
+    ProposalSignedData proposalData2 = randomProposalSignedData();
+    List<Bytes48> proposalSignature2 = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    // Create copy of proposalSignature1 and reverse to ensure it is different.
+    List<Bytes48> reverseProposalSignature1 = new ArrayList<Bytes48>(proposalSignature1);
+    Collections.reverse(reverseProposalSignature1);
+
+    ProposerSlashing ps1 =
+        new ProposerSlashing(
+            proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
+    ProposerSlashing ps2 =
+        new ProposerSlashing(
+            proposerIndex,
+            proposalData1,
+            reverseProposalSignature1,
+            proposalData2,
+            proposalSignature2);
+
+    assertNotEquals(ps1, ps2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenProposalData2IsDifferent() {
+    int proposerIndex = randomInt();
+    ProposalSignedData proposalData1 = randomProposalSignedData();
+    List<Bytes48> proposalSignature1 = Arrays.asList(Bytes48.random(), Bytes48.random());
+    ProposalSignedData proposalData2 = randomProposalSignedData();
+    List<Bytes48> proposalSignature2 = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    // ProposalSignedData is rather involved to create. Just create a random one until it is not the
+    // same as the original.
+    ProposalSignedData otherProposalData2 = randomProposalSignedData();
+    while (Objects.equals(otherProposalData2, proposalData2)) {
+      otherProposalData2 = randomProposalSignedData();
+    }
+
+    ProposerSlashing ps1 =
+        new ProposerSlashing(
+            proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
+    ProposerSlashing ps2 =
+        new ProposerSlashing(
+            proposerIndex,
+            proposalData1,
+            proposalSignature1,
+            otherProposalData2,
+            proposalSignature2);
+
+    assertNotEquals(ps1, ps2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenProposalSignature2sAreDifferent() {
+    int proposerIndex = randomInt();
+    ProposalSignedData proposalData1 = randomProposalSignedData();
+    List<Bytes48> proposalSignature1 = Arrays.asList(Bytes48.random(), Bytes48.random());
+    ProposalSignedData proposalData2 = randomProposalSignedData();
+    List<Bytes48> proposalSignature2 = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    // Create copy of proposalSignature1 and reverse to ensure it is different.
+    List<Bytes48> reverseProposalSignature2 = new ArrayList<Bytes48>(proposalSignature2);
+    Collections.reverse(reverseProposalSignature2);
+
+    ProposerSlashing ps1 =
+        new ProposerSlashing(
+            proposerIndex, proposalData1, proposalSignature1, proposalData2, proposalSignature2);
+    ProposerSlashing ps2 =
+        new ProposerSlashing(
+            proposerIndex,
+            proposalData1,
+            proposalSignature1,
+            proposalData2,
+            reverseProposalSignature2);
+
+    assertNotEquals(ps1, ps2);
+  }
+
+  @Test
+  void rountripSSZ() {
+    ProposerSlashing proposerSlashing =
+        new ProposerSlashing(
+            randomInt(),
+            randomProposalSignedData(),
+            Arrays.asList(Bytes48.random(), Bytes48.random()),
+            randomProposalSignedData(),
+            Arrays.asList(Bytes48.random(), Bytes48.random()));
+    Bytes sszProposerSlashingBytes = proposerSlashing.toBytes();
+    assertEquals(proposerSlashing, ProposerSlashing.fromBytes(sszProposerSlashingBytes));
+  }
+
+  private int randomInt() {
+    return (int) (Math.random() * 1000000);
+  }
+
+  private long randomLong() {
+    return Math.round(Math.random() * 1000000);
+  }
+
+  private UnsignedLong randomUnsignedLong() {
+    return UnsignedLong.fromLongBits(randomLong());
+  }
+
+  private ProposalSignedData randomProposalSignedData() {
+    return new ProposalSignedData(randomUnsignedLong(), randomUnsignedLong(), Bytes32.random());
+  }
+}

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/SlashableVoteDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/SlashableVoteDataTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.operations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.bytes.Bytes32;
+import net.consensys.cava.bytes.Bytes48;
+import org.junit.jupiter.api.Test;
+
+class SlashableVoteDataTest {
+
+  @Test
+  void equalsReturnsTrueWhenObjectAreSame() {
+    List<Integer> custodyBit0Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
+    List<Integer> custodyBit1Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
+    AttestationData data = randomAttestationData();
+    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    SlashableVoteData svd1 =
+        new SlashableVoteData(custodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
+    SlashableVoteData svd2 = svd1;
+
+    assertEquals(svd1, svd2);
+  }
+
+  @Test
+  void equalsReturnsTrueWhenObjectFieldsAreEqual() {
+    List<Integer> custodyBit0Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
+    List<Integer> custodyBit1Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
+    AttestationData data = randomAttestationData();
+    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    SlashableVoteData svd1 =
+        new SlashableVoteData(custodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
+    SlashableVoteData svd2 =
+        new SlashableVoteData(custodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
+
+    assertEquals(svd1, svd2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenCustodyBit0IndicesAreDifferent() {
+    List<Integer> custodyBit0Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
+    List<Integer> custodyBit1Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
+    AttestationData data = randomAttestationData();
+    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    // Create copy of custodyBit0Indices and reverse to ensure it is different.
+    List<Integer> reverseCustodyBit0Indices = new ArrayList<Integer>(custodyBit0Indices);
+    Collections.reverse(reverseCustodyBit0Indices);
+
+    SlashableVoteData svd1 =
+        new SlashableVoteData(custodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
+    SlashableVoteData svd2 =
+        new SlashableVoteData(
+            reverseCustodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
+
+    assertNotEquals(svd1, svd2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenCustodyBit1IndicesAreDifferent() {
+    List<Integer> custodyBit0Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
+    List<Integer> custodyBit1Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
+    AttestationData data = randomAttestationData();
+    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    // Create copy of custodyBit1Indices and reverse to ensure it is different.
+    List<Integer> reverseCustodyBit1Indices = new ArrayList<Integer>(custodyBit1Indices);
+    Collections.reverse(reverseCustodyBit1Indices);
+
+    SlashableVoteData svd1 =
+        new SlashableVoteData(custodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
+    SlashableVoteData svd2 =
+        new SlashableVoteData(
+            custodyBit0Indices, reverseCustodyBit1Indices, data, aggregateSignature);
+
+    assertNotEquals(svd1, svd2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenAttestationDataIsDifferent() {
+    List<Integer> custodyBit0Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
+    List<Integer> custodyBit1Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
+    AttestationData data = randomAttestationData();
+    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    // AttestationData is rather involved to create. Just create a random one until it is not the
+    // same as the original.
+    AttestationData otherData = randomAttestationData();
+    while (Objects.equals(otherData, data)) {
+      otherData = randomAttestationData();
+    }
+
+    SlashableVoteData svd1 =
+        new SlashableVoteData(custodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
+    SlashableVoteData svd2 =
+        new SlashableVoteData(
+            custodyBit0Indices, custodyBit1Indices, otherData, aggregateSignature);
+
+    assertNotEquals(svd1, svd2);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenAggregrateSignaturesAreDifferent() {
+    List<Integer> custodyBit0Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
+    List<Integer> custodyBit1Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
+    AttestationData data = randomAttestationData();
+    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+    // Create copy of custodyBit1Indices and reverse to ensure it is different.
+    List<Bytes48> reverseAggregateSignature = new ArrayList<Bytes48>(aggregateSignature);
+    Collections.reverse(reverseAggregateSignature);
+
+    SlashableVoteData svd1 =
+        new SlashableVoteData(custodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
+    SlashableVoteData svd2 =
+        new SlashableVoteData(
+            custodyBit0Indices, custodyBit1Indices, data, reverseAggregateSignature);
+
+    assertNotEquals(svd1, svd2);
+  }
+
+  @Test
+  void rountripSSZ() {
+    SlashableVoteData slashableVoteData =
+        new SlashableVoteData(
+            Arrays.asList(randomInt(), randomInt(), randomInt()),
+            Arrays.asList(randomInt(), randomInt(), randomInt()),
+            randomAttestationData(),
+            Arrays.asList(Bytes48.random(), Bytes48.random()));
+    Bytes sszSlashableVoteDataBytes = slashableVoteData.toBytes();
+    assertEquals(slashableVoteData, SlashableVoteData.fromBytes(sszSlashableVoteDataBytes));
+  }
+
+  private int randomInt() {
+    return (int) (Math.random() * 1000000);
+  }
+
+  private long randomLong() {
+    return Math.round(Math.random() * 1000000);
+  }
+
+  private UnsignedLong randomUnsignedLong() {
+    return UnsignedLong.fromLongBits(randomLong());
+  }
+
+  private AttestationData randomAttestationData() {
+    return new AttestationData(
+        randomLong(),
+        randomUnsignedLong(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Bytes32.random(),
+        Bytes32.random(),
+        randomUnsignedLong(),
+        Bytes32.random());
+  }
+}

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/SlashableVoteDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/SlashableVoteDataTest.java
@@ -15,15 +15,15 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomAttestationData;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomInt;
 
-import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
-import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
 
@@ -151,29 +151,5 @@ class SlashableVoteDataTest {
             Arrays.asList(Bytes48.random(), Bytes48.random()));
     Bytes sszSlashableVoteDataBytes = slashableVoteData.toBytes();
     assertEquals(slashableVoteData, SlashableVoteData.fromBytes(sszSlashableVoteDataBytes));
-  }
-
-  private int randomInt() {
-    return (int) (Math.random() * 1000000);
-  }
-
-  private long randomLong() {
-    return Math.round(Math.random() * 1000000);
-  }
-
-  private UnsignedLong randomUnsignedLong() {
-    return UnsignedLong.fromLongBits(randomLong());
-  }
-
-  private AttestationData randomAttestationData() {
-    return new AttestationData(
-        randomLong(),
-        randomUnsignedLong(),
-        Bytes32.random(),
-        Bytes32.random(),
-        Bytes32.random(),
-        Bytes32.random(),
-        randomUnsignedLong(),
-        Bytes32.random());
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/SlashableVoteDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/SlashableVoteDataTest.java
@@ -29,82 +29,57 @@ import org.junit.jupiter.api.Test;
 
 class SlashableVoteDataTest {
 
+  List<Integer> custodyBit0Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
+  List<Integer> custodyBit1Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
+  AttestationData data = randomAttestationData();
+  List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+
+  SlashableVoteData slashableVoteData =
+      new SlashableVoteData(custodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
+
   @Test
   void equalsReturnsTrueWhenObjectAreSame() {
-    List<Integer> custodyBit0Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
-    List<Integer> custodyBit1Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
-    AttestationData data = randomAttestationData();
-    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
+    SlashableVoteData testSlashableVoteData = slashableVoteData;
 
-    SlashableVoteData svd1 =
-        new SlashableVoteData(custodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
-    SlashableVoteData svd2 = svd1;
-
-    assertEquals(svd1, svd2);
+    assertEquals(slashableVoteData, testSlashableVoteData);
   }
 
   @Test
   void equalsReturnsTrueWhenObjectFieldsAreEqual() {
-    List<Integer> custodyBit0Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
-    List<Integer> custodyBit1Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
-    AttestationData data = randomAttestationData();
-    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
-
-    SlashableVoteData svd1 =
-        new SlashableVoteData(custodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
-    SlashableVoteData svd2 =
+    SlashableVoteData testSlashableVoteData =
         new SlashableVoteData(custodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
 
-    assertEquals(svd1, svd2);
+    assertEquals(slashableVoteData, testSlashableVoteData);
   }
 
   @Test
   void equalsReturnsFalseWhenCustodyBit0IndicesAreDifferent() {
-    List<Integer> custodyBit0Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
-    List<Integer> custodyBit1Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
-    AttestationData data = randomAttestationData();
-    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
-
     // Create copy of custodyBit0Indices and reverse to ensure it is different.
     List<Integer> reverseCustodyBit0Indices = new ArrayList<Integer>(custodyBit0Indices);
     Collections.reverse(reverseCustodyBit0Indices);
 
-    SlashableVoteData svd1 =
-        new SlashableVoteData(custodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
-    SlashableVoteData svd2 =
+    SlashableVoteData testSlashableVoteData =
         new SlashableVoteData(
             reverseCustodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
 
-    assertNotEquals(svd1, svd2);
+    assertNotEquals(slashableVoteData, testSlashableVoteData);
   }
 
   @Test
   void equalsReturnsFalseWhenCustodyBit1IndicesAreDifferent() {
-    List<Integer> custodyBit0Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
-    List<Integer> custodyBit1Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
-    AttestationData data = randomAttestationData();
-    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
-
     // Create copy of custodyBit1Indices and reverse to ensure it is different.
     List<Integer> reverseCustodyBit1Indices = new ArrayList<Integer>(custodyBit1Indices);
     Collections.reverse(reverseCustodyBit1Indices);
 
-    SlashableVoteData svd1 =
-        new SlashableVoteData(custodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
-    SlashableVoteData svd2 =
+    SlashableVoteData testSlashableVoteData =
         new SlashableVoteData(
             custodyBit0Indices, reverseCustodyBit1Indices, data, aggregateSignature);
 
-    assertNotEquals(svd1, svd2);
+    assertNotEquals(slashableVoteData, testSlashableVoteData);
   }
 
   @Test
   void equalsReturnsFalseWhenAttestationDataIsDifferent() {
-    List<Integer> custodyBit0Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
-    List<Integer> custodyBit1Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
-    AttestationData data = randomAttestationData();
-    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
-
     // AttestationData is rather involved to create. Just create a random one until it is not the
     // same as the original.
     AttestationData otherData = randomAttestationData();
@@ -112,43 +87,28 @@ class SlashableVoteDataTest {
       otherData = randomAttestationData();
     }
 
-    SlashableVoteData svd1 =
-        new SlashableVoteData(custodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
-    SlashableVoteData svd2 =
+    SlashableVoteData testSlashableVoteData =
         new SlashableVoteData(
             custodyBit0Indices, custodyBit1Indices, otherData, aggregateSignature);
 
-    assertNotEquals(svd1, svd2);
+    assertNotEquals(slashableVoteData, testSlashableVoteData);
   }
 
   @Test
   void equalsReturnsFalseWhenAggregrateSignaturesAreDifferent() {
-    List<Integer> custodyBit0Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
-    List<Integer> custodyBit1Indices = Arrays.asList(randomInt(), randomInt(), randomInt());
-    AttestationData data = randomAttestationData();
-    List<Bytes48> aggregateSignature = Arrays.asList(Bytes48.random(), Bytes48.random());
-
     // Create copy of custodyBit1Indices and reverse to ensure it is different.
     List<Bytes48> reverseAggregateSignature = new ArrayList<Bytes48>(aggregateSignature);
     Collections.reverse(reverseAggregateSignature);
 
-    SlashableVoteData svd1 =
-        new SlashableVoteData(custodyBit0Indices, custodyBit1Indices, data, aggregateSignature);
-    SlashableVoteData svd2 =
+    SlashableVoteData testSlashableVoteData =
         new SlashableVoteData(
             custodyBit0Indices, custodyBit1Indices, data, reverseAggregateSignature);
 
-    assertNotEquals(svd1, svd2);
+    assertNotEquals(slashableVoteData, testSlashableVoteData);
   }
 
   @Test
   void rountripSSZ() {
-    SlashableVoteData slashableVoteData =
-        new SlashableVoteData(
-            Arrays.asList(randomInt(), randomInt(), randomInt()),
-            Arrays.asList(randomInt(), randomInt(), randomInt()),
-            randomAttestationData(),
-            Arrays.asList(Bytes48.random(), Bytes48.random()));
     Bytes sszSlashableVoteDataBytes = slashableVoteData.toBytes();
     assertEquals(slashableVoteData, SlashableVoteData.fromBytes(sszSlashableVoteDataBytes));
   }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -31,7 +31,7 @@ dependencyManagement {
     dependency 'io.vertx:vertx-web:3.6.3'
 
 
-    dependencySet(group: 'net.consensys.cava', version: '1.0.0-425F50-snapshot') {
+    dependencySet(group: 'net.consensys.cava', version: '1.0.0-752375-snapshot') {
       entry 'cava-bytes'
       entry 'cava-crypto'
       entry 'cava-junit'

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/MockP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/MockP2PNetwork.java
@@ -13,31 +13,17 @@
 
 package tech.pegasys.artemis.networking.p2p;
 
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomAttestation;
+import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBeaconBlock;
+
 import com.google.common.eventbus.EventBus;
-import com.google.common.primitives.UnsignedLong;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
-import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import tech.pegasys.artemis.datastructures.Constants;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
-import tech.pegasys.artemis.datastructures.blocks.BeaconBlockBody;
-import tech.pegasys.artemis.datastructures.blocks.Eth1Data;
-import tech.pegasys.artemis.datastructures.blocks.ProposalSignedData;
 import tech.pegasys.artemis.datastructures.operations.Attestation;
-import tech.pegasys.artemis.datastructures.operations.AttestationData;
-import tech.pegasys.artemis.datastructures.operations.CasperSlashing;
-import tech.pegasys.artemis.datastructures.operations.Deposit;
-import tech.pegasys.artemis.datastructures.operations.DepositData;
-import tech.pegasys.artemis.datastructures.operations.DepositInput;
-import tech.pegasys.artemis.datastructures.operations.Exit;
-import tech.pegasys.artemis.datastructures.operations.ProposerSlashing;
-import tech.pegasys.artemis.datastructures.operations.SlashableVoteData;
 import tech.pegasys.artemis.networking.p2p.api.P2PNetwork;
 
 public class MockP2PNetwork implements P2PNetwork {
@@ -110,95 +96,15 @@ public class MockP2PNetwork implements P2PNetwork {
         long n = 1000L * Integer.toUnsignedLong(random.nextInt(7) + 2);
         Thread.sleep(n);
         if (n % 3 == 0) {
-          BeaconBlock block = createEmptyBeaconBlock(n);
+          BeaconBlock block = randomBeaconBlock(n);
           this.eventBus.post(block);
         } else {
-          Attestation attestation = createEmptyAttestation(n);
+          Attestation attestation = randomAttestation(n);
           this.eventBus.post(attestation);
         }
       }
     } catch (InterruptedException e) {
       LOG.warn(e.toString());
     }
-  }
-
-  // TODO: These helper methods below almost certianly belong somewhere else.
-  private Attestation createEmptyAttestation(long slotNum) {
-    return new Attestation(
-        createEmptyAttestationData(slotNum), Bytes32.ZERO, Bytes32.ZERO, Constants.EMPTY_SIGNATURE);
-  }
-
-  private AttestationData createEmptyAttestationData(long slotNum) {
-    return new AttestationData(
-        slotNum,
-        UnsignedLong.ZERO,
-        Bytes32.ZERO,
-        Bytes32.ZERO,
-        Bytes32.ZERO,
-        Bytes32.ZERO,
-        UnsignedLong.ZERO,
-        Bytes32.ZERO);
-  }
-
-  private BeaconBlock createEmptyBeaconBlock(long slotNum) {
-    return new BeaconBlock(
-        slotNum,
-        Arrays.asList(Bytes32.ZERO),
-        Bytes32.ZERO,
-        Constants.EMPTY_SIGNATURE,
-        new Eth1Data(Bytes32.ZERO, Bytes32.ZERO),
-        Constants.EMPTY_SIGNATURE,
-        createEmptyBeaconBlockBody(slotNum));
-  }
-
-  private BeaconBlockBody createEmptyBeaconBlockBody(long slotNum) {
-    return new BeaconBlockBody(
-        Arrays.asList(createEmptyAttestation(slotNum)),
-        Arrays.asList(createEmptyProposerSlashing()),
-        Arrays.asList(createEmptyCasperSlashing(slotNum)),
-        Arrays.asList(createEmptyDeposit()),
-        Arrays.asList(createEmptyExit()));
-  }
-
-  private ProposerSlashing createEmptyProposerSlashing() {
-    return new ProposerSlashing(
-        0,
-        createEmptyProposalSignedData(),
-        Constants.EMPTY_SIGNATURE,
-        createEmptyProposalSignedData(),
-        Constants.EMPTY_SIGNATURE);
-  }
-
-  private ProposalSignedData createEmptyProposalSignedData() {
-    return new ProposalSignedData(UnsignedLong.ZERO, UnsignedLong.ZERO, Bytes32.ZERO);
-  }
-
-  private CasperSlashing createEmptyCasperSlashing(long slotNum) {
-    return new CasperSlashing(
-        createEmptySlashableVoteData(slotNum), createEmptySlashableVoteData(slotNum));
-  }
-
-  private SlashableVoteData createEmptySlashableVoteData(long slotNum) {
-    return new SlashableVoteData(
-        Arrays.asList(0),
-        Arrays.asList(0),
-        createEmptyAttestationData(slotNum),
-        Constants.EMPTY_SIGNATURE);
-  }
-
-  private Deposit createEmptyDeposit() {
-    return new Deposit(Arrays.asList(Bytes32.ZERO), UnsignedLong.ZERO, createEmptyDepositData());
-  }
-
-  private DepositData createEmptyDepositData() {
-    return new DepositData(createEmptyDepositInput(), UnsignedLong.ZERO, UnsignedLong.ZERO);
-  }
-
-  private DepositInput createEmptyDepositInput() {
-    return new DepositInput(Bytes48.ZERO, Bytes32.ZERO, new ArrayList<Bytes48>());
-  }
-
-  private Exit createEmptyExit() {
-    return new Exit(UnsignedLong.ZERO, UnsignedLong.ZERO, Constants.EMPTY_SIGNATURE);
   }
 }


### PR DESCRIPTION
## PR Description
This PR implements SSZ toBytes/fromBytes and tests the round trip serialization for datastructures in:

- `tech.pegasys.artemis.datastructures.blocks`
- `tech.pegasys.artemis.datastructures.operations`  


_**Note**: The following classes were excluded from SSZ implementation in this PR:_

- `tech.pegasys.artemis.datastructures.blocks`:
  - `Eth1DataVote`
- `tech.pegasys.artemis.datastructures.operations`:
  - `AttestationDataAndCustodyBit`
  - `LatestBlockRoots`
  - `ProofOfCustodyChallenge`
  - `ProofOfCustodyResponse`
  - `ProofOfCustodySeedChange`

## Fixed Issue(s)
Fixes #234 
Fixes #270
