### PR TITLE
Fix shuffling test divide by zero

### DIFF
--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
@@ -415,7 +415,7 @@ class BeaconStateUtilTest {
   @Test
   void succeedsWhenGetPermutedIndexAndShuffleGiveTheSameResults() {
     Bytes32 seed = Bytes32.random();
-    int listSize = (int) randomUnsignedLong().longValue() % 1000;
+    int listSize = 1 + (int) randomUnsignedLong().longValue() % 1000;
     int[] shuffling = BeaconStateUtil.shuffle(listSize, seed);
     for (int i = 0; i < listSize; i++) {
       int idx = BeaconStateUtil.get_permuted_index(i, listSize, seed);


### PR DESCRIPTION
## PR Description
One of the shuffling tests used a random list length. If it happened to be zero, the modulo method would fail. Now it is minimum one.
