### PR TITLE
[BC-91] Validate attestations before re-gossiping

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
@@ -82,8 +82,15 @@ public class AttestationUtil {
       BeaconState headState,
       HashMap<UnsignedLong, List<Triple<List<Integer>, UnsignedLong, Integer>>>
           committeeAssignments) {
-
     UnsignedLong slot = headState.getSlot();
+    return getAttesterInformation(headState, committeeAssignments, slot);
+  }
+
+  public static List<Triple<BLSPublicKey, Integer, CrosslinkCommittee>> getAttesterInformation(
+      BeaconState state,
+      HashMap<UnsignedLong, List<Triple<List<Integer>, UnsignedLong, Integer>>>
+          committeeAssignments,
+      final UnsignedLong slot) {
     List<Triple<List<Integer>, UnsignedLong, Integer>> committeeAssignmentsForSlot =
         committeeAssignments.get(slot);
     List<Triple<BLSPublicKey, Integer, CrosslinkCommittee>> attesters = new ArrayList<>();
@@ -97,7 +104,7 @@ public class AttestationUtil {
         CrosslinkCommittee crosslinkCommittee = new CrosslinkCommittee(shard, committee);
         attesters.add(
             new MutableTriple<>(
-                headState.getValidators().get(validatorIndex).getPubkey(),
+                state.getValidators().get(validatorIndex).getPubkey(),
                 indexIntoCommittee,
                 crosslinkCommittee));
       }

--- a/ethereum/statetransition/build.gradle
+++ b/ethereum/statetransition/build.gradle
@@ -19,6 +19,8 @@ dependencies {
   implementation 'tech.pegasys.pantheon.internal:metrics-core'
   runtime 'org.apache.logging.log4j:log4j-core'
 
+  testSupportImplementation project(path: ':util', configuration: 'testSupportArtifacts')
+
   test {
     testLogging.showStandardStreams = true
   }

--- a/ethereum/statetransition/src/test-support/java/tech/pegasys/artemis/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/test-support/java/tech/pegasys/artemis/statetransition/BeaconChainUtil.java
@@ -34,12 +34,12 @@ import tech.pegasys.artemis.datastructures.operations.Attestation;
 import tech.pegasys.artemis.datastructures.operations.Deposit;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.state.BeaconStateWithCache;
-import tech.pegasys.artemis.datastructures.util.MockStartValidatorKeyPairFactory;
 import tech.pegasys.artemis.statetransition.util.EpochProcessingException;
 import tech.pegasys.artemis.statetransition.util.SlotProcessingException;
 import tech.pegasys.artemis.statetransition.util.StartupUtil;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.util.SSZTypes.SSZList;
+import tech.pegasys.artemis.util.bls.BLSKeyGenerator;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
@@ -57,13 +57,17 @@ public class BeaconChainUtil {
 
   public static BeaconChainUtil create(
       final int validatorCount, final ChainStorageClient storageClient) {
-    final List<BLSKeyPair> validatorKeys =
-        new MockStartValidatorKeyPairFactory().generateKeyPairs(validatorCount);
+    final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(validatorCount);
     return new BeaconChainUtil(validatorKeys, storageClient);
   }
 
-  public void initializeStorage(final ChainStorageClient chainStorageClient) {
+  public static void initializeStorage(
+      final ChainStorageClient chainStorageClient, final List<BLSKeyPair> validatorKeys) {
     StartupUtil.setupInitialState(chainStorageClient, 0, null, validatorKeys);
+  }
+
+  public void initializeStorage(final ChainStorageClient chainStorageClient) {
+    initializeStorage(chainStorageClient, validatorKeys);
   }
 
   public BeaconBlock createBlockAtSlot(final UnsignedLong slot)

--- a/networking/p2p/build.gradle
+++ b/networking/p2p/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   testImplementation 'org.mockito:mockito-core'
   testImplementation project(path: ':ethereum:statetransition', configuration: 'testSupportArtifacts')
   testImplementation project(path: ':util', configuration: 'testSupportArtifacts')
+  testImplementation project(path: ':validator:client', configuration: 'testSupportArtifacts')
 
   integrationTestImplementation project(path: ':ethereum:statetransition', configuration: 'testSupportArtifacts')
   integrationTestImplementation project(path: ':util', configuration: 'testSupportArtifacts')

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandler.java
@@ -18,10 +18,8 @@ import static tech.pegasys.artemis.datastructures.util.AttestationUtil.is_valid_
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
-import io.libp2p.core.pubsub.MessageApi;
 import io.libp2p.core.pubsub.PubsubPublisherApi;
 import io.libp2p.core.pubsub.Topic;
-import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -38,7 +36,10 @@ public class AttestationTopicHandler extends GossipTopicHandler<Attestation> {
   private static final Topic ATTESTATIONS_TOPIC = new Topic("/eth2/beacon_attestation/ssz");
   private final ChainStorageClient chainStorageClient;
 
-  protected AttestationTopicHandler(final PubsubPublisherApi publisher, final EventBus eventBus, final ChainStorageClient chainStorageClient) {
+  protected AttestationTopicHandler(
+      final PubsubPublisherApi publisher,
+      final EventBus eventBus,
+      final ChainStorageClient chainStorageClient) {
     super(publisher, eventBus);
     this.chainStorageClient = chainStorageClient;
   }
@@ -54,20 +55,22 @@ public class AttestationTopicHandler extends GossipTopicHandler<Attestation> {
   }
 
   @Override
-  public Optional<Attestation> processData(MessageApi message, Bytes bytes) throws SSZException {
-    final Attestation attestation = SimpleOffsetSerializer.deserialize(bytes, Attestation.class);
-    if (attestation == null) {
-      LOG.trace("Received malformed attestation from {} on {}", message.getFrom(), getTopic());
-    }
+  protected Attestation deserialize(final Bytes bytes) throws SSZException {
+    return SimpleOffsetSerializer.deserialize(bytes, Attestation.class);
+  }
 
-    final BeaconState state = chainStorageClient.getStore().getBlockState(attestation.getData().getBeacon_block_root());
+  @Override
+  protected boolean validateData(final Attestation attestation) {
+    final BeaconState state =
+        chainStorageClient.getStore().getBlockState(attestation.getData().getBeacon_block_root());
     final IndexedAttestation indexedAttestation = get_indexed_attestation(state, attestation);
     final boolean validAttestation = is_valid_indexed_attestation(state, indexedAttestation);
     if (!validAttestation) {
-      LOG.trace("Received invalid attestation ({}) on {}", attestation.hash_tree_root(), getTopic());
-      return Optional.empty();
+      LOG.trace(
+          "Received invalid attestation ({}) on {}", attestation.hash_tree_root(), getTopic());
+      return false;
     }
 
-    return Optional.ofNullable(attestation);
+    return true;
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandler.java
@@ -13,23 +13,34 @@
 
 package tech.pegasys.artemis.networking.p2p.jvmlibp2p.gossip;
 
+import static tech.pegasys.artemis.datastructures.util.AttestationUtil.get_indexed_attestation;
+import static tech.pegasys.artemis.datastructures.util.AttestationUtil.is_valid_indexed_attestation;
+
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import io.libp2p.core.pubsub.MessageApi;
 import io.libp2p.core.pubsub.PubsubPublisherApi;
 import io.libp2p.core.pubsub.Topic;
 import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.ssz.SSZException;
 import tech.pegasys.artemis.datastructures.operations.Attestation;
+import tech.pegasys.artemis.datastructures.operations.IndexedAttestation;
+import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
+import tech.pegasys.artemis.storage.ChainStorageClient;
 
 public class AttestationTopicHandler extends GossipTopicHandler<Attestation> {
 
+  private static final Logger LOG = LogManager.getLogger();
   private static final Topic ATTESTATIONS_TOPIC = new Topic("/eth2/beacon_attestation/ssz");
+  private final ChainStorageClient chainStorageClient;
 
-  protected AttestationTopicHandler(final PubsubPublisherApi publisher, final EventBus eventBus) {
+  protected AttestationTopicHandler(final PubsubPublisherApi publisher, final EventBus eventBus, final ChainStorageClient chainStorageClient) {
     super(publisher, eventBus);
+    this.chainStorageClient = chainStorageClient;
   }
 
   @Override
@@ -44,7 +55,19 @@ public class AttestationTopicHandler extends GossipTopicHandler<Attestation> {
 
   @Override
   public Optional<Attestation> processData(MessageApi message, Bytes bytes) throws SSZException {
-    Attestation attestation = SimpleOffsetSerializer.deserialize(bytes, Attestation.class);
+    final Attestation attestation = SimpleOffsetSerializer.deserialize(bytes, Attestation.class);
+    if (attestation == null) {
+      LOG.trace("Received malformed attestation from {} on {}", message.getFrom(), getTopic());
+    }
+
+    final BeaconState state = chainStorageClient.getStore().getBlockState(attestation.getData().getBeacon_block_root());
+    final IndexedAttestation indexedAttestation = get_indexed_attestation(state, attestation);
+    final boolean validAttestation = is_valid_indexed_attestation(state, indexedAttestation);
+    if (!validAttestation) {
+      LOG.trace("Received invalid attestation ({}) on {}", attestation.hash_tree_root(), getTopic());
+      return Optional.empty();
+    }
+
     return Optional.ofNullable(attestation);
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/GossipMessageHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/GossipMessageHandler.java
@@ -69,7 +69,7 @@ public class GossipMessageHandler {
       final EventBus eventBus,
       final ChainStorageClient chainStorageClient) {
     return List.of(
-        new AttestationTopicHandler(publisher, eventBus),
+        new AttestationTopicHandler(publisher, eventBus, chainStorageClient),
         new BlocksTopicHandler(publisher, eventBus, chainStorageClient));
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/GossipTopicHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/GossipTopicHandler.java
@@ -69,7 +69,7 @@ public abstract class GossipTopicHandler<T extends SimpleOffsetSerializable>
       LOG.trace("Received malformed gossip message on {}", getTopic());
       return;
     } catch (Throwable e) {
-      LOG.error("Encountered exception while processing message for topic {}", getTopic(), e);
+      LOG.warn("Encountered exception while processing message for topic {}", getTopic(), e);
       return;
     }
 

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
@@ -36,14 +36,18 @@ import tech.pegasys.artemis.datastructures.operations.Attestation;
 import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
 import tech.pegasys.artemis.network.p2p.jvmlibp2p.MockMessageApi;
+import tech.pegasys.artemis.statetransition.BeaconChainUtil;
+import tech.pegasys.artemis.storage.ChainStorageClient;
 
 public class AttestationTopicHandlerTest {
 
   private final PubsubPublisherApi publisher = mock(PubsubPublisherApi.class);
   private final EventBus eventBus = spy(new EventBus());
+  private final ChainStorageClient storageClient = new ChainStorageClient(eventBus);
+  private final BeaconChainUtil beaconChainUtil = BeaconChainUtil.create(12, storageClient);
 
   private final AttestationTopicHandler topicHandler =
-      new AttestationTopicHandler(publisher, eventBus);
+      new AttestationTopicHandler(publisher, eventBus, storageClient);
 
   ArgumentCaptor<ByteBuf> byteBufCaptor = ArgumentCaptor.forClass(ByteBuf.class);
   ArgumentCaptor<Topic> topicCaptor = ArgumentCaptor.forClass(Topic.class);

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.artemis.datastructures.operations.Attestation;
@@ -104,7 +103,6 @@ public class AttestationTopicHandlerTest {
     verify(publisher, never()).publish(any(), any());
   }
 
-  @Disabled("Gossiped attestations do not yet undergo any validation")
   @Test
   public void accept_invalidAttestation_badData() {
     final Bytes serialized = Bytes.fromHexString("0x3456");

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/GossipTopicHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/GossipTopicHandlerTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.artemis.networking.p2p.jvmlibp2p.gossip;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -42,7 +43,7 @@ public class GossipTopicHandlerTest {
 
   private final PubsubPublisherApi publisher = mock(PubsubPublisherApi.class);
   private final EventBus eventBus = spy(new EventBus());
-  private final MockTopicHandler topicHandler = new MockTopicHandler(publisher, eventBus);
+  private final MockTopicHandler topicHandler = spy(new MockTopicHandler(publisher, eventBus));
 
   ArgumentCaptor<ByteBuf> byteBufCaptor = ArgumentCaptor.forClass(ByteBuf.class);
   ArgumentCaptor<Topic> topicCaptor = ArgumentCaptor.forClass(Topic.class);
@@ -53,7 +54,7 @@ public class GossipTopicHandlerTest {
   }
 
   @Test
-  public void accept_successfulProcessing() {
+  public void accept_validMessage() {
     final Bytes data = Bytes.fromHexString("0x1234");
     final MockSimpleOffsetSerializable mockObject = new MockSimpleOffsetSerializable(data);
     final Bytes serialized = SimpleOffsetSerializer.serialize(mockObject);
@@ -70,7 +71,7 @@ public class GossipTopicHandlerTest {
   }
 
   @Test
-  public void accept_unsuccessfulProcessing() {
+  public void accept_invalidMessage() {
     topicHandler.setShouldValidate(false);
 
     final Bytes data = Bytes.fromHexString("0x1234");
@@ -78,6 +79,51 @@ public class GossipTopicHandlerTest {
     final Bytes serialized = SimpleOffsetSerializer.serialize(mockObject);
 
     final MessageApi mockMessage = new MockMessageApi(serialized, topicHandler.getTopic());
+
+    topicHandler.accept(mockMessage);
+
+    verify(eventBus, never()).post(mockObject);
+    verify(publisher, never()).publish(any(), any());
+  }
+
+  @Test
+  public void accept_malformedData_deserializesToNull() {
+    final Bytes data = Bytes.fromHexString("0x1234");
+    final MockSimpleOffsetSerializable mockObject = new MockSimpleOffsetSerializable(data);
+    final Bytes serialized = SimpleOffsetSerializer.serialize(mockObject);
+
+    final MessageApi mockMessage = new MockMessageApi(serialized, topicHandler.getTopic());
+    doReturn(null).when(topicHandler).deserialize(any());
+
+    topicHandler.accept(mockMessage);
+
+    verify(eventBus, never()).post(mockObject);
+    verify(publisher, never()).publish(any(), any());
+  }
+
+  @Test
+  public void accept_malformedData_exceptionalDeserialization() {
+    final Bytes data = Bytes.fromHexString("0x1234");
+    final MockSimpleOffsetSerializable mockObject = new MockSimpleOffsetSerializable(data);
+    final Bytes serialized = SimpleOffsetSerializer.serialize(mockObject);
+
+    final MessageApi mockMessage = new MockMessageApi(serialized, topicHandler.getTopic());
+    doThrow(new SSZException("whoops")).when(topicHandler).deserialize(any());
+
+    topicHandler.accept(mockMessage);
+
+    verify(eventBus, never()).post(mockObject);
+    verify(publisher, never()).publish(any(), any());
+  }
+
+  @Test
+  public void accept_unableToValidate() {
+    final Bytes data = Bytes.fromHexString("0x1234");
+    final MockSimpleOffsetSerializable mockObject = new MockSimpleOffsetSerializable(data);
+    final Bytes serialized = SimpleOffsetSerializer.serialize(mockObject);
+
+    final MessageApi mockMessage = new MockMessageApi(serialized, topicHandler.getTopic());
+    doThrow(new RuntimeException("whoops")).when(topicHandler).validateData(any());
 
     topicHandler.accept(mockMessage);
 

--- a/util/src/test-support/java/tech/pegasys/artemis/util/bls/BLSKeyGenerator.java
+++ b/util/src/test-support/java/tech/pegasys/artemis/util/bls/BLSKeyGenerator.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.util.bls;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class BLSKeyGenerator {
+  public static List<BLSKeyPair> generateKeyPairs(final int count) {
+    return Stream.generate(BLSKeyPair::random).limit(count).collect(Collectors.toList());
+  }
+}

--- a/validator/client/build.gradle
+++ b/validator/client/build.gradle
@@ -19,4 +19,8 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation 'org.apache.commons:commons-lang3'
   runtime 'org.apache.logging.log4j:log4j-core'
+
+  testSupportImplementation project(':storage')
+  testSupportImplementation project(path: ':util', configuration: 'testSupportArtifacts')
+  testSupportImplementation project(path: ':validator:client')
 }

--- a/validator/client/src/test-support/java/tech/pegasys/artemis/validator/client/AttestationGenerator.java
+++ b/validator/client/src/test-support/java/tech/pegasys/artemis/validator/client/AttestationGenerator.java
@@ -60,7 +60,7 @@ public class AttestationGenerator {
     return createAttestation(block, state, false);
   }
 
-  public Attestation createAttestation(
+  private Attestation createAttestation(
       final BeaconBlock block, final BeaconState state, final boolean withValidSignature) {
     final UnsignedLong epoch = compute_epoch_of_slot(state.getSlot());
     HashMap<UnsignedLong, List<Triple<List<Integer>, UnsignedLong, Integer>>> committeeAssignments =

--- a/validator/client/src/test-support/java/tech/pegasys/artemis/validator/client/AttestationGenerator.java
+++ b/validator/client/src/test-support/java/tech/pegasys/artemis/validator/client/AttestationGenerator.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.validator.client;
+
+import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_epoch_of_slot;
+import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_domain;
+import static tech.pegasys.artemis.util.config.Constants.DOMAIN_ATTESTATION;
+import static tech.pegasys.artemis.util.config.Constants.MAX_VALIDATORS_PER_COMMITTEE;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import org.apache.commons.lang3.tuple.MutableTriple;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
+import tech.pegasys.artemis.datastructures.operations.Attestation;
+import tech.pegasys.artemis.datastructures.operations.AttestationData;
+import tech.pegasys.artemis.datastructures.state.BeaconState;
+import tech.pegasys.artemis.datastructures.state.CrosslinkCommittee;
+import tech.pegasys.artemis.datastructures.util.AttestationUtil;
+import tech.pegasys.artemis.storage.ChainStorageClient;
+import tech.pegasys.artemis.util.SSZTypes.Bitlist;
+import tech.pegasys.artemis.util.bls.BLSKeyPair;
+import tech.pegasys.artemis.util.bls.BLSPublicKey;
+import tech.pegasys.artemis.util.bls.BLSSignature;
+
+public class AttestationGenerator {
+  private final List<BLSKeyPair> validatorKeys;
+  private final BLSKeyPair randomKeyPair = BLSKeyPair.random();
+
+  public AttestationGenerator(final List<BLSKeyPair> validatorKeys) {
+    this.validatorKeys = validatorKeys;
+  }
+
+  public Attestation validAttestation(final ChainStorageClient storageClient) {
+    final Bytes32 bestBlockRoot = storageClient.getBestBlockRoot();
+    BeaconBlock block = storageClient.getStore().getBlock(bestBlockRoot);
+    BeaconState state = storageClient.getStore().getBlockState(bestBlockRoot);
+    return createAttestation(block, state, true);
+  }
+
+  public Attestation attestationWithInvalidSignature(final ChainStorageClient storageClient) {
+    final Bytes32 bestBlockRoot = storageClient.getBestBlockRoot();
+    BeaconBlock block = storageClient.getStore().getBlock(bestBlockRoot);
+    BeaconState state = storageClient.getStore().getBlockState(bestBlockRoot);
+    return createAttestation(block, state, false);
+  }
+
+  public Attestation createAttestation(
+      final BeaconBlock block, final BeaconState state, final boolean withValidSignature) {
+    final UnsignedLong epoch = compute_epoch_of_slot(state.getSlot());
+    HashMap<UnsignedLong, List<Triple<List<Integer>, UnsignedLong, Integer>>> committeeAssignments =
+        new HashMap<>();
+    int validatorIndex;
+    for (validatorIndex = 0; validatorIndex < validatorKeys.size(); validatorIndex++) {
+      final Optional<Triple<List<Integer>, UnsignedLong, UnsignedLong>> maybeAssignment =
+          ValidatorClientUtil.get_committee_assignment(state, epoch, validatorIndex);
+      if (maybeAssignment.isPresent()) {
+        UnsignedLong slot = maybeAssignment.get().getRight();
+        final Triple<List<Integer>, UnsignedLong, Integer> committeeAssignment =
+            new MutableTriple<>(
+                maybeAssignment.get().getLeft(), // List of validator indices in this committee
+                maybeAssignment.get().getMiddle(), // Assigned shard
+                validatorIndex // The index of the current validator
+                );
+        committeeAssignments.put(slot, List.of(committeeAssignment));
+        break;
+      }
+    }
+    if (committeeAssignments.isEmpty()) {
+      throw new IllegalStateException("Unable to find committee assignment among validators");
+    }
+
+    final UnsignedLong slot = committeeAssignments.keySet().iterator().next();
+    Triple<BLSPublicKey, Integer, CrosslinkCommittee> attesterInfo =
+        AttestationUtil.getAttesterInformation(state, committeeAssignments, slot).get(0);
+    AttestationData genericAttestationData =
+        AttestationUtil.getGenericAttestationData(state, block);
+
+    final BLSKeyPair validatorKeyPair =
+        withValidSignature ? validatorKeys.get(validatorIndex) : randomKeyPair;
+    return createAttestation(
+        state,
+        validatorKeyPair,
+        attesterInfo.getMiddle(),
+        attesterInfo.getRight(),
+        genericAttestationData);
+  }
+
+  private Attestation createAttestation(
+      BeaconState state,
+      BLSKeyPair attesterKeyPair,
+      int indexIntoCommittee,
+      CrosslinkCommittee committee,
+      AttestationData genericAttestationData) {
+    int commmitteSize = committee.getCommitteeSize();
+    Bitlist aggregationBitfield =
+        AttestationUtil.getAggregationBits(commmitteSize, indexIntoCommittee);
+    Bitlist custodyBits = new Bitlist(commmitteSize, MAX_VALIDATORS_PER_COMMITTEE);
+    AttestationData attestationData =
+        AttestationUtil.completeAttestationCrosslinkData(
+            state, new AttestationData(genericAttestationData), committee);
+    Bytes32 attestationMessage = AttestationUtil.getAttestationMessageToSign(attestationData);
+    Bytes domain = get_domain(state, DOMAIN_ATTESTATION, attestationData.getTarget().getEpoch());
+
+    BLSSignature signature = BLSSignature.sign(attesterKeyPair, attestationMessage, domain);
+    return new Attestation(aggregationBitfield, attestationData, custodyBits, signature);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Summary:
* Add validation for gossiped attestations
* Refactor topic handler code to reduce duplication across handlers
* Add a test utility for creating valid and invalid attestations
