### PR TITLE
Add Missing Merkleizable Flag to Select Composite Types

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/blocks/Eth1DataVote.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/blocks/Eth1DataVote.java
@@ -22,8 +22,9 @@ import net.consensys.cava.ssz.SSZ;
 import tech.pegasys.artemis.datastructures.Copyable;
 import tech.pegasys.artemis.util.hashtree.HashTreeUtil;
 import tech.pegasys.artemis.util.hashtree.HashTreeUtil.SSZTypes;
+import tech.pegasys.artemis.util.hashtree.Merkleizable;
 
-public final class Eth1DataVote implements Copyable<Eth1DataVote> {
+public final class Eth1DataVote implements Copyable<Eth1DataVote>, Merkleizable {
 
   private Eth1Data eth1_data;
   private UnsignedLong vote_count;
@@ -104,6 +105,7 @@ public final class Eth1DataVote implements Copyable<Eth1DataVote> {
     this.vote_count = vote_count;
   }
 
+  @Override
   public Bytes32 hash_tree_root() {
     return HashTreeUtil.merkleize(
         Arrays.asList(

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/PendingAttestation.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/PendingAttestation.java
@@ -23,8 +23,9 @@ import tech.pegasys.artemis.datastructures.Copyable;
 import tech.pegasys.artemis.datastructures.operations.AttestationData;
 import tech.pegasys.artemis.util.hashtree.HashTreeUtil;
 import tech.pegasys.artemis.util.hashtree.HashTreeUtil.SSZTypes;
+import tech.pegasys.artemis.util.hashtree.Merkleizable;
 
-public class PendingAttestation implements Copyable<PendingAttestation> {
+public class PendingAttestation implements Copyable<PendingAttestation>, Merkleizable {
 
   private Bytes aggregation_bitfield;
   private AttestationData data;
@@ -134,6 +135,7 @@ public class PendingAttestation implements Copyable<PendingAttestation> {
     this.inclusion_slot = inclusion_slot;
   }
 
+  @Override
   public Bytes32 hash_tree_root() {
     return HashTreeUtil.merkleize(
         Arrays.asList(

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/Validator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/Validator.java
@@ -23,8 +23,9 @@ import tech.pegasys.artemis.datastructures.Copyable;
 import tech.pegasys.artemis.util.bls.BLSPublicKey;
 import tech.pegasys.artemis.util.hashtree.HashTreeUtil;
 import tech.pegasys.artemis.util.hashtree.HashTreeUtil.SSZTypes;
+import tech.pegasys.artemis.util.hashtree.Merkleizable;
 
-public final class Validator implements Copyable<Validator> {
+public final class Validator implements Copyable<Validator>, Merkleizable {
 
   // BLS public key
   private BLSPublicKey pubkey;
@@ -192,6 +193,7 @@ public final class Validator implements Copyable<Validator> {
     this.slashed = slashed;
   }
 
+  @Override
   public Bytes32 hash_tree_root() {
     return HashTreeUtil.merkleize(
         Arrays.asList(


### PR DESCRIPTION
## PR Description
This PR adds the Merkleizable interface flag to missing composite types, which cause BeaconState hash mismatch.
