### PR TITLE
Remove expectation to pass length mixin when reading BLS primitives.

### DIFF
--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSPublicKey.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSPublicKey.java
@@ -57,12 +57,12 @@ public class BLSPublicKey {
   }
 
   public static BLSPublicKey fromBytes(Bytes bytes) {
-    checkArgument(bytes.size() == 52, "Expected 52 bytes but received %s.", bytes.size());
-    if (SSZ.decodeBytes(bytes).isZero()) {
+    checkArgument(bytes.size() == 48, "Expected 48 bytes but received %s.", bytes.size());
+    if (SSZ.decodeBytes(bytes, 48).isZero()) {
       return BLSPublicKey.empty();
     } else {
       return SSZ.decode(
-          bytes, reader -> new BLSPublicKey(PublicKey.fromBytesCompressed(reader.readBytes())));
+          bytes, reader -> new BLSPublicKey(PublicKey.fromBytesCompressed(reader.readFixedBytes(48))));
     }
   }
 

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSSignature.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSSignature.java
@@ -95,12 +95,12 @@ public final class BLSSignature {
   }
 
   public static BLSSignature fromBytes(Bytes bytes) {
-    checkArgument(bytes.size() == 100, "Expected 100 bytes but received %s.", bytes.size());
-    if (SSZ.decodeBytes(bytes).isZero()) {
+    checkArgument(bytes.size() == 96, "Expected 96 bytes but received %s.", bytes.size());
+    if (SSZ.decodeBytes(bytes, 96).isZero()) {
       return BLSSignature.empty();
     } else {
       return SSZ.decode(
-          bytes, reader -> new BLSSignature(Signature.fromBytesCompressed(reader.readBytes())));
+          bytes, reader -> new BLSSignature(Signature.fromBytesCompressed(reader.readFixedBytes(96))));
     }
   }
 


### PR DESCRIPTION
## PR Description
This PR uses the fixed bytes functions when handing reading BLS signatures and public keys. This will eliminate the off by 4 error that we were experiencing due to expecting the length mixin.
