### PR TITLE
Treat slots as a delta not a target in slotsMinimal and slotsMainnet

### DIFF
--- a/eth-reference-tests/src/test/java/tech/pegasys/artemis/reference/phase0/sanity/slotsMainnet.java
+++ b/eth-reference-tests/src/test/java/tech/pegasys/artemis/reference/phase0/sanity/slotsMainnet.java
@@ -41,7 +41,8 @@ public class slotsMainnet extends TestSuite {
     StateTransition stateTransition = new StateTransition(printEnabled);
     BeaconStateWithCache preWithCache = BeaconStateWithCache.fromBeaconState(pre);
 
-    assertDoesNotThrow(() -> stateTransition.process_slots(preWithCache, slot, false));
+    assertDoesNotThrow(
+        () -> stateTransition.process_slots(preWithCache, pre.getSlot().plus(slot), false));
     assertEquals(preWithCache, post);
   }
 

--- a/eth-reference-tests/src/test/java/tech/pegasys/artemis/reference/phase0/sanity/slotsMinimal.java
+++ b/eth-reference-tests/src/test/java/tech/pegasys/artemis/reference/phase0/sanity/slotsMinimal.java
@@ -41,7 +41,8 @@ public class slotsMinimal extends TestSuite {
     StateTransition stateTransition = new StateTransition(printEnabled);
     BeaconStateWithCache preWithCache = BeaconStateWithCache.fromBeaconState(pre);
 
-    assertDoesNotThrow(() -> stateTransition.process_slots(preWithCache, slot, false));
+    assertDoesNotThrow(
+        () -> stateTransition.process_slots(preWithCache, pre.getSlot().plus(slot), false));
     assertEquals(preWithCache, post);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
@@ -615,7 +615,7 @@ public final class EpochProcessorUtil {
       List<UnsignedLong> penalties1 = attestation_deltas.getRight();
       Pair<List<UnsignedLong>, List<UnsignedLong>> crosslink_deltas = get_crosslink_deltas(state);
       List<UnsignedLong> rewards2 = crosslink_deltas.getLeft();
-      List<UnsignedLong> penalties2 = crosslink_deltas.getLeft();
+      List<UnsignedLong> penalties2 = crosslink_deltas.getRight();
 
       for (int i = 0; i < state.getValidators().size(); i++) {
         increase_balance(state, i, rewards1.get(i).plus(rewards2.get(i)));


### PR DESCRIPTION
## PR Description
The slots.yaml file contains the number of slots to process, not the final slot to aim for.  Fixes remaining slots sanity tests.