### PR TITLE
Fix attestionInclusion

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
@@ -433,6 +433,7 @@ public class EpochProcessorUtil {
           base_reward(state, index, previous_total_balance)
               .dividedBy(UnsignedLong.valueOf(INCLUDER_REWARD_QUOTIENT));
       balance = balance.plus(reward);
+      balances.set(proposer_index, balance);
     }
   }
 


### PR DESCRIPTION
UnsignedLong's are final, so the copy returned by a getter should not manipulate the actual object.
