### PR TITLE
Fix: UnsignedLong.valueOf to UnsignedLong.fromLongBits

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/AttestationData.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/AttestationData.java
@@ -55,12 +55,12 @@ public class AttestationData {
         reader ->
             new AttestationData(
                 reader.readUInt64(),
-                UnsignedLong.valueOf(reader.readUInt64()),
+                UnsignedLong.fromLongBits(reader.readUInt64()),
                 Bytes32.wrap(reader.readBytes()),
                 Bytes32.wrap(reader.readBytes()),
                 Bytes32.wrap(reader.readBytes()),
                 Bytes32.wrap(reader.readBytes()),
-                UnsignedLong.valueOf(reader.readUInt64()),
+                UnsignedLong.fromLongBits(reader.readUInt64()),
                 Bytes32.wrap(reader.readBytes())));
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/AttestationUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/AttestationUtil.java
@@ -46,9 +46,9 @@ public class AttestationUtil {
                   .getSlot()
                   .minus(UnsignedLong.valueOf(2))
                   .times(UnsignedLong.valueOf(Constants.EPOCH_LENGTH))
-                  .compareTo(UnsignedLong.valueOf(record.getData().getSlot()))
+                  .compareTo(UnsignedLong.fromLongBits(record.getData().getSlot()))
               <= 0
-          && UnsignedLong.valueOf(record.getData().getSlot())
+          && UnsignedLong.fromLongBits(record.getData().getSlot())
                   .compareTo(state.getSlot().minus(UnsignedLong.valueOf(Constants.EPOCH_LENGTH)))
               < 0) previous_epoch_attestations.add(record);
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
@@ -219,7 +219,7 @@ public class BeaconStateUtil {
     for (int i = 0; i < committees_per_slot; i++) {
       CrosslinkCommittee committee =
           new CrosslinkCommittee(
-              UnsignedLong.valueOf(committees_per_slot * offset + i),
+              UnsignedLong.fromLongBits(committees_per_slot * offset + i),
               shuffling.get(toIntExact(slot_start_shard + i) % Constants.SHARD_COUNT));
       crosslink_committees_at_slot.add(committee);
     }
@@ -380,7 +380,7 @@ public class BeaconStateUtil {
   public static Bytes32 get_block_root(BeaconState state, long slot) throws Exception {
     long slot_upper_bound = slot + state.getLatest_block_roots().size();
     // TODO: change values to UnsignedLong
-    if ((state.getSlot().compareTo(UnsignedLong.valueOf(slot_upper_bound)) <= 0)
+    if ((state.getSlot().compareTo(UnsignedLong.fromLongBits(slot_upper_bound)) <= 0)
         || UnsignedLong.valueOf(slot).compareTo(state.getSlot()) < 0)
       return state
           .getLatest_block_roots()

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
@@ -34,7 +34,7 @@ public class EpochProcessorUtil {
         state
             .getJustification_bitfield()
             .times(UnsignedLong.valueOf(2))
-            .mod(UnsignedLong.valueOf((long) Math.pow(2, 64))));
+            .mod(UnsignedLong.fromLongBits((long) Math.pow(2, 64))));
     double total_balance = BeaconStateUtil.calc_total_balance(state);
     // TODO: change values to UnsignedLong
     // TODO: Method requires major changes following BeaconState refactor


### PR DESCRIPTION
## PR Description
Change UnsignedLong.valueOf to UnsignedLong.fromLongBits when potential signed integer overrun can occur.

## Fixed Issue(s)
Fixes #272 
