### PR TITLE
Improve is_power_of_two()

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -705,8 +705,8 @@ public class BeaconStateUtil {
 
   /** Returns true if the operand is an exact power of two */
   public static boolean is_power_of_two(UnsignedLong value) {
-    return (value.compareTo(UnsignedLong.ZERO) != 0)
-        && (Long.lowestOneBit(value.longValue()) == Long.highestOneBit(value.longValue()));
+    long longValue = value.longValue();
+    return longValue != 0 && ((longValue - 1) & longValue) == 0;
   }
 
   /**

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
@@ -29,7 +29,6 @@ import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_activ
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_current_epoch;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_initial_beacon_state;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_randao_mix;
-import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.is_power_of_two;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.shuffle;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.split;
 import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomDeposits;
@@ -390,17 +389,6 @@ class BeaconStateTest {
     expected.add(new ArrayList<>(three));
 
     assertThat(actual).isEqualTo(expected);
-  }
-
-  @Test
-  void isPowerOfTwo() {
-    assertThat(is_power_of_two(UnsignedLong.ZERO)).isEqualTo(false);
-    assertThat(is_power_of_two(UnsignedLong.valueOf(42L))).isEqualTo(false);
-    assertThat(is_power_of_two(UnsignedLong.valueOf(Long.MAX_VALUE))).isEqualTo(false);
-    assertThat(is_power_of_two(UnsignedLong.ONE)).isEqualTo(true);
-    assertThat(is_power_of_two(UnsignedLong.ONE.plus(UnsignedLong.ONE))).isEqualTo(true);
-    assertThat(is_power_of_two(UnsignedLong.valueOf(65536L))).isEqualTo(true);
-    assertThat(is_power_of_two(UnsignedLong.valueOf(4611686018427387904L))).isEqualTo(true);
   }
 
   @Test

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
@@ -13,10 +13,12 @@
 
 package tech.pegasys.artemis.datastructures.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.is_power_of_two;
 import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomDepositInput;
 import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomValidator;
@@ -329,6 +331,20 @@ class BeaconStateUtilTest {
     assertEquals(expectedBadActorBalance, beaconState.getValidator_balances().get(validatorIndex));
     assertEquals(
         expectedWhistleblowerBalance, beaconState.getValidator_balances().get(whistleblowerIndex));
+  }
+
+  @Test
+  void isPowerOfTwo() {
+    // Not powers of two:
+    assertThat(is_power_of_two(UnsignedLong.ZERO)).isEqualTo(false);
+    assertThat(is_power_of_two(UnsignedLong.valueOf(42L))).isEqualTo(false);
+    assertThat(is_power_of_two(UnsignedLong.valueOf(Long.MAX_VALUE))).isEqualTo(false);
+    // Powers of two:
+    assertThat(is_power_of_two(UnsignedLong.ONE)).isEqualTo(true);
+    assertThat(is_power_of_two(UnsignedLong.ONE.plus(UnsignedLong.ONE))).isEqualTo(true);
+    assertThat(is_power_of_two(UnsignedLong.valueOf(0x040000L))).isEqualTo(true);
+    assertThat(is_power_of_two(UnsignedLong.valueOf(0x0100000000L))).isEqualTo(true);
+    assertThat(is_power_of_two(UnsignedLong.fromLongBits(0x8000000000000000L))).isEqualTo(true);
   }
 
   private BeaconState createBeaconState() {


### PR DESCRIPTION
## PR Description
Changes the `is_power_of_two()` function implementation. 

It now uses the improved version in the spec (the original spec version was terrible). Also moves the tests into the appropriate class.

## Fixed Issue(s)
@cemozerr was sad 😂 