### PR TITLE
message_type attribute integration

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
@@ -651,10 +651,7 @@ public class AttestationUtil {
         int indexIntoCommittee = crosslinkCommittee.getCommittee().indexOf(validatorIndex);
         int array_length = Math.toIntExact((crosslinkCommittee.getCommittee().size() + 7) / 8);
         byte[] aggregation_bitfield = new byte[array_length];
-        aggregation_bitfield[indexIntoCommittee / 8] =
-            (byte)
-                (aggregation_bitfield[indexIntoCommittee / 8]
-                    | (byte) Math.pow(2, (indexIntoCommittee % 8)));
+        aggregation_bitfield[indexIntoCommittee / 8] |= (byte) (1 << (indexIntoCommittee % 8L));
 
         // Create custody_bitfield
         Bytes custody_bitfield = Bytes.wrap(new byte[array_length]);

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/HobbitsP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/HobbitsP2PNetwork.java
@@ -106,13 +106,17 @@ public final class HobbitsP2PNetwork implements P2PNetwork {
   }
 
   private void sendMessage(
-      MessageSender.Verb verb, org.apache.tuweni.plumtree.Peer peer, Bytes hash, Bytes bytes) {
+      MessageSender.Verb verb,
+      String attributes,
+      org.apache.tuweni.plumtree.Peer peer,
+      Bytes hash,
+      Bytes bytes) {
     if (!started.get()) {
       return;
     }
     HobbitsSocketHandler handler = handlersMap.get(((Peer) peer).uri());
     if (handler != null) {
-      handler.gossipMessage(verb, hash, Bytes32.random(), bytes);
+      handler.gossipMessage(verb, attributes, hash, Bytes32.random(), bytes);
     }
   }
 
@@ -254,7 +258,7 @@ public final class HobbitsP2PNetwork implements P2PNetwork {
     LOG.log(
         Level.INFO, "Gossiping new block with state root: " + block.getState_root().toHexString());
     Bytes bytes = block.toBytes();
-    state.sendGossipMessage(bytes);
+    state.sendGossipMessage("BLOCK", bytes);
     // TODO: this will be modified once Tuweni merges
     // https://github.com/apache/incubator-tuweni/pull/3
     this.receivedMessages.put(Hash.sha2_256(bytes).toHexString(), true);
@@ -267,7 +271,7 @@ public final class HobbitsP2PNetwork implements P2PNetwork {
         "Gossiping new attestation for block_root: "
             + attestation.getData().getBeacon_block_root().toHexString());
     Bytes bytes = attestation.toBytes();
-    state.sendGossipMessage(bytes);
+    state.sendGossipMessage("ATTESTATION", bytes);
     // TODO: this will be modified once Tuweni merges
     // https://github.com/apache/incubator-tuweni/pull/3
     this.receivedMessages.put(Hash.sha2_256(bytes).toHexString(), true);

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/HobbitsSubProtocolHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/HobbitsSubProtocolHandler.java
@@ -73,9 +73,13 @@ final class HobbitsSubProtocolHandler implements SubProtocolHandler {
   }
 
   private void sendMessage(
-      MessageSender.Verb verb, org.apache.tuweni.plumtree.Peer peer, Bytes hash, Bytes bytes) {
+      MessageSender.Verb verb,
+      String attributes,
+      org.apache.tuweni.plumtree.Peer peer,
+      Bytes hash,
+      Bytes bytes) {
     HobbitsSocketHandler handler = handlerMap.get(((Peer) peer).uri().toString());
-    handler.gossipMessage(verb, hash, Bytes32.random(), bytes);
+    handler.gossipMessage(verb, attributes, hash, Bytes32.random(), bytes);
   }
 
   @Override
@@ -115,7 +119,7 @@ final class HobbitsSubProtocolHandler implements SubProtocolHandler {
     LOG.log(
         Level.INFO, "Gossiping new block with state root: " + block.getState_root().toHexString());
     Bytes bytes = block.toBytes();
-    state.sendGossipMessage(bytes);
+    state.sendGossipMessage("BLOCK", bytes);
     // TODO: this will be modified once Tuweni merges
     // https://github.com/apache/incubator-tuweni/pull/3
     this.receivedMessages.put(Hash.sha2_256(bytes).toHexString(), true);

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/hobbits/GossipMessage.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/hobbits/GossipMessage.java
@@ -20,14 +20,21 @@ import org.apache.tuweni.bytes.Bytes32;
 public final class GossipMessage {
 
   private final GossipMethod method;
+  private final String attributes;
   private final Bytes32 messageHash;
   private final Bytes32 hashSignature;
   private final Bytes body;
   private final int length;
 
   public GossipMessage(
-      GossipMethod method, Bytes32 messageHash, Bytes32 hashSignature, Bytes body, int length) {
+      GossipMethod method,
+      String attributes,
+      Bytes32 messageHash,
+      Bytes32 hashSignature,
+      Bytes body,
+      int length) {
     this.method = method;
+    this.attributes = attributes;
     this.messageHash = messageHash;
     this.hashSignature = hashSignature;
     this.body = body;
@@ -38,7 +45,10 @@ public final class GossipMessage {
   public GossipMethod method() {
     return method;
   }
-
+  /** @return the message type used in the Gossi[ call. */
+  public String getAttributes() {
+    return attributes;
+  }
   /** @return the messageHash used by the Gossip call. */
   public Bytes32 messageHash() {
     return messageHash;

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/hobbits/MessageType.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/hobbits/MessageType.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.p2p.hobbits;
+
+/** Enumeration of supported Gossip operations. */
+public enum MessageType {
+  BLOCK(0),
+  ATTESTATION(1);
+
+  private int code;
+
+  MessageType(int code) {
+    this.code = code;
+  }
+
+  /** @return the encoded code of the Gossip method */
+  int code() {
+    return code;
+  }
+
+  /**
+   * Finds the matching Gossip method from its code.
+   *
+   * @param code the code
+   * @return the matching Gossip method
+   * @throws IllegalArgumentException if no matching code exists.
+   */
+  static MessageType valueOf(int code) {
+    switch (code) {
+      case 0:
+        return BLOCK;
+      case 1:
+        return ATTESTATION;
+      default:
+        throw new IllegalArgumentException("Unsupported code " + code);
+    }
+  }
+}

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/hobbits/GossipCodecTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/hobbits/GossipCodecTest.java
@@ -30,7 +30,11 @@ final class GossipCodecTest {
     BeaconBlock block = DataStructureUtil.randomBeaconBlock(Constants.GENESIS_SLOT);
     Bytes encoded =
         GossipCodec.encode(
-            MessageSender.Verb.GOSSIP, Bytes32.random(), Bytes32.random(), block.toBytes());
+            MessageSender.Verb.GOSSIP,
+            "BLOCK",
+            Bytes32.random(),
+            Bytes32.random(),
+            block.toBytes());
     GossipMessage message = GossipCodec.decode(encoded);
     assertEquals(GossipMethod.GOSSIP, message.method());
     BeaconBlock read = BeaconBlock.fromBytes(message.body());

--- a/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
@@ -26,7 +26,6 @@ import java.util.concurrent.PriorityBlockingQueue;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.Level;
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.ssz.InvalidSSZTypeException;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.operations.Attestation;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
@@ -225,17 +224,5 @@ public class ChainStorageClient implements ChainStorage {
             + " detected."
             + ANSI_RESET);
     addUnprocessedAttestation(attestation);
-  }
-
-  @Subscribe
-  public void onReceievedMessage(Bytes bytes) {
-    try {
-      //
-      Attestation attestation = Attestation.fromBytes(bytes);
-      onNewUnprocessedAttestation(attestation);
-    } catch (InvalidSSZTypeException e) {
-      BeaconBlock block = BeaconBlock.fromBytes(bytes);
-      onNewUnprocessedBlock(block);
-    }
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
integrate changes to plumtree and hobbits that allows for an attributes header to specify the datatype (BLOCK or ATTESTATION).
