### PR TITLE
Add hobbits p2p network

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
@@ -86,7 +86,13 @@ public class BeaconNode {
               config.getAdvertisedPort(),
               config.getNetworkInterface());
     } else if ("hobbits".equals(config.getNetworkMode())) {
-      this.p2pNetwork = new HobbitsP2PNetwork(eventBus, vertx, config.getPort(), config.getAdvertisedPort(), config.getNetworkInterface());
+      this.p2pNetwork =
+          new HobbitsP2PNetwork(
+              eventBus,
+              vertx,
+              config.getPort(),
+              config.getAdvertisedPort(),
+              config.getNetworkInterface());
     } else {
       throw new IllegalArgumentException("Unsupported network mode " + config.getNetworkMode());
     }

--- a/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
@@ -32,6 +32,7 @@ import tech.pegasys.artemis.data.provider.CSVProvider;
 import tech.pegasys.artemis.data.provider.FileProvider;
 import tech.pegasys.artemis.data.provider.JSONProvider;
 import tech.pegasys.artemis.data.provider.ProviderTypes;
+import tech.pegasys.artemis.networking.p2p.HobbitsP2PNetwork;
 import tech.pegasys.artemis.networking.p2p.MockP2PNetwork;
 import tech.pegasys.artemis.networking.p2p.RLPxP2PNetwork;
 import tech.pegasys.artemis.networking.p2p.api.P2PNetwork;
@@ -73,9 +74,9 @@ public class BeaconNode {
   public BeaconNode(CommandLine commandLine, CommandLineArguments cliArgs) {
     ArtemisConfiguration config = ArtemisConfiguration.fromFile(cliArgs.getConfigFile());
     this.eventBus = new AsyncEventBus(threadPool);
-    if (config.getNetworkMode() == 0) {
+    if ("mock".equals(config.getNetworkMode())) {
       this.p2pNetwork = new MockP2PNetwork(eventBus);
-    } else if (config.getNetworkMode() == 1) {
+    } else if ("rlpx".equals(config.getNetworkMode())) {
       this.p2pNetwork =
           new RLPxP2PNetwork(
               eventBus,
@@ -84,6 +85,8 @@ public class BeaconNode {
               config.getPort(),
               config.getAdvertisedPort(),
               config.getNetworkInterface());
+    } else if ("hobbits".equals(config.getNetworkMode())) {
+      this.p2pNetwork = new HobbitsP2PNetwork(eventBus, vertx, config.getPort(), config.getAdvertisedPort(), config.getNetworkInterface());
     } else {
       throw new IllegalArgumentException("Unsupported network mode " + config.getNetworkMode());
     }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/HobbitsP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/HobbitsP2PNetwork.java
@@ -1,0 +1,115 @@
+package tech.pegasys.artemis.networking.p2p;
+
+import com.google.common.eventbus.EventBus;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.net.NetServer;
+import io.vertx.core.net.NetServerOptions;
+import io.vertx.core.net.NetSocket;
+import net.consensys.cava.bytes.Bytes;
+import net.consensys.cava.concurrent.AsyncCompletion;
+import net.consensys.cava.concurrent.CompletableAsyncCompletion;
+import tech.pegasys.artemis.networking.p2p.api.P2PNetwork;
+
+import java.io.IOException;
+import java.sql.Time;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Hobbits Ethereum Wire Protocol implementation.
+ *
+ * This P2P implementation uses clear messages relying on the hobbits wire format.
+ */
+public final class HobbitsP2PNetwork implements P2PNetwork  {
+
+  private final AtomicBoolean started = new AtomicBoolean(false);
+  private final EventBus eventBus;
+  private final Vertx vertx;
+  private final int port;
+  private final int advertisedPort;
+  private final String networkInterface;
+  private NetServer server;
+  private NetClient client;
+
+  /**
+   * Default constructor
+   * @param eventBus the event bus of the instance
+   * @param vertx the vertx instance to rely to build network elements
+   * @param port the port to bind to
+   * @param advertisedPort the port to advertise on
+   * @param networkInterface the network interface to bind to
+   */
+  public HobbitsP2PNetwork(EventBus eventBus, Vertx vertx, int port, int advertisedPort, String networkInterface) {
+    this.eventBus = eventBus;
+    this.vertx = vertx;
+    this.port = port;
+    this.advertisedPort = advertisedPort;
+    this.networkInterface = networkInterface;
+  }
+
+  @Override
+  public void run() {
+    if (started.compareAndSet(false, true)) {
+      client = vertx.createNetClient(new NetClientOptions().setTcpKeepAlive(true));
+      server = vertx
+          .createNetServer(new NetServerOptions().setPort(port).setHost(networkInterface).setTcpKeepAlive(true))
+          .connectHandler(this::receiveMessage);
+    }
+  }
+
+  private void receiveMessage(NetSocket netSocket) {
+    netSocket.write(Buffer.buffer("there and back again")); // TODO
+  }
+
+  @Override
+  public Collection<?> getPeers() {
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<?> connect(String peer) {
+    return null;
+  }
+
+  @Override
+  public void subscribe(String event) {
+
+  }
+
+  @Override
+  public void stop() {
+    if (started.compareAndSet(true, false)) {
+      try {
+        CompletableAsyncCompletion completed = AsyncCompletion.incomplete();
+        server.close(res -> {
+          if (res.failed()) {
+            completed.completeExceptionally(res.cause());
+          } else {
+            completed.complete();
+          }
+        });
+        completed.join(10, TimeUnit.SECONDS);
+      } catch (InterruptedException | TimeoutException e) {
+        throw new RuntimeException(e);
+      } finally {
+        client.close();
+      }
+    }
+  }
+
+  @Override
+  public boolean isListening() {
+    return started.get();
+  }
+
+  @Override
+  public void close() throws IOException {
+    stop();
+  }
+}

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/HobbitsP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/HobbitsP2PNetwork.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.artemis.networking.p2p;
 
 import com.google.common.eventbus.EventBus;
@@ -8,25 +21,22 @@ import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.NetSocket;
-import net.consensys.cava.bytes.Bytes;
-import net.consensys.cava.concurrent.AsyncCompletion;
-import net.consensys.cava.concurrent.CompletableAsyncCompletion;
-import tech.pegasys.artemis.networking.p2p.api.P2PNetwork;
-
 import java.io.IOException;
-import java.sql.Time;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import net.consensys.cava.concurrent.AsyncCompletion;
+import net.consensys.cava.concurrent.CompletableAsyncCompletion;
+import tech.pegasys.artemis.networking.p2p.api.P2PNetwork;
 
 /**
  * Hobbits Ethereum Wire Protocol implementation.
  *
- * This P2P implementation uses clear messages relying on the hobbits wire format.
+ * <p>This P2P implementation uses clear messages relying on the hobbits wire format.
  */
-public final class HobbitsP2PNetwork implements P2PNetwork  {
+public final class HobbitsP2PNetwork implements P2PNetwork {
 
   private final AtomicBoolean started = new AtomicBoolean(false);
   private final EventBus eventBus;
@@ -39,13 +49,15 @@ public final class HobbitsP2PNetwork implements P2PNetwork  {
 
   /**
    * Default constructor
+   *
    * @param eventBus the event bus of the instance
    * @param vertx the vertx instance to rely to build network elements
    * @param port the port to bind to
    * @param advertisedPort the port to advertise on
    * @param networkInterface the network interface to bind to
    */
-  public HobbitsP2PNetwork(EventBus eventBus, Vertx vertx, int port, int advertisedPort, String networkInterface) {
+  public HobbitsP2PNetwork(
+      EventBus eventBus, Vertx vertx, int port, int advertisedPort, String networkInterface) {
     this.eventBus = eventBus;
     this.vertx = vertx;
     this.port = port;
@@ -57,9 +69,14 @@ public final class HobbitsP2PNetwork implements P2PNetwork  {
   public void run() {
     if (started.compareAndSet(false, true)) {
       client = vertx.createNetClient(new NetClientOptions().setTcpKeepAlive(true));
-      server = vertx
-          .createNetServer(new NetServerOptions().setPort(port).setHost(networkInterface).setTcpKeepAlive(true))
-          .connectHandler(this::receiveMessage);
+      server =
+          vertx
+              .createNetServer(
+                  new NetServerOptions()
+                      .setPort(port)
+                      .setHost(networkInterface)
+                      .setTcpKeepAlive(true))
+              .connectHandler(this::receiveMessage);
     }
   }
 
@@ -78,22 +95,21 @@ public final class HobbitsP2PNetwork implements P2PNetwork  {
   }
 
   @Override
-  public void subscribe(String event) {
-
-  }
+  public void subscribe(String event) {}
 
   @Override
   public void stop() {
     if (started.compareAndSet(true, false)) {
       try {
         CompletableAsyncCompletion completed = AsyncCompletion.incomplete();
-        server.close(res -> {
-          if (res.failed()) {
-            completed.completeExceptionally(res.cause());
-          } else {
-            completed.complete();
-          }
-        });
+        server.close(
+            res -> {
+              if (res.failed()) {
+                completed.completeExceptionally(res.cause());
+              } else {
+                completed.complete();
+              }
+            });
         completed.join(10, TimeUnit.SECONDS);
       } catch (InterruptedException | TimeoutException e) {
         throw new RuntimeException(e);

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
@@ -37,11 +37,11 @@ public final class ArtemisConfiguration {
   static final Schema createSchema() {
     SchemaBuilder builder =
         SchemaBuilder.create()
-            .addInteger(
+            .addString(
                 "networkMode",
-                0,
+                "mock",
                 "represents what network to use",
-                PropertyValidator.inRange(0, 1));
+                PropertyValidator.anyOf("mock", "rlpx", "hobbits"));
     builder.addString("identity", null, "Identity of the peer", PropertyValidator.isPresent());
     builder.addString("networkInterface", "0.0.0.0", "Peer to peer network interface", null);
     builder.addInteger("port", 9000, "Peer to peer port", PropertyValidator.inRange(0, 65535));
@@ -181,8 +181,8 @@ public final class ArtemisConfiguration {
     return config.getLong("networkID");
   }
 
-  /** @return the mode of the network to use - 0 for mock, or 1 for rlpx */
-  public int getNetworkMode() {
-    return config.getInteger("networkMode");
+  /** @return the mode of the network to use - mock, rlpx or hobbits */
+  public String getNetworkMode() {
+    return config.getString("networkMode");
   }
 }

--- a/util/src/test/java/tech/pegasys/artemis/util/config/ArtemisConfigurationTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/config/ArtemisConfigurationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.util.config;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+final class ArtemisConfigurationTest {
+
+  @Test
+  void missingIdentity() {
+    assertThrows(IllegalArgumentException.class, () -> ArtemisConfiguration.fromString(""));
+  }
+
+  @Test
+  void validMinimum() {
+    ArtemisConfiguration.fromString("identity=\"a3e4b1c5\"");
+  }
+
+  @Test
+  void wrongPort() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ArtemisConfiguration.fromString("identity=\"2345\"\nport=100000"));
+  }
+
+  @Test
+  void invalidAdvertisedPort() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ArtemisConfiguration.fromString("identity=\"2345\"\nadvertisedPort=100000"));
+  }
+
+  @Test
+  void validPeer() {
+    ArtemisConfiguration.fromString(
+        "identity=\"2345\"\npeers=[\"enode://a0b0e0f099@localhost:9000\"]");
+  }
+
+  @Test
+  void invalidPeer() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ArtemisConfiguration.fromString(
+                "identity=\"2345\"\npeers=[\"enode://localhost:9000\"]"));
+  }
+
+  @Test
+  void invalidNetworkMode() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ArtemisConfiguration.fromString(
+                "identity=\"2345\"\nnetworkMode=\"tcpblah\""));
+  }
+}

--- a/util/src/test/java/tech/pegasys/artemis/util/config/ArtemisConfigurationTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/config/ArtemisConfigurationTest.java
@@ -62,8 +62,6 @@ final class ArtemisConfigurationTest {
   void invalidNetworkMode() {
     assertThrows(
         IllegalArgumentException.class,
-        () ->
-            ArtemisConfiguration.fromString(
-                "identity=\"2345\"\nnetworkMode=\"tcpblah\""));
+        () -> ArtemisConfiguration.fromString("identity=\"2345\"\nnetworkMode=\"tcpblah\""));
   }
 }


### PR DESCRIPTION
This adds an empty p2p network for hobbits.

Also changes `networkMode`configuration property to use `mock`, `rlpx` and `hobbits`.