### PR TITLE
Make AttestationData immutable

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/AttestationData.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/AttestationData.java
@@ -34,14 +34,14 @@ public class AttestationData implements SimpleOffsetSerializable, Merkleizable, 
   public static final int SSZ_FIELD_COUNT = 3;
 
   private final UnsignedLong slot;
-  private UnsignedLong index;
+  private final UnsignedLong index;
 
   // LMD GHOST vote
-  private Bytes32 beacon_block_root;
+  private final Bytes32 beacon_block_root;
 
   // FFG vote
-  private Checkpoint source;
-  private Checkpoint target;
+  private final Checkpoint source;
+  private final Checkpoint target;
 
   public AttestationData(
       UnsignedLong slot,
@@ -112,32 +112,20 @@ public class AttestationData implements SimpleOffsetSerializable, Merkleizable, 
     return index;
   }
 
-  public void setIndex(final UnsignedLong index) {
-    this.index = index;
-  }
-
   public Bytes32 getBeacon_block_root() {
     return beacon_block_root;
-  }
-
-  public void setBeacon_block_root(Bytes32 beacon_block_root) {
-    this.beacon_block_root = beacon_block_root;
   }
 
   public Checkpoint getSource() {
     return source;
   }
 
-  public void setSource(Checkpoint source) {
-    this.source = source;
-  }
-
   public Checkpoint getTarget() {
     return target;
   }
 
-  public void setTarget(Checkpoint target) {
-    this.target = target;
+  public AttestationData withIndex(final UnsignedLong index) {
+    return new AttestationData(slot, index, beacon_block_root, source, target);
   }
 
   @Override

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
@@ -126,12 +126,6 @@ public class AttestationUtil {
     return aggregationBits;
   }
 
-  public static AttestationData completeAttestationCrosslinkData(
-      BeaconState state, AttestationData attestation_data, Committee committee) {
-    attestation_data.setIndex(committee.getIndex());
-    return attestation_data;
-  }
-
   public static Bytes32 getAttestationMessageToSign(AttestationData attestationData) {
     AttestationDataAndCustodyBit attestation_data_and_custody_bit =
         new AttestationDataAndCustodyBit(attestationData, false);

--- a/validator/client/src/test-support/java/tech/pegasys/artemis/validator/client/AttestationGenerator.java
+++ b/validator/client/src/test-support/java/tech/pegasys/artemis/validator/client/AttestationGenerator.java
@@ -129,9 +129,7 @@ public class AttestationGenerator {
     Bitlist aggregationBitfield =
         AttestationUtil.getAggregationBits(commmitteSize, indexIntoCommittee);
     Bitlist custodyBits = new Bitlist(commmitteSize, MAX_VALIDATORS_PER_COMMITTEE);
-    AttestationData attestationData =
-        AttestationUtil.completeAttestationCrosslinkData(
-            state, new AttestationData(genericAttestationData), committee);
+    AttestationData attestationData = genericAttestationData.withIndex(committee.getIndex());
     Bytes32 attestationMessage = AttestationUtil.getAttestationMessageToSign(attestationData);
     Bytes domain =
         get_domain(state, DOMAIN_BEACON_ATTESTER, attestationData.getTarget().getEpoch());

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinator.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinator.java
@@ -233,9 +233,7 @@ public class ValidatorCoordinator {
     Bitlist aggregationBitfield =
         AttestationUtil.getAggregationBits(commmitteSize, indexIntoCommittee);
     Bitlist custodyBits = new Bitlist(commmitteSize, MAX_VALIDATORS_PER_COMMITTEE);
-    AttestationData attestationData =
-        AttestationUtil.completeAttestationCrosslinkData(
-            state, new AttestationData(genericAttestationData), committee);
+    AttestationData attestationData = genericAttestationData.withIndex(committee.getIndex());
     Bytes32 attestationMessage = AttestationUtil.getAttestationMessageToSign(attestationData);
     Bytes domain =
         get_domain(state, DOMAIN_BEACON_ATTESTER, attestationData.getTarget().getEpoch());


### PR DESCRIPTION
## PR Description
The only place we need to mutate is, we also need to make a copy at the same point. This prevents the bug we had we generating invalid attestations and simplifies the places that were using the mutators.