### PR TITLE
reward and penalty helper functions

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
@@ -930,12 +930,14 @@ public class BeaconStateUtil {
    * @param n highest bound of x.
    * @return x
    */
-  private int integer_squareroot(int n) {
-    int x = n;
-    int y = (x + 1) / 2;
-    while (y < x) {
+  public static UnsignedLong integer_squareroot(UnsignedLong n) {
+    checkArgument(n.compareTo(UnsignedLong.ZERO) >= 0);
+    UnsignedLong TWO = UnsignedLong.valueOf(2L);
+    UnsignedLong x = n;
+    UnsignedLong y = x.plus(UnsignedLong.ONE).dividedBy(TWO);
+    while (y.compareTo(x) < 0) {
       x = y;
-      y = (x + n / x) / 2;
+      y = x.plus(n.dividedBy(x)).dividedBy(TWO);
     }
     return x;
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtilTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtilTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.artemis.statetransition.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.primitives.UnsignedLong;
 import net.consensys.cava.junit.BouncyCastleExtension;
@@ -29,6 +30,7 @@ class BeaconStateUtilTest {
     assertEquals(expected, actual);
   }
 
+  @Test
   void minReturnsMinWhenEqual() {
     UnsignedLong actual = BeaconStateUtil.min(UnsignedLong.valueOf(12L), UnsignedLong.valueOf(12L));
     UnsignedLong expected = UnsignedLong.valueOf(12L);
@@ -42,9 +44,33 @@ class BeaconStateUtilTest {
     assertEquals(expected, actual);
   }
 
+  @Test
   void maxReturnsMaxWhenEqual() {
     UnsignedLong actual = BeaconStateUtil.max(UnsignedLong.valueOf(13L), UnsignedLong.valueOf(13L));
     UnsignedLong expected = UnsignedLong.valueOf(13L);
     assertEquals(expected, actual);
+  }
+
+  @Test
+  void sqrtOfSquareNumber() {
+    UnsignedLong actual = BeaconStateUtil.integer_squareroot(UnsignedLong.valueOf(3481L));
+    UnsignedLong expected = UnsignedLong.valueOf(59L);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void sqrtOfANonSquareNumber() {
+    UnsignedLong actual = BeaconStateUtil.integer_squareroot(UnsignedLong.valueOf(27L));
+    UnsignedLong expected = UnsignedLong.valueOf(5L);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void sqrtOfANegativeNumber() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          BeaconStateUtil.integer_squareroot(UnsignedLong.valueOf(-1L));
+        });
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Added the helper functions defined in the spec:
```
First, we define some additional helpers:

Let base_reward_quotient = integer_squareroot(previous_total_balance) // BASE_REWARD_QUOTIENT.
Let base_reward(state, index) = get_effective_balance(state, index) // base_reward_quotient // 5 for any validator with the given index.
Let inactivity_penalty(state, index, epochs_since_finality) = base_reward(state, index) + get_effective_balance(state, index) * epochs_since_finality // INACTIVITY_PENALTY_QUOTIENT // 2 for any validator with the given index.
```

also, had to update the integer square root function to work with UnsignedLongs (and wrote unit tests for it)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->

resolves part of #296
