### PR TITLE
Add hash_tree_root support to HistoricalBatch.

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/BeaconState.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/BeaconState.java
@@ -731,8 +731,7 @@ public class BeaconState {
             HashTreeUtil.hash_tree_root(
                 SSZTypes.BASIC, SSZ.encodeUInt64(validator_registry_update_epoch.longValue())),
             // Randomness and committees
-            HashTreeUtil.hash_tree_root(
-                SSZTypes.TUPLE_OF_COMPOSITE, latest_randao_mixes.toArray(new Bytes32[0])),
+            HashTreeUtil.hash_tree_root(SSZTypes.TUPLE_OF_COMPOSITE, latest_randao_mixes),
             HashTreeUtil.hash_tree_root(
                 SSZTypes.BASIC, SSZ.encodeUInt64(previous_shuffling_start_shard.longValue())),
             HashTreeUtil.hash_tree_root(
@@ -762,12 +761,9 @@ public class BeaconState {
                 latest_crosslinks.stream()
                     .map(item -> item.hash_tree_root())
                     .collect(Collectors.toList())),
-            HashTreeUtil.hash_tree_root(
-                SSZTypes.TUPLE_OF_COMPOSITE, latest_block_roots.toArray(new Bytes32[0])),
-            HashTreeUtil.hash_tree_root(
-                SSZTypes.TUPLE_OF_COMPOSITE, latest_state_roots.toArray(new Bytes32[0])),
-            HashTreeUtil.hash_tree_root(
-                SSZTypes.TUPLE_OF_COMPOSITE, latest_active_index_roots.toArray(new Bytes32[0])),
+            HashTreeUtil.hash_tree_root(SSZTypes.TUPLE_OF_COMPOSITE, latest_block_roots),
+            HashTreeUtil.hash_tree_root(SSZTypes.TUPLE_OF_COMPOSITE, latest_state_roots),
+            HashTreeUtil.hash_tree_root(SSZTypes.TUPLE_OF_COMPOSITE, latest_active_index_roots),
             HashTreeUtil.hash_tree_root(
                 SSZTypes.TUPLE_OF_BASIC,
                 latest_slashed_balances.stream()

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/HistoricalBatch.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/HistoricalBatch.java
@@ -14,6 +14,7 @@
 package tech.pegasys.artemis.datastructures.state;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -22,6 +23,8 @@ import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.ssz.SSZ;
 import tech.pegasys.artemis.datastructures.Constants;
 import tech.pegasys.artemis.datastructures.Copyable;
+import tech.pegasys.artemis.util.hashtree.HashTreeUtil;
+import tech.pegasys.artemis.util.hashtree.HashTreeUtil.SSZTypes;
 
 public class HistoricalBatch implements Copyable<HistoricalBatch> {
 
@@ -110,5 +113,12 @@ public class HistoricalBatch implements Copyable<HistoricalBatch> {
 
   public void setStateRoots(List<Bytes32> state_roots) {
     this.state_roots = state_roots;
+  }
+
+  public Bytes32 hash_tree_root() {
+    return HashTreeUtil.merkleize(
+        Arrays.asList(
+            HashTreeUtil.hash_tree_root(SSZTypes.TUPLE_OF_COMPOSITE, block_roots),
+            HashTreeUtil.hash_tree_root(SSZTypes.TUPLE_OF_COMPOSITE, state_roots)));
   }
 }


### PR DESCRIPTION
## PR Description
Adds limited HashTreeUtil support for hash_tree_root's of tuples of composites.
Adds hash_tree_root support to HistoricalBatch.
