### PR TITLE
Update justification helper methods

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
@@ -429,16 +429,20 @@ public class BeaconStateUtil {
     return randao_mixes.get(index.intValue());
   }
 
-  // https://github.com/ethereum/eth2.0-specs/blob/master/specs/core/0_beacon-chain.md#get_block_root
-  public static Bytes32 get_block_root(BeaconState state, long slot) throws Exception {
-    long slot_upper_bound = slot + state.getLatest_block_roots().size();
-    // TODO: change values to UnsignedLong
-    if ((state.getSlot().compareTo(UnsignedLong.fromLongBits(slot_upper_bound)) <= 0)
-        || UnsignedLong.valueOf(slot).compareTo(state.getSlot()) < 0)
-      return state
-          .getLatest_block_roots()
-          .get(toIntExact(slot) % state.getLatest_block_roots().size());
-    throw new BlockValidationException("Desired block root not within the provided bounds");
+  //  Return the block root at a recent ``slot``.
+  public static Bytes32 get_block_root(BeaconState state, UnsignedLong slot) throws Exception {
+    if ((state
+                .getSlot()
+                .compareTo(slot.plus(UnsignedLong.valueOf(Constants.LATEST_BLOCK_ROOTS_LENGTH)))
+            <= 0)
+        || (slot.compareTo(state.getSlot()) < 0)) {
+      throw new BlockValidationException("Desired block root not within the provided bounds");
+    }
+
+    // Todo: Remove .intValue() as soon as our list wrapper supports unsigned longs
+    return state
+        .getLatest_block_roots()
+        .get(slot.mod(UnsignedLong.valueOf(Constants.LATEST_BLOCK_ROOTS_LENGTH)).intValue());
   }
 
   /*

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
@@ -28,7 +28,7 @@ import net.consensys.cava.bytes.Bytes32;
 import tech.pegasys.artemis.datastructures.Constants;
 import tech.pegasys.artemis.datastructures.state.Crosslink;
 import tech.pegasys.artemis.datastructures.state.CrosslinkCommittee;
-import tech.pegasys.artemis.datastructures.state.PendingAttestationRecord;
+import tech.pegasys.artemis.datastructures.state.PendingAttestation;
 import tech.pegasys.artemis.datastructures.state.Validator;
 import tech.pegasys.artemis.statetransition.BeaconState;
 import tech.pegasys.artemis.util.bitwise.BitwiseOps;
@@ -103,7 +103,7 @@ public class EpochProcessorUtil {
     state.setJustified_epoch(new_justified_epoch);
   }
 
-  public static void updateCrosslinks(BeaconState state) throws BlockValidationException {
+  public static void updateCrosslinks(BeaconState state) throws Exception {
     UnsignedLong current_epoch = BeaconStateUtil.get_current_epoch(state);
     UnsignedLong slot = state.getSlot();
     UnsignedLong end = UnsignedLong.valueOf(2 * Constants.EPOCH_LENGTH);
@@ -312,11 +312,11 @@ public class EpochProcessorUtil {
     UnsignedLong current_epoch = BeaconStateUtil.get_current_epoch(state);
 
     // Get current_epoch_attestations
-    List<PendingAttestationRecord> current_epoch_attestations =
+    List<PendingAttestation> current_epoch_attestations =
         AttestationUtil.get_epoch_attestations(state, current_epoch);
 
     // Get current epoch_boundary_attestations
-    List<PendingAttestationRecord> current_epoch_boundary_attestations =
+    List<PendingAttestation> current_epoch_boundary_attestations =
         AttestationUtil.get_current_epoch_boundary_attestations(state, current_epoch_attestations);
 
     // Get current_epoch_boundary_attester_indices
@@ -344,11 +344,11 @@ public class EpochProcessorUtil {
     UnsignedLong previous_epoch = BeaconStateUtil.get_previous_epoch(state);
 
     // Get previous_epoch_attestations
-    List<PendingAttestationRecord> previous_epoch_attestations =
+    List<PendingAttestation> previous_epoch_attestations =
         AttestationUtil.get_epoch_attestations(state, previous_epoch);
 
     // Get previous_epoch_boundary_attestations
-    List<PendingAttestationRecord> previous_epoch_boundary_attestations =
+    List<PendingAttestation> previous_epoch_boundary_attestations =
         AttestationUtil.get_previous_epoch_boundary_attestations(
             state, previous_epoch_attestations);
 
@@ -364,19 +364,6 @@ public class EpochProcessorUtil {
     return previous_epoch_boundary_attesting_balance;
   }
 
-  static UnsignedLong get_total_effective_balance(BeaconState state, List<Validator> validators) {
-    UnsignedLong total_balance = UnsignedLong.ZERO;
-
-    for (int i = 0; i < validators.size(); i++) {
-      total_balance = total_balance.plus(get_effective_balance(state, i));
-    }
-    return total_balance;
-  }
-
-  static UnsignedLong get_effective_balance(BeaconState state, int index) {
-    return BeaconStateUtil.min(
-        state.getValidator_balances().get(index),
-        UnsignedLong.valueOf(Constants.MAX_DEPOSIT_AMOUNT));
   /**
    * calculates the base reward for the supplied validator index
    *

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/SlotProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/SlotProcessorUtil.java
@@ -17,6 +17,7 @@ import static java.lang.Math.toIntExact;
 import static tech.pegasys.artemis.datastructures.Constants.LATEST_BLOCK_ROOTS_LENGTH;
 import static tech.pegasys.artemis.datastructures.Constants.LATEST_RANDAO_MIXES_LENGTH;
 
+import com.google.common.primitives.UnsignedLong;
 import java.util.List;
 import net.consensys.cava.bytes.Bytes32;
 import tech.pegasys.artemis.datastructures.Constants;
@@ -38,7 +39,7 @@ public class SlotProcessorUtil {
       throws Exception {
     // TODO: change values to UnsignedLong
     Bytes32 previous_block_root =
-        BeaconStateUtil.get_block_root(state, state.getSlot().intValue() - 1);
+        BeaconStateUtil.get_block_root(state, state.getSlot().minus(UnsignedLong.ONE));
     if (previous_block_root != null) {
       List<Bytes32> latest_block_roots = state.getLatest_block_roots();
 


### PR DESCRIPTION
Added the helper functions that were previously only stubbed for updateJustification. 

Made those helper functions generic so that they can be used in other parts of the per-Epoch processing