### PR TITLE
Fixes bug in get_randao_mix that breaks tests

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/BeaconState.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/BeaconState.java
@@ -29,7 +29,7 @@ import tech.pegasys.artemis.datastructures.blocks.Eth1DataVote;
 
 public class BeaconState {
   // Misc
-  public long slot;
+  protected long slot;
   protected long genesis_time;
   protected Fork fork; // For versioning hard forks
 

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/BeaconState.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/BeaconState.java
@@ -29,7 +29,7 @@ import tech.pegasys.artemis.datastructures.blocks.Eth1DataVote;
 
 public class BeaconState {
   // Misc
-  protected long slot;
+  public long slot;
   protected long genesis_time;
   protected Fork fork; // For versioning hard forks
 

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -114,7 +114,6 @@ public class BeaconStateUtil {
    */
   public static ArrayList<CrosslinkCommittee> get_crosslink_committees_at_slot(
       BeaconState state, long slot, boolean registry_change) throws IllegalArgumentException {
-    //     epoch: 3005 current_epoch: 3005 previous_epoch: 67108864 next_epoch: 3006
     long epoch = slot_to_epoch(slot);
     long current_epoch = get_current_epoch(state);
     long previous_epoch = get_previous_epoch(state);
@@ -846,15 +845,15 @@ public class BeaconStateUtil {
    */
   public static int get_beacon_proposer_index(BeaconState state, long slot)
       throws IllegalArgumentException {
-    //    if (state instanceof BeaconStateWithCache
-    //        && ((BeaconStateWithCache) state).getCurrentBeaconProposerIndex() > -1) {
-    //      return ((BeaconStateWithCache) state).getCurrentBeaconProposerIndex();
-    //    } else {
-    List<Integer> first_committee =
-        get_crosslink_committees_at_slot(state, slot).get(0).getCommittee();
+    if (state instanceof BeaconStateWithCache
+        && ((BeaconStateWithCache) state).getCurrentBeaconProposerIndex() > -1) {
+      return ((BeaconStateWithCache) state).getCurrentBeaconProposerIndex();
+    } else {
+      List<Integer> first_committee =
+          get_crosslink_committees_at_slot(state, slot).get(0).getCommittee();
 
-    return first_committee.get(Math.toIntExact(slot % first_committee.size()));
-    //    }
+      return first_committee.get(Math.toIntExact(slot % first_committee.size()));
+    }
   }
 
   /**

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateTest.java
@@ -41,7 +41,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.Hash;
 import org.apache.tuweni.junit.BouncyCastleExtension;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tech.pegasys.artemis.datastructures.blocks.Eth1Data;
@@ -67,7 +66,7 @@ class BeaconStateTest {
     }
   }
 
-  @Disabled
+  @Test
   void activateValidator() {
     BeaconState state = newState(5);
     int validator_index = 0;
@@ -82,7 +81,7 @@ class BeaconStateTest {
     assertThat(activation_epoch).isEqualTo(GENESIS_EPOCH + 1 + ACTIVATION_EXIT_DELAY);
   }
 
-  @Disabled
+  @Test
   void initiateValidatorExitNotActive() {
     BeaconState state = newState(5);
     int validator_index = 0;
@@ -92,7 +91,7 @@ class BeaconStateTest {
         .isEqualTo(true);
   }
 
-  @Disabled
+  @Test
   void initiateValidatorExit() {
     BeaconState state = newState(5);
     int validator_index = 2;
@@ -102,7 +101,7 @@ class BeaconStateTest {
         .isEqualTo(true);
   }
 
-  @Disabled
+  @Test
   void deepCopyBeaconState() {
     BeaconStateWithCache state = (BeaconStateWithCache) newState(1);
     BeaconState deepCopy = BeaconStateWithCache.deepCopy(state);
@@ -136,7 +135,6 @@ class BeaconStateTest {
 
   /* TODO: reinstate test
     @Test
-    @Disabled
     void testShuffle() {
       List<Integer> input = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
       ArrayList<Integer> sample = new ArrayList<>(input);
@@ -214,7 +212,7 @@ class BeaconStateTest {
     assertThat(actual).isEqualTo(expected);
   }
 
-  @Disabled
+  @Test
   void getRandaoMixThrowsExceptions() {
     BeaconState state = newState(5);
     state.setSlot(LATEST_RANDAO_MIXES_LENGTH * SLOTS_PER_EPOCH);
@@ -226,7 +224,7 @@ class BeaconStateTest {
         RuntimeException.class, () -> get_randao_mix(state, LATEST_RANDAO_MIXES_LENGTH + 1));
   }
 
-  @Disabled
+  @Test
   void getRandaoMixReturnsCorrectValue() {
     BeaconState state = newState(5);
     state.setSlot(LATEST_RANDAO_MIXES_LENGTH * SLOTS_PER_EPOCH);
@@ -243,7 +241,7 @@ class BeaconStateTest {
         .isEqualTo(Bytes32.fromHexString("0xdeadbeef"));
   }
 
-  @Disabled
+  @Test
   void generateSeedReturnsCorrectValue() {
     BeaconState state = newState(5);
     state.setSlot(LATEST_RANDAO_MIXES_LENGTH * SLOTS_PER_EPOCH);
@@ -268,7 +266,7 @@ class BeaconStateTest {
     }
   }
 
-  @Disabled
+  @Test
   void roundtripSSZ() {
     BeaconState state = newState(1);
     Bytes sszBeaconBlockBytes = state.toBytes();

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateWithCacheTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/BeaconStateWithCacheTest.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.junit.BouncyCastleExtension;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tech.pegasys.artemis.datastructures.blocks.Eth1Data;
 import tech.pegasys.artemis.util.bls.BLSPublicKey;
@@ -47,7 +47,7 @@ class BeaconStateWithCacheTest {
     }
   }
 
-  @Disabled
+  @Test
   void deepCopyModifyForkDoesNotEqualTest() {
     BeaconStateWithCache state = (BeaconStateWithCache) newState(1);
     BeaconState deepCopy = BeaconStateWithCache.deepCopy(state);
@@ -62,7 +62,7 @@ class BeaconStateWithCacheTest {
         .isNotEqualTo(state.getFork().getPrevious_version());
   }
 
-  @Disabled
+  @Test
   void deepCopyModifyIncrementSlotDoesNotEqualTest() {
     BeaconStateWithCache state = (BeaconStateWithCache) newState(1);
     BeaconState deepCopy = BeaconStateWithCache.deepCopy(state);
@@ -72,7 +72,7 @@ class BeaconStateWithCacheTest {
     assertThat(deepCopy.getSlot()).isNotEqualTo(state.getSlot());
   }
 
-  @Disabled
+  @Test
   void deepCopyModifyModifyValidatorsDoesNotEqualTest() {
     BeaconStateWithCache state = (BeaconStateWithCache) newState(1);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Fixes bug in get_randao_mix that broke tests by setting a check for when epoch is 0. This issue was caused because epoch starts at 0, causing get_randao_mix to be indexed at -1, throwing an error in get_beacon_proposer_index, thus causing get_genesis_beacon_state in newState() in BeaconStateTest to fail.
