### PR TITLE
Implement swap-or-not-shuffle

### DIFF
--- a/eth-reference-tests/build.gradle
+++ b/eth-reference-tests/build.gradle
@@ -6,6 +6,7 @@ repositories {
 
 dependencies {
   testCompile project(':util')
+  testCompile project(':ethereum:datastructures')
 
   compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.9.8'
   testCompile 'org.miracl.milagro.amcl:milagro-crypto-java:0.4.0'

--- a/eth-reference-tests/src/test/java/pegasys/artemis/reference/PermutedIndexTestSuite.java
+++ b/eth-reference-tests/src/test/java/pegasys/artemis/reference/PermutedIndexTestSuite.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.errorprone.annotations.MustBeClosed;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import net.consensys.cava.bytes.Bytes32;
+import net.consensys.cava.io.Resources;
+import net.consensys.cava.junit.BouncyCastleExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(BouncyCastleExtension.class)
+public class PermutedIndexTestSuite {
+
+  // TODO: point this to the official test file repo when it is available and correct
+  private static String testFile = "**/test_vector_permutated_index_tmp.yml";
+
+  @ParameterizedTest(name = "{index}. Test permuted index {0}")
+  @MethodSource("readPermutedIndexTestVectors")
+  void testPermutedIndex(int index, int listSize, int indexExpected, Bytes32 seed) {
+
+    int indexActual = BeaconStateUtil.get_permuted_index(index, listSize, seed);
+
+    assertEquals(indexExpected, indexActual);
+  }
+
+  @MustBeClosed
+  private static Stream<Arguments> findTests(String glob) throws IOException {
+    return Resources.find(glob)
+        .flatMap(
+            url -> {
+              try (InputStream in = url.openConnection().getInputStream()) {
+                return readTestCase(in);
+              } catch (IOException e) {
+                throw new UncheckedIOException(e);
+              }
+            });
+  }
+
+  @MustBeClosed
+  private static Stream<Arguments> readPermutedIndexTestVectors() throws IOException {
+    return findTests(testFile);
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static Stream<Arguments> readTestCase(InputStream in) throws IOException {
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    Map allTests = mapper.readerFor(Map.class).readValue(in);
+
+    return ((List<Map>) allTests.get("test_cases"))
+        .stream()
+            .map(
+                testCase ->
+                    Arguments.of(
+                        testCase.get("index"),
+                        testCase.get("list_size"),
+                        testCase.get("permutated_index"),
+                        Bytes32.fromHexString(testCase.get("seed").toString())));
+  }
+}

--- a/eth-reference-tests/src/test/resources/eth2.0-tests_tmp/test_vector_permutated_index_tmp.yml
+++ b/eth-reference-tests/src/test/resources/eth2.0-tests_tmp/test_vector_permutated_index_tmp.yml
@@ -1,0 +1,86 @@
+fork: tchaikovsky
+summary: Test vectors for list shuffling using `get_permutated_index`
+test_suite: permutated_index
+title: Permutated Index Tests
+version: 1.0
+test_cases:
+- {index: 0, list_size: 1, permutated_index: 0, seed: '0xc0c7f226fbd574a8c63dc26864c27833ea931e7c70b34409ba765f3d2031633d',
+  shuffle_round_count: 90}
+- {index: 0, list_size: 2, permutated_index: 0, seed: '0xb20420b2b7b1c64600cbe962544052d0bbe13da403950d198d4f4ea28762953f',
+  shuffle_round_count: 90}
+- {index: 1, list_size: 2, permutated_index: 0, seed: '0x11f1322c3a4cfce20efb7d7eca50291470043d6e8a2c62956e687571607d3f0e',
+  shuffle_round_count: 90}
+- {index: 0, list_size: 3, permutated_index: 2, seed: '0x5bd0af3f74fe6986bb99b3ecc0ea15a403456ce708c05ceeeddc0a4205caf072',
+  shuffle_round_count: 90}
+- {index: 1, list_size: 3, permutated_index: 1, seed: '0xba06ff9bde03f37eddeacb261a51109676d549c1bea3b81edd82df68cc03a97f',
+  shuffle_round_count: 90}
+- {index: 2, list_size: 3, permutated_index: 2, seed: '0xf58a8970c63ca86dd3b8b8a615302ec06cddea1279bf4a2725c781ce6aba348d',
+  shuffle_round_count: 90}
+- {index: 0, list_size: 1024, permutated_index: 1005, seed: '0x383556e23fcb9e73c23ad33cfb50f4c098f49688a84b128c2885960e5f1b3982',
+  shuffle_round_count: 90}
+- {index: 1023, list_size: 1024, permutated_index: 934, seed: '0x2ee5dab30ad1580cdabb175a4b1512cac5566866d65a15e9e22c8444f460c9dc',
+  shuffle_round_count: 90}
+- {index: 3925, list_size: 4040, permutated_index: 32, seed: '0x34a3c13f211e63c56e9e1187f31a56a4230d8d5bf5e584f0e4fe93946af91cce',
+  shuffle_round_count: 90}
+- {index: 885, list_size: 2417, permutated_index: 1822, seed: '0x1346e3970815107154b58b1eff411bfca3342ea0d8282a86304d79d62d5f3c52',
+  shuffle_round_count: 90}
+- {index: 840, list_size: 1805, permutated_index: 808, seed: '0x0810c104b75e25bf89c0066deebc3461937fc0e72ae04ee74f245616c15718df',
+  shuffle_round_count: 90}
+- {index: 881, list_size: 1788, permutated_index: 582, seed: '0x34adb35f3fc2880d220e520120a032bbaa0f4bd7a5fcf1c2269de21075e7a464',
+  shuffle_round_count: 90}
+- {index: 1362, list_size: 1817, permutated_index: 1018, seed: '0xc9b0c76e11f4c3c3c38b447aca5352d93132ad5678da420ca2e69d92588e0fba',
+  shuffle_round_count: 90}
+- {index: 28, list_size: 111, permutated_index: 0, seed: '0x293145c31aeb3eb29ccdf3327d0f3dd4592cdfb2fad3703229c6c2e720dc792f',
+  shuffle_round_count: 90}
+- {index: 959, list_size: 2558, permutated_index: 2094, seed: '0xc9f4c5fbb2a397fd8ea36dbfcec0d733d0af7ec3a03d789a66231f3bc7cafa5e',
+  shuffle_round_count: 90}
+- {index: 887, list_size: 2406, permutated_index: 831, seed: '0x565729e0d5de524e6dee54d1b8b5882ad8e55c18a30462ac02c4bb86c27d26cb',
+  shuffle_round_count: 90}
+- {index: 3526, list_size: 3674, permutated_index: 3531, seed: '0x2951395b1a1bbda8d53b776c7fc8bdad6030de943c4e3f938202ac553f44381d',
+  shuffle_round_count: 90}
+- {index: 978, list_size: 3175, permutated_index: 2257, seed: '0x74aac23523cb45b7ee52d5d2f7b2d24ebc6bf2d63ef189efccabc4a16bb17cd8',
+  shuffle_round_count: 90}
+- {index: 37, list_size: 231, permutated_index: 48, seed: '0xe4083e61b31931bad662392758e8bc30a4ce7b26b6897c2221a3358f25fdc1d8',
+  shuffle_round_count: 90}
+- {index: 340, list_size: 693, permutated_index: 234, seed: '0x8089c1f242aa48c6611180f221c120e930adeecaf3084b2b85f9b1dfebe34f63',
+  shuffle_round_count: 90}
+- {index: 0, list_size: 9, permutated_index: 1, seed: '0x7fda0ab6a746b6b0206febb8259891e0e6f88bf52143b20d6c78caf7caf8e7b3',
+  shuffle_round_count: 90}
+- {index: 200, list_size: 1108, permutated_index: 952, seed: '0x87b210d000b5f57e9834388d4bc2b86ae8b31383fa10a34b029546c2ebabb807',
+  shuffle_round_count: 90}
+- {index: 1408, list_size: 1531, permutated_index: 584, seed: '0x0670a78b38e0419aaead5d1cc8f40f58044b7076ced8193c08b580dd95a13555',
+  shuffle_round_count: 90}
+- {index: 1704, list_size: 1863, permutated_index: 1022, seed: '0xdbf78665190a6133191e91ab35b1106e8984dfc0dfa36018004f880b431c2a14',
+  shuffle_round_count: 90}
+- {index: 793, list_size: 3938, permutated_index: 2607, seed: '0x54bf0192292ffae0bf39b39f12e0540b97591af0a2980d32f277bd33201395d3',
+  shuffle_round_count: 90}
+- {index: 14, list_size: 28, permutated_index: 10, seed: '0x43054417c6056404c586c907dfc5fceb66ebef541d143b00a3b676f3c0fbf4c5',
+  shuffle_round_count: 90}
+- {index: 2909, list_size: 3920, permutated_index: 726, seed: '0x5eabf289fdcfe0a3aba33a185fb1a4ae2f2b6f78daf61f5d356971e0cb270207',
+  shuffle_round_count: 90}
+- {index: 1943, list_size: 1959, permutated_index: 1292, seed: '0xca86322db56927d727101e31c93f616f746317d29aa10d88f371592963de92aa',
+  shuffle_round_count: 90}
+- {index: 1647, list_size: 2094, permutated_index: 1805, seed: '0x3cfe274230a112bc68614882645339fda2f134501a042079d620ec65cf8d3fa6',
+  shuffle_round_count: 90}
+- {index: 1012, list_size: 1877, permutated_index: 216, seed: '0x7b5ff8a848af32d85c6d37c26e61a57e96780fcebc350ad1845e83fe5e4679ac',
+  shuffle_round_count: 90}
+- {index: 35, list_size: 2081, permutated_index: 1458, seed: '0x40691aa31a49c2391e025ec272c812510cb07c055f6201e84479499326330628',
+  shuffle_round_count: 90}
+- {index: 1136, list_size: 2189, permutated_index: 1579, seed: '0x31a0deb2c8c5f809f413b7a36ec680ee8b19bbb9a39c4e207326155864bc8be5',
+  shuffle_round_count: 90}
+- {index: 1775, list_size: 3434, permutated_index: 707, seed: '0x92f30d8556382b72a5797db811486e7a213e0145d6c946e5121aa6a8f761d164',
+  shuffle_round_count: 90}
+- {index: 1109, list_size: 2010, permutated_index: 433, seed: '0x093fb976f2497361897012dfa6dc019009eda2e48bbeb4b7c56d4aa5da7d5f87',
+  shuffle_round_count: 90}
+- {index: 359, list_size: 538, permutated_index: 115, seed: '0xa79b35beacbe48c662d60884c704040024c55ab879e5f61521013c5f45eb3b70',
+  shuffle_round_count: 90}
+- {index: 1259, list_size: 1473, permutated_index: 1351, seed: '0x02c53c9c6ddf259716ff02e49a294eba33e4ad255d7e90dbefdbc991adf603e5',
+  shuffle_round_count: 90}
+- {index: 2087, list_size: 2634, permutated_index: 1497, seed: '0xa5a4c57c5705ec697a74e6c7161191b18f58ca882a0fcc18f68dc3b57a1aa5b6',
+  shuffle_round_count: 90}
+- {index: 2069, list_size: 2511, permutated_index: 1837, seed: '0xe7051ebc07f2e7b4d4b28f48d1e42d7b9dcec31c240ca6e1a0c06139ccfc4b8f',
+  shuffle_round_count: 90}
+- {index: 1660, list_size: 3932, permutated_index: 3046, seed: '0x8687c029ffc443879527a64c31b7acbb38ab6e343779d0b2c6e250046fdb9de8',
+  shuffle_round_count: 90}
+- {index: 379, list_size: 646, permutated_index: 32, seed: '0x17e854f4e80401345e13f72af45b221c9f7a840f6a8c1328ddf9c9ca9a088379',
+  shuffle_round_count: 90}

--- a/eth-reference-tests/src/test/resources/log4j2.xml
+++ b/eth-reference-tests/src/test/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO" monitorInterval="30">
+    <Properties>
+        <Property name="root.log.level">INFO</Property>
+    </Properties>
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSSZZZ} | %t | %-5level | %c{1} | %msg%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="${sys:root.log.level}">
+            <AppenderRef ref="Console" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
@@ -244,6 +244,7 @@ class BeaconStateTest {
   }
 
   @Test
+  @Disabled
   void deepCopyBeaconState() {
     BeaconState state = newState(1);
     BeaconState deepCopy = BeaconState.deepCopy(state);

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
@@ -23,14 +23,12 @@ import static tech.pegasys.artemis.datastructures.Constants.INITIATED_EXIT;
 import static tech.pegasys.artemis.datastructures.Constants.LATEST_RANDAO_MIXES_LENGTH;
 import static tech.pegasys.artemis.datastructures.Constants.MIN_SEED_LOOKAHEAD;
 import static tech.pegasys.artemis.datastructures.Constants.SLOTS_PER_EPOCH;
-import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.bytes3ToInt;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.generate_seed;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_active_index_root;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_current_epoch;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_initial_beacon_state;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_randao_mix;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.is_power_of_two;
-import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.shuffle;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.split;
 import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomDeposits;
 
@@ -281,54 +279,23 @@ class BeaconStateTest {
     return Hash.keccak256(bytes);
   }
 
-  @Test
-  void failsWhenInvalidArgumentsBytes3ToInt() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> bytes3ToInt(Bytes.wrap(new byte[] {(byte) 0, (byte) 0, (byte) 0}), -1));
-  }
+  /* TODO: reinstate test
+    @Test
+    @Disabled
+    void testShuffle() {
+      List<Integer> input = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+      ArrayList<Integer> sample = new ArrayList<>(input);
 
-  @Test
-  void convertBytes3ToInt() {
-    // Smoke Tests
-    // Test that MSB [00000001][00000000][11110000] LSB == 65656
-    assertThat(bytes3ToInt(Bytes.wrap(new byte[] {(byte) 1, (byte) 0, (byte) 120}), 0))
-        .isEqualTo(65656);
-
-    // Boundary Tests
-    // Test that MSB [00000000][00000000][00000000] LSB == 0
-    assertThat(bytes3ToInt(Bytes.wrap(new byte[] {(byte) 0, (byte) 0, (byte) 0}), 0)).isEqualTo(0);
-    // Test that MSB [00000000][00000000][11111111] LSB == 255
-    assertThat(bytes3ToInt(Bytes.wrap(new byte[] {(byte) 0, (byte) 0, (byte) 255}), 0))
-        .isEqualTo(255);
-    // Test that MSB [00000000][00000001][00000000] LSB == 256
-    assertThat(bytes3ToInt(Bytes.wrap(new byte[] {(byte) 0, (byte) 1, (byte) 0}), 0))
-        .isEqualTo(256);
-    // Test that MSB [00000000][11111111][11111111] LSB == 65535
-    assertThat(bytes3ToInt(Bytes.wrap(new byte[] {(byte) 0, (byte) 255, (byte) 255}), 0))
-        .isEqualTo(65535);
-    // Test that MSB [00000001][00000000][00000000] LSB == 65536
-    assertThat(bytes3ToInt(Bytes.wrap(new byte[] {(byte) 1, (byte) 0, (byte) 0}), 0))
-        .isEqualTo(65536);
-    // Test that MSB [11111111][11111111][11111111] LSB == 16777215
-    assertThat(bytes3ToInt(Bytes.wrap(new byte[] {(byte) 255, (byte) 255, (byte) 255}), 0))
-        .isEqualTo(16777215);
-  }
-
-  @Test
-  void testShuffle() {
-    List<Integer> input = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-    ArrayList<Integer> sample = new ArrayList<>(input);
-
-    try {
-      List<Integer> actual = shuffle(sample, hashSrc());
-      List<Integer> expected_input = Arrays.asList(4, 7, 2, 1, 5, 10, 3, 6, 8, 9);
-      ArrayList<Integer> expected = new ArrayList<>(expected_input);
-      assertThat(actual).isEqualTo(expected);
-    } catch (IllegalStateException e) {
-      fail(e.toString());
+      try {
+        List<Integer> actual = shuffle(sample, hashSrc());
+        List<Integer> expected_input = Arrays.asList(4, 7, 2, 1, 5, 10, 3, 6, 8, 9);
+        ArrayList<Integer> expected = new ArrayList<>(expected_input);
+        assertThat(actual).isEqualTo(expected);
+      } catch (IllegalStateException e) {
+        fail(e.toString());
+      }
     }
-  }
+  */
 
   @Test
   void failsWhenInvalidArgumentTestSplit() {

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
@@ -244,7 +244,6 @@ class BeaconStateTest {
   }
 
   @Test
-  @Disabled
   void deepCopyBeaconState() {
     BeaconState state = newState(1);
     BeaconState deepCopy = BeaconState.deepCopy(state);

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
@@ -367,7 +367,10 @@ class BeaconStateUtilTest {
 
   // *************** START Shuffling Tests ***************
 
-  // TODO: tests for get_shuffling()
+  // TODO: tests for get_shuffling() - the reference tests are out of date.
+
+  // The following are just sanity checks. The real testing is against the official test vectors,
+  // elsewhere.
 
   @Test
   void succeedsWhenGetPermutedIndexReturnsAPermutation() {
@@ -378,44 +381,6 @@ class BeaconStateUtilTest {
       int idx = BeaconStateUtil.get_permuted_index(i, listSize, seed);
       assertFalse(done[idx]);
       done[idx] = true;
-    }
-  }
-
-  @Test
-  void succeedsWhenGetPermutedIndexResultMatchesTestDataForOneHundredElements() {
-    // TODO: this is from protolambda's test data based on SHA256 - to be updated
-    Bytes32 seed =
-        Bytes32.fromHexString("0xdf3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119");
-    int listSize = 100;
-    int[] shuffling = {
-      3, 61, 89, 23, 54, 47, 20, 58, 68, 95, 31, 4, 46, 55, 98, 2, 67, 15, 8, 19, 72, 56, 79, 64,
-      96, 45, 42, 71, 22, 87, 6, 29, 70, 53, 24, 5, 41, 81, 59, 90, 86, 10, 51, 83, 44, 91, 26, 97,
-      9, 85, 36, 21, 88, 18, 94, 0, 14, 82, 30, 65, 78, 28, 63, 92, 12, 76, 84, 25, 52, 33, 49, 50,
-      7, 40, 35, 77, 62, 27, 38, 73, 11, 17, 99, 75, 32, 43, 74, 60, 48, 16, 13, 69, 80, 34, 93, 39,
-      1, 37, 57, 66
-    };
-    for (int i = 0; i < listSize; i++) {
-      int idx = BeaconStateUtil.get_permuted_index(i, listSize, seed);
-      assertEquals(shuffling[i], idx);
-    }
-  }
-
-  @Test
-  void succeedsWhenShuffleResultMatchesTestDataForOneHundredElements() {
-    // TODO: this is from protolambda's test data based on SHA256 - to be updated
-    Bytes32 seed =
-        Bytes32.fromHexString("0xdf3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119");
-    int listSize = 100;
-    int[] shuffling = {
-      3, 61, 89, 23, 54, 47, 20, 58, 68, 95, 31, 4, 46, 55, 98, 2, 67, 15, 8, 19, 72, 56, 79, 64,
-      96, 45, 42, 71, 22, 87, 6, 29, 70, 53, 24, 5, 41, 81, 59, 90, 86, 10, 51, 83, 44, 91, 26, 97,
-      9, 85, 36, 21, 88, 18, 94, 0, 14, 82, 30, 65, 78, 28, 63, 92, 12, 76, 84, 25, 52, 33, 49, 50,
-      7, 40, 35, 77, 62, 27, 38, 73, 11, 17, 99, 75, 32, 43, 74, 60, 48, 16, 13, 69, 80, 34, 93, 39,
-      1, 37, 57, 66
-    };
-    int[] indices = BeaconStateUtil.shuffle(listSize, seed);
-    for (int i = 0; i < listSize; i++) {
-      assertEquals(shuffling[i], indices[i]);
     }
   }
 

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
@@ -367,13 +367,15 @@ class BeaconStateUtilTest {
 
   // *************** START Shuffling Tests ***************
 
+  // TODO: tests for get_shuffling()
+
   @Test
   void succeedsWhenGetPermutedIndexReturnsAPermutation() {
     Bytes32 seed = Bytes32.random();
     int listSize = 1000;
     boolean[] done = new boolean[listSize]; // Initialised to false
     for (int i = 0; i < listSize; i++) {
-      int idx = (int) BeaconStateUtil.get_permuted_index(i, listSize, seed);
+      int idx = BeaconStateUtil.get_permuted_index(i, listSize, seed);
       assertFalse(done[idx]);
       done[idx] = true;
     }
@@ -384,7 +386,7 @@ class BeaconStateUtilTest {
     // TODO: this is from protolambda's test data based on SHA256 - to be updated
     Bytes32 seed =
         Bytes32.fromHexString("0xdf3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119");
-    long listSize = 100;
+    int listSize = 100;
     int[] shuffling = {
       3, 61, 89, 23, 54, 47, 20, 58, 68, 95, 31, 4, 46, 55, 98, 2, 67, 15, 8, 19, 72, 56, 79, 64,
       96, 45, 42, 71, 22, 87, 6, 29, 70, 53, 24, 5, 41, 81, 59, 90, 86, 10, 51, 83, 44, 91, 26, 97,
@@ -393,7 +395,7 @@ class BeaconStateUtilTest {
       1, 37, 57, 66
     };
     for (int i = 0; i < listSize; i++) {
-      int idx = (int) BeaconStateUtil.get_permuted_index(i, listSize, seed);
+      int idx = BeaconStateUtil.get_permuted_index(i, listSize, seed);
       assertEquals(shuffling[i], idx);
     }
   }
@@ -403,17 +405,28 @@ class BeaconStateUtilTest {
     // TODO: this is from protolambda's test data based on SHA256 - to be updated
     Bytes32 seed =
         Bytes32.fromHexString("0xdf3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119");
-    long listSize = 100;
-    long[] shuffling = {
+    int listSize = 100;
+    int[] shuffling = {
       3, 61, 89, 23, 54, 47, 20, 58, 68, 95, 31, 4, 46, 55, 98, 2, 67, 15, 8, 19, 72, 56, 79, 64,
       96, 45, 42, 71, 22, 87, 6, 29, 70, 53, 24, 5, 41, 81, 59, 90, 86, 10, 51, 83, 44, 91, 26, 97,
       9, 85, 36, 21, 88, 18, 94, 0, 14, 82, 30, 65, 78, 28, 63, 92, 12, 76, 84, 25, 52, 33, 49, 50,
       7, 40, 35, 77, 62, 27, 38, 73, 11, 17, 99, 75, 32, 43, 74, 60, 48, 16, 13, 69, 80, 34, 93, 39,
       1, 37, 57, 66
     };
-    long[] indices = BeaconStateUtil.shuffle(listSize, seed);
+    int[] indices = BeaconStateUtil.shuffle(listSize, seed);
     for (int i = 0; i < listSize; i++) {
       assertEquals(shuffling[i], indices[i]);
+    }
+  }
+
+  @Test
+  void succeedsWhenGetPermutedIndexAndShuffleGiveTheSameResults() {
+    Bytes32 seed = Bytes32.random();
+    int listSize = (int) randomUnsignedLong().longValue() % 1000;
+    int[] shuffling = BeaconStateUtil.shuffle(listSize, seed);
+    for (int i = 0; i < listSize; i++) {
+      int idx = BeaconStateUtil.get_permuted_index(i, listSize, seed);
+      assertEquals(shuffling[i], idx);
     }
   }
 

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
@@ -368,7 +368,7 @@ class BeaconStateUtilTest {
   // *************** START Shuffling Tests ***************
 
   @Test
-  void succeedsWhenARandomShufflingIsAPermutation() {
+  void succeedsWhenGetPermutedIndexReturnsAPermutation() {
     Bytes32 seed = Bytes32.random();
     int listSize = 1000;
     boolean[] done = new boolean[listSize]; // Initialised to false
@@ -380,7 +380,7 @@ class BeaconStateUtilTest {
   }
 
   @Test
-  void succeedsWhenResultMatchesTestDataForOneHundredElements() {
+  void succeedsWhenGetPermutedIndexResultMatchesTestDataForOneHundredElements() {
     // TODO: this is from protolambda's test data based on SHA256 - to be updated
     Bytes32 seed =
         Bytes32.fromHexString("0xdf3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119");
@@ -395,6 +395,25 @@ class BeaconStateUtilTest {
     for (int i = 0; i < listSize; i++) {
       int idx = (int) BeaconStateUtil.get_permuted_index(i, listSize, seed);
       assertEquals(shuffling[i], idx);
+    }
+  }
+
+  @Test
+  void succeedsWhenShuffleResultMatchesTestDataForOneHundredElements() {
+    // TODO: this is from protolambda's test data based on SHA256 - to be updated
+    Bytes32 seed =
+        Bytes32.fromHexString("0xdf3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119");
+    long listSize = 100;
+    long[] shuffling = {
+      3, 61, 89, 23, 54, 47, 20, 58, 68, 95, 31, 4, 46, 55, 98, 2, 67, 15, 8, 19, 72, 56, 79, 64,
+      96, 45, 42, 71, 22, 87, 6, 29, 70, 53, 24, 5, 41, 81, 59, 90, 86, 10, 51, 83, 44, 91, 26, 97,
+      9, 85, 36, 21, 88, 18, 94, 0, 14, 82, 30, 65, 78, 28, 63, 92, 12, 76, 84, 25, 52, 33, 49, 50,
+      7, 40, 35, 77, 62, 27, 38, 73, 11, 17, 99, 75, 32, 43, 74, 60, 48, 16, 13, 69, 80, 34, 93, 39,
+      1, 37, 57, 66
+    };
+    long[] indices = BeaconStateUtil.shuffle(listSize, seed);
+    for (int i = 0; i < listSize; i++) {
+      assertEquals(shuffling[i], indices[i]);
     }
   }
 

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
@@ -379,5 +379,24 @@ class BeaconStateUtilTest {
     }
   }
 
+  @Test
+  void succeedsWhenResultMatchesTestDataForOneHundredElements() {
+    // TODO: this is from protolambda's test data based on SHA256 - to be updated
+    Bytes32 seed =
+        Bytes32.fromHexString("0xdf3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119");
+    long listSize = 100;
+    int[] shuffling = {
+      3, 61, 89, 23, 54, 47, 20, 58, 68, 95, 31, 4, 46, 55, 98, 2, 67, 15, 8, 19, 72, 56, 79, 64,
+      96, 45, 42, 71, 22, 87, 6, 29, 70, 53, 24, 5, 41, 81, 59, 90, 86, 10, 51, 83, 44, 91, 26, 97,
+      9, 85, 36, 21, 88, 18, 94, 0, 14, 82, 30, 65, 78, 28, 63, 92, 12, 76, 84, 25, 52, 33, 49, 50,
+      7, 40, 35, 77, 62, 27, 38, 73, 11, 17, 99, 75, 32, 43, 74, 60, 48, 16, 13, 69, 80, 34, 93, 39,
+      1, 37, 57, 66
+    };
+    for (int i = 0; i < listSize; i++) {
+      int idx = (int) BeaconStateUtil.get_permuted_index(i, listSize, seed);
+      assertEquals(shuffling[i], idx);
+    }
+  }
+
   // *************** END Shuffling Tests *****************
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
@@ -364,4 +364,20 @@ class BeaconStateUtilTest {
     beaconState.setValidator_balances(balanceList);
     return beaconState;
   }
+
+  // *************** START Shuffling Tests ***************
+
+  @Test
+  void succeedsWhenARandomShufflingIsAPermutation() {
+    Bytes32 seed = Bytes32.random();
+    int listSize = 1000;
+    boolean[] done = new boolean[listSize]; // Initialised to false
+    for (int i = 0; i < listSize; i++) {
+      int idx = (int) BeaconStateUtil.get_permuted_index(i, listSize, seed);
+      assertFalse(done[idx]);
+      done[idx] = true;
+    }
+  }
+
+  // *************** END Shuffling Tests *****************
 }


### PR DESCRIPTION
## PR Description
Replaces the v0.1 shuffle with the swap-or-not-shuffle.

- [x] Implement `get_permuted_index()` for computing a single index as per the v0.4 spec
- [x] Implement `shuffle()` [optimised](https://github.com/ethereum/eth2.0-specs/commit/70e482be28a10ca0d37de34fb3a0b5cd94108ad3) for computing the whole list of permuted indices as per 
- [x] Basic tests for the above
- [x] Integrate the new shuffle with the surrounding code
- [x] Find and add the reference tests
- [x] Change the hash algorithm to match the tests (currently it's sha256 as I only have protolambda's test data)

## Fixed Issue(s)
Fixes #388
