### PR TITLE
Move the Signature type closer to the BLS routines

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/BLSSignature.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/BLSSignature.java
@@ -13,19 +13,15 @@
 
 package tech.pegasys.artemis.datastructures.operations;
 
-import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.ssz.SSZ;
+import tech.pegasys.artemis.util.bls.Signature;
 
-public final class BLSSignature {
-
-  Bytes48 c0;
-  Bytes48 c1;
+public final class BLSSignature extends Signature {
 
   public BLSSignature(Bytes48 c0, Bytes48 c1) {
-    this.c0 = c0;
-    this.c1 = c1;
+    super(c0, c1);
   }
 
   public static BLSSignature fromBytes(Bytes bytes) {
@@ -41,49 +37,5 @@ public final class BLSSignature {
           writer.writeBytes(c0);
           writer.writeBytes(c1);
         });
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(c0, c1);
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (Objects.isNull(obj)) {
-      return false;
-    }
-
-    if (this == obj) {
-      return true;
-    }
-
-    if (!(obj instanceof BLSSignature)) {
-      return false;
-    }
-
-    BLSSignature other = (BLSSignature) obj;
-    return Objects.equals(this.getC0(), other.getC0())
-        && Objects.equals(this.getC1(), other.getC1());
-  }
-
-  /** @return the c0 */
-  public Bytes48 getC0() {
-    return c0;
-  }
-
-  /** @param c0 the c0 to set */
-  public void setC0(Bytes48 c0) {
-    this.c0 = c0;
-  }
-
-  /** @return the c1 */
-  public Bytes48 getC1() {
-    return c1;
-  }
-
-  /** @param c1 the c1 to set */
-  public void setC1(Bytes48 c1) {
-    this.c1 = c1;
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
@@ -33,7 +33,6 @@ import static tech.pegasys.artemis.util.bls.BLSVerify.bls_verify;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import net.consensys.cava.bytes.Bytes;
@@ -751,8 +750,8 @@ public class BeaconStateUtil {
     DepositInput proof_of_possession_data =
         new DepositInput(pubkey, withdrawal_credentials, proof_of_possession);
 
-    List<Bytes48> signature =
-        Arrays.asList(
+    BLSSignature signature =
+        new BLSSignature(
             Bytes48.leftPad(proof_of_possession.getC0()),
             Bytes48.leftPad(proof_of_possession.getC1()));
     UnsignedLong domain = get_domain(state.getFork(), state.getSlot(), DOMAIN_DEPOSIT);

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSVerify.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSVerify.java
@@ -14,14 +14,13 @@
 package tech.pegasys.artemis.util.bls;
 
 import com.google.common.primitives.UnsignedLong;
-import java.util.List;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.bytes.Bytes48;
 
 public class BLSVerify {
 
   public static boolean bls_verify(
-      Bytes48 pubkey, Bytes32 message, List<Bytes48> signature, UnsignedLong domain) {
+      Bytes48 pubkey, Bytes32 message, Signature signature, UnsignedLong domain) {
     return true;
   }
 }

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/Signature.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/Signature.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.util.bls;
+
+import java.util.Objects;
+import net.consensys.cava.bytes.Bytes48;
+
+public class Signature {
+
+  protected final Bytes48 c0;
+  protected final Bytes48 c1;
+
+  public Signature(Bytes48 c0, Bytes48 c1) {
+    this.c0 = c0;
+    this.c1 = c1;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(c0, c1);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (Objects.isNull(obj)) {
+      return false;
+    }
+
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof Signature)) {
+      return false;
+    }
+
+    Signature other = (Signature) obj;
+    return Objects.equals(this.getC0(), other.getC0())
+        && Objects.equals(this.getC1(), other.getC1());
+  }
+
+  /** @return the c0 */
+  public Bytes48 getC0() {
+    return c0;
+  }
+
+  /** @return the c1 */
+  public Bytes48 getC1() {
+    return c1;
+  }
+}


### PR DESCRIPTION
Create a new `Signature` type in the BLS package.
Modify `BLSSignature` to extend it.
Use the new type when calling `bls_verify()`.

I can redo this with composition rather than inheritance if required (our guidelines say that we prefer composition), but I think inheritance is quite natural here.