### PR TITLE
Upgrade vertx to 3.8.0

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -29,10 +29,10 @@ dependencyManagement {
     dependency "io.prometheus:simpleclient_hotspot:0.6.0"
     dependency "io.prometheus:simpleclient_vertx:0.6.0"
 
-    dependency 'io.vertx:vertx-codegen:3.6.3'
-    dependency 'io.vertx:vertx-core:3.6.3'
-    dependency 'io.vertx:vertx-unit:3.6.3'
-    dependency 'io.vertx:vertx-web:3.6.3'
+    dependency 'io.vertx:vertx-codegen:3.8.0'
+    dependency 'io.vertx:vertx-core:3.8.0'
+    dependency 'io.vertx:vertx-unit:3.8.0'
+    dependency 'io.vertx:vertx-web:3.8.0'
 
     dependencySet(group: 'org.logl', version : '0.3.1') {
       entry 'logl-log4j2'


### PR DESCRIPTION
## PR Description
Fixes compatibility with metrics server because Vertx broke backwards binary compatibility between 3.6 and 3.8.