### PR TITLE
Finalize Block Processing AND Add to State Transition

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/Constants.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/Constants.java
@@ -83,7 +83,7 @@ public final class Constants {
   public static final int DOMAIN_ATTESTATION = 1; //
   public static final int DOMAIN_PROPOSAL = 2; //
   public static final int DOMAIN_EXIT = 3; //
-  public static final int MAX_DOMAIN_RANDAOEXITS = 4; //
+  public static final int DOMAIN_RANDAO = 4; //
 
   private static long slot_to_epoch(long slot) {
     return slot / Constants.EPOCH_LENGTH;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
@@ -19,7 +19,6 @@ import static tech.pegasys.artemis.datastructures.Constants.EPOCH_LENGTH;
 import com.google.common.primitives.UnsignedLong;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.statetransition.util.BeaconStateUtil;
 import tech.pegasys.artemis.statetransition.util.BlockProcessorUtil;
@@ -75,10 +74,11 @@ public class StateTransition {
 
     // Block Header
     // Verify Slot
-    checkArgument(BlockProcessorUtil.verify_slot(state, block));
+    BlockProcessorUtil.verify_slot(state, block);
     // Verify Proposer Signature
-    checkArgument(BlockProcessorUtil.verify_signature(state, block));
-    // verifyAndUpdateRandao(state, block);
+    BlockProcessorUtil.verify_signature(state, block);
+    // Verify and Update RANDAO
+    BlockProcessorUtil.verify_and_update_randao(state, block);
 
     // block body operations
     // processAttestations(state, block);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
@@ -87,8 +87,8 @@ public class StateTransition {
     BlockProcessorUtil.proposer_slashing(state, block);
     // Execute Attester Slashings
     BlockProcessorUtil.attester_slashing(state, block);
-
-    // processAttestations(state, block);
+    // Process Attestations
+    BlockProcessorUtil.processAttestations(state, block);
   }
 
   protected void epochProcessor(BeaconState state) throws Exception {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
@@ -85,6 +85,8 @@ public class StateTransition {
     // Block Body - Operations
     // Execute Proposer Slashings
     BlockProcessorUtil.proposer_slashing(state, block);
+    // Execute Attester Slashings
+    BlockProcessorUtil.attester_slashing(state, block);
 
     // processAttestations(state, block);
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
@@ -89,6 +89,8 @@ public class StateTransition {
     BlockProcessorUtil.attester_slashing(state, block);
     // Process Attestations
     BlockProcessorUtil.processAttestations(state, block);
+    // Process Deposits
+    BlockProcessorUtil.processDeposits(state, block);
   }
 
   protected void epochProcessor(BeaconState state) throws Exception {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
@@ -91,6 +91,8 @@ public class StateTransition {
     BlockProcessorUtil.processAttestations(state, block);
     // Process Deposits
     BlockProcessorUtil.processDeposits(state, block);
+    // Process Exits
+    BlockProcessorUtil.processExits(state, block);
   }
 
   protected void epochProcessor(BeaconState state) throws Exception {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
@@ -82,7 +82,10 @@ public class StateTransition {
     // Update Eth1 Data
     BlockProcessorUtil.update_eth1_data(state, block);
 
-    // block body operations
+    // Block Body - Operations
+    // Execute Proposer Slashings
+    BlockProcessorUtil.proposer_slashing(state, block);
+
     // processAttestations(state, block);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
@@ -79,6 +79,8 @@ public class StateTransition {
     BlockProcessorUtil.verify_signature(state, block);
     // Verify and Update RANDAO
     BlockProcessorUtil.verify_and_update_randao(state, block);
+    // Update Eth1 Data
+    BlockProcessorUtil.update_eth1_data(state, block);
 
     // block body operations
     // processAttestations(state, block);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
@@ -19,6 +19,7 @@ import static tech.pegasys.artemis.datastructures.Constants.EPOCH_LENGTH;
 import com.google.common.primitives.UnsignedLong;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.statetransition.util.BeaconStateUtil;
 import tech.pegasys.artemis.statetransition.util.BlockProcessorUtil;
@@ -71,8 +72,12 @@ public class StateTransition {
 
   protected void blockProcessor(BeaconState state, BeaconBlock block) throws Exception {
     LOG.info("Processing new block in slot: " + block.getSlot());
-    // block header
-    BlockProcessorUtil.verify_signature(state, block);
+
+    // Block Header
+    // Verify Slot
+    checkArgument(BlockProcessorUtil.verify_slot(state, block));
+    // Verify Proposer Signature
+    checkArgument(BlockProcessorUtil.verify_signature(state, block));
     // verifyAndUpdateRandao(state, block);
 
     // block body operations

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
@@ -521,7 +521,7 @@ public class BeaconStateUtil {
   }
 
   //  Return the block root at a recent ``slot``.
-  public static Bytes32 get_block_root(BeaconState state, UnsignedLong slot) throws Exception {
+  public static Bytes32 get_block_root(BeaconState state, UnsignedLong slot) {
     checkArgument(
         state
                 .getSlot()

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BeaconStateUtil.java
@@ -462,6 +462,8 @@ public class BeaconStateUtil {
    *
    * @param state - The current BeaconState. NOTE: State will be mutated per spec logic.
    * @param index - The index of the validator that will be penalized.
+   * @see
+   *     https://github.com/ethereum/eth2.0-specs/blob/v0.1/specs/core/0_beacon-chain.md#penalize_validator
    */
   public static void penalize_validator(BeaconState state, int index) {
     exit_validator(state, index);
@@ -479,7 +481,6 @@ public class BeaconStateUtil {
     UnsignedLong whistleblower_reward =
         get_effective_balance(state, index)
             .dividedBy(UnsignedLong.valueOf(WHISTLEBLOWER_REWARD_QUOTIENT));
-
     state
         .getValidator_balances()
         .set(
@@ -488,6 +489,7 @@ public class BeaconStateUtil {
     state
         .getValidator_balances()
         .set(index, state.getValidator_balances().get(index).minus(whistleblower_reward));
+
     validator.setPenalized_epoch(get_current_epoch(state));
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
@@ -76,7 +76,18 @@ public class BlockProcessorUtil {
 
   /**
    * Spec:
-   * https://github.com/ethereum/eth2.0-specs/blob/master/specs/core/0_beacon-chain.md#proposer-signature
+   * https://github.com/ethereum/eth2.0-specs/blob/v0.1/specs/core/0_beacon-chain.md#slot-1
+   *
+   * @param state
+   * @param block
+   */
+  public static boolean verify_slot(BeaconState state, BeaconBlock block) {
+    return Objects.equals(state.getSlot(), UnsignedLong.fromLongBits(block.getSlot()));
+  }
+
+  /**
+   * Spec:
+   * https://github.com/ethereum/eth2.0-specs/blob/v0.1/specs/core/0_beacon-chain.md#proposer-signature
    *
    * @param state
    * @param block

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
@@ -377,7 +377,7 @@ public class BlockProcessorUtil {
 
       // - Verify that attestation.data.shard_block_root == ZERO_HASH
       // TO BE REMOVED IN PHASE 1
-      checkArgument(attestation.getData().getShard_block_root() == ZERO_HASH);
+      checkArgument(attestation.getData().getShard_block_root().equals(ZERO_HASH));
 
       // - Append PendingAttestation(data=attestation.data,
       //     aggregation_bitfield=attestation.aggregation_bitfield,
@@ -582,6 +582,6 @@ public class BlockProcessorUtil {
         value = Hash.keccak256(Bytes.concatenate(value, branch.get(i)));
       }
     }
-    return value == root;
+    return value.equals(root);
   }
 }


### PR DESCRIPTION
## PR Description
This PR finalizes v0.1 per-block processing logic and adds the relevant functions to `StateTransition#blockProcessor`.

## Fixed Issue(s)
Work Not Tracked in an Issue

## WIP Tracking
- [x] Finalize Slot Validation
- [x] Add Slot Validation to State Transition Handler
- [x] Finalize Proposer Signature Validation
- [x] Add Proposer Signature Validation to State Transition Handler
- [x] Finalize RANDAO Validation
- [x] Finalize RANDAO Mix Updates
- [x] Add RANDAO Validation and Updates to State Transition Handler
- [x] Finalize Eth1 Data Updates
- [x] Add Eth1 Data Updates to State Transition Handler
- [x] Finalize Proposer Slashing
- [x] Add Proposer Slashing to State Transition Handler
- [x] Finalize Attester Slashing
- [x] Add Attester Slashing to State Transition Handler
- [x] Finalize Attestation Handling
- [x] Add Attestation Handling to State Transition Handler
- [x] Finalize Deposit Handling
- [x] Add Deposit Handling to State Transition Handler
- [x] Finalize Exit Handling
- [x] Add Exit Handling to State Transition Handler
- [x] ~Javadocs and Code Cleanup etc~ - Tracked in https://github.com/PegaSysEng/artemis/issues/373