### PR TITLE
BLS reference tests

### DIFF
--- a/eth-reference-tests/build.gradle
+++ b/eth-reference-tests/build.gradle
@@ -8,6 +8,8 @@ dependencies {
   testCompile project(':util')
 
   compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.9.8'
+  testCompile 'org.miracl.milagro.amcl:milagro-crypto-java:0.4.0'
+  testCompile 'net.consensys.cava:cava-bytes'
   testCompile 'com.fasterxml.jackson.core:jackson-databind'
   testCompile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   testCompile 'org.junit.jupiter:junit-jupiter-api'

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -949,7 +949,7 @@ public class BeaconStateUtil {
         Arrays.asList(
             bls_aggregate_pubkeys(custody_bit_0_pubkeys),
             bls_aggregate_pubkeys(custody_bit_1_pubkeys));
-    List<Bytes> messages =
+    List<Bytes32> messages =
         Arrays.asList(
             hash_tree_root(
                 new AttestationDataAndCustodyBit(slashable_attestation.getData(), false).toBytes()),

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -949,7 +949,7 @@ public class BeaconStateUtil {
         Arrays.asList(
             bls_aggregate_pubkeys(custody_bit_0_pubkeys),
             bls_aggregate_pubkeys(custody_bit_1_pubkeys));
-    List<Bytes32> messages =
+    List<Bytes> messages =
         Arrays.asList(
             hash_tree_root(
                 new AttestationDataAndCustodyBit(slashable_attestation.getData(), false).toBytes()),

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/G1Point.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/G1Point.java
@@ -57,7 +57,7 @@ final class G1Point implements Group<G1Point> {
   static G1Point fromBytesCompressed(Bytes bytes) {
     checkArgument(
         bytes.size() == fpPointSize,
-        "Expected %s bytes but received %s",
+        "Expected %s bytes but received %s.",
         fpPointSize,
         bytes.size());
     byte[] xBytes = bytes.toArray();
@@ -125,7 +125,7 @@ final class G1Point implements Group<G1Point> {
    * @throws IllegalArgumentException if the point is not on the curve or the flags are incorrect
    */
   private G1Point(ECP point, boolean a1, boolean b1, boolean c1) {
-    checkArgument(isValid(point, a1, b1, c1));
+    checkArgument(isValid(point, a1, b1, c1), "Trying to create invalid point.");
     this.point = point;
     this.a = a1;
     this.b = b1;

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/G2Point.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/G2Point.java
@@ -205,7 +205,7 @@ final class G2Point implements Group<G2Point> {
    * @throws IllegalArgumentException if the point is not on the curve or the flags are incorrect
    */
   private G2Point(ECP2 point, boolean a1, boolean b1, boolean c1) {
-    checkArgument(isValid(point, a1, b1, c1));
+    checkArgument(isValid(point, a1, b1, c1), "Trying to create invalid point.");
     this.point = point;
     this.a1 = a1;
     this.b1 = b1;

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/KeyPair.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/KeyPair.java
@@ -39,9 +39,7 @@ public final class KeyPair {
     Scalar secret = new Scalar(BIG.randomnum(curveOrder, rng));
 
     SecretKey secretKey = new SecretKey(secret);
-    G1Point g1Point = g1Generator.mul(secret);
-    PublicKey publicKey = new PublicKey(g1Point);
-    return new KeyPair(secretKey, publicKey);
+    return new KeyPair(secretKey);
   }
 
   /**
@@ -56,9 +54,7 @@ public final class KeyPair {
     Scalar secret = new Scalar(BIG.randomnum(curveOrder, rng));
 
     SecretKey secretKey = new SecretKey(secret);
-    G1Point g1Point = g1Generator.mul(secret);
-    PublicKey publicKey = new PublicKey(g1Point);
-    return new KeyPair(secretKey, publicKey);
+    return new KeyPair(secretKey);
   }
 
   private final SecretKey secretKey;
@@ -67,6 +63,18 @@ public final class KeyPair {
   public KeyPair(SecretKey secretKey, PublicKey publicKey) {
     this.secretKey = secretKey;
     this.publicKey = publicKey;
+  }
+
+  public KeyPair(SecretKey secretKey) {
+    this.secretKey = secretKey;
+    this.publicKey = new PublicKey(this.secretKey);
+    ;
+  }
+
+  public KeyPair(Scalar secretKey) {
+    this.secretKey = new SecretKey(secretKey);
+    this.publicKey = new PublicKey(this.secretKey);
+    ;
   }
 
   public PublicKey publicKey() {

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/PublicKey.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/PublicKey.java
@@ -70,6 +70,10 @@ public final class PublicKey {
     this.point = point;
   }
 
+  PublicKey(SecretKey secretKey) {
+    this.point = KeyPair.g1Generator.mul(secretKey.getScalarValue());
+  }
+
   PublicKey combine(PublicKey pk) {
     return new PublicKey(point.add(pk.point));
   }

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/SecretKey.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/SecretKey.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.artemis.util.mikuli;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.milagro.amcl.BLS381.BIG.MODBYTES;
 
 import java.util.Objects;
@@ -39,6 +40,8 @@ public final class SecretKey {
    * @return a new SecretKey object
    */
   public static SecretKey fromBytes(Bytes bytes) {
+    checkArgument(
+        bytes.size() == MODBYTES, "Expected %s bytes, received %s.", MODBYTES, bytes.size());
     return new SecretKey(new Scalar(BIG.fromBytes(bytes.toArrayUnsafe())));
   }
 
@@ -56,6 +59,10 @@ public final class SecretKey {
     byte[] bytea = new byte[MODBYTES];
     scalarValue.value().toBytes(bytea);
     return Bytes.wrap(bytea);
+  }
+
+  Scalar getScalarValue() {
+    return scalarValue;
   }
 
   @Override


### PR DESCRIPTION
## PR Description
I've filled out the reference test framework for the official BLS tests from https://github.com/ethereum/eth2.0-tests/

Unfortunately, there are many issues with the input data, so this is a mess. Specific issue are as follows:

```
 * The point compression used is broken. See https://github.com/ethereum/eth2.0-tests/issues/20
 * This leads to extensive and tedious work-arounds in the below. Test 06 is too hard to fix
 * Specifically:
 *   > The c flag is missing
 *   > The a flag is inverted and is at the wrong bit position
 *   > The compressed coordinate ordering is inverted: should be [Im, Re], but is [Re, Im]
 *   > The a flag doesn't always match the Y-coordinate, which matters when interpreting
 *     compressed input data, such as for the aggregation tests.
 * Also
 *   > Our yaml ingester doesn't like the test case 07 input data format (a missing "-")
 * Finally, note that the spec and test data will likely be changing.
```

See [here](https://github.com/ethereum/eth2.0-specs/issues/508) and [here](https://github.com/ethereum/trinity/issues/233) for more on the Y co-ord selection issue.

I've worked around these where I can, but it's not complete. However, I don't believe it's worth spending any more time on this until (a) the spec has stabilised and (b) the test vectors are updated.

Meanwhile, I'm satisfied that our implementation is basically correct. 🙌 