### PR TITLE
Update Deposit Helper Functions to v0.1

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.bytes.Bytes48;
+import tech.pegasys.artemis.datastructures.Constants;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlockBody;
 import tech.pegasys.artemis.datastructures.blocks.Eth1Data;
@@ -32,6 +33,7 @@ import tech.pegasys.artemis.datastructures.operations.DepositInput;
 import tech.pegasys.artemis.datastructures.operations.Exit;
 import tech.pegasys.artemis.datastructures.operations.ProposerSlashing;
 import tech.pegasys.artemis.datastructures.operations.SlashableAttestation;
+import tech.pegasys.artemis.datastructures.state.Validator;
 
 public final class DataStructureUtil {
 
@@ -159,5 +161,16 @@ public final class DataStructureUtil {
 
   public static BeaconBlock randomBeaconBlock() {
     return randomBeaconBlock(randomLong());
+  }
+
+  public static Validator randomValidator() {
+    return new Validator(
+        Bytes48.random(),
+        Bytes32.random(),
+        Constants.FAR_FUTURE_EPOCH,
+        Constants.FAR_FUTURE_EPOCH,
+        Constants.FAR_FUTURE_EPOCH,
+        Constants.FAR_FUTURE_EPOCH,
+        randomUnsignedLong());
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
@@ -763,7 +763,7 @@ public class BeaconStateUtil {
    * @param fork
    * @param slot
    * @param domain_type
-   * @return
+   * @return the fork version of the given epoch
    */
   private static UnsignedLong get_domain(Fork fork, UnsignedLong slot, int domain_type) {
     return get_fork_version(fork, slot)
@@ -772,13 +772,21 @@ public class BeaconStateUtil {
   }
 
   /**
-   * @param fork
-   * @param epoch
-   * @return
+   * TODO It seems to make sense to move this to {@link Fork}.
+   *
+   * <p>Returns the fork version of the given epoch.
+   *
+   * @param fork - The Fork to retrieve the version for.
+   * @param epoch - The epoch to retrieve the fork version for.
+   * @return The fork version of the given epoch. (previousVersion if epoch < fork.epoch, otherwise
+   *     currentVersion)
    */
   public static UnsignedLong get_fork_version(Fork fork, UnsignedLong epoch) {
-    if (epoch.compareTo(fork.getEpoch()) < 0) return fork.getPrevious_version();
-    else return fork.getCurrent_version();
+    if (epoch.compareTo(fork.getEpoch()) < 0) {
+      return fork.getPrevious_version();
+    } else {
+      return fork.getCurrent_version();
+    }
   }
 
   /**

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
@@ -760,13 +760,21 @@ public class BeaconStateUtil {
   }
 
   /**
-   * @param fork
-   * @param slot
-   * @param domain_type
-   * @return the fork version of the given epoch
+   * TODO It seems to make sense to move this to {@link Fork}.
+   *
+   * <p>Get the domain number that represents the fork meta and signature domain.
+   * https://github.com/ethereum/eth2.0-specs/blob/v0.1/specs/core/0_beacon-chain.md#get_domain
+   *
+   * @param fork - The Fork to retrieve the verion for.
+   * @param epoch - The epoch to retrieve the fork version for. See {@link
+   *     #get_fork_version(Fork,UnsignedLong)}
+   * @param domain_type - The domain type. See
+   *     https://github.com/ethereum/eth2.0-specs/blob/v0.1/specs/core/0_beacon-chain.md#signature-domains
+   * @return The fork version and signature domain. This format ((fork version << 32) +
+   *     SignatureDomain) is used to partition BLS signatures.
    */
-  private static UnsignedLong get_domain(Fork fork, UnsignedLong slot, int domain_type) {
-    return get_fork_version(fork, slot)
+  static UnsignedLong get_domain(Fork fork, UnsignedLong epoch, int domain_type) {
+    return get_fork_version(fork, epoch)
         .times(UnsignedLong.valueOf((long) Math.pow(2, 32)))
         .plus(UnsignedLong.valueOf(domain_type));
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtilTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtilTest.java
@@ -114,4 +114,62 @@ class BeaconStateUtilTest {
 
     assertEquals(BeaconStateUtil.get_fork_version(fork, givenEpoch), currentVersion);
   }
+
+  @Test
+  void getDomainReturnsAsExpectedForAllSignatureDomainTypesWithPreviousVersionFork() {
+    // Setup Fork Versions
+    // The values of these don't really matter, it just makes sense that
+    // previous version is less than current version.
+    UnsignedLong previousVersion = UnsignedLong.ZERO;
+    UnsignedLong currentVersion = previousVersion.plus(UnsignedLong.valueOf(1L));
+
+    // Setup Epochs
+    UnsignedLong givenEpoch = UnsignedLong.valueOf(100L);
+    UnsignedLong forkEpoch = givenEpoch.plus(UnsignedLong.valueOf(1L));
+
+    // Setup Fork
+    Fork fork = new Fork(previousVersion, currentVersion, forkEpoch);
+
+    // Iterate Over the Possible Signature Domains
+    // 0 - DOMAIN_DEPOSIT
+    // 1 - DOMAIN_ATTESTATION
+    // 2 - DOMAIN_PROPOSAL
+    // 3 - DOMAIN_EXIT
+    // 4 - DOMAIN_RANDAO
+    for (int domain = 0; domain <= 4; ++domain) {
+      assertEquals(
+          BeaconStateUtil.get_domain(fork, givenEpoch, domain),
+          UnsignedLong.valueOf(
+              (BeaconStateUtil.get_fork_version(fork, givenEpoch).longValue() << 32) + domain));
+    }
+  }
+
+  @Test
+  void getDomainReturnsAsExpectedForAllSignatureDomainTypesWithCurrentVersionFork() {
+    // Setup Fork Versions
+    // The values of these don't really matter, it just makes sense that
+    // previous version is less than current version.
+    UnsignedLong previousVersion = UnsignedLong.ZERO;
+    UnsignedLong currentVersion = previousVersion.plus(UnsignedLong.valueOf(1L));
+
+    // Setup Epochs
+    UnsignedLong forkEpoch = UnsignedLong.valueOf(100L);
+    UnsignedLong givenEpoch = forkEpoch.plus(UnsignedLong.valueOf(1L));
+
+    // Setup Fork
+    Fork fork = new Fork(previousVersion, currentVersion, forkEpoch);
+
+    // Iterate Over the Possible Signature Domains
+    // 0 - DOMAIN_DEPOSIT
+    // 1 - DOMAIN_ATTESTATION
+    // 2 - DOMAIN_PROPOSAL
+    // 3 - DOMAIN_EXIT
+    // 4 - DOMAIN_RANDAO
+    for (int domain = 0; domain <= 4; ++domain) {
+      assertEquals(
+          BeaconStateUtil.get_domain(fork, givenEpoch, domain),
+          UnsignedLong.valueOf(
+              (BeaconStateUtil.get_fork_version(fork, givenEpoch).longValue() << 32) + domain));
+    }
+  }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtilTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtilTest.java
@@ -20,6 +20,7 @@ import com.google.common.primitives.UnsignedLong;
 import net.consensys.cava.junit.BouncyCastleExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import tech.pegasys.artemis.datastructures.state.Fork;
 
 @ExtendWith(BouncyCastleExtension.class)
 class BeaconStateUtilTest {
@@ -72,5 +73,45 @@ class BeaconStateUtilTest {
         () -> {
           BeaconStateUtil.integer_squareroot(UnsignedLong.valueOf(-1L));
         });
+  }
+
+  // TODO It may make sense to move these tests to a Fork specific test class in the future.
+  // *************** START Fork Tests ***************
+  @Test
+  void getForkVersionReturnsPreviousVersionWhenGivenEpochIsLessThanForkEpoch() {
+    // Setup Fork Versions
+    // The values of these don't really matter, it just makes sense that
+    // previous version is less than current version.
+    UnsignedLong previousVersion = UnsignedLong.ZERO;
+    UnsignedLong currentVersion = previousVersion.plus(UnsignedLong.valueOf(1L));
+
+    // Setup Epochs
+    // It is necessary for this test that givenEpoch is less than forkEpoch.
+    UnsignedLong givenEpoch = UnsignedLong.valueOf(100L);
+    UnsignedLong forkEpoch = givenEpoch.plus(UnsignedLong.valueOf(1L));
+
+    // Setup Fork
+    Fork fork = new Fork(previousVersion, currentVersion, forkEpoch);
+
+    assertEquals(BeaconStateUtil.get_fork_version(fork, givenEpoch), previousVersion);
+  }
+
+  @Test
+  void getForkVersionReturnsCurrentVersionWhenGivenEpochIsGreaterThanForkEpoch() {
+    // Setup Fork Versions
+    // The values of these don't really matter, it just makes sense that
+    // previous version is less than current version.
+    UnsignedLong previousVersion = UnsignedLong.ZERO;
+    UnsignedLong currentVersion = previousVersion.plus(UnsignedLong.valueOf(1L));
+
+    // Setup Epochs
+    // It is necessary for this test that givenEpoch is greater than forkEpoch.
+    UnsignedLong forkEpoch = UnsignedLong.valueOf(100L);
+    UnsignedLong givenEpoch = forkEpoch.plus(UnsignedLong.valueOf(1L));
+
+    // Setup Fork
+    Fork fork = new Fork(previousVersion, currentVersion, forkEpoch);
+
+    assertEquals(BeaconStateUtil.get_fork_version(fork, givenEpoch), currentVersion);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtilTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtilTest.java
@@ -14,13 +14,20 @@
 package tech.pegasys.artemis.statetransition.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.primitives.UnsignedLong;
+import net.consensys.cava.bytes.Bytes32;
+import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.junit.BouncyCastleExtension;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import tech.pegasys.artemis.datastructures.operations.BLSSignature;
 import tech.pegasys.artemis.datastructures.state.Fork;
+import tech.pegasys.artemis.statetransition.BeaconState;
 
 @ExtendWith(BouncyCastleExtension.class)
 class BeaconStateUtilTest {
@@ -171,5 +178,33 @@ class BeaconStateUtilTest {
           UnsignedLong.valueOf(
               (BeaconStateUtil.get_fork_version(fork, givenEpoch).longValue() << 32) + domain));
     }
+  }
+
+  @Test
+  @Disabled
+  // TODO Fill out and enable this test case when bls_verify is complete.
+  void validateProofOfPosessionReturnsTrueIfTheBLSSignatureIsValidForGivenDepositInputData() {
+    BeaconState beaconState = null;
+    Bytes48 pubkey = null;
+    BLSSignature proofOfPossession = null;
+    Bytes32 withdrawalCredentials = null;
+
+    assertTrue(
+        BeaconStateUtil.validate_proof_of_possession(
+            beaconState, pubkey, proofOfPossession, withdrawalCredentials));
+  }
+
+  @Test
+  @Disabled
+  // TODO Fill out and enable this test case when bls_verify is complete.
+  void validateProofOfPosessionReturnsFalseIfTheBLSSignatureIsNotValidForGivenDepositInputData() {
+    BeaconState beaconState = null;
+    Bytes48 pubkey = null;
+    BLSSignature proofOfPossession = null;
+    Bytes32 withdrawalCredentials = null;
+
+    assertFalse(
+        BeaconStateUtil.validate_proof_of_possession(
+            beaconState, pubkey, proofOfPossession, withdrawalCredentials));
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtilTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtilTest.java
@@ -219,26 +219,15 @@ class BeaconStateUtilTest {
   @Test
   void processDepositAddsNewValidatorWhenPubkeyIsNotFoundInRegistry() {
     // Data Setup
-    BeaconState beaconState = new BeaconState();
-    beaconState.setSlot(randomUnsignedLong());
-    beaconState.setFork(new Fork(randomUnsignedLong(), randomUnsignedLong(), randomUnsignedLong()));
-
-    List<Validator> validatorList =
-        new ArrayList<>(Arrays.asList(randomValidator(), randomValidator(), randomValidator()));
-    List<UnsignedLong> balanceList =
-        new ArrayList<>(
-            Arrays.asList(randomUnsignedLong(), randomUnsignedLong(), randomUnsignedLong()));
-
-    beaconState.setValidator_registry(validatorList);
-    beaconState.setValidator_balances(balanceList);
-
-    int originalValidatorRegistrySize = beaconState.getValidator_registry().size();
-    int originalValidatorBalancesSize = beaconState.getValidator_balances().size();
-
     Bytes48 pubkey = Bytes48.random();
     UnsignedLong amount = UnsignedLong.valueOf(100L);
     BLSSignature proofOfPossession = Constants.EMPTY_SIGNATURE;
     Bytes32 withdrawalCredentials = Bytes32.random();
+
+    BeaconState beaconState = createBeaconState();
+
+    int originalValidatorRegistrySize = beaconState.getValidator_registry().size();
+    int originalValidatorBalancesSize = beaconState.getValidator_balances().size();
 
     // Attempt to process deposit with above data.
     BeaconStateUtil.process_deposit(
@@ -281,20 +270,7 @@ class BeaconStateUtilTest {
             Constants.FAR_FUTURE_EPOCH,
             UnsignedLong.ZERO);
 
-    BeaconState beaconState = new BeaconState();
-    beaconState.setSlot(randomUnsignedLong());
-    beaconState.setFork(new Fork(randomUnsignedLong(), randomUnsignedLong(), randomUnsignedLong()));
-
-    List<Validator> validatorList =
-        new ArrayList<>(
-            Arrays.asList(randomValidator(), randomValidator(), randomValidator(), knownValidator));
-    List<UnsignedLong> balanceList =
-        new ArrayList<>(
-            Arrays.asList(
-                randomUnsignedLong(), randomUnsignedLong(), randomUnsignedLong(), amount));
-
-    beaconState.setValidator_registry(validatorList);
-    beaconState.setValidator_balances(balanceList);
+    BeaconState beaconState = createBeaconState(amount, knownValidator);
 
     int originalValidatorRegistrySize = beaconState.getValidator_registry().size();
     int originalValidatorBalancesSize = beaconState.getValidator_balances().size();
@@ -314,5 +290,35 @@ class BeaconStateUtilTest {
     assertEquals(
         amount.times(UnsignedLong.valueOf(2L)),
         beaconState.getValidator_balances().get(originalValidatorBalancesSize - 1));
+  }
+
+  private BeaconState createBeaconState() {
+    return createBeaconState(false, null, null);
+  }
+
+  private BeaconState createBeaconState(UnsignedLong amount, Validator knownValidator) {
+    return createBeaconState(true, amount, knownValidator);
+  }
+
+  private BeaconState createBeaconState(
+      boolean addToList, UnsignedLong amount, Validator knownValidator) {
+    BeaconState beaconState = new BeaconState();
+    beaconState.setSlot(randomUnsignedLong());
+    beaconState.setFork(new Fork(randomUnsignedLong(), randomUnsignedLong(), randomUnsignedLong()));
+
+    List<Validator> validatorList =
+        new ArrayList<>(Arrays.asList(randomValidator(), randomValidator(), randomValidator()));
+    List<UnsignedLong> balanceList =
+        new ArrayList<>(
+            Arrays.asList(randomUnsignedLong(), randomUnsignedLong(), randomUnsignedLong()));
+
+    if (addToList) {
+      validatorList.add(knownValidator);
+      balanceList.add(amount);
+    }
+
+    beaconState.setValidator_registry(validatorList);
+    beaconState.setValidator_balances(balanceList);
+    return beaconState;
   }
 }


### PR DESCRIPTION
## PR Description
This PR updates helper functions associated with deposit operations of the per-block processing logic to v0.1 of the spec, and adds unit tests for those functions.

Functions updated and unit tested in `BeaconStateUtil` are:
  - `get_fork_version`
  - `get_domain`
  - `validate_proof_of_possession`  - _(the tests for this are stubs which are disabled)_
  - `process_deposit`

## Fixed Issue(s)
Resolves #319 
