### PR TITLE
Implement Req/Resp SSZ protocol header and response codes

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/JvmLibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/JvmLibP2PNetwork.java
@@ -124,12 +124,7 @@ public class JvmLibP2PNetwork implements P2PNetwork {
     return host.start()
         .thenApply(
             i -> {
-              STDOUT.log(
-                  Level.INFO,
-                  "Listening for connections on port "
-                      + config.getListenPort()
-                      + " with peerId "
-                      + getPeerId().toBase58());
+              STDOUT.log(Level.INFO, "Listening for connections on: " + getPeerAddress());
               return null;
             })
         .thenRun(() -> config.getPeers().forEach(this::connect));

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/Response.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/Response.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc;
+
+import java.util.Objects;
+
+public class Response<T> {
+  private final byte responseCode;
+  private final T data;
+
+  public Response(final byte responseCode, final T data) {
+    this.responseCode = responseCode;
+    this.data = data;
+  }
+
+  public boolean isSuccess() {
+    return responseCode == 0;
+  }
+
+  public T getData() {
+    return data;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final Response<?> response = (Response<?>) o;
+    return responseCode == response.responseCode && Objects.equals(data, response.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(responseCode, data);
+  }
+}

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/Response.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/Response.java
@@ -14,18 +14,20 @@
 package tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc;
 
 import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes;
 
 public class Response<T> {
-  private final byte responseCode;
+  public static final Bytes SUCCESS_RESPONSE_CODE = Bytes.of(0);
+  private final Bytes responseCode;
   private final T data;
 
-  public Response(final byte responseCode, final T data) {
+  public Response(final Bytes responseCode, final T data) {
     this.responseCode = responseCode;
     this.data = data;
   }
 
   public boolean isSuccess() {
-    return responseCode == 0;
+    return SUCCESS_RESPONSE_CODE.equals(responseCode);
   }
 
   public T getData() {

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcCodec.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcCodec.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
 import java.io.ByteArrayOutputStream;
@@ -59,12 +61,12 @@ public final class RpcCodec {
   }
 
   /**
-   * Decodes a RPC message into a payload.
+   * Decodes a RPC request into a payload.
    *
    * @param message the bytes of the message to read
    * @return the payload, decoded
    */
-  public static <T> T decode(Bytes message, Class<T> clazz) {
+  public static <T> T decodeRequest(Bytes message, Class<T> clazz) {
     try {
       final CodedInputStream in = CodedInputStream.newInstance(message.toArrayUnsafe());
       final int expectedLength = in.readRawVarint32();
@@ -73,5 +75,11 @@ public final class RpcCodec {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  public static <T> Response<T> decodeResponse(Bytes message, Class<T> clazz) {
+    checkArgument(!message.isEmpty(), "Cannot decode an empty response");
+    final byte responseCode = message.get(0);
+    return new Response<>(responseCode, decodeRequest(message.slice(1), clazz));
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMethod.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMethod.java
@@ -18,30 +18,39 @@ import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.BeaconBlocksMes
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.BeaconBlocksMessageResponse;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.GoodbyeMessage;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.StatusMessage;
+import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.encodings.RpcEncoding;
+import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.encodings.SszEncoding;
 import tech.pegasys.artemis.util.sos.SimpleOffsetSerializable;
 
 public class RpcMethod<I extends SimpleOffsetSerializable, O extends SimpleOffsetSerializable> {
 
+  private static final RpcEncoding SSZ = new SszEncoding();
   public static final RpcMethod<StatusMessage, StatusMessage> STATUS =
       new RpcMethod<>(
-          "/eth2/beacon_chain/req/status/1/ssz", StatusMessage.class, StatusMessage.class);
+          "/eth2/beacon_chain/req/status/1", SSZ, StatusMessage.class, StatusMessage.class);
   public static final RpcMethod<GoodbyeMessage, GoodbyeMessage> GOODBYE =
       new RpcMethod<>(
-          "/eth2/beacon_chain/req/goodbye/1/ssz", GoodbyeMessage.class, GoodbyeMessage.class);
+          "/eth2/beacon_chain/req/goodbye/1", SSZ, GoodbyeMessage.class, GoodbyeMessage.class);
   public static final RpcMethod<BeaconBlocksMessageRequest, BeaconBlocksMessageResponse>
       BEACON_BLOCKS =
           new RpcMethod<>(
-              "/eth2/beacon_chain/req/beacon_blocks/1/ssz",
+              "/eth2/beacon_chain/req/beacon_blocks/1",
+              SSZ,
               BeaconBlocksMessageRequest.class,
               BeaconBlocksMessageResponse.class);
 
   private final String methodMultistreamId;
+  private final RpcEncoding encoding;
   private final Class<I> requestType;
   private final Class<O> responseType;
 
   RpcMethod(
-      final String methodMultistreamId, final Class<I> requestType, final Class<O> responseType) {
-    this.methodMultistreamId = methodMultistreamId;
+      final String methodMultistreamId,
+      final RpcEncoding encoding,
+      final Class<I> requestType,
+      final Class<O> responseType) {
+    this.methodMultistreamId = methodMultistreamId + "/" + encoding.getName();
+    this.encoding = encoding;
     this.requestType = requestType;
     this.responseType = responseType;
   }
@@ -56,6 +65,10 @@ public class RpcMethod<I extends SimpleOffsetSerializable, O extends SimpleOffse
 
   public Class<O> getResponseType() {
     return responseType;
+  }
+
+  public RpcEncoding getEncoding() {
+    return encoding;
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/encodings/RpcEncoding.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/encodings/RpcEncoding.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.encodings;
+
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.artemis.util.sos.SimpleOffsetSerializable;
+
+public interface RpcEncoding {
+  <T extends SimpleOffsetSerializable> Bytes encodeMessage(T data);
+
+  <T> T decodeMessage(Bytes message, Class<T> clazz);
+
+  String getName();
+}

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/encodings/SszEncoding.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/encodings/SszEncoding.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.encodings;
+
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
+import tech.pegasys.artemis.util.sos.SimpleOffsetSerializable;
+
+public class SszEncoding implements RpcEncoding {
+
+  @Override
+  public <T extends SimpleOffsetSerializable> Bytes encodeMessage(final T data) {
+    final Bytes payload = SimpleOffsetSerializer.serialize(data);
+    final Bytes header = writeVarInt(payload.size());
+    return Bytes.concatenate(header, payload);
+  }
+
+  @Override
+  public <T> T decodeMessage(final Bytes message, final Class<T> clazz) {
+    try {
+      final CodedInputStream in = CodedInputStream.newInstance(message.toArrayUnsafe());
+      final int expectedLength = in.readRawVarint32();
+      final Bytes payload = Bytes.wrap(in.readRawBytes(expectedLength));
+      return SimpleOffsetSerializer.deserialize(payload, clazz);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "ssz";
+  }
+
+  private static Bytes writeVarInt(final int value) {
+    try {
+      final ByteArrayOutputStream output = new ByteArrayOutputStream();
+      final CodedOutputStream codedOutputStream = CodedOutputStream.newInstance(output);
+      codedOutputStream.writeUInt32NoTag(value);
+      codedOutputStream.flush();
+      return Bytes.wrap(output.toByteArray());
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/RpcCodecTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/RpcCodecTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.artemis.networking.p2p.jvmlibp2p;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.primitives.UnsignedLong;
@@ -25,8 +26,20 @@ import tech.pegasys.artemis.util.SSZTypes.Bytes4;
 
 final class RpcCodecTest {
 
+  private static final Bytes RECORDED_STATUS_REQUEST_BYTES =
+      Bytes.fromHexString(
+          "0x54000000000000000000000000000000000000000000000000000000000000000000000000000000000000000030A903798306695D21D1FAA76363A0070677130835E503760B0E84479B7819E60000000000000000");
+  private static final StatusMessage RECORDED_STATUS_MESSAGE_DATA =
+      new StatusMessage(
+          new Bytes4(Bytes.of(0, 0, 0, 0)),
+          Bytes32.ZERO,
+          UnsignedLong.ZERO,
+          Bytes32.fromHexString(
+              "0x30A903798306695D21D1FAA76363A0070677130835E503760B0E84479B7819E6"),
+          UnsignedLong.ZERO);
+
   @Test
-  void testHelloRoundtripSerialization() {
+  void testStatusRoundtripSerialization() {
     StatusMessage hello =
         new StatusMessage(
             Bytes4.rightPad(Bytes.of(4)),
@@ -35,9 +48,23 @@ final class RpcCodecTest {
             Bytes32.random(),
             UnsignedLong.ZERO);
 
-    Bytes encoded = RpcCodec.encode(hello);
+    final Bytes encoded = RpcCodec.encodeRequest(hello);
     StatusMessage message = RpcCodec.decode(encoded, StatusMessage.class);
 
     assertEquals(hello, message);
+  }
+
+  @Test
+  public void shouldDecodeStatusMessage() {
+    final StatusMessage actualMessage =
+        RpcCodec.decode(RECORDED_STATUS_REQUEST_BYTES, StatusMessage.class);
+    assertThat(actualMessage)
+        .isEqualToComparingFieldByFieldRecursively(RECORDED_STATUS_MESSAGE_DATA);
+  }
+
+  @Test
+  public void shouldEncodeStatusRequestCorrectly() {
+    final Bytes actualBytes = RpcCodec.encodeRequest(RECORDED_STATUS_MESSAGE_DATA);
+    assertThat(actualBytes).isEqualTo(RECORDED_STATUS_REQUEST_BYTES);
   }
 }

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/RpcCodecTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/RpcCodecTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.artemis.networking.p2p.jvmlibp2p;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes;
@@ -23,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.Response;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.RpcCodec;
+import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.encodings.SszEncoding;
 import tech.pegasys.artemis.util.SSZTypes.Bytes4;
 
 final class RpcCodecTest {
@@ -42,9 +42,11 @@ final class RpcCodecTest {
               "0x30A903798306695D21D1FAA76363A0070677130835E503760B0E84479B7819E6"),
           UnsignedLong.ZERO);
 
+  private final RpcCodec codec = new RpcCodec(new SszEncoding());
+
   @Test
   void testStatusRoundtripSerialization() {
-    StatusMessage hello =
+    final StatusMessage expected =
         new StatusMessage(
             Bytes4.rightPad(Bytes.of(4)),
             Bytes32.random(),
@@ -52,38 +54,38 @@ final class RpcCodecTest {
             Bytes32.random(),
             UnsignedLong.ZERO);
 
-    final Bytes encoded = RpcCodec.encodeRequest(hello);
-    StatusMessage message = RpcCodec.decodeRequest(encoded, StatusMessage.class);
+    final Bytes encoded = codec.encodeRequest(expected);
+    final StatusMessage actual = codec.decodeRequest(encoded, StatusMessage.class);
 
-    assertEquals(hello, message);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
   public void shouldDecodeStatusMessageRequest() {
     final StatusMessage actualMessage =
-        RpcCodec.decodeRequest(RECORDED_STATUS_REQUEST_BYTES, StatusMessage.class);
+        codec.decodeRequest(RECORDED_STATUS_REQUEST_BYTES, StatusMessage.class);
     assertThat(actualMessage)
         .isEqualToComparingFieldByFieldRecursively(RECORDED_STATUS_MESSAGE_DATA);
   }
 
   @Test
   public void shouldEncodeStatusRequest() {
-    final Bytes actualBytes = RpcCodec.encodeRequest(RECORDED_STATUS_MESSAGE_DATA);
+    final Bytes actualBytes = codec.encodeRequest(RECORDED_STATUS_MESSAGE_DATA);
     assertThat(actualBytes).isEqualTo(RECORDED_STATUS_REQUEST_BYTES);
   }
 
   @Test
   public void shouldDecodeStatusResponse() {
     final Response<StatusMessage> actualMessage =
-        RpcCodec.decodeResponse(RECORDED_STATUS_RESPONSE_BYTES, StatusMessage.class);
+        codec.decodeResponse(RECORDED_STATUS_RESPONSE_BYTES, StatusMessage.class);
     assertThat(actualMessage)
         .isEqualToComparingFieldByFieldRecursively(
-            new Response<>((byte) 0, RECORDED_STATUS_MESSAGE_DATA));
+            new Response<>(Bytes.of(0), RECORDED_STATUS_MESSAGE_DATA));
   }
 
   @Test
   public void shouldEncodeSuccessfulResponse() {
-    final Bytes actual = RpcCodec.encodeSuccessfulResponse(RECORDED_STATUS_MESSAGE_DATA);
+    final Bytes actual = codec.encodeSuccessfulResponse(RECORDED_STATUS_MESSAGE_DATA);
     assertThat(actual).isEqualTo(RECORDED_STATUS_RESPONSE_BYTES);
   }
 }

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/RpcCodecTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/RpcCodecTest.java
@@ -21,6 +21,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.StatusMessage;
+import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.Response;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.RpcCodec;
 import tech.pegasys.artemis.util.SSZTypes.Bytes4;
 
@@ -29,6 +30,9 @@ final class RpcCodecTest {
   private static final Bytes RECORDED_STATUS_REQUEST_BYTES =
       Bytes.fromHexString(
           "0x54000000000000000000000000000000000000000000000000000000000000000000000000000000000000000030A903798306695D21D1FAA76363A0070677130835E503760B0E84479B7819E60000000000000000");
+  private static final Bytes RECORDED_STATUS_RESPONSE_BYTES =
+      Bytes.fromHexString(
+          "0x0054000000000000000000000000000000000000000000000000000000000000000000000000000000000000000030A903798306695D21D1FAA76363A0070677130835E503760B0E84479B7819E60000000000000000");
   private static final StatusMessage RECORDED_STATUS_MESSAGE_DATA =
       new StatusMessage(
           new Bytes4(Bytes.of(0, 0, 0, 0)),
@@ -49,22 +53,37 @@ final class RpcCodecTest {
             UnsignedLong.ZERO);
 
     final Bytes encoded = RpcCodec.encodeRequest(hello);
-    StatusMessage message = RpcCodec.decode(encoded, StatusMessage.class);
+    StatusMessage message = RpcCodec.decodeRequest(encoded, StatusMessage.class);
 
     assertEquals(hello, message);
   }
 
   @Test
-  public void shouldDecodeStatusMessage() {
+  public void shouldDecodeStatusMessageRequest() {
     final StatusMessage actualMessage =
-        RpcCodec.decode(RECORDED_STATUS_REQUEST_BYTES, StatusMessage.class);
+        RpcCodec.decodeRequest(RECORDED_STATUS_REQUEST_BYTES, StatusMessage.class);
     assertThat(actualMessage)
         .isEqualToComparingFieldByFieldRecursively(RECORDED_STATUS_MESSAGE_DATA);
   }
 
   @Test
-  public void shouldEncodeStatusRequestCorrectly() {
+  public void shouldEncodeStatusRequest() {
     final Bytes actualBytes = RpcCodec.encodeRequest(RECORDED_STATUS_MESSAGE_DATA);
     assertThat(actualBytes).isEqualTo(RECORDED_STATUS_REQUEST_BYTES);
+  }
+
+  @Test
+  public void shouldDecodeStatusResponse() {
+    final Response<StatusMessage> actualMessage =
+        RpcCodec.decodeResponse(RECORDED_STATUS_RESPONSE_BYTES, StatusMessage.class);
+    assertThat(actualMessage)
+        .isEqualToComparingFieldByFieldRecursively(
+            new Response<>((byte) 0, RECORDED_STATUS_MESSAGE_DATA));
+  }
+
+  @Test
+  public void shouldEncodeSuccessfulResponse() {
+    final Bytes actual = RpcCodec.encodeSuccessfulResponse(RECORDED_STATUS_MESSAGE_DATA);
+    assertThat(actual).isEqualTo(RECORDED_STATUS_RESPONSE_BYTES);
   }
 }


### PR DESCRIPTION
## PR Description
Req/Resp messages need to be prefixed with the expected message length.
Responses need to be further prefixed with a status code indicating success or failure.
Also need to delay closing Netty channels until the last write has actually completed.