### PR TITLE
Change bitfields to use variable length Bytes.

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/Attestation.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/Attestation.java
@@ -15,21 +15,20 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
-import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.ssz.SSZ;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
 public class Attestation {
 
-  private Bytes32 aggregation_bitfield;
+  private Bytes aggregation_bitfield;
   private AttestationData data;
-  private Bytes32 custody_bitfield;
+  private Bytes custody_bitfield;
   private BLSSignature aggregate_signature;
 
   public Attestation(
-      Bytes32 aggregation_bitfield,
+      Bytes aggregation_bitfield,
       AttestationData data,
-      Bytes32 custody_bitfield,
+      Bytes custody_bitfield,
       BLSSignature aggregate_signature) {
     this.aggregation_bitfield = aggregation_bitfield;
     this.data = data;
@@ -42,9 +41,9 @@ public class Attestation {
         bytes,
         reader ->
             new Attestation(
-                Bytes32.wrap(reader.readBytes()),
+                Bytes.wrap(reader.readBytes()),
                 AttestationData.fromBytes(reader.readBytes()),
-                Bytes32.wrap(reader.readBytes()),
+                Bytes.wrap(reader.readBytes()),
                 BLSSignature.fromBytes(reader.readBytes())));
   }
 
@@ -85,11 +84,11 @@ public class Attestation {
   }
 
   /** ******************* * GETTERS & SETTERS * * ******************* */
-  public Bytes32 getAggregation_bitfield() {
+  public Bytes getAggregation_bitfield() {
     return aggregation_bitfield;
   }
 
-  public void setAggregation_bitfield(Bytes32 aggregation_bitfield) {
+  public void setAggregation_bitfield(Bytes aggregation_bitfield) {
     this.aggregation_bitfield = aggregation_bitfield;
   }
 
@@ -101,11 +100,11 @@ public class Attestation {
     this.data = data;
   }
 
-  public Bytes32 getCustody_bitfield() {
+  public Bytes getCustody_bitfield() {
     return custody_bitfield;
   }
 
-  public void setCustody_bitfield(Bytes32 custody_bitfield) {
+  public void setCustody_bitfield(Bytes custody_bitfield) {
     this.custody_bitfield = custody_bitfield;
   }
 

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/SlashableAttestation.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/SlashableAttestation.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import net.consensys.cava.bytes.Bytes;
-import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.ssz.SSZ;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
@@ -26,13 +25,13 @@ public class SlashableAttestation {
 
   private List<UnsignedLong> validator_indices;
   private AttestationData data;
-  private Bytes32 custody_bitfield;
+  private Bytes custody_bitfield;
   private BLSSignature aggregate_signature;
 
   public SlashableAttestation(
       List<UnsignedLong> validator_indices,
       AttestationData data,
-      Bytes32 custody_bitfield,
+      Bytes custody_bitfield,
       BLSSignature aggregate_signature) {
     this.validator_indices = validator_indices;
     this.data = data;
@@ -49,7 +48,7 @@ public class SlashableAttestation {
                     .map(UnsignedLong::fromLongBits)
                     .collect(Collectors.toList()),
                 AttestationData.fromBytes(reader.readBytes()),
-                Bytes32.wrap(reader.readBytes()),
+                Bytes.wrap(reader.readBytes()),
                 BLSSignature.fromBytes(reader.readBytes())));
   }
 
@@ -116,11 +115,11 @@ public class SlashableAttestation {
     this.validator_indices = validator_indices;
   }
 
-  public Bytes32 getCustody_bitfield() {
+  public Bytes getCustody_bitfield() {
     return custody_bitfield;
   }
 
-  public void setCustody_bitfield(Bytes32 custody_bitfield) {
+  public void setCustody_bitfield(Bytes custody_bitfield) {
     this.custody_bitfield = custody_bitfield;
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/PendingAttestation.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/PendingAttestation.java
@@ -16,21 +16,20 @@ package tech.pegasys.artemis.datastructures.state;
 import com.google.common.primitives.UnsignedLong;
 import java.util.Objects;
 import net.consensys.cava.bytes.Bytes;
-import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.ssz.SSZ;
 import tech.pegasys.artemis.datastructures.operations.AttestationData;
 
 public class PendingAttestation {
 
-  private Bytes32 aggregation_bitfield;
+  private Bytes aggregation_bitfield;
   private AttestationData data;
-  private Bytes32 custody_bitfield;
+  private Bytes custody_bitfield;
   private UnsignedLong slot_included;
 
   public PendingAttestation(
-      Bytes32 aggregation_bitfield,
+      Bytes aggregation_bitfield,
       AttestationData data,
-      Bytes32 custody_bitfield,
+      Bytes custody_bitfield,
       UnsignedLong slot_included) {
     this.aggregation_bitfield = aggregation_bitfield;
     this.data = data;
@@ -43,9 +42,9 @@ public class PendingAttestation {
         bytes,
         reader ->
             new PendingAttestation(
-                Bytes32.wrap(reader.readBytes()),
+                Bytes.wrap(reader.readBytes()),
                 AttestationData.fromBytes(reader.readBytes()),
-                Bytes32.wrap(reader.readBytes()),
+                Bytes.wrap(reader.readBytes()),
                 UnsignedLong.fromLongBits(reader.readUInt64())));
   }
 
@@ -86,11 +85,11 @@ public class PendingAttestation {
   }
 
   /** ******************* * GETTERS & SETTERS * * ******************* */
-  public Bytes32 getAggregation_bitfield() {
+  public Bytes getAggregation_bitfield() {
     return aggregation_bitfield;
   }
 
-  public void setAggregation_bitfield(Bytes32 aggregation_bitfield) {
+  public void setAggregation_bitfield(Bytes aggregation_bitfield) {
     this.aggregation_bitfield = aggregation_bitfield;
   }
 
@@ -102,11 +101,11 @@ public class PendingAttestation {
     this.data = data;
   }
 
-  public Bytes32 getCustody_bitfield() {
+  public Bytes getCustody_bitfield() {
     return custody_bitfield;
   }
 
-  public void setCustody_bitfield(Bytes32 custody_bitfield) {
+  public void setCustody_bitfield(Bytes custody_bitfield) {
     this.custody_bitfield = custody_bitfield;
   }
 

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockBodyTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockBodyTest.java
@@ -146,7 +146,7 @@ class BeaconBlockBodyTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszBeaconBlockBodyBytes = beaconBlockBody.toBytes();
     assertEquals(beaconBlockBody, BeaconBlockBody.fromBytes(sszBeaconBlockBodyBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockTest.java
@@ -137,7 +137,7 @@ class BeaconBlockTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszBeaconBlockBytes = beaconBlock.toBytes();
     assertEquals(beaconBlock, BeaconBlock.fromBytes(sszBeaconBlockBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/Eth1DataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/Eth1DataTest.java
@@ -56,7 +56,7 @@ class Eth1DataTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszEth1DataBytes = eth1Data.toBytes();
     assertEquals(eth1Data, Eth1Data.fromBytes(sszEth1DataBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/Eth1DataVoteTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/Eth1DataVoteTest.java
@@ -66,7 +66,7 @@ class Eth1DataVoteTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszEth1DataVoteBytes = eth1DataVote.toBytes();
     assertEquals(eth1DataVote, Eth1DataVote.fromBytes(sszEth1DataVoteBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/ProposalSignedDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/ProposalSignedDataTest.java
@@ -69,7 +69,7 @@ class ProposalSignedDataTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszProposalSignedDataBytes = proposalSignedData.toBytes();
     assertEquals(proposalSignedData, ProposalSignedData.fromBytes(sszProposalSignedDataBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationDataAndCustodyBitTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationDataAndCustodyBitTest.java
@@ -68,7 +68,7 @@ class AttestationDataAndCustodyBitTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszAttestationDataAndCustodyBitBytes = attestationDataAndCustodyBit.toBytes();
     assertEquals(
         attestationDataAndCustodyBit,

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationDataTest.java
@@ -204,7 +204,7 @@ class AttestationDataTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszAttestationDataBytes = attestationData.toBytes();
     assertEquals(attestationData, AttestationData.fromBytes(sszAttestationDataBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationTest.java
@@ -25,9 +25,9 @@ import tech.pegasys.artemis.util.bls.BLSSignature;
 
 class AttestationTest {
 
-  private Bytes32 aggregationBitfield = Bytes32.random();
+  private Bytes aggregationBitfield = Bytes32.random();
   private AttestationData data = randomAttestationData();
-  private Bytes32 custodyBitfield = Bytes32.random();
+  private Bytes custodyBitfield = Bytes32.random();
   private BLSSignature aggregateSignature = BLSSignature.random();
 
   private Attestation attestation =

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationTest.java
@@ -93,13 +93,13 @@ class AttestationTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszAttestationBytes = attestation.toBytes();
     assertEquals(attestation, Attestation.fromBytes(sszAttestationBytes));
   }
 
   @Test
-  void rountripSSZVariableLengthBitfield() {
+  void roundtripSSZVariableLengthBitfield() {
     Attestation byte1BitfieldAttestation =
         new Attestation(
             Bytes.fromHexString("0x00"), data, Bytes.fromHexString("0x00"), aggregateSignature);

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationTest.java
@@ -97,4 +97,37 @@ class AttestationTest {
     Bytes sszAttestationBytes = attestation.toBytes();
     assertEquals(attestation, Attestation.fromBytes(sszAttestationBytes));
   }
+
+  @Test
+  void rountripSSZVariableLengthBitfield() {
+    Attestation byte1BitfieldAttestation =
+        new Attestation(
+            Bytes.fromHexString("0x00"), data, Bytes.fromHexString("0x00"), aggregateSignature);
+    Attestation byte4BitfieldAttestation =
+        new Attestation(
+            Bytes.fromHexString("0x00000000"),
+            data,
+            Bytes.fromHexString("0x00000000"),
+            aggregateSignature);
+    Attestation byte8BitfieldAttestation =
+        new Attestation(
+            Bytes.fromHexString("0x0000000000000000"),
+            data,
+            Bytes.fromHexString("0x0000000000000000"),
+            aggregateSignature);
+    Attestation byte16BitfieldAttestation =
+        new Attestation(
+            Bytes.fromHexString("0x00000000000000000000000000000000"),
+            data,
+            Bytes.fromHexString("0x00000000000000000000000000000000"),
+            aggregateSignature);
+    Bytes byte1BitfieldAttestationBytes = byte1BitfieldAttestation.toBytes();
+    Bytes byte4BitfieldAttestationBytes = byte4BitfieldAttestation.toBytes();
+    Bytes byte8BitfieldAttestationBytes = byte8BitfieldAttestation.toBytes();
+    Bytes byte16BitfieldAttestationBytes = byte16BitfieldAttestation.toBytes();
+    assertEquals(byte1BitfieldAttestation, Attestation.fromBytes(byte1BitfieldAttestationBytes));
+    assertEquals(byte4BitfieldAttestation, Attestation.fromBytes(byte4BitfieldAttestationBytes));
+    assertEquals(byte8BitfieldAttestation, Attestation.fromBytes(byte8BitfieldAttestationBytes));
+    assertEquals(byte16BitfieldAttestation, Attestation.fromBytes(byte16BitfieldAttestationBytes));
+  }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttesterSlashingTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttesterSlashingTest.java
@@ -75,7 +75,7 @@ class AttesterSlashingTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszAttesterSlashingBytes = attesterSlashing.toBytes();
     assertEquals(attesterSlashing, AttesterSlashing.fromBytes(sszAttesterSlashingBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositDataTest.java
@@ -79,7 +79,7 @@ class DepositDataTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszDepositDataBytes = depositData.toBytes();
     assertEquals(depositData, DepositData.fromBytes(sszDepositDataBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositInputTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositInputTest.java
@@ -80,7 +80,7 @@ class DepositInputTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszDepositInputBytes = depositInput.toBytes();
     assertEquals(depositInput, DepositInput.fromBytes(sszDepositInputBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositTest.java
@@ -87,7 +87,7 @@ class DepositTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszDepositBytes = deposit.toBytes();
     assertEquals(deposit, Deposit.fromBytes(sszDepositBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ExitTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ExitTest.java
@@ -71,7 +71,7 @@ class ExitTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszExitBytes = exit.toBytes();
     assertEquals(exit, Exit.fromBytes(sszExitBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ProposerSlashingTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ProposerSlashingTest.java
@@ -143,7 +143,7 @@ class ProposerSlashingTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszProposerSlashingBytes = proposerSlashing.toBytes();
     assertEquals(proposerSlashing, ProposerSlashing.fromBytes(sszProposerSlashingBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/SlashableAttestationTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/SlashableAttestationTest.java
@@ -106,13 +106,13 @@ class SlashableAttestationTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszSlashableVoteDataBytes = slashableAttestation.toBytes();
     assertEquals(slashableAttestation, SlashableAttestation.fromBytes(sszSlashableVoteDataBytes));
   }
 
   @Test
-  void rountripSSZVariableLengthBitfield() {
+  void roundtripSSZVariableLengthBitfield() {
     SlashableAttestation byte1BitfieldSlashableAttestation =
         new SlashableAttestation(
             validatorIndices, data, Bytes.fromHexString("0x00"), aggregateSignature);

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/SlashableAttestationTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/SlashableAttestationTest.java
@@ -34,7 +34,7 @@ class SlashableAttestationTest {
   private List<UnsignedLong> validatorIndices =
       Arrays.asList(randomUnsignedLong(), randomUnsignedLong(), randomUnsignedLong());
   private AttestationData data = randomAttestationData();
-  private Bytes32 custodyBitfield = Bytes32.random();
+  private Bytes custodyBitfield = Bytes32.random();
   private BLSSignature aggregateSignature = BLSSignature.random();
 
   private SlashableAttestation slashableAttestation =
@@ -85,10 +85,8 @@ class SlashableAttestationTest {
 
   @Test
   void equalsReturnsFalseWhenCustodyBitfieldIsDifferent() {
-    Bytes32 otherCustodyBitfield = custodyBitfield.and(Bytes32.random());
-
     SlashableAttestation testSlashableAttestation =
-        new SlashableAttestation(validatorIndices, data, otherCustodyBitfield, aggregateSignature);
+        new SlashableAttestation(validatorIndices, data, custodyBitfield.not(), aggregateSignature);
 
     assertNotEquals(slashableAttestation, testSlashableAttestation);
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/SlashableAttestationTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/SlashableAttestationTest.java
@@ -110,4 +110,36 @@ class SlashableAttestationTest {
     Bytes sszSlashableVoteDataBytes = slashableAttestation.toBytes();
     assertEquals(slashableAttestation, SlashableAttestation.fromBytes(sszSlashableVoteDataBytes));
   }
+
+  @Test
+  void rountripSSZVariableLengthBitfield() {
+    SlashableAttestation byte1BitfieldSlashableAttestation =
+        new SlashableAttestation(
+            validatorIndices, data, Bytes.fromHexString("0x00"), aggregateSignature);
+    SlashableAttestation byte4BitfieldSlashableAttestation =
+        new SlashableAttestation(
+            validatorIndices, data, Bytes.fromHexString("0x00"), aggregateSignature);
+    SlashableAttestation byte8BitfieldSlashableAttestation =
+        new SlashableAttestation(
+            validatorIndices, data, Bytes.fromHexString("0x00"), aggregateSignature);
+    SlashableAttestation byte16BitfieldSlashableAttestation =
+        new SlashableAttestation(
+            validatorIndices, data, Bytes.fromHexString("0x00"), aggregateSignature);
+    Bytes byte1BitfieldSlashableAttestationBytes = byte1BitfieldSlashableAttestation.toBytes();
+    Bytes byte4BitfieldSlashableAttestationBytes = byte4BitfieldSlashableAttestation.toBytes();
+    Bytes byte8BitfieldSlashableAttestationBytes = byte8BitfieldSlashableAttestation.toBytes();
+    Bytes byte16BitfieldSlashableAttestationBytes = byte16BitfieldSlashableAttestation.toBytes();
+    assertEquals(
+        byte1BitfieldSlashableAttestation,
+        SlashableAttestation.fromBytes(byte1BitfieldSlashableAttestationBytes));
+    assertEquals(
+        byte4BitfieldSlashableAttestation,
+        SlashableAttestation.fromBytes(byte4BitfieldSlashableAttestationBytes));
+    assertEquals(
+        byte8BitfieldSlashableAttestation,
+        SlashableAttestation.fromBytes(byte8BitfieldSlashableAttestationBytes));
+    assertEquals(
+        byte16BitfieldSlashableAttestation,
+        SlashableAttestation.fromBytes(byte16BitfieldSlashableAttestationBytes));
+  }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/CrosslinkTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/CrosslinkTest.java
@@ -58,7 +58,7 @@ class CrosslinkTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszCrosslinkBytes = crosslink.toBytes();
     assertEquals(crosslink, Crosslink.fromBytes(sszCrosslinkBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/ForkTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/ForkTest.java
@@ -65,7 +65,7 @@ class ForkTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszForkBytes = fork.toBytes();
     assertEquals(fork, Fork.fromBytes(sszForkBytes));
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/PendingAttestationTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/PendingAttestationTest.java
@@ -27,9 +27,9 @@ import tech.pegasys.artemis.datastructures.operations.AttestationData;
 
 class PendingAttestationTest {
 
-  private Bytes32 participationBitfield = Bytes32.random();
+  private Bytes participationBitfield = Bytes32.random();
   private AttestationData data = randomAttestationData();
-  private Bytes32 custodyBitfield = Bytes32.random();
+  private Bytes custodyBitfield = Bytes32.random();
   private UnsignedLong slotIncluded = randomUnsignedLong();
 
   private PendingAttestation pendingAttestation =

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/PendingAttestationTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/PendingAttestationTest.java
@@ -95,4 +95,45 @@ class PendingAttestationTest {
     Bytes sszPendingAttestationBytes = pendingAttestation.toBytes();
     assertEquals(pendingAttestation, PendingAttestation.fromBytes(sszPendingAttestationBytes));
   }
+
+  @Test
+  void rountripSSZVariableLengthBitfield() {
+    PendingAttestation byte1BitfieldPendingAttestation =
+        new PendingAttestation(
+            Bytes.fromHexString("0x00"), data, Bytes.fromHexString("0x00"), slotIncluded);
+    PendingAttestation byte4BitfieldPendingAttestation =
+        new PendingAttestation(
+            Bytes.fromHexString("0x00000000"),
+            data,
+            Bytes.fromHexString("0x00000000"),
+            slotIncluded);
+    PendingAttestation byte8BitfieldPendingAttestation =
+        new PendingAttestation(
+            Bytes.fromHexString("0x0000000000000000"),
+            data,
+            Bytes.fromHexString("0x0000000000000000"),
+            slotIncluded);
+    PendingAttestation byte16BitfieldPendingAttestation =
+        new PendingAttestation(
+            Bytes.fromHexString("0x00000000000000000000000000000000"),
+            data,
+            Bytes.fromHexString("0x00000000000000000000000000000000"),
+            slotIncluded);
+    Bytes byte1BitfieldPendingAttestationBytes = byte1BitfieldPendingAttestation.toBytes();
+    Bytes byte4BitfieldPendingAttestationBytes = byte4BitfieldPendingAttestation.toBytes();
+    Bytes byte8BitfieldPendingAttestationBytes = byte8BitfieldPendingAttestation.toBytes();
+    Bytes byte16BitfieldPendingAttestationBytes = byte16BitfieldPendingAttestation.toBytes();
+    assertEquals(
+        byte1BitfieldPendingAttestation,
+        PendingAttestation.fromBytes(byte1BitfieldPendingAttestationBytes));
+    assertEquals(
+        byte4BitfieldPendingAttestation,
+        PendingAttestation.fromBytes(byte4BitfieldPendingAttestationBytes));
+    assertEquals(
+        byte8BitfieldPendingAttestation,
+        PendingAttestation.fromBytes(byte8BitfieldPendingAttestationBytes));
+    assertEquals(
+        byte16BitfieldPendingAttestation,
+        PendingAttestation.fromBytes(byte16BitfieldPendingAttestationBytes));
+  }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/PendingAttestationTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/PendingAttestationTest.java
@@ -91,13 +91,13 @@ class PendingAttestationTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszPendingAttestationBytes = pendingAttestation.toBytes();
     assertEquals(pendingAttestation, PendingAttestation.fromBytes(sszPendingAttestationBytes));
   }
 
   @Test
-  void rountripSSZVariableLengthBitfield() {
+  void roundtripSSZVariableLengthBitfield() {
     PendingAttestation byte1BitfieldPendingAttestation =
         new PendingAttestation(
             Bytes.fromHexString("0x00"), data, Bytes.fromHexString("0x00"), slotIncluded);

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/ValidatorTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/ValidatorTest.java
@@ -175,7 +175,7 @@ class ValidatorTest {
   }
 
   @Test
-  void rountripSSZ() {
+  void roundtripSSZ() {
     Bytes sszValidatorBytes = validator.toBytes();
     assertEquals(validator, Validator.fromBytes(sszValidatorBytes));
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
@@ -427,13 +427,15 @@ public class BlockProcessorUtil {
    */
   private static boolean verify_bitfields_and_aggregate_signature(
       Attestation attestation, BeaconState state) throws BlockProcessingException {
-    // NOTE: The spec defines this verification in terms of the custody bitfield length,
-    //   however because we've implemented the bitfield as a static Bytes32 value
-    //   instead of a variable length bitfield, checking against Bytes32.ZERO will suffice.
     checkArgument(
         Objects.equals(
-            attestation.getCustody_bitfield(), Bytes32.ZERO)); // [TO BE REMOVED IN PHASE 1]
-    checkArgument(!Objects.equals(attestation.getAggregation_bitfield(), Bytes32.ZERO));
+            attestation.getCustody_bitfield(),
+            Bytes.wrap(
+                new byte[attestation.getCustody_bitfield().size()]))); // [TO BE REMOVED IN PHASE 1]
+    checkArgument(
+        !Objects.equals(
+            attestation.getAggregation_bitfield(),
+            Bytes.wrap(new byte[attestation.getAggregation_bitfield().size()])));
 
     List<List<Integer>> crosslink_committees = new ArrayList<>();
     for (CrosslinkCommittee crosslink_committee :


### PR DESCRIPTION
## PR Description
Changes all spec bitfields to be variable length bytes instead of fixes bytes32.

Tasks:
- [x] Change all occurrences of bitfield to variable length Bytes, and update corresponding logic.
- [x] Add tests to ensure variable length bitfields work as intended.

## Fixed Issue(s)
Fixes #398 
