### PR TITLE
Update metrics library

### DIFF
--- a/artemis/build.gradle
+++ b/artemis/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   implementation 'io.vertx:vertx-web'
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation 'org.slf4j:slf4j-nop:1.7.25'
-  implementation 'tech.pegasys.pantheon.internal:core'
+  implementation 'tech.pegasys.pantheon.internal:metrics-core'
 
   runtimeOnly 'org.apache.logging.log4j:log4j-core'
 

--- a/data/metrics/build.gradle
+++ b/data/metrics/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation 'io.prometheus:simpleclient_vertx'
     implementation 'org.apache.logging.log4j:log4j-api'
     implementation 'org.apache.commons:commons-lang3'
-    implementation 'tech.pegasys.pantheon.internal:core'
+    implementation 'tech.pegasys.pantheon.internal:metrics-core'
     runtime 'org.apache.logging.log4j:log4j-core'
 
     test {

--- a/ethereum/statetransition/build.gradle
+++ b/ethereum/statetransition/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation 'com.google.code.gson:gson'
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation 'org.apache.commons:commons-lang3:3.6'
-  implementation 'tech.pegasys.pantheon.internal:core'
+  implementation 'tech.pegasys.pantheon.internal:metrics-core'
   runtime 'org.apache.logging.log4j:log4j-core'
 
   test {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -85,6 +85,6 @@ dependencyManagement {
 
     dependency 'org.xerial.snappy:snappy-java:1.1.7.2'
 
-    dependency 'tech.pegasys.pantheon.internal:core:1.2.0'
+    dependency 'tech.pegasys.pantheon.internal:metrics-core:1.2.1'
   }
 }

--- a/services/serviceutils/build.gradle
+++ b/services/serviceutils/build.gradle
@@ -17,7 +17,7 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-config'
   implementation 'io.vertx:vertx-core'
   implementation 'io.vertx:vertx-web'
-  implementation 'tech.pegasys.pantheon.internal:core'
+  implementation 'tech.pegasys.pantheon.internal:metrics-core'
 }
 
 configurations { testArtifacts }


### PR DESCRIPTION
## PR Description
Pantheon 1.2.1 went out today and the metrics client abstraction artemis uses from it now has a much more sensible artefact name.  Updating to pull that in - no other changes to metrics.