### PR TITLE
Update tests for BLS domain as Bytes

### DIFF
--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/Signature.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/Signature.java
@@ -70,7 +70,7 @@ public final class Signature {
   public static Signature random() {
     KeyPair keyPair = KeyPair.random();
     byte[] message = "Hello, world!".getBytes(UTF_8);
-    SignatureAndPublicKey sigAndPubKey = BLS12381.sign(keyPair, message, 48);
+    SignatureAndPublicKey sigAndPubKey = BLS12381.sign(keyPair, message, Bytes.ofUnsignedLong(48L));
     return sigAndPubKey.signature();
   }
 
@@ -83,7 +83,7 @@ public final class Signature {
   public static Signature random(int entropy) {
     KeyPair keyPair = KeyPair.random(entropy);
     byte[] message = "Hello, world!".getBytes(UTF_8);
-    SignatureAndPublicKey sigAndPubKey = BLS12381.sign(keyPair, message, 48);
+    SignatureAndPublicKey sigAndPubKey = BLS12381.sign(keyPair, message, Bytes.ofUnsignedLong(48L));
 
     return sigAndPubKey.signature();
   }

--- a/util/src/test/java/tech/pegasys/artemis/util/bls/BLSAggregationTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/bls/BLSAggregationTest.java
@@ -61,7 +61,7 @@ public class BLSAggregationTest {
     List<Bytes> messages = Arrays.asList(message, message, message);
 
     assertThrows(
-        IllegalArgumentException.class, () -> signature.checkSignature(publicKeys, messages, 0));
+        IllegalArgumentException.class, () -> signature.checkSignature(publicKeys, messages, Bytes.ofUnsignedLong(0L)));
   }
 
   @Test
@@ -75,11 +75,13 @@ public class BLSAggregationTest {
     BLSKeyPair keyPair3 = BLSKeyPair.random();
     BLSKeyPair keyPair4 = BLSKeyPair.random();
 
+    Bytes domain = Bytes.ofUnsignedLong(0L);
+
     // 1 & 2 sign message1; 3 & 4 sign message2
-    BLSSignature signature1 = BLSSignature.sign(keyPair1, message1, 0);
-    BLSSignature signature2 = BLSSignature.sign(keyPair2, message1, 0);
-    BLSSignature signature3 = BLSSignature.sign(keyPair3, message2, 0);
-    BLSSignature signature4 = BLSSignature.sign(keyPair4, message2, 0);
+    BLSSignature signature1 = BLSSignature.sign(keyPair1, message1, domain);
+    BLSSignature signature2 = BLSSignature.sign(keyPair2, message1, domain);
+    BLSSignature signature3 = BLSSignature.sign(keyPair3, message2, domain);
+    BLSSignature signature4 = BLSSignature.sign(keyPair4, message2, domain);
 
     // Aggregate keys 1 & 2, and keys 3 & 4
     BLSPublicKey aggregatePublicKey12 =
@@ -96,7 +98,7 @@ public class BLSAggregationTest {
         aggregateSignature.checkSignature(
             Arrays.asList(aggregatePublicKey12, aggregatePublicKey34),
             Arrays.asList(message1, message2),
-            0));
+            domain));
   }
 
   @Test
@@ -110,11 +112,13 @@ public class BLSAggregationTest {
     BLSKeyPair keyPair3 = BLSKeyPair.random();
     BLSKeyPair keyPair4 = BLSKeyPair.random();
 
+    Bytes domain = Bytes.ofUnsignedLong(0L);
+
     // 1 & 2 sign message1; 3 & 4 sign message2
-    BLSSignature signature1 = BLSSignature.sign(keyPair1, message1, 0);
-    BLSSignature signature2 = BLSSignature.sign(keyPair2, message1, 0);
-    BLSSignature signature3 = BLSSignature.sign(keyPair3, message2, 0);
-    BLSSignature signature4 = BLSSignature.sign(keyPair4, message2, 0);
+    BLSSignature signature1 = BLSSignature.sign(keyPair1, message1, domain);
+    BLSSignature signature2 = BLSSignature.sign(keyPair2, message1, domain);
+    BLSSignature signature3 = BLSSignature.sign(keyPair3, message2, domain);
+    BLSSignature signature4 = BLSSignature.sign(keyPair4, message2, domain);
 
     // Aggregate keys 1 & 2, and keys 3 & 4
     BLSPublicKey aggregatePublicKey12 =
@@ -131,6 +135,6 @@ public class BLSAggregationTest {
         aggregateSignature.checkSignature(
             Arrays.asList(aggregatePublicKey12, aggregatePublicKey34),
             Arrays.asList(message2, message1),
-            0));
+            domain));
   }
 }

--- a/util/src/test/java/tech/pegasys/artemis/util/bls/BLSSignatureTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/bls/BLSSignatureTest.java
@@ -45,7 +45,7 @@ class BLSSignatureTest {
     assertThrows(
         BLSException.class,
         () ->
-            signature.checkSignature(BLSPublicKey.random(), Bytes.wrap("Test".getBytes(UTF_8)), 0));
+            signature.checkSignature(BLSPublicKey.random(), Bytes.wrap("Test".getBytes(UTF_8)), Bytes.wrap(new byte[8])));
   }
 
   @Test
@@ -109,7 +109,7 @@ class BLSSignatureTest {
   void succeedsWhenAMessageSignsAndVerifies() throws BLSException {
     BLSKeyPair keyPair = BLSKeyPair.random();
     Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
-    long domain = 42;
+    Bytes domain = Bytes.random(8);
     BLSSignature signature = BLSSignature.sign(keyPair, message, domain);
     assertTrue(signature.checkSignature(keyPair.getPublicKey(), message, domain));
   }
@@ -118,8 +118,8 @@ class BLSSignatureTest {
   void succeedsWhenVerifyingDifferentDomainFails() throws BLSException {
     BLSKeyPair keyPair = BLSKeyPair.random();
     Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
-    long domain1 = 42;
-    long domain2 = 43;
+    Bytes domain1 = Bytes.ofUnsignedLong(42L);
+    Bytes domain2 = Bytes.ofUnsignedLong(43L);
     BLSSignature signature = BLSSignature.sign(keyPair, message, domain1);
     assertFalse(signature.checkSignature(keyPair.getPublicKey(), message, domain2));
   }
@@ -129,7 +129,7 @@ class BLSSignatureTest {
     BLSKeyPair keyPair = BLSKeyPair.random();
     Bytes message1 = Bytes.wrap("Hello, world!".getBytes(UTF_8));
     Bytes message2 = Bytes.wrap("Hello, world?".getBytes(UTF_8));
-    long domain = 42;
+    Bytes domain = Bytes.ofUnsignedLong(42L);
     BLSSignature signature = BLSSignature.sign(keyPair, message1, domain);
     assertFalse(signature.checkSignature(keyPair.getPublicKey(), message2, domain));
   }
@@ -142,7 +142,7 @@ class BLSSignatureTest {
       keyPair2 = BLSKeyPair.random();
     }
     Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
-    long domain = 42;
+    Bytes domain = Bytes.ofUnsignedLong(42L);
     BLSSignature signature = BLSSignature.sign(keyPair1, message, domain);
     assertFalse(signature.checkSignature(keyPair2.getPublicKey(), message, domain));
   }
@@ -153,7 +153,7 @@ class BLSSignatureTest {
     BLSKeyPair keyPair2 = BLSKeyPair.random(1);
     assertEquals(keyPair1.getPublicKey(), keyPair2.getPublicKey());
     Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
-    long domain = 42;
+    Bytes domain = Bytes.ofUnsignedLong(42L);
     BLSSignature signature1 = BLSSignature.sign(keyPair1, message, domain);
     BLSSignature signature2 = BLSSignature.sign(keyPair2, message, domain);
     assertEquals(signature1, signature2);

--- a/util/src/test/java/tech/pegasys/artemis/util/mikuli/G2PointTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/mikuli/G2PointTest.java
@@ -357,7 +357,7 @@ class G2PointTest {
   @Test
   void succeedsWhenHashToG2MatchesTestDataCase1() {
     Bytes message = Bytes.fromHexString("0x6d657373616765");
-    G2Point point = G2Point.hashToG2(message, 0L);
+    G2Point point = G2Point.hashToG2(message, Bytes.ofUnsignedLong(0L));
 
     String[] testCasesResult = {
       "0x0e34a428411c115e094b51afa596b0e594fb325dfe42d481a87a1e89ab35f531aadc7b4f8eb5ce9d3973d2cfef8f20fd",
@@ -375,7 +375,7 @@ class G2PointTest {
   @Test
   void succeedsWhenHashToG2MatchesTestDataCase2() {
     Bytes message = Bytes.fromHexString("0x6d657373616765");
-    G2Point point = G2Point.hashToG2(message, 1L);
+    G2Point point = G2Point.hashToG2(message, Bytes.ofUnsignedLong(1L));
 
     String[] testCasesResult = {
       "0x0c4efb2057400f7316bdfd6a89aa3afd34411b045e81bc75fa7f6a6bc5736f6528ceb5857c04866b98a43f6fdf08037c",
@@ -398,7 +398,7 @@ class G2PointTest {
                 + "56657279202e2e2e2e2e2e2e2e2e2e2e2e2e2e206c6f6e67202e2e2e2e2e2e2e"
                 + "2e2e2e2e2e2e206d657373616765202e2e2e2e207769746820656e74726f7079"
                 + "3a20313233343536373839302d626561636f6e2d636861696e");
-    G2Point point = G2Point.hashToG2(message, 0xffffffffL);
+    G2Point point = G2Point.hashToG2(message, Bytes.ofUnsignedLong(0xffffffffL));
 
     String[] testCasesResult = {
       "0x1735fa1eeb8f5927bfbd50497a0f5d0dda9b77e044bbdc2305ad4fed35a2e7fad2f97aa43a0c25e19741481acf836973",


### PR DESCRIPTION
## PR Description

Update BLS tests to use the `Bytes` type for the `domain` parameter, see #784.
