### PR TITLE
Block Processing JMH Benchmarking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
       - run:
           name: FetchReferenceTests
           command: |
-            if [ ! -d "eth-reference-tests/src/referenceTest/resources/eth2.0-spec-tests/tests" ]
+            if [ ! -d "eth-reference-tests/src/test-support/resources/eth2.0-spec-tests/tests" ]
             then
               ./gradlew --no-daemon expandRefTests
             fi
@@ -155,7 +155,7 @@ jobs:
           name: Caching reference tests
           key: reftests-{{ checksum "build.gradle" }}
           paths:
-            - eth-reference-tests/src/referenceTest/resources/eth2.0-spec-tests/
+            - eth-reference-tests/src/test-support/resources/eth2.0-spec-tests/
       - capture_test_results
 
   docker:

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,3 @@ scripts/.java-version
 config/peer_ids.dat
 eth-reference-tests/src/test/
 eth-reference-tests/src/test-support/resources/eth2.0-spec-tests/
-
-# Deprecated - Reference Test Resources Should Be Moved from ./src/referenceTest/... to ./src/test-support/...
-eth-reference-tests/src/referenceTest/resources/eth2.0-spec-tests/

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ proto/gen/*
 scripts/.java-version
 config/peer_ids.dat
 eth-reference-tests/src/test/
+eth-reference-tests/src/test-support/resources/eth2.0-spec-tests/
+
+# Deprecated - Reference Test Resources Should Be Moved from ./src/referenceTest/... to ./src/test-support/...
 eth-reference-tests/src/referenceTest/resources/eth2.0-spec-tests/
-
-

--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,7 @@ allprojects {
 def refTestVersion = 'v0.9.0'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
 def refTestDownloadDir = "${buildDir}/refTests/${refTestVersion}"
-def refTestExpandDir = "${project.rootDir}/eth-reference-tests/src/referenceTest/resources/eth2.0-spec-tests/"
+def refTestExpandDir = "${project.rootDir}/eth-reference-tests/src/test-support/resources/eth2.0-spec-tests/"
 
 task downloadRefTests(type: Download) {
   src([
@@ -282,7 +282,6 @@ subprojects {
       java {
         srcDir file('src/referenceTest/java')
       }
-      resources.srcDir file('src/referenceTest/resources')
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -282,6 +282,7 @@ subprojects {
       java {
         srcDir file('src/referenceTest/java')
       }
+      resources.srcDir file('src/referenceTest/resources')
     }
   }
 

--- a/eth-benchmark-tests/build.gradle
+++ b/eth-benchmark-tests/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   implementation project(':ethereum:datastructures')
   implementation project(':ethereum:statetransition')
   implementation 'org.apache.tuweni:tuweni-bytes'
+  implementation 'org.apache.tuweni:tuweni-io'
 
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   implementation 'org.miracl.milagro.amcl:milagro-crypto-java'
@@ -18,6 +19,8 @@ dependencies {
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   implementation 'org.junit.jupiter:junit-jupiter-api'
   implementation 'org.junit.jupiter:junit-jupiter-params'
+
+  runtime project(path: ':eth-reference-tests', configuration: 'testSupportArtifacts')
 }
 
 jmh {

--- a/eth-benchmark-tests/build.gradle
+++ b/eth-benchmark-tests/build.gradle
@@ -6,6 +6,7 @@ dependencies {
   implementation project(':util')
   implementation project(':eth-tests')
   implementation project(':ethereum:datastructures')
+  implementation project(':ethereum:statetransition')
   implementation 'org.apache.tuweni:tuweni-bytes'
 
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/artemis/benchmarks/BlockProcessingBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/artemis/benchmarks/BlockProcessingBenchmark.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.benchmarks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.primitives.UnsignedLong;
+import com.google.errorprone.annotations.MustBeClosed;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.Level;
+import org.apache.tuweni.bytes.Bytes;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import tech.pegasys.artemis.datastructures.Constants;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
+import tech.pegasys.artemis.datastructures.state.BeaconState;
+import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
+import tech.pegasys.artemis.ethtests.MapObjectUtil;
+import tech.pegasys.artemis.ethtests.TestObject;
+import tech.pegasys.artemis.ethtests.TestSet;
+import tech.pegasys.artemis.statetransition.util.BlockProcessingException;
+import tech.pegasys.artemis.statetransition.util.BlockProcessorUtil;
+import tech.pegasys.artemis.util.alogger.ALogger;
+
+public class BlockProcessingBenchmark {
+  protected static Path configPath = null;
+  private static final ALogger LOG = new ALogger(BlockProcessingBenchmark.class.getName());
+  private static final Path pathToTests =
+      Paths.get(
+          System.getProperty("user.dir").toString(),
+          "src",
+          "referenceTest",
+          "resources",
+          "eth2.0-spec-tests",
+          "tests");
+  private static final String FILE = "file://";
+
+  @State(Scope.Benchmark)
+  public static class ProcessBlockHeaderJMHState {
+    public BeaconBlock block;
+    public BeaconState state;
+
+    @Setup
+    public void setup() throws Exception {
+      System.out.println(pathToTests);
+      List<Object> list = minimalBeaconBlockHeaderSuccessSetup();
+      block = (BeaconBlock) list.get(0);
+      state = (BeaconState) list.get(1);
+      // block = DataStructureUtil.randomBeaconBlock(0, 0);
+      // state = DataStructureUtil.randomBeaconState(0);
+    }
+  }
+
+  @Benchmark
+  @Warmup(iterations = 2, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+  @Measurement(iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+  public void mainnetProcessBeaconBlockHeaderSuccess(
+      ProcessBlockHeaderJMHState processBlockHeaderJMHState) throws BlockProcessingException {
+    // Throwing BlockProcessingException is intentional in this method, as the input parameters
+    // are designed to be processed without error. As we're not benchmarking error handling in this
+    // case, it doesn't make sense to catch and blackhole the error. We want the benchmark to fail.
+
+    BlockProcessorUtil.process_block_header(
+        processBlockHeaderJMHState.state, processBlockHeaderJMHState.block, true);
+  }
+
+  @MustBeClosed
+  static Stream<Object> blockSuccessSetup(String config) throws Exception {
+    Path path = Paths.get(config, "phase0", "operations", "block_header", "pyspec_tests");
+    return operationSuccessSetup(path, Paths.get(config), "block.ssz", BeaconBlock.class);
+  }
+
+  static List<Object> minimalBeaconBlockHeaderSuccessSetup() throws Exception {
+    Stream<Object> blockSuccessStream = blockSuccessSetup("minimal");
+    try {
+      return blockSuccessStream.collect(Collectors.toList());
+    } finally {
+      blockSuccessStream.close();
+    }
+  }
+
+  @MustBeClosed
+  @SuppressWarnings("rawtypes")
+  public static Stream<Object> operationSuccessSetup(
+      Path path, Path configPath, String operationName, Class operationClass) throws Exception {
+    loadConfigFromPath(configPath);
+
+    TestSet testSet = new TestSet(path);
+    testSet.add(new TestObject(operationName, operationClass, null));
+    testSet.add(new TestObject("pre.ssz", BeaconState.class, null));
+    testSet.add(new TestObject("post.ssz", BeaconState.class, null));
+
+    return findTestsByPath(testSet);
+  }
+
+  @SuppressWarnings({"rawtypes"})
+  public static void loadConfigFromPath(Path path) throws Exception {
+    path = Path.of(pathToTests.toString(), path.toString());
+    String result = "";
+    while (result.isEmpty() && path.getNameCount() > 0) {
+      try (Stream<Path> walk = Files.walk(path)) {
+        result =
+            walk.map(x -> x.toString())
+                .filter(currentPath -> currentPath.contains("config.yaml"))
+                .collect(Collectors.joining());
+      } catch (IOException e) {
+        LOG.log(Level.WARN, e.toString());
+      }
+      if (result.isEmpty()) path = path.getParent();
+    }
+    if (result.isEmpty())
+      throw new Exception(
+          "TestSuite.loadConfigFromPath(): Configuration files was not found in the hierarchy of the provided path");
+    String constants = path.toString().contains("mainnet") ? "mainnet" : "minimal";
+    Constants.setConstants(constants);
+
+    // TODO fix this massacre of a technical debt
+    // Checks if constants were changed from minimal to mainnet or vice-versa, and updates
+    // reflection information
+    if (Constants.SLOTS_PER_HISTORICAL_ROOT
+        != SimpleOffsetSerializer.classReflectionInfo
+            .get(BeaconState.class)
+            .getVectorLengths()
+            .get(0)) {
+      SimpleOffsetSerializer.setConstants();
+    }
+  }
+
+  public static Stream<Object> findTestsByPath(TestSet testSet) {
+    Path path = Path.of(pathToTests.toString(), testSet.getPath().toString());
+    try (Stream<Path> walk = Files.walk(path)) {
+      List<String> result = walk.map(x -> x.toString()).collect(Collectors.toList());
+      result =
+          result.stream()
+              .filter(walkPath -> isFilePathConfiguredForTest(testSet, walkPath))
+              .collect(Collectors.toList());
+
+      return result.stream()
+          .map(
+              walkPath -> {
+                return testSet.getFileNames().stream()
+                    .flatMap(
+                        fileName -> {
+                          Object object =
+                              pathToObject(
+                                  Path.of(walkPath, fileName),
+                                  testSet.getTestObjectByFileName(fileName));
+                          return testSet.getTestObjectByFileName(fileName).stream()
+                              .map(
+                                  testObject -> {
+                                    if (fileName.contains(".ssz")) {
+                                      Bytes objectBytes =
+                                          getSSZBytesFromPath(Path.of(walkPath, fileName));
+                                      return SimpleOffsetSerializer.deserialize(
+                                          objectBytes, testObject.getClassName());
+                                    } else {
+                                      return parseObjectFromFile(
+                                          testObject.getClassName(), testObject.getPath(), object);
+                                    }
+                                  });
+                        })
+                    .collect(Collectors.toList());
+              });
+    } catch (IOException e) {
+      LOG.log(Level.WARN, e.toString());
+    }
+    return null;
+  }
+
+  public static Object pathToObject(Path path, List<TestObject> testObjects) {
+    return getObjectFromYAMLInputStream(getInputStreamFromPath(path), testObjects);
+  }
+
+  @SuppressWarnings({"rawtypes"})
+  public static Object getObjectFromYAMLInputStream(InputStream in, List<TestObject> testObjects) {
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    Object object = null;
+    try {
+      if (testObjects != null
+          && (testObjects.get(0).getClassName().equals(UnsignedLong.class)
+              || testObjects.get(0).getClassName().equals(Boolean.class)
+              || testObjects.get(0).getClassName().equals(String.class))) {
+        object = ((String) mapper.readerFor(String.class).readValue(in));
+      } else {
+        object = ((Map) mapper.readerFor(Map.class).readValue(in));
+      }
+
+    } catch (IOException e) {
+      LOG.log(Level.WARN, e.toString());
+    }
+    return object;
+  }
+
+  @SuppressWarnings({"rawtypes"})
+  private static Object parseObjectFromFile(Class className, Path path, Object object) {
+    if (path != null) {
+      Iterator<Path> itr = path.iterator();
+      while (itr.hasNext()) {
+        object = ((Map) object).get(itr.next().toString());
+      }
+    }
+    return MapObjectUtil.convertMapToTypedObject(className, object);
+  }
+
+  @SuppressWarnings({"rawtypes"})
+  public static Bytes getSSZBytesFromPath(Path path) {
+    InputStream in = getInputStreamFromPath(path);
+    try {
+      byte[] targetArray = new byte[in.available()];
+      in.read(targetArray);
+      return Bytes.wrap(targetArray);
+    } catch (IOException e) {
+      LOG.log(Level.WARN, e.toString());
+    }
+    return null;
+  }
+
+  public static InputStream getInputStreamFromPath(Path path) {
+    URL url = null;
+    InputStream in = null;
+    try {
+      url = new URL(FILE + path);
+      in = url.openConnection().getInputStream();
+    } catch (MalformedURLException e) {
+      LOG.log(Level.WARN, e.toString());
+    } catch (IOException e) {
+      LOG.log(Level.WARN, e.toString());
+    }
+    return in;
+  }
+
+  public static boolean isFilePathConfiguredForTest(TestSet testSet, String walkPath) {
+    boolean isIncludedPath =
+        testSet.getFileNames().stream()
+            .allMatch(fileName -> Files.exists(Path.of(walkPath, fileName)));
+    boolean isSuccessTest =
+        testSet.getFileNames().stream()
+                .filter(
+                    fileName ->
+                        fileName.contains("pre.yaml")
+                            || fileName.contains("pre.ssz")
+                            || fileName.contains("post.yaml")
+                            || fileName.contains("post.ssz"))
+                .collect(Collectors.toList())
+                .size()
+            > 1;
+    if (isSuccessTest) return isIncludedPath;
+    boolean isNotExcludedPath =
+        !(Files.exists(Path.of(walkPath, "post.ssz"))
+            || Files.exists(Path.of(walkPath, "post.yaml")));
+    boolean isMetaPath =
+        testSet.getFileNames().size() == 1 && testSet.getFileNames().get(0).equals("meta.yaml");
+    return isIncludedPath && (isNotExcludedPath || isMetaPath);
+  }
+}

--- a/eth-reference-tests/src/test-support/resources/log4j2.xml
+++ b/eth-reference-tests/src/test-support/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="DEBUG">
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout
+                pattern="%d{HH:mm:ss.SSS} [%-5level] - %msg%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="stdout" level="debug">
+            <AppenderRef ref="console"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/eth-tests/src/main/java/tech/pegasys/artemis/ethtests/TestSuite.java
+++ b/eth-tests/src/main/java/tech/pegasys/artemis/ethtests/TestSuite.java
@@ -52,7 +52,7 @@ public abstract class TestSuite {
       Paths.get(
           System.getProperty("user.dir").toString(),
           "src",
-          "referenceTest",
+          "test-support",
           "resources",
           "eth2.0-spec-tests",
           "tests");

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -
 # Enable configure on demand.
 org.gradle.configureondemand=true
 
-version=0.8.2-SNAPSHOT
+version=0.8.3-SNAPSHOT

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -55,6 +55,7 @@ dependencyManagement {
       entry 'tuweni-bytes'
       entry 'tuweni-config'
       entry 'tuweni-crypto' 
+      entry 'tuweni-io'
       entry 'tuweni-junit'
       entry 'tuweni-kv'
       entry 'tuweni-plumtree'


### PR DESCRIPTION
## PR Description
This PR adds block processing JMH benchmarking to Artemis.

### Changes:
#### Breaking:
 - `eth-reference-test` resources (test vectors downloaded from EF) have been moved to the `src/test-support/` source set from the `src/referenceTest/` source set.<br/>
_The download/expand script, as well as `TestSuite` have been updated to expect the new file path. If you already have the vectors downloaded in `src/referenceTest/`, they must be manually moved to `src/test-support/`. Alternatively, you can delete the contents of `src/referenceTest/resources` and re-pull with `./gradlew expandRefTests`._

#### All Other Changes:
 - Add 'tuweni-io` dependency to project for `eth-benchmark-tests`. It is used to load the test vectors as resources from the Java classloader.
 - Add `statetransition` module as a dependency to `eth-benchmark-tests`.
 - Add reference test loader method from `TestSuite`. (Modified to return `Stream<Object>` instead of junit's `Stream<Argument>`).

TODO:
- [ ] Modularize ref test loader methods to cut down on duplicated code from `TestSuite`. 
