### PR TITLE
Update domain type for BLS from long to Bytes

### DIFF
--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSSignature.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSSignature.java
@@ -40,7 +40,7 @@ public final class BLSSignature implements SimpleOffsetSerializable {
    * @param domain the signature domain as per the Eth2 spec
    * @return the resulting signature
    */
-  public static BLSSignature sign(BLSKeyPair keyPair, Bytes message, long domain) {
+  public static BLSSignature sign(BLSKeyPair keyPair, Bytes message, Bytes domain) {
     return new BLSSignature(
         BLS12381
             .sign(
@@ -138,7 +138,7 @@ public final class BLSSignature implements SimpleOffsetSerializable {
    * @return true if the signature is valid, false if it is not
    * @throws BLSException
    */
-  boolean checkSignature(BLSPublicKey publicKey, Bytes message, long domain) throws BLSException {
+  boolean checkSignature(BLSPublicKey publicKey, Bytes message, Bytes domain) throws BLSException {
     if (isNull(signature)) {
       throw new BLSException("The checkSignature method was called on an empty signature.");
     }
@@ -158,7 +158,7 @@ public final class BLSSignature implements SimpleOffsetSerializable {
    * @return true if the signature is valid, false if it is not
    * @throws BLSException
    */
-  boolean checkSignature(List<BLSPublicKey> publicKeys, List<Bytes> messages, long domain)
+  boolean checkSignature(List<BLSPublicKey> publicKeys, List<Bytes> messages, Bytes domain)
       throws BLSException {
     checkArgument(
         publicKeys.size() == messages.size(),

--- a/util/src/main/java/tech/pegasys/artemis/util/bls/BLSVerify.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/bls/BLSVerify.java
@@ -30,7 +30,7 @@ public class BLSVerify {
    * @return true if the signature is valid over these parameters, false if not
    */
   public static boolean bls_verify(
-      BLSPublicKey pubkey, Bytes32 messageHash, BLSSignature signature, long domain) {
+      BLSPublicKey pubkey, Bytes32 messageHash, BLSSignature signature, Bytes domain) {
     try {
       return signature.checkSignature(pubkey, Bytes.wrap(messageHash), domain);
     } catch (BLSException e) {
@@ -53,7 +53,7 @@ public class BLSVerify {
       List<BLSPublicKey> pubkeys,
       List<Bytes32> messageHashes,
       BLSSignature aggregateSignature,
-      long domain) {
+      Bytes domain) {
     try {
       List<Bytes> messageHashesAsBytes =
           messageHashes.stream().map(x -> Bytes.wrap(x)).collect(Collectors.toList());

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/BLS12381.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/BLS12381.java
@@ -45,10 +45,10 @@ public final class BLS12381 {
    *
    * @param keyPair The public and private key pair, not null
    * @param message The message to sign, not null
-   * @param domain The domain value added to the message
+   * @param domain The domain value appended to the message. 8 bytes.
    * @return The SignatureAndPublicKey, not null
    */
-  public static SignatureAndPublicKey sign(KeyPair keyPair, Bytes message, long domain) {
+  public static SignatureAndPublicKey sign(KeyPair keyPair, Bytes message, Bytes domain) {
     G2Point hashInGroup2 = hashFunction(message, domain);
     G2Point sig = keyPair.secretKey().sign(hashInGroup2);
     return new SignatureAndPublicKey(new Signature(sig), keyPair.publicKey());
@@ -59,10 +59,10 @@ public final class BLS12381 {
    *
    * @param keyPair The public and private key pair, not null
    * @param message The message to sign, not null
-   * @param domain The domain value added to the message
+   * @param domain The domain value appended to the message. 8 bytes.
    * @return The SignatureAndPublicKey, not null
    */
-  public static SignatureAndPublicKey sign(KeyPair keyPair, byte[] message, long domain) {
+  public static SignatureAndPublicKey sign(KeyPair keyPair, byte[] message, Bytes domain) {
     return sign(keyPair, Bytes.wrap(message), domain);
   }
 
@@ -72,11 +72,11 @@ public final class BLS12381 {
    * @param publicKey The public key, not null
    * @param signature The signature, not null
    * @param message The message data to verify, not null
-   * @param domain The domain value added to the message
+   * @param domain The domain value appended to the message. 8 bytes.
    * @return True if the verification is successful.
    */
   public static boolean verify(
-      PublicKey publicKey, Signature signature, Bytes message, long domain) {
+      PublicKey publicKey, Signature signature, Bytes message, Bytes domain) {
     G1Point g1Generator = KeyPair.g1Generator;
 
     G2Point hashInGroup2 = hashFunction(message, domain);
@@ -92,11 +92,11 @@ public final class BLS12381 {
    * @param publicKeys The list of public keys, not null
    * @param signature The signature, not null
    * @param messages The list of lmessage data to verify, not null
-   * @param domain The domain value added to the message
+   * @param domain The domain value appended to the message. 8 bytes.
    * @return True if the verification is successful.
    */
   public static boolean verifyMultiple(
-      List<PublicKey> publicKeys, Signature signature, List<Bytes> messages, long domain) {
+      List<PublicKey> publicKeys, Signature signature, List<Bytes> messages, Bytes domain) {
     if (publicKeys.size() == 0 || publicKeys.size() != messages.size()) {
       return false;
     }
@@ -120,11 +120,11 @@ public final class BLS12381 {
    * @param publicKey The public key, not null
    * @param signature The signature, not null
    * @param message The message data to verify, not null
-   * @param domain The domain value added to the message
+   * @param domain The domain value added to the message. 8 bytes.
    * @return True if the verification is successful.
    */
   public static boolean verify(
-      PublicKey publicKey, Signature signature, byte[] message, long domain) {
+      PublicKey publicKey, Signature signature, byte[] message, Bytes domain) {
     return verify(publicKey, signature, Bytes.wrap(message), domain);
   }
 
@@ -133,10 +133,10 @@ public final class BLS12381 {
    *
    * @param sigAndPubKey The signature and public key, not null
    * @param message The message data to verify, not null
-   * @param domain The domain value added to the message
+   * @param domain The domain value added to the message. 8 bytes.
    * @return True if the verification is successful, not null
    */
-  public static boolean verify(SignatureAndPublicKey sigAndPubKey, byte[] message, long domain) {
+  public static boolean verify(SignatureAndPublicKey sigAndPubKey, byte[] message, Bytes domain) {
     return verify(sigAndPubKey.publicKey(), sigAndPubKey.signature(), message, domain);
   }
 
@@ -145,14 +145,14 @@ public final class BLS12381 {
    *
    * @param sigAndPubKey The public key, not null
    * @param message The message data to verify, not null
-   * @param domain The domain value added to the message
+   * @param domain The domain value added to the message. 8 bytes.
    * @return True if the verification is successful.
    */
-  public static boolean verify(SignatureAndPublicKey sigAndPubKey, Bytes message, long domain) {
+  public static boolean verify(SignatureAndPublicKey sigAndPubKey, Bytes message, Bytes domain) {
     return verify(sigAndPubKey.publicKey(), sigAndPubKey.signature(), message, domain);
   }
 
-  private static G2Point hashFunction(Bytes message, long domain) {
+  private static G2Point hashFunction(Bytes message, Bytes domain) {
     return hashToG2(message, domain);
   }
 }

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/G2Point.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/G2Point.java
@@ -61,13 +61,12 @@ public final class G2Point implements Group<G2Point> {
    * Hashes to the G2 curve as described in the Eth2 spec
    *
    * @param message the message to be hashed. This is usually the 32 byte message digest.
-   * @param domain the signature domain as defined in the Eth2 spec
+   * @param domainBytes the signature domain as defined in the Eth2 spec. Should be 8 bytes.
    * @return a point from the G2 group representing the message hash
    */
   @VisibleForTesting
-  public static G2Point hashToG2(Bytes message, long domain) {
+  public static G2Point hashToG2(Bytes message, Bytes domainBytes) {
     Security.addProvider(new BouncyCastleProvider());
-    Bytes domainBytes = Bytes.ofUnsignedLong(domain);
     Bytes padding = Bytes.wrap(new byte[16]);
 
     byte[] xReBytes =


### PR DESCRIPTION
## PR Description

Updates BLS signature methods to use `Bytes` rather than `long` for the domain.

Completely untested as much in this branch is currently broken.

## Fixed Issue(s)
fixes #783 
