### PR TITLE
Implement BeaconBlocksByRoot request

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/BeaconBlocksByRootRequestMessage.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/BeaconBlocksByRootRequestMessage.java
@@ -39,6 +39,10 @@ public final class BeaconBlocksByRootRequestMessage
     this.blockRoots.addAll(blockRoots);
   }
 
+  public SSZList<Bytes32> getBlockRoots() {
+    return blockRoots;
+  }
+
   @Override
   public int getSSZFieldCount() {
     return 1;

--- a/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/BeaconBlocksByRootIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/BeaconBlocksByRootIntegrationTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.p2p.jvmlibp2p;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.artemis.network.p2p.jvmlibp2p.ChainStorageClientFactory.initChainStorageClient;
+import static tech.pegasys.artemis.util.Waiter.waitFor;
+
+import com.google.common.eventbus.EventBus;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
+import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
+import tech.pegasys.artemis.network.p2p.jvmlibp2p.NetworkFactory;
+import tech.pegasys.artemis.networking.p2p.JvmLibP2PNetwork;
+import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.RpcMethod;
+import tech.pegasys.artemis.storage.ChainStorageClient;
+import tech.pegasys.artemis.storage.Store.Transaction;
+
+public class BeaconBlocksByRootIntegrationTest {
+
+  private final NetworkFactory networkFactory = new NetworkFactory();
+  private int seed = 1000;
+  private Peer peer1;
+  private ChainStorageClient storageClient1;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    final EventBus eventBus1 = new EventBus();
+    storageClient1 = new ChainStorageClient(eventBus1);
+    final JvmLibP2PNetwork network1 = networkFactory.startNetwork(eventBus1, storageClient1);
+    final JvmLibP2PNetwork network2 = networkFactory.startNetwork(network1);
+    peer1 = network2.getPeerManager().getAvailablePeer(network1.getPeerId()).orElseThrow();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    networkFactory.stopAll();
+  }
+
+  @Test
+  public void shouldSendEmptyResponsePreGenesisEvent() throws Exception {
+    final List<Bytes32> blockRoots = singletonList(Bytes32.ZERO);
+    final List<BeaconBlock> response = requestBlocks(blockRoots);
+    assertThat(response).isEmpty();
+  }
+
+  @Test
+  public void shouldSendEmptyResponseWhenNoBlocksAreAvailable() throws Exception {
+    initChainStorageClient(storageClient1);
+    final List<BeaconBlock> response = requestBlocks(singletonList(Bytes32.ZERO));
+    assertThat(response).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnSingleBlockWhenOnlyOneMatches() throws Exception {
+    initChainStorageClient(storageClient1);
+    final BeaconBlock block = addBlock();
+
+    final List<BeaconBlock> response = requestBlocks(singletonList(block.hash_tree_root()));
+    assertThat(response).containsExactly(block);
+  }
+
+  @Test
+  public void shouldReturnMultipleBlocksWhenAllRequestsMatch() throws Exception {
+    initChainStorageClient(storageClient1);
+    final List<BeaconBlock> blocks = asList(addBlock(), addBlock(), addBlock());
+    final List<Bytes32> blockRoots =
+        blocks.stream().map(BeaconBlock::hash_tree_root).collect(toList());
+    final List<BeaconBlock> response = requestBlocks(blockRoots);
+    assertThat(response).containsExactlyElementsOf(blocks);
+  }
+
+  @Test
+  public void shouldReturnMatchingBlocksWhenSomeRequestsDoNotMatch() throws Exception {
+    initChainStorageClient(storageClient1);
+    final List<BeaconBlock> blocks = asList(addBlock(), addBlock(), addBlock());
+
+    // Real block roots interspersed with ones that don't match any blocks
+    final List<Bytes32> blockRoots =
+        blocks.stream()
+            .map(BeaconBlock::hash_tree_root)
+            .flatMap(hash -> Stream.of(Bytes32.fromHexStringLenient("0x123456789"), hash))
+            .collect(toList());
+
+    final List<BeaconBlock> response = requestBlocks(blockRoots);
+    assertThat(response).containsExactlyElementsOf(blocks);
+  }
+
+  private BeaconBlock addBlock() {
+    final BeaconBlock block = DataStructureUtil.randomBeaconBlock(seed, seed++);
+    final Bytes32 blockRoot = block.hash_tree_root();
+    final Transaction transaction = storageClient1.getStore().startTransaction();
+    transaction.putBlock(blockRoot, block);
+    transaction.commit();
+    return block;
+  }
+
+  private List<BeaconBlock> requestBlocks(final List<Bytes32> blockRoots)
+      throws InterruptedException, java.util.concurrent.ExecutionException,
+          java.util.concurrent.TimeoutException {
+    final List<BeaconBlock> blocks = new ArrayList<>();
+    waitFor(
+        peer1.requestStream(
+            RpcMethod.BEACON_BLOCKS_BY_ROOT,
+            new BeaconBlocksByRootRequestMessage(blockRoots),
+            blocks::add));
+    return blocks;
+  }
+}

--- a/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/BeaconBlocksByRootIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/BeaconBlocksByRootIntegrationTest.java
@@ -29,11 +29,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
-import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
 import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.network.p2p.jvmlibp2p.NetworkFactory;
 import tech.pegasys.artemis.networking.p2p.JvmLibP2PNetwork;
-import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.RpcMethod;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.storage.Store.Transaction;
 
@@ -120,11 +118,7 @@ public class BeaconBlocksByRootIntegrationTest {
       throws InterruptedException, java.util.concurrent.ExecutionException,
           java.util.concurrent.TimeoutException {
     final List<BeaconBlock> blocks = new ArrayList<>();
-    waitFor(
-        peer1.requestStream(
-            RpcMethod.BEACON_BLOCKS_BY_ROOT,
-            new BeaconBlocksByRootRequestMessage(blockRoots),
-            blocks::add));
+    waitFor(peer1.requestBlocksByRoot(blockRoots, blocks::add));
     return blocks;
   }
 }

--- a/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/ErrorConditionsIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/ErrorConditionsIntegrationTest.java
@@ -27,6 +27,7 @@ import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.network.p2p.jvmlibp2p.NetworkFactory;
 import tech.pegasys.artemis.networking.p2p.JvmLibP2PNetwork;
+import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.ResponseStream;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.RpcException;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.RpcMethod;
 import tech.pegasys.artemis.util.Waiter;
@@ -49,7 +50,8 @@ public class ErrorConditionsIntegrationTest {
         network1.getPeerManager().getAvailablePeer(network2.getPeerId()).orElseThrow();
 
     final CompletableFuture<StatusMessage> response =
-        peer.requestSingle(RpcMethod.STATUS, new InvalidStatusMessage());
+        peer.invoke(RpcMethod.STATUS, new InvalidStatusMessage())
+            .thenCompose(ResponseStream::expectSingleResponse);
 
     Assertions.assertThatThrownBy(() -> Waiter.waitFor(response))
         .isInstanceOf(ExecutionException.class)

--- a/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/ErrorConditionsIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/ErrorConditionsIntegrationTest.java
@@ -49,7 +49,7 @@ public class ErrorConditionsIntegrationTest {
         network1.getPeerManager().getAvailablePeer(network2.getPeerId()).orElseThrow();
 
     final CompletableFuture<StatusMessage> response =
-        peer.send(RpcMethod.STATUS, new InvalidStatusMessage());
+        peer.requestSingle(RpcMethod.STATUS, new InvalidStatusMessage());
 
     Assertions.assertThatThrownBy(() -> Waiter.waitFor(response))
         .isInstanceOf(ExecutionException.class)

--- a/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/GoodbyeIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/GoodbyeIntegrationTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.GoodbyeMessage;
 import tech.pegasys.artemis.network.p2p.jvmlibp2p.NetworkFactory;
 import tech.pegasys.artemis.networking.p2p.JvmLibP2PNetwork;
-import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.RpcMethod;
 
 public class GoodbyeIntegrationTest {
   private final NetworkFactory networkFactory = new NetworkFactory();
@@ -46,8 +45,7 @@ public class GoodbyeIntegrationTest {
 
   @Test
   public void shouldCloseConnectionAfterGoodbyeReceived() throws Exception {
-    waitFor(
-        peer1.send(RpcMethod.GOODBYE, new GoodbyeMessage(GoodbyeMessage.REASON_CLIENT_SHUT_DOWN)));
+    waitFor(peer1.sendGoodbye(GoodbyeMessage.REASON_CLIENT_SHUT_DOWN));
     waitFor(() -> assertThat(peer1.isConnected()).isFalse());
     waitFor(() -> assertThat(peer2.isConnected()).isFalse());
     assertThat(network1.getPeerManager().getAvailablePeerCount()).isZero();

--- a/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/GoodbyeIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/GoodbyeIntegrationTest.java
@@ -46,11 +46,8 @@ public class GoodbyeIntegrationTest {
 
   @Test
   public void shouldCloseConnectionAfterGoodbyeReceived() throws Exception {
-    final GoodbyeMessage response =
-        waitFor(
-            peer1.send(
-                RpcMethod.GOODBYE, new GoodbyeMessage(GoodbyeMessage.REASON_CLIENT_SHUT_DOWN)));
-    assertThat(response).isNull();
+    waitFor(
+        peer1.send(RpcMethod.GOODBYE, new GoodbyeMessage(GoodbyeMessage.REASON_CLIENT_SHUT_DOWN)));
     waitFor(() -> assertThat(peer1.isConnected()).isFalse());
     waitFor(() -> assertThat(peer2.isConnected()).isFalse());
     assertThat(network1.getPeerManager().getAvailablePeerCount()).isZero();

--- a/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/PeerStatusIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/PeerStatusIntegrationTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.artemis.networking.p2p.jvmlibp2p;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.artemis.network.p2p.jvmlibp2p.ChainStorageClientFactory.createInitedStorageClient;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.primitives.UnsignedLong;
@@ -122,11 +123,5 @@ public class PeerStatusIntegrationTest {
         network2Store.getFinalizedCheckpoint().getEpoch(),
         storageClient.getBestBlockRoot(),
         storageClient.getBestSlot());
-  }
-
-  private ChainStorageClient createInitedStorageClient(final EventBus eventBus2) {
-    final ChainStorageClient chainStorageClient = new ChainStorageClient(eventBus2);
-    StartupUtil.setupInitialState(chainStorageClient, 0, null, 0);
-    return chainStorageClient;
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/Peer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/Peer.java
@@ -17,11 +17,16 @@ import com.google.common.base.MoreObjects;
 import com.google.common.primitives.UnsignedLong;
 import io.libp2p.core.Connection;
 import io.libp2p.core.PeerId;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
+import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
+import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.GoodbyeMessage;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.ResponseStream;
+import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.ResponseStream.ResponseListener;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.RpcMethod;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.RpcMethods;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.methods.StatusMessageFactory;
@@ -64,7 +69,8 @@ public class Peer {
   }
 
   public CompletableFuture<StatusData> sendStatus() {
-    return requestSingle(RpcMethod.STATUS, statusMessageFactory.createStatusMessage())
+    return invoke(RpcMethod.STATUS, statusMessageFactory.createStatusMessage())
+        .thenCompose(ResponseStream::expectSingleResponse)
         .thenApply(
             remoteStatus -> {
               updateStatus(remoteStatus);
@@ -72,7 +78,20 @@ public class Peer {
             });
   }
 
-  public <I extends SimpleOffsetSerializable, O extends SimpleOffsetSerializable>
+  public CompletableFuture<Void> sendGoodbye(final UnsignedLong reason) {
+    return invoke(RpcMethod.GOODBYE, new GoodbyeMessage(reason))
+        .thenCompose(ResponseStream::expectNoResponse);
+  }
+
+  public CompletableFuture<Void> requestBlocksByRoot(
+      final List<Bytes32> blockRoots, final ResponseListener<BeaconBlock> listener) {
+    return requestStream(
+        RpcMethod.BEACON_BLOCKS_BY_ROOT,
+        new BeaconBlocksByRootRequestMessage(blockRoots),
+        listener);
+  }
+
+  private <I extends SimpleOffsetSerializable, O extends SimpleOffsetSerializable>
       CompletableFuture<Void> requestStream(
           final RpcMethod<I, O> method,
           I request,
@@ -81,17 +100,7 @@ public class Peer {
         .thenCompose(responseStream -> responseStream.expectMultipleResponses(listener));
   }
 
-  public <I extends SimpleOffsetSerializable, O extends SimpleOffsetSerializable>
-      CompletableFuture<O> requestSingle(final RpcMethod<I, O> method, I request) {
-    return invoke(method, request).thenCompose(ResponseStream::expectSingleResponse);
-  }
-
-  public <I extends SimpleOffsetSerializable> CompletableFuture<Void> send(
-      final RpcMethod<I, ?> method, I request) {
-    return invoke(method, request).thenCompose(ResponseStream::expectNoResponse);
-  }
-
-  private <I extends SimpleOffsetSerializable, O extends SimpleOffsetSerializable>
+  <I extends SimpleOffsetSerializable, O extends SimpleOffsetSerializable>
       CompletableFuture<ResponseStream<O>> invoke(final RpcMethod<I, O> method, I request) {
     return rpcMethods.invoke(method, connection, request);
   }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/PeerManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/PeerManager.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.Level;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.RpcMessageHandler;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.RpcMethods;
-import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.methods.BeaconBlocksMessageHandler;
+import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.methods.BeaconBlocksByRootMessageHandler;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.methods.GoodbyeMessageHandler;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.methods.StatusMessageFactory;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.methods.StatusMessageHandler;
@@ -61,7 +61,7 @@ public class PeerManager implements ConnectionHandler, PeerLookup {
             this,
             new StatusMessageHandler(statusMessageFactory),
             new GoodbyeMessageHandler(metricsSystem),
-            new BeaconBlocksMessageHandler());
+            new BeaconBlocksByRootMessageHandler(chainStorageClient));
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/ResponseStream.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/ResponseStream.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface ResponseStream<O> {
+  CompletableFuture<O> expectSingleResponse();
+
+  CompletableFuture<Void> expectNoResponse();
+
+  CompletableFuture<Void> expectMultipleResponses(ResponseListener<O> listener);
+
+  interface ResponseListener<O> {
+    void onResponse(O response);
+  }
+}

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/ResponseStreamImpl.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/ResponseStreamImpl.java
@@ -28,7 +28,6 @@ public class ResponseStreamImpl<O extends SimpleOffsetSerializable> implements R
   @Override
   public CompletableFuture<O> expectSingleResponse() {
     final AtomicReference<O> firstResponse = new AtomicReference<>();
-    // TODO: Should we throw an error if multiple responses were received?
     expectMultipleResponses(
         response -> {
           if (!firstResponse.compareAndSet(null, response)) {
@@ -67,12 +66,10 @@ public class ResponseStreamImpl<O extends SimpleOffsetSerializable> implements R
   }
 
   public void completeSuccessfully() {
-    System.out.println("Completed successfully: " + completionFuture.isCompletedExceptionally());
     completionFuture.complete(null);
   }
 
   public void completeWithError(final Throwable error) {
-    System.out.println("Got error");
     completionFuture.completeExceptionally(error);
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/ResponseStreamImpl.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/ResponseStreamImpl.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Preconditions;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import tech.pegasys.artemis.util.sos.SimpleOffsetSerializable;
+
+public class ResponseStreamImpl<O extends SimpleOffsetSerializable> implements ResponseStream<O> {
+
+  private final CompletableFuture<Void> completionFuture = new CompletableFuture<>();
+  private ResponseListener<O> responseListener;
+
+  @Override
+  public CompletableFuture<O> expectSingleResponse() {
+    final AtomicReference<O> firstResponse = new AtomicReference<>();
+    // TODO: Should we throw an error if multiple responses were received?
+    expectMultipleResponses(
+        response -> {
+          if (!firstResponse.compareAndSet(null, response)) {
+            completionFuture.completeExceptionally(
+                new IllegalStateException(
+                    "Received multiple responses when single response expected"));
+          }
+        });
+    return completionFuture.thenApply(
+        done -> {
+          checkNotNull(firstResponse.get(), "No response received when single response expected");
+          return firstResponse.get();
+        });
+  }
+
+  @Override
+  public CompletableFuture<Void> expectNoResponse() {
+    expectMultipleResponses(
+        data ->
+            completionFuture.completeExceptionally(
+                new IllegalStateException("Received response when none expected")));
+    return completionFuture;
+  }
+
+  @Override
+  public CompletableFuture<Void> expectMultipleResponses(final ResponseListener<O> listener) {
+    Preconditions.checkArgument(
+        responseListener == null, "Multiple calls to 'expect' methods not allowed");
+    responseListener = listener;
+    return completionFuture;
+  }
+
+  public void respond(final O data) {
+    checkNotNull(responseListener, "Must call an 'expect' method");
+    responseListener.onResponse(data);
+  }
+
+  public void completeSuccessfully() {
+    System.out.println("Completed successfully: " + completionFuture.isCompletedExceptionally());
+    completionFuture.complete(null);
+  }
+
+  public void completeWithError(final Throwable error) {
+    System.out.println("Got error");
+    completionFuture.completeExceptionally(error);
+  }
+}

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMethod.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMethod.java
@@ -15,7 +15,7 @@ package tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc;
 
 import java.util.Objects;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
-import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.BeaconBlocksMessageRequest;
+import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.GoodbyeMessage;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.encodings.RpcEncoding;
@@ -31,12 +31,13 @@ public class RpcMethod<I extends SimpleOffsetSerializable, O extends SimpleOffse
   public static final RpcMethod<GoodbyeMessage, GoodbyeMessage> GOODBYE =
       new RpcMethod<>(
           "/eth2/beacon_chain/req/goodbye/1", SSZ, GoodbyeMessage.class, GoodbyeMessage.class);
-  public static final RpcMethod<BeaconBlocksMessageRequest, BeaconBlock> BEACON_BLOCKS =
-      new RpcMethod<>(
-          "/eth2/beacon_chain/req/beacon_blocks/1",
-          SSZ,
-          BeaconBlocksMessageRequest.class,
-          BeaconBlock.class);
+  public static final RpcMethod<BeaconBlocksByRootRequestMessage, BeaconBlock>
+      BEACON_BLOCKS_BY_ROOT =
+          new RpcMethod<>(
+              "/eth2/beacon_chain/req/beacon_blocks_by_root/1",
+              SSZ,
+              BeaconBlocksByRootRequestMessage.class,
+              BeaconBlock.class);
 
   private final String methodMultistreamId;
   private final RpcEncoding encoding;

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMethods.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMethods.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
-import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.BeaconBlocksMessageRequest;
+import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.GoodbyeMessage;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.PeerLookup;
@@ -35,14 +35,15 @@ public class RpcMethods {
       PeerLookup peerLookup,
       LocalMessageHandler<StatusMessage, StatusMessage> helloHandler,
       LocalMessageHandler<GoodbyeMessage, GoodbyeMessage> goodbyeHandler,
-      LocalMessageHandler<BeaconBlocksMessageRequest, BeaconBlock> beaconBlocksHandler) {
+      LocalMessageHandler<BeaconBlocksByRootRequestMessage, BeaconBlock> beaconBlocksHandler) {
 
     this.methods =
         createMethodMap(
             new RpcMessageHandler<>(RpcMethod.STATUS, peerLookup, helloHandler),
             new RpcMessageHandler<>(RpcMethod.GOODBYE, peerLookup, goodbyeHandler)
                 .setCloseNotification(),
-            new RpcMessageHandler<>(RpcMethod.BEACON_BLOCKS, peerLookup, beaconBlocksHandler));
+            new RpcMessageHandler<>(
+                RpcMethod.BEACON_BLOCKS_BY_ROOT, peerLookup, beaconBlocksHandler));
   }
 
   private Map<RpcMethod<?, ?>, RpcMessageHandler<?, ?>> createMethodMap(
@@ -54,7 +55,7 @@ public class RpcMethods {
   }
 
   public <I extends SimpleOffsetSerializable, O extends SimpleOffsetSerializable>
-      CompletableFuture<O> invoke(
+      CompletableFuture<ResponseStream<O>> invoke(
           final RpcMethod<I, O> method, final Connection connection, final I request) {
     return getHandler(method).invokeRemote(connection, request);
   }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/methods/BeaconBlocksByRootMessageHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/methods/BeaconBlocksByRootMessageHandler.java
@@ -13,18 +13,17 @@
 
 package tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.methods;
 
-import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.Peer;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.LocalMessageHandler;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.ResponseCallback;
 import tech.pegasys.artemis.storage.ChainStorageClient;
-import tech.pegasys.artemis.util.alogger.ALogger;
 
 public class BeaconBlocksByRootMessageHandler
     implements LocalMessageHandler<BeaconBlocksByRootRequestMessage, BeaconBlock> {
-  private final ALogger LOG = new ALogger(BeaconBlocksByRootMessageHandler.class.getName());
+  private static final org.apache.logging.log4j.Logger LOG = LogManager.getLogger();
 
   private final ChainStorageClient storageClient;
 
@@ -37,12 +36,8 @@ public class BeaconBlocksByRootMessageHandler
       final Peer peer,
       final BeaconBlocksByRootRequestMessage message,
       final ResponseCallback<BeaconBlock> callback) {
-    LOG.log(
-        Level.DEBUG,
-        "Peer "
-            + peer.getPeerId()
-            + " requested BeaconBlocks with roots: "
-            + message.getBlockRoots());
+    LOG.trace(
+        "Peer {} requested BeaconBlocks with roots: {}", peer.getPeerId(), message.getBlockRoots());
     if (storageClient.getStore() != null) {
       message
           .getBlockRoots()
@@ -54,7 +49,6 @@ public class BeaconBlocksByRootMessageHandler
                 }
               });
     }
-
     callback.completeSuccessfully();
   }
 }

--- a/networking/p2p/src/test-support/java/tech/pegasys/artemis/network/p2p/jvmlibp2p/ChainStorageClientFactory.java
+++ b/networking/p2p/src/test-support/java/tech/pegasys/artemis/network/p2p/jvmlibp2p/ChainStorageClientFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.network.p2p.jvmlibp2p;
+
+import com.google.common.eventbus.EventBus;
+import tech.pegasys.artemis.statetransition.util.StartupUtil;
+import tech.pegasys.artemis.storage.ChainStorageClient;
+
+public class ChainStorageClientFactory {
+
+  public static ChainStorageClient createInitedStorageClient(final EventBus eventBus) {
+    final ChainStorageClient chainStorageClient = new ChainStorageClient(eventBus);
+    initChainStorageClient(chainStorageClient);
+    return chainStorageClient;
+  }
+
+  public static void initChainStorageClient(final ChainStorageClient chainStorageClient) {
+    StartupUtil.setupInitialState(chainStorageClient, 0, null, 0);
+  }
+}


### PR DESCRIPTION
## PR Description
Adds support for the beacon blocks by root req/resp method. This requires supporting responses which return a stream of responses. So we now have three cases - no response (GOODBYE), single response (STATUS) and stream of responses (BLOCKS_BY_ROOT).

There's some ugliness under the covers to make no-response and single-response requests work nicely while still supporting the streaming of responses where the could be multiple and not have to collect all the responses into a list.  The `Peer` class provides a nice simple API for external callers to use which handles nearly all those details.

The API for multiple-response handling may need to be tweaked further in the future - the tests work best when it is collected into a List - will have to see how it works when in actual use. The main oddity there is that the data is sent to a callback handler but the "response complete" and error signals are sent via the returned `CompletableFuture`. We may want to pass them through to the callback handler instead but the tests work out nicer with the current approach, so let's see how it goes...