### PR TITLE
off by one error

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -759,7 +759,12 @@ public class BeaconStateUtil {
 
     // Note: this should be faster than manually creating the list in a for loop
     // https://stackoverflow.com/questions/10242380/how-can-i-generate-a-list-or-array-of-sequential-integers-in-java
-    int[] indices = IntStream.rangeClosed(0, listSize).toArray();
+    int[] indices = IntStream.rangeClosed(0, listSize - 1).toArray();
+
+    // int[] indices = new int[listSize];
+    // for (int i = 0; i < listSize; i++) {
+    //   indices[i] = i;
+    // }
 
     byte[] powerOfTwoNumbers = {1, 2, 4, 8, 16, 32, 64, (byte) 128};
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Fixing an off by one error in shuffle that I created.  

in shuffle(), a list of integers was originally created this way:

```java
int[] indices = new int[listSize];
for (int i = 0; i < listSize; i++) {
  indices[i] = i;
}
```

I changed it to this for performance reasons:

```java
int[] indices = IntStream.rangeClosed(0, listSize).toArray();
```

Then realized that I made the list too big and now I am correcting it like this:

```java
int[] indices = IntStream.rangeClosed(0, listSize-1).toArray();
```

🤦‍♂️