### PR TITLE
Make nodes arg optional

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # **** Usage **** #
 
@@ -19,6 +19,7 @@ DIR=$(dirname $0)
 
 # Create the arrays to hold the input files that were specified 
 INPUTS=()
+NODES=4
 
 # Source the functions from the utilities script
 source $DIR/run_utils.sh

--- a/scripts/run_utils.sh
+++ b/scripts/run_utils.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Create the configuration file for a specific node
 create_config() {


### PR DESCRIPTION
## PR Description
Make the nodes argument to `run.sh` optional. Also use `bash` explicitly when we're using bash specific functions (some systems strictly emulate `sh` whereas MacOS just uses a full `bash`).