### PR TITLE
Make sure to gossip from outside peer communications

### DIFF
--- a/artemis/src/main/resources/log4j2.xml
+++ b/artemis/src/main/resources/log4j2.xml
@@ -5,7 +5,7 @@
             <PatternLayout
                 pattern="%d{HH:mm:ss.SSS} [%-5level] - %msg%n" />
         </Console>
-        <RollingFile name="rollingFile" fileName="$${sys:logPath:-.}/$${sys:rollingFileName:-artemis.log}.log" filePattern="$${sys:logPath:-.}/$${sys:rollingFileName:-artemis.log}_%d{yyyy-MM-dd}.log">
+        <RollingFile name="rollingFile" fileName="${sys:logPath:-.}/${sys:rollingFileName:-artemis}.log" filePattern="${sys:logPath:-.}/${sys:rollingFileName:-artemis}_%d{yyyy-MM-dd}.log">
             <PatternLayout
                     pattern="%d{HH:mm:ss.SSS} [%-5level] - %msg%n" />
             <Policies>

--- a/artemis/src/test/resources/log4j2.xml
+++ b/artemis/src/test/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="DEBUG">
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout
+                pattern="%d{HH:mm:ss.SSS} [%-5level] - %msg%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="stdout" level="info">
+            <AppenderRef ref="console"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/config/config.toml
+++ b/config/config.toml
@@ -22,6 +22,8 @@ contractAddr = "0x77f7bED277449F51505a4C54550B074030d989bC"
 nodeUrl = "http://localhost:7545"
 
 [output]
+logPath = "."
+logFile = "artemis.log"
 outputFile = "artemis.json"
 providerType = "JSON"
 events = [ "TimeSeriesRecord", "Eth2Genesis", "Deposit" ]

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -39,7 +39,7 @@ dependencyManagement {
       entry 'logl-logl'
     }
 
-    dependencySet(group: 'org.apache.tuweni', version: '0.8.0-20190531144026') {
+    dependencySet(group: 'org.apache.tuweni', version: '0.8.0-20190610164304') {
       entry 'tuweni-bytes'
       entry 'tuweni-config'
       entry 'tuweni-crypto'

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/HobbitsP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/HobbitsP2PNetwork.java
@@ -128,7 +128,15 @@ public final class HobbitsP2PNetwork implements P2PNetwork {
     }
   }
 
-  private void processGossip(Bytes message) {}
+  @SuppressWarnings("StringSplitter")
+  private void processGossip(Bytes gossipMessage, String attr) {
+    String[] attributes = attr.split(",");
+    if (attributes[0].equalsIgnoreCase("ATTESTATION")) {
+      this.eventBus.post(Attestation.fromBytes(gossipMessage));
+    } else if (attributes[0].equalsIgnoreCase("BLOCK")) {
+      this.eventBus.post(BeaconBlock.fromBytes(gossipMessage));
+    }
+  }
 
   @Override
   public void run() {

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/hobbits/RPCCodec.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/hobbits/RPCCodec.java
@@ -110,7 +110,7 @@ public final class RPCCodec implements Codec {
     Bytes requestLineBytes = null;
     for (int i = 0; i < message.size(); i++) {
       if (message.get(i) == (byte) '\n') {
-        requestLineBytes = message.slice(0, i);
+        requestLineBytes = message.slice(0, i + 1);
         break;
       }
     }
@@ -123,7 +123,7 @@ public final class RPCCodec implements Codec {
     String version = segments.next();
     String command = segments.next();
     int headerLength = Integer.parseInt(segments.next());
-    int bodyLength = Integer.parseInt(segments.next());
+    int bodyLength = Integer.parseInt(segments.next().trim());
 
     if (message.size() < bodyLength + headerLength + requestLineBytes.size()) {
       return null;
@@ -131,7 +131,7 @@ public final class RPCCodec implements Codec {
 
     try {
       byte[] payload =
-          message.slice(requestLineBytes.size() + 1 + headerLength, bodyLength).toArrayUnsafe();
+          message.slice(requestLineBytes.size() + headerLength, bodyLength).toArrayUnsafe();
       payload = Snappy.uncompress(payload);
       ObjectNode rpcmessage = (ObjectNode) mapper.readTree(payload);
       long id = rpcmessage.get("id").longValue();

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/hobbits/GossipCodecTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/hobbits/GossipCodecTest.java
@@ -39,5 +39,6 @@ final class GossipCodecTest {
     assertEquals(GossipMethod.GOSSIP, message.method());
     BeaconBlock read = BeaconBlock.fromBytes(message.body());
     assertEquals(read.getSignature(), block.getSignature());
+    assertEquals(encoded.size(), message.length());
   }
 }

--- a/scripts/run_utils.sh
+++ b/scripts/run_utils.sh
@@ -16,6 +16,7 @@ create_config() {
 
   # Create the configuration file for the node
   cat $TEMPLATE | \
+    sed "s/logFile\ =.*/logFile = \"artemis-$NODE.log\"/"             |# Use a unique log file
     sed "s/advertisedPort\ =.*//"                                     |# Remove the advertised port field
     sed "s/identity\ =.*/identity\ =\ \"$IDENTITY\"/"                 |# Update the identity field to the value set above
     sed "s/port\ =.*/port\ =\ $PORT/"                                 |# Update the port field to the value set above


### PR DESCRIPTION
Remove the need to keep track of gossip messages.
Move consumption of messages outside of the socket handler, back to the top level network.
