### PR TITLE
Generalize the run.sh scripts configuration and output files

### DIFF
--- a/scripts/configurator.sh
+++ b/scripts/configurator.sh
@@ -6,3 +6,4 @@ then
 fi
 
 sed -i.bak "s/$2\ =.*/$2\ =\ $3/g" $1
+rm $1.bak 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -28,6 +28,7 @@ for arg in "$@"
 do 
   shift
   case "$arg" in
+
     # Match the -n or --numNodes option and set NODES to the provided argument
     -n=*|--numNodes=*)
       if [ "$NODES" != "" ]
@@ -35,6 +36,7 @@ do
         usage >&2; exit 1
       fi
       NODES="${arg#*=}" ;;
+
     # Match the -i or --inputFile option and update the INPUTS array with the output file path
     "--inputFile"*) 
       FILE="${arg#*=}"
@@ -45,9 +47,12 @@ do
       then 
         usage >&2; exit 2
       fi 
+
       INPUTS[$IDX]="$FILE" ;;
+
     # Print the usage and exit if the help flag is provided 
     -h|--help) usage; exit 0 ;;
+
     # Pipe the usage to stderr and exit on exitcode 1 if an incorrect flag is provided
     --*) usage >&2; exit 1 ;;
   esac
@@ -61,8 +66,8 @@ then
 fi
 
 # Clean the demo directory
-rm -rf ./demo 
-mkdir -p ./demo 
+rm -rf ./demo
+mkdir -p ./demo
 
 # Clean out the old configuration files
 rm ../config/runConfig.*
@@ -70,9 +75,9 @@ rm ../config/runConfig.*
 # Create a list of all the peers for the configure node procedure to use
 PEERS=$(generate_peers_list 19000 $NODES "hob+tcp" "abcf@localhost")
 
-# Loop over all of the nodes to be created and configure them
+# Create the binaries, configuration files, and symlinks for each node
 i=0
-while [ "$i" -lt "$NODES" ] 
+while [ $i -lt $NODES ] 
 do
   configure_node $i $NODES ${INPUTS[$i]}
   i=$(($i + 1))

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,36 +1,80 @@
 #!/bin/sh
 
+# **** Usage **** #
+
+usage() {
+  echo "Usage: sh run.sh NODES"
+  echo "Runs a simulation of artemis with NODES nodes, where NODES > 0 and NODES < 256"
+  echo "Usage: sh run.sh {--numNodes=NODES|-n=NODES} [--inputFile=INPUT|-i=INPUT]"
+  echo "                 [--help|-h]"
+  echo "Runs a simulation of artemis with NODES nodes, where NODES > 0 and NODES < 256."
+  echo "If input files are specifed for specific nodes, those input files will be used to"
+  echo "configure their respective nodes."
+}
+
+# **** Script **** #
+
 # Get the working directory of this script file
 DIR=$(dirname $0)
 
-# Get the shell parameter that was provided
-NODES=$1
+# Create the arrays to hold the input files that were specified 
+INPUTS=()
 
 # Source the functions from the utilities script
-source $DIR/utils.sh
+source $DIR/run_utils.sh
 
-# If the shell parameters are invalid, print the usage statement and exit
-if [[ "$#" -ne 1 || "$NODES" -lt 1 || "$NODES" -gt 255 ]]
+# Parse the inputs to the script
+for arg in "$@"
+do 
+  shift
+  case "$arg" in
+    # Match the -n or --numNodes option and set NODES to the provided argument
+    -n=*|--numNodes=*)
+      if [ "$NODES" != "" ]
+      then 
+        usage >&2; exit 1
+      fi
+      NODES="${arg#*=}" ;;
+    # Match the -i or --inputFile option and update the INPUTS array with the output file path
+    "--inputFile"*) 
+      FILE="${arg#*=}"
+      IDX=$(echo $FILE | sed -E "s/.*[a-zA-Z0-9]+\.([0-9]+)\.toml/\1/")
+      # If the input file for a given node is ambiguous, pipe the usage statement to stderr and exit
+      # with exit code 2
+      if [ "${INPUTS[$IDX]}" != "" ]
+      then 
+        usage >&2; exit 2
+      fi 
+      INPUTS[$IDX]="$FILE" ;;
+    # Print the usage and exit if the help flag is provided 
+    -h|--help) usage; exit 0 ;;
+    # Pipe the usage to stderr and exit on exitcode 1 if an incorrect flag is provided
+    --*) usage >&2; exit 1 ;;
+  esac
+done
+
+# If NODES is not an integer or is an invalid number, pipe the usage statement to stderr and exit
+# with exit code 3
+if [ "$(echo "$NODES" | sed "s/[0-9]//g")" != "" ] || [[ $NODES -lt 1 || $NODES -gt 255 ]] 
 then 
-  usage 
-  exit
+  usage >&2; exit 3
 fi
 
 # Clean the demo directory
-clean demo
+rm -rf ./demo 
+mkdir -p ./demo 
 
 # Clean out the old configuration files
-clean_config
+rm ../config/runConfig.*
 
 # Create a list of all the peers for the configure node procedure to use
-COMBINATIONS=$(seq 19000 $((19000 + $NODES - 1)))
-PEERS=$(echo "$COMBINATIONS" | sed -E "s/^([0-9]+)/\"hob+tcp:\/\/abcf@localhost:\1\"/g")
+PEERS=$(generate_peers_list 19000 $NODES "hob+tcp" "abcf@localhost")
 
 # Loop over all of the nodes to be created and configure them
 i=0
 while [ $i -lt $NODES ] 
 do
-  configure_node $i $NODES
+  configure_node $i $NODES ${INPUTS[$i]}
   i=$(($i + 1))
 done
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -72,7 +72,7 @@ PEERS=$(generate_peers_list 19000 $NODES "hob+tcp" "abcf@localhost")
 
 # Loop over all of the nodes to be created and configure them
 i=0
-while [ $i -lt $NODES ] 
+while [ "$i" -lt "$NODES" ] 
 do
   configure_node $i $NODES ${INPUTS[$i]}
   i=$(($i + 1))

--- a/scripts/run_utils.sh
+++ b/scripts/run_utils.sh
@@ -1,16 +1,5 @@
 #!/bin/sh
 
-# Delete a directory and then recreate it to clean its contents out
-clean() {
-  local DIR="$1"
-  rm -rf "$DIR"
-  mkdir -p "$DIR"
-}
-
-clean_config() {
-  rm ../config/runConfig.*
-}
-
 # Create the configuration file for a specific
 create_config() {
   local NODE="$1"
@@ -118,8 +107,17 @@ create_tmux_windows() {
   tmux attach-session -d
 }
 
-# Prints the usage statement
-usage() {
-  echo "Usage: sh run.sh NODES"
-  echo "Runs a simulation of artemis with NODES nodes, where NODES > 0 and NODES < 256"
+generate_peers_list() {
+  seq $1 $(($1 + $2 - 1)) | sed -E "s/([0-9]+)/\"$3:\/\/$4:\1\"/g"
+}
+
+# Takes a number, $1, and the name of an environment variable, $2, and sets the environment variable in the parent shell 
+# with the specified name to the hexadecimal representation of the provided number.
+setAsHex() {
+  if [[ $1 -lt 16 ]]
+  then
+    printf -v "$2" "0x0%X" $1
+  else
+    printf -v "$2" "0x%X" $1
+  fi
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->
## PR Description
This change adds a more sophisticated interface to the `run.sh` script by adding:
1. -n and --numNodes flags to specify the number of nodes to run in the demo
2. -i and --inputFile flags to specify the template config file for specific nodes
3. -o and --outputFile flags to specify the output files for specific nodes

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#662 
