### PR TITLE
Use correct value for crosslink penalties

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
@@ -615,7 +615,7 @@ public final class EpochProcessorUtil {
       List<UnsignedLong> penalties1 = attestation_deltas.getRight();
       Pair<List<UnsignedLong>, List<UnsignedLong>> crosslink_deltas = get_crosslink_deltas(state);
       List<UnsignedLong> rewards2 = crosslink_deltas.getLeft();
-      List<UnsignedLong> penalties2 = crosslink_deltas.getLeft();
+      List<UnsignedLong> penalties2 = crosslink_deltas.getRight();
 
       for (int i = 0; i < state.getValidators().size(); i++) {
         increase_balance(state, i, rewards1.get(i).plus(rewards2.get(i)));


### PR DESCRIPTION
## PR Description
We were using the crosslink rewards as both rewards and penalties. Fixes slotsMinimal double_empty_epoch and blocksMinimal sanity tests.