### PR TITLE
Fix '==: unary operator expected' error from run.sh

### DIFF
--- a/scripts/run_utils.sh
+++ b/scripts/run_utils.sh
@@ -90,7 +90,7 @@ create_tmux_windows() {
   create_tmux_panes $idx
 
   ## Use the vertical layout if the flag is set
-  if [ $VERTICAL == true ]
+  if [ "$VERTICAL" == true ]
   then
     tmux select-layout even-vertical
   else


### PR DESCRIPTION
## PR Description

When running `scripts/run.sh` without using vertical mode it prints the error:
`./run_utils.sh: line 93: [: ==: unary operator expected`

Quote the variable to avoid this.