### PR TITLE
Guava `EventBus` exception handling fix (#850)

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
@@ -117,11 +117,11 @@ final class EventBusExceptionHandler implements SubscriberExceptionHandler {
     logger.log(Level.WARN, specFailedMessage(exception, context));
   }
 
-  private boolean isSpecFailure(final Throwable exception) {
+  private static boolean isSpecFailure(final Throwable exception) {
     return exception instanceof IllegalArgumentException;
   }
 
-  private String specFailedMessage(
+  private static String specFailedMessage(
       final Throwable exception, final SubscriberExceptionContext context) {
     return "Spec failed"
         + " for event '"

--- a/artemis/src/test/java/tech/pegasys/artemis/EventBusExceptionHandlerTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/EventBusExceptionHandlerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.eventbus.AsyncEventBus;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import com.google.common.eventbus.SubscriberExceptionContext;
+import com.google.common.eventbus.SubscriberExceptionHandler;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.logging.log4j.Level;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.util.alogger.ALogger;
+
+class EventBusExceptionHandlerTest {
+
+  private static ExecutorService executor;
+
+  private EventBus bus;
+
+  private final CompletableFuture<Level> logLevelFuture = new CompletableFuture<>();
+  private final CompletableFuture<Throwable> exceptionFuture = new CompletableFuture<>();
+
+  @BeforeAll
+  static void setupExecutor() {
+    executor = Executors.newCachedThreadPool();
+  }
+
+  @AfterAll
+  static void closeExecutor() {
+    executor.shutdown();
+  }
+
+  @BeforeEach
+  void setupBus() {
+
+    final var recordingLogger =
+        new ALogger() {
+          @Override
+          public void log(final Level level, final String message) {
+            logLevelFuture.complete(level);
+          }
+        };
+
+    final var exceptionHandlerRecordingWrapper =
+        new SubscriberExceptionHandler() {
+          private final SubscriberExceptionHandler delegate =
+              new EventBusExceptionHandler(recordingLogger);
+
+          @Override
+          public void handleException(
+              final Throwable exception, final SubscriberExceptionContext context) {
+            try {
+              delegate.handleException(exception, context);
+            } catch (final RuntimeException thrown) {
+              exceptionFuture.complete(thrown);
+              throw thrown;
+            }
+          }
+        };
+
+    bus = new AsyncEventBus(executor, exceptionHandlerRecordingWrapper);
+  }
+
+  @Test
+  void logWarningIfAssertFails() throws ExecutionException, InterruptedException {
+    bus.register(
+        new Object() {
+          @Subscribe
+          void onString(final String test) {
+            checkArgument("other".equals(test), "Assertion failed");
+          }
+        });
+    bus.post("test");
+
+    assertEquals(Level.WARN, logLevelFuture.get());
+    assertFalse(exceptionFuture.isDone());
+  }
+
+  @Test
+  void logFatalAndRethrowIfNonAssertExceptionThrown()
+      throws ExecutionException, InterruptedException {
+    bus.register(
+        new Object() {
+          @Subscribe
+          void onString(String test) {
+            throw new RuntimeException("test");
+          }
+        });
+    bus.post("test");
+
+    assertEquals(Level.FATAL, logLevelFuture.get());
+
+    var exception = exceptionFuture.get();
+    assertTrue(exception instanceof RuntimeException);
+    assertTrue(exception.getCause() instanceof RuntimeException);
+  }
+}


### PR DESCRIPTION
## PR Description

The rationale behind this fix proposal is the following:

* Guava's `EventBus` and exceptions in handlers can't really be "bubbled up" because they are thrown in an executor thread and so they should always be somehow handled; I guess that's why `EventBus` doesn't even let custom exception handlers re-throw them (the second answer in that SO thread highlights this behavior).
* On the other hand: is it true in general (or at least commonly) that the correct behavior for an Artemis handler, when it encounters a spec violation, is just to abort and log an error (without stack trace)?
* Assuming that the answer is yes, something like the exception handler proposed here could make sense (possibly with some integrations to `isSpecFailure`).
* If that's not the case though, each and every handler should specifically handle assert failures locally.

## Fixed Issue(s)

Fixes #850
