### PR TITLE
Add CircleCI Build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,17 @@ jobs:
             ./gradlew --no-daemon --parallel test
       - capture_test_results
 
-
+  javadoc:
+    executor: medium_executor
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: JavaDoc
+          no_output_timeout: 20m
+          command: |
+            ./gradlew --no-daemon --parallel javadoc
 
   docker:
     executor: medium_executor
@@ -107,6 +117,16 @@ jobs:
           command: |
             ./gradlew --no-daemon --parallel distDockerWhiteblock
 
+  publish:
+    executor: medium_executor
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Publish
+          command: |
+            echo "Not really publishing at this stage."
 
 workflows:
   version: 2
@@ -122,4 +142,10 @@ workflows:
       - docker:
           requires:
             - unitTests
+      - javadoc
+      - publish:
+          requires:
+            - unitTests
             - referenceTests
+            - docker
+            - javadoc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,10 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run:
-          name: Build
+          name: UnitTests
           no_output_timeout: 20m
           command: |
-            ./gradlew --no-daemon --parallel build -x :eth-reference-tests:test
+            ./gradlew --no-daemon --parallel test -x :eth-reference-tests:test
 
   referenceTests:
     executor: medium_executor
@@ -63,6 +63,11 @@ jobs:
           name: FetchReferenceTests
           command: |
             ./scripts/get-ref-tests.sh
+      - save_cache:
+          name: Caching gradle dependencies
+          key: deps-{{ checksum "scripts/get-ref-tests" }}-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - eth2.0-spec-tests/tests
       - run:
           name: ReferenceTests
           // TODO: Skip non-reference tests here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
           command: |
             ls /home/circleci/project/build/refTests/v0.8.3/general.tar.gz || true
             pwd
-            ./gradlew expandRefTests
+            ./gradlew --no-daemon --no-parallel expandRefTests
       - run:
           name: ReferenceTests
           // TODO: Skip non-reference tests here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,17 +84,11 @@ jobs:
           keys:
             - reftests-{{ checksum "build.gradle" }}
       - run:
-          name: Debug
-          command: |
-            ls /home/circleci/project/build/refTests/v0.8.3/general.tar.gz || true
-            ls -R /home/circleci/project/build/refTests || true
-            ls /home/circleci/project/eth-reference-tests/src/test/resources/eth2.0-spec-tests/tests/ || true
-      - run:
           name: FetchReferenceTests
           command: |
             ls /home/circleci/project/build/refTests/v0.8.3/general.tar.gz || true
             pwd
-            ./gradlew --no-daemon --no-parallel expandRefTests
+            ./gradlew --no-daemon --no-parallel --debug expandRefTests
       - run:
           name: ReferenceTests
           // TODO: Skip non-reference tests here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ executors:
     resource_class: medium
     working_directory: ~/project
     environment:
-      JAVA_TOOL_OPTIONS: -Xmx3g
-      _JAVA_OPTIONS: -Xmx3g
+      JAVA_TOOL_OPTIONS: -Xmx2g
+      _JAVA_OPTIONS: -Xmx2g
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+#                - master
                 - /^release-.*/
           requires:
             - unitTests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ executors:
   medium_executor:
     docker:
       - image: circleci/openjdk:11.0.4-jdk-stretch
-      resource_class: medium
-      working_directory: ~/project
-      environment:
-        JAVA_TOOL_OPTIONS: -Xmx2g
-        GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
+    resource_class: medium
+    working_directory: ~/project
+    environment:
+      JAVA_TOOL_OPTIONS: -Xmx2g
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
 
 commands:
   prepare:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,18 +109,6 @@ jobs:
             - eth-reference-tests/src/test/resources/eth2.0-spec-tests/
       - capture_test_results
 
-  javadoc:
-    executor: medium_executor
-    steps:
-      - prepare
-      - attach_workspace:
-          at: ~/project
-      - run:
-          name: JavaDoc
-          no_output_timeout: 20m
-          command: |
-            ./gradlew --no-daemon --parallel javadoc
-
   docker:
     executor: medium_executor
     steps:
@@ -164,17 +152,13 @@ workflows:
           requires:
             - assemble
             - unitTests
-#      - javadoc:
-#          requires:
-#            - assemble
       - publish:
           filters:
             branches:
               only:
-#                - master
+                - master
                 - /^release-.*/
           requires:
             - unitTests
             - referenceTests
             - docker
-#            - javadoc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ executors:
     resource_class: medium
     working_directory: ~/project
     environment:
-      JAVA_TOOL_OPTIONS: -Xmx2g
-      _JAVA_OPTIONS: -Xmx2g
+      JAVA_TOOL_OPTIONS: -Xmx3g
+      _JAVA_OPTIONS: -Xmx3g
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
 
 commands:
@@ -137,17 +137,17 @@ jobs:
       - run:
           name: Publish
           command: |
-            echo "Not really publishing at this stage."
+            ./gradlew --no-daemon --prallel bintrayUpload
 
 workflows:
   version: 2
   standard_build:
     jobs:
       - assemble
-      - unitTests:
+      - referenceTests:
           requires:
             - assemble
-      - referenceTests:
+      - unitTests:
           requires:
             - assemble
       - docker:
@@ -158,6 +158,11 @@ workflows:
 #          requires:
 #            - assemble
       - publish:
+          filters:
+            branches:
+              only:
+#                - master
+                - /^release-.*/
           requires:
             - unitTests
             - referenceTests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ jobs:
           paths:
             - build/refTests
             - eth-reference-tests/src/test/resources/eth2.0-spec-tests/
+            - .gradle
       - capture_test_results
 
   javadoc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,106 @@
+version: 2.1
+executors:
+  medium_executor:
+    docker:
+      - image: circleci/openjdk:11.0.4-jdk-stretch
+      resource_class: medium
+      working_directory: ~/project
+      environment:
+        JAVA_TOOL_OPTIONS: -Xmx2g
+        GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
+
+commands:
+  prepare:
+    description: "Prepare"
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore cached gradle dependencies
+          keys:
+            - deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
+            - deps-{{ checksum "build.gradle" }}
+            - deps-
+
+jobs:
+  assemble:
+    executor: medium_executor
+    steps:
+      - prepare
+      - run:
+          name: Assemble
+          command: |
+            ./gradlew --no-daemon --parallel clean compileJava compileTestJava assemble
+      - save_cache:
+          name: Caching gradle dependencies
+          key: deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
+            paths:
+              - .gradle
+              - ~/.gradle
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - ./
+
+  unitTests:
+    executor: medium_executor
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project
+      - run:
+        name: Build
+        no_output_timeout: 20m
+        command: |
+          ./graldew --no-daemon --parallel build -x :eth-reference-tests:test
+
+  referenceTests:
+    executor: medium_executor
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project
+      - run:
+        name: FetchReferenceTests
+        command: |
+          ./scripts/get-ref-tests.sh
+      - run:
+        name: ReferenceTests
+        // TODO: Skip non-reference tests here
+        command: |
+          ./gradlew --no-daemon --parallel test
+
+
+
+  docker:
+    executor: medium_executor
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project
+      - setup_remote_docker
+      - run:
+        name: Docker
+        command: |
+          ./gradlew --no-daemon --parallel distDocker
+
+      - run:
+        name: DockerWhiteblock
+        command: |
+          ./gradlew --no-daemon --parallel distDockerWhiteblock
+
+
+workflows:
+  version: 2
+  default:
+    jobs:
+      - assemble
+      - unitTests:
+          requires:
+            - assemble
+      - referenceTests:
+          requires:
+            - assemble
+      - docker:
+          requires:
+            - unitTests
+            - referenceTests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,12 +144,12 @@ workflows:
           requires:
             - assemble
             - unitTests
-      - javadoc:
-          requires:
-            - assemble
+#      - javadoc:
+#          requires:
+#            - assemble
       - publish:
           requires:
             - unitTests
             - referenceTests
             - docker
-            - javadoc
+#            - javadoc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,8 @@ jobs:
       - run:
           name: Debug
           command: |
-            ls -R build/refTests
-            ls ~/project/eth-reference-tests/src/test/resources/eth2.0-spec-tests/tests/
+            ls -R build/refTests || true
+            ls ~/project/eth-reference-tests/src/test/resources/eth2.0-spec-tests/tests/ || true
       - run:
           name: FetchReferenceTests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,11 @@ jobs:
           keys:
             - reftests-{{ checksum "build.gradle" }}
       - run:
+          name: Debug
+          command: |
+            ls -R build/refTests
+            ls eth-reference-tests/src/test/resources/eth2.0-spec-tests/tests/
+      - run:
           name: FetchReferenceTests
           command: |
             ./gradlew expandRefTests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,6 @@ jobs:
             ./gradlew --no-daemon --parallel test -x :eth-reference-tests:test
       - capture_test_results
 
-
   referenceTests:
     parallelism: 4
     executor: medium_executor
@@ -86,9 +85,7 @@ jobs:
       - run:
           name: FetchReferenceTests
           command: |
-            ls /home/circleci/project/build/refTests/v0.8.3/general.tar.gz || true
-            pwd
-            ./gradlew --no-daemon --no-parallel --debug expandRefTests
+            ./gradlew --no-daemon -Partemis.reftest.download.dir=$HOME/refTests expandRefTests
       - run:
           name: ReferenceTests
           // TODO: Skip non-reference tests here
@@ -107,9 +104,8 @@ jobs:
           name: Caching reference tests
           key: reftests-{{ checksum "build.gradle" }}
           paths:
-            - build/refTests
+            - $HOME/refTests
             - eth-reference-tests/src/test/resources/eth2.0-spec-tests/
-            - .gradle
       - capture_test_results
 
   javadoc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,10 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run:
-        name: Build
-        no_output_timeout: 20m
-        command: |
-          ./graldew --no-daemon --parallel build -x :eth-reference-tests:test
+          name: Build
+          no_output_timeout: 20m
+          command: |
+            ./graldew --no-daemon --parallel build -x :eth-reference-tests:test
 
   referenceTests:
     executor: medium_executor
@@ -60,14 +60,14 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run:
-        name: FetchReferenceTests
-        command: |
-          ./scripts/get-ref-tests.sh
+          name: FetchReferenceTests
+          command: |
+            ./scripts/get-ref-tests.sh
       - run:
-        name: ReferenceTests
-        // TODO: Skip non-reference tests here
-        command: |
-          ./gradlew --no-daemon --parallel test
+          name: ReferenceTests
+          // TODO: Skip non-reference tests here
+          command: |
+            ./gradlew --no-daemon --parallel test
 
 
 
@@ -79,14 +79,14 @@ jobs:
           at: ~/project
       - setup_remote_docker
       - run:
-        name: Docker
-        command: |
-          ./gradlew --no-daemon --parallel distDocker
+          name: Docker
+          command: |
+            ./gradlew --no-daemon --parallel distDocker
 
       - run:
-        name: DockerWhiteblock
-        command: |
-          ./gradlew --no-daemon --parallel distDockerWhiteblock
+          name: DockerWhiteblock
+          command: |
+            ./gradlew --no-daemon --parallel distDockerWhiteblock
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,10 +79,19 @@ jobs:
       - prepare
       - attach_workspace:
           at: ~/project
+      - restore_cache:
+          name: Restore cached reference test downloads
+          keys:
+            - reftests-{{ checksum "build.gradle" }}
       - run:
           name: FetchReferenceTests
           command: |
             ./gradlew getRefTests
+      - save_cache:
+          name: Caching gradle dependencies
+          key: reftests-{{ checksum "build.gradle" }}
+          paths:
+            - build/refTests
       - run:
           name: ReferenceTests
           // TODO: Skip non-reference tests here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,9 @@ jobs:
       - run:
           name: Debug
           command: |
-            ls -R build/refTests || true
-            ls ~/project/eth-reference-tests/src/test/resources/eth2.0-spec-tests/tests/ || true
+            ls /home/circleci/project/build/refTests/v0.8.3/general.tar.gz || true
+            ls -R /home/circleci/project/build/refTests || true
+            ls /home/circleci/project/eth-reference-tests/src/test/resources/eth2.0-spec-tests/tests/ || true
       - run:
           name: FetchReferenceTests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,10 @@ jobs:
       - run:
           name: FetchReferenceTests
           command: |
-            ./gradlew --no-daemon -Partemis.reftest.download.dir=$HOME/refTests expandRefTests
+            if [ ! -d "eth-reference-tests/src/test/resources/eth2.0-spec-tests/tests" ]
+            then
+              ./gradlew --no-daemon expandRefTests
+            fi
       - run:
           name: ReferenceTests
           // TODO: Skip non-reference tests here
@@ -104,8 +107,7 @@ jobs:
           name: Caching reference tests
           key: reftests-{{ checksum "build.gradle" }}
           paths:
-            - ~/refTests
-#            - eth-reference-tests/src/test/resources/eth2.0-spec-tests/
+            - eth-reference-tests/src/test/resources/eth2.0-spec-tests/
       - capture_test_results
 
   javadoc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
           command: |
             ./gradlew expandRefTests
       - save_cache:
-          name: Caching gradle dependencies
+          name: Caching reference tests
           key: reftests-{{ checksum "build.gradle" }}
           paths:
             - build/refTests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           name: Build
           no_output_timeout: 20m
           command: |
-            ./graldew --no-daemon --parallel build -x :eth-reference-tests:test
+            ./gradlew --no-daemon --parallel build -x :eth-reference-tests:test
 
   referenceTests:
     executor: medium_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,11 +63,6 @@ jobs:
           name: FetchReferenceTests
           command: |
             ./scripts/get-ref-tests.sh
-      - save_cache:
-          name: Caching gradle dependencies
-          key: deps-{{ checksum "scripts/get-ref-tests" }}-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - eth2.0-spec-tests/tests
       - run:
           name: ReferenceTests
           // TODO: Skip non-reference tests here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ commands:
   prepare:
     description: "Prepare"
     steps:
+      - checkout
       - restore_cache:
           name: Restore cached gradle dependencies
           keys:
@@ -42,7 +43,6 @@ jobs:
     executor: medium_executor
     steps:
       - prepare
-      - checkout
       - run:
           name: Assemble
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,9 @@ jobs:
       - save_cache:
           name: Caching gradle dependencies
           key: deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
-            paths:
-              - .gradle
-              - ~/.gradle
+          paths:
+            - .gradle
+            - ~/.gradle
       - persist_to_workspace:
           root: ~/project
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           name: ReferenceTests
           // TODO: Skip non-reference tests here
           command: |
-            ./gradlew --no-daemon --parallel :eth-reference-tests:test
+            ./gradlew --no-daemon --no-parallel :eth-reference-tests:test
       - capture_test_results
 
   javadoc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,16 @@ jobs:
           name: ReferenceTests
           // TODO: Skip non-reference tests here
           command: |
-            ./gradlew --no-daemon --no-parallel :eth-reference-tests:test
+            cd eth-reference-tests/src/test/java
+            CLASSNAMES=$(circleci tests glob "**/*.java" \
+              | cut -c 1- | sed 's@/@.@g' \
+              | sed 's/.\{5\}$//' \
+              | circleci tests split --split-by=timings --timings-type=classname)
+            cd ../../..
+            # Format the arguments to "./gradlew test"
+            GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
+            echo "Prepared arguments for Gradle: $GRADLE_ARGS"
+            ./gradlew --no-daemon --no-parallel :eth-reference-tests:test $GRADLE_ARGS
       - capture_test_results
 
   javadoc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
 
 
   referenceTests:
+    parallelism: 5
     executor: medium_executor
     steps:
       - prepare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
               | cut -c 1- | sed 's@/@.@g' \
               | sed 's/.\{5\}$//' \
               | circleci tests split --split-by=timings --timings-type=classname)
-            cd ../../..
+            cd ../../../..
             # Format the arguments to "./gradlew test"
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
             echo "Prepared arguments for Gradle: $GRADLE_ARGS"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,22 @@ commands:
             - deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
             - deps-{{ checksum "build.gradle" }}
             - deps-
+  capture_test_results:
+    description: "Capture test results"
+    steps:
+      - run:
+          name: "Gather test results"
+          command: |
+            FILES=`find . -name test-results`
+            for FILE in $FILES
+            do
+              MODULE=`echo "$FILE" | sed -e 's@./\(.*\)/build/test-results@\1@'`
+              TARGET="build/test-results/$MODULE"
+              mkdir -p "$TARGET"
+              cp -rf ${FILE}/test/* "build/test-results/$MODULE"
+            done
+      - store_test_results:
+          path: build/test-results
 
 jobs:
   assemble:
@@ -52,6 +68,8 @@ jobs:
           no_output_timeout: 20m
           command: |
             ./gradlew --no-daemon --parallel test -x :eth-reference-tests:test
+      - capture_test_results
+
 
   referenceTests:
     executor: medium_executor
@@ -68,6 +86,7 @@ jobs:
           // TODO: Skip non-reference tests here
           command: |
             ./gradlew --no-daemon --parallel test
+      - capture_test_results
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,11 @@ workflows:
       - referenceTests:
           requires:
             - assemble
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
       - unitTests:
           requires:
             - assemble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
       - run:
           name: FetchReferenceTests
           command: |
-            ./scripts/get-ref-tests.sh
+            ./gradlew getRefTests
       - run:
           name: ReferenceTests
           // TODO: Skip non-reference tests here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ commands:
   prepare:
     description: "Prepare"
     steps:
-      - checkout
       - restore_cache:
           name: Restore cached gradle dependencies
           keys:
@@ -43,6 +42,7 @@ jobs:
     executor: medium_executor
     steps:
       - prepare
+      - checkout
       - run:
           name: Assemble
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,7 @@ jobs:
             ./gradlew --no-daemon --parallel test -x :eth-reference-tests:test
       - capture_test_results
 
-  referenceTests:
-    parallelism: 4
+  downloadReferenceTests:
     executor: medium_executor
     steps:
       - prepare
@@ -89,9 +88,25 @@ jobs:
             then
               ./gradlew --no-daemon expandRefTests
             fi
+      - save_cache:
+          name: Caching reference tests
+          key: reftests-{{ checksum "build.gradle" }}
+          paths:
+            - eth-reference-tests/src/test/resources/eth2.0-spec-tests/
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - ./
+
+  referenceTests:
+    parallelism: 4
+    executor: medium_executor
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project
       - run:
           name: ReferenceTests
-          // TODO: Skip non-reference tests here
           command: |
             cd eth-reference-tests/src/test/java
             CLASSNAMES=$(circleci tests glob "**/*.java" \
@@ -103,11 +118,6 @@ jobs:
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
             echo "Prepared arguments for Gradle: $GRADLE_ARGS"
             ./gradlew --no-daemon --no-parallel :eth-reference-tests:test $GRADLE_ARGS
-      - save_cache:
-          name: Caching reference tests
-          key: reftests-{{ checksum "build.gradle" }}
-          paths:
-            - eth-reference-tests/src/test/resources/eth2.0-spec-tests/
       - capture_test_results
 
   javadoc:
@@ -155,9 +165,13 @@ workflows:
   standard_build:
     jobs:
       - assemble
+      - downloadReferenceTests:
+          requires:
+            - assemble
       - referenceTests:
           requires:
             - assemble
+            - downloadReferenceTests
       - unitTests:
           requires:
             - assemble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
           name: Debug
           command: |
             ls -R build/refTests
-            ls eth-reference-tests/src/test/resources/eth2.0-spec-tests/tests/
+            ls ~/project/eth-reference-tests/src/test/resources/eth2.0-spec-tests/tests/
       - run:
           name: FetchReferenceTests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ workflows:
           filters:
             branches:
               only:
-#                - master
+                - master
                 - /^release-.*/
           requires:
             - unitTests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
 
 
   referenceTests:
-    parallelism: 5
+    parallelism: 4
     executor: medium_executor
     steps:
       - prepare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
       - run:
           name: FetchReferenceTests
           command: |
-            ./gradlew getRefTests
+            ./gradlew expandRefTests
       - save_cache:
           name: Caching gradle dependencies
           key: reftests-{{ checksum "build.gradle" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,8 @@ jobs:
             ./gradlew --no-daemon --parallel test -x :eth-reference-tests:test
       - capture_test_results
 
-  downloadReferenceTests:
+  referenceTests:
+    parallelism: 4
     executor: medium_executor
     steps:
       - prepare
@@ -88,23 +89,6 @@ jobs:
             then
               ./gradlew --no-daemon expandRefTests
             fi
-      - save_cache:
-          name: Caching reference tests
-          key: reftests-{{ checksum "build.gradle" }}
-          paths:
-            - eth-reference-tests/src/test/resources/eth2.0-spec-tests/
-      - persist_to_workspace:
-          root: ~/project
-          paths:
-            - ./
-
-  referenceTests:
-    parallelism: 4
-    executor: medium_executor
-    steps:
-      - prepare
-      - attach_workspace:
-          at: ~/project
       - run:
           name: ReferenceTests
           command: |
@@ -118,6 +102,11 @@ jobs:
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
             echo "Prepared arguments for Gradle: $GRADLE_ARGS"
             ./gradlew --no-daemon --no-parallel :eth-reference-tests:test $GRADLE_ARGS
+      - save_cache:
+          name: Caching reference tests
+          key: reftests-{{ checksum "build.gradle" }}
+          paths:
+            - eth-reference-tests/src/test/resources/eth2.0-spec-tests/
       - capture_test_results
 
   javadoc:
@@ -165,13 +154,9 @@ workflows:
   standard_build:
     jobs:
       - assemble
-      - downloadReferenceTests:
-          requires:
-            - assemble
       - referenceTests:
           requires:
             - assemble
-            - downloadReferenceTests
       - unitTests:
           requires:
             - assemble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ executors:
     working_directory: ~/project
     environment:
       JAVA_TOOL_OPTIONS: -Xmx2g
+      _JAVA_OPTIONS: -Xmx2g
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
 
 commands:
@@ -141,8 +142,11 @@ workflows:
             - assemble
       - docker:
           requires:
+            - assemble
             - unitTests
-      - javadoc
+      - javadoc:
+          requires:
+            - assemble
       - publish:
           requires:
             - unitTests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           key: reftests-{{ checksum "build.gradle" }}
           paths:
             - ~/refTests
-            - eth-reference-tests/src/test/resources/eth2.0-spec-tests/
+#            - eth-reference-tests/src/test/resources/eth2.0-spec-tests/
       - capture_test_results
 
   javadoc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,13 +92,9 @@ jobs:
       - run:
           name: FetchReferenceTests
           command: |
+            ls /home/circleci/project/build/refTests/v0.8.3/general.tar.gz || true
+            pwd
             ./gradlew expandRefTests
-      - save_cache:
-          name: Caching reference tests
-          key: reftests-{{ checksum "build.gradle" }}
-          paths:
-            - build/refTests
-            - eth-reference-tests/src/test/resources/eth2.0-spec-tests/
       - run:
           name: ReferenceTests
           // TODO: Skip non-reference tests here
@@ -113,6 +109,12 @@ jobs:
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
             echo "Prepared arguments for Gradle: $GRADLE_ARGS"
             ./gradlew --no-daemon --no-parallel :eth-reference-tests:test $GRADLE_ARGS
+      - save_cache:
+          name: Caching reference tests
+          key: reftests-{{ checksum "build.gradle" }}
+          paths:
+            - build/refTests
+            - eth-reference-tests/src/test/resources/eth2.0-spec-tests/
       - capture_test_results
 
   javadoc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           name: ReferenceTests
           // TODO: Skip non-reference tests here
           command: |
-            ./gradlew --no-daemon --parallel test
+            ./gradlew --no-daemon --parallel :eth-reference-tests:test
       - capture_test_results
 
   javadoc:
@@ -131,7 +131,7 @@ jobs:
 
 workflows:
   version: 2
-  default:
+  standard_build:
     jobs:
       - assemble
       - unitTests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
           name: Caching reference tests
           key: reftests-{{ checksum "build.gradle" }}
           paths:
-            - $HOME/refTests
+            - ~/refTests
             - eth-reference-tests/src/test/resources/eth2.0-spec-tests/
       - capture_test_results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
           key: reftests-{{ checksum "build.gradle" }}
           paths:
             - build/refTests
+            - eth-reference-tests/src/test/resources/eth2.0-spec-tests/
       - run:
           name: ReferenceTests
           // TODO: Skip non-reference tests here

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.log
 .classpath
 .DS_Store
+.gradletasknamecache
 .externalToolBuilders/
 .gradle/
 .idea/

--- a/build.gradle
+++ b/build.gradle
@@ -189,47 +189,34 @@ allprojects {
 
 def refTestVersion = 'v0.8.3'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
-def refTestDownloadDir = "${buildDir}/refTests/${refTestVersion}"
+def refTestDownloadDir = project.hasProperty("artemis.reftest.download.dir") ? project.property("artemis.reftest.download.dir") + "/${refTestVersion}" : "${buildDir}/refTests/${refTestVersion}"
 def refTestExpandDir = 'eth-reference-tests/src/test/resources/eth2.0-spec-tests/'
-
-task downloadRefTestsGeneral(type: Download) {
-  doFirst {
-    println "Download target ${refTestDownloadDir}/general.tar.gz: " + (file(refTestDownloadDir + "/general.tar.gz").exists())
+println "Pretask Download target ${refTestDownloadDir}/general.tar.gz: " + (file(refTestDownloadDir + "/general.tar.gz").exists())
+task downloadRefTests {
+  doLast {
+    download {
+      src([
+          "${refTestBaseUrl}/${refTestVersion}/general.tar.gz",
+          "${refTestBaseUrl}/${refTestVersion}/minimal.tar.gz",
+          "${refTestBaseUrl}/${refTestVersion}/mainnet.tar.gz"
+      ])
+      dest "${refTestDownloadDir}"
+      overwrite false
+    }
   }
-  src "${refTestBaseUrl}/${refTestVersion}/general.tar.gz"
-  dest "${refTestDownloadDir}/general.tar.gz"
-  overwrite false
 }
 
-task downloadRefTestsMainnet(type: Download) {
-  doFirst {
-    println "Download target ${refTestDownloadDir}/mainnet.tar.gz: " + (file(refTestDownloadDir + "/mainnet.tar.gz").exists())
-  }
-  src "${refTestBaseUrl}/${refTestVersion}/mainnet.tar.gz"
-  dest "${refTestDownloadDir}/mainnet.tar.gz"
-  overwrite false
-}
-
-task downloadRefTestsMinimal(type: Download) {
-  doFirst {
-    println "Download target ${refTestDownloadDir}/minimal.tar.gz: " + (file(refTestDownloadDir + "/minimal.tar.gz").exists())
-  }
-  src "${refTestBaseUrl}/${refTestVersion}/minimal.tar.gz"
-  dest "${refTestDownloadDir}/minimal.tar.gz"
-  overwrite false
-}
-
-task expandRefTestsGeneral(type: Copy, dependsOn: downloadRefTestsGeneral) {
+task expandRefTestsGeneral(type: Copy, dependsOn: downloadRefTests) {
   from tarTree("${refTestDownloadDir}/general.tar.gz")
   into refTestExpandDir
 }
 
-task expandRefTestsMainnet(type: Copy, dependsOn: downloadRefTestsMainnet) {
+task expandRefTestsMainnet(type: Copy, dependsOn: downloadRefTests) {
   from tarTree("${refTestDownloadDir}/mainnet.tar.gz")
   into refTestExpandDir
 }
 
-task expandRefTestsMinimal(type: Copy, dependsOn: downloadRefTestsMinimal) {
+task expandRefTestsMinimal(type: Copy, dependsOn: downloadRefTests) {
   from tarTree("${refTestDownloadDir}/minimal.tar.gz")
   into refTestExpandDir
 }

--- a/build.gradle
+++ b/build.gradle
@@ -192,30 +192,44 @@ def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/dow
 def refTestDownloadDir = "${buildDir}/refTests/${refTestVersion}"
 def refTestExpandDir = 'eth-reference-tests/src/test/resources/eth2.0-spec-tests/'
 println "Pretask Download target ${refTestDownloadDir}/general.tar.gz: " + (file(refTestDownloadDir + "/general.tar.gz").exists())
-task downloadRefTests(type: Download) {
+task downloadRefTestsGeneral(type: Download) {
   doFirst {
     println "Download target ${refTestDownloadDir}/general.tar.gz: " + (file(refTestDownloadDir + "/general.tar.gz").exists())
   }
-  src([
-      "${refTestBaseUrl}/${refTestVersion}/general.tar.gz",
-      "${refTestBaseUrl}/${refTestVersion}/minimal.tar.gz",
-      "${refTestBaseUrl}/${refTestVersion}/mainnet.tar.gz"
-  ])
-  dest "${refTestDownloadDir}/"
+  src "${refTestBaseUrl}/${refTestVersion}/general.tar.gz"
+  dest "${refTestDownloadDir}/general.tar.gz"
   overwrite false
 }
 
-task expandRefTestsGeneral(type: Copy, dependsOn: downloadRefTests) {
+task downloadRefTestsMainnet(type: Download) {
+  doFirst {
+    println "Download target ${refTestDownloadDir}/mainnet.tar.gz: " + (file(refTestDownloadDir + "/mainnet.tar.gz").exists())
+  }
+  src "${refTestBaseUrl}/${refTestVersion}/mainnet.tar.gz"
+  dest "${refTestDownloadDir}/mainnet.tar.gz"
+  overwrite false
+}
+
+task downloadRefTestsMinimal(type: Download) {
+  doFirst {
+    println "Download target ${refTestDownloadDir}/minimal.tar.gz: " + (file(refTestDownloadDir + "/minimal.tar.gz").exists())
+  }
+  src "${refTestBaseUrl}/${refTestVersion}/minimal.tar.gz"
+  dest "${refTestDownloadDir}/minimal.tar.gz"
+  overwrite false
+}
+
+task expandRefTestsGeneral(type: Copy, dependsOn: downloadRefTestsGeneral) {
   from tarTree("${refTestDownloadDir}/general.tar.gz")
   into refTestExpandDir
 }
 
-task expandRefTestsMainnet(type: Copy, dependsOn: downloadRefTests) {
+task expandRefTestsMainnet(type: Copy, dependsOn: downloadRefTestsMainnet) {
   from tarTree("${refTestDownloadDir}/mainnet.tar.gz")
   into refTestExpandDir
 }
 
-task expandRefTestsMinimal(type: Copy, dependsOn: downloadRefTests) {
+task expandRefTestsMinimal(type: Copy, dependsOn: downloadRefTestsMinimal) {
   from tarTree("${refTestDownloadDir}/minimal.tar.gz")
   into refTestExpandDir
 }

--- a/build.gradle
+++ b/build.gradle
@@ -192,18 +192,14 @@ def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/dow
 def refTestDownloadDir = project.hasProperty("artemis.reftest.download.dir") ? project.property("artemis.reftest.download.dir") + "/${refTestVersion}" : "${buildDir}/refTests/${refTestVersion}"
 def refTestExpandDir = 'eth-reference-tests/src/test/resources/eth2.0-spec-tests/'
 
-task downloadRefTests {
-  doLast {
-    download {
-      src([
-          "${refTestBaseUrl}/${refTestVersion}/general.tar.gz",
-          "${refTestBaseUrl}/${refTestVersion}/minimal.tar.gz",
-          "${refTestBaseUrl}/${refTestVersion}/mainnet.tar.gz"
-      ])
-      dest "${refTestDownloadDir}"
-      overwrite false
-    }
-  }
+task downloadRefTests(type: Download) {
+  src([
+      "${refTestBaseUrl}/${refTestVersion}/general.tar.gz",
+      "${refTestBaseUrl}/${refTestVersion}/minimal.tar.gz",
+      "${refTestBaseUrl}/${refTestVersion}/mainnet.tar.gz"
+  ])
+  dest "${refTestDownloadDir}"
+  overwrite false
 }
 
 task expandRefTestsGeneral(type: Copy, dependsOn: downloadRefTests) {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,9 @@ plugins {
   id 'net.ltgt.errorprone' version '0.7' apply false
   id 'net.researchgate.release' version '2.7.0'
   id 'com.gradle.build-scan' version '2.1'
+  id 'de.undercouch.download' version '4.0.0'
 }
+apply plugin: 'de.undercouch.download'
 
 defaultTasks 'build','checkLicenses'
 
@@ -182,6 +184,26 @@ allprojects {
       options.addStringOption('Xwerror', '-html5')
     }
     options.encoding = 'UTF-8'
+  }
+}
+
+def refTestVersion = 'v0.8.3'
+def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
+task downloadRefTests(type: Download) {
+  src([
+      "${refTestBaseUrl}/${refTestVersion}/general.tar.gz",
+      "${refTestBaseUrl}/${refTestVersion}/minimal.tar.gz",
+      "${refTestBaseUrl}/${refTestVersion}/mainnet.tar.gz"
+      ])
+  dest "${buildDir}/refTests/"
+  overwrite false
+}
+task getRefTests() {
+  dependsOn downloadRefTests
+  doLast {
+    ant.untar(src: "${buildDir}/refTests/general.tar.gz", dest: "eth2.0-spec-tests/", compression: "gzip")
+    ant.untar(src: "${buildDir}/refTests/minimal.tar.gz", dest: "eth2.0-spec-tests/", compression: "gzip")
+    ant.untar(src: "${buildDir}/refTests/mainnet.tar.gz", dest: "eth2.0-spec-tests/", compression: "gzip")
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -191,7 +191,7 @@ def refTestVersion = 'v0.8.3'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
 def refTestDownloadDir = "${buildDir}/refTests/${refTestVersion}"
 def refTestExpandDir = 'eth-reference-tests/src/test/resources/eth2.0-spec-tests/'
-println "Pretask Download target ${refTestDownloadDir}/general.tar.gz: " + (file(refTestDownloadDir + "/general.tar.gz").exists())
+
 task downloadRefTestsGeneral(type: Download) {
   doFirst {
     println "Download target ${refTestDownloadDir}/general.tar.gz: " + (file(refTestDownloadDir + "/general.tar.gz").exists())

--- a/build.gradle
+++ b/build.gradle
@@ -189,24 +189,35 @@ allprojects {
 
 def refTestVersion = 'v0.8.3'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
+def refTestDownloadDir = "${buildDir}/refTests/${refTestVersion}"
+def refTestExpandDir = 'eth-reference-tests/src/test/resources/eth2.0-spec-tests/'
+
 task downloadRefTests(type: Download) {
   src([
       "${refTestBaseUrl}/${refTestVersion}/general.tar.gz",
       "${refTestBaseUrl}/${refTestVersion}/minimal.tar.gz",
       "${refTestBaseUrl}/${refTestVersion}/mainnet.tar.gz"
-      ])
-  dest "${buildDir}/refTests/"
+  ])
+  dest "${refTestDownloadDir}/"
   overwrite false
 }
-task getRefTests() {
-  dependsOn downloadRefTests
-  doLast {
-    def expandDir = 'eth-reference-tests/src/test/resources/eth2.0-spec-tests/'
-    ant.untar(src: "${buildDir}/refTests/general.tar.gz", dest: expandDir, compression: "gzip")
-    ant.untar(src: "${buildDir}/refTests/minimal.tar.gz", dest: expandDir, compression: "gzip")
-    ant.untar(src: "${buildDir}/refTests/mainnet.tar.gz", dest: expandDir, compression: "gzip")
-  }
+
+task expandRefTestsGeneral(type: Copy, dependsOn: downloadRefTests) {
+  from tarTree("${refTestDownloadDir}/general.tar.gz")
+  into refTestExpandDir
 }
+
+task expandRefTestsMainnet(type: Copy, dependsOn: downloadRefTests) {
+  from tarTree("${refTestDownloadDir}/mainnet.tar.gz")
+  into refTestExpandDir
+}
+
+task expandRefTestsMinimal(type: Copy, dependsOn: downloadRefTests) {
+  from tarTree("${refTestDownloadDir}/minimal.tar.gz")
+  into refTestExpandDir
+}
+
+task expandRefTests(dependsOn: [expandRefTestsGeneral, expandRefTestsMainnet, expandRefTestsMinimal])
 
 task deploy() {}
 

--- a/build.gradle
+++ b/build.gradle
@@ -201,9 +201,10 @@ task downloadRefTests(type: Download) {
 task getRefTests() {
   dependsOn downloadRefTests
   doLast {
-    ant.untar(src: "${buildDir}/refTests/general.tar.gz", dest: "eth2.0-spec-tests/", compression: "gzip")
-    ant.untar(src: "${buildDir}/refTests/minimal.tar.gz", dest: "eth2.0-spec-tests/", compression: "gzip")
-    ant.untar(src: "${buildDir}/refTests/mainnet.tar.gz", dest: "eth2.0-spec-tests/", compression: "gzip")
+    def expandDir = 'eth-reference-tests/src/test/resources/eth2.0-spec-tests/'
+    ant.untar(src: "${buildDir}/refTests/general.tar.gz", dest: expandDir, compression: "gzip")
+    ant.untar(src: "${buildDir}/refTests/minimal.tar.gz", dest: expandDir, compression: "gzip")
+    ant.untar(src: "${buildDir}/refTests/mainnet.tar.gz", dest: expandDir, compression: "gzip")
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -191,7 +191,7 @@ def refTestVersion = 'v0.8.3'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
 def refTestDownloadDir = "${buildDir}/refTests/${refTestVersion}"
 def refTestExpandDir = 'eth-reference-tests/src/test/resources/eth2.0-spec-tests/'
-
+println "Pretask Download target ${refTestDownloadDir}/general.tar.gz: " + (file(refTestDownloadDir + "/general.tar.gz").exists())
 task downloadRefTests(type: Download) {
   doFirst {
     println "Download target ${refTestDownloadDir}/general.tar.gz: " + (file(refTestDownloadDir + "/general.tar.gz").exists())

--- a/build.gradle
+++ b/build.gradle
@@ -191,7 +191,7 @@ def refTestVersion = 'v0.8.3'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
 def refTestDownloadDir = project.hasProperty("artemis.reftest.download.dir") ? project.property("artemis.reftest.download.dir") + "/${refTestVersion}" : "${buildDir}/refTests/${refTestVersion}"
 def refTestExpandDir = 'eth-reference-tests/src/test/resources/eth2.0-spec-tests/'
-println "Pretask Download target ${refTestDownloadDir}/general.tar.gz: " + (file(refTestDownloadDir + "/general.tar.gz").exists())
+
 task downloadRefTests {
   doLast {
     download {

--- a/build.gradle
+++ b/build.gradle
@@ -189,7 +189,7 @@ allprojects {
 
 def refTestVersion = 'v0.8.3'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
-def refTestDownloadDir = project.hasProperty("artemis.reftest.download.dir") ? project.property("artemis.reftest.download.dir") + "/${refTestVersion}" : "${buildDir}/refTests/${refTestVersion}"
+def refTestDownloadDir = "${buildDir}/refTests/${refTestVersion}"
 def refTestExpandDir = 'eth-reference-tests/src/test/resources/eth2.0-spec-tests/'
 
 task downloadRefTests(type: Download) {

--- a/build.gradle
+++ b/build.gradle
@@ -193,6 +193,9 @@ def refTestDownloadDir = "${buildDir}/refTests/${refTestVersion}"
 def refTestExpandDir = 'eth-reference-tests/src/test/resources/eth2.0-spec-tests/'
 
 task downloadRefTests(type: Download) {
+  doFirst {
+    println "Download target ${refTestDownloadDir}/general.tar.gz: " + (file(refTestDownloadDir + "/general.tar.gz").exists())
+  }
   src([
       "${refTestBaseUrl}/${refTestVersion}/general.tar.gz",
       "${refTestBaseUrl}/${refTestVersion}/minimal.tar.gz",


### PR DESCRIPTION
## PR Description
Adds configuration for using CircleCI for builds. Refs tests are split across 4 boxes for faster execution.

Download and expansion of reference tests is done in gradle to be cross platform compatible and make it easier to take advantage of CircleCI caching.