### PR TITLE
Refactor point serialisation and improve testing

### DIFF
--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSPublicKey.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSPublicKey.java
@@ -106,7 +106,7 @@ public class BLSPublicKey {
 
   @Override
   public int hashCode() {
-    return Objects.hash(publicKey);
+    return isEmpty() ? 0 : publicKey.hashCode();
   }
 
   @Override

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSSignature.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSSignature.java
@@ -188,7 +188,7 @@ public final class BLSSignature {
 
   @Override
   public int hashCode() {
-    return Objects.hash(signature);
+    return isEmpty() ? 0 : signature.hashCode();
   }
 
   @Override

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/BLS12381.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/BLS12381.java
@@ -79,10 +79,6 @@ public final class BLS12381 {
       PublicKey publicKey, Signature signature, Bytes message, long domain) {
     G1Point g1Generator = KeyPair.g1Generator;
 
-    if (!G2Point.isValid(signature.g2Point()) || !G1Point.isValid(publicKey.g1Point())) {
-      return false;
-    }
-
     G2Point hashInGroup2 = hashFunction(message, domain);
     GTPoint e1 = AtePairing.pair(publicKey.g1Point(), hashInGroup2);
     GTPoint e2 = AtePairing.pair(g1Generator, signature.g2Point());
@@ -101,9 +97,7 @@ public final class BLS12381 {
    */
   public static boolean verifyMultiple(
       List<PublicKey> publicKeys, Signature signature, List<Bytes> messages, long domain) {
-    if (!G2Point.isValid(signature.g2Point())
-        || publicKeys.size() == 0
-        || publicKeys.size() != messages.size()) {
+    if (publicKeys.size() == 0 || publicKeys.size() != messages.size()) {
       return false;
     }
 
@@ -111,9 +105,6 @@ public final class BLS12381 {
 
     GTPoint eCombined = new GTPoint(new FP12(1));
     for (int i = 0; i < publicKeys.size(); i++) {
-      if (!G1Point.isValid(publicKeys.get(i).g1Point())) {
-        return false;
-      }
       G2Point hashInGroup2 = hashFunction(messages.get(i), domain);
       eCombined = eCombined.mul(AtePairing.pair(publicKeys.get(i).g1Point(), hashInGroup2));
     }

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/G1Point.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/G1Point.java
@@ -94,7 +94,7 @@ final class G1Point implements Group<G1Point> {
     // faulty input.
     BIG xBig = BIG.fromBytes(xBytes);
     BIG modulus = new BIG(ROM.Modulus);
-    if (BIG.comp(modulus, xBig) < 0) {
+    if (BIG.comp(modulus, xBig) <= 0) {
       throw new IllegalArgumentException("X coordinate is too large.");
     }
 

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/G1Point.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/G1Point.java
@@ -16,7 +16,6 @@ package tech.pegasys.artemis.util.mikuli;
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.artemis.util.mikuli.Util.calculateYFlag;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.security.SecureRandom;
 import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
@@ -51,7 +50,14 @@ final class G1Point implements Group<G1Point> {
     return new G1Point(point);
   }
 
+  /**
+   * Deserialise the point from compressed form as per the Eth2 spec
+   *
+   * @param bytes the compressed serialised form of the point
+   * @return the point
+   */
   static G1Point fromBytes(Bytes bytes) {
+    checkArgument(bytes.size() == 49, "Expected 49 bytes, received %s.", bytes.size());
     return new G1Point(ECP.fromBytes(bytes.toArrayUnsafe()));
   }
 
@@ -63,22 +69,43 @@ final class G1Point implements Group<G1Point> {
         bytes.size());
     byte[] xBytes = bytes.toArray();
 
-    boolean a = (xBytes[0] & (byte) (1 << 5)) != 0;
-    boolean b = (xBytes[0] & (byte) (1 << 6)) != 0;
-    boolean c = (xBytes[0] & (byte) (1 << 7)) != 0;
+    boolean aIn = (xBytes[0] & (byte) (1 << 5)) != 0;
+    boolean bIn = (xBytes[0] & (byte) (1 << 6)) != 0;
+    boolean cIn = (xBytes[0] & (byte) (1 << 7)) != 0;
     xBytes[0] &= (byte) 31;
+
+    if (!cIn) {
+      throw new IllegalArgumentException("The serialised input does not have the C flag set.");
+    }
+
+    if (bIn) {
+      if (!aIn && Bytes.wrap(xBytes).isZero()) {
+        // This is a correctly formed serialisation of infinity
+        return new G1Point();
+      } else {
+        // The input is malformed
+        throw new IllegalArgumentException(
+            "The serialised input has B flag set, but A flag is set, or X is non-zero.");
+      }
+    }
 
     // Per the spec, we must check that x < q (the curve modulus) for this serialisation to be valid
     // We raise an exception (that should be caught) if this check fails: somebody might feed us
     // faulty input.
     BIG xBig = BIG.fromBytes(xBytes);
     BIG modulus = new BIG(ROM.Modulus);
-    checkArgument(BIG.comp(xBig, modulus) < 0, "Deserialised X coordinate is too large.");
+    if (BIG.comp(modulus, xBig) < 0) {
+      throw new IllegalArgumentException("X coordinate is too large.");
+    }
 
     ECP point = new ECP(xBig);
 
+    if (point.is_infinity()) {
+      throw new IllegalArgumentException("X coordinate is not on the curve.");
+    }
+
     // Did we get the right branch of the sqrt?
-    if (!point.is_infinity() && a != calculateYFlag(point.getY())) {
+    if (!point.is_infinity() && aIn != calculateYFlag(point.getY())) {
       // We didn't: so choose the other branch of the sqrt.
       FP x = new FP(point.getX());
       FP yneg = new FP(point.getY());
@@ -86,58 +113,25 @@ final class G1Point implements Group<G1Point> {
       point = new ECP(x.redc(), yneg.redc());
     }
 
-    return new G1Point(point, a, b, c);
+    return new G1Point(point);
   }
 
   private final ECP point;
 
-  // Bit 381 of the imaginary part of X. Equal to ((y_im * 2) / q == 1)
-  private final boolean a;
-  // Bit 382 of the imaginary part of X. True only for the point at infinity.
-  private final boolean b;
-  // Bit 383 of the imaginary part of X. Always true.
-  private final boolean c;
-
   private static final int fpPointSize = BIG.MODBYTES;
 
   /** Default constructor creates the point at infinity (the zero point) */
-  public G1Point() {
-    this(new ECP(), false, true, true);
+  G1Point() {
+    this(new ECP());
   }
 
   /**
-   * Constructor for point that calculates the correct flags as per Eth2 Spec
+   * Constructor for point
    *
-   * <p>Will throw an exception if an invalid point is specified. We don't want to crash since this
-   * may simply be due to bad data that has been sent to us, so the exception needs to be caught and
-   * handled higher up the stack.
-   *
-   * @param point the ec2p point
-   * @throws IllegalArgumentException if the point is not on the curve
+   * @param point the ecp point
    */
   G1Point(ECP point) {
-    this(point, !point.is_infinity() && calculateYFlag(point.getY()), point.is_infinity(), true);
-  }
-
-  /**
-   * Constructor for point with flags as per Eth2 Spec
-   *
-   * <p>Will throw an exception if an invalid point is specified. We don't want to crash since this
-   * may simply be due to bad data that has been sent to us, so the exception needs to be caught and
-   * handled higher up the stack.
-   *
-   * @param point the ec2p point
-   * @param a1 the Y coordinate branch flag
-   * @param b1 the infinity flag
-   * @param c1 always true
-   * @throws IllegalArgumentException if the point is not on the curve or the flags are incorrect
-   */
-  private G1Point(ECP point, boolean a1, boolean b1, boolean c1) {
-    checkArgument(isValid(point, a1, b1, c1), "Trying to create invalid point.");
     this.point = point;
-    this.a = a1;
-    this.b = b1;
-    this.c = c1;
   }
 
   @Override
@@ -177,6 +171,11 @@ final class G1Point implements Group<G1Point> {
     byte[] xBytes = new byte[fpPointSize];
     point.getX().toBytes(xBytes);
 
+    // Serialisation flags as defined in the Eth2 specs
+    boolean c = true;
+    boolean b = point.is_infinity();
+    boolean a = !b && calculateYFlag(point.getY());
+
     byte flags = (byte) ((a ? 1 << 5 : 0) | (b ? 1 << 6 : 0) | (c ? 1 << 7 : 0));
     byte mask = (byte) 31;
     xBytes[0] &= mask;
@@ -185,65 +184,18 @@ final class G1Point implements Group<G1Point> {
     return Bytes.wrap(xBytes);
   }
 
-  /**
-   * Check the validity of a G2 point according to the Eth2 spec.
-   *
-   * @return true if this is a valid point
-   */
-  static boolean isValid(G1Point point) {
-    return isValid(point.ecpPoint(), point.a, point.b, point.c);
-  }
-
-  /**
-   * Check the validity of an ECP2 point and its flags according to the Eth2 spec.
-   *
-   * @return true if point is consistent with the flags
-   */
-  @VisibleForTesting
-  static boolean isValid(ECP point, boolean a, boolean b, boolean c) {
-    BIG x = point.getX();
-    BIG y = point.getY();
-
-    if (!c) {
-      return false;
-    }
-
-    // Point at infinity
-    if (b != point.is_infinity()) {
-      return false;
-    }
-    if (b) {
-      return (!a && x.iszilch());
-    }
-
-    // Check that we have the right branch for Y
-    if (a != calculateYFlag(y)) {
-      return false;
-    }
-
-    // Check that both X and Y are on the curve
-    ECP newPoint = new ECP(point.getX(), point.getY());
-    return point.equals(newPoint);
-  }
-
   ECP ecpPoint() {
     return point;
   }
 
   @Override
   public String toString() {
-    return point.toString() + " a:" + a + " b:" + b + " c:" + 1;
+    return point.toString();
   }
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    long x = point.getX().norm();
-    long y = point.getY().norm();
-    result = prime * result + (int) (x ^ (x >>> 32));
-    result = prime * result + (int) (y ^ (y >>> 32));
-    return result;
+    return Objects.hash(point.getX().norm(), point.getY().norm());
   }
 
   @Override
@@ -258,20 +210,6 @@ final class G1Point implements Group<G1Point> {
       return false;
     }
     G1Point other = (G1Point) obj;
-    return point.equals(other.point) && a == other.a && b == other.b && c == other.c;
-  }
-
-  // Getters used only for testing
-
-  boolean getA() {
-    return a;
-  }
-
-  boolean getB() {
-    return b;
-  }
-
-  boolean getC() {
-    return c;
+    return point.equals(other.point);
   }
 }

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/G2Point.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/G2Point.java
@@ -272,7 +272,7 @@ final class G2Point implements Group<G2Point> {
     BIG xImBig = BIG.fromBytes(xImBytes);
     BIG xReBig = BIG.fromBytes(xReBytes);
     BIG modulus = new BIG(ROM.Modulus);
-    if (BIG.comp(modulus, xReBig) < 0 || BIG.comp(modulus, xImBig) < 0) {
+    if (BIG.comp(modulus, xReBig) <= 0 || BIG.comp(modulus, xImBig) <= 0) {
       throw new IllegalArgumentException(
           "The deserialised X real or imaginary coordinate is too large.");
     }

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/PublicKey.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/PublicKey.java
@@ -116,7 +116,7 @@ public final class PublicKey {
 
   @Override
   public int hashCode() {
-    return Objects.hash(point);
+    return point.hashCode();
   }
 
   @Override

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/Signature.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/Signature.java
@@ -142,7 +142,7 @@ public final class Signature {
 
   @Override
   public int hashCode() {
-    return Objects.hash(point);
+    return point.hashCode();
   }
 
   G2Point g2Point() {

--- a/util/src/test/java/tech/pegasys/artemis/util/mikuli/G1PointTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/mikuli/G1PointTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static tech.pegasys.artemis.util.mikuli.G1Point.isValid;
 
 import net.consensys.cava.bytes.Bytes;
 import org.junit.jupiter.api.Test;
@@ -51,38 +50,9 @@ class G1PointTest {
   }
 
   @Test
-  void succeedsWhenIsValidReturnsTrueForARandomPoint() {
-    G1Point point = G1Point.random();
-    assertTrue(G1Point.isValid(point));
-  }
-
-  @Test
-  void succeedsWhenPointWithCFalseIsInvalid() {
-    G1Point point = G1Point.random();
-    // C1 should always be true
-    assertFalse(isValid(point.ecpPoint(), point.getA(), point.getB(), false));
-  }
-
-  @Test
-  void succeedsWhenPointWithBTrueIsInvalid() {
-    G1Point point = G1Point.random();
-    // B1 is true only for the point at infinity
-    assertFalse(isValid(point.ecpPoint(), point.getA(), true, true));
-  }
-
-  @Test
-  void succeedsWhenPointWithAInvertedIsInvalid() {
-    G1Point point = G1Point.random();
-    assertFalse(isValid(point.ecpPoint(), !point.getA(), false, true));
-  }
-
-  @Test
-  void succeedsWhenPointAtInfinityHasCorrectFlags() {
+  void succeedsWhenDefaultConstructorReturnsThePointAtInfinity() {
     G1Point infinity = new G1Point();
     assertTrue(infinity.ecpPoint().is_infinity());
-    assertFalse(infinity.getA());
-    assertTrue(infinity.getB());
-    assertTrue(infinity.getC());
     assertTrue(infinity.ecpPoint().getX().iszilch());
   }
 
@@ -101,28 +71,137 @@ class G1PointTest {
   }
 
   @Test
+  void succeedsWhenDeserialisingACorrectPointDoesNotThrow() {
+    String xInput =
+        "0x8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    assertAll(() -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
+  void succeedsWhenDeserialisingAnIncorrectPointThrowsIllegalArgumentException() {
+    String xInput =
+        "0x8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde0";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
   void succeedsWhenAttemptToDeserialiseXEqualToModulusThrowsIllegalArgumentException() {
     // Exactly the modulus, q
-    String x =
+    String xInput =
         "0x01a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaab";
     assertThrows(
-        IllegalArgumentException.class, () -> G1Point.fromBytesCompressed(Bytes.fromHexString(x)));
+        IllegalArgumentException.class,
+        () -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
   }
 
   @Test
   void succeedsWhenAttemptToDeserialiseXGreaterThanModulusThrowsIllegalArgumentException() {
     // One more than the modulus, q
-    String x =
+    String xInput =
         "0x01a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaac";
     assertThrows(
-        IllegalArgumentException.class, () -> G1Point.fromBytesCompressed(Bytes.fromHexString(x)));
+        IllegalArgumentException.class,
+        () -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
   }
 
   @Test
   void succeedsWhenAttemptToDeserialiseXLessThanModulusDoesNotThrowIllegalArgumentException() {
     // There's a valid X two less than the modulus. We prepend the c flag.
-    String x =
+    String xInput =
         "0x81a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa9";
-    assertAll(() -> G1Point.fromBytesCompressed(Bytes.fromHexString(x)));
+    assertAll(() -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
+  void succeedsWhenProvidingTooFewBytesToFromBytesCompressedThrowsIllegalArgumentException() {
+    String xInput =
+        "0x81a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
+  void succeedsWhenProvidingTooManyBytesToFromBytesCompressedThrowsIllegalArgumentException() {
+    String xInput =
+        "0x81a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa900";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
+  void succeedsWhenRoundTripDeserialiseSerialiseCompressedReturnsTheOriginalInput() {
+    String xInput =
+        "0x8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    String xOutput =
+        G1Point.fromBytesCompressed(Bytes.fromHexString(xInput))
+            .toBytesCompressed()
+            .toHexString()
+            .toLowerCase();
+    assertEquals(xInput, xOutput);
+  }
+
+  @Test
+  void succeedsWhenDeserialiseCompressedInfinityWithTrueBFlagCreatesPointAtInfinity() {
+    String xInput =
+        "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+    G1Point point = G1Point.fromBytesCompressed(Bytes.fromHexString(xInput));
+    assertTrue(point.ecpPoint().is_infinity());
+  }
+
+  @Test
+  void succeedsWhenDeserialiseCompressedInfinityWithFalseBFlagDoesNotCreatePointAtInfinity() {
+    String xInput =
+        "0x800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+    G1Point point = G1Point.fromBytesCompressed(Bytes.fromHexString(xInput));
+    assertFalse(point.ecpPoint().is_infinity());
+  }
+
+  @Test
+  void succeedsWhenSerialiseDeserialiseCompressedInfinityGivesOriginalInput() {
+    G1Point point = new G1Point();
+    assertEquals(point, G1Point.fromBytesCompressed(point.toBytesCompressed()));
+  }
+
+  @Test
+  void succeedsWhenDeserialiseSerialiseCompressedInfinityGivesOriginalInput() {
+    String xInput =
+        "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+    String xOutput =
+        G1Point.fromBytesCompressed(Bytes.fromHexString(xInput))
+            .toBytesCompressed()
+            .toHexString()
+            .toLowerCase();
+    assertEquals(xInput, xOutput);
+  }
+
+  @Test
+  void succeedsWhenAttemptToDeserialiseWithWrongCFlagThrowsIllegalArgumentException() {
+    String xInput =
+        "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
+  void succeedsWhenAttemptToDeserialiseWithBFlagAndXNonzeroThrowsIllegalArgumentException1() {
+    String xInput =
+        "0xc123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
+  void succeedsWhenAttemptToDeserialiseWithBFlagAndAFlagTrueThrowsIllegalArgumentException1() {
+    String xInput =
+        "0xe00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
   }
 }

--- a/util/src/test/java/tech/pegasys/artemis/util/mikuli/G1PointTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/mikuli/G1PointTest.java
@@ -90,7 +90,7 @@ class G1PointTest {
   void succeedsWhenAttemptToDeserialiseXEqualToModulusThrowsIllegalArgumentException() {
     // Exactly the modulus, q
     String xInput =
-        "0x01a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaab";
+        "0x9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab";
     assertThrows(
         IllegalArgumentException.class,
         () -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
@@ -100,7 +100,7 @@ class G1PointTest {
   void succeedsWhenAttemptToDeserialiseXGreaterThanModulusThrowsIllegalArgumentException() {
     // One more than the modulus, q
     String xInput =
-        "0x01a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaac";
+        "0x9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaac";
     assertThrows(
         IllegalArgumentException.class,
         () -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
@@ -108,16 +108,16 @@ class G1PointTest {
 
   @Test
   void succeedsWhenAttemptToDeserialiseXLessThanModulusDoesNotThrowIllegalArgumentException() {
-    // There's a valid X two less than the modulus. We prepend the c flag.
+    // There's a valid X three less than the modulus. We prepend the c flag.
     String xInput =
-        "0x81a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa9";
+        "0x9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaa8";
     assertAll(() -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
   }
 
   @Test
   void succeedsWhenProvidingTooFewBytesToFromBytesCompressedThrowsIllegalArgumentException() {
     String xInput =
-        "0x81a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa";
+        "0x9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa";
     assertThrows(
         IllegalArgumentException.class,
         () -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
@@ -126,7 +126,7 @@ class G1PointTest {
   @Test
   void succeedsWhenProvidingTooManyBytesToFromBytesCompressedThrowsIllegalArgumentException() {
     String xInput =
-        "0x81a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa900";
+        "0x9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaa900";
     assertThrows(
         IllegalArgumentException.class,
         () -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));

--- a/util/src/test/java/tech/pegasys/artemis/util/mikuli/G2PointTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/mikuli/G2PointTest.java
@@ -162,8 +162,8 @@ class G2PointTest {
   void succeedsWhenAttemptToDeserialiseXReEqualToModulusThrowsIllegalArgumentException() {
     // xRe is exactly the modulus, q, xIm is zero
     String x =
-        "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-            + "0x01a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaab";
+        "0x800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+            + "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab";
     assertThrows(
         IllegalArgumentException.class, () -> G2Point.fromBytesCompressed(Bytes.fromHexString(x)));
   }
@@ -172,7 +172,7 @@ class G2PointTest {
   void succeedsWhenAttemptToDeserialiseXImEqualToModulusThrowsIllegalArgumentException() {
     // xIm is exactly the modulus, q, xRe is zero
     String x =
-        "0x01a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaab"
+        "0x9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab"
             + "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
     assertThrows(
         IllegalArgumentException.class, () -> G2Point.fromBytesCompressed(Bytes.fromHexString(x)));
@@ -182,8 +182,8 @@ class G2PointTest {
   void succeedsWhenAttemptToDeserialiseXReGreaterThanModulusThrowsIllegalArgumentException() {
     // xRe is the modulus plus 1, xIm is zero
     String x =
-        "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-            + "0x01a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaac";
+        "0x800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+            + "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaac";
     assertThrows(
         IllegalArgumentException.class, () -> G2Point.fromBytesCompressed(Bytes.fromHexString(x)));
   }
@@ -192,7 +192,7 @@ class G2PointTest {
   void succeedsWhenAttemptToDeserialiseXImGreaterThanModulusThrowsIllegalArgumentException() {
     // xIm is the modulus plus 1, xRe is zero
     String x =
-        "0x01a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaac"
+        "0x9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaac"
             + "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
     assertThrows(
         IllegalArgumentException.class, () -> G2Point.fromBytesCompressed(Bytes.fromHexString(x)));

--- a/util/src/test/java/tech/pegasys/artemis/util/mikuli/G2PointTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/mikuli/G2PointTest.java
@@ -13,12 +13,11 @@
 
 package tech.pegasys.artemis.util.mikuli;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static tech.pegasys.artemis.util.mikuli.G2Point.isValid;
 import static tech.pegasys.artemis.util.mikuli.G2Point.normaliseY;
 import static tech.pegasys.artemis.util.mikuli.G2Point.scaleWithCofactor;
 
@@ -55,38 +54,9 @@ class G2PointTest {
   }
 
   @Test
-  void succeedsWhenIsValidReturnsTrueForARandomPoint() {
-    G2Point point = G2Point.random();
-    assertTrue(G2Point.isValid(point));
-  }
-
-  @Test
-  void succeedsWhenPointWithC1FalseIsInvalid() {
-    G2Point point = G2Point.random();
-    // C1 should always be true
-    assertFalse(isValid(point.ecp2Point(), point.getA1(), point.getB1(), false));
-  }
-
-  @Test
-  void succeedsWhenPointWithB1TrueIsInvalid() {
-    G2Point point = G2Point.random();
-    // B1 is true only for the point at infinity
-    assertFalse(isValid(point.ecp2Point(), point.getA1(), true, true));
-  }
-
-  @Test
-  void succeedsWhenPointWithA1InvertedIsInvalid() {
-    G2Point point = G2Point.random();
-    assertFalse(isValid(point.ecp2Point(), !point.getA1(), false, true));
-  }
-
-  @Test
-  void succeedsWhenPointAtInfinityHasCorrectFlags() {
+  void succeedsWhenDefaultConstructorReturnsThePointAtInfinity() {
     G2Point infinity = new G2Point();
     assertTrue(infinity.ecp2Point().is_infinity());
-    assertFalse(infinity.getA1());
-    assertTrue(infinity.getB1());
-    assertTrue(infinity.getC1());
     assertTrue(infinity.ecp2Point().getX().iszilch());
   }
 
@@ -188,75 +158,6 @@ class G2PointTest {
     assertEquals(scaledPoint1, scaledPoint2);
   }
 
-  /**
-   * The data in the tests below comes from the reference Eth2 reference BLS tests
-   * https://github.com/ethereum/eth2.0-tests/blob/df7888e658943d3e733f660bb7ace7d829d70011/test_vectors/test_bls.yml
-   * We should find a way to automate this. Note that these test cases are out of date, and will
-   * need need updating when we start passing the hash of the message rather than the message. There
-   * are also bugs in the tests around the selection of Y coordinate.
-   */
-  @Test
-  void succeedsWhenHashToG2MatchesTestDataCase1() {
-    // TODO: Update to latest spec when we have new test cases
-    Bytes message = Bytes.fromHexString("0x6d657373616765");
-    G2Point point = G2Point.hashToG2(message, 0L);
-
-    String[] testCasesResult = {
-      "0x0e34a428411c115e094b51afa596b0e594fb325dfe42d481a87a1e89ab35f531aadc7b4f8eb5ce9d3973d2cfef8f20fd",
-      "0x12830258cc04219871cd71eb9478eb1f1971104bcf49ac60ec6e3368e9047e10acef61b75d803849942bea06e3bc99a8",
-      "0x162f48744b91343105f5b1830f3346da815ada6b615afc57c611b423470fb53d26c9e8a1e6288b524f75a8e69492cd31",
-      "0x129b6b431d1d3dabda12739eadac269e7d85e2940f270b5486bfddf2c36109164dd20ba5369e9305ef16e470d0eafad0",
-      "0x05825be2264001369d47bfac0fef4735d4cbbc8e6e0cd2f25b68948122b94a856473f07b9e6d16af7a7286bab41fc9d6",
-      "0x0a2fba34dddfa47d0363fdf88d6d7fdb9db3d914f70275ea6923b3fceffee565dd7de1b2109293a72139bf3b82126a52"
-    };
-
-    G2Point expected = makePoint(testCasesResult);
-    assertEquals(expected, point);
-  }
-
-  @Test
-  void succeedsWhenHashToG2MatchesTestDataCase2() {
-    // TODO: Update to latest spec when we have new test cases
-    Bytes message = Bytes.fromHexString("0x6d657373616765");
-    G2Point point = G2Point.hashToG2(message, 1L);
-
-    String[] testCasesResult = {
-      "0x0c4efb2057400f7316bdfd6a89aa3afd34411b045e81bc75fa7f6a6bc5736f6528ceb5857c04866b98a43f6fdf08037c",
-      "0x1539234325ccfd75fda86b1acd449af4a954b0ce45840c4a1e7596f41a99d12735b69968ebe998b4379aa3c3cdc9a8c4",
-      "0x05488381cf53bd9f750451eb40c6bdd04b86689b8b6374a8df30c7d1a2ecc4a33dbe4f13ce7ed6f7e21c123480c4e959",
-      "0x180d467a582e8fd8e766ed90d9a993ae22503fa0358af72ba405350f7e97b910fc2f849a77f0b9ba869fec3d65c4331a",
-      "0x143c969735b29ecb356f2406d001d220d54c3e90d254769a350e7da60de287d4a89ca6dc1bff53e825fa6b889a0801b5",
-      "0x048daeee78cefb03a26e382c7dd582d61a873461b3b1b79c3dc5706cac133666b1cc3b923fed6de46fb63f399d985a1c"
-    };
-
-    G2Point expected = makePoint(testCasesResult);
-    assertEquals(expected, point);
-  }
-
-  @Test
-  void succeedsWhenHashToG2MatchesTestDataCase3() {
-    // TODO: Update to latest spec when we have new test cases
-    Bytes message =
-        Bytes.fromHexString(
-            "0x"
-                + "56657279202e2e2e2e2e2e2e2e2e2e2e2e2e2e206c6f6e67202e2e2e2e2e2e2e"
-                + "2e2e2e2e2e2e206d657373616765202e2e2e2e207769746820656e74726f7079"
-                + "3a20313233343536373839302d626561636f6e2d636861696e");
-    G2Point point = G2Point.hashToG2(message, 0xffffffffL);
-
-    String[] testCasesResult = {
-      "0x1735fa1eeb8f5927bfbd50497a0f5d0dda9b77e044bbdc2305ad4fed35a2e7fad2f97aa43a0c25e19741481acf836973",
-      "0x06a71fb5c75ca78fefe799c8951e24fde9feb58f07e0da3165a73c40f6cd48eb7d82f6d95c18e3c10abd4e293d3ec6b3",
-      "0x0a852998b4535f26f3dd91af9d0ec9a19cf692ed90523f288f5600cbc8c1a6694d9525b714af12e55ee02ba408ba451a",
-      "0x015a8507b42edd62bd82a12a59bdb9b9ae4b2c53c94bcadaa693a8c0c920718e035f849fd70e5d4c74cce782d3eb2096",
-      "0x1422202b89e51c324096d038174fdf2f1671b09ee9315054d000b500db4c992de5aa9b333a54d1b1cfc73069ee634c14",
-      "0x0af76bfd57821e779b7f2fbed3b314c5b3407be1b4a703396c2afa95e6465b46881b459aca082e72a4613b31b98f7467"
-    };
-
-    G2Point expected = makePoint(testCasesResult);
-    assertEquals(expected, point);
-  }
-
   @Test
   void succeedsWhenAttemptToDeserialiseXReEqualToModulusThrowsIllegalArgumentException() {
     // xRe is exactly the modulus, q, xIm is zero
@@ -297,7 +198,200 @@ class G2PointTest {
         IllegalArgumentException.class, () -> G2Point.fromBytesCompressed(Bytes.fromHexString(x)));
   }
 
-  // More rigorous higher level tests are performed using the Ethereum 2.0 BLS test data suite
+  @Test
+  void succeedsWhenDeserialisingACorrectPointDoesNotThrow() {
+    String xInput =
+        "0x"
+            + "8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    assertAll(() -> G2Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
+  void succeedsWhenDeserialisingAnIncorrectPointThrowsIllegalArgumentException() {
+    String xInput =
+        "0x"
+            + "8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde0";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G2Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
+  void succeedsWhenProvidingTooFewBytesToFromBytesCompressedThrowsIllegalArgumentException() {
+    String xInput =
+        "0x"
+            + "8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G2Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
+  void succeedsWhenProvidingTooManyBytesToFromBytesCompressedThrowsIllegalArgumentException() {
+    String xInput =
+        "0x"
+            + "8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdefff";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G2Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
+  void succeedsWhenRoundTripDeserialiseSerialiseCompressedReturnsTheOriginalInput() {
+    String xInput =
+        "0x"
+            + "8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    String xOutput =
+        G2Point.fromBytesCompressed(Bytes.fromHexString(xInput))
+            .toBytesCompressed()
+            .toHexString()
+            .toLowerCase();
+    assertEquals(xInput, xOutput);
+  }
+
+  @Test
+  void succeedsWhenDeserialiseCompressedInfinityWithTrueBFlagCreatesPointAtInfinity() {
+    String xInput =
+        "0x"
+            + "c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+            + "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+    G2Point point = G2Point.fromBytesCompressed(Bytes.fromHexString(xInput));
+    assertTrue(point.ecp2Point().is_infinity());
+  }
+
+  @Test
+  void succeedsWhenDeserialiseCompressedInfinityWithFalseBFlagDoesNotCreatePointAtInfinity() {
+    String xInput =
+        "0x"
+            + "800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+            + "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G2Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
+  void succeedsWhenSerialiseDeserialiseCompressedInfinityGivesOriginalInput() {
+    G2Point point = new G2Point();
+    assertEquals(point, G2Point.fromBytesCompressed(point.toBytesCompressed()));
+  }
+
+  @Test
+  void succeedsWhenDeserialiseSerialiseCompressedInfinityGivesOriginalInput() {
+    String xInput =
+        "0x"
+            + "c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+            + "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+    String xOutput =
+        G2Point.fromBytesCompressed(Bytes.fromHexString(xInput))
+            .toBytesCompressed()
+            .toHexString()
+            .toLowerCase();
+    assertEquals(xInput, xOutput);
+  }
+
+  @Test
+  void succeedsWhenAttemptToDeserialiseWithWrongCFlagThrowsIllegalArgumentException() {
+    String xInput =
+        "0x"
+            + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G2Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
+  void succeedsWhenAttemptToDeserialiseWithBFlagAndXNonzeroThrowsIllegalArgumentException1() {
+    String xInput =
+        "0x"
+            + "c123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G2Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
+  void succeedsWhenAttemptToDeserialiseWithBFlagAndAFlagTrueThrowsIllegalArgumentException1() {
+    String xInput =
+        "0x"
+            + "e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+            + "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G2Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  /*
+   * The data in the tests below is based on the reference Eth2 reference BLS tests
+   * https://github.com/ethereum/eth2.0-tests/blob/df7888e658943d3e733f660bb7ace7d829d70011/test_vectors/test_bls.yml
+   * The tests have since changed, and are now automated, but these remain here for reference.
+   */
+
+  @Test
+  void succeedsWhenHashToG2MatchesTestDataCase1() {
+    Bytes message = Bytes.fromHexString("0x6d657373616765");
+    G2Point point = G2Point.hashToG2(message, 0L);
+
+    String[] testCasesResult = {
+      "0x0e34a428411c115e094b51afa596b0e594fb325dfe42d481a87a1e89ab35f531aadc7b4f8eb5ce9d3973d2cfef8f20fd",
+      "0x12830258cc04219871cd71eb9478eb1f1971104bcf49ac60ec6e3368e9047e10acef61b75d803849942bea06e3bc99a8",
+      "0x162f48744b91343105f5b1830f3346da815ada6b615afc57c611b423470fb53d26c9e8a1e6288b524f75a8e69492cd31",
+      "0x129b6b431d1d3dabda12739eadac269e7d85e2940f270b5486bfddf2c36109164dd20ba5369e9305ef16e470d0eafad0",
+      "0x05825be2264001369d47bfac0fef4735d4cbbc8e6e0cd2f25b68948122b94a856473f07b9e6d16af7a7286bab41fc9d6",
+      "0x0a2fba34dddfa47d0363fdf88d6d7fdb9db3d914f70275ea6923b3fceffee565dd7de1b2109293a72139bf3b82126a52"
+    };
+
+    G2Point expected = makePoint(testCasesResult);
+    assertEquals(expected, point);
+  }
+
+  @Test
+  void succeedsWhenHashToG2MatchesTestDataCase2() {
+    Bytes message = Bytes.fromHexString("0x6d657373616765");
+    G2Point point = G2Point.hashToG2(message, 1L);
+
+    String[] testCasesResult = {
+      "0x0c4efb2057400f7316bdfd6a89aa3afd34411b045e81bc75fa7f6a6bc5736f6528ceb5857c04866b98a43f6fdf08037c",
+      "0x1539234325ccfd75fda86b1acd449af4a954b0ce45840c4a1e7596f41a99d12735b69968ebe998b4379aa3c3cdc9a8c4",
+      "0x05488381cf53bd9f750451eb40c6bdd04b86689b8b6374a8df30c7d1a2ecc4a33dbe4f13ce7ed6f7e21c123480c4e959",
+      "0x180d467a582e8fd8e766ed90d9a993ae22503fa0358af72ba405350f7e97b910fc2f849a77f0b9ba869fec3d65c4331a",
+      "0x143c969735b29ecb356f2406d001d220d54c3e90d254769a350e7da60de287d4a89ca6dc1bff53e825fa6b889a0801b5",
+      "0x048daeee78cefb03a26e382c7dd582d61a873461b3b1b79c3dc5706cac133666b1cc3b923fed6de46fb63f399d985a1c"
+    };
+
+    G2Point expected = makePoint(testCasesResult);
+    assertEquals(expected, point);
+  }
+
+  @Test
+  void succeedsWhenHashToG2MatchesTestDataCase3() {
+    Bytes message =
+        Bytes.fromHexString(
+            "0x"
+                + "56657279202e2e2e2e2e2e2e2e2e2e2e2e2e2e206c6f6e67202e2e2e2e2e2e2e"
+                + "2e2e2e2e2e2e206d657373616765202e2e2e2e207769746820656e74726f7079"
+                + "3a20313233343536373839302d626561636f6e2d636861696e");
+    G2Point point = G2Point.hashToG2(message, 0xffffffffL);
+
+    String[] testCasesResult = {
+      "0x1735fa1eeb8f5927bfbd50497a0f5d0dda9b77e044bbdc2305ad4fed35a2e7fad2f97aa43a0c25e19741481acf836973",
+      "0x06a71fb5c75ca78fefe799c8951e24fde9feb58f07e0da3165a73c40f6cd48eb7d82f6d95c18e3c10abd4e293d3ec6b3",
+      "0x0a852998b4535f26f3dd91af9d0ec9a19cf692ed90523f288f5600cbc8c1a6694d9525b714af12e55ee02ba408ba451a",
+      "0x015a8507b42edd62bd82a12a59bdb9b9ae4b2c53c94bcadaa693a8c0c920718e035f849fd70e5d4c74cce782d3eb2096",
+      "0x1422202b89e51c324096d038174fdf2f1671b09ee9315054d000b500db4c992de5aa9b333a54d1b1cfc73069ee634c14",
+      "0x0af76bfd57821e779b7f2fbed3b314c5b3407be1b4a703396c2afa95e6465b46881b459aca082e72a4613b31b98f7467"
+    };
+
+    G2Point expected = makePoint(testCasesResult);
+    assertEquals(expected, point);
+  }
 
   /* ==== Helper Functions ===================================================================== */
 


### PR DESCRIPTION
## PR Description
This is a purely internal refactor of the compressed point serialisation and deserialisation in the Mikuli library. The serialisation flags are now checked only when deserialising points, and are generated when serialising points. The flags are no longer stored as part of the point objects.

More thorough tests also added.

## Fixed Issue(s)
Caching the flags for compressed points was ugly and unnecessary. Knowing that I had perpetrated this began to make me sad, so I had to fix it to be able to sleep at night.