### PR TITLE
Fix update validator registry

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
@@ -508,8 +508,8 @@ public class EpochProcessorUtil {
     UnsignedLong current_epoch_start_shard = state.getCurrent_epoch_start_shard();
     state.setPrevious_epoch_start_shard(current_epoch_start_shard);
 
-    Bytes32 previous_epoch_seed = state.getCurrent_epoch_seed();
-    state.setPrevious_epoch_seed(previous_epoch_seed);
+    Bytes32 current_epoch_seed = state.getCurrent_epoch_seed();
+    state.setPrevious_epoch_seed(current_epoch_seed);
   }
 
   /**

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
@@ -590,8 +590,10 @@ public class EpochProcessorUtil {
                   .getExit_epoch()
                   .compareTo(BeaconStateUtil.get_entry_exit_effect_epoch(currentEpoch))
               > 0
-          && validator.getStatus_flags().compareTo(UnsignedLong.valueOf(Constants.INITIATED_EXIT))
-              == 0) {
+          && BitwiseOps.and(
+                      validator.getStatus_flags(), UnsignedLong.valueOf(Constants.INITIATED_EXIT))
+                  .compareTo(UnsignedLong.ZERO)
+              != 0) {
         balance_churn = balance_churn.plus(get_effective_balance(state, validator));
         if (balance_churn.compareTo(max_balance_churn) > 0) break;
         BeaconStateUtil.exit_validator(state, index);

--- a/util/src/main/java/tech/pegasys/artemis/util/bitwise/BitwiseOps.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bitwise/BitwiseOps.java
@@ -22,6 +22,11 @@ public class BitwiseOps {
     return UnsignedLong.fromLongBits(a.longValue() | b.longValue());
   }
 
+  /** Returns a bitwiseAnd of the parameters a and b */
+  public static UnsignedLong and(UnsignedLong a, UnsignedLong b) {
+    return UnsignedLong.fromLongBits(a.longValue() & b.longValue());
+  }
+
   // Shift methods below might differ from actual bitwise implementations
   // i.e. leftShift might result in an overflow, where it should only
   // slide the bits to the left, and drop the one at most significant position

--- a/util/src/test/java/tech/pegasys/artemis/util/bitwise/BitwiseOpstTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/bitwise/BitwiseOpstTest.java
@@ -60,6 +60,16 @@ class BitwiseOpstTest {
   }
 
   @Test
+  void bitwiseAnd() {
+    UnsignedLong binary1 = UnsignedLong.ONE;
+    UnsignedLong binary10 = UnsignedLong.valueOf(2);
+    UnsignedLong binary0 = UnsignedLong.valueOf(0);
+    UnsignedLong result = BitwiseOps.and(binary1, binary10);
+
+    assertThat(result).isEqualTo(binary0);
+  }
+
+  @Test
   void bitwiseLeftShift() {
     // Define random variables
     Random rand = new Random();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Update validator registry function included a bitwiseAnd operation that we previously just had a integer comparison for. This PR implements the bitwiseAnd where it is done in the spec and adds a bitwiseAnd test.

The variable change is to make implementation in line with previous variable namings.

## Fixed Issue(s)
No fixed issue. Noticed and fixed during proof reading epoch processing.
