### PR TITLE
Implement Logic Necessary for Aggregation at Networking Layer

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/events/CommitteeAssignmentEvent.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/events/CommitteeAssignmentEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.statetransition.events;
+
+import java.util.List;
+
+public class CommitteeAssignmentEvent {
+
+  List<Integer> committeeIndices;
+
+  public CommitteeAssignmentEvent(List<Integer> committeeIndices) {
+    this.committeeIndices = committeeIndices;
+  }
+
+  public List<Integer> getCommitteeIndices() {
+    return this.committeeIndices;
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/events/CommitteeDismissalEvent.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/events/CommitteeDismissalEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.statetransition.events;
+
+import java.util.List;
+
+public class CommitteeDismissalEvent {
+
+  List<Integer> committeeIndices;
+
+  public CommitteeDismissalEvent(List<Integer> committeeIndices) {
+    this.committeeIndices = committeeIndices;
+  }
+
+  public List<Integer> getCommitteeIndices() {
+    return this.committeeIndices;
+  }
+}

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandler.java
@@ -36,6 +36,7 @@ public class AttestationTopicHandler extends GossipTopicHandler<Attestation> {
   private static final Logger LOG = LogManager.getLogger();
   private final Topic attestationsTopic;
   private final ChainStorageClient chainStorageClient;
+
   private final int committeeIndex;
 
   protected AttestationTopicHandler(
@@ -79,5 +80,9 @@ public class AttestationTopicHandler extends GossipTopicHandler<Attestation> {
     }
 
     return true;
+  }
+
+  public int getCommitteeIndex() {
+    return committeeIndex;
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandler.java
@@ -71,6 +71,14 @@ public class AttestationTopicHandler extends GossipTopicHandler<Attestation> {
   protected boolean validateData(final Attestation attestation) {
     final BeaconState state =
         chainStorageClient.getStore().getBlockState(attestation.getData().getBeacon_block_root());
+    if (state == null) {
+      LOG.trace(
+          "Attestation BeaconState was not found in Store. Attestation: ({}), block_root: ({}) on {}",
+          attestation.hash_tree_root(),
+          attestation.getData().getBeacon_block_root(),
+          getTopic());
+      return false;
+    }
     final IndexedAttestation indexedAttestation = get_indexed_attestation(state, attestation);
     final boolean validAttestation = is_valid_indexed_attestation(state, indexedAttestation);
     if (!validAttestation) {

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/GossipMessageHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/GossipMessageHandler.java
@@ -89,7 +89,8 @@ public class GossipMessageHandler {
   }
 
   @Subscribe
-  synchronized public void registerAttestationTopicHandlers(CommitteeAssignmentEvent assignmentEvent) {
+  public synchronized void registerAttestationTopicHandlers(
+      CommitteeAssignmentEvent assignmentEvent) {
     List<Integer> committeeIndices = assignmentEvent.getCommitteeIndices();
     for (int committeeIndex : committeeIndices) {
       if (!attestationTopicHandlers.containsKey(committeeIndex)) {
@@ -104,7 +105,8 @@ public class GossipMessageHandler {
   }
 
   @Subscribe
-  synchronized public void unregisterAttestationTopicHandlers(CommitteeDismissalEvent dismissalEvent) {
+  public synchronized void unregisterAttestationTopicHandlers(
+      CommitteeDismissalEvent dismissalEvent) {
     List<Integer> committeeIndices = dismissalEvent.getCommitteeIndices();
     for (int committeeIndex : committeeIndices) {
       if (attestationTopicHandlers.containsKey(committeeIndex)) {

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/GossipMessageHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/GossipMessageHandler.java
@@ -69,7 +69,7 @@ public class GossipMessageHandler {
       final EventBus eventBus,
       final ChainStorageClient chainStorageClient) {
     return List.of(
-        new AttestationTopicHandler(publisher, eventBus, chainStorageClient),
+        new AggregateTopicHandler(publisher, eventBus, chainStorageClient),
         new BlocksTopicHandler(publisher, eventBus, chainStorageClient));
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/GossipMessageHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/GossipMessageHandler.java
@@ -89,27 +89,27 @@ public class GossipMessageHandler {
   }
 
   @Subscribe
-  public void registerAttestationTopicHandlers(CommitteeAssignmentEvent assignmentEvent) {
+  synchronized public void registerAttestationTopicHandlers(CommitteeAssignmentEvent assignmentEvent) {
     List<Integer> committeeIndices = assignmentEvent.getCommitteeIndices();
-    for (int i : committeeIndices) {
-      if (!attestationTopicHandlers.containsKey(i)) {
+    for (int committeeIndex : committeeIndices) {
+      if (!attestationTopicHandlers.containsKey(committeeIndex)) {
         AttestationTopicHandler topicHandler =
-            new AttestationTopicHandler(publisher, eventBus, chainStorageClient, i);
-        attestationTopicHandlers.put(i, topicHandler);
+            new AttestationTopicHandler(publisher, eventBus, chainStorageClient, committeeIndex);
+        attestationTopicHandlers.put(committeeIndex, topicHandler);
         PubsubSubscription subscription = gossip.subscribe(topicHandler, topicHandler.getTopic());
-        subscriptions.put(i, subscription);
+        subscriptions.put(committeeIndex, subscription);
         eventBus.register(topicHandler);
       }
     }
   }
 
   @Subscribe
-  public void unregisterAttestationTopicHandlers(CommitteeDismissalEvent dismissalEvent) {
+  synchronized public void unregisterAttestationTopicHandlers(CommitteeDismissalEvent dismissalEvent) {
     List<Integer> committeeIndices = dismissalEvent.getCommitteeIndices();
-    for (int i : committeeIndices) {
-      if (attestationTopicHandlers.containsKey(i)) {
-        AttestationTopicHandler topicHandler = attestationTopicHandlers.remove(i);
-        PubsubSubscription subscription = subscriptions.remove(i);
+    for (int committeeIndex : committeeIndices) {
+      if (attestationTopicHandlers.containsKey(committeeIndex)) {
+        AttestationTopicHandler topicHandler = attestationTopicHandlers.remove(committeeIndex);
+        PubsubSubscription subscription = subscriptions.remove(committeeIndex);
         subscription.unsubscribe();
         eventBus.unregister(topicHandler);
       }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/GossipMessageHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/GossipMessageHandler.java
@@ -14,12 +14,18 @@
 package tech.pegasys.artemis.networking.p2p.jvmlibp2p.gossip;
 
 import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
 import io.libp2p.core.crypto.PrivKey;
 import io.libp2p.core.pubsub.PubsubPublisherApi;
+import io.libp2p.core.pubsub.PubsubSubscription;
 import io.libp2p.pubsub.gossip.Gossip;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
+import tech.pegasys.artemis.statetransition.events.CommitteeAssignmentEvent;
+import tech.pegasys.artemis.statetransition.events.CommitteeDismissalEvent;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 
 public class GossipMessageHandler {
@@ -27,16 +33,25 @@ public class GossipMessageHandler {
   private final Gossip gossip;
   private EventBus eventBus;
   private final List<GossipTopicHandler<?>> topicHandlers;
+  private final PubsubPublisherApi publisher;
+  private final ChainStorageClient chainStorageClient;
 
   private final AtomicBoolean started = new AtomicBoolean(false);
+  private final Map<Integer, AttestationTopicHandler> attestationTopicHandlers = new HashMap<>();
+  private final Map<Integer, PubsubSubscription> subscriptions = new HashMap<>();
 
   GossipMessageHandler(
+      final ChainStorageClient chainStorageClient,
+      final PubsubPublisherApi publisher,
       final Gossip gossip,
       final EventBus eventBus,
       final List<GossipTopicHandler<?>> topicHandlers) {
+    this.chainStorageClient = chainStorageClient;
+    this.publisher = publisher;
     this.gossip = gossip;
     this.eventBus = eventBus;
     this.topicHandlers = topicHandlers;
+    this.eventBus.register(this);
   }
 
   public void start() {
@@ -57,7 +72,7 @@ public class GossipMessageHandler {
     final PubsubPublisherApi publisher = createPublisher(gossip, privateKey);
     final List<GossipTopicHandler<?>> topicHandlers =
         createDefaultTopicHandlers(publisher, eventBus, chainStorageClient);
-    return new GossipMessageHandler(gossip, eventBus, topicHandlers);
+    return new GossipMessageHandler(chainStorageClient, publisher, gossip, eventBus, topicHandlers);
   }
 
   static PubsubPublisherApi createPublisher(final Gossip gossip, final PrivKey privateKey) {
@@ -71,5 +86,33 @@ public class GossipMessageHandler {
     return List.of(
         new AggregateTopicHandler(publisher, eventBus, chainStorageClient),
         new BlocksTopicHandler(publisher, eventBus, chainStorageClient));
+  }
+
+  @Subscribe
+  public void registerAttestationTopicHandlers(CommitteeAssignmentEvent assignmentEvent) {
+    List<Integer> committeeIndices = assignmentEvent.getCommitteeIndices();
+    for (int i : committeeIndices) {
+      if (!attestationTopicHandlers.containsKey(i)) {
+        AttestationTopicHandler topicHandler =
+            new AttestationTopicHandler(publisher, eventBus, chainStorageClient, i);
+        attestationTopicHandlers.put(i, topicHandler);
+        PubsubSubscription subscription = gossip.subscribe(topicHandler, topicHandler.getTopic());
+        subscriptions.put(i, subscription);
+        eventBus.register(topicHandler);
+      }
+    }
+  }
+
+  @Subscribe
+  public void unregisterAttestationTopicHandlers(CommitteeDismissalEvent dismissalEvent) {
+    List<Integer> committeeIndices = dismissalEvent.getCommitteeIndices();
+    for (int i : committeeIndices) {
+      if (attestationTopicHandlers.containsKey(i)) {
+        AttestationTopicHandler topicHandler = attestationTopicHandlers.remove(i);
+        PubsubSubscription subscription = subscriptions.remove(i);
+        subscription.unsubscribe();
+        eventBus.unregister(topicHandler);
+      }
+    }
   }
 }

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AggregateTopicHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AggregateTopicHandlerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.p2p.jvmlibp2p.gossip;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.eventbus.EventBus;
+import io.libp2p.core.pubsub.PubsubPublisherApi;
+import io.libp2p.core.pubsub.Topic;
+import io.netty.buffer.ByteBuf;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import tech.pegasys.artemis.datastructures.operations.AggregateAndProof;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
+import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
+import tech.pegasys.artemis.statetransition.BeaconChainUtil;
+import tech.pegasys.artemis.storage.ChainStorageClient;
+import tech.pegasys.artemis.util.bls.BLSKeyGenerator;
+import tech.pegasys.artemis.util.bls.BLSKeyPair;
+
+public class AggregateTopicHandlerTest {
+
+  private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(12);
+  private final PubsubPublisherApi publisher = mock(PubsubPublisherApi.class);
+  private final EventBus eventBus = spy(new EventBus());
+  private final ChainStorageClient storageClient = new ChainStorageClient(eventBus);
+
+  private final AggregateTopicHandler topicHandler =
+      new AggregateTopicHandler(publisher, eventBus, storageClient);
+
+  ArgumentCaptor<ByteBuf> byteBufCaptor = ArgumentCaptor.forClass(ByteBuf.class);
+  ArgumentCaptor<Topic> topicCaptor = ArgumentCaptor.forClass(Topic.class);
+
+  @BeforeEach
+  public void setup() {
+    BeaconChainUtil.initializeStorage(storageClient, validatorKeys);
+    doReturn(CompletableFuture.completedFuture(null)).when(publisher).publish(any(), any());
+    eventBus.register(topicHandler);
+  }
+
+  @Test
+  public void onNewAggregate() {
+    final AggregateAndProof aggregate = DataStructureUtil.randomAggregateAndProof(1);
+    final Bytes serialized = SimpleOffsetSerializer.serialize(aggregate);
+    eventBus.post(aggregate);
+    // Handler should publish broadcast attestations
+
+    verify(publisher).publish(byteBufCaptor.capture(), topicCaptor.capture());
+    assertThat(byteBufCaptor.getValue().array()).isEqualTo(serialized.toArray());
+    assertThat(topicCaptor.getAllValues().size()).isEqualTo(1);
+    assertThat(topicCaptor.getValue()).isEqualTo(topicHandler.getTopic());
+  }
+}

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AggregateTopicHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AggregateTopicHandlerTest.java
@@ -38,7 +38,6 @@ import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
 import tech.pegasys.artemis.network.p2p.jvmlibp2p.MockMessageApi;
 import tech.pegasys.artemis.statetransition.BeaconChainUtil;
 import tech.pegasys.artemis.storage.ChainStorageClient;
-import tech.pegasys.artemis.storage.Store;
 import tech.pegasys.artemis.util.bls.BLSKeyGenerator;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
 
@@ -67,7 +66,7 @@ public class AggregateTopicHandlerTest {
     final AggregateAndProof aggregate = DataStructureUtil.randomAggregateAndProof(1);
     final Bytes serialized = SimpleOffsetSerializer.serialize(aggregate);
     eventBus.post(aggregate);
-    // Handler should publish broadcast attestations
+    // Handler should publish broadcast aggregate
 
     verify(publisher).publish(byteBufCaptor.capture(), topicCaptor.capture());
     assertThat(byteBufCaptor.getValue().array()).isEqualTo(serialized.toArray());
@@ -78,9 +77,6 @@ public class AggregateTopicHandlerTest {
   @Test
   public void accept_invalidAttestation_badState() throws Exception {
     final AggregateAndProof aggregate = DataStructureUtil.randomAggregateAndProof(1);
-    Store.Transaction transaction = storageClient.getStore().startTransaction();
-    transaction.putBlockState(aggregate.getAggregate().getData().getBeacon_block_root(), null);
-    transaction.commit();
     final Bytes serialized = SimpleOffsetSerializer.serialize(aggregate);
 
     final MessageApi mockMessage = new MockMessageApi(serialized, topicHandler.getTopic());

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
@@ -50,7 +50,7 @@ public class AttestationTopicHandlerTest {
   private final ChainStorageClient storageClient = new ChainStorageClient(eventBus);
 
   private final AttestationTopicHandler topicHandler =
-      new AttestationTopicHandler(publisher, eventBus, storageClient);
+      new AttestationTopicHandler(publisher, eventBus, storageClient, 10);
 
   ArgumentCaptor<ByteBuf> byteBufCaptor = ArgumentCaptor.forClass(ByteBuf.class);
   ArgumentCaptor<Topic> topicCaptor = ArgumentCaptor.forClass(Topic.class);

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.eventbus.EventBus;
+import com.google.common.primitives.UnsignedLong;
 import io.libp2p.core.pubsub.MessageApi;
 import io.libp2p.core.pubsub.PubsubPublisherApi;
 import io.libp2p.core.pubsub.Topic;
@@ -65,6 +66,8 @@ public class AttestationTopicHandlerTest {
   @Test
   public void onNewAttestation() {
     final Attestation attestation = DataStructureUtil.randomAttestation(1);
+    attestation.setData(
+        attestation.getData().withIndex(UnsignedLong.valueOf(topicHandler.getCommitteeIndex())));
     final Bytes serialized = SimpleOffsetSerializer.serialize(attestation);
     eventBus.post(attestation);
     // Handler should publish broadcast attestations

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
@@ -79,6 +79,19 @@ public class AttestationTopicHandlerTest {
   }
 
   @Test
+  public void onNewAttestationOnDifferentSubnet() {
+    final Attestation attestation = DataStructureUtil.randomAttestation(1);
+    attestation.setData(
+        attestation
+            .getData()
+            .withIndex(UnsignedLong.valueOf(topicHandler.getCommitteeIndex() + 1)));
+    eventBus.post(attestation);
+    // Handler should publish broadcast attestations
+
+    verify(publisher, never()).publish(any(), any());
+  }
+
+  @Test
   public void accept_validAttestation() throws Exception {
     final AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
     final Attestation attestation = attestationGenerator.validAttestation(storageClient);

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
@@ -87,7 +87,6 @@ public class AttestationTopicHandlerTest {
             .getData()
             .withIndex(UnsignedLong.valueOf(topicHandler.getCommitteeIndex() + 1)));
     eventBus.post(attestation);
-    // Handler should publish broadcast attestations
 
     verify(publisher, never()).publish(any(), any());
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
This PR makes changes necessary to the networking layer for the aggregation strategy to be implemented:

- [x] Implement and register an AggregateAndProof topic handler for aggregated attestations

- [x] Make multiple instances of AttestationTopicHandler for each subnet.

- [x] Make AttestationTopicHandler's registerable and deregisterable so that we can register to different subnet topics when our validator join different subnets.

- [x] in validateData() of Topic Handlers, check if state being used to validate the attestation is already in Store or not so that we don't throw a NPE.