### PR TITLE
Build Errors Occur When Building Sub-Projects Independently

### DIFF
--- a/ethereum/datastructures/build.gradle
+++ b/ethereum/datastructures/build.gradle
@@ -10,8 +10,8 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation 'org.apache.commons:commons-lang3'
   runtime 'org.apache.logging.log4j:log4j-core'
-  compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-  implementation 'com.fasterxml.jackson.core:jackson-databind'
+  testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind'
   
   test {
     testLogging.showStandardStreams = true

--- a/networking/p2p/build.gradle
+++ b/networking/p2p/build.gradle
@@ -9,7 +9,7 @@ dependencies {
   implementation project(':validator:coordinator')
   implementation 'com.google.guava:guava'
   implementation 'io.libp2p:jvm-libp2p-minimal'
-  compile "com.google.protobuf:protobuf-java"
+  implementation 'com.google.protobuf:protobuf-java'
   implementation 'io.vertx:vertx-core'
 
   implementation 'org.apache.tuweni:tuweni-bytes'
@@ -19,7 +19,6 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-units'
 
   implementation 'io.projectreactor:reactor-core'
-  compile group: 'org.javatuples', name: 'javatuples', version: '1.2'
 
   implementation 'org.apache.logging.log4j:log4j-api'
   runtime 'org.apache.logging.log4j:log4j-core'

--- a/proto/build.gradle
+++ b/proto/build.gradle
@@ -11,10 +11,10 @@ buildscript {
 }
 
 dependencies {
-    compile 'io.grpc:grpc-netty-shaded'
-    compile 'io.grpc:grpc-protobuf'
-    compile 'io.grpc:grpc-stub'
-    compile("javax.annotation:javax.annotation-api")
+    compileOnly 'io.grpc:grpc-netty-shaded'
+    compileOnly 'io.grpc:grpc-protobuf'
+    compileOnly 'io.grpc:grpc-stub'
+    compileOnly 'javax.annotation:javax.annotation-api'
 }
 
 protobuf {

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -13,7 +13,7 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-core'
   implementation 'org.miracl.milagro.amcl:milagro-crypto-java'
 
-  compile (group: 'org.quartz-scheduler', name: 'quartz') {
+  implementation (group: 'org.quartz-scheduler', name: 'quartz') {
     exclude group: 'com.mchange'
   }
 

--- a/validator/client/build.gradle
+++ b/validator/client/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   api 'org.bouncycastle:bcprov-jdk15on'
   implementation project(':pow')
-  compile project(':proto')
+  implementation project(':proto')
   implementation project(':ethereum:datastructures')
   implementation project(':util')
   implementation project(':data')
@@ -13,6 +13,8 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-crypto'
   implementation 'org.apache.tuweni:tuweni-kv'
   implementation 'org.apache.tuweni:tuweni-bytes'
+  implementation 'io.grpc:grpc-stub'
+  implementation 'com.google.protobuf:protobuf-java'
 
   implementation 'com.google.code.gson:gson'
   implementation 'com.google.guava:guava'

--- a/validator/coordinator/build.gradle
+++ b/validator/coordinator/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
   implementation project(':validator:client')
-  compile project(':proto')
+  implementation project(':proto')
   implementation project(':storage')
   implementation project(':services:serviceutils')
   implementation project(':ethereum:statetransition')
@@ -8,8 +8,7 @@ dependencies {
   implementation project(':util')
   implementation project(':pow')
 
-
-  compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+  implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'org.apache.tuweni:tuweni-kv'
   implementation 'org.apache.tuweni:tuweni-bytes'
@@ -19,6 +18,8 @@ dependencies {
   // implementation files('../../lib/tuweni-ssz-0.9.0-SNAPSHOT.jar')
   implementation 'com.google.guava:guava'
   implementation 'org.apache.logging.log4j:log4j-api'
+  implementation 'io.grpc:grpc-stub'
+  implementation 'com.google.protobuf:protobuf-java'
   runtime 'org.apache.logging.log4j:log4j-core'
 
   testImplementation 'org.mockito:mockito-core'


### PR DESCRIPTION
## PR Description
This PR fixes build issues that are encountered when Artemis sub-projects are built with Gradle independently. See the linked issue for more information.

## Fixed Issue(s)
Fixes #1028 