### PR TITLE
Start building integration test framework for jvm-libp2p

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,19 @@ jobs:
             ./gradlew --no-daemon --parallel test
       - capture_test_results
 
+  integrationTests:
+    executor: medium_plus_executor
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: IntegrationTests
+          no_output_timeout: 20m
+          command: |
+            ./gradlew --no-daemon --parallel integrationTest
+      - capture_test_results
+
   referenceTests:
     parallelism: 4
     executor: large_executor
@@ -199,6 +212,10 @@ workflows:
           requires:
             - assemble
             - spotless
+      - integrationTests:
+          requires:
+            - assemble
+            - spotless
       - docker:
           requires:
             - assemble
@@ -212,6 +229,7 @@ workflows:
                 - /^release-.*/
           requires:
             - unitTests
+            - integrationTests
             - referenceTests
             - docker
       - publishDocker:
@@ -222,5 +240,6 @@ workflows:
                 - /^release-.*/
           requires:
             - unitTests
+            - integrationTests
             - referenceTests
             - docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
       - run:
           name: Assemble
           command: |
-            ./gradlew --no-daemon --parallel clean compileJava compileTestJava assemble
+            ./gradlew --no-daemon --parallel clean compileJava compileTestJava compileJmhJava compileIntegrationTestJava compileReferenceTestJava assemble
       - save_cache:
           name: Caching gradle dependencies
           key: deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}

--- a/build.gradle
+++ b/build.gradle
@@ -272,13 +272,16 @@ subprojects {
     testSupportImplementation.extendsFrom implementation
     integrationTestImplementation.extendsFrom implementation
     referenceTestImplementation.extendsFrom implementation
-    testSupportArtifacts
+    testSupportArtifacts.extendsFrom testSupportImplementation
   }
 
   task testSupportJar (type: Jar) {
     baseName = "${project.name}-support-test"
     from sourceSets.testSupport.output
   }
+
+  artifacts { testSupportArtifacts testSupportJar }
+
   def jarName = project.name
   def parent = project.parent
   while (parent != null) {

--- a/networking/p2p/build.gradle
+++ b/networking/p2p/build.gradle
@@ -32,4 +32,10 @@ dependencies {
   implementation 'tech.pegasys.pantheon.internal:metrics-core'
 
   testImplementation 'org.mockito:mockito-core'
+
+  integrationTestImplementation project(path: ':util', configuration: 'testSupportArtifacts')
+  integrationTestImplementation 'org.mockito:mockito-core'
+
+  testSupportImplementation project(path: ':util', configuration: 'testSupportArtifacts')
+  testSupportCompile 'org.assertj:assertj-core'
 }

--- a/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/JvmLibP2pSmokeIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/JvmLibP2pSmokeIntegrationTest.java
@@ -58,7 +58,7 @@ public class JvmLibP2pSmokeIntegrationTest {
     final EventBus eventBus1 = new EventBus();
     final EventBus eventBus2 = mock(EventBus.class);
     final JvmLibP2PNetwork network1 = networkFactory.startNetwork();
-    final JvmLibP2PNetwork network2 = networkFactory.startNetwork(network1);
+    networkFactory.startNetwork(network1);
 
     final BeaconBlock block = DataStructureUtil.randomBeaconBlock(100, 100);
     eventBus1.post(block);

--- a/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/JvmLibP2pSmokeIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/JvmLibP2pSmokeIntegrationTest.java
@@ -48,8 +48,6 @@ public class JvmLibP2pSmokeIntegrationTest {
           assertThat(network1.getPeerCount()).isEqualTo(1);
           assertThat(network2.getPeerCount()).isEqualTo(1);
         });
-    network1.stop();
-    network2.stop();
   }
 
   @Test

--- a/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/JvmLibP2pSmokeIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/JvmLibP2pSmokeIntegrationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.p2p.jvmlibp2p;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.eventbus.EventBus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
+import tech.pegasys.artemis.network.p2p.jvmlibp2p.NetworkFactory;
+import tech.pegasys.artemis.networking.p2p.JvmLibP2PNetwork;
+import tech.pegasys.artemis.util.Waiter;
+
+public class JvmLibP2pSmokeIntegrationTest {
+
+  private final NetworkFactory networkFactory = new NetworkFactory();
+
+  @AfterEach
+  public void tearDown() {
+    networkFactory.stopAll();
+  }
+
+  @Test
+  public void shouldConnectToPeers() throws Exception {
+    final JvmLibP2PNetwork network1 = networkFactory.startNetwork();
+    final JvmLibP2PNetwork network2 = networkFactory.startNetwork();
+
+    network1.connect(network2.getPeerAddress());
+    Waiter.waitFor(
+        () -> {
+          assertThat(network1.getPeerCount()).isEqualTo(1);
+          assertThat(network2.getPeerCount()).isEqualTo(1);
+        });
+    network1.stop();
+    network2.stop();
+  }
+
+  @Test
+  @Disabled("Chain storage is not configured so HELLO messages cause immediate disconnects")
+  public void shouldGossipBlocks() throws Exception {
+    final EventBus eventBus1 = new EventBus();
+    final EventBus eventBus2 = mock(EventBus.class);
+    final JvmLibP2PNetwork network1 = networkFactory.startNetwork();
+    final JvmLibP2PNetwork network2 = networkFactory.startNetwork(network1);
+
+    final BeaconBlock block = DataStructureUtil.randomBeaconBlock(100, 100);
+    eventBus1.post(block);
+
+    Waiter.waitFor(() -> verify(eventBus2).post(refEq(block)));
+  }
+}

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/JvmLibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/JvmLibP2PNetwork.java
@@ -143,7 +143,7 @@ public class JvmLibP2PNetwork implements P2PNetwork {
     return advertisedAddr + "/p2p/" + getPeerId();
   }
 
-  public int getPeerCount(){
+  public int getPeerCount() {
     return peerManager.getPeerCount();
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/JvmLibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/JvmLibP2PNetwork.java
@@ -53,6 +53,7 @@ public class JvmLibP2PNetwork implements P2PNetwork {
   private final Host host;
   private final ScheduledExecutorService scheduler;
   private final PeerManager peerManager;
+  private final Multiaddr advertisedAddr;
 
   public JvmLibP2PNetwork(
       final Config config,
@@ -70,6 +71,7 @@ public class JvmLibP2PNetwork implements P2PNetwork {
     Gossip gossip = new Gossip();
     GossipMessageHandler.init(gossip, privKey, eventBus);
     peerManager = new PeerManager(scheduler, chainStorageClient, metricsSystem);
+    advertisedAddr = new Multiaddr("/ip4/127.0.0.1/tcp/" + config.getAdvertisedPort());
 
     host =
         BuildersJKt.hostJ(
@@ -89,14 +91,10 @@ public class JvmLibP2PNetwork implements P2PNetwork {
                       .setAgentVersion(
                           VersionProvider.CLIENT_IDENTITY + "/" + VersionProvider.VERSION)
                       .setPublicKey(ByteArrayExtKt.toProtobuf(privKey.publicKey().bytes()))
-                      .addListenAddrs(
-                          ByteArrayExtKt.toProtobuf(
-                              new Multiaddr("/ip4/127.0.0.1/tcp/" + config.getAdvertisedPort())
-                                  .getBytes()))
+                      .addListenAddrs(ByteArrayExtKt.toProtobuf(advertisedAddr.getBytes()))
                       .setObservedAddr(
                           ByteArrayExtKt.toProtobuf( // TODO: Report external IP?
-                              new Multiaddr("/ip4/127.0.0.1/tcp/" + config.getAdvertisedPort())
-                                  .getBytes()))
+                              advertisedAddr.getBytes()))
                       .addProtocols(ping.getAnnounce())
                       .addProtocols(gossip.getAnnounce())
                       .build();
@@ -121,9 +119,9 @@ public class JvmLibP2PNetwork implements P2PNetwork {
   }
 
   @Override
-  public void start() {
+  public CompletableFuture<?> start() {
     STDOUT.log(Level.INFO, "Starting libp2p network...");
-    host.start()
+    return host.start()
         .thenApply(
             i -> {
               STDOUT.log(
@@ -131,20 +129,22 @@ public class JvmLibP2PNetwork implements P2PNetwork {
                   "Listening for connections on port "
                       + config.getListenPort()
                       + " with peerId "
-                      + PeerId.fromPubKey(privKey.publicKey()).toBase58());
+                      + getPeerId());
               return null;
             })
-        .whenComplete(
-            (object, throwable) -> {
-              try {
-                // Sleep long enough for network listening to complete
-                Thread.sleep(2000);
-              } catch (InterruptedException e) {
-                e.printStackTrace();
-                throw new IllegalArgumentException(e.getMessage());
-              }
-              config.getPeers().forEach(peer -> connect(peer));
-            });
+        .thenRun(() -> config.getPeers().forEach(this::connect));
+  }
+
+  private String getPeerId() {
+    return PeerId.fromPubKey(privKey.publicKey()).toBase58();
+  }
+
+  public String getPeerAddress() {
+    return advertisedAddr + "/p2p/" + getPeerId();
+  }
+
+  public int getPeerCount(){
+    return peerManager.getPeerCount();
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/MockP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/MockP2PNetwork.java
@@ -33,5 +33,7 @@ public class MockP2PNetwork implements P2PNetwork {
   public void stop() {}
 
   @Override
-  public void start() {}
+  public CompletableFuture<?> start() {
+    return CompletableFuture.completedFuture(null);
+  }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/api/P2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/api/P2PNetwork.java
@@ -29,7 +29,7 @@ public interface P2PNetwork {
    *
    * @return
    */
-  void start();
+  CompletableFuture<?> start();
 
   /** Stops the P2P network layer. */
   void stop();

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/PeerManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/PeerManager.java
@@ -126,4 +126,8 @@ public class PeerManager implements ConnectionHandler, PeerLookup {
   public Collection<RpcMessageHandler<?, ?>> getRpcMessageHandlers() {
     return rpcMethods.all();
   }
+
+  public int getPeerCount() {
+    return connectedPeerMap.size();
+  }
 }

--- a/networking/p2p/src/test-support/java/tech/pegasys/artemis/network/p2p/jvmlibp2p/NetworkFactory.java
+++ b/networking/p2p/src/test-support/java/tech/pegasys/artemis/network/p2p/jvmlibp2p/NetworkFactory.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.artemis.network.p2p.jvmlibp2p;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,9 +48,7 @@ public class NetworkFactory {
     return startNetwork(new EventBus(), peers);
   }
 
-  public JvmLibP2PNetwork startNetwork(
-      final EventBus eventBus,
-      final JvmLibP2PNetwork... peers)
+  public JvmLibP2PNetwork startNetwork(final EventBus eventBus, final JvmLibP2PNetwork... peers)
       throws TimeoutException, InterruptedException, ExecutionException {
     final ChainStorageClient chainStorageClient = new ChainStorageClient(eventBus);
     final Random random = new Random();

--- a/networking/p2p/src/test-support/java/tech/pegasys/artemis/network/p2p/jvmlibp2p/NetworkFactory.java
+++ b/networking/p2p/src/test-support/java/tech/pegasys/artemis/network/p2p/jvmlibp2p/NetworkFactory.java
@@ -1,0 +1,81 @@
+package tech.pegasys.artemis.network.p2p.jvmlibp2p;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.eventbus.EventBus;
+import java.net.BindException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.artemis.networking.p2p.JvmLibP2PNetwork;
+import tech.pegasys.artemis.networking.p2p.jvmlibp2p.Config;
+import tech.pegasys.artemis.storage.ChainStorageClient;
+import tech.pegasys.artemis.util.Waiter;
+import tech.pegasys.pantheon.metrics.noop.NoOpMetricsSystem;
+
+public class NetworkFactory {
+
+  private static final Logger LOG = LogManager.getLogger();
+  private static final NoOpMetricsSystem METRICS_SYSTEM = new NoOpMetricsSystem();
+  private static final int MIN_PORT = 6000;
+  private static final int MAX_PORT = 9000;
+
+  private final List<JvmLibP2PNetwork> networks = new ArrayList<>();
+
+  public JvmLibP2PNetwork startNetwork(final JvmLibP2PNetwork... peers)
+      throws TimeoutException, InterruptedException, ExecutionException {
+    return startNetwork(new EventBus(), peers);
+  }
+
+  public JvmLibP2PNetwork startNetwork(
+      final EventBus eventBus,
+      final JvmLibP2PNetwork... peers)
+      throws TimeoutException, InterruptedException, ExecutionException {
+    final ChainStorageClient chainStorageClient = new ChainStorageClient(eventBus);
+    final Random random = new Random();
+    final List<String> peerAddresses =
+        Stream.of(peers).map(JvmLibP2PNetwork::getPeerAddress).collect(Collectors.toList());
+    int attempt = 1;
+    while (true) {
+      int port = MIN_PORT + random.nextInt(MAX_PORT - MIN_PORT);
+      final JvmLibP2PNetwork network =
+          new JvmLibP2PNetwork(
+              new Config(
+                  Optional.empty(), "127.0.0.1", port, port, peerAddresses, false, false, false),
+              eventBus,
+              chainStorageClient,
+              METRICS_SYSTEM);
+      try {
+        network.start().get(30, TimeUnit.SECONDS);
+        networks.add(network);
+        Waiter.waitFor(() -> assertThat(network.getPeerCount()).isEqualTo(peers.length));
+        return network;
+      } catch (ExecutionException e) {
+        if (e.getCause() instanceof BindException) {
+          if (attempt > 10) {
+            throw new RuntimeException("Failed to find a free port after multiple attempts", e);
+          }
+          LOG.info(
+              "Port conflict detected, retrying with a new port. Original message: {}",
+              e.getMessage());
+          attempt++;
+          network.stop();
+        } else {
+          throw e;
+        }
+      }
+    }
+  }
+
+  public void stopAll() {
+    networks.forEach(JvmLibP2PNetwork::stop);
+  }
+}

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -16,4 +16,6 @@ dependencies {
   compile (group: 'org.quartz-scheduler', name: 'quartz') {
     exclude group: 'com.mchange'
   }
+
+  testSupportImplementation 'org.awaitility:awaitility'
 }

--- a/util/src/test-support/java/tech/pegasys/artemis/util/Waiter.java
+++ b/util/src/test-support/java/tech/pegasys/artemis/util/Waiter.java
@@ -1,0 +1,20 @@
+package tech.pegasys.artemis.util;
+
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+
+/**
+ * A simpler wrapper around Awaitility that directs people towards best practices for waiting. The
+ * native Awaitility wrapper has a number of "gotchas" that can lead to intermittency which this
+ * wrapper aims to prevent.
+ */
+public class Waiter {
+
+  public static void waitFor(final Condition assertion) {
+    Awaitility.waitAtMost(30, TimeUnit.SECONDS).untilAsserted(assertion::run);
+  }
+
+  public interface Condition {
+    void run() throws Throwable;
+  }
+}

--- a/util/src/test-support/java/tech/pegasys/artemis/util/Waiter.java
+++ b/util/src/test-support/java/tech/pegasys/artemis/util/Waiter.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.artemis.util;
 
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
Start to create a framework to support testing our jvm-libp2p integration.

 * Adds a class that handles creating `JvmLibP2PNetwork` instances including finding a free port etc.
 * Starts on a package of useful test util (initially just a simpler wrapper for `Awaitility` which exposes too many different options and details)
 * Add an initial smoke test which checks the network starts and connects to another instance.
 * Second test is disabled because currently the `ChainStorageClient` isn't setup correctly so peers immediately disconnect due to a `NullPointerException` when sending hello messages.
