### PR TITLE
Use generics to check the element type for SSZList and SSZVector

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/BeaconStateWithCache.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/BeaconStateWithCache.java
@@ -127,7 +127,7 @@ public final class BeaconStateWithCache extends BeaconState {
     this.validators =
         copyList(
             state.getValidators(),
-            new SSZList<>(state.getValidators().getClass(), state.getValidators().getMaxSize()));
+            new SSZList<>(Validator.class, state.getValidators().getMaxSize()));
     this.balances = new SSZList<>(state.getBalances());
 
     // Shuffling
@@ -144,14 +144,12 @@ public final class BeaconStateWithCache extends BeaconState {
         copyList(
             state.getPrevious_epoch_attestations(),
             new SSZList<>(
-                state.getPrevious_epoch_attestations().getClass(),
-                state.getPrevious_epoch_attestations().getMaxSize()));
+                PendingAttestation.class, state.getPrevious_epoch_attestations().getMaxSize()));
     this.current_epoch_attestations =
         copyList(
             state.getCurrent_epoch_attestations(),
             new SSZList<>(
-                state.getCurrent_epoch_attestations().getClass(),
-                state.getCurrent_epoch_attestations().getMaxSize()));
+                PendingAttestation.class, state.getCurrent_epoch_attestations().getMaxSize()));
 
     // Crosslinks
     SSZVector<Crosslink> newCurrentCrosslinks =

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DataStructureUtil.java
@@ -74,16 +74,14 @@ public final class DataStructureUtil {
     return Bytes32.random(new SecureRandom(buffer.array()));
   }
 
-  @SuppressWarnings({"rawtypes", "unchecked"})
   public static <T> SSZList<T> randomSSZList(
-      Class classInfo, long maxSize, Function<Integer, T> randomFunction, int seed) {
+      Class<T> classInfo, long maxSize, Function<Integer, T> randomFunction, int seed) {
     SSZList<T> sszList = new SSZList<>(classInfo, maxSize);
     long numItems = maxSize / 10;
     LongStream.range(0, numItems).forEach(i -> sszList.add(randomFunction.apply(seed)));
     return sszList;
   }
 
-  @SuppressWarnings({"rawtypes", "unchecked"})
   public static <T> SSZVector<T> randomSSZVector(
       T defaultClassObject, long maxSize, Function<Integer, T> randomFunction, int seed) {
     SSZVector<T> sszvector = new SSZVector<>(toIntExact(maxSize), defaultClassObject);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/EpochProcessorUtil.java
@@ -75,7 +75,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.ssz.SSZ;
 import tech.pegasys.artemis.datastructures.blocks.Eth1Data;
-import tech.pegasys.artemis.datastructures.operations.Attestation;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.state.BeaconStateWithCache;
 import tech.pegasys.artemis.datastructures.state.Checkpoint;
@@ -833,6 +832,6 @@ public final class EpochProcessorUtil {
     // Rotate current/previous epoch attestations
     state.setPrevious_epoch_attestations(state.getCurrent_epoch_attestations());
     state.setCurrent_epoch_attestations(
-        new SSZList<>(Attestation.class, MAX_ATTESTATIONS * SLOTS_PER_EPOCH));
+        new SSZList<>(PendingAttestation.class, MAX_ATTESTATIONS * SLOTS_PER_EPOCH));
   }
 }

--- a/util/src/main/java/tech/pegasys/artemis/util/SSZTypes/SSZList.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/SSZTypes/SSZList.java
@@ -16,17 +16,12 @@ package tech.pegasys.artemis.util.SSZTypes;
 import java.util.ArrayList;
 import java.util.List;
 
-@SuppressWarnings("rawtypes")
 public class SSZList<T> extends ArrayList<T> {
 
   private long maxSize;
-  private Class classInfo;
+  private Class<T> classInfo;
 
-  public SSZList() throws UnsupportedOperationException {
-    throw new UnsupportedOperationException("SSZList must have specified max size");
-  }
-
-  public SSZList(Class classInfo, long maxSize) {
+  public SSZList(Class<T> classInfo, long maxSize) {
     super();
     this.classInfo = classInfo;
     this.maxSize = maxSize;
@@ -38,7 +33,7 @@ public class SSZList<T> extends ArrayList<T> {
     this.classInfo = list.getElementType();
   }
 
-  public SSZList(List<T> list, long maxSize, Class classInfo) {
+  public SSZList(List<T> list, long maxSize, Class<T> classInfo) {
     super(list);
     this.maxSize = maxSize;
     this.classInfo = classInfo;
@@ -57,7 +52,7 @@ public class SSZList<T> extends ArrayList<T> {
     return maxSize;
   }
 
-  public Class getElementType() {
+  public Class<T> getElementType() {
     return classInfo;
   }
 }

--- a/util/src/main/java/tech/pegasys/artemis/util/SSZTypes/SSZVector.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/SSZTypes/SSZVector.java
@@ -17,23 +17,23 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-@SuppressWarnings("rawtypes")
 public class SSZVector<T> extends ArrayList<T> {
 
   private int maxSize;
-  private Class classInfo;
+  private Class<T> classInfo;
 
   public SSZVector() throws UnsupportedOperationException {
     throw new UnsupportedOperationException("SSZVector must have specified size");
   }
 
+  @SuppressWarnings("unchecked")
   public SSZVector(int size, T object) {
     super(Collections.nCopies(size, object));
     this.maxSize = size;
-    classInfo = object.getClass();
+    classInfo = (Class<T>) object.getClass();
   }
 
-  public SSZVector(List<T> list, Class classInfo) {
+  public SSZVector(List<T> list, Class<T> classInfo) {
     super(list);
     maxSize = list.size();
     this.classInfo = classInfo;
@@ -54,7 +54,7 @@ public class SSZVector<T> extends ArrayList<T> {
     throw new UnsupportedOperationException("SSZVector does not support add, only set");
   }
 
-  public Class getElementType() {
+  public Class<T> getElementType() {
     return classInfo;
   }
 }


### PR DESCRIPTION
## PR Description
`SSZList` and `SSZVector` require a `Class` to be provided for the element type they contain. Use generics to ensure that they actually match and fix the couple of places where the wrong type was being specified.