### PR TITLE
Integrate Lmd Ghost

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
@@ -302,7 +302,7 @@ public final class DataStructureUtil {
 
     for (int i = 0; i < numDeposits; i++) {
       DepositInput deposit_input =
-          new DepositInput(BLSPublicKey.empty(), Bytes32.ZERO, BLSSignature.empty());
+          new DepositInput(BLSPublicKey.random(), Bytes32.ZERO, BLSSignature.empty());
       UnsignedLong timestamp = UnsignedLong.valueOf(i);
       DepositData deposit_data =
           new DepositData(UnsignedLong.valueOf(MAX_DEPOSIT_AMOUNT), timestamp, deposit_input);
@@ -334,7 +334,7 @@ public final class DataStructureUtil {
   public static BeaconState createInitialBeaconState() {
 
     return BeaconStateUtil.get_initial_beacon_state(
-        newDeposits(0),
+        newDeposits(50),
         UnsignedLong.valueOf(Constants.GENESIS_SLOT),
         new Eth1Data(Bytes32.ZERO, Bytes32.ZERO));
   }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
@@ -334,7 +334,7 @@ public final class DataStructureUtil {
   public static BeaconState createInitialBeaconState() {
 
     return BeaconStateUtil.get_initial_beacon_state(
-        newDeposits(100),
+        newDeposits(0),
         UnsignedLong.valueOf(Constants.GENESIS_SLOT),
         new Eth1Data(Bytes32.ZERO, Bytes32.ZERO));
   }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
@@ -297,12 +297,12 @@ public final class DataStructureUtil {
         randomBeaconBlockBody());
   }
 
-  public static ArrayList<Deposit> newDeposits(int numDeposits) {
+  public static ArrayList<Deposit> newDeposits(int numDeposits, int slot) {
     ArrayList<Deposit> deposits = new ArrayList<Deposit>();
 
     for (int i = 0; i < numDeposits; i++) {
       DepositInput deposit_input =
-          new DepositInput(BLSPublicKey.random(), Bytes32.ZERO, BLSSignature.empty());
+          new DepositInput(BLSPublicKey.random(i + slot), Bytes32.ZERO, BLSSignature.empty());
       UnsignedLong timestamp = UnsignedLong.valueOf(i);
       DepositData deposit_data =
           new DepositData(UnsignedLong.valueOf(MAX_DEPOSIT_AMOUNT), timestamp, deposit_input);
@@ -332,9 +332,8 @@ public final class DataStructureUtil {
   }
 
   public static BeaconState createInitialBeaconState() {
-
     return BeaconStateUtil.get_initial_beacon_state(
-        newDeposits(50),
+        newDeposits(50, Math.toIntExact(Constants.GENESIS_SLOT)),
         UnsignedLong.valueOf(Constants.GENESIS_SLOT),
         new Eth1Data(Bytes32.ZERO, Bytes32.ZERO));
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/LmdGhost.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/LmdGhost.java
@@ -108,8 +108,8 @@ public class LmdGhost {
    *  Let get_latest_attestation_target(store: Store, validator: Validator) -> BeaconBlock
    *  be the target block in the attestation get_latest_attestation(store, validator).
    */
-  public static BeaconBlock get_latest_attestation_target(ChainStorageClient store, int validatorIndex)
-      throws StateTransitionException {
+  public static BeaconBlock get_latest_attestation_target(
+      ChainStorageClient store, int validatorIndex) throws StateTransitionException {
     Attestation latest_attestation = get_latest_attestation(store, validatorIndex);
     Optional<BeaconBlock> latest_attestation_target =
         store.getProcessedBlock(latest_attestation.getData().getBeacon_block_root());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/LmdGhost.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/LmdGhost.java
@@ -111,10 +111,9 @@ public class LmdGhost {
     Optional<Attestation> latest_attestation = get_latest_attestation(store, validatorIndex);
     if (latest_attestation.isPresent()) {
       Optional<BeaconBlock> latest_attestation_target =
-              store.getProcessedBlock(latest_attestation.get().getData().getBeacon_block_root());
+          store.getProcessedBlock(latest_attestation.get().getData().getBeacon_block_root());
       return latest_attestation_target;
-    }
-    else {
+    } else {
       return Optional.empty();
     }
   }
@@ -125,8 +124,8 @@ public class LmdGhost {
    *  be the attestation with the highest slot number in store from validator. If
    *  several such attestations exist, use the one the validator v observed first.
    */
-  public static Optional<Attestation> get_latest_attestation(ChainStorageClient store, int validatorIndex)
-      throws StateTransitionException {
+  public static Optional<Attestation> get_latest_attestation(
+      ChainStorageClient store, int validatorIndex) throws StateTransitionException {
     Optional<Attestation> latestAttestation = store.getLatestAttestation(validatorIndex);
     return latestAttestation;
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/LmdGhost.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/LmdGhost.java
@@ -31,7 +31,7 @@ import tech.pegasys.artemis.storage.ChainStorageClient;
 
 public class LmdGhost {
 
-  public BeaconBlock lmd_ghost(
+  public static BeaconBlock lmd_ghost(
       ChainStorageClient store, BeaconState start_state, BeaconBlock start_block)
       throws StateTransitionException {
     List<Integer> active_validator_indices =
@@ -71,7 +71,7 @@ public class LmdGhost {
   /*
    * This function is defined inside lmd_ghost in spec. It is defined here separately for legibility.
    */
-  public UnsignedLong get_vote_count(
+  public static UnsignedLong get_vote_count(
       ChainStorageClient store, BeaconBlock block, List<BeaconBlock> attestation_targets) {
     UnsignedLong vote_count = UnsignedLong.ZERO;
     for (BeaconBlock target : attestation_targets) {
@@ -91,7 +91,7 @@ public class LmdGhost {
    *  the child blocks of the given block.
    */
   // TODO: OPTIMIZE: currently goes through all the values in processedBlockLookup
-  public List<BeaconBlock> get_children(ChainStorageClient store, BeaconBlock block) {
+  public static List<BeaconBlock> get_children(ChainStorageClient store, BeaconBlock block) {
     List<BeaconBlock> children = new ArrayList<>();
     for (Map.Entry<Bytes, BeaconBlock> entry : store.getProcessedBlockLookup().entrySet()) {
       BeaconBlock potential_child = entry.getValue();
@@ -108,7 +108,7 @@ public class LmdGhost {
    *  Let get_latest_attestation_target(store: Store, validator: Validator) -> BeaconBlock
    *  be the target block in the attestation get_latest_attestation(store, validator).
    */
-  public BeaconBlock get_latest_attestation_target(ChainStorageClient store, int validatorIndex)
+  public static BeaconBlock get_latest_attestation_target(ChainStorageClient store, int validatorIndex)
       throws StateTransitionException {
     Attestation latest_attestation = get_latest_attestation(store, validatorIndex);
     Optional<BeaconBlock> latest_attestation_target =
@@ -125,7 +125,7 @@ public class LmdGhost {
    *  be the attestation with the highest slot number in store from validator. If
    *  several such attestations exist, use the one the validator v observed first.
    */
-  public Attestation get_latest_attestation(ChainStorageClient store, int validatorIndex)
+  public static Attestation get_latest_attestation(ChainStorageClient store, int validatorIndex)
       throws StateTransitionException {
     Optional<Attestation> latestAttestation = store.getLatestAttestation(validatorIndex);
     if (!latestAttestation.isPresent()) {
@@ -140,7 +140,7 @@ public class LmdGhost {
    *  be the ancestor of block with slot number slot. The get_ancestor function can be
    *  defined recursively as:
    */
-  public Optional<BeaconBlock> get_ancestor(
+  public static Optional<BeaconBlock> get_ancestor(
       ChainStorageClient store, BeaconBlock block, UnsignedLong slotNumber) {
     requireNonNull(block);
     UnsignedLong blockSlot = UnsignedLong.valueOf(block.getSlot());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTreeManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTreeManager.java
@@ -121,8 +121,8 @@ public class StateTreeManager {
       newStateRoot = HashTreeUtil.hash_tree_root(newState.toBytes());
       this.store.addState(newStateRoot, newState);
     }
-    LOG.info("latest block root: " + head_block_root);
-    LOG.info("latest state root: " + newStateRoot.toHexString());
+    LOG.info("latest head block root: " + head_block_root);
+    LOG.info("latest head state root: " + newStateRoot.toHexString());
   }
 
   protected Boolean inspectBlock(Optional<BeaconBlock> block) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTreeManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTreeManager.java
@@ -16,10 +16,12 @@ package tech.pegasys.artemis.statetransition;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.primitives.UnsignedLong;
+
 import java.util.Date;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+
 import net.consensys.cava.bytes.Bytes32;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,10 +35,12 @@ import tech.pegasys.artemis.storage.ChainStorage;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.util.hashtree.HashTreeUtil;
 
-/** Class to manage the state tree and initiate state transitions */
+/**
+ * Class to manage the state tree and initiate state transitions
+ */
 public class StateTreeManager {
 
-  private BeaconState canonical_state;
+  private BeaconBlock head;
   private UnsignedLong nodeTime;
   private UnsignedLong nodeSlot;
   private final EventBus eventBus;
@@ -49,17 +53,7 @@ public class StateTreeManager {
     this.stateTransition = new StateTransition();
     this.eventBus.register(this);
     this.store = ChainStorage.Create(ChainStorageClient.class, eventBus);
-  }
 
-  @Subscribe
-  public void onChainStarted(ChainStartEvent event) {
-    LOG.info("******* ChainStart Event Detected *******");
-    this.nodeSlot = UnsignedLong.valueOf(Constants.GENESIS_SLOT);
-    this.nodeTime =
-        UnsignedLong.valueOf(Constants.GENESIS_SLOT)
-            .times(UnsignedLong.valueOf(Constants.SLOT_DURATION));
-    LOG.info("node time: " + nodeTime.longValue());
-    Boolean result = false;
     try {
       BeaconState initial_state = DataStructureUtil.createInitialBeaconState();
       Bytes32 initial_state_root = HashTreeUtil.hash_tree_root(initial_state.toBytes());
@@ -68,15 +62,23 @@ public class StateTreeManager {
       LOG.info("Initial State:");
       LOG.info("  initial state root is " + initial_state_root.toHexString());
       this.store.addState(initial_state_root, initial_state);
-      this.store.addProcessedBlock(initial_state_root, genesis_block);
       this.store.addProcessedBlock(genesis_block_root, genesis_block);
-      this.canonical_state = initial_state;
-      result = true;
+      this.head = genesis_block;
     } catch (IllegalStateException e) {
       LOG.fatal(e);
-    } finally {
-      this.eventBus.post(result);
     }
+  }
+
+  @Subscribe
+  public void onChainStarted(ChainStartEvent event) {
+    LOG.info("******* ChainStart Event Detected *******");
+    this.nodeSlot = UnsignedLong.valueOf(Constants.GENESIS_SLOT);
+    this.nodeTime =
+            UnsignedLong.valueOf(Constants.GENESIS_SLOT)
+                    .times(UnsignedLong.valueOf(Constants.SLOT_DURATION));
+    LOG.info("node time: " + nodeTime.longValue());
+    boolean result = true;
+    this.eventBus.post(result);
   }
 
   @Subscribe
@@ -86,7 +88,7 @@ public class StateTreeManager {
   }
 
   @Subscribe
-  public void onNewSlot(Date date) {
+  public void onNewSlot(Date date) throws StateTransitionException{
     this.nodeSlot = this.nodeSlot.plus(UnsignedLong.ONE);
     this.nodeTime = this.nodeTime.plus(UnsignedLong.valueOf(Constants.SLOT_DURATION));
 
@@ -95,8 +97,34 @@ public class StateTreeManager {
     LOG.info("node slot: " + nodeSlot.longValue());
 
     List<Optional<BeaconBlock>> unprocessedBlocks =
-        this.store.getUnprocessedBlocksUntilSlot(nodeSlot);
-    unprocessedBlocks.stream().forEach((block) -> processFork(this.nodeSlot, block));
+            this.store.getUnprocessedBlocksUntilSlot(nodeSlot);
+    unprocessedBlocks.forEach((block) -> processFork(block));
+
+    // Run lmd_ghost to get the head
+    try {
+      this.head = LmdGhost.lmd_ghost(store, store.get_justified_head_state(), store.get_justified_head_block());
+    } catch (StateTransitionException e) {
+      LOG.fatal(e);
+    }
+
+    // Run state transition from the new head to node.slot
+    Bytes32 head_block_root = this.head.getState_root();
+    BeaconState newState = store.getState(head_block_root).get();
+    Bytes32 newStateRoot = HashTreeUtil.hash_tree_root(newState.toBytes());
+    boolean firstLoop = true;
+    while (newState.getSlot().compareTo(nodeSlot) < 0) {
+      if (firstLoop) {
+        LOG.info(
+                "Transitioning state from slot: " + newState.getSlot() + " to slot: " + nodeSlot);
+        firstLoop = false;
+      }
+      newState = BeaconState.deepCopy(newState);
+      stateTransition.initiate(newState, null, store);
+      newStateRoot = HashTreeUtil.hash_tree_root(newState.toBytes());
+      this.store.addState(newStateRoot, newState);
+    }
+    LOG.info("latest block root: " + head_block_root);
+    LOG.info("latest state root: " + newStateRoot.toHexString());
   }
 
   protected Boolean inspectBlock(Optional<BeaconBlock> block) {
@@ -107,8 +135,8 @@ public class StateTreeManager {
       return false;
     }
     UnsignedLong blockTime =
-        UnsignedLong.valueOf(block.get().getSlot())
-            .times(UnsignedLong.valueOf(Constants.SLOT_DURATION));
+            UnsignedLong.valueOf(block.get().getSlot())
+                    .times(UnsignedLong.valueOf(Constants.SLOT_DURATION));
     // TODO: Here we reject block because time is not there,
     // however, the block is already removed from queue, so
     // we're losing a valid block here.
@@ -118,90 +146,67 @@ public class StateTreeManager {
     return true;
   }
 
-  protected void processFork(UnsignedLong current_slot, Optional<BeaconBlock> fork_head) {
+  protected void processFork(Optional<BeaconBlock> unprocessedBlock) {
     try {
-      BeaconState newState = null;
-      Bytes32 newStateRoot = Bytes32.ZERO;
-      Boolean shouldProcessBlock = inspectBlock(fork_head);
+      Boolean shouldProcessBlock = inspectBlock(unprocessedBlock);
       if (shouldProcessBlock) {
-        Bytes32 blockStateRoot = fork_head.get().getState_root();
-        Bytes32 blockRoot = HashTreeUtil.hash_tree_root(fork_head.get().toBytes());
-        BeaconBlock parentBlock = this.store.getParent(fork_head.get()).get();
+
+        // Get block, block root and block state root
+        BeaconBlock block = unprocessedBlock.get();
+        Bytes32 blockStateRoot = block.getState_root();
+        Bytes32 blockRoot = HashTreeUtil.hash_tree_root(block.toBytes());
+
+        // Get parent block and parent block state root
+        BeaconBlock parentBlock = this.store.getParent(block).get();
         Bytes32 parentBlockStateRoot = parentBlock.getState_root();
-        // get state corresponding to the parent fork_head
+
+        // Get parent block state
         BeaconState parentState = this.store.getState(parentBlockStateRoot).get();
+
         LOG.info("parent fork_head slot: " + parentState.getSlot());
         LOG.info("parent fork_head state root: " + parentBlockStateRoot.toHexString());
-        LOG.info("fork_head slot: " + fork_head.get().getSlot());
+        LOG.info("fork_head slot: " + block.getSlot());
         LOG.info("fork_head state root: " + blockStateRoot.toHexString());
-        newState = BeaconState.deepCopy(parentState);
+
+        BeaconState currentState = BeaconState.deepCopy(parentState);
 
         // TODO: check if the fork_head's parent slot is further back than the weak subjectivity
         // period, should we check?
-        // run stateTransition.initiate() on empty slots from parentBlock.slot to fork_head.slot-1
-        int counter = 0;
-        while (newState.getSlot().compareTo(UnsignedLong.valueOf(fork_head.get().getSlot() - 1))
-            < 0) {
-          if (counter == 0) {
+
+        // Run state transition from block’s parentState and parent’s slot with no blocks until block.slot - 1
+        Bytes32 currentStateRoot;
+        boolean firstLoop = true;
+        while (currentState.getSlot().compareTo(UnsignedLong.valueOf(block.getSlot() - 1))
+                < 0) {
+          if (firstLoop) {
             LOG.info(
-                "Transitioning state from slot: "
-                    + newState.getSlot()
-                    + " to slot: "
-                    + UnsignedLong.valueOf(fork_head.get().getSlot() - 1));
+                    "Transitioning state from slot: "
+                            + currentState.getSlot()
+                            + " to slot: "
+                            + UnsignedLong.valueOf(block.getSlot() - 1));
+            firstLoop = false;
           }
-          stateTransition.initiate(newState, null, store);
-          newStateRoot = HashTreeUtil.hash_tree_root(newState.toBytes());
-          this.store.addState(newStateRoot, newState);
-          newState = BeaconState.deepCopy(newState);
-          counter++;
+          stateTransition.initiate(currentState, null, store);
+          currentStateRoot = HashTreeUtil.hash_tree_root(currentState.toBytes());
+          this.store.addState(currentStateRoot, currentState);
+          currentState = BeaconState.deepCopy(currentState);
         }
 
-        // run stateTransition.initiate() on fork_head.slot
-        stateTransition.initiate(newState, fork_head.get(), store);
-        newStateRoot = HashTreeUtil.hash_tree_root(newState.toBytes());
+        // Run state transition using the block
+        stateTransition.initiate(currentState, block, store);
+        currentStateRoot = HashTreeUtil.hash_tree_root(currentState.toBytes());
 
-        // state root verification
-        if (blockStateRoot.equals(newStateRoot)) {
+        // Verify that the state root we have computed is the state root that block is
+        // claiming us we should reach, save the block and the state if its correct.
+        if (blockStateRoot.equals(currentStateRoot)) {
           LOG.info("The fork_head's state root matches the calculated state root!");
-          LOG.info("  new state root: " + newStateRoot.toHexString());
+          LOG.info("  new state root: " + currentStateRoot.toHexString());
           LOG.info("  fork_head state root: " + blockStateRoot.toHexString());
           // TODO: storing fork_head and state together as a tuple would be more convenient
-          this.store.addProcessedBlock(blockStateRoot, fork_head.get());
-          this.store.addProcessedBlock(blockRoot, fork_head.get());
-          this.store.addState(newStateRoot, newState);
-
-          // run stateTransition.initiate() on slots from fork_head.slot to node.slot
-          counter = 0;
-          while (newState.getSlot().compareTo(nodeSlot) < 0) {
-            if (counter == 0) {
-              LOG.info(
-                  "Transitioning state from slot: " + newState.getSlot() + " to slot: " + nodeSlot);
-            }
-            newState = BeaconState.deepCopy(newState);
-            stateTransition.initiate(newState, null, store);
-            newStateRoot = HashTreeUtil.hash_tree_root(newState.toBytes());
-            this.store.addState(newStateRoot, newState);
-            counter++;
-          }
-          LOG.info("latest state root: " + newStateRoot.toHexString());
-          this.canonical_state = newState;
-        } else {
-          LOG.info("The fork_head's state root does not match the calculated state root!");
-          LOG.info("  new state root: " + newStateRoot.toHexString());
-          LOG.info("  fork_head state root: " + blockStateRoot.toHexString());
-          shouldProcessBlock = false;
+          this.store.addProcessedBlock(blockStateRoot, block);
+          this.store.addProcessedBlock(blockRoot, block);
+          this.store.addState(currentStateRoot, currentState);
         }
-      }
-      // this conditional evaluates true if:
-      // 1. inspectBlock returns false
-      // 2. state root verification fails on a fork_head
-      if (!shouldProcessBlock) {
-        newState = BeaconState.deepCopy(this.canonical_state);
-        stateTransition.initiate(newState, null, store);
-        newStateRoot = HashTreeUtil.hash_tree_root(newState.toBytes());
-        this.store.addState(newStateRoot, newState);
-        LOG.info("latest state root: " + newStateRoot.toHexString());
-        this.canonical_state = newState;
       }
     } catch (NoSuchElementException | IllegalArgumentException | StateTransitionException e) {
       LOG.warn(e);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTreeManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTreeManager.java
@@ -17,6 +17,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.primitives.UnsignedLong;
 import java.util.Date;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import net.consensys.cava.bytes.Bytes32;
@@ -93,8 +94,9 @@ public class StateTreeManager {
     LOG.info("node time: " + nodeTime.longValue());
     LOG.info("node slot: " + nodeSlot.longValue());
 
-    Optional<BeaconBlock> block = this.store.getUnprocessedBlock();
-    processFork(this.nodeSlot, block);
+    List<Optional<BeaconBlock>> unprocessedBlocks =
+        this.store.getUnprocessedBlocksUntilSlot(nodeSlot);
+    unprocessedBlocks.stream().forEach((block) -> processFork(this.nodeSlot, block));
   }
 
   protected Boolean inspectBlock(Optional<BeaconBlock> block) {

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/MockP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/MockP2PNetwork.java
@@ -14,12 +14,14 @@
 package tech.pegasys.artemis.networking.p2p;
 
 import com.google.common.eventbus.EventBus;
+import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import net.consensys.cava.bytes.Bytes32;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import tech.pegasys.artemis.datastructures.Constants;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.operations.Deposit;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
@@ -107,6 +109,13 @@ public class MockP2PNetwork implements P2PNetwork {
         state.incrementSlot();
         // Block Processing
         state_root = HashTreeUtil.hash_tree_root(state.toBytes());
+        if (state
+                .getSlot()
+                .compareTo(
+                    UnsignedLong.valueOf(Constants.GENESIS_SLOT).plus(UnsignedLong.valueOf(5)))
+            == 0) {
+          deposits = DataStructureUtil.newDeposits(64);
+        }
         block =
             DataStructureUtil.newBeaconBlock(state.getSlot(), parent_root, state_root, deposits);
         parent_root = HashTreeUtil.hash_tree_root(block.toBytes());

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/MockP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/MockP2PNetwork.java
@@ -14,14 +14,12 @@
 package tech.pegasys.artemis.networking.p2p;
 
 import com.google.common.eventbus.EventBus;
-import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import net.consensys.cava.bytes.Bytes32;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import tech.pegasys.artemis.datastructures.Constants;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.operations.Deposit;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
@@ -109,21 +107,11 @@ public class MockP2PNetwork implements P2PNetwork {
         state.incrementSlot();
         // Block Processing
         state_root = HashTreeUtil.hash_tree_root(state.toBytes());
-        if (state
-                .getSlot()
-                .compareTo(
-                    UnsignedLong.valueOf(Constants.GENESIS_SLOT).plus(UnsignedLong.valueOf(5)))
-            == 0) {
-          deposits = DataStructureUtil.newDeposits(64);
-        }
+
         block =
             DataStructureUtil.newBeaconBlock(state.getSlot(), parent_root, state_root, deposits);
         parent_root = HashTreeUtil.hash_tree_root(block.toBytes());
         this.eventBus.post(block);
-
-        // Attestation attestation = randomAttestation(state.getSlot());
-        // this.eventBus.post(attestation);
-
       }
     } catch (InterruptedException e) {
       LOG.warn(e.toString());

--- a/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorage.java
@@ -100,4 +100,18 @@ public interface ChainStorage {
     }
     return result;
   }
+
+  /**
+   * Peek an item from a Queue
+   *
+   * @param items
+   * @return
+   */
+  static <S, T extends Queue<S>> Optional<S> peek(T items) {
+    Optional<S> result = Optional.ofNullable(null);
+    if (items.size() > 0) {
+      result = Optional.of(items.peek());
+    }
+    return result;
+  }
 }

--- a/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorage.java
@@ -15,7 +15,6 @@ package tech.pegasys.artemis.storage;
 
 import com.google.common.eventbus.EventBus;
 import java.util.HashMap;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Queue;
 import net.consensys.cava.bytes.Bytes;
@@ -96,12 +95,8 @@ public interface ChainStorage {
    */
   static <S, T extends Queue<S>> Optional<S> remove(T items) {
     Optional<S> result = Optional.ofNullable(null);
-    try {
-      if (items.size() > 0) {
-        result = Optional.of(items.remove());
-      }
-    } catch (NoSuchElementException e) {
-      LOG.debug(items.getClass().toString() + ": There is nothing to remove");
+    if (items.size() > 0) {
+      result = Optional.of(items.poll());
     }
     return result;
   }

--- a/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
@@ -15,9 +15,11 @@ package tech.pegasys.artemis.storage;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.PriorityQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import net.consensys.cava.bytes.Bytes;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
@@ -32,7 +34,8 @@ public class ChainStorageClient implements ChainStorage {
   protected BeaconBlock justified_head_block;
   protected BeaconState justified_head_state;
   protected final HashMap<Integer, Attestation> latestAttestations = new HashMap<>();
-  protected final LinkedBlockingQueue<BeaconBlock> unprocessedBlocks = new LinkedBlockingQueue<>();
+  protected final PriorityQueue<BeaconBlock> unprocessedBlocks =
+      new PriorityQueue<>(Comparator.comparing(BeaconBlock::getSlot));
   protected final LinkedBlockingQueue<Attestation> unprocessedAttestations =
       new LinkedBlockingQueue<>();
   protected final HashMap<Bytes, BeaconBlock> processedBlockLookup = new HashMap<>();
@@ -76,7 +79,7 @@ public class ChainStorageClient implements ChainStorage {
    * @param block
    */
   public void addUnprocessedBlock(BeaconBlock block) {
-    ChainStorage.<BeaconBlock, LinkedBlockingQueue<BeaconBlock>>add(block, this.unprocessedBlocks);
+    ChainStorage.<BeaconBlock, PriorityQueue<BeaconBlock>>add(block, this.unprocessedBlocks);
   }
 
   /**
@@ -129,8 +132,7 @@ public class ChainStorageClient implements ChainStorage {
    * @return
    */
   public Optional<BeaconBlock> getUnprocessedBlock() {
-    return ChainStorage.<BeaconBlock, LinkedBlockingQueue<BeaconBlock>>remove(
-        this.unprocessedBlocks);
+    return ChainStorage.<BeaconBlock, PriorityQueue<BeaconBlock>>remove(this.unprocessedBlocks);
   }
 
   /**

--- a/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
@@ -15,6 +15,8 @@ package tech.pegasys.artemis.storage;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -131,8 +133,22 @@ public class ChainStorageClient implements ChainStorage {
    *
    * @return
    */
-  public Optional<BeaconBlock> getUnprocessedBlock() {
-    return ChainStorage.<BeaconBlock, PriorityQueue<BeaconBlock>>remove(this.unprocessedBlocks);
+  public List<Optional<BeaconBlock>> getUnprocessedBlocksUntilSlot(UnsignedLong slot) {
+    List<Optional<BeaconBlock>> unprocessedBlocks = new ArrayList<>();
+    boolean unproccesedBlocksLeft = true;
+    Optional<BeaconBlock> currentBlock;
+    while (unproccesedBlocksLeft) {
+      currentBlock =
+          ChainStorage.<BeaconBlock, PriorityQueue<BeaconBlock>>peek(this.unprocessedBlocks);
+      if (currentBlock.isPresent()
+          && UnsignedLong.valueOf(currentBlock.get().getSlot()).compareTo(slot) <= 0) {
+        unprocessedBlocks.add(
+            ChainStorage.<BeaconBlock, PriorityQueue<BeaconBlock>>remove(this.unprocessedBlocks));
+      } else {
+        unproccesedBlocksLeft = false;
+      }
+    }
+    return unprocessedBlocks;
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
This PR aims to make the modifications needed to integrate lmd_ghost fork choice rule into our current chain processing in onNewSlot().

- [x] Move all code inside onNewSlot to processFork(current_slot,fork_head)
- [x] Make unprocessedBlock a priority queue (by slot)
- [x] Consume all the blocks from the unprocessedBlock priority queue, up until block <= node.slot()
- [x] For all the fork heads that was found above, run them through processFork()
- [x] Calculate the observed head using lmd_ghost()

## Fixed Issue(s)
#410 
Also fixes the divide by zero error.
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Notes for Reviewers
You will notice that I removed the try and catch block from the remove() function in the ChainStorage file, and the reason for this is that I switched from .remove on the abstract Queue object to .poll, which has the same functionality but returns null in a failure scenario instead of throwing. 