### PR TITLE
Added abort logic to build process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,9 @@
 #!/usr/bin/env groovy
 
+import hudson.model.Result
+import hudson.model.Run
+import jenkins.model.CauseOfInterruption.UserInterruption
+
 if (env.BRANCH_NAME == "master") {
     properties([
         buildDiscarder(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,26 @@ if (env.BRANCH_NAME == "master") {
     ])
 }
 
+def abortPreviousBuilds() {
+    Run previousBuild = currentBuild.rawBuild.getPreviousBuildInProgress()
+
+    while (previousBuild != null) {
+        if (previousBuild.isInProgress()) {
+            def executor = previousBuild.getExecutor()
+            if (executor != null) {
+                echo ">> Aborting older build #${previousBuild.number}"
+                executor.interrupt(Result.ABORTED, new UserInterruption(
+                    "Aborted by newer build #${currentBuild.number}"
+                ))
+            }
+        }
+
+        previousBuild = previousBuild.getPreviousBuildInProgress()
+    }
+}
+
+abortPreviousBuilds()
+
 try {
     node {
         checkout scm


### PR DESCRIPTION
Where there are recent pushes to a PR or stalled jobs in jenkins you're ending up with multiple of the same builds in flight. Copying the job abort logic from pantheon that will abort previous builds of a PR or master if an updated job is triggered.