### PR TITLE
Tidy up BLS reference tests

### DIFF
--- a/eth-reference-tests/src/test/java/pegasys/artemis/reference/TestSuite.java
+++ b/eth-reference-tests/src/test/java/pegasys/artemis/reference/TestSuite.java
@@ -87,8 +87,6 @@ public abstract class TestSuite {
         .map(objects -> Arguments.of(objects.toArray()));
   }
 
-
-
   @SuppressWarnings({"unchecked", "rawtypes"})
   public static Pair<Class, List<String>> getParams(Class classType, List<String> args) {
     return new Pair<Class, List<String>>(classType, args);

--- a/eth-reference-tests/src/test/java/pegasys/artemis/reference/bls/aggregate_pubkeys.java
+++ b/eth-reference-tests/src/test/java/pegasys/artemis/reference/bls/aggregate_pubkeys.java
@@ -41,7 +41,6 @@ class aggregate_pubkeys extends TestSuite {
     assertEquals(aggregatePubkeyExpected, aggregatePubkeyActual);
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
   @MustBeClosed
   static Stream<Arguments> readAggregatePubKeys() throws IOException {
     List<Pair<Class, List<String>>> arguments = new ArrayList<Pair<Class, List<String>>>();

--- a/eth-reference-tests/src/test/java/pegasys/artemis/reference/bls/aggregate_sigs.java
+++ b/eth-reference-tests/src/test/java/pegasys/artemis/reference/bls/aggregate_sigs.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 import kotlin.Pair;
-import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -34,17 +33,16 @@ class aggregate_sigs extends TestSuite {
 
   @ParameterizedTest(name = "{index}. aggregate sigs {0} -> {1}")
   @MethodSource("readAggregateSigs")
-  void aggregateSig(List<Signature> signatures, Bytes aggregateSignatureExpected) {
-    Bytes aggregateSignatureActual = Signature.aggregate(signatures).g2Point().toBytesCompressed();
+  void aggregateSig(List<Signature> signatures, Signature aggregateSignatureExpected) {
+    Signature aggregateSignatureActual = Signature.aggregate(signatures);
     assertEquals(aggregateSignatureExpected, aggregateSignatureActual);
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
   @MustBeClosed
   static Stream<Arguments> readAggregateSigs() throws IOException {
     List<Pair<Class, List<String>>> arguments = new ArrayList<Pair<Class, List<String>>>();
     arguments.add(getParams(Signature[].class, Arrays.asList("input")));
-    arguments.add(getParams(Bytes.class, Arrays.asList("output")));
+    arguments.add(getParams(Signature.class, Arrays.asList("output")));
 
     return findTests(testFile, arguments);
   }

--- a/eth-reference-tests/src/test/java/pegasys/artemis/reference/bls/g2_compressed.java
+++ b/eth-reference-tests/src/test/java/pegasys/artemis/reference/bls/g2_compressed.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.stream.Stream;
 import kotlin.Pair;
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes48;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -35,20 +34,17 @@ class g2_compressed extends TestSuite {
 
   @ParameterizedTest(name = "{index}. message hash to G2 compressed {0} -> {1}")
   @MethodSource("readMessageHashG2Compressed")
-  void messageHashToG2Compressed(G2Point g2Point, List<Bytes> output) {
-    Bytes48 xReExpected = Bytes48.leftPad(output.get(0));
-    Bytes48 xImExpected = Bytes48.leftPad(output.get(1));
-    Bytes expectedBytes = Bytes.concatenate(xReExpected, xImExpected);
-    Bytes actualBytes = g2Point.toBytesCompressed();
-    assertEquals(expectedBytes, actualBytes);
+  void messageHashToG2Compressed(Bytes message, Bytes domain, G2Point g2PointExpected) {
+    G2Point g2PointActual = G2Point.hashToG2(message, domain);
+    assertEquals(g2PointExpected, g2PointActual);
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
   @MustBeClosed
   static Stream<Arguments> readMessageHashG2Compressed() throws IOException {
     List<Pair<Class, List<String>>> arguments = new ArrayList<Pair<Class, List<String>>>();
-    arguments.add(getParams(G2Point.class, Arrays.asList("input")));
-    arguments.add(getParams(Bytes[].class, Arrays.asList("output")));
+    arguments.add(getParams(Bytes.class, Arrays.asList("input", "message")));
+    arguments.add(getParams(Bytes.class, Arrays.asList("input", "domain")));
+    arguments.add(getParams(G2Point.class, Arrays.asList("output")));
 
     return findTests(testFile, arguments);
   }

--- a/eth-reference-tests/src/test/java/pegasys/artemis/reference/bls/g2_uncompressed.java
+++ b/eth-reference-tests/src/test/java/pegasys/artemis/reference/bls/g2_uncompressed.java
@@ -22,13 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 import kotlin.Pair;
-import java.util.LinkedHashMap;
-import java.util.stream.Stream;
-import org.apache.milagro.amcl.BLS381.BIG;
-import org.apache.milagro.amcl.BLS381.ECP2;
-import org.apache.milagro.amcl.BLS381.FP2;
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes48;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -40,15 +34,16 @@ class g2_uncompressed extends TestSuite {
 
   @ParameterizedTest(name = "{index}. message hash to G2 uncompressed {0} -> {1}")
   @MethodSource("readMessageHashG2Uncompressed")
-  void messageHashToG2Uncompressed(G2Point g2PointExpected, G2Point g2PointActual) {
+  void messageHashToG2Uncompressed(Bytes message, Bytes domain, G2Point g2PointExpected) {
+    G2Point g2PointActual = G2Point.hashToG2(message, domain);
     assertEquals(g2PointExpected, g2PointActual);
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
   @MustBeClosed
   static Stream<Arguments> readMessageHashG2Uncompressed() throws IOException {
     List<Pair<Class, List<String>>> arguments = new ArrayList<Pair<Class, List<String>>>();
-    arguments.add(getParams(G2Point.class, Arrays.asList("input")));
+    arguments.add(getParams(Bytes.class, Arrays.asList("input", "message")));
+    arguments.add(getParams(Bytes.class, Arrays.asList("input", "domain")));
     arguments.add(getParams(G2Point.class, Arrays.asList("output")));
 
     return findTests(testFile, arguments);

--- a/eth-reference-tests/src/test/java/pegasys/artemis/reference/bls/priv_to_pub.java
+++ b/eth-reference-tests/src/test/java/pegasys/artemis/reference/bls/priv_to_pub.java
@@ -39,7 +39,6 @@ class priv_to_pub extends TestSuite {
     assertEquals(pubkeyExpected, pubkeyActual);
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
   @MustBeClosed
   static Stream<Arguments> readPrivateToPublicKey() throws IOException {
     List<Pair<Class, List<String>>> arguments = new ArrayList<Pair<Class, List<String>>>();

--- a/eth-reference-tests/src/test/java/pegasys/artemis/reference/bls/sign_msg.java
+++ b/eth-reference-tests/src/test/java/pegasys/artemis/reference/bls/sign_msg.java
@@ -30,30 +30,26 @@ import pegasys.artemis.reference.TestSuite;
 import tech.pegasys.artemis.util.mikuli.BLS12381;
 import tech.pegasys.artemis.util.mikuli.KeyPair;
 import tech.pegasys.artemis.util.mikuli.SecretKey;
+import tech.pegasys.artemis.util.mikuli.Signature;
 
 class sign_msg extends TestSuite {
   private static String testFile = "**/sign_msg.yaml";
 
   @ParameterizedTest(name = "{index}. sign messages {0} -> {1}")
   @MethodSource("readSignMessages")
-  void signMessages(Bytes message, Bytes domain, SecretKey secretKey, Bytes signatureExpected) {
-    Bytes signatureActual =
-        BLS12381
-            .sign(new KeyPair(secretKey), message.toArray(), domain)
-            .signature()
-            .g2Point()
-            .toBytesCompressed();
+  void signMessages(Bytes message, Bytes domain, SecretKey secretKey, Signature signatureExpected) {
+    Signature signatureActual =
+        BLS12381.sign(new KeyPair(secretKey), message.toArray(), domain).signature();
     assertEquals(signatureExpected, signatureActual);
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
   @MustBeClosed
   static Stream<Arguments> readSignMessages() throws IOException {
     List<Pair<Class, List<String>>> arguments = new ArrayList<Pair<Class, List<String>>>();
     arguments.add(getParams(Bytes.class, Arrays.asList("input", "message")));
     arguments.add(getParams(Bytes.class, Arrays.asList("input", "domain")));
     arguments.add(getParams(SecretKey.class, Arrays.asList("input", "privkey")));
-    arguments.add(getParams(Bytes.class, Arrays.asList("output")));
+    arguments.add(getParams(Signature.class, Arrays.asList("output")));
 
     return findTests(testFile, arguments);
   }

--- a/eth-reference-tests/src/test/java/pegasys/artemis/reference/ssz_static/core/ssz_minimal_zero.java
+++ b/eth-reference-tests/src/test/java/pegasys/artemis/reference/ssz_static/core/ssz_minimal_zero.java
@@ -13,7 +13,14 @@
 
 package pegasys.artemis.reference.ssz_static.core;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.google.errorprone.annotations.MustBeClosed;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
 import kotlin.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -45,14 +52,6 @@ import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.datastructures.state.HistoricalBatch;
 import tech.pegasys.artemis.datastructures.state.PendingAttestation;
 import tech.pegasys.artemis.datastructures.state.Validator;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(BouncyCastleExtension.class)
 class ssz_minimal_zero extends TestSuite {
@@ -473,7 +472,7 @@ class ssz_minimal_zero extends TestSuite {
         getParams(PendingAttestation.class, Arrays.asList("PendingAttestation", "value")));
     arguments.add(getParams(Bytes.class, Arrays.asList("PendingAttestation", "serialized")));
     arguments.add(getParams(Bytes32.class, Arrays.asList("PendingAttestation", "root")));
-    
+
     return findTests(testFile, arguments);
   }
 

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/G2Point.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/G2Point.java
@@ -231,7 +231,7 @@ public final class G2Point implements Group<G2Point> {
    * @param bytes the compressed serialised form of the point
    * @return the point
    */
-  static G2Point fromBytesCompressed(Bytes bytes) {
+  public static G2Point fromBytesCompressed(Bytes bytes) {
     checkArgument(
         bytes.size() == 2 * fpPointSize,
         "Expected %s bytes but received %s",

--- a/util/src/main/java/tech/pegasys/artemis/util/mikuli/KeyPair.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/mikuli/KeyPair.java
@@ -68,13 +68,11 @@ public final class KeyPair {
   public KeyPair(SecretKey secretKey) {
     this.secretKey = secretKey;
     this.publicKey = new PublicKey(this.secretKey);
-    ;
   }
 
   public KeyPair(Scalar secretKey) {
     this.secretKey = new SecretKey(secretKey);
     this.publicKey = new PublicKey(this.secretKey);
-    ;
   }
 
   public PublicKey publicKey() {


### PR DESCRIPTION
## PR Description

A tidy up of the BLS reference tests:
 - Refactor of the G2Point generation to handle both compressed and uncompressed consistently
 - Introduce methods for `Signature`, `PublicKey` and `SecretKey`, and use these when building lists
 - Delete redundant `@SuppressWarnings`
 - Other tidying