### PR TITLE
Improve empty signature implementation

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/Constants.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/Constants.java
@@ -16,7 +16,7 @@ package tech.pegasys.artemis.datastructures;
 import com.google.common.primitives.UnsignedLong;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
-import tech.pegasys.artemis.util.bls.BLSSignature;
+import tech.pegasys.artemis.util.bls.BLSEmptySignature;
 
 public final class Constants {
   // The constants below are correct as of spec v0.1
@@ -43,7 +43,7 @@ public final class Constants {
   public static final long GENESIS_START_SHARD = 0;
   public static UnsignedLong FAR_FUTURE_EPOCH = UnsignedLong.MAX_VALUE; //
   public static Bytes32 ZERO_HASH = Bytes32.ZERO; //
-  public static final BLSSignature EMPTY_SIGNATURE = BLSSignature.empty();
+  public static final BLSEmptySignature EMPTY_SIGNATURE = new BLSEmptySignature();
   public static Bytes BLS_WITHDRAWAL_PREFIX_BYTE = Bytes.EMPTY;
 
   // Time parameters

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSEmptySignature.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSEmptySignature.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.util.bls;
+
+import java.util.Objects;
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.bytes.Bytes48;
+import net.consensys.cava.ssz.SSZ;
+import tech.pegasys.artemis.util.mikuli.Signature;
+
+public final class BLSEmptySignature extends BLSSignature {
+
+  public BLSEmptySignature() {}
+
+  /**
+   * Serialise the empty signature
+   *
+   * <p>The empty signature must serialise as 96 * zero bytes as defined in the Eth specification.
+   * No valid signature can do this.
+   *
+   * @return the serialisation of the empty signature
+   */
+  @Override
+  public Bytes toBytes() {
+    return SSZ.encode(
+        writer -> {
+          writer.writeBytes(Bytes.wrap(new byte[96]));
+        });
+  }
+
+  /**
+   * Calling the checkSignature method on an empty signature indicates a logic error somewhere, so
+   * we throw a runtime exception.
+   *
+   * @param publicKey not used
+   * @param message not used
+   * @param domain not used
+   * @throws RuntimeException when called
+   */
+  @Override
+  boolean checkSignature(Bytes48 publicKey, Bytes message, long domain) {
+    throw new RuntimeException("The checkSignature method was called on an empty signature.");
+  }
+
+  /**
+   * Calling the getSignature method on an empty signature indicates a logic error somewhere, so we
+   * throw a runtime exception.
+   */
+  @Override
+  public Signature getSignature() {
+    throw new RuntimeException("The getSignature method was called on an empty signature.");
+  }
+
+  @Override
+  public String toString() {
+    return "Empty Signature";
+  }
+
+  @Override
+  public int hashCode() {
+    return 42;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (Objects.isNull(obj)) {
+      return false;
+    }
+    if (this == obj) {
+      return true;
+    }
+    return (obj instanceof BLSEmptySignature);
+  }
+}

--- a/util/src/test/java/tech/pegasys/artemis/util/bls/BLSSignatureTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/bls/BLSSignatureTest.java
@@ -17,18 +17,47 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import net.consensys.cava.bytes.Bytes;
-import org.junit.jupiter.api.Disabled;
+import net.consensys.cava.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
 
-public class BLSSignatureTest {
+class BLSSignatureTest {
+
+  // Tests for BLSEmptySignature subclass
+
+  @Test
+  void succeedsWhenEqualsReturnsTrueForTheSameEmptySignature() {
+    BLSEmptySignature signature = new BLSEmptySignature();
+    assertEquals(signature, signature);
+  }
+
+  @Test
+  void succeedsWhenEqualsReturnsTrueForTwoEmptySignatures() {
+    BLSEmptySignature signature1 = new BLSEmptySignature();
+    BLSEmptySignature signature2 = new BLSEmptySignature();
+    assertEquals(signature1, signature2);
+  }
+
+  @Test
+  void succeedsWhenCallingCheckSignatureOnEmptySignatureThrowsRuntimeException() {
+    BLSEmptySignature signature = new BLSEmptySignature();
+    assertThrows(
+        RuntimeException.class,
+        () -> signature.checkSignature(Bytes48.random(), Bytes.wrap("Test".getBytes(UTF_8)), 0));
+  }
+
+  @Test
+  void succeedsWhenCallingGetSignatureOnEmptySignatureThrowsRuntimeException() {
+    BLSEmptySignature signature = new BLSEmptySignature();
+    assertThrows(RuntimeException.class, () -> signature.getSignature());
+  }
 
   @Test
   void succeedsIfEmptySignatureIsCorrectlyFormed() {
-    BLSSignature emptySignature = BLSSignature.empty();
-    assertTrue(emptySignature.isEmpty());
+    BLSEmptySignature emptySignature = new BLSEmptySignature();
     // SSZ prepends the length as four little-endian bytes
     assertEquals(
         "0x60000000"
@@ -38,11 +67,7 @@ public class BLSSignatureTest {
         emptySignature.toBytes().toHexString());
   }
 
-  @Test
-  void succeedsIfValidSignatureIsNotEmpty() {
-    BLSSignature signature = BLSSignature.random();
-    assertTrue(!signature.isEmpty());
-  }
+  // Tests for BLSSignature class
 
   @Test
   void succeedsWhenEqualsReturnsTrueForTheSameSignature() {
@@ -113,15 +138,6 @@ public class BLSSignatureTest {
   @Test
   void succeedsWhenSSZDecodeEncodeReturnsTheSameSignature() {
     BLSSignature signature1 = BLSSignature.random();
-    BLSSignature signature2 = BLSSignature.fromBytes(signature1.toBytes());
-    assertEquals(signature1, signature2);
-  }
-
-  @Test
-  @Disabled
-  // This is not yet implemented
-  void succeedsWhenSSZDecodeEncodeReturnsTheSameSignatureForTheEmptySignature() {
-    BLSSignature signature1 = BLSSignature.empty();
     BLSSignature signature2 = BLSSignature.fromBytes(signature1.toBytes());
     assertEquals(signature1, signature2);
   }


### PR DESCRIPTION
## PR Description
Introduces a more Java-like way to handle empty signatures by introducing a subclass of BLSSignature.

Let me know if this is horrible, or there's a better way to do this. (Seems like a lot of work to avoid a couple of `if` statements 😝)
