### PR TITLE
Remove merkle_root in favor of hash_tree_root functions

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -138,14 +138,14 @@ public class BeaconStateUtil {
         Objects.equals(state.getDeposit_index(), deposit.getIndex()), "Deposits not in order");
 
     // Verify the Merkle branch
-    checkArgument(
-        verify_merkle_branch(
-            Hash.keccak256(serialized_deposit_data),
-            deposit.getProof(),
-            Constants.DEPOSIT_CONTRACT_TREE_DEPTH,
-            toIntExact(deposit.getIndex().longValue()),
-            state.getLatest_eth1_data().getDeposit_root()),
-        "Merkle branch is not valid");
+    //    checkArgument(
+    //        verify_merkle_branch(
+    //            Hash.keccak256(serialized_deposit_data),
+    //            deposit.getProof(),
+    //            Constants.DEPOSIT_CONTRACT_TREE_DEPTH,
+    //            toIntExact(deposit.getIndex().longValue()),
+    //            state.getLatest_eth1_data().getDeposit_root()),
+    //        "Merkle branch is not valid");
 
     //  Increment the next deposit index we are expecting. Note that this
     //  needs to be done here because while the deposit contract will never

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -706,28 +706,6 @@ public class BeaconStateUtil {
   }
 
   /**
-   * Merkelize given values (where list.size() is a power of 2), and return the merkle root.
-   *
-   * <p><b>NOTE:</b> The leaves are not hashed.
-   *
-   * @param list - The List of values to get the merkle root for.
-   * @return The merkle root for the provided list of values.
-   * @see <a
-   *     href="https://github.com/ethereum/eth2.0-specs/blob/v0.4.0/specs/core/0_beacon-chain.md#merkle_root">merkle_root
-   *     - Spec v0.4</a>
-   */
-  public static Bytes32 merkle_root(List<Bytes32> list) throws IllegalStateException {
-    Bytes32[] o = new Bytes32[list.size() * 2];
-    for (int i = 0; i < list.size(); i++) {
-      o[i + list.size()] = list.get(i);
-    }
-    for (int i = list.size() - 1; i > 0; i--) {
-      o[i] = Hash.keccak256(Bytes.wrap(o[i * 2], o[i * 2 + 1]));
-    }
-    return o[1];
-  }
-
-  /**
    * Returns the number of committees in one epoch.
    *
    * @param active_validator_count - The number of active validators.

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -138,14 +138,14 @@ public class BeaconStateUtil {
         Objects.equals(state.getDeposit_index(), deposit.getIndex()), "Deposits not in order");
 
     // Verify the Merkle branch
-    /*checkArgument(
-    verify_merkle_branch(
-        Hash.keccak256(serialized_deposit_data),
-        deposit.getProof(),
-        DEPOSIT_CONTRACT_TREE_DEPTH,
-        toIntExact(deposit.getIndex().longValue()),
-        state.getLatest_eth1_data().getDeposit_root()),
-    "Merkle branch is not valid");*/
+    checkArgument(
+        verify_merkle_branch(
+            Hash.keccak256(serialized_deposit_data),
+            deposit.getProof(),
+            Constants.DEPOSIT_CONTRACT_TREE_DEPTH,
+            toIntExact(deposit.getIndex().longValue()),
+            state.getLatest_eth1_data().getDeposit_root()),
+        "Merkle branch is not valid");
 
     //  Increment the next deposit index we are expecting. Note that this
     //  needs to be done here because while the deposit contract will never
@@ -157,9 +157,7 @@ public class BeaconStateUtil {
         state.getValidator_registry().stream()
             .map(Validator::getPubkey)
             .collect(Collectors.toList());
-
     BLSPublicKey pubkey = deposit_input.getPubkey();
-
     UnsignedLong amount = deposit.getDeposit_data().getAmount();
     Bytes32 withdrawal_credentials = deposit_input.getWithdrawal_credentials();
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
@@ -1045,7 +1045,7 @@ public final class EpochProcessorUtil {
       HistoricalBatch historical_batch =
           new HistoricalBatch(state.getLatest_block_roots(), state.getLatest_state_roots());
       state.setHistorical_roots(
-          state.getHistorical_roots().add(HashTreeUtil.hash_tree_root(historical_batch)));
+          state.getHistorical_roots().add(historical_batch.hash_tree_root()));
     }
 
     // Rotate current/previous epoch attestations

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
@@ -1044,8 +1044,7 @@ public final class EpochProcessorUtil {
     if (next_epoch.intValue() % (SLOTS_PER_HISTORICAL_ROOT / SLOTS_PER_EPOCH) == 0) {
       HistoricalBatch historical_batch =
           new HistoricalBatch(state.getLatest_block_roots(), state.getLatest_state_roots());
-      state.setHistorical_roots(
-          state.getHistorical_roots().add(historical_batch.hash_tree_root()));
+      state.setHistorical_roots(state.getHistorical_roots().add(historical_batch.hash_tree_root()));
     }
 
     // Rotate current/previous epoch attestations

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
@@ -1034,6 +1034,8 @@ public final class EpochProcessorUtil {
     if (next_epoch.intValue() % (SLOTS_PER_HISTORICAL_ROOT / SLOTS_PER_EPOCH) == 0) {
       HistoricalBatch historical_batch =
           new HistoricalBatch(state.getLatest_block_roots(), state.getLatest_state_roots());
+      state.setHistorical_roots(
+          state.getHistorical_roots().add(HashTreeUtil.hash_tree_root(historical_batch)));
     }
 
     // Rotate current/previous epoch attestations


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Remove merkle_root in favor of hash_tree_root functions. Need HashTreeUtil.hash_tree_root(historical_batch) to be implemented for green build.