### PR TITLE
Switch attestation key to hash

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/hobbits/AbstractSocketHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/hobbits/AbstractSocketHandler.java
@@ -46,7 +46,6 @@ import tech.pegasys.artemis.networking.p2p.hobbits.rpc.RequestAttestationMessage
 import tech.pegasys.artemis.networking.p2p.hobbits.rpc.RequestBlocksMessage;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.util.alogger.ALogger;
-import tech.pegasys.artemis.util.bls.BLSSignature;
 
 /** TCP persistent connection handler for hobbits messages. */
 public abstract class AbstractSocketHandler {
@@ -225,14 +224,14 @@ public abstract class AbstractSocketHandler {
 
   public void replyAttestation(RPCMessage rpcMessage) {
     RequestAttestationMessage rb = rpcMessage.bodyAs(RequestAttestationMessage.class);
-    BLSSignature signature = rb.aggregateSignature();
+    Bytes32 attestationHash = rb.attestationHash();
     store
-        .getUnprocessedAttestation(signature)
+        .getUnprocessedAttestation(attestationHash)
         .ifPresent(a -> sendReply(RPCMethod.ATTESTATION, a.toBytes(), rpcMessage.requestId()));
   }
 
-  public void sendGetAttestations(BLSSignature signature) {
-    sendMessage(RPCMethod.GET_ATTESTATION, new RequestAttestationMessage(signature));
+  public void sendGetAttestations(Bytes32 attestationHash) {
+    sendMessage(RPCMethod.GET_ATTESTATION, new RequestAttestationMessage(attestationHash));
   }
 
   public void replyBlockHeaders(RPCMessage rpcMessage) {

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/hobbits/FloodsubSocketHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/hobbits/FloodsubSocketHandler.java
@@ -22,7 +22,6 @@ import org.apache.tuweni.plumtree.State;
 import tech.pegasys.artemis.networking.p2p.hobbits.gossip.GossipMessage;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.util.alogger.ALogger;
-import tech.pegasys.artemis.util.bls.BLSSignature;
 
 /** TCP persistent connection handler for hobbits messages. */
 public final class FloodsubSocketHandler extends AbstractSocketHandler {
@@ -48,8 +47,8 @@ public final class FloodsubSocketHandler extends AbstractSocketHandler {
         peer.setPeerGossip(gossipMessage.body());
         String[] attributes = gossipMessage.getAttributes().split(",");
         if (attributes[0].equalsIgnoreCase("ATTESTATION")) {
-          BLSSignature signature = BLSSignature.fromBytes(gossipMessage.body());
-          this.sendGetAttestations(signature);
+          Bytes32 attestationHash = (Bytes32) gossipMessage.body();
+          this.sendGetAttestations(attestationHash);
         } else if (attributes[0].equalsIgnoreCase("BLOCK")) {
           Bytes32 blockRoot = Bytes32.wrap(gossipMessage.body());
           this.sendGetBlockBodies(blockRoot);

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/hobbits/rpc/RequestAttestationMessage.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/hobbits/rpc/RequestAttestationMessage.java
@@ -15,20 +15,19 @@ package tech.pegasys.artemis.networking.p2p.hobbits.rpc;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import tech.pegasys.artemis.util.bls.BLSSignature;
+import org.apache.tuweni.bytes.Bytes32;
 
 public final class RequestAttestationMessage {
 
-  private final BLSSignature aggregateSignature;
+  private final Bytes32 attestationHash;
 
   @JsonCreator
-  public RequestAttestationMessage(
-      @JsonProperty("aggregate_signature") BLSSignature aggregateSignature) {
-    this.aggregateSignature = aggregateSignature;
+  public RequestAttestationMessage(@JsonProperty("attestationHash") Bytes32 attestationHash) {
+    this.attestationHash = attestationHash;
   }
 
-  @JsonProperty("aggregate_signature")
-  public BLSSignature aggregateSignature() {
-    return aggregateSignature;
+  @JsonProperty("attestationHash")
+  public Bytes32 attestationHash() {
+    return attestationHash;
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Switch attestation identifiers in both networking and storage to hash_tree_root of attestations, instead of the aggregateSignature.

