### PR TITLE
Update hash function for BLS to SHA256

### DIFF
--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/G2Point.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/G2Point.java
@@ -72,14 +72,12 @@ public final class G2Point implements Group<G2Point> {
     byte[] xReBytes =
         Bytes.concatenate(
                 padding,
-                Hash.keccak256(
-                    Bytes.concatenate(message, domainBytes, Bytes.fromHexString("0x01"))))
+                Hash.sha2_256(Bytes.concatenate(message, domainBytes, Bytes.fromHexString("0x01"))))
             .toArray();
     byte[] xImBytes =
         Bytes.concatenate(
                 padding,
-                Hash.keccak256(
-                    Bytes.concatenate(message, domainBytes, Bytes.fromHexString("0x02"))))
+                Hash.sha2_256(Bytes.concatenate(message, domainBytes, Bytes.fromHexString("0x02"))))
             .toArray();
 
     BIG xRe = BIG.fromBytes(xReBytes);

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/PublicKey.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/PublicKey.java
@@ -111,7 +111,7 @@ public final class PublicKey {
 
   @Override
   public String toString() {
-    return "Signature [ecpPoint=" + point.toString() + "]";
+    return "PublicKey [ecpPoint=" + point.toString() + "]";
   }
 
   @Override


### PR DESCRIPTION
## PR Description

At some point the BLS hash function (used in _hashToG2_) changed from Keccak256 to SHA256. This PR implements that (and fixes a typo).

Note that this change is required to pass the v0.8 BLS reference tests.
