### PR TITLE
Ensure the configured genesis time is used in mock start interop mode

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateProcessor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateProcessor.java
@@ -186,7 +186,10 @@ public class StateProcessor {
   }
 
   private void setSimulationGenesisTime(BeaconState state) {
-    if (Constants.GENESIS_TIME.equals(UnsignedLong.MAX_VALUE)) {
+    if (config.getInteropActive()
+        && config.getInteropMode().equals(Constants.MOCKED_START_INTEROP)) {
+      state.setGenesis_time(UnsignedLong.valueOf(config.getInteropGenesisTime()));
+    } else if (Constants.GENESIS_TIME.equals(UnsignedLong.MAX_VALUE)) {
       Date date = new Date();
       state.setGenesis_time(
           UnsignedLong.valueOf((date.getTime() / 1000)).plus(Constants.GENESIS_START_DELAY));


### PR DESCRIPTION
## PR Description
Quick change to ensure we really do use the configured genesis time when in mock start mode.