### PR TITLE
Check that G1 and G2 points lie in the correct subgroups when created

### DIFF
--- a/util/src/test/java/tech/pegasys/artemis/util/mikuli/G1PointTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/mikuli/G1PointTest.java
@@ -15,15 +15,23 @@ package tech.pegasys.artemis.util.mikuli;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static tech.pegasys.artemis.util.mikuli.G1Point.isInGroup;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 
 class G1PointTest {
+
+  @Test
+  void succeedsWhenRandomPointsAreInTheG1Subgroup() {
+    for (int i = 0; i < 20; i++) {
+      G1Point point = G1Point.random();
+      assertTrue(isInGroup(point.ecpPoint()));
+    }
+  }
 
   @Test
   void succeedsWhenEqualsReturnsTrueForTheSamePoint() {
@@ -73,8 +81,17 @@ class G1PointTest {
   @Test
   void succeedsWhenDeserialisingACorrectPointDoesNotThrow() {
     String xInput =
-        "0x8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a";
     assertAll(() -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
+  void succeedsWhenDeserialisingAPointOnCurveButNotInG1ThrowsIllegalArgumentException() {
+    String xInput =
+        "0x8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
   }
 
   @Test
@@ -107,14 +124,6 @@ class G1PointTest {
   }
 
   @Test
-  void succeedsWhenAttemptToDeserialiseXLessThanModulusDoesNotThrowIllegalArgumentException() {
-    // There's a valid X three less than the modulus. We prepend the c flag.
-    String xInput =
-        "0x9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaa8";
-    assertAll(() -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
-  }
-
-  @Test
   void succeedsWhenProvidingTooFewBytesToFromBytesCompressedThrowsIllegalArgumentException() {
     String xInput =
         "0x9a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa";
@@ -135,7 +144,7 @@ class G1PointTest {
   @Test
   void succeedsWhenRoundTripDeserialiseSerialiseCompressedReturnsTheOriginalInput() {
     String xInput =
-        "0x8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81";
     String xOutput =
         G1Point.fromBytesCompressed(Bytes.fromHexString(xInput))
             .toBytesCompressed()
@@ -156,8 +165,9 @@ class G1PointTest {
   void succeedsWhenDeserialiseCompressedInfinityWithFalseBFlagDoesNotCreatePointAtInfinity() {
     String xInput =
         "0x800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
-    G1Point point = G1Point.fromBytesCompressed(Bytes.fromHexString(xInput));
-    assertFalse(point.ecpPoint().is_infinity());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G1Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
   }
 
   @Test

--- a/util/src/test/java/tech/pegasys/artemis/util/mikuli/G2PointTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/mikuli/G2PointTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static tech.pegasys.artemis.util.mikuli.G2Point.isInGroup;
 import static tech.pegasys.artemis.util.mikuli.G2Point.normaliseY;
 import static tech.pegasys.artemis.util.mikuli.G2Point.scaleWithCofactor;
 
@@ -28,6 +29,14 @@ import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 
 class G2PointTest {
+
+  @Test
+  void succeedsWhenRandomPointsAreInTheG2Subgroup() {
+    for (int i = 0; i < 20; i++) {
+      G2Point point = G2Point.random();
+      assertTrue(isInGroup(point.ecp2Point()));
+    }
+  }
 
   @Test
   void succeedsWhenEqualsReturnsTrueForTheSamePoint() {
@@ -202,9 +211,20 @@ class G2PointTest {
   void succeedsWhenDeserialisingACorrectPointDoesNotThrow() {
     String xInput =
         "0x"
+            + "b2cc74bc9f089ed9764bbceac5edba416bef5e73701288977b9cac1ccb6964269d4ebf78b4e8aa7792ba09d3e49c8e6a"
+            + "1351bdf582971f796bbaf6320e81251c9d28f674d720cca07ed14596b96697cf18238e0e03ebd7fc1353d885a39407e0";
+    assertAll(() -> G2Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+  }
+
+  @Test
+  void succeedsWhenDeserialisingAPointOnCurveButNotInG2ThrowsIllegalArgumentException() {
+    String xInput =
+        "0x"
             + "8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
             + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    assertAll(() -> G2Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> G2Point.fromBytesCompressed(Bytes.fromHexString(xInput)));
   }
 
   @Test
@@ -244,8 +264,8 @@ class G2PointTest {
   void succeedsWhenRoundTripDeserialiseSerialiseCompressedReturnsTheOriginalInput() {
     String xInput =
         "0x"
-            + "8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-            + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+            + "b2cc74bc9f089ed9764bbceac5edba416bef5e73701288977b9cac1ccb6964269d4ebf78b4e8aa7792ba09d3e49c8e6a"
+            + "1351bdf582971f796bbaf6320e81251c9d28f674d720cca07ed14596b96697cf18238e0e03ebd7fc1353d885a39407e0";
     String xOutput =
         G2Point.fromBytesCompressed(Bytes.fromHexString(xInput))
             .toBytesCompressed()


### PR DESCRIPTION
## PR Description

Adds further checking for created G1 and G2 points to ensure that they do indeed lie in the correct subgroups. We do this by multiplying by the group order and checking that we get the identity point. This is relevant to points deserialised from hex and for randomly created points.

Failing to do this could result in verifying signatures that other clients consider invalid, for example.

Updates tests accordingly.