### PR TITLE
Test method to generate validator JSON

### DIFF
--- a/artemis/src/test/java/tech/pegasys/artemis/PowchainServiceTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/PowchainServiceTest.java
@@ -1,0 +1,59 @@
+package tech.pegasys.artemis;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.SECP256K1;
+import org.apache.tuweni.junit.BouncyCastleExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tech.pegasys.artemis.util.mikuli.KeyPair;
+import tech.pegasys.artemis.validator.client.ValidatorClientUtil;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@ExtendWith(BouncyCastleExtension.class)
+public class PowchainServiceTest {
+
+    @Test
+    void generateValidatorDepositJSON(){
+        int validatorCount = 100;
+        JsonArray array = new JsonArray();
+        for (int i = 0; i < validatorCount; i++) {
+
+            // key generation and signature
+            Bytes32 withdrawal_credentials = Bytes32.random();
+            KeyPair blsKeys = KeyPair.random();
+            SECP256K1.KeyPair secpKeys = SECP256K1.KeyPair.random();
+            long amount = 32000000000l;
+            Bytes proof_of_posssesion =
+                    ValidatorClientUtil.blsSignatureHelper(
+                            blsKeys, withdrawal_credentials, amount);
+
+            // JSON object creation
+            JsonObject object = new JsonObject();
+            object.addProperty("withdrawal_credentials", withdrawal_credentials.toHexString());
+            object.addProperty("blsKey", blsKeys.secretKey().toBytes().toHexString());
+            object.addProperty("secpKey", secpKeys.secretKey().bytes().toHexString());
+            object.addProperty("amount", amount);
+            object.addProperty("proof_of_posssesion", proof_of_posssesion.toHexString());
+            array.add(object);
+        }
+
+        // Write JSON file
+        try (Writer file =
+                     Files.newBufferedWriter(Paths.get("../ValidatorDeposit.json"), UTF_8)) {
+            file.write(array.toString());
+            file.flush();
+
+        } catch (IOException e) {
+            System.out.println(e.toString());
+        }
+    }
+}


### PR DESCRIPTION
Added new test method to generate ValidatorDeposits.json files for WhiteBlock's sidecar.

Example:
 ```
[
	{
		//amount for all deposits is 32 ETH
		"withdrawal_credentials": "0x0",
		"blsKey": "0x0", //hex string os the private key
		"secpKey": "0x0", //hex string of the private key
         "amount": 32000000000,
		"withdrawal_credentials": "0x0" //signature of the deposit
	}
]
```