### PR TITLE
Update get_bitfield_bit logic to have little endian bit numbering.

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -978,7 +978,7 @@ public class BeaconStateUtil {
    * @param bitPosition - The index.
    */
   public static int get_bitfield_bit(Bytes bitfield, int bitPosition) {
-    return (bitfield.get(bitPosition / 8) >> (7 - (bitPosition % 8))) % 2;
+    return (bitfield.get(bitPosition / 8) >> (bitPosition % 8)) % 2;
   }
 
   /**


### PR DESCRIPTION
## PR Description
This PR changes bit ordering in the aggregation and custody bitfields to little endian. Justification bitfield is unaffected as there is no direct bit access, and all bitwise operators assume starting from 0 in the genesis beacon state.

## Fixed Issue(s)
Resolves #452 
