### PR TITLE
BLSException type and temporary trap

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -68,6 +68,7 @@ import tech.pegasys.artemis.datastructures.state.CrosslinkCommittee;
 import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.datastructures.state.Validator;
 import tech.pegasys.artemis.util.bitwise.BitwiseOps;
+import tech.pegasys.artemis.util.bls.BLSException;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
 public class BeaconStateUtil {
@@ -264,9 +265,10 @@ public class BeaconStateUtil {
     return get_crosslink_committees_at_slot(state, slot, false);
   }
 
-  /* TODO: Note from spec -
-   * Note: this definition and the next few definitions make heavy use of repetitive computing.
-   * Production implementations are expected to appropriately use caching/memoization to avoid redoing work.
+  /*
+   * TODO: Note from spec - Note: this definition and the next few definitions
+   * make heavy use of repetitive computing. Production implementations are
+   * expected to appropriately use caching/memoization to avoid redoing work.
    */
 
   private static UnsignedLong get_previous_epoch_committee_count(BeaconState state) {
@@ -306,7 +308,8 @@ public class BeaconStateUtil {
 
   public static Bytes32 get_active_index_root(BeaconState state, UnsignedLong epoch) {
     checkArgument(
-        // Since we're using UnsignedLong here, we can't subtract LATEST_INDEX_ROOTS_LENGTH
+        // Since we're using UnsignedLong here, we can't subtract
+        // LATEST_INDEX_ROOTS_LENGTH
         get_current_epoch(state)
                 .plus(UnsignedLong.valueOf(ENTRY_EXIT_DELAY))
                 .compareTo(epoch.plus(UnsignedLong.valueOf(LATEST_INDEX_ROOTS_LENGTH)))
@@ -512,7 +515,8 @@ public class BeaconStateUtil {
   /** Return the randao mix at a recent ``epoch``. */
   public static Bytes32 get_randao_mix(BeaconState state, UnsignedLong epoch) {
     checkArgument(
-        // If we're going to use UnsignedLongs then we can't subtract LATEST_RANDAO_MIXES_LENGTH
+        // If we're going to use UnsignedLongs then we can't subtract
+        // LATEST_RANDAO_MIXES_LENGTH
         // here
         get_current_epoch(state)
                 .compareTo(epoch.plus(UnsignedLong.valueOf(LATEST_RANDAO_MIXES_LENGTH)))
@@ -523,7 +527,7 @@ public class BeaconStateUtil {
     return randao_mixes.get(index.intValue());
   }
 
-  //  Return the block root at a recent ``slot``.
+  // Return the block root at a recent ``slot``.
   public static Bytes32 get_block_root(BeaconState state, UnsignedLong slot) {
     checkArgument(
         state
@@ -539,6 +543,7 @@ public class BeaconStateUtil {
 
   /*
    * @param values
+   *
    * @return The merkle root.
    */
   public static Bytes32 merkle_root(List<Bytes32> list) throws IllegalStateException {
@@ -591,7 +596,8 @@ public class BeaconStateUtil {
         get_epoch_committee_count(UnsignedLong.valueOf(active_validator_indices.size())).intValue();
 
     // Shuffle with seed
-    // TODO: we may need to treat `epoch` as little-endian here. Revisit as the spec evolves.
+    // TODO: we may need to treat `epoch` as little-endian here. Revisit as the spec
+    // evolves.
     seed.xor(Bytes32.leftPad(Bytes.ofUnsignedLong(epoch.longValue())));
     List<Integer> shuffled_active_validator_indices = shuffle(active_validator_indices, seed);
 
@@ -728,6 +734,7 @@ public class BeaconStateUtil {
    * @param amount - The amount to add to the validator's balance (in Gwei).
    * @param proof_of_possession - The validator's proof of posession
    * @param withdrawal_credentials - The withdrawal credentials for the deposit to be processed.
+   * @throws BLSException
    */
   public static void process_deposit(
       BeaconState state,
@@ -750,7 +757,8 @@ public class BeaconStateUtil {
             .map(validator -> validator.getPubkey())
             .collect(Collectors.toList());
 
-    // If the provided pubkey isn't in the state, add a new validator to the registry.
+    // If the provided pubkey isn't in the state, add a new validator to the
+    // registry.
     // Otherwise, top up the balance for the validator whose pubkey was provided.
     if (!validator_pubkeys.contains(pubkey)) {
       // We depend on our add operation appending the below objects at the same index.
@@ -817,6 +825,7 @@ public class BeaconStateUtil {
    * @param withdrawal_credentials - The withdrawal credentials for the current deposit data to
    *     verify.
    * @return True if the BLS signature is a valid proof of posession, false otherwise.
+   * @throws BLSException
    */
   static boolean validate_proof_of_possession(
       BeaconState state,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
@@ -75,6 +75,7 @@ import tech.pegasys.artemis.datastructures.state.CrosslinkCommittee;
 import tech.pegasys.artemis.datastructures.state.PendingAttestation;
 import tech.pegasys.artemis.datastructures.state.Validator;
 import tech.pegasys.artemis.datastructures.util.BeaconStateUtil;
+import tech.pegasys.artemis.util.bls.BLSException;
 
 public class BlockProcessorUtil {
 
@@ -96,9 +97,10 @@ public class BlockProcessorUtil {
    *
    * @param state
    * @param block
+   * @throws BLSException
    */
   public static void verify_signature(BeaconState state, BeaconBlock block)
-      throws IllegalStateException, IllegalArgumentException {
+      throws IllegalStateException, IllegalArgumentException, BLSException {
     // Let block_without_signature_root be the hash_tree_root of block where
     //   block.signature is set to EMPTY_SIGNATURE.
     block.setSignature(EMPTY_SIGNATURE);

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSException.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.util.bls;
+
+public class BLSException extends Exception {
+  public BLSException(String err) {
+    super(err);
+  }
+}

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSSignature.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSSignature.java
@@ -79,10 +79,11 @@ public final class BLSSignature {
    * @param message the message
    * @param domain the domain as specified in the Eth2 spec
    * @return true if the signature is valid, false if it is not
+   * @throws BLSException
    */
-  boolean checkSignature(Bytes48 publicKey, Bytes message, long domain) {
+  boolean checkSignature(Bytes48 publicKey, Bytes message, long domain) throws BLSException {
     if (isNull(signature)) {
-      throw new RuntimeException("The checkSignature method was called on an empty signature.");
+      throw new BLSException("The checkSignature method was called on an empty signature.");
     }
     return BLS12381.verify(PublicKey.fromBytes(publicKey), signature, message, domain);
   }

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSVerify.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSVerify.java
@@ -23,7 +23,13 @@ public class BLSVerify {
 
   public static boolean bls_verify(
       Bytes48 pubkey, Bytes message, BLSSignature signature, UnsignedLong domain) {
-    return signature.checkSignature(pubkey, message, domain.longValue());
+    try {
+      return signature.checkSignature(pubkey, message, domain.longValue());
+    } catch (BLSException e) {
+      // TODO: once we stop using random (unseeded signatures) keypairs,
+      // then the signatures will be predictable and the resulting state can be precomputed
+      return true;
+    }
   }
 
   public static boolean bls_verify_multiple(

--- a/util/src/test/java/tech/pegasys/artemis/util/bls/BLSSignatureTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/bls/BLSSignatureTest.java
@@ -43,7 +43,7 @@ class BLSSignatureTest {
   void succeedsWhenCallingCheckSignatureOnEmptySignatureThrowsRuntimeException() {
     BLSSignature signature = BLSSignature.empty();
     assertThrows(
-        RuntimeException.class,
+        BLSException.class,
         () -> signature.checkSignature(Bytes48.random(), Bytes.wrap("Test".getBytes(UTF_8)), 0));
   }
 
@@ -91,7 +91,7 @@ class BLSSignatureTest {
   }
 
   @Test
-  void succeedsWhenAMessageSignsAndVerifies() {
+  void succeedsWhenAMessageSignsAndVerifies() throws BLSException {
     BLSKeyPair keyPair = BLSKeyPair.random();
     Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
     long domain = 42;
@@ -100,7 +100,7 @@ class BLSSignatureTest {
   }
 
   @Test
-  void succeedsWhenVerifyingDifferentDomainFails() {
+  void succeedsWhenVerifyingDifferentDomainFails() throws BLSException {
     BLSKeyPair keyPair = BLSKeyPair.random();
     Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
     long domain1 = 42;
@@ -110,7 +110,7 @@ class BLSSignatureTest {
   }
 
   @Test
-  void succeedsWhenVerifyingDifferentMessageFails() {
+  void succeedsWhenVerifyingDifferentMessageFails() throws BLSException {
     BLSKeyPair keyPair = BLSKeyPair.random();
     Bytes message1 = Bytes.wrap("Hello, world!".getBytes(UTF_8));
     Bytes message2 = Bytes.wrap("Hello, world?".getBytes(UTF_8));
@@ -120,7 +120,7 @@ class BLSSignatureTest {
   }
 
   @Test
-  void succeedsWhenVerifyingDifferentPublicKeyFails() {
+  void succeedsWhenVerifyingDifferentPublicKeyFails() throws BLSException {
     BLSKeyPair keyPair1 = BLSKeyPair.random();
     BLSKeyPair keyPair2 = BLSKeyPair.random();
     while (keyPair1.equals(keyPair2)) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
added explicit BLSException class so that i can explicitly trap for BLS errors.  

i need this for the development of the simulation as i am having to generate empty signatures so that i can pre-calculate the result of the next state to attach to a newly created block (so it can be verified).
i need to trap for this error in bls_verify until i can figure out how to seed all random simulation parameters so that i can generate a good blocks on the fly.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->

