### PR TITLE
Check that little-endian is used and add int_to_bytes functions

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -306,7 +306,7 @@ public class BeaconStateUtil {
         get_randao_mix(state, epoch.minus(UnsignedLong.valueOf(Constants.MIN_SEED_LOOKAHEAD)));
     Bytes32 index_root = get_active_index_root(state, epoch);
     Bytes32 epochBytes = int_to_bytes32(epoch.longValue());
-    return Hash.keccak256(Bytes.concatenate(randao_mix, index_root, epochBytes));
+    return Hash.keccak256(Bytes.wrap(randao_mix, index_root, epochBytes));
   }
 
   public static Bytes32 get_active_index_root(BeaconState state, UnsignedLong epoch) {
@@ -664,7 +664,7 @@ public class BeaconStateUtil {
       int pivot =
           (int)
               Long.remainderUnsigned(
-                  bytes_to_int(Hash.keccak256(Bytes.concatenate(seed, roundAsByte)).slice(0, 8)),
+                  bytes_to_int(Hash.keccak256(Bytes.wrap(seed, roundAsByte)).slice(0, 8)),
                   listSize);
       int flip = (pivot - indexRet) % listSize;
       if (flip < 0) {
@@ -675,7 +675,7 @@ public class BeaconStateUtil {
       int position = (indexRet < flip) ? flip : indexRet;
 
       Bytes positionDiv256 = int_to_bytes(position / 256, 4);
-      Bytes source = Hash.keccak256(Bytes.concatenate(seed, roundAsByte, positionDiv256));
+      Bytes source = Hash.keccak256(Bytes.wrap(seed, roundAsByte, positionDiv256));
 
       // The byte type is signed in Java, but the right shift should be fine as we just use bit 0.
       // But we can't use % in the normal way because of signedness, so we `& 1` instead.
@@ -731,16 +731,14 @@ public class BeaconStateUtil {
       Bytes hashBytes = Bytes.EMPTY;
       for (int i = 0; i < (listSize + 255) / 256; i++) {
         Bytes iAsBytes4 = int_to_bytes(i, 4);
-        hashBytes =
-            Bytes.concatenate(
-                hashBytes, Hash.keccak256(Bytes.concatenate(seed, roundAsByte, iAsBytes4)));
+        hashBytes = Bytes.wrap(hashBytes, Hash.keccak256(Bytes.wrap(seed, roundAsByte, iAsBytes4)));
       }
 
       // This needs to be unsigned modulo.
       int pivot =
           (int)
               Long.remainderUnsigned(
-                  bytes_to_int(Hash.keccak256(Bytes.concatenate(seed, roundAsByte)).slice(0, 8)),
+                  bytes_to_int(Hash.keccak256(Bytes.wrap(seed, roundAsByte)).slice(0, 8)),
                   listSize);
 
       for (int i = 0; i < listSize; i++) {
@@ -1203,7 +1201,7 @@ public class BeaconStateUtil {
     if (numBytes <= longBytes) {
       return valueBytes.slice(0, numBytes);
     } else {
-      return Bytes.concatenate(valueBytes, Bytes.wrap(new byte[numBytes - longBytes]));
+      return Bytes.wrap(valueBytes, Bytes.wrap(new byte[numBytes - longBytes]));
     }
   }
 

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -654,13 +654,11 @@ public class BeaconStateUtil {
      */
 
     int indexRet = index;
-    byte[] byteTmp = new byte[1];
     byte[] powerOfTwoNumbers = {1, 2, 4, 8, 16, 32, 64, (byte) 128};
 
     for (int round = 0; round < SHUFFLE_ROUND_COUNT; round++) {
 
-      byteTmp[0] = (byte) round;
-      Bytes roundAsByte = Bytes.wrap(byteTmp);
+      Bytes roundAsByte = Bytes.of((byte) round);
 
       // This needs to be unsigned modulo.
       int pivot =
@@ -676,8 +674,7 @@ public class BeaconStateUtil {
 
       int position = (indexRet < flip) ? flip : indexRet;
 
-      // We skip the first byte which is equivalent to dividing by 256
-      Bytes positionDiv256 = Bytes.ofUnsignedLong(position, ByteOrder.LITTLE_ENDIAN).slice(1, 4);
+      Bytes positionDiv256 = int_to_bytes(position / 256, 4);
       Bytes source = Hash.keccak256(Bytes.concatenate(seed, roundAsByte, positionDiv256));
 
       // The byte type is signed in Java, but the right shift should be fine as we just use bit 0.
@@ -725,17 +722,15 @@ public class BeaconStateUtil {
       indices[i] = i;
     }
 
-    byte[] byteTmp = new byte[1];
     byte[] powerOfTwoNumbers = {1, 2, 4, 8, 16, 32, 64, (byte) 128};
 
     for (int round = 0; round < SHUFFLE_ROUND_COUNT; round++) {
 
-      byteTmp[0] = (byte) round;
-      Bytes roundAsByte = Bytes.wrap(byteTmp);
+      Bytes roundAsByte = Bytes.of((byte) round);
 
       Bytes hashBytes = Bytes.EMPTY;
       for (int i = 0; i < (listSize + 255) / 256; i++) {
-        Bytes iAsBytes4 = Bytes.ofUnsignedInt(i, ByteOrder.LITTLE_ENDIAN);
+        Bytes iAsBytes4 = int_to_bytes(i, 4);
         hashBytes =
             Bytes.concatenate(
                 hashBytes, Hash.keccak256(Bytes.concatenate(seed, roundAsByte, iAsBytes4)));
@@ -1192,8 +1187,28 @@ public class BeaconStateUtil {
     return x;
   }
 
+  /**
+   * Convert a long value into a number of bytes, little endian.
+   *
+   * <p>If numBytes is more than the size of a long then the returned value is right-padded with
+   * zero bytes. If numBytes is less than the size of a long then the value is truncated.
+   *
+   * @param value The value to be converted to bytes.
+   * @param numBytes The number of bytes to be returned.
+   * @return The requested number of bytes.
+   */
+  public static Bytes int_to_bytes(long value, int numBytes) {
+    final int longBytes = Long.SIZE / 8;
+    Bytes valueBytes = Bytes.ofUnsignedLong(value, ByteOrder.LITTLE_ENDIAN);
+    if (numBytes <= longBytes) {
+      return valueBytes.slice(0, numBytes);
+    } else {
+      return Bytes.concatenate(valueBytes, Bytes.wrap(new byte[numBytes - longBytes]));
+    }
+  }
+
   public static Bytes32 int_to_bytes32(long value) {
-    return Bytes32.rightPad(Bytes.ofUnsignedLong(value, ByteOrder.LITTLE_ENDIAN));
+    return Bytes32.wrap(int_to_bytes(value, 32));
   }
 
   public static Bytes32 int_to_bytes32(UnsignedLong value) {

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -305,8 +305,8 @@ public class BeaconStateUtil {
     Bytes32 randao_mix =
         get_randao_mix(state, epoch.minus(UnsignedLong.valueOf(Constants.MIN_SEED_LOOKAHEAD)));
     Bytes32 index_root = get_active_index_root(state, epoch);
-    Bytes epochBytes = Bytes.ofUnsignedLong(epoch.longValue());
-    return Hash.keccak256(Bytes.wrap(Bytes.wrap(randao_mix, index_root), epochBytes));
+    Bytes32 epochBytes = int_to_bytes32(epoch.longValue());
+    return Hash.keccak256(Bytes.concatenate(randao_mix, index_root, epochBytes));
   }
 
   public static Bytes32 get_active_index_root(BeaconState state, UnsignedLong epoch) {
@@ -666,9 +666,7 @@ public class BeaconStateUtil {
       int pivot =
           (int)
               Long.remainderUnsigned(
-                  Hash.keccak256(Bytes.concatenate(seed, roundAsByte))
-                      .slice(0, 8)
-                      .toLong(ByteOrder.LITTLE_ENDIAN),
+                  bytes_to_int(Hash.keccak256(Bytes.concatenate(seed, roundAsByte)).slice(0, 8)),
                   listSize);
       int flip = (pivot - indexRet) % listSize;
       if (flip < 0) {
@@ -747,9 +745,7 @@ public class BeaconStateUtil {
       int pivot =
           (int)
               Long.remainderUnsigned(
-                  Hash.keccak256(Bytes.concatenate(seed, roundAsByte))
-                      .slice(0, 8)
-                      .toLong(ByteOrder.LITTLE_ENDIAN),
+                  bytes_to_int(Hash.keccak256(Bytes.concatenate(seed, roundAsByte)).slice(0, 8)),
                   listSize);
 
       for (int i = 0; i < listSize; i++) {
@@ -1194,5 +1190,17 @@ public class BeaconStateUtil {
       y = x.plus(n.dividedBy(x)).dividedBy(TWO);
     }
     return x;
+  }
+
+  public static Bytes32 int_to_bytes32(long value) {
+    return Bytes32.rightPad(Bytes.ofUnsignedLong(value, ByteOrder.LITTLE_ENDIAN));
+  }
+
+  public static Bytes32 int_to_bytes32(UnsignedLong value) {
+    return int_to_bytes32(value.longValue());
+  }
+
+  public static long bytes_to_int(Bytes bytes) {
+    return bytes.toLong(ByteOrder.LITTLE_ENDIAN);
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
@@ -424,7 +424,7 @@ class BeaconStateTest {
       assertThat(generate_seed(state, epoch))
           .isEqualTo(
               Hash.keccak256(
-                  Bytes.concatenate(
+                  Bytes.wrap(
                       Bytes32.fromHexString("0x029a"),
                       get_active_index_root(state, epoch),
                       int_to_bytes32(epoch))));

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
@@ -28,6 +28,7 @@ import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_activ
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_current_epoch;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_initial_beacon_state;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_randao_mix;
+import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.int_to_bytes32;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.is_power_of_two;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.split;
 import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomDeposits;
@@ -423,10 +424,10 @@ class BeaconStateTest {
       assertThat(generate_seed(state, epoch))
           .isEqualTo(
               Hash.keccak256(
-                  Bytes.wrap(
-                      Bytes.wrap(
-                          Bytes32.fromHexString("0x029a"), get_active_index_root(state, epoch)),
-                      Bytes.ofUnsignedLong(epoch.longValue()))));
+                  Bytes.concatenate(
+                      Bytes32.fromHexString("0x029a"),
+                      get_active_index_root(state, epoch),
+                      int_to_bytes32(epoch))));
     } catch (IllegalStateException e) {
       fail(e.toString());
     }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
@@ -25,6 +25,7 @@ import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.junit.BouncyCastleExtension;
 import org.junit.jupiter.api.Disabled;
@@ -366,6 +367,48 @@ class BeaconStateUtilTest {
     assertEquals(
         UnsignedLong.valueOf(Constants.GENESIS_EPOCH + 1),
         BeaconStateUtil.get_next_epoch(beaconState));
+  }
+
+  @Test
+  void intToBytes32Long() {
+    assertEquals(
+        Bytes32.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000"),
+        BeaconStateUtil.int_to_bytes32(0L));
+    assertEquals(
+        Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000"),
+        BeaconStateUtil.int_to_bytes32(1L));
+    assertEquals(
+        Bytes32.fromHexString("0xffffffffffffffff000000000000000000000000000000000000000000000000"),
+        BeaconStateUtil.int_to_bytes32(-1L));
+    assertEquals(
+        Bytes32.fromHexString("0xefcdab8967452301000000000000000000000000000000000000000000000000"),
+        BeaconStateUtil.int_to_bytes32(0x0123456789abcdefL));
+  }
+
+  @Test
+  void intToBytes32UnsignedLong() {
+    assertEquals(
+        Bytes32.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000"),
+        BeaconStateUtil.int_to_bytes32(UnsignedLong.ZERO));
+    assertEquals(
+        Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000"),
+        BeaconStateUtil.int_to_bytes32(UnsignedLong.ONE));
+    assertEquals(
+        Bytes32.fromHexString("0xffffffffffffffff000000000000000000000000000000000000000000000000"),
+        BeaconStateUtil.int_to_bytes32(UnsignedLong.MAX_VALUE));
+    assertEquals(
+        Bytes32.fromHexString("0xefcdab8967452301000000000000000000000000000000000000000000000000"),
+        BeaconStateUtil.int_to_bytes32(UnsignedLong.valueOf(0x0123456789abcdefL)));
+  }
+
+  @Test
+  void bytesToInt() {
+    assertEquals(0L, BeaconStateUtil.bytes_to_int(Bytes.fromHexString("0x00")));
+    assertEquals(1L, BeaconStateUtil.bytes_to_int(Bytes.fromHexString("0x01")));
+    assertEquals(1L, BeaconStateUtil.bytes_to_int(Bytes.fromHexString("0x0100000000000000")));
+    assertEquals(
+        0x123456789abcdef0L,
+        BeaconStateUtil.bytes_to_int(Bytes.fromHexString("0xf0debc9a78563412")));
   }
 
   private BeaconState createBeaconState() {

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
@@ -370,6 +370,22 @@ class BeaconStateUtilTest {
   }
 
   @Test
+  void intToBytes() {
+    long value = 0x0123456789abcdefL;
+    assertEquals(Bytes.EMPTY, BeaconStateUtil.int_to_bytes(value, 0));
+    assertEquals(Bytes.fromHexString("0xef"), BeaconStateUtil.int_to_bytes(value, 1));
+    assertEquals(Bytes.fromHexString("0xefcd"), BeaconStateUtil.int_to_bytes(value, 2));
+    assertEquals(Bytes.fromHexString("0xefcdab89"), BeaconStateUtil.int_to_bytes(value, 4));
+    assertEquals(Bytes.fromHexString("0xefcdab8967452301"), BeaconStateUtil.int_to_bytes(value, 8));
+    assertEquals(
+        Bytes.fromHexString("0xefcdab89674523010000000000000000"),
+        BeaconStateUtil.int_to_bytes(value, 16));
+    assertEquals(
+        Bytes.fromHexString("0xefcdab8967452301000000000000000000000000000000000000000000000000"),
+        BeaconStateUtil.int_to_bytes(value, 32));
+  }
+
+  @Test
   void intToBytes32Long() {
     assertEquals(
         Bytes32.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000"),

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/MockP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/MockP2PNetwork.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.artemis.networking.p2p;
 
+import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.int_to_bytes;
+
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.primitives.UnsignedLong;
@@ -134,13 +136,13 @@ public class MockP2PNetwork implements P2PNetwork {
 
     UnsignedLong domain =
         BeaconStateUtil.get_domain(state.getFork(), epoch, Constants.DOMAIN_RANDAO);
-    Bytes32 currentEpochBytes = Bytes32.leftPad(Bytes.ofUnsignedLong(epoch.longValue()));
+    Bytes32 messageHash = HashTreeUtil.hash_tree_root(int_to_bytes(epoch.longValue(), 8));
     LOG.info("Sign Epoch");
     LOG.info("Proposer pubkey: " + keypair.getPublicKey());
     LOG.info("state: " + HashTreeUtil.hash_tree_root(state.toBytes()));
     LOG.info("slot: " + slot);
     LOG.info("domain: " + domain);
-    return BLSSignature.sign(keypair, currentEpochBytes, domain.longValue());
+    return BLSSignature.sign(keypair, messageHash, domain.longValue());
   }
 
   private BLSSignature signProposalData(BeaconState state, BeaconBlock block) {


### PR DESCRIPTION
## PR Description
I've been through and looked at all the places I can think of where enddianness may be an issue in bytes <-> number conversions.

This PR corrects a couple of places where big-endian was incorrectly being used, and clarifies others by introducing some int_to_bytes functions as per the spec (with tests).

## Fixed Issue(s)
Resolves #394 
Resolves #446 