### PR TITLE
Change Bytes48 to BLSPublicKey

### DIFF
--- a/eth-reference-tests/src/test/java/pegasys/artemis/reference/BLSTestSuite.java
+++ b/eth-reference-tests/src/test/java/pegasys/artemis/reference/BLSTestSuite.java
@@ -124,7 +124,7 @@ class BLSTestSuite {
     //   PublicKey publicKeyExpected = PublicKey.fromBytes(Bytes.fromHexString(output));
     byte[] tmp = Bytes.fromHexString(output).toArray();
     tmp[0] |= (byte) 0xa0;
-    PublicKey publicKeyExpected = PublicKey.fromBytes(tmp);
+    PublicKey publicKeyExpected = PublicKey.fromBytesCompressed(tmp);
     assertEquals(publicKeyExpected, publicKeyActual);
   }
 

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/DepositInput.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/DepositInput.java
@@ -16,21 +16,21 @@ package tech.pegasys.artemis.datastructures.operations;
 import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.ssz.SSZ;
+import tech.pegasys.artemis.util.bls.BLSPublicKey;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
 public final class DepositInput {
 
   // BLS pubkey
-  Bytes48 pubkey;
+  BLSPublicKey pubkey;
   // Withdrawal credentials
   Bytes32 withdrawal_credentials;
   // A BLS signature of this `DepositInput`
   BLSSignature proof_of_possession;
 
   public DepositInput(
-      Bytes48 pubkey, Bytes32 withdrawal_credentials, BLSSignature proof_of_possession) {
+      BLSPublicKey pubkey, Bytes32 withdrawal_credentials, BLSSignature proof_of_possession) {
     this.pubkey = pubkey;
     this.withdrawal_credentials = withdrawal_credentials;
     this.proof_of_possession = proof_of_possession;
@@ -41,7 +41,7 @@ public final class DepositInput {
         bytes,
         reader ->
             new DepositInput(
-                Bytes48.wrap(reader.readBytes()),
+                BLSPublicKey.fromBytes(reader.readBytes()),
                 Bytes32.wrap(reader.readBytes()),
                 BLSSignature.fromBytes(reader.readBytes())));
   }
@@ -49,7 +49,7 @@ public final class DepositInput {
   public Bytes toBytes() {
     return SSZ.encode(
         writer -> {
-          writer.writeBytes(pubkey);
+          writer.writeBytes(pubkey.toBytes());
           writer.writeBytes(withdrawal_credentials);
           writer.writeBytes(proof_of_possession.toBytes());
         });
@@ -81,11 +81,11 @@ public final class DepositInput {
   }
 
   /** ******************* * GETTERS & SETTERS * * ******************* */
-  public Bytes48 getPubkey() {
+  public BLSPublicKey getPubkey() {
     return pubkey;
   }
 
-  public void setPubkey(Bytes48 pubkey) {
+  public void setPubkey(BLSPublicKey pubkey) {
     this.pubkey = pubkey;
   }
 

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/BeaconState.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/BeaconState.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.ssz.SSZ;
 import tech.pegasys.artemis.datastructures.blocks.Eth1Data;
 import tech.pegasys.artemis.datastructures.blocks.Eth1DataVote;
@@ -71,7 +70,6 @@ public class BeaconState {
     Gson gson =
         new GsonBuilder()
             .registerTypeAdapter(Bytes32.class, new InterfaceAdapter<Bytes32>())
-            .registerTypeAdapter(Bytes48.class, new InterfaceAdapter<Bytes48>())
             .create();
     return gson.fromJson(gson.toJson(state), BeaconState.class);
   }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/Validator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/Validator.java
@@ -17,13 +17,13 @@ import com.google.common.primitives.UnsignedLong;
 import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.ssz.SSZ;
+import tech.pegasys.artemis.util.bls.BLSPublicKey;
 
 public class Validator {
 
   // BLS public key
-  private Bytes48 pubkey;
+  private BLSPublicKey pubkey;
   // Withdrawal credentials
   private Bytes32 withdrawal_credentials;
   // Epoch when validator activated
@@ -38,7 +38,7 @@ public class Validator {
   private UnsignedLong status_flags;
 
   public Validator(
-      Bytes48 pubkey,
+      BLSPublicKey pubkey,
       Bytes32 withdrawal_credentials,
       UnsignedLong activation_epoch,
       UnsignedLong exit_epoch,
@@ -59,7 +59,7 @@ public class Validator {
         bytes,
         reader ->
             new Validator(
-                Bytes48.wrap(reader.readBytes()),
+                BLSPublicKey.fromBytes(reader.readBytes()),
                 Bytes32.wrap(reader.readBytes()),
                 UnsignedLong.fromLongBits(reader.readUInt64()),
                 UnsignedLong.fromLongBits(reader.readUInt64()),
@@ -71,7 +71,7 @@ public class Validator {
   public Bytes toBytes() {
     return SSZ.encode(
         writer -> {
-          writer.writeBytes(pubkey);
+          writer.writeBytes(pubkey.toBytes());
           writer.writeBytes(withdrawal_credentials);
           writer.writeUInt64(activation_epoch.longValue());
           writer.writeUInt64(exit_epoch.longValue());
@@ -117,11 +117,11 @@ public class Validator {
         && Objects.equals(this.getStatus_flags(), other.getStatus_flags());
   }
 
-  public Bytes48 getPubkey() {
+  public BLSPublicKey getPubkey() {
     return pubkey;
   }
 
-  public void setPubkey(Bytes48 pubkey) {
+  public void setPubkey(BLSPublicKey pubkey) {
     this.pubkey = pubkey;
   }
 

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -51,7 +51,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.crypto.Hash;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -69,6 +68,7 @@ import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.datastructures.state.Validator;
 import tech.pegasys.artemis.util.bitwise.BitwiseOps;
 import tech.pegasys.artemis.util.bls.BLSException;
+import tech.pegasys.artemis.util.bls.BLSPublicKey;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
 public class BeaconStateUtil {
@@ -738,7 +738,7 @@ public class BeaconStateUtil {
    */
   public static void process_deposit(
       BeaconState state,
-      Bytes48 pubkey,
+      BLSPublicKey pubkey,
       UnsignedLong amount,
       BLSSignature proof_of_possession,
       Bytes32 withdrawal_credentials) {
@@ -752,7 +752,7 @@ public class BeaconStateUtil {
         validate_proof_of_possession(state, pubkey, proof_of_possession, withdrawal_credentials));
 
     // Retrieve the list of validator's public keys from the current state.
-    List<Bytes48> validator_pubkeys =
+    List<BLSPublicKey> validator_pubkeys =
         validatorRegistry.stream()
             .map(validator -> validator.getPubkey())
             .collect(Collectors.toList());
@@ -829,7 +829,7 @@ public class BeaconStateUtil {
    */
   static boolean validate_proof_of_possession(
       BeaconState state,
-      Bytes48 pubkey,
+      BLSPublicKey pubkey,
       BLSSignature proof_of_possession,
       Bytes32 withdrawal_credentials) {
     // Create a new DepositInput with the pubkey and withdrawal_credentials.
@@ -936,16 +936,16 @@ public class BeaconStateUtil {
       }
     }
 
-    ArrayList<Bytes48> custody_bit_0_pubkeys = new ArrayList<>();
+    ArrayList<BLSPublicKey> custody_bit_0_pubkeys = new ArrayList<>();
     for (int i = 0; i < custody_bit_0_indices.size(); i++) {
       custody_bit_0_pubkeys.add(state.getValidator_registry().get(i).getPubkey());
     }
-    ArrayList<Bytes48> custody_bit_1_pubkeys = new ArrayList<>();
+    ArrayList<BLSPublicKey> custody_bit_1_pubkeys = new ArrayList<>();
     for (int i = 0; i < custody_bit_1_indices.size(); i++) {
       custody_bit_1_pubkeys.add(state.getValidator_registry().get(i).getPubkey());
     }
 
-    List<Bytes48> pubkeys =
+    List<BLSPublicKey> pubkeys =
         Arrays.asList(
             bls_aggregate_pubkeys(custody_bit_0_pubkeys),
             bls_aggregate_pubkeys(custody_bit_1_pubkeys));

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
@@ -88,18 +88,6 @@ public final class DataStructureUtil {
     return BLSPublicKey.random(seed);
   }
 
-  /*
-    public static Bytes48 randomBytes48(long seed) {
-      ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
-      buffer.putLong(seed);
-      return Bytes48.random(new SecureRandom(buffer.array()));
-    }
-
-    public static Bytes48 randomBytes48() {
-      return Bytes48.random();
-    }
-  */
-
   public static Eth1Data randomEth1Data() {
     return new Eth1Data(randomBytes32(), randomBytes32());
   }
@@ -211,9 +199,6 @@ public final class DataStructureUtil {
             keyPair,
             HashTreeUtil.hash_tree_root(proof_of_possession_data.toBytes()),
             Constants.DOMAIN_DEPOSIT);
-
-    // BLSSignature proof_of_possession =
-    //    BLSSignature.sign(keyPair, withdrawal_credentials, Constants.DOMAIN_DEPOSIT);
 
     return new DepositInput(keyPair.getPublicKey(), withdrawal_credentials, proof_of_possession);
   }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 import tech.pegasys.artemis.datastructures.Constants;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlockBody;
@@ -41,6 +40,7 @@ import tech.pegasys.artemis.datastructures.operations.SlashableAttestation;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.state.Validator;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
+import tech.pegasys.artemis.util.bls.BLSPublicKey;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 import tech.pegasys.artemis.util.hashtree.HashTreeUtil;
 
@@ -80,15 +80,25 @@ public final class DataStructureUtil {
     return Bytes32.random();
   }
 
-  public static Bytes48 randomBytes48(long seed) {
-    ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
-    buffer.putLong(seed);
-    return Bytes48.random(new SecureRandom(buffer.array()));
+  public static BLSPublicKey randomPublicKey() {
+    return BLSPublicKey.random();
   }
 
-  public static Bytes48 randomBytes48() {
-    return Bytes48.random();
+  public static BLSPublicKey randomPublicKey(int seed) {
+    return BLSPublicKey.random(seed);
   }
+
+  /*
+    public static Bytes48 randomBytes48(long seed) {
+      ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+      buffer.putLong(seed);
+      return Bytes48.random(new SecureRandom(buffer.array()));
+    }
+
+    public static Bytes48 randomBytes48() {
+      return Bytes48.random();
+    }
+  */
 
   public static Eth1Data randomEth1Data() {
     return new Eth1Data(randomBytes32(), randomBytes32());
@@ -190,7 +200,7 @@ public final class DataStructureUtil {
 
   public static DepositInput randomDepositInput() {
     BLSKeyPair keyPair = BLSKeyPair.random();
-    Bytes48 pubkey = keyPair.publicKeyAsBytes();
+    BLSPublicKey pubkey = keyPair.getPublicKey();
     Bytes32 withdrawal_credentials = Bytes32.random();
 
     DepositInput proof_of_possession_data =
@@ -205,12 +215,12 @@ public final class DataStructureUtil {
     // BLSSignature proof_of_possession =
     //    BLSSignature.sign(keyPair, withdrawal_credentials, Constants.DOMAIN_DEPOSIT);
 
-    return new DepositInput(
-        keyPair.publicKeyAsBytes(), withdrawal_credentials, proof_of_possession);
+    return new DepositInput(keyPair.getPublicKey(), withdrawal_credentials, proof_of_possession);
   }
 
   public static DepositInput randomDepositInput(int seed) {
-    return new DepositInput(randomBytes48(seed), randomBytes32(seed++), BLSSignature.random(seed));
+    return new DepositInput(
+        randomPublicKey(seed), randomBytes32(seed++), BLSSignature.random(seed));
   }
 
   public static DepositData randomDepositData() {
@@ -307,7 +317,7 @@ public final class DataStructureUtil {
 
     for (int i = 0; i < numDeposits; i++) {
       DepositInput deposit_input =
-          new DepositInput(Bytes48.ZERO, Bytes32.ZERO, BLSSignature.empty());
+          new DepositInput(BLSPublicKey.empty(), Bytes32.ZERO, BLSSignature.empty());
       UnsignedLong timestamp = UnsignedLong.valueOf(i);
       DepositData deposit_data =
           new DepositData(UnsignedLong.valueOf(MAX_DEPOSIT_AMOUNT), timestamp, deposit_input);
@@ -346,7 +356,7 @@ public final class DataStructureUtil {
 
   public static Validator randomValidator() {
     return new Validator(
-        randomBytes48(),
+        randomPublicKey(),
         randomBytes32(),
         Constants.FAR_FUTURE_EPOCH,
         Constants.FAR_FUTURE_EPOCH,
@@ -357,7 +367,7 @@ public final class DataStructureUtil {
 
   public static Validator randomValidator(int seed) {
     return new Validator(
-        randomBytes48(seed),
+        randomPublicKey(seed),
         randomBytes32(seed++),
         Constants.FAR_FUTURE_EPOCH,
         Constants.FAR_FUTURE_EPOCH,

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositInputTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositInputTest.java
@@ -18,13 +18,13 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.util.bls.BLSPublicKey;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
 class DepositInputTest {
 
-  private Bytes48 pubkey = Bytes48.random();
+  private BLSPublicKey pubkey = BLSPublicKey.random();
   private Bytes32 withdrawalCredentials = Bytes32.random();
   private BLSSignature proofOfPossession = BLSSignature.random();
 
@@ -48,8 +48,12 @@ class DepositInputTest {
 
   @Test
   void equalsReturnsFalseWhenPubkeysAreDifferent() {
+    BLSPublicKey differentPublicKey = BLSPublicKey.random();
+    while (pubkey.equals(differentPublicKey)) {
+      differentPublicKey = BLSPublicKey.random();
+    }
     DepositInput testDepositInput =
-        new DepositInput(pubkey.not(), withdrawalCredentials, proofOfPossession);
+        new DepositInput(differentPublicKey, withdrawalCredentials, proofOfPossession);
 
     assertNotEquals(depositInput, testDepositInput);
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
@@ -42,7 +42,6 @@ import java.util.Collections;
 import java.util.List;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.crypto.Hash;
 import net.consensys.cava.junit.BouncyCastleExtension;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -52,6 +51,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import tech.pegasys.artemis.datastructures.blocks.Eth1Data;
 import tech.pegasys.artemis.datastructures.operations.AttestationData;
 import tech.pegasys.artemis.datastructures.util.BeaconStateUtil;
+import tech.pegasys.artemis.util.bls.BLSPublicKey;
 
 @ExtendWith(BouncyCastleExtension.class)
 class BeaconStateTest {
@@ -263,7 +263,7 @@ class BeaconStateTest {
             Collections.nCopies(
                 12,
                 new Validator(
-                    Bytes48.ZERO,
+                    BLSPublicKey.empty(),
                     Bytes32.ZERO,
                     UnsignedLong.ZERO,
                     UnsignedLong.valueOf(GENESIS_EPOCH),

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/ValidatorTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/ValidatorTest.java
@@ -20,12 +20,12 @@ import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomU
 import com.google.common.primitives.UnsignedLong;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.util.bls.BLSPublicKey;
 
 class ValidatorTest {
 
-  private Bytes48 pubkey = Bytes48.random();
+  private BLSPublicKey pubkey = BLSPublicKey.random();
   private Bytes32 withdrawalCredentials = Bytes32.random();
   private UnsignedLong activationEpoch = randomUnsignedLong();
   private UnsignedLong exitEpoch = randomUnsignedLong();
@@ -67,9 +67,13 @@ class ValidatorTest {
 
   @Test
   void equalsReturnsFalseWhenPubkeysAreDifferent() {
+    BLSPublicKey differentPublicKey = BLSPublicKey.random();
+    while (pubkey.equals(differentPublicKey)) {
+      differentPublicKey = BLSPublicKey.random();
+    }
     Validator testValidator =
         new Validator(
-            pubkey.not(),
+            differentPublicKey,
             withdrawalCredentials,
             activationEpoch,
             exitEpoch,

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.junit.BouncyCastleExtension;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -36,6 +35,7 @@ import tech.pegasys.artemis.datastructures.operations.DepositInput;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.datastructures.state.Validator;
+import tech.pegasys.artemis.util.bls.BLSPublicKey;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
 @ExtendWith(BouncyCastleExtension.class)
@@ -195,7 +195,7 @@ class BeaconStateUtilTest {
   // TODO Fill out and enable this test case when bls_verify is complete.
   void validateProofOfPosessionReturnsTrueIfTheBLSSignatureIsValidForGivenDepositInputData() {
     BeaconState beaconState = null;
-    Bytes48 pubkey = null;
+    BLSPublicKey pubkey = null;
     BLSSignature proofOfPossession = null;
     Bytes32 withdrawalCredentials = null;
 
@@ -209,7 +209,7 @@ class BeaconStateUtilTest {
   // TODO Fill out and enable this test case when bls_verify is complete.
   void validateProofOfPosessionReturnsFalseIfTheBLSSignatureIsNotValidForGivenDepositInputData() {
     BeaconState beaconState = null;
-    Bytes48 pubkey = null;
+    BLSPublicKey pubkey = null;
     BLSSignature proofOfPossession = null;
     Bytes32 withdrawalCredentials = null;
 
@@ -222,7 +222,7 @@ class BeaconStateUtilTest {
   void processDepositAddsNewValidatorWhenPubkeyIsNotFoundInRegistry() {
     // Data Setup
     DepositInput depositInput = randomDepositInput();
-    Bytes48 pubkey = depositInput.getPubkey();
+    BLSPublicKey pubkey = depositInput.getPubkey();
     BLSSignature proofOfPossession = depositInput.getProof_of_possession();
     Bytes32 withdrawalCredentials = depositInput.getWithdrawal_credentials();
     UnsignedLong amount = UnsignedLong.valueOf(100L);
@@ -259,7 +259,7 @@ class BeaconStateUtilTest {
   void processDepositTopsUpValidatorBalanceWhenPubkeyIsFoundInRegistry() {
     // Data Setup
     DepositInput depositInput = randomDepositInput();
-    Bytes48 pubkey = depositInput.getPubkey();
+    BLSPublicKey pubkey = depositInput.getPubkey();
     BLSSignature proofOfPossession = depositInput.getProof_of_possession();
     Bytes32 withdrawalCredentials = depositInput.getWithdrawal_credentials();
     UnsignedLong amount = UnsignedLong.valueOf(100L);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
@@ -57,7 +57,6 @@ import java.util.List;
 import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.crypto.Hash;
 import tech.pegasys.artemis.datastructures.Constants;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
@@ -76,6 +75,7 @@ import tech.pegasys.artemis.datastructures.state.PendingAttestation;
 import tech.pegasys.artemis.datastructures.state.Validator;
 import tech.pegasys.artemis.datastructures.util.BeaconStateUtil;
 import tech.pegasys.artemis.util.bls.BLSException;
+import tech.pegasys.artemis.util.bls.BLSPublicKey;
 
 public class BlockProcessorUtil {
 
@@ -117,7 +117,7 @@ public class BlockProcessorUtil {
     //   state.slot)].pubkey, message=proposal_root, signature=block.signature,
     //   domain=get_domain(state.fork, state.slot, DOMAIN_PROPOSAL)) is valid.
     int proposerIndex = BeaconStateUtil.get_beacon_proposer_index(state, state.getSlot());
-    Bytes48 pubkey = state.getValidator_registry().get(proposerIndex).getPubkey();
+    BLSPublicKey pubkey = state.getValidator_registry().get(proposerIndex).getPubkey();
     UnsignedLong domain = get_domain(state.getFork(), get_current_epoch(state), DOMAIN_PROPOSAL);
     checkArgument(bls_verify(pubkey, proposalRoot, block.getSignature(), domain));
   }
@@ -458,12 +458,12 @@ public class BlockProcessorUtil {
       }
     }
 
-    List<Bytes48> pubkey0 = new ArrayList<>();
+    List<BLSPublicKey> pubkey0 = new ArrayList<>();
     for (int i = 0; i < custody_bit_0_participants.size(); i++) {
       pubkey0.add(state.getValidator_registry().get(i).getPubkey());
     }
 
-    List<Bytes48> pubkey1 = new ArrayList<>();
+    List<BLSPublicKey> pubkey1 = new ArrayList<>();
     for (int i = 0; i < custody_bit_1_participants.size(); i++) {
       pubkey1.add(state.getValidator_registry().get(i).getPubkey());
     }

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSAggregate.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSAggregate.java
@@ -14,7 +14,6 @@
 package tech.pegasys.artemis.util.bls;
 
 import java.util.List;
-import net.consensys.cava.bytes.Bytes48;
 
 public class BLSAggregate {
 
@@ -24,7 +23,7 @@ public class BLSAggregate {
    * @param pubKeys the list of compressed public keys
    * @return the aggregated public key
    */
-  public static Bytes48 bls_aggregate_pubkeys(List<Bytes48> pubKeys) {
+  public static BLSPublicKey bls_aggregate_pubkeys(List<BLSPublicKey> pubKeys) {
     return BLSPublicKey.aggregate(pubKeys);
   }
 

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSKeyPair.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSKeyPair.java
@@ -13,47 +13,27 @@
 
 package tech.pegasys.artemis.util.bls;
 
-import net.consensys.cava.bytes.Bytes48;
 import tech.pegasys.artemis.util.mikuli.KeyPair;
-import tech.pegasys.artemis.util.mikuli.PublicKey;
-import tech.pegasys.artemis.util.mikuli.SecretKey;
 
 public class BLSKeyPair {
 
-  private BLSPublicKey blsPublicKey;
-  private BLSSecretKey blsSecretKey;
+  private BLSPublicKey publicKey;
+  private BLSSecretKey secretKey;
 
   public static BLSKeyPair random() {
     return new BLSKeyPair(KeyPair.random());
   }
 
   BLSKeyPair(KeyPair keyPair) {
-    this.blsPublicKey = new BLSPublicKey(keyPair.publicKey());
-    this.blsSecretKey = new BLSSecretKey(keyPair.secretKey());
+    this.publicKey = new BLSPublicKey(keyPair.publicKey());
+    this.secretKey = new BLSSecretKey(keyPair.secretKey());
   }
 
-  public BLSPublicKey getBlsPublicKey() {
-    return blsPublicKey;
+  public BLSPublicKey getPublicKey() {
+    return publicKey;
   }
 
-  public BLSSecretKey getBlsSecretKey() {
-    return blsSecretKey;
-  }
-
-  public PublicKey publicKey() {
-    return blsPublicKey.getPublicKey();
-  }
-
-  public SecretKey secretKey() {
-    return blsSecretKey.getSecretKey();
-  }
-
-  // TODO: find out why this causes the deepCopyBeaconState test to fail
-  public Bytes48 publicKeyAsBytesBroken() {
-    return Bytes48.wrap(publicKey().toBytes());
-  }
-
-  public Bytes48 publicKeyAsBytes() {
-    return Bytes48.wrap(publicKey().toBytes()).copy();
+  public BLSSecretKey getSecretKey() {
+    return secretKey;
   }
 }

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSPublicKey.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSPublicKey.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.isNull;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.ssz.SSZ;
@@ -105,7 +106,7 @@ public class BLSPublicKey {
 
   @Override
   public int hashCode() {
-    return isNull(publicKey) ? 61016 : publicKey.hashCode();
+    return Objects.hash(publicKey);
   }
 
   @Override
@@ -120,6 +121,6 @@ public class BLSPublicKey {
       return false;
     }
     BLSPublicKey other = (BLSPublicKey) obj;
-    return isNull(publicKey) ? isNull(other.publicKey) : publicKey.equals(other.publicKey);
+    return Objects.equals(this.publicKey, other.publicKey);
   }
 }

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSPublicKey.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSPublicKey.java
@@ -13,9 +13,13 @@
 
 package tech.pegasys.artemis.util.bls;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.isNull;
+
 import java.util.List;
 import java.util.stream.Collectors;
-import net.consensys.cava.bytes.Bytes48;
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.ssz.SSZ;
 import tech.pegasys.artemis.util.mikuli.PublicKey;
 
 public class BLSPublicKey {
@@ -25,24 +29,97 @@ public class BLSPublicKey {
    *
    * @return PublicKey The public key, not null
    */
-  public static Bytes48 random() {
-    return Bytes48.wrap(PublicKey.random().toBytes());
+  public static BLSPublicKey random() {
+    return new BLSPublicKey(PublicKey.random());
   }
 
-  public static Bytes48 aggregate(List<Bytes48> publicKeys) {
+  public static BLSPublicKey random(int seed) {
+    return new BLSPublicKey(PublicKey.random(seed));
+  }
+
+  /**
+   * Creates an empty public key (all zero bytes)
+   *
+   * <p>Due to the flags, this is not actually a valid key, so we use null to flag that the public
+   * key is empty.
+   *
+   * @return the empty public key as per the Eth2 spec
+   */
+  public static BLSPublicKey empty() {
+    return new BLSPublicKey(null);
+  }
+
+  public static BLSPublicKey aggregate(List<BLSPublicKey> publicKeys) {
     List<PublicKey> publicKeyObjects =
-        publicKeys.stream().map(x -> PublicKey.fromBytes(x)).collect(Collectors.toList());
-    PublicKey aggregateKey = PublicKey.aggregate(publicKeyObjects);
-    return Bytes48.wrap(aggregateKey.toBytes());
+        publicKeys.stream().map(x -> x.publicKey).collect(Collectors.toList());
+    return new BLSPublicKey(PublicKey.aggregate(publicKeyObjects));
   }
 
-  private PublicKey publicKey;
+  public static BLSPublicKey fromBytes(Bytes bytes) {
+    checkArgument(bytes.size() == 52, "Expected 52 bytes but received %s.", bytes.size());
+    if (SSZ.decodeBytes(bytes).isZero()) {
+      return BLSPublicKey.empty();
+    } else {
+      return SSZ.decode(
+          bytes, reader -> new BLSPublicKey(PublicKey.fromBytesCompressed(reader.readBytes())));
+    }
+  }
+
+  private final PublicKey publicKey;
 
   BLSPublicKey(PublicKey publicKey) {
     this.publicKey = publicKey;
   }
 
+  /**
+   * Returns the SSZ serialisation of the <em>compressed</em> form of the signature
+   *
+   * @return the serialisation of the compressed form of the signature.
+   */
+  public Bytes toBytes() {
+    if (isNull(publicKey)) {
+      return SSZ.encode(
+          writer -> {
+            writer.writeBytes(Bytes.wrap(new byte[48]));
+          });
+    } else {
+      return SSZ.encode(
+          writer -> {
+            writer.writeBytes(publicKey.toBytesCompressed());
+          });
+    }
+  }
+
   PublicKey getPublicKey() {
     return publicKey;
+  }
+
+  boolean isEmpty() {
+    return isNull(publicKey);
+  }
+
+  @Override
+  public String toString() {
+    return isNull(publicKey) ? "Empty Public Key" : publicKey.toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return isNull(publicKey) ? 61016 : publicKey.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (isNull(obj)) {
+      return false;
+    }
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof BLSPublicKey)) {
+      return false;
+    }
+    BLSPublicKey other = (BLSPublicKey) obj;
+    return isNull(publicKey) ? isNull(other.publicKey) : publicKey.equals(other.publicKey);
   }
 }

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSSignature.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSSignature.java
@@ -19,7 +19,6 @@ import static java.util.Objects.isNull;
 import java.util.List;
 import java.util.stream.Collectors;
 import net.consensys.cava.bytes.Bytes;
-import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.ssz.SSZ;
 import tech.pegasys.artemis.util.mikuli.BLS12381;
 import tech.pegasys.artemis.util.mikuli.KeyPair;
@@ -39,7 +38,11 @@ public final class BLSSignature {
   public static BLSSignature sign(BLSKeyPair keyPair, Bytes message, long domain) {
     return new BLSSignature(
         BLS12381
-            .sign(new KeyPair(keyPair.secretKey(), keyPair.publicKey()), message, domain)
+            .sign(
+                new KeyPair(
+                    keyPair.getSecretKey().getSecretKey(), keyPair.getPublicKey().getPublicKey()),
+                message,
+                domain)
             .signature());
   }
 
@@ -96,7 +99,7 @@ public final class BLSSignature {
       return BLSSignature.empty();
     } else {
       return SSZ.decode(
-          bytes, reader -> new BLSSignature(Signature.decodeCompressed(reader.readBytes())));
+          bytes, reader -> new BLSSignature(Signature.fromBytesCompressed(reader.readBytes())));
     }
   }
 
@@ -115,11 +118,14 @@ public final class BLSSignature {
    * @return true if the signature is valid, false if it is not
    * @throws BLSException
    */
-  boolean checkSignature(Bytes48 publicKey, Bytes message, long domain) throws BLSException {
+  boolean checkSignature(BLSPublicKey publicKey, Bytes message, long domain) throws BLSException {
     if (isNull(signature)) {
       throw new BLSException("The checkSignature method was called on an empty signature.");
     }
-    return BLS12381.verify(PublicKey.fromBytes(publicKey), signature, message, domain);
+    if (isNull(publicKey)) {
+      throw new BLSException("The checkSignature method was called with an empty public key.");
+    }
+    return BLS12381.verify(publicKey.getPublicKey(), signature, message, domain);
   }
 
   /**
@@ -132,7 +138,7 @@ public final class BLSSignature {
    * @return true if the signature is valid, false if it is not
    * @throws BLSException
    */
-  boolean checkSignature(List<Bytes48> publicKeys, List<Bytes> messages, long domain)
+  boolean checkSignature(List<BLSPublicKey> publicKeys, List<Bytes> messages, long domain)
       throws BLSException {
     checkArgument(
         publicKeys.size() == messages.size(),
@@ -143,7 +149,7 @@ public final class BLSSignature {
       throw new BLSException("The checkSignature method was called on an empty signature.");
     }
     List<PublicKey> publicKeyObjects =
-        publicKeys.stream().map(x -> PublicKey.fromBytes(x)).collect(Collectors.toList());
+        publicKeys.stream().map(x -> x.getPublicKey()).collect(Collectors.toList());
     return BLS12381.verifyMultiple(publicKeyObjects, signature, messages, domain);
   }
 
@@ -161,7 +167,7 @@ public final class BLSSignature {
     } else {
       return SSZ.encode(
           writer -> {
-            writer.writeBytes(signature.encodeCompressed());
+            writer.writeBytes(signature.toBytesCompressed());
           });
     }
   }

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSSignature.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSSignature.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.isNull;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.ssz.SSZ;
@@ -187,7 +188,7 @@ public final class BLSSignature {
 
   @Override
   public int hashCode() {
-    return isNull(signature) ? 42 : signature.hashCode();
+    return Objects.hash(signature);
   }
 
   @Override
@@ -202,6 +203,6 @@ public final class BLSSignature {
       return false;
     }
     BLSSignature other = (BLSSignature) obj;
-    return isNull(signature) ? isNull(other.signature) : signature.equals(other.signature);
+    return Objects.equals(this.signature, other.signature);
   }
 }

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSVerify.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSVerify.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
-import net.consensys.cava.bytes.Bytes48;
 
 public class BLSVerify {
 
@@ -32,7 +31,7 @@ public class BLSVerify {
    * @return true if the signature is valid over these parameters, false if not
    */
   public static boolean bls_verify(
-      Bytes48 pubkey, Bytes32 messageHash, BLSSignature signature, UnsignedLong domain) {
+      BLSPublicKey pubkey, Bytes32 messageHash, BLSSignature signature, UnsignedLong domain) {
     try {
       return signature.checkSignature(pubkey, Bytes.wrap(messageHash), domain.longValue());
     } catch (BLSException e) {
@@ -54,7 +53,7 @@ public class BLSVerify {
    * @return true if the signature is valid over these parameters, false if not
    */
   public static boolean bls_verify_multiple(
-      List<Bytes48> pubkeys,
+      List<BLSPublicKey> pubkeys,
       List<Bytes32> messageHashes,
       BLSSignature aggregateSignature,
       UnsignedLong domain) {

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/PublicKey.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/PublicKey.java
@@ -116,10 +116,7 @@ public final class PublicKey {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + Objects.hashCode(point);
-    return result;
+    return Objects.hash(point);
   }
 
   @Override

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/PublicKey.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/PublicKey.java
@@ -30,6 +30,15 @@ public final class PublicKey {
   }
 
   /**
+   * Generates a random, valid public key given entropy
+   *
+   * @return PublicKey The public key, not null
+   */
+  public static PublicKey random(int entropy) {
+    return KeyPair.random(entropy).publicKey();
+  }
+
+  /**
    * Aggregates list of PublicKeys
    *
    * @param keys The list of public keys to aggregate, not null
@@ -49,8 +58,8 @@ public final class PublicKey {
    * @param bytes the bytes to read the public key from
    * @return a valid public key
    */
-  public static PublicKey fromBytes(byte[] bytes) {
-    return fromBytes(Bytes.wrap(bytes));
+  public static PublicKey fromBytesCompressed(byte[] bytes) {
+    return fromBytesCompressed(Bytes.wrap(bytes));
   }
 
   /**
@@ -59,7 +68,7 @@ public final class PublicKey {
    * @param bytes the bytes to read the public key from
    * @return a valid public key
    */
-  public static PublicKey fromBytes(Bytes bytes) {
+  public static PublicKey fromBytesCompressed(Bytes bytes) {
     G1Point point = G1Point.fromBytesCompressed(bytes);
     return new PublicKey(point);
   }
@@ -92,12 +101,17 @@ public final class PublicKey {
    *
    * @return byte array representation of the public key
    */
-  public Bytes toBytes() {
+  public Bytes toBytesCompressed() {
     return point.toBytesCompressed();
   }
 
   G1Point g1Point() {
     return point;
+  }
+
+  @Override
+  public String toString() {
+    return "Signature [ecpPoint=" + point.toString() + "]";
   }
 
   @Override

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/Signature.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/Signature.java
@@ -142,10 +142,7 @@ public final class Signature {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((point == null) ? 0 : point.hashCode());
-    return result;
+    return Objects.hash(point);
   }
 
   G2Point g2Point() {

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/Signature.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/Signature.java
@@ -45,7 +45,7 @@ public final class Signature {
    * @param bytes the bytes of the signature
    * @return the signature
    */
-  public static Signature decode(Bytes bytes) {
+  public static Signature fromBytes(Bytes bytes) {
     checkArgument(bytes.size() == 192, "Expected 192 bytes of input but got %s", bytes.size());
     return new Signature(G2Point.fromBytes(bytes));
   }
@@ -56,7 +56,7 @@ public final class Signature {
    * @param bytes the bytes of the signature
    * @return the signature
    */
-  public static Signature decodeCompressed(Bytes bytes) {
+  public static Signature fromBytesCompressed(Bytes bytes) {
     checkArgument(bytes.size() == 96, "Expected 96 bytes of input but got %s", bytes.size());
     return new Signature(G2Point.fromBytesCompressed(bytes));
   }
@@ -122,7 +122,7 @@ public final class Signature {
    *
    * @return byte array representation of the signature, not null
    */
-  public Bytes encode() {
+  public Bytes toBytes() {
     return point.toBytes();
   }
 
@@ -131,13 +131,13 @@ public final class Signature {
    *
    * @return byte array representation of the signature, not null
    */
-  public Bytes encodeCompressed() {
+  public Bytes toBytesCompressed() {
     return point.toBytesCompressed();
   }
 
   @Override
   public String toString() {
-    return "Signature [ecpPoint=" + point.toString() + "]";
+    return "Signature [ecp2Point=" + point.toString() + "]";
   }
 
   @Override

--- a/util/src/test/java/tech/pegasys/artemis/util/bls/BLSAggregationTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/bls/BLSAggregationTest.java
@@ -22,9 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import java.util.List;
 import net.consensys.cava.bytes.Bytes;
-import net.consensys.cava.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.artemis.util.mikuli.PublicKey;
 
 public class BLSAggregationTest {
 
@@ -36,7 +34,7 @@ public class BLSAggregationTest {
 
   @Test
   void succeedsWhenAggregatingASinglePublicKeyReturnsTheSamePublicKey() {
-    Bytes48 publicKeyCompressed = Bytes48.wrap(BLSKeyPair.random().publicKey().toBytes());
+    BLSPublicKey publicKeyCompressed = BLSPublicKey.random();
     assertEquals(publicKeyCompressed, BLSPublicKey.aggregate(Arrays.asList(publicKeyCompressed)));
   }
 
@@ -55,8 +53,8 @@ public class BLSAggregationTest {
     BLSSignature signature = BLSSignature.random();
 
     // Two keys
-    Bytes48 publicKey = Bytes48.wrap(PublicKey.random().toBytes());
-    List<Bytes48> publicKeys = Arrays.asList(publicKey, publicKey);
+    BLSPublicKey publicKey = BLSPublicKey.random();
+    List<BLSPublicKey> publicKeys = Arrays.asList(publicKey, publicKey);
 
     // Three messages
     Bytes message = Bytes.wrap("Ceci n'est pas une pipe".getBytes(UTF_8));
@@ -84,16 +82,10 @@ public class BLSAggregationTest {
     BLSSignature signature4 = BLSSignature.sign(keyPair4, message2, 0);
 
     // Aggregate keys 1 & 2, and keys 3 & 4
-    Bytes48 aggregatePublicKey12 =
-        BLSPublicKey.aggregate(
-            Arrays.asList(
-                Bytes48.wrap(keyPair1.getBlsPublicKey().getPublicKey().toBytes()),
-                Bytes48.wrap(keyPair2.getBlsPublicKey().getPublicKey().toBytes())));
-    Bytes48 aggregatePublicKey34 =
-        BLSPublicKey.aggregate(
-            Arrays.asList(
-                Bytes48.wrap(keyPair3.getBlsPublicKey().getPublicKey().toBytes()),
-                Bytes48.wrap(keyPair4.getBlsPublicKey().getPublicKey().toBytes())));
+    BLSPublicKey aggregatePublicKey12 =
+        BLSPublicKey.aggregate(Arrays.asList(keyPair1.getPublicKey(), keyPair2.getPublicKey()));
+    BLSPublicKey aggregatePublicKey34 =
+        BLSPublicKey.aggregate(Arrays.asList(keyPair3.getPublicKey(), keyPair4.getPublicKey()));
 
     // Aggregate the signatures
     BLSSignature aggregateSignature =
@@ -125,16 +117,10 @@ public class BLSAggregationTest {
     BLSSignature signature4 = BLSSignature.sign(keyPair4, message2, 0);
 
     // Aggregate keys 1 & 2, and keys 3 & 4
-    Bytes48 aggregatePublicKey12 =
-        BLSPublicKey.aggregate(
-            Arrays.asList(
-                Bytes48.wrap(keyPair1.getBlsPublicKey().getPublicKey().toBytes()),
-                Bytes48.wrap(keyPair2.getBlsPublicKey().getPublicKey().toBytes())));
-    Bytes48 aggregatePublicKey34 =
-        BLSPublicKey.aggregate(
-            Arrays.asList(
-                Bytes48.wrap(keyPair3.getBlsPublicKey().getPublicKey().toBytes()),
-                Bytes48.wrap(keyPair4.getBlsPublicKey().getPublicKey().toBytes())));
+    BLSPublicKey aggregatePublicKey12 =
+        BLSPublicKey.aggregate(Arrays.asList(keyPair1.getPublicKey(), keyPair2.getPublicKey()));
+    BLSPublicKey aggregatePublicKey34 =
+        BLSPublicKey.aggregate(Arrays.asList(keyPair3.getPublicKey(), keyPair4.getPublicKey()));
 
     // Aggregate the signatures
     BLSSignature aggregateSignature =

--- a/util/src/test/java/tech/pegasys/artemis/util/bls/BLSPublicKeyTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/bls/BLSPublicKeyTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.util.bls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.ssz.SSZ;
+import org.junit.jupiter.api.Test;
+
+class BLSPublicKeyTest {
+
+  @Test
+  void succeedsWhenEqualsReturnsTrueForTheSameEmptyPublicKey() {
+    BLSPublicKey publicKey = BLSPublicKey.empty();
+    assertEquals(publicKey, publicKey);
+  }
+
+  @Test
+  void succeedsWhenEqualsReturnsTrueForTwoEmptyPublicKeys() {
+    BLSPublicKey publicKey1 = BLSPublicKey.empty();
+    BLSPublicKey publicKey2 = BLSPublicKey.empty();
+    assertEquals(publicKey1, publicKey2);
+  }
+
+  @Test
+  void succeedsIfSerialisationOfEmptyPublicKeyIsCorrect() {
+    BLSPublicKey emptyPublicKey = BLSPublicKey.empty();
+    assertTrue(emptyPublicKey.isEmpty());
+    // SSZ prepends the length as four little-endian bytes
+    assertEquals(
+        "0x30000000"
+            + "000000000000000000000000000000000000000000000000"
+            + "000000000000000000000000000000000000000000000000",
+        emptyPublicKey.toBytes().toHexString());
+  }
+
+  @Test
+  void succeedsIfDeserialisationOfEmptyPublicKeyIsCorrect() {
+    BLSPublicKey emptyPublicKey = BLSPublicKey.empty();
+    assertTrue(emptyPublicKey.isEmpty());
+    Bytes zeroBytes = Bytes.wrap(new byte[48]);
+    Bytes emptyBytesSsz = SSZ.encodeBytes(zeroBytes);
+    BLSPublicKey deserialisedPublicKey = BLSPublicKey.fromBytes(emptyBytesSsz);
+    assertEquals(emptyPublicKey, deserialisedPublicKey);
+  }
+
+  @Test
+  void succeedsIfDeserialisationThrowsWithTooFewBytes() {
+    Bytes tooFewBytes = Bytes.wrap(new byte[51]);
+    assertThrows(IllegalArgumentException.class, () -> BLSPublicKey.fromBytes(tooFewBytes));
+  }
+
+  @Test
+  void succeedsIfValidPublicKeyIsNotEmpty() {
+    BLSPublicKey publicKey = BLSPublicKey.random();
+    assertTrue(!publicKey.isEmpty());
+  }
+
+  @Test
+  void succeedsWhenEqualsReturnsTrueForTheSamePublicKey() {
+    BLSPublicKey publicKey = BLSPublicKey.random();
+    assertEquals(publicKey, publicKey);
+  }
+
+  @Test
+  void succeedsWhenEqualsReturnsTrueForIdenticalPublicKeys() {
+    BLSPublicKey publicKey = BLSPublicKey.random();
+    BLSPublicKey copyOfPublicKey = new BLSPublicKey(publicKey.getPublicKey());
+    assertEquals(publicKey, copyOfPublicKey);
+  }
+
+  @Test
+  void succeedsWhenEqualsReturnsFalseForDifferentPublicKeys() {
+    BLSPublicKey publicKey1 = BLSPublicKey.random();
+    BLSPublicKey publicKey2 = BLSPublicKey.random();
+    // Ensure that we have two different publicKeys, without assuming too much about .equals
+    while (publicKey1.getPublicKey().equals(publicKey2.getPublicKey())) {
+      publicKey2 = BLSPublicKey.random();
+    }
+    assertNotEquals(publicKey1, publicKey2);
+  }
+
+  @Test
+  void succeedsWhenRoundtripSSZReturnsTheSamePublicKey() {
+    BLSPublicKey publicKey1 = BLSPublicKey.random();
+    BLSPublicKey publicKey2 = BLSPublicKey.fromBytes(publicKey1.toBytes());
+    assertEquals(publicKey1, publicKey2);
+  }
+
+  @Test
+  void succeedsWhenRoundtripSSZReturnsTheEmptyPublicKey() {
+    BLSPublicKey publicKey1 = BLSPublicKey.empty();
+    BLSPublicKey publicKey2 = BLSPublicKey.fromBytes(publicKey1.toBytes());
+    assertEquals(publicKey1, publicKey2);
+  }
+}

--- a/util/src/test/java/tech/pegasys/artemis/util/bls/BLSSignatureTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/bls/BLSSignatureTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import net.consensys.cava.bytes.Bytes;
-import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.ssz.SSZ;
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +44,8 @@ class BLSSignatureTest {
     BLSSignature signature = BLSSignature.empty();
     assertThrows(
         BLSException.class,
-        () -> signature.checkSignature(Bytes48.random(), Bytes.wrap("Test".getBytes(UTF_8)), 0));
+        () ->
+            signature.checkSignature(BLSPublicKey.random(), Bytes.wrap("Test".getBytes(UTF_8)), 0));
   }
 
   @Test
@@ -113,7 +113,7 @@ class BLSSignatureTest {
     Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
     long domain = 42;
     BLSSignature signature = BLSSignature.sign(keyPair, message, domain);
-    assertTrue(signature.checkSignature(keyPair.publicKeyAsBytes(), message, domain));
+    assertTrue(signature.checkSignature(keyPair.getPublicKey(), message, domain));
   }
 
   @Test
@@ -123,7 +123,7 @@ class BLSSignatureTest {
     long domain1 = 42;
     long domain2 = 43;
     BLSSignature signature = BLSSignature.sign(keyPair, message, domain1);
-    assertFalse(signature.checkSignature(keyPair.publicKeyAsBytes(), message, domain2));
+    assertFalse(signature.checkSignature(keyPair.getPublicKey(), message, domain2));
   }
 
   @Test
@@ -133,7 +133,7 @@ class BLSSignatureTest {
     Bytes message2 = Bytes.wrap("Hello, world?".getBytes(UTF_8));
     long domain = 42;
     BLSSignature signature = BLSSignature.sign(keyPair, message1, domain);
-    assertFalse(signature.checkSignature(keyPair.publicKeyAsBytes(), message2, domain));
+    assertFalse(signature.checkSignature(keyPair.getPublicKey(), message2, domain));
   }
 
   @Test
@@ -146,7 +146,7 @@ class BLSSignatureTest {
     Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
     long domain = 42;
     BLSSignature signature = BLSSignature.sign(keyPair1, message, domain);
-    assertFalse(signature.checkSignature(keyPair2.publicKeyAsBytes(), message, domain));
+    assertFalse(signature.checkSignature(keyPair2.getPublicKey(), message, domain));
   }
 
   @Test

--- a/util/src/test/java/tech/pegasys/artemis/util/mikuli/SignatureTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/mikuli/SignatureTest.java
@@ -47,9 +47,9 @@ class SignatureTest {
   }
 
   @Test
-  void succeedsWhenEncodedSignaturesAre192BytesLong() {
+  void succeedsWhenSerialisedSignaturesAre192BytesLong() {
     Signature signature = Signature.random();
-    assertEquals(signature.encode().size(), 192);
+    assertEquals(signature.toBytes().size(), 192);
   }
 
   @Test
@@ -60,12 +60,12 @@ class SignatureTest {
   @Test
   void roundtripEncodeDecode() {
     Signature signature = Signature.random();
-    assertEquals(signature, Signature.decode(signature.encode()));
+    assertEquals(signature, Signature.fromBytes(signature.toBytes()));
   }
 
   @Test
   void roundtripEncodeDecodeCompressed() {
     Signature signature = Signature.random();
-    assertEquals(signature, Signature.decodeCompressed(signature.encodeCompressed()));
+    assertEquals(signature, Signature.fromBytesCompressed(signature.toBytesCompressed()));
   }
 }


### PR DESCRIPTION
## PR Description
Replace `Bytes48` throughout with `BLSPublicKey` similarly to how we use BLSSignature.

Main work is done. Everything builds and tests all run. Remaining work is to add more thorough unit tests for BLSPublicKey.