### PR TITLE
[BC-114] Undo changes to AttestionUtil

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
@@ -73,14 +73,6 @@ public class AttestationUtil {
       HashMap<UnsignedLong, List<Triple<List<Integer>, UnsignedLong, Integer>>>
           committeeAssignments) {
     UnsignedLong slot = headState.getSlot();
-    return getAttesterInformation(headState, committeeAssignments, slot);
-  }
-
-  public static List<Triple<BLSPublicKey, Integer, Committee>> getAttesterInformation(
-      BeaconState state,
-      HashMap<UnsignedLong, List<Triple<List<Integer>, UnsignedLong, Integer>>>
-          committeeAssignments,
-      final UnsignedLong slot) {
     List<Triple<List<Integer>, UnsignedLong, Integer>> committeeAssignmentsForSlot =
         committeeAssignments.get(slot);
     List<Triple<BLSPublicKey, Integer, Committee>> attesters = new ArrayList<>();
@@ -94,7 +86,7 @@ public class AttestationUtil {
         Committee crosslinkCommittee = new Committee(index, committee);
         attesters.add(
             new MutableTriple<>(
-                state.getValidators().get(validatorIndex).getPubkey(),
+                headState.getValidators().get(validatorIndex).getPubkey(),
                 indexIntoCommittee,
                 crosslinkCommittee));
       }
@@ -105,12 +97,6 @@ public class AttestationUtil {
   // Get attestation data that does not include attester specific shard or crosslink information
   public static AttestationData getGenericAttestationData(BeaconState state, BeaconBlock block) {
     UnsignedLong slot = state.getSlot();
-    return getGenericAttestationData(state, block, slot);
-  }
-
-  // Get attestation data that does not include attester specific shard or crosslink information
-  public static AttestationData getGenericAttestationData(
-      BeaconState state, BeaconBlock block, UnsignedLong slot) {
     // Get variables necessary that can be shared among Attestations of all validators
     Bytes32 beacon_block_root = block.signing_root("signature");
     UnsignedLong start_slot = compute_start_slot_at_epoch(get_current_epoch(state));

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
@@ -101,7 +101,7 @@ public class AttestationUtil {
     Bytes32 beacon_block_root = block.signing_root("signature");
     UnsignedLong start_slot = compute_start_slot_at_epoch(get_current_epoch(state));
     Bytes32 epoch_boundary_block_root =
-        start_slot.compareTo(slot) <= 0
+        start_slot.compareTo(slot) == 0
             ? block.signing_root("signature")
             : get_block_root_at_slot(state, start_slot);
     Checkpoint source = state.getCurrent_justified_checkpoint();

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
@@ -76,7 +76,7 @@ public class AttestationTopicHandlerTest {
   }
 
   @Test
-  public void accept_validAttestation() {
+  public void accept_validAttestation() throws Exception {
     final AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
     final Attestation attestation = attestationGenerator.validAttestation(storageClient);
     final Bytes serialized = SimpleOffsetSerializer.serialize(attestation);
@@ -91,7 +91,7 @@ public class AttestationTopicHandlerTest {
   }
 
   @Test
-  public void accept_invalidAttestationSignature() {
+  public void accept_invalidAttestationSignature() throws Exception {
     final AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
     final Attestation attestation =
         attestationGenerator.attestationWithInvalidSignature(storageClient);

--- a/validator/client/build.gradle
+++ b/validator/client/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   runtime 'org.apache.logging.log4j:log4j-core'
 
   testSupportImplementation project(':storage')
+  testSupportImplementation project(':ethereum:statetransition')
   testSupportImplementation project(path: ':util', configuration: 'testSupportArtifacts')
   testSupportImplementation project(path: ':validator:client')
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Revert changes made to `AttestationUtil` that were added in support of the test utility `AttestationGenerator`.  Instead of modifying production code, add logic to the test utility to update the beacon state so that existing production methods work without modification.
