### PR TITLE
Update to get_next_epoch()

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -419,6 +419,18 @@ public class BeaconStateUtil {
   }
 
   /**
+   * Return the next ``epoch`` of the given state.
+   *
+   * <p>This method is no longer in the spec as of v0.4, but is retained here for convenience.
+   *
+   * @param state The beacon state under consideration.
+   * @return The next epoch number.
+   */
+  public static UnsignedLong get_next_epoch(BeaconState state) {
+    return get_current_epoch(state).plus(UnsignedLong.ONE);
+  }
+
+  /**
    * Return the slot that the given ``epoch`` starts at.
    *
    * @param epoch
@@ -426,10 +438,6 @@ public class BeaconStateUtil {
    */
   public static UnsignedLong get_epoch_start_slot(UnsignedLong epoch) {
     return epoch.times(UnsignedLong.valueOf(SLOTS_PER_EPOCH));
-  }
-
-  public static UnsignedLong get_next_epoch(BeaconState state) {
-    return get_current_epoch(state).plus(UnsignedLong.ONE);
   }
 
   /**

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
@@ -359,6 +359,15 @@ class BeaconStateUtilTest {
         BeaconStateUtil.get_previous_epoch(beaconState));
   }
 
+  @Test
+  void succeedsWhenGetNextEpochReturnsTheEpochPlusOne() {
+    BeaconState beaconState = createBeaconState();
+    beaconState.setSlot(UnsignedLong.valueOf(Constants.GENESIS_SLOT));
+    assertEquals(
+        UnsignedLong.valueOf(Constants.GENESIS_EPOCH + 1),
+        BeaconStateUtil.get_next_epoch(beaconState));
+  }
+
   private BeaconState createBeaconState() {
     return createBeaconState(false, null, null);
   }


### PR DESCRIPTION
## PR Description
Was going to remove `get_next_epoch()` as per the 0.4 spec, but it is easier and more intuitive to leave it in place. So I commented it and added a test.

## Fixed Issue(s)
Fixes #436