### PR TITLE
[BC-92] Add slot to block lookup

### DIFF
--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/gossip/AttestationTopicHandlerTest.java
@@ -138,8 +138,8 @@ public class AttestationTopicHandlerTest {
 
     // Set up state to be missing
     final Bytes32 blockRoot = attestation.getData().getBeacon_block_root();
-    Store mockStore = spy(storageClient.getStore());
-    doReturn(mockStore).when(storageClient).getStore();
+    Store mockStore = mock(Store.class);
+    storageClient.setStore(mockStore);
     doReturn(null).when(mockStore).getBlockState(blockRoot);
 
     final MessageApi mockMessage = new MockMessageApi(serialized, topicHandler.getTopic());

--- a/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
@@ -28,6 +28,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NavigableMap;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
@@ -331,7 +332,7 @@ public class ChainStorageClient implements ChainStorage {
 
     UnsignedLong currentSlot = slot;
     Bytes32 currentRoot = bestBlockRoot;
-    while (slotToCanonicalBlockRoot.get(currentSlot) != currentRoot) {
+    while (!Objects.equals(slotToCanonicalBlockRoot.get(currentSlot), currentRoot)) {
       updatedIndices.put(currentSlot, currentRoot);
       if (currentSlot.compareTo(UnsignedLong.valueOf(Constants.GENESIS_SLOT)) <= 0) {
         // We've reached the genesis slot, nothing left to index

--- a/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
@@ -66,13 +66,14 @@ public class ChainStorageClient implements ChainStorage {
       new PriorityBlockingQueue<>(
           QUEUE_MAX_SIZE, Comparator.comparing(a -> a.getData().getTarget().getEpoch()));
 
-  private Store store;
-  private Bytes32 bestBlockRoot = Bytes32.ZERO; // block chosen by lmd ghost to build and attest on
-  private UnsignedLong bestSlot =
+  private volatile Store store;
+  private volatile Bytes32 bestBlockRoot =
+      Bytes32.ZERO; // block chosen by lmd ghost to build and attest on
+  private volatile UnsignedLong bestSlot =
       UnsignedLong.ZERO; // slot of the block chosen by lmd ghost to build and attest on
 
   // Time
-  private UnsignedLong genesisTime;
+  private volatile UnsignedLong genesisTime;
 
   public ChainStorageClient(EventBus eventBus) {
     this.eventBus = eventBus;
@@ -169,7 +170,7 @@ public class ChainStorageClient implements ChainStorage {
    * @param root
    * @param slot
    */
-  public void updateBestBlock(Bytes32 root, UnsignedLong slot) {
+  public synchronized void updateBestBlock(Bytes32 root, UnsignedLong slot) {
     this.bestBlockRoot = root;
     this.bestSlot = slot;
     updateCanonicalBlockIndex(root, slot);

--- a/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
@@ -336,6 +336,16 @@ public class ChainStorageClient implements ChainStorage {
       }
       currentRoot = store.getBlock(currentRoot).getParent_root();
       BeaconBlock currentBlock = store.getBlock(currentRoot);
+      if (currentBlock == null) {
+        // The store is not guaranteed to make all blocks available
+        // Prune any unavailable indices
+        slotToCanonicalBlockRoot
+            .headMap(currentSlot, false)
+            .navigableKeySet()
+            .iterator()
+            .forEachRemaining(slotToCanonicalBlockRoot::remove);
+        break;
+      }
       currentSlot = currentBlock.getSlot();
     }
 

--- a/storage/src/test-support/java/tech/pegasys/artemis/storage/ChainStorageClientSetup.java
+++ b/storage/src/test-support/java/tech/pegasys/artemis/storage/ChainStorageClientSetup.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.storage;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
+import tech.pegasys.artemis.storage.Store.Transaction;
+import tech.pegasys.artemis.util.config.Constants;
+
+public class ChainStorageClientSetup {
+  private final AtomicInteger randomSeed = new AtomicInteger();
+  private final EventBus eventBus = new EventBus();
+  private final ChainStorageClient client = new ChainStorageClient(eventBus);
+
+  public ChainStorageClient getClient() {
+    return client;
+  }
+
+  public void initForGenesis() {
+    // Setup genesis store
+    final Store store = Store.get_genesis_store(DataStructureUtil.randomBeaconState(1));
+    client.setStore(store);
+  }
+
+  public Optional<BeaconBlock> genesisBlock() {
+    return blockStream()
+        .filter(b -> b.getSlot().compareTo(UnsignedLong.valueOf(Constants.GENESIS_SLOT)) == 0)
+        .findFirst();
+  }
+
+  /**
+   * Creates blocks in a chain from {@code fromSlot} (inclusive) to {@code toSlot} (exclusive), and
+   * add the blocks to the {@link Store}.
+   *
+   * @param fromSlot The slot at which the new chain begins.
+   * @param toSlot The slot at which the new chain stops.
+   * @return The list of created blocks which form a chain in ascending order.
+   */
+  public List<BeaconBlock> createChain(final long fromSlot, final long toSlot) {
+    final List<BeaconBlock> newChain = new ArrayList<>();
+    Optional<BeaconBlock> previousBlock = Optional.empty();
+    for (long i = fromSlot; i < toSlot; i++) {
+      UnsignedLong slot = UnsignedLong.valueOf(i);
+      BeaconBlock newBlock = addBlockAtSlot(slot, previousBlock);
+      newChain.add(newBlock);
+      previousBlock = Optional.of(newBlock);
+    }
+
+    return newChain;
+  }
+
+  private BeaconBlock addBlockAtSlot(final UnsignedLong slot, final Optional<BeaconBlock> parent) {
+    checkState(client.getStore() != null);
+    final Transaction tx = client.getStore().startTransaction();
+
+    Bytes32 parentRoot =
+        parent
+            .or(() -> blockStreamDesc().filter(b -> b.getSlot().compareTo(slot) < 0).findFirst())
+            .map(b -> b.signing_root("signature"))
+            .orElse(Bytes32.ZERO);
+
+    BeaconBlock newBlock =
+        DataStructureUtil.randomBeaconBlock(slot.longValue(), randomSeed.incrementAndGet());
+    newBlock.setParent_root(parentRoot);
+    tx.putBlock(newBlock.signing_root("signature"), newBlock);
+
+    tx.commit();
+    return newBlock;
+  }
+
+  /** Streams available blocks */
+  private Stream<BeaconBlock> blockStream() {
+    final Store store = client.getStore();
+    if (store == null) {
+      return Stream.empty();
+    }
+    return store.getBlockRoots().stream().map(store::getBlock);
+  }
+
+  /**
+   * Return stream of blocks in descending order by slot
+   *
+   * @return stream of blocks ordered by slot number
+   */
+  private Stream<BeaconBlock> blockStreamDesc() {
+    return blockStream().sorted(Comparator.comparing(BeaconBlock::getSlot).reversed());
+  }
+}

--- a/storage/src/test-support/java/tech/pegasys/artemis/storage/ChainStorageClientSetup.java
+++ b/storage/src/test-support/java/tech/pegasys/artemis/storage/ChainStorageClientSetup.java
@@ -50,18 +50,25 @@ public class ChainStorageClientSetup {
         .findFirst();
   }
 
+  public List<BeaconBlock> createChain(final long fromSlot, final long toSlot) {
+    return createChain(fromSlot, toSlot, 0);
+  }
+
   /**
    * Creates blocks in a chain from {@code fromSlot} (inclusive) to {@code toSlot} (exclusive), and
    * add the blocks to the {@link Store}.
    *
    * @param fromSlot The slot at which the new chain begins.
    * @param toSlot The slot at which the new chain stops.
+   * @param skippedSlots The number of slots to skip between blocks
    * @return The list of created blocks which form a chain in ascending order.
    */
-  public List<BeaconBlock> createChain(final long fromSlot, final long toSlot) {
+  public List<BeaconBlock> createChain(
+      final long fromSlot, final long toSlot, final long skippedSlots) {
     final List<BeaconBlock> newChain = new ArrayList<>();
     Optional<BeaconBlock> previousBlock = Optional.empty();
-    for (long i = fromSlot; i < toSlot; i++) {
+    final long delta = 1 + skippedSlots;
+    for (long i = fromSlot; i < toSlot; i += delta) {
       UnsignedLong slot = UnsignedLong.valueOf(i);
       BeaconBlock newBlock = addBlockAtSlot(slot, previousBlock);
       newChain.add(newBlock);

--- a/storage/src/test/java/tech/pegasys/artemis/storage/ChainStorageClientTest.java
+++ b/storage/src/test/java/tech/pegasys/artemis/storage/ChainStorageClientTest.java
@@ -183,7 +183,7 @@ public class ChainStorageClientTest {
   }
 
   private void testUpdateBestBlockToFork(final long origChainLength, final long newChainLength) {
-    testUpdateBestBlockToFork(origChainLength, newChainLength, 0, 0, -1L);
+    testUpdateBestBlockToFork(origChainLength, newChainLength, 0, 0, 0L);
   }
 
   private void testUpdateBestBlockToFork(
@@ -192,12 +192,12 @@ public class ChainStorageClientTest {
       final long origChainSkippedSlots,
       final long newChainSkippedSlots) {
     testUpdateBestBlockToFork(
-        origChainLength, newChainLength, origChainSkippedSlots, newChainSkippedSlots, -1L);
+        origChainLength, newChainLength, origChainSkippedSlots, newChainSkippedSlots, 0L);
   }
 
   private void testUpdateBestBlockToFork(
       final long origChainLength, final long newChainLength, final long skippedSlots) {
-    testUpdateBestBlockToFork(origChainLength, newChainLength, skippedSlots, skippedSlots, -1L);
+    testUpdateBestBlockToFork(origChainLength, newChainLength, skippedSlots, skippedSlots, 0L);
   }
 
   private void testUpdateBestBlockToFork(

--- a/storage/src/test/java/tech/pegasys/artemis/storage/ChainStorageClientTest.java
+++ b/storage/src/test/java/tech/pegasys/artemis/storage/ChainStorageClientTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
+import tech.pegasys.artemis.util.config.Constants;
+
+public class ChainStorageClientTest {
+
+  private final ChainStorageClientSetup setup = new ChainStorageClientSetup();
+  private final ChainStorageClient client = setup.getClient();
+
+  @Test
+  public void getBlockBySlot_noStore() {
+    assertThat(client.getBlockBySlot(UnsignedLong.ONE)).isEmpty();
+  }
+
+  @Test
+  public void getBlockBySlot_forGenesis() {
+    // Setup chain
+    setup.initForGenesis();
+    final BeaconBlock genesisBlock = setup.genesisBlock().orElseThrow();
+    client.updateBestBlock(genesisBlock.signing_root("signature"), genesisBlock.getSlot());
+
+    final UnsignedLong genesisSlot = UnsignedLong.valueOf(Constants.GENESIS_SLOT);
+    assertThat(client.getBlockBySlot(genesisSlot)).contains(genesisBlock);
+  }
+
+  @Test
+  public void getBlockBySlot_forIndexedChainHead() {
+    // Setup and index chain
+    setup.initForGenesis();
+    final List<BeaconBlock> chain =
+        setup.createChain(Constants.GENESIS_SLOT + 1, Constants.GENESIS_SLOT + 5);
+    final BeaconBlock chainHead = chain.get(chain.size() - 1);
+    client.updateBestBlock(chainHead.signing_root("signature"), chainHead.getSlot());
+
+    assertThat(client.getBlockBySlot(chainHead.getSlot())).contains(chainHead);
+  }
+
+  @Test
+  public void getBlockBySlot_futureSlot() {
+    // Setup and index chain
+    setup.initForGenesis();
+    final List<BeaconBlock> chain =
+        setup.createChain(Constants.GENESIS_SLOT + 1, Constants.GENESIS_SLOT + 5);
+    final BeaconBlock chainHead = chain.get(chain.size() - 1);
+    client.updateBestBlock(chainHead.signing_root("signature"), chainHead.getSlot());
+
+    assertThat(client.getBlockBySlot(chainHead.getSlot().plus(UnsignedLong.ONE))).isEmpty();
+  }
+
+  @Test
+  public void updateBestBlock_forNewChain() {
+    // Setup genesis block
+    setup.initForGenesis();
+    final BeaconBlock genesisBlock = setup.genesisBlock().orElseThrow();
+
+    // Add a new chain of blocks
+    final List<BeaconBlock> newChain =
+        setup.createChain(Constants.GENESIS_SLOT + 1, Constants.GENESIS_SLOT + 5);
+    final BeaconBlock newHead = newChain.get(newChain.size() - 1);
+
+    // Update client so that blocks are indexed
+    client.updateBestBlock(newHead.signing_root("signature"), newHead.getSlot());
+
+    // Verify that all blocks are indexed
+    UnsignedLong currentSlot = genesisBlock.getSlot();
+    assertThat(client.getBlockBySlot(genesisBlock.getSlot())).contains(genesisBlock);
+    for (BeaconBlock newBlock : newChain) {
+      // Sanity check that slots are sequential
+      currentSlot = currentSlot.plus(UnsignedLong.ONE);
+      assertThat(newBlock.getSlot()).isEqualTo(currentSlot);
+      // Check that this block is indexed by slot
+      assertThat(client.getBlockBySlot(newBlock.getSlot())).contains(newBlock);
+    }
+  }
+
+  @Test
+  public void updateBestBlock_toDifferentForkOfSameHeight() {
+    testUpdateBestBlockToFork(3L, 3L);
+  }
+
+  @Test
+  public void updateBestBlock_toDifferentForkOfLesserHeight() {
+    testUpdateBestBlockToFork(5L, 3L);
+  }
+
+  @Test
+  public void updateBestBlock_toDifferentForkOfGreaterHeight() {
+    testUpdateBestBlockToFork(3L, 4L);
+  }
+
+  @Test
+  public void updateBestBlock_toForkOfHeight1() {
+    testUpdateBestBlockToFork(1L, 1L);
+  }
+
+  private void testUpdateBestBlockToFork(final long origChainLength, final long newChainLength) {
+    // Setup genesis block
+    setup.initForGenesis();
+    final BeaconBlock genesisBlock = setup.genesisBlock().orElseThrow();
+    // Define chain parameters
+    final long chainStartSlot = Constants.GENESIS_SLOT + 1L;
+
+    // Add a new chain of blocks
+    final List<BeaconBlock> oldChain =
+        setup.createChain(chainStartSlot, chainStartSlot + origChainLength);
+    assertThat(oldChain.size()).isEqualTo(origChainLength);
+    final BeaconBlock oldHead = oldChain.get(oldChain.size() - 1);
+    // Update client so that blocks are indexed
+    client.updateBestBlock(oldHead.signing_root("signature"), oldHead.getSlot());
+
+    // Add another chain of blocks
+    final List<BeaconBlock> newChain =
+        setup.createChain(chainStartSlot, chainStartSlot + newChainLength);
+    assertThat(newChain.size()).isEqualTo(newChainLength);
+    final BeaconBlock newHead = newChain.get(newChain.size() - 1);
+    // Update client so that blocks are indexed
+    client.updateBestBlock(newHead.signing_root("signature"), newHead.getSlot());
+
+    // Verify that all canonical blocks are indexed
+    UnsignedLong currentSlot = genesisBlock.getSlot();
+    assertThat(client.getBlockBySlot(genesisBlock.getSlot())).contains(genesisBlock);
+    for (BeaconBlock newBlock : newChain) {
+      // Sanity check that slots are sequential
+      currentSlot = currentSlot.plus(UnsignedLong.ONE);
+      assertThat(newBlock.getSlot()).isEqualTo(currentSlot);
+      // Check that this block is indexed by slot
+      assertThat(client.getBlockBySlot(newBlock.getSlot())).contains(newBlock);
+    }
+
+    // Verify that old blocks are no longer indexed
+    currentSlot = genesisBlock.getSlot();
+    for (BeaconBlock oldBlock : oldChain) {
+      // Sanity check that slots are sequential
+      currentSlot = currentSlot.plus(UnsignedLong.ONE);
+      assertThat(oldBlock.getSlot()).isEqualTo(currentSlot);
+      // Check that old block is no longer indexed
+      if (currentSlot.compareTo(newHead.getSlot()) > 0) {
+        assertThat(client.getBlockBySlot(oldBlock.getSlot())).isEmpty();
+      } else {
+        assertThat(client.getBlockBySlot(oldBlock.getSlot()))
+            .hasValueSatisfying(s -> assertThat(s).isNotEqualTo(oldBlock));
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Add a basic slot-to-block index that allows us to look up canonical blocks by slot number.  The index is currently in memory only and if a long chain is loaded from disk, we'll do a lot of work to build the initial index.  We can rework the index to be persistent and more performant in a follow-up PR.  