### PR TITLE
Fix cli args for slot transition delta.

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/TransitionCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/TransitionCommand.java
@@ -95,7 +95,7 @@ public class TransitionCommand implements Runnable {
   public void slots(
       @Mixin InAndOutParams params,
       @Option(
-              names = "delta",
+              names = {"--delta", "-d"},
               description = "to interpret the slot number as a delta from the pre-state")
           boolean delta,
       @Parameters(paramLabel = "<number>", description = "Number of slots to process")


### PR DESCRIPTION
## PR Description
Fix `delta` command line arg for slot transitions so it has a `--` prefix and supports the short `-d` variant.