### PR TITLE
Refactor setting constants to minimal/mainnet

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
@@ -57,7 +57,7 @@ public class BeaconNode {
     metricsEndpoint = new MetricsEndpoint(config, vertx);
     this.serviceConfig =
         new ServiceConfig(eventBus, vertx, metricsEndpoint.getMetricsSystem(), config);
-    Constants.init(config);
+    Constants.setConstants(config.getConstants());
 
     final String transitionRecordDir = config.getTransitionRecordDir();
     if (transitionRecordDir != null) {

--- a/artemis/src/main/java/tech/pegasys/artemis/TransitionCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/TransitionCommand.java
@@ -116,7 +116,7 @@ public class TransitionCommand {
 
   private void processStateTransition(
       final InAndOutParams params, final StateTransitionFunction transition) {
-    Constants.init(ArtemisConfiguration.fromFile(params.configFile));
+    Constants.setConstants(ArtemisConfiguration.fromFile(params.configFile).getConstants());
     try (final InputStream in = selectInputStream(params);
         final OutputStream out = selectOutputStream(params)) {
       final Bytes inData = Bytes.wrap(ByteStreams.toByteArray(in));

--- a/config/config.toml
+++ b/config/config.toml
@@ -12,13 +12,14 @@ bootnodes = ""
 isBootnode = true
 advertisedPort = 9000
 naughtinessPercentage = 0
+constants = "minimal"
 
 [interop]
 active = false
 genesisTime = 1567777777
 ownedValidatorStartIndex = 0
-ownedValidatorCount = 4
-startState = "/tmp/genesis.ssz"
+ownedValidatorCount = 16
+startState = ""
 #this.privKey.bytes().toHexString() who's corresponding sha2(publicKey) == 16Uiu2HAm8cQB9DcwMtaSVuHNiJEPSq9mXM6FHho7c55M6XN2P3EQ
 privateKey = "0x08021221008166B8EF20C11F3A18F8774BF834173B07F64BAEDA981766896B4A8F53B52EDF"
 
@@ -54,135 +55,3 @@ port = 8008
 metricsNetworkInterface = "127.0.0.1"
 #metricsCategories = [ "BEACONCHAIN", "JVM", "PROCESS" ]
 
-
-# Modify constants in Constants.java
-[constants]
-
-# Minimal preset
-
-
-# Misc
-# ---------------------------------------------------------------
-
-# [customized] Just 8 shards for testing purposes
-SHARD_COUNT = 8
-# [customized] unsecure, but fast
-TARGET_COMMITTEE_SIZE = 4
-# 2**12 (= 4,096)
-MAX_VALIDATORS_PER_COMMITTEE = 4096
-# 2**2 (= 4)
-MIN_PER_EPOCH_CHURN_LIMIT = 4
-# 2**16 (= 65,536)
-CHURN_LIMIT_QUOTIENT = 65536
-# [customized] Faster, but unsecure.
-SHUFFLE_ROUND_COUNT = 10
-# [customized]
-MIN_GENESIS_ACTIVE_VALIDATOR_COUNT = 64
-# Jan 3, 2020
-MIN_GENESIS_TIME = 1578009600
-
-
-
-# Deposit contract
-# ---------------------------------------------------------------
-# **TBD**
-DEPOSIT_CONTRACT_ADDRESS = '0x1234567890123456789012345678901234567890'
-
-
-# Gwei values
-# ---------------------------------------------------------------
-# 2**0 * 10**9 (= 1,000,000,000) Gwei
-MIN_DEPOSIT_AMOUNT = 1000000000
-# 2**5 * 10**9 (= 32,000,000,000) Gwei
-MAX_EFFECTIVE_BALANCE = 32000000000
-# 2**4 * 10**9 (= 16,000,000,000) Gwei
-EJECTION_BALANCE = 16000000000
-# 2**0 * 10**9 (= 1,000,000,000) Gwei
-EFFECTIVE_BALANCE_INCREMENT = 1000000000
-
-
-# Initial values
-# ---------------------------------------------------------------
-# 0, GENESIS_EPOCH is derived from this constant
-GENESIS_SLOT = 0
-BLS_WITHDRAWAL_PREFIX = '0x00'
-
-
-# Time parameters
-# ---------------------------------------------------------------
-# 6 seconds
-SECONDS_PER_SLOT = 6
-# 2**0 (= 1) slots 6 seconds
-MIN_ATTESTATION_INCLUSION_DELAY = 1
-# [customized] fast epochs
-SLOTS_PER_EPOCH = 8
-# 2**0 (= 1) epochs
-MIN_SEED_LOOKAHEAD = 1
-# 2**2 (= 4) epochs
-ACTIVATION_EXIT_DELAY = 4
-# [customized] higher frequency new deposits from eth1 for testing
-SLOTS_PER_ETH1_VOTING_PERIOD = 16
-# [customized] smaller state
-SLOTS_PER_HISTORICAL_ROOT = 64
-# 2**8 (= 256) epochs
-MIN_VALIDATOR_WITHDRAWABILITY_DELAY = 256
-# 2**11 (= 2,048) epochs
-PERSISTENT_COMMITTEE_PERIOD = 2048
-# [customized] fast catchup crosslinks
-MAX_EPOCHS_PER_CROSSLINK = 4
-# 2**2 (= 4) epochs
-MIN_EPOCHS_TO_INACTIVITY_PENALTY = 4
-# [customized] 2**12 (= 4,096) epochs
-EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS = 4096
-
-
-# State vector lengths
-# ---------------------------------------------------------------
-# [customized] smaller state
-EPOCHS_PER_HISTORICAL_VECTOR = 64
-# [customized] smaller state
-EPOCHS_PER_SLASHINGS_VECTOR = 64
-# 2**24 (= 16,777,216) historical roots
-HISTORICAL_ROOTS_LIMIT = 16777216
-# 2**40 (= 1,099,511,627,776) validator spots
-VALIDATOR_REGISTRY_LIMIT = 1099511627776
-
-
-# Reward and penalty quotients
-# ---------------------------------------------------------------
-# 2**6 (= 64)
-BASE_REWARD_FACTOR = 64
-# 2**9 (= 512)
-WHISTLEBLOWER_REWARD_QUOTIENT = 512
-# 2**3 (= 8)
-PROPOSER_REWARD_QUOTIENT = 8
-# 2**25 (= 33,554,432)
-INACTIVITY_PENALTY_QUOTIENT = 33554432
-# 2**5 (= 32)
-MIN_SLASHING_PENALTY_QUOTIENT = 32
-
-
-# Max operations per block
-# ---------------------------------------------------------------
-# 2**4 (= 16)
-MAX_PROPOSER_SLASHINGS = 16
-# 2**0 (= 1)
-MAX_ATTESTER_SLASHINGS = 1
-# 2**7 (= 128)
-MAX_ATTESTATIONS = 128
-# 2**4 (= 16)
-MAX_DEPOSITS = 16
-# 2**4 (= 16)
-MAX_VOLUNTARY_EXITS = 16
-# Originally 2**4 (= 16), disabled for now.
-MAX_TRANSFERS = 0
-
-
-# Signature domains
-# ---------------------------------------------------------------
-DOMAIN_BEACON_PROPOSER = 0
-DOMAIN_RANDAO = 1
-DOMAIN_ATTESTATION = 2
-DOMAIN_DEPOSIT = 3
-DOMAIN_VOLUNTARY_EXIT = 4
-DOMAIN_TRANSFER = 5

--- a/eth-reference-tests/src/test/java/tech/pegasys/artemis/reference/TestSuite.java
+++ b/eth-reference-tests/src/test/java/tech/pegasys/artemis/reference/TestSuite.java
@@ -80,7 +80,8 @@ public abstract class TestSuite {
     if (result.isEmpty())
       throw new Exception(
           "TestSuite.loadConfigFromPath(): Configuration files was not found in the hierarchy of the provided path");
-    Constants.init((Map) pathToObject(Paths.get(result), null));
+    String constants = path.toString().contains("mainnet") ? "mainnet" : "minimal";
+    Constants.setConstants(constants);
 
     // TODO fix this massacre of a technical debt
     // Checks if constants were changed from minimal to mainnet or vice-versa, and updates

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/Constants.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/Constants.java
@@ -16,12 +16,10 @@ package tech.pegasys.artemis.datastructures;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.int_to_bytes;
 
 import com.google.common.primitives.UnsignedLong;
-import java.util.Map;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.artemis.util.SSZTypes.Bytes4;
 import tech.pegasys.artemis.util.bls.BLSSignature;
-import tech.pegasys.artemis.util.config.ArtemisConfiguration;
 
 public class Constants {
 
@@ -110,7 +108,8 @@ public class Constants {
   public static String DEPOSIT_TEST = "test";
   public static String DEPOSIT_SIM = "simulation";
 
-  public static Bytes DEPOSIT_CONTRACT_ADDRESS = Bytes.fromHexString("0x1234567890123456789012345678901234567890");
+  public static Bytes DEPOSIT_CONTRACT_ADDRESS =
+      Bytes.fromHexString("0x1234567890123456789012345678901234567890");
   public static Bytes DOMAIN_CUSTODY_BIT_CHALLENGE;
   public static Bytes DOMAIN_SHARD_PROPOSER;
   public static Bytes DOMAIN_SHARD_ATTESTER;
@@ -236,7 +235,6 @@ public class Constants {
       MAX_DEPOSITS = 16;
       MAX_VOLUNTARY_EXITS = 16;
       MAX_TRANSFERS = 0;
-
     }
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/Constants.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/Constants.java
@@ -34,56 +34,57 @@ public class Constants {
   public static String ENDIANNESS = "little";
 
   // Misc
-  public static int SHARD_COUNT = 1024;
-  public static int TARGET_COMMITTEE_SIZE = 128;
-  public static int MAX_VALIDATORS_PER_COMMITTEE = 4096;
-  public static int MIN_PER_EPOCH_CHURN_LIMIT = 4;
-  public static int CHURN_LIMIT_QUOTIENT = 65536;
-  public static int SHUFFLE_ROUND_COUNT = 90;
-  public static int MIN_GENESIS_ACTIVE_VALIDATOR_COUNT = 65536;
-  public static UnsignedLong MIN_GENESIS_TIME = UnsignedLong.valueOf(1567222226);
+  public static int SHARD_COUNT;
+  public static int TARGET_COMMITTEE_SIZE;
+  public static int MAX_VALIDATORS_PER_COMMITTEE;
+  public static int MIN_PER_EPOCH_CHURN_LIMIT;
+  public static int CHURN_LIMIT_QUOTIENT;
+  public static int SHUFFLE_ROUND_COUNT;
+  public static int MIN_GENESIS_ACTIVE_VALIDATOR_COUNT;
+  public static UnsignedLong MIN_GENESIS_TIME;
 
   // Gwei values
-  public static long MIN_DEPOSIT_AMOUNT = 1000000000L;
-  public static long MAX_EFFECTIVE_BALANCE = 32000000000L;
-  public static long EJECTION_BALANCE = 16000000000L;
-  public static long EFFECTIVE_BALANCE_INCREMENT = 1000000000L;
+  public static long MIN_DEPOSIT_AMOUNT;
+  public static long MAX_EFFECTIVE_BALANCE;
+  public static long EJECTION_BALANCE;
+  public static long EFFECTIVE_BALANCE_INCREMENT;
 
   // Initial values
-  public static long GENESIS_SLOT = 0;
-  public static long GENESIS_EPOCH = 0;
-  public static Bytes BLS_WITHDRAWAL_PREFIX = Bytes.wrap(new byte[1]);
+  public static long GENESIS_SLOT;
+  public static long GENESIS_EPOCH;
+  public static Bytes BLS_WITHDRAWAL_PREFIX;
 
   // Time parameters
-  public static int MIN_ATTESTATION_INCLUSION_DELAY = 1;
-  public static int SLOTS_PER_EPOCH = 64;
-  public static int MIN_SEED_LOOKAHEAD = 1;
-  public static int ACTIVATION_EXIT_DELAY = 4;
-  public static int SLOTS_PER_ETH1_VOTING_PERIOD = 1024;
-  public static int SLOTS_PER_HISTORICAL_ROOT = 8192;
-  public static int MIN_VALIDATOR_WITHDRAWABILITY_DELAY = 256;
-  public static int PERSISTENT_COMMITTEE_PERIOD = 2048;
-  public static int MAX_EPOCHS_PER_CROSSLINK = 64;
-  public static int MIN_EPOCHS_TO_INACTIVITY_PENALTY = 4;
+  public static int SECONDS_PER_SLOT = 6;
+  public static int MIN_ATTESTATION_INCLUSION_DELAY;
+  public static int SLOTS_PER_EPOCH;
+  public static int MIN_SEED_LOOKAHEAD;
+  public static int ACTIVATION_EXIT_DELAY;
+  public static int SLOTS_PER_ETH1_VOTING_PERIOD;
+  public static int SLOTS_PER_HISTORICAL_ROOT;
+  public static int MIN_VALIDATOR_WITHDRAWABILITY_DELAY;
+  public static int PERSISTENT_COMMITTEE_PERIOD;
+  public static int MAX_EPOCHS_PER_CROSSLINK;
+  public static int MIN_EPOCHS_TO_INACTIVITY_PENALTY;
 
   // State list lengths
-  public static int EPOCHS_PER_HISTORICAL_VECTOR = 65536;
-  public static int EPOCHS_PER_SLASHINGS_VECTOR = 8192;
-  public static int HISTORICAL_ROOTS_LIMIT = 16777216;
-  public static long VALIDATOR_REGISTRY_LIMIT = 1099511627776L;
+  public static int EPOCHS_PER_HISTORICAL_VECTOR;
+  public static int EPOCHS_PER_SLASHINGS_VECTOR;
+  public static int HISTORICAL_ROOTS_LIMIT;
+  public static long VALIDATOR_REGISTRY_LIMIT;
 
   // Reward and penalty quotients
-  public static int BASE_REWARD_FACTOR = 64;
-  public static int WHISTLEBLOWER_REWARD_QUOTIENT = 512;
-  public static int PROPOSER_REWARD_QUOTIENT = 8;
-  public static int INACTIVITY_PENALTY_QUOTIENT = 33554432;
-  public static int MIN_SLASHING_PENALTY_QUOTIENT = 32;
+  public static int BASE_REWARD_FACTOR;
+  public static int WHISTLEBLOWER_REWARD_QUOTIENT;
+  public static int PROPOSER_REWARD_QUOTIENT;
+  public static int INACTIVITY_PENALTY_QUOTIENT;
+  public static int MIN_SLASHING_PENALTY_QUOTIENT;
 
   // Max transactions per block
-  public static int MAX_PROPOSER_SLASHINGS = 16;
-  public static int MAX_ATTESTER_SLASHINGS = 1;
-  public static int MAX_ATTESTATIONS = 128;
-  public static int MAX_DEPOSITS = 16;
+  public static int MAX_PROPOSER_SLASHINGS;
+  public static int MAX_ATTESTER_SLASHINGS;
+  public static int MAX_ATTESTATIONS;
+  public static int MAX_DEPOSITS;
   public static int MAX_VOLUNTARY_EXITS = 16;
   public static int MAX_TRANSFERS = 0;
 
@@ -100,291 +101,142 @@ public class Constants {
   public static int DEPOSIT_DATA_SIZE = 512; //
   public static int VALIDATOR_CLIENT_PORT_BASE = 50000;
   public static Bytes32 ZERO_HASH = Bytes32.ZERO;
-  public static int SECONDS_PER_SLOT = 6;
   public static double TIME_TICKER_REFRESH_RATE = 2; // per sec
   public static UnsignedLong GENESIS_TIME = UnsignedLong.MAX_VALUE;
   public static UnsignedLong GENESIS_START_DELAY = UnsignedLong.valueOf(5);
-  // TODO make this variable through yaml
 
   // Deposit
   public static String DEPOSIT_NORMAL = "normal";
   public static String DEPOSIT_TEST = "test";
   public static String DEPOSIT_SIM = "simulation";
 
-  // Added values by proto for v0.8.2 tests TODO organize
-  public static Bytes DEPOSIT_CONTRACT_ADDRESS;
+  public static Bytes DEPOSIT_CONTRACT_ADDRESS = Bytes.fromHexString("0x1234567890123456789012345678901234567890");
   public static Bytes DOMAIN_CUSTODY_BIT_CHALLENGE;
   public static Bytes DOMAIN_SHARD_PROPOSER;
   public static Bytes DOMAIN_SHARD_ATTESTER;
-  public static int EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS;
+  public static int EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS = 4096;
 
   public static BLSSignature EMPTY_SIGNATURE = BLSSignature.empty();
   public static UnsignedLong BYTES_PER_LENGTH_OFFSET = UnsignedLong.valueOf(4L);
 
-  public static void init(ArtemisConfiguration config) {
-    // Misc
-    SHARD_COUNT =
-        config.getShardCount() != Integer.MIN_VALUE ? config.getShardCount() : SHARD_COUNT;
-
-    TARGET_COMMITTEE_SIZE =
-        config.getTargetCommitteeSize() != Integer.MIN_VALUE
-            ? config.getTargetCommitteeSize()
-            : TARGET_COMMITTEE_SIZE;
-    MAX_VALIDATORS_PER_COMMITTEE =
-        config.getMaxValidatorsPerCommittee() != Integer.MIN_VALUE
-            ? config.getMaxValidatorsPerCommittee()
-            : MAX_VALIDATORS_PER_COMMITTEE;
-    MIN_PER_EPOCH_CHURN_LIMIT =
-        config.getMinPerEpochChurnLimit() != Integer.MIN_VALUE
-            ? config.getMinPerEpochChurnLimit()
-            : MIN_PER_EPOCH_CHURN_LIMIT;
-    CHURN_LIMIT_QUOTIENT =
-        config.getChurnLimitQuotient() != Integer.MIN_VALUE
-            ? config.getChurnLimitQuotient()
-            : CHURN_LIMIT_QUOTIENT; // 2^7 validators
-    SHUFFLE_ROUND_COUNT =
-        config.getShuffleRoundCount() != Integer.MIN_VALUE
-            ? config.getShuffleRoundCount()
-            : SHUFFLE_ROUND_COUNT;
-    MIN_GENESIS_ACTIVE_VALIDATOR_COUNT =
-        config.getMinGenesisActiveValidatorCount() != Integer.MIN_VALUE
-            ? config.getShuffleRoundCount()
-            : MIN_GENESIS_ACTIVE_VALIDATOR_COUNT;
-    MIN_GENESIS_TIME =
-        config.getMinGenesisTime() != Integer.MIN_VALUE
-            ? UnsignedLong.valueOf(config.getMinGenesisTime())
-            : MIN_GENESIS_TIME;
-
-    // Gwei values
-    MIN_DEPOSIT_AMOUNT =
-        config.getMinDepositAmount() != Long.MIN_VALUE
-            ? config.getMinDepositAmount()
-            : MIN_DEPOSIT_AMOUNT;
-    MAX_EFFECTIVE_BALANCE =
-        config.getMaxEffectiveBalance() != Long.MIN_VALUE
-            ? config.getMaxEffectiveBalance()
-            : MAX_EFFECTIVE_BALANCE;
-    EJECTION_BALANCE =
-        config.getEjectionBalance() != Long.MIN_VALUE
-            ? config.getEjectionBalance()
-            : EJECTION_BALANCE;
-    EFFECTIVE_BALANCE_INCREMENT =
-        config.getEffectiveBalanceIncrement() != Long.MIN_VALUE
-            ? config.getEffectiveBalanceIncrement()
-            : EFFECTIVE_BALANCE_INCREMENT;
-
-    // Initial values
-    GENESIS_SLOT =
-        config.getGenesisSlot() != Long.MIN_VALUE ? config.getGenesisSlot() : GENESIS_SLOT;
-    GENESIS_EPOCH =
-        config.getGenesisEpoch() != Long.MIN_VALUE ? config.getGenesisEpoch() : GENESIS_SLOT;
-    BLS_WITHDRAWAL_PREFIX =
-        !config.getBlsWithdrawalPrefix().equals("")
-            ? Bytes.fromHexString(config.getBlsWithdrawalPrefix())
-            : BLS_WITHDRAWAL_PREFIX;
-
-    // Time parameters
-    MIN_ATTESTATION_INCLUSION_DELAY =
-        config.getMinAttestationInclusionDelay() != Integer.MIN_VALUE
-            ? config.getMinAttestationInclusionDelay()
-            : MIN_ATTESTATION_INCLUSION_DELAY;
-    SLOTS_PER_EPOCH =
-        config.getSlotsPerEpoch() != Integer.MIN_VALUE
-            ? config.getSlotsPerEpoch()
-            : SLOTS_PER_EPOCH;
-    MIN_SEED_LOOKAHEAD =
-        config.getMinSeedLookahead() != Integer.MIN_VALUE
-            ? config.getMinSeedLookahead()
-            : MIN_SEED_LOOKAHEAD;
-    ACTIVATION_EXIT_DELAY =
-        config.getActivationExitDelay() != Integer.MIN_VALUE
-            ? config.getActivationExitDelay()
-            : ACTIVATION_EXIT_DELAY;
-    SLOTS_PER_ETH1_VOTING_PERIOD =
-        config.getSlotsPerEth1VotingPeriod() != Integer.MIN_VALUE
-            ? config.getSlotsPerEth1VotingPeriod()
-            : SLOTS_PER_ETH1_VOTING_PERIOD;
-    SLOTS_PER_HISTORICAL_ROOT =
-        config.getSlotsPerHistoricalRoot() != Integer.MIN_VALUE
-            ? config.getSlotsPerHistoricalRoot()
-            : SLOTS_PER_HISTORICAL_ROOT;
-    MIN_VALIDATOR_WITHDRAWABILITY_DELAY =
-        config.getMinValidatorWithdrawabilityDelay() != Integer.MIN_VALUE
-            ? config.getMinValidatorWithdrawabilityDelay()
-            : MIN_VALIDATOR_WITHDRAWABILITY_DELAY;
-    PERSISTENT_COMMITTEE_PERIOD =
-        config.getPersistentCommitteePeriod() != Integer.MIN_VALUE
-            ? config.getPersistentCommitteePeriod()
-            : PERSISTENT_COMMITTEE_PERIOD;
-    MAX_EPOCHS_PER_CROSSLINK =
-        config.getMaxEpochsPerCrosslink() != Integer.MIN_VALUE
-            ? config.getMaxEpochsPerCrosslink()
-            : MAX_EPOCHS_PER_CROSSLINK;
-    MIN_EPOCHS_TO_INACTIVITY_PENALTY =
-        config.getMinEpochsToInactivityPenalty() != Integer.MIN_VALUE
-            ? config.getMinEpochsToInactivityPenalty()
-            : MIN_EPOCHS_TO_INACTIVITY_PENALTY;
-
-    // State list lengths
-    EPOCHS_PER_HISTORICAL_VECTOR =
-        config.getEpochsPerHistoricalVector() != Integer.MIN_VALUE
-            ? config.getEpochsPerHistoricalVector()
-            : EPOCHS_PER_HISTORICAL_VECTOR;
-    EPOCHS_PER_SLASHINGS_VECTOR =
-        config.getEpochsPerSlashingsVector() != Integer.MIN_VALUE
-            ? config.getEpochsPerSlashingsVector()
-            : EPOCHS_PER_SLASHINGS_VECTOR;
-    HISTORICAL_ROOTS_LIMIT =
-        config.getHistoricalRootsLimit() != Integer.MIN_VALUE
-            ? config.getHistoricalRootsLimit()
-            : HISTORICAL_ROOTS_LIMIT;
-    VALIDATOR_REGISTRY_LIMIT =
-        config.getValidatorRegistryLimit() != Long.MIN_VALUE
-            ? config.getValidatorRegistryLimit()
-            : VALIDATOR_REGISTRY_LIMIT;
-    // Rewards and penalties
-    BASE_REWARD_FACTOR =
-        config.getBaseRewardFactor() != Integer.MIN_VALUE
-            ? config.getBaseRewardFactor()
-            : BASE_REWARD_FACTOR;
-    WHISTLEBLOWER_REWARD_QUOTIENT =
-        config.getWhistleblowerRewardQuotient() != Integer.MIN_VALUE
-            ? config.getWhistleblowerRewardQuotient()
-            : WHISTLEBLOWER_REWARD_QUOTIENT;
-    PROPOSER_REWARD_QUOTIENT =
-        config.getProposerRewardQuotient() != Integer.MIN_VALUE
-            ? config.getProposerRewardQuotient()
-            : PROPOSER_REWARD_QUOTIENT;
-    INACTIVITY_PENALTY_QUOTIENT =
-        config.getInactivityPenaltyQuotient() != Integer.MIN_VALUE
-            ? config.getInactivityPenaltyQuotient()
-            : INACTIVITY_PENALTY_QUOTIENT;
-    MIN_SLASHING_PENALTY_QUOTIENT =
-        config.getMinSlashingPenaltyQuotient() != Integer.MIN_VALUE
-            ? config.getMinSlashingPenaltyQuotient()
-            : MIN_SLASHING_PENALTY_QUOTIENT;
-
-    // Max operations per block
-    MAX_PROPOSER_SLASHINGS =
-        config.getMaxProposerSlashings() != Integer.MIN_VALUE
-            ? config.getMaxProposerSlashings()
-            : MAX_PROPOSER_SLASHINGS; // 2^4
-    MAX_ATTESTER_SLASHINGS =
-        config.getMaxAttesterSlashings() != Integer.MIN_VALUE
-            ? config.getMaxAttesterSlashings()
-            : MAX_ATTESTER_SLASHINGS; // 2^0
-    MAX_ATTESTATIONS =
-        config.getMaxAttestations() != Integer.MIN_VALUE
-            ? config.getMaxAttestations()
-            : MAX_ATTESTATIONS; // 2^7
-    MAX_DEPOSITS =
-        config.getMaxDeposits() != Integer.MIN_VALUE
-            ? config.getMaxDeposits()
-            : MAX_DEPOSITS; // 2^4
-    MAX_VOLUNTARY_EXITS =
-        config.getMaxVoluntaryExits() != Integer.MIN_VALUE
-            ? config.getMaxVoluntaryExits()
-            : MAX_VOLUNTARY_EXITS; // 2^4
-    MAX_TRANSFERS =
-        config.getMaxTransfers() != Integer.MIN_VALUE
-            ? config.getMaxTransfers()
-            : MAX_TRANSFERS; // 2^4
-
-    /*
-    // Signature domains
-    DOMAIN_BEACON_PROPOSER =
-            config.getDomainBeaconProposer() != Integer.MIN_VALUE
-                    ? config.getDomainBeaconProposer()
-                    : DOMAIN_BEACON_PROPOSER;
-    DOMAIN_RANDAO =
-            config.getDomainRandao() != Integer.MIN_VALUE ? config.getDomainRandao() : DOMAIN_RANDAO;
-    DOMAIN_ATTESTATION =
-            config.getDomainAttestation() != Integer.MIN_VALUE
-                    ? config.getDomainAttestation()
-                    : DOMAIN_ATTESTATION;
-    DOMAIN_DEPOSIT =
-            config.getDomainDeposit() != Integer.MIN_VALUE ? config.getDomainDeposit() : DOMAIN_DEPOSIT;
-    DOMAIN_VOLUNTARY_EXIT =
-            config.getDomainVoluntaryExit() != Integer.MIN_VALUE
-                    ? config.getDomainVoluntaryExit()
-                    : DOMAIN_VOLUNTARY_EXIT;
-    DOMAIN_TRANSFER =
-            config.getDomainTransfer() != Integer.MIN_VALUE
-                    ? config.getDomainTransfer()
-                    : DOMAIN_TRANSFER;
-    */
-
-    // Artemis specific
-    SIM_DEPOSIT_VALUE =
-        !config.getSimDepositValue().equals("") ? config.getSimDepositValue() : SIM_DEPOSIT_VALUE;
-    DEPOSIT_DATA_SIZE =
-        config.getDepositDataSize() != Integer.MIN_VALUE
-            ? config.getDepositDataSize()
-            : DEPOSIT_DATA_SIZE;
-    SECONDS_PER_SLOT =
-        config.getSecondsPerSlot() != Integer.MIN_VALUE
-            ? config.getSecondsPerSlot()
-            : SECONDS_PER_SLOT; // 6 seconds
-  }
-
   @SuppressWarnings("rawtypes")
-  public static void init(Map config) {
-    SHARD_COUNT = (int) config.get("SHARD_COUNT");
-    TARGET_COMMITTEE_SIZE = (int) config.get("TARGET_COMMITTEE_SIZE");
-    MAX_VALIDATORS_PER_COMMITTEE = (int) config.get("MAX_VALIDATORS_PER_COMMITTEE");
-    MIN_PER_EPOCH_CHURN_LIMIT = (int) config.get("MIN_PER_EPOCH_CHURN_LIMIT");
-    CHURN_LIMIT_QUOTIENT = (int) config.get("CHURN_LIMIT_QUOTIENT");
-    SHUFFLE_ROUND_COUNT = (int) config.get("SHUFFLE_ROUND_COUNT");
-    MIN_GENESIS_ACTIVE_VALIDATOR_COUNT = (int) config.get("MIN_GENESIS_ACTIVE_VALIDATOR_COUNT");
-    MIN_GENESIS_TIME = UnsignedLong.valueOf(config.get("MIN_GENESIS_TIME").toString());
-    DEPOSIT_CONTRACT_ADDRESS =
-        Bytes.fromHexString(config.get("DEPOSIT_CONTRACT_ADDRESS").toString());
-    MIN_DEPOSIT_AMOUNT = ((Integer) config.get("MIN_DEPOSIT_AMOUNT")).longValue();
-    MAX_EFFECTIVE_BALANCE = (long) config.get("MAX_EFFECTIVE_BALANCE");
-    EJECTION_BALANCE = (long) config.get("EJECTION_BALANCE");
-    EFFECTIVE_BALANCE_INCREMENT = ((Integer) config.get("EFFECTIVE_BALANCE_INCREMENT")).longValue();
-    GENESIS_SLOT = ((Integer) config.get("GENESIS_SLOT")).longValue();
-    BLS_WITHDRAWAL_PREFIX = Bytes.fromHexString(config.get("BLS_WITHDRAWAL_PREFIX").toString());
-    SECONDS_PER_SLOT = (int) config.get("SECONDS_PER_SLOT");
-    MIN_ATTESTATION_INCLUSION_DELAY = (int) config.get("MIN_ATTESTATION_INCLUSION_DELAY");
-    SLOTS_PER_EPOCH = (int) config.get("SLOTS_PER_EPOCH");
-    MIN_SEED_LOOKAHEAD = (int) config.get("MIN_SEED_LOOKAHEAD");
-    ACTIVATION_EXIT_DELAY = (int) config.get("ACTIVATION_EXIT_DELAY");
-    SLOTS_PER_ETH1_VOTING_PERIOD = (int) config.get("SLOTS_PER_ETH1_VOTING_PERIOD");
-    SLOTS_PER_HISTORICAL_ROOT = (int) config.get("SLOTS_PER_HISTORICAL_ROOT");
-    MIN_VALIDATOR_WITHDRAWABILITY_DELAY = (int) config.get("MIN_VALIDATOR_WITHDRAWABILITY_DELAY");
-    PERSISTENT_COMMITTEE_PERIOD = (int) config.get("PERSISTENT_COMMITTEE_PERIOD");
-    MAX_EPOCHS_PER_CROSSLINK = (int) config.get("MAX_EPOCHS_PER_CROSSLINK");
-    MIN_EPOCHS_TO_INACTIVITY_PENALTY = (int) config.get("MIN_EPOCHS_TO_INACTIVITY_PENALTY");
-    EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS =
-        (int) config.get("EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS");
-    EPOCHS_PER_HISTORICAL_VECTOR = (int) config.get("EPOCHS_PER_HISTORICAL_VECTOR");
-    EPOCHS_PER_SLASHINGS_VECTOR = (int) config.get("EPOCHS_PER_SLASHINGS_VECTOR");
-    HISTORICAL_ROOTS_LIMIT = (int) config.get("HISTORICAL_ROOTS_LIMIT");
-    VALIDATOR_REGISTRY_LIMIT = (long) config.get("VALIDATOR_REGISTRY_LIMIT");
-    BASE_REWARD_FACTOR = (int) config.get("BASE_REWARD_FACTOR");
-    WHISTLEBLOWER_REWARD_QUOTIENT = (int) config.get("WHISTLEBLOWER_REWARD_QUOTIENT");
-    PROPOSER_REWARD_QUOTIENT = (int) config.get("PROPOSER_REWARD_QUOTIENT");
-    INACTIVITY_PENALTY_QUOTIENT = (int) config.get("INACTIVITY_PENALTY_QUOTIENT");
-    MIN_SLASHING_PENALTY_QUOTIENT = (int) config.get("MIN_SLASHING_PENALTY_QUOTIENT");
-    MAX_PROPOSER_SLASHINGS = (int) config.get("MAX_PROPOSER_SLASHINGS");
-    MAX_ATTESTER_SLASHINGS = (int) config.get("MAX_ATTESTER_SLASHINGS");
-    MAX_ATTESTATIONS = (int) config.get("MAX_ATTESTATIONS");
-    MAX_DEPOSITS = (int) config.get("MAX_DEPOSITS");
-    MAX_VOLUNTARY_EXITS = (int) config.get("MAX_VOLUNTARY_EXITS");
-    MAX_TRANSFERS = (int) config.get("MAX_TRANSFERS");
-    DOMAIN_BEACON_PROPOSER =
-        new Bytes4(Bytes.fromHexString(config.get("DOMAIN_BEACON_PROPOSER").toString()));
-    DOMAIN_RANDAO = new Bytes4(Bytes.fromHexString(config.get("DOMAIN_RANDAO").toString()));
-    DOMAIN_ATTESTATION =
-        new Bytes4(Bytes.fromHexString(config.get("DOMAIN_ATTESTATION").toString()));
-    DOMAIN_DEPOSIT = new Bytes4(Bytes.fromHexString(config.get("DOMAIN_DEPOSIT").toString()));
-    DOMAIN_VOLUNTARY_EXIT =
-        new Bytes4(Bytes.fromHexString(config.get("DOMAIN_VOLUNTARY_EXIT").toString()));
-    DOMAIN_TRANSFER = new Bytes4(Bytes.fromHexString(config.get("DOMAIN_TRANSFER").toString()));
-    DOMAIN_CUSTODY_BIT_CHALLENGE =
-        Bytes.fromHexString(config.get("DOMAIN_CUSTODY_BIT_CHALLENGE").toString());
-    DOMAIN_SHARD_PROPOSER = Bytes.fromHexString(config.get("DOMAIN_SHARD_PROPOSER").toString());
-    DOMAIN_SHARD_ATTESTER = Bytes.fromHexString(config.get("DOMAIN_SHARD_ATTESTER").toString());
+  public static void setConstants(String Constants) {
+    if (Constants.equals("mainnet")) {
+
+      // Mainnet settings
+
+      // Misc
+      SHARD_COUNT = 1024;
+      TARGET_COMMITTEE_SIZE = 128;
+      MAX_VALIDATORS_PER_COMMITTEE = 4096;
+      MIN_PER_EPOCH_CHURN_LIMIT = 4;
+      CHURN_LIMIT_QUOTIENT = 65536;
+      SHUFFLE_ROUND_COUNT = 90;
+      MIN_GENESIS_ACTIVE_VALIDATOR_COUNT = 65536;
+      MIN_GENESIS_TIME = UnsignedLong.valueOf(1567222226);
+
+      // Gwei values
+      MIN_DEPOSIT_AMOUNT = 1000000000L;
+      MAX_EFFECTIVE_BALANCE = 32000000000L;
+      EJECTION_BALANCE = 16000000000L;
+      EFFECTIVE_BALANCE_INCREMENT = 1000000000L;
+
+      // Initial values
+      GENESIS_SLOT = 0;
+      GENESIS_EPOCH = 0;
+      BLS_WITHDRAWAL_PREFIX = Bytes.wrap(new byte[1]);
+
+      // Time parameters
+      MIN_ATTESTATION_INCLUSION_DELAY = 1;
+      SLOTS_PER_EPOCH = 64;
+      MIN_SEED_LOOKAHEAD = 1;
+      ACTIVATION_EXIT_DELAY = 4;
+      SLOTS_PER_ETH1_VOTING_PERIOD = 1024;
+      SLOTS_PER_HISTORICAL_ROOT = 8192;
+      MIN_VALIDATOR_WITHDRAWABILITY_DELAY = 256;
+      PERSISTENT_COMMITTEE_PERIOD = 2048;
+      MAX_EPOCHS_PER_CROSSLINK = 64;
+      MIN_EPOCHS_TO_INACTIVITY_PENALTY = 4;
+
+      // State list lengths
+      EPOCHS_PER_HISTORICAL_VECTOR = 65536;
+      EPOCHS_PER_SLASHINGS_VECTOR = 8192;
+      HISTORICAL_ROOTS_LIMIT = 16777216;
+      VALIDATOR_REGISTRY_LIMIT = 1099511627776L;
+
+      // Reward and penalty quotients
+      BASE_REWARD_FACTOR = 64;
+      WHISTLEBLOWER_REWARD_QUOTIENT = 512;
+      PROPOSER_REWARD_QUOTIENT = 8;
+      INACTIVITY_PENALTY_QUOTIENT = 33554432;
+      MIN_SLASHING_PENALTY_QUOTIENT = 32;
+
+      // Max transactions per block
+      MAX_PROPOSER_SLASHINGS = 16;
+      MAX_ATTESTER_SLASHINGS = 1;
+      MAX_ATTESTATIONS = 128;
+      MAX_DEPOSITS = 16;
+      MAX_VOLUNTARY_EXITS = 16;
+      MAX_TRANSFERS = 0;
+
+    } else {
+
+      // Minimal settings
+
+      // Misc
+      SHARD_COUNT = 8;
+      TARGET_COMMITTEE_SIZE = 4;
+      MAX_VALIDATORS_PER_COMMITTEE = 4096;
+      MIN_PER_EPOCH_CHURN_LIMIT = 4;
+      CHURN_LIMIT_QUOTIENT = 65536;
+      SHUFFLE_ROUND_COUNT = 10;
+      MIN_GENESIS_ACTIVE_VALIDATOR_COUNT = 64;
+      MIN_GENESIS_TIME = UnsignedLong.valueOf(1578009600);
+
+      // Gwei values
+      MIN_DEPOSIT_AMOUNT = 1000000000L;
+      MAX_EFFECTIVE_BALANCE = 32000000000L;
+      EJECTION_BALANCE = 16000000000L;
+      EFFECTIVE_BALANCE_INCREMENT = 1000000000L;
+
+      // Initial values
+      GENESIS_SLOT = 0;
+      GENESIS_EPOCH = 0;
+      BLS_WITHDRAWAL_PREFIX = Bytes.wrap(new byte[1]);
+
+      // Time parameters
+      MIN_ATTESTATION_INCLUSION_DELAY = 1;
+      SLOTS_PER_EPOCH = 8;
+      MIN_SEED_LOOKAHEAD = 1;
+      ACTIVATION_EXIT_DELAY = 4;
+      SLOTS_PER_ETH1_VOTING_PERIOD = 16;
+      SLOTS_PER_HISTORICAL_ROOT = 64;
+      MIN_VALIDATOR_WITHDRAWABILITY_DELAY = 256;
+      PERSISTENT_COMMITTEE_PERIOD = 2048;
+      MAX_EPOCHS_PER_CROSSLINK = 4;
+      MIN_EPOCHS_TO_INACTIVITY_PENALTY = 4;
+
+      // State list lengths
+      EPOCHS_PER_HISTORICAL_VECTOR = 64;
+      EPOCHS_PER_SLASHINGS_VECTOR = 64;
+      HISTORICAL_ROOTS_LIMIT = 16777216;
+      VALIDATOR_REGISTRY_LIMIT = 1099511627776L;
+
+      // Reward and penalty quotients
+      BASE_REWARD_FACTOR = 64;
+      WHISTLEBLOWER_REWARD_QUOTIENT = 512;
+      PROPOSER_REWARD_QUOTIENT = 8;
+      INACTIVITY_PENALTY_QUOTIENT = 33554432;
+      MIN_SLASHING_PENALTY_QUOTIENT = 32;
+
+      // Max transactions per block
+      MAX_PROPOSER_SLASHINGS = 16;
+      MAX_ATTESTER_SLASHINGS = 1;
+      MAX_ATTESTATIONS = 128;
+      MAX_DEPOSITS = 16;
+      MAX_VOLUNTARY_EXITS = 16;
+      MAX_TRANSFERS = 0;
+
+    }
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/Constants.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/Constants.java
@@ -113,10 +113,14 @@ public class Constants {
   public static Bytes DOMAIN_CUSTODY_BIT_CHALLENGE;
   public static Bytes DOMAIN_SHARD_PROPOSER;
   public static Bytes DOMAIN_SHARD_ATTESTER;
-  public static int EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS = 4096;
+  public static int EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS;
 
   public static BLSSignature EMPTY_SIGNATURE = BLSSignature.empty();
   public static UnsignedLong BYTES_PER_LENGTH_OFFSET = UnsignedLong.valueOf(4L);
+
+  static {
+    setConstants("minimal");
+  }
 
   @SuppressWarnings("rawtypes")
   public static void setConstants(String Constants) {
@@ -156,6 +160,7 @@ public class Constants {
       PERSISTENT_COMMITTEE_PERIOD = 2048;
       MAX_EPOCHS_PER_CROSSLINK = 64;
       MIN_EPOCHS_TO_INACTIVITY_PENALTY = 4;
+      EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS = 16384;
 
       // State list lengths
       EPOCHS_PER_HISTORICAL_VECTOR = 65536;
@@ -214,6 +219,7 @@ public class Constants {
       PERSISTENT_COMMITTEE_PERIOD = 2048;
       MAX_EPOCHS_PER_CROSSLINK = 4;
       MIN_EPOCHS_TO_INACTIVITY_PENALTY = 4;
+      EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS = 4096;
 
       // State list lengths
       EPOCHS_PER_HISTORICAL_VECTOR = 64;

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockBodyTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockBodyTest.java
@@ -239,11 +239,4 @@ class BeaconBlockBodyTest {
 
     assertNotEquals(beaconBlockBody, testBeaconBlockBody);
   }
-
-  @Test
-  void roundtripSSZ() {
-    // todo
-    // Bytes sszBeaconBlockBodyBytes = beaconBlockBody.toBytes();
-    // assertEquals(beaconBlockBody, BeaconBlockBody.fromBytes(sszBeaconBlockBodyBytes));
-  }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/MockStartBeaconStateGeneratorTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/MockStartBeaconStateGeneratorTest.java
@@ -164,11 +164,7 @@ class MockStartBeaconStateGeneratorTest {
   @Disabled
   @SuppressWarnings({"rawtypes"})
   public void printBeaconState() throws Exception {
-    Map config =
-        (Map)
-            fileToObject(
-                "https://media.githubusercontent.com/media/ethereum/eth2.0-spec-tests/v0.8.2/tests/minimal/config.yaml");
-    Constants.init(config);
+    Constants.setConstants("minimal");
 
     final UnsignedLong genesisTime = UnsignedLong.valueOf(1567719788L);
     final int validatorCount = 16;

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
@@ -79,6 +79,7 @@ public class ArtemisConfiguration {
     builder.addListOfString("node.peers", Collections.emptyList(), "Static peers", null);
     builder.addLong(
         "node.networkID", 1L, "The identifier of the network (mainnet, testnet, sidechain)", null);
+    builder.addString("node.constants", "minimal", "Determines whether to use minimal or mainnet constants", null);
 
     // Interop
     builder.addBoolean("interop.active", false, "Enable interop mode", null);
@@ -117,75 +118,6 @@ public class ArtemisConfiguration {
         "",
         "Directory to record transition pre and post states",
         null);
-
-    // Constants
-    // Misc
-    builder.addInteger("constants.SHARD_COUNT", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.TARGET_COMMITTEE_SIZE", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.MAX_VALIDATORS_PER_COMMITTEE", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.MIN_PER_EPOCH_CHURN_LIMIT", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.CHURN_LIMIT_QUOTIENT", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.SHUFFLE_ROUND_COUNT", Integer.MIN_VALUE, null, null);
-    builder.addInteger(
-        "constants.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.MIN_GENESIS_TIME", Integer.MIN_VALUE, null, null);
-
-    // Gwei values
-    builder.addLong("constants.MIN_DEPOSIT_AMOUNT", Long.MIN_VALUE, null, null);
-    builder.addLong("constants.MAX_EFFECTIVE_BALANCE", Long.MIN_VALUE, null, null);
-    builder.addLong("constants.EJECTION_BALANCE", Long.MIN_VALUE, null, null);
-    builder.addLong("constants.EFFECTIVE_BALANCE_INCREMENT", Long.MIN_VALUE, null, null);
-
-    // Deposit Contract
-    builder.addString("constants.DEPOSIT_CONTRACT_ADDRESS", "", null, null);
-
-    // Initial Values
-    builder.addLong("constants.GENESIS_SLOT", Long.MIN_VALUE, null, null);
-    builder.addLong("constants.GENESIS_EPOCH", Long.MIN_VALUE, null, null);
-    builder.addString("constants.BLS_WITHDRAWAL_PREFIX", "", null, null);
-
-    // Time parameters
-    builder.addInteger("constants.SECONDS_PER_SLOT", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.MIN_ATTESTATION_INCLUSION_DELAY", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.SLOTS_PER_EPOCH", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.MIN_SEED_LOOKAHEAD", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.ACTIVATION_EXIT_DELAY", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.SLOTS_PER_ETH1_VOTING_PERIOD", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.SLOTS_PER_HISTORICAL_ROOT", Integer.MIN_VALUE, null, null);
-    builder.addInteger(
-        "constants.MIN_VALIDATOR_WITHDRAWABILITY_DELAY", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.PERSISTENT_COMMITTEE_PERIOD", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.MAX_EPOCHS_PER_CROSSLINK", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.MIN_EPOCHS_TO_INACTIVITY_PENALTY", Integer.MIN_VALUE, null, null);
-
-    // State list lengths
-    builder.addInteger("constants.EPOCHS_PER_HISTORICAL_VECTOR", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.EPOCHS_PER_SLASHINGS_VECTOR", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.HISTORICAL_ROOTS_LIMIT", Integer.MIN_VALUE, null, null);
-    builder.addLong("constants.VALIDATOR_REGISTRY_LIMIT", Long.MIN_VALUE, null, null);
-
-    // Reward and penalty quotients
-    builder.addInteger("constants.BASE_REWARD_FACTOR", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.WHISTLEBLOWER_REWARD_QUOTIENT", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.PROPOSER_REWARD_QUOTIENT", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.INACTIVITY_PENALTY_QUOTIENT", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.MIN_SLASHING_PENALTY_QUOTIENT", Integer.MIN_VALUE, null, null);
-
-    // Max transactions per block
-    builder.addInteger("constants.MAX_PROPOSER_SLASHINGS", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.MAX_ATTESTER_SLASHINGS", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.MAX_ATTESTATIONS", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.MAX_DEPOSITS", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.MAX_VOLUNTARY_EXITS", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.MAX_TRANSFERS", Integer.MIN_VALUE, null, null);
-
-    // Signature domains
-    builder.addInteger("constants.DOMAIN_BEACON_PROPOSER", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.DOMAIN_RANDAO", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.DOMAIN_ATTESTATION", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.DOMAIN_DEPOSIT", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.DOMAIN_VOLUNTARY_EXIT", Integer.MIN_VALUE, null, null);
-    builder.addInteger("constants.DOMAIN_TRANSFER", Integer.MIN_VALUE, null, null);
 
     // Artemis specific
     builder.addString("constants.SIM_DEPOSIT_VALUE", "", null, null);
@@ -281,6 +213,10 @@ public class ArtemisConfiguration {
     return config.getString("node.networkInterface");
   }
 
+  public String getConstants() {
+    return config.getString("node.constants");
+  }
+
   /** @return the total number of validators in the network */
   public int getNumValidators() {
     return config.getInteger("deposit.numValidators");
@@ -367,215 +303,8 @@ public class ArtemisConfiguration {
     return config.getString("output.transitionRecordDir");
   }
 
-  /** @return misc constants */
-  public int getShardCount() {
-    return config.getInteger("constants.SHARD_COUNT");
-  }
-
-  public int getTargetCommitteeSize() {
-    return config.getInteger("constants.TARGET_COMMITTEE_SIZE");
-  }
-
-  public int getMaxValidatorsPerCommittee() {
-    return config.getInteger("constants.MAX_VALIDATORS_PER_COMMITTEE");
-  }
-
-  public int getMinPerEpochChurnLimit() {
-    return config.getInteger("constants.MIN_PER_EPOCH_CHURN_LIMIT");
-  }
-
-  public int getChurnLimitQuotient() {
-    return config.getInteger("constants.CHURN_LIMIT_QUOTIENT");
-  }
-
-  public int getShuffleRoundCount() {
-    return config.getInteger("constants.SHUFFLE_ROUND_COUNT");
-  }
-
-  public int getMinGenesisActiveValidatorCount() {
-    return config.getInteger("constants.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT");
-  }
-
-  public long getMinGenesisTime() {
-    return config.getLong("constants.MIN_GENESIS_TIME");
-  }
-
-  /** @return deposit contract constants */
-  public String getDepositContractAddress() {
-    return config.getString("constants.DEPOSIT_CONTRACT_ADDRESS");
-  }
-
-  /** @return gwei value constants */
-  public long getMinDepositAmount() {
-    return config.getLong("constants.MIN_DEPOSIT_AMOUNT");
-  }
-
-  public long getMaxEffectiveBalance() {
-    return config.getLong("constants.MAX_EFFECTIVE_BALANCE");
-  }
-
-  public long getEffectiveBalanceIncrement() {
-    return config.getLong("constants.EFFECTIVE_BALANCE_INCREMENT");
-  }
-
-  public long getEjectionBalance() {
-    return config.getLong("constants.EJECTION_BALANCE");
-  }
-
-  public long getGenesisSlot() {
-    return config.getLong("constants.GENESIS_SLOT");
-  }
-
-  public long getGenesisEpoch() {
-    return config.getLong("constants.GENESIS_EPOCH");
-  }
-
-  public String getBlsWithdrawalPrefix() {
-    return config.getString("constants.BLS_WITHDRAWAL_PREFIX");
-  }
-
-  /** @return time parameter constants */
-  public int getSecondsPerSlot() {
-    return config.getInteger("constants.SECONDS_PER_SLOT");
-  }
-
-  public int getMinAttestationInclusionDelay() {
-    return config.getInteger("constants.MIN_ATTESTATION_INCLUSION_DELAY");
-  }
-
-  public int getSlotsPerEpoch() {
-    return config.getInteger("constants.SLOTS_PER_EPOCH");
-  }
-
-  public int getMinSeedLookahead() {
-    return config.getInteger("constants.MIN_SEED_LOOKAHEAD");
-  }
-
-  public int getActivationExitDelay() {
-    return config.getInteger("constants.ACTIVATION_EXIT_DELAY");
-  }
-
-  public int getSlotsPerEth1VotingPeriod() {
-    return config.getInteger("constants.SLOTS_PER_ETH1_VOTING_PERIOD");
-  }
-
-  public int getSlotsPerHistoricalRoot() {
-    return config.getInteger("constants.SLOTS_PER_HISTORICAL_ROOT");
-  }
-
-  public int getMinValidatorWithdrawabilityDelay() {
-    return config.getInteger("constants.MIN_VALIDATOR_WITHDRAWABILITY_DELAY");
-  }
-
-  public int getPersistentCommitteePeriod() {
-    return config.getInteger("constants.PERSISTENT_COMMITTEE_PERIOD");
-  }
-
-  public int getMaxEpochsPerCrosslink() {
-    return config.getInteger("constants.MAX_EPOCHS_PER_CROSSLINK");
-  }
-
-  public int getMinEpochsToInactivityPenalty() {
-    return config.getInteger("constants.MIN_EPOCHS_TO_INACTIVITY_PENALTY");
-  }
-
-  /** @return state list length constants */
-  public int getEpochsPerHistoricalVector() {
-    return config.getInteger("constants.EPOCHS_PER_HISTORICAL_VECTOR");
-  }
-
-  public int getEpochsPerSlashingsVector() {
-    return config.getInteger("constants.EPOCHS_PER_SLASHINGS_VECTOR");
-  }
-
-  public int getHistoricalRootsLimit() {
-    return config.getInteger("constants.HISTORICAL_ROOTS_LIMIT");
-  }
-
-  public long getValidatorRegistryLimit() {
-    return config.getLong("constants.VALIDATOR_REGISTRY_LIMIT");
-  }
-
-  /** @return reward and penalty quotient constants */
-  public int getBaseRewardFactor() {
-    return config.getInteger("constants.BASE_REWARD_FACTOR");
-  }
-
-  public int getWhistleblowerRewardQuotient() {
-    return config.getInteger("constants.WHISTLEBLOWER_REWARD_QUOTIENT");
-  }
-
-  public int getProposerRewardQuotient() {
-    return config.getInteger("constants.PROPOSER_REWARD_QUOTIENT");
-  }
-
-  public int getInactivityPenaltyQuotient() {
-    return config.getInteger("constants.INACTIVITY_PENALTY_QUOTIENT");
-  }
-
-  public int getMinSlashingPenaltyQuotient() {
-    return config.getInteger("constants.MIN_SLASHING_PENALTY_QUOTIENT");
-  }
-
-  /** @return max transactions per block constants */
-  public int getMaxProposerSlashings() {
-    return config.getInteger("constants.MAX_PROPOSER_SLASHINGS");
-  }
-
-  public int getMaxAttesterSlashings() {
-    return config.getInteger("constants.MAX_ATTESTER_SLASHINGS");
-  }
-
-  public int getMaxAttestations() {
-    return config.getInteger("constants.MAX_ATTESTATIONS");
-  }
-
-  public int getMaxDeposits() {
-    return config.getInteger("constants.MAX_DEPOSITS");
-  }
-
-  public int getMaxVoluntaryExits() {
-    return config.getInteger("constants.MAX_VOLUNTARY_EXITS");
-  }
-
-  public int getMaxTransfers() {
-    return config.getInteger("constants.MAX_TRANSFERS");
-  }
-
-  /** @return signature domain constants */
-  public int getDomainBeaconProposer() {
-    return config.getInteger("constants.DOMAIN_BEACON_PROPOSER");
-  }
-
-  public int getDomainRandao() {
-    return config.getInteger("constants.DOMAIN_RANDAO");
-  }
-
-  public int getDomainAttestation() {
-    return config.getInteger("constants.DOMAIN_ATTESTATION");
-  }
-
-  public int getDomainDeposit() {
-    return config.getInteger("constants.DOMAIN_DEPOSIT");
-  }
-
-  public int getDomainVoluntaryExit() {
-    return config.getInteger("constants.DOMAIN_VOLUNTARY_EXIT");
-  }
-
-  public int getDomainTransfer() {
-    return config.getInteger("constants.DOMAIN_TRANSFER");
-  }
 
   /** @return Artemis specific constants */
-  public String getSimDepositValue() {
-    return config.getString("constants.SIM_DEPOSIT_VALUE");
-  }
-
-  public int getDepositDataSize() {
-    return config.getInteger("constants.DEPOSIT_DATA_SIZE");
-  }
-
   public List<String> getStaticPeers() {
     return config.getListOfString("node.peers");
   }

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
@@ -79,7 +79,11 @@ public class ArtemisConfiguration {
     builder.addListOfString("node.peers", Collections.emptyList(), "Static peers", null);
     builder.addLong(
         "node.networkID", 1L, "The identifier of the network (mainnet, testnet, sidechain)", null);
-    builder.addString("node.constants", "minimal", "Determines whether to use minimal or mainnet constants", null);
+    builder.addString(
+        "node.constants",
+        "minimal",
+        "Determines whether to use minimal or mainnet constants",
+        null);
 
     // Interop
     builder.addBoolean("interop.active", false, "Enable interop mode", null);
@@ -302,7 +306,6 @@ public class ArtemisConfiguration {
   public String getTransitionRecordDir() {
     return config.getString("output.transitionRecordDir");
   }
-
 
   /** @return Artemis specific constants */
   public List<String> getStaticPeers() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
This PR refactors constants so that there is only one function we use to set our constants. Removes unnecessary loading of minimal constants from config.toml.

