### PR TITLE
Disconnect req/resp streams after the maximum allowed number of responses are received

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/BeaconBlocksByRootRequestMessage.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/BeaconBlocksByRootRequestMessage.java
@@ -20,10 +20,8 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.ssz.SSZ;
 import tech.pegasys.artemis.util.SSZTypes.SSZContainer;
 import tech.pegasys.artemis.util.SSZTypes.SSZList;
-import tech.pegasys.artemis.util.sos.SimpleOffsetSerializable;
 
-public final class BeaconBlocksByRootRequestMessage
-    implements SimpleOffsetSerializable, SSZContainer {
+public final class BeaconBlocksByRootRequestMessage implements RpcRequest, SSZContainer {
 
   private final SSZList<Bytes32> blockRoots = new SSZList<>(Bytes32.class, Integer.MAX_VALUE);
 
@@ -78,5 +76,10 @@ public final class BeaconBlocksByRootRequestMessage
 
   public List<Bytes32> blockRoots() {
     return blockRoots;
+  }
+
+  @Override
+  public int getMaximumRequestChunks() {
+    return blockRoots.size();
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/BeaconBlocksMessageRequest.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/BeaconBlocksMessageRequest.java
@@ -21,9 +21,8 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.ssz.SSZ;
 import tech.pegasys.artemis.util.SSZTypes.SSZContainer;
-import tech.pegasys.artemis.util.sos.SimpleOffsetSerializable;
 
-public final class BeaconBlocksMessageRequest implements SimpleOffsetSerializable, SSZContainer {
+public final class BeaconBlocksMessageRequest implements RpcRequest, SSZContainer {
 
   private final Bytes32 headBlockRoot;
   private final UnsignedLong startSlot;
@@ -95,5 +94,10 @@ public final class BeaconBlocksMessageRequest implements SimpleOffsetSerializabl
 
   public UnsignedLong getStep() {
     return step;
+  }
+
+  @Override
+  public int getMaximumRequestChunks() {
+    return Math.toIntExact(count.longValue());
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/GoodbyeMessage.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/GoodbyeMessage.java
@@ -22,9 +22,8 @@ import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.ssz.SSZ;
 import tech.pegasys.artemis.util.SSZTypes.SSZContainer;
-import tech.pegasys.artemis.util.sos.SimpleOffsetSerializable;
 
-public final class GoodbyeMessage implements SimpleOffsetSerializable, SSZContainer {
+public final class GoodbyeMessage implements RpcRequest, SSZContainer {
 
   private final UnsignedLong reason;
 
@@ -83,5 +82,10 @@ public final class GoodbyeMessage implements SimpleOffsetSerializable, SSZContai
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("reason", reason).toString();
+  }
+
+  @Override
+  public int getMaximumRequestChunks() {
+    return 0;
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/RpcRequest.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/RpcRequest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.networking.libp2p.rpc;
+
+import tech.pegasys.artemis.util.sos.SimpleOffsetSerializable;
+
+public interface RpcRequest extends SimpleOffsetSerializable {
+  int getMaximumRequestChunks();
+}

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/StatusMessage.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/StatusMessage.java
@@ -22,9 +22,8 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.ssz.SSZ;
 import tech.pegasys.artemis.util.SSZTypes.Bytes4;
 import tech.pegasys.artemis.util.SSZTypes.SSZContainer;
-import tech.pegasys.artemis.util.sos.SimpleOffsetSerializable;
 
-public class StatusMessage implements SimpleOffsetSerializable, SSZContainer {
+public class StatusMessage implements RpcRequest, SSZContainer {
 
   private final Bytes4 headForkVersion;
   private final Bytes32 finalizedRoot;
@@ -118,5 +117,10 @@ public class StatusMessage implements SimpleOffsetSerializable, SSZContainer {
         .add("headRoot", headRoot)
         .add("headSlot", headSlot)
         .toString();
+  }
+
+  @Override
+  public int getMaximumRequestChunks() {
+    return 1;
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/Peer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/Peer.java
@@ -24,6 +24,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.GoodbyeMessage;
+import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.RpcRequest;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.ResponseStream;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.rpc.ResponseStream.ResponseListener;
@@ -91,7 +92,7 @@ public class Peer {
         listener);
   }
 
-  private <I extends SimpleOffsetSerializable, O extends SimpleOffsetSerializable>
+  private <I extends RpcRequest, O extends SimpleOffsetSerializable>
       CompletableFuture<Void> requestStream(
           final RpcMethod<I, O> method,
           I request,
@@ -100,7 +101,7 @@ public class Peer {
         .thenCompose(responseStream -> responseStream.expectMultipleResponses(listener));
   }
 
-  <I extends SimpleOffsetSerializable, O extends SimpleOffsetSerializable>
+  <I extends RpcRequest, O extends SimpleOffsetSerializable>
       CompletableFuture<ResponseStream<O>> invoke(final RpcMethod<I, O> method, I request) {
     return rpcMethods.invoke(method, connection, request);
   }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/ResponseStreamImpl.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/ResponseStreamImpl.java
@@ -23,6 +23,7 @@ import tech.pegasys.artemis.util.sos.SimpleOffsetSerializable;
 public class ResponseStreamImpl<O extends SimpleOffsetSerializable> implements ResponseStream<O> {
 
   private final CompletableFuture<Void> completionFuture = new CompletableFuture<>();
+  private int receivedResponseCount = 0;
   private ResponseListener<O> responseListener;
 
   @Override
@@ -62,7 +63,12 @@ public class ResponseStreamImpl<O extends SimpleOffsetSerializable> implements R
 
   public void respond(final O data) {
     checkNotNull(responseListener, "Must call an 'expect' method");
+    receivedResponseCount++;
     responseListener.onResponse(data);
+  }
+
+  public int getResponseChunkCount() {
+    return receivedResponseCount;
   }
 
   public void completeSuccessfully() {

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMessageHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMessageHandler.java
@@ -22,7 +22,6 @@ import io.libp2p.core.multistream.Multistream;
 import io.libp2p.core.multistream.ProtocolBinding;
 import io.libp2p.core.multistream.ProtocolMatcher;
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import java.util.concurrent.CompletableFuture;
@@ -170,14 +169,16 @@ public class RpcMessageHandler<
       reqByteBuf.writeBytes(encoded.toArrayUnsafe());
       responseStream = new ResponseStreamImpl<>();
       responseHandler = new ResponseRpcDecoder<>(responseStream::respond, method);
-      final ChannelFuture writeFuture = ctx.writeAndFlush(reqByteBuf);
-      if (closeNotification) {
-        writeFuture.addListener(
-            future -> {
-              ctx.channel().close();
-              responseStream.completeSuccessfully();
-            });
-      }
+      ctx.writeAndFlush(reqByteBuf)
+          .addListener(
+              future -> {
+                if (closeNotification) {
+                  ctx.channel().close();
+                  responseStream.completeSuccessfully();
+                } else {
+                  ctx.disconnect();
+                }
+              });
       return CompletableFuture.completedFuture(responseStream);
     }
 

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMessageHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMessageHandler.java
@@ -22,6 +22,7 @@ import io.libp2p.core.multistream.Multistream;
 import io.libp2p.core.multistream.ProtocolBinding;
 import io.libp2p.core.multistream.ProtocolMatcher;
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import java.util.concurrent.CompletableFuture;
@@ -169,16 +170,14 @@ public class RpcMessageHandler<
       reqByteBuf.writeBytes(encoded.toArrayUnsafe());
       responseStream = new ResponseStreamImpl<>();
       responseHandler = new ResponseRpcDecoder<>(responseStream::respond, method);
-      ctx.writeAndFlush(reqByteBuf)
-          .addListener(
-              future -> {
-                if (closeNotification) {
-                  ctx.channel().close();
-                  responseStream.completeSuccessfully();
-                } else {
-                  ctx.channel().disconnect();
-                }
-              });
+      final ChannelFuture writeFuture = ctx.writeAndFlush(reqByteBuf);
+      if (closeNotification) {
+        writeFuture.addListener(
+            future -> {
+              ctx.channel().close();
+              responseStream.completeSuccessfully();
+            });
+      }
       return CompletableFuture.completedFuture(responseStream);
     }
 

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMessageHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMessageHandler.java
@@ -175,6 +175,8 @@ public class RpcMessageHandler<
                 if (closeNotification) {
                   ctx.channel().close();
                   responseStream.completeSuccessfully();
+                } else {
+                  ctx.disconnect();
                 }
               });
       return CompletableFuture.completedFuture(responseStream);

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMessageHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMessageHandler.java
@@ -175,8 +175,6 @@ public class RpcMessageHandler<
                 if (closeNotification) {
                   ctx.channel().close();
                   responseStream.completeSuccessfully();
-                } else {
-                  ctx.disconnect();
                 }
               });
       return CompletableFuture.completedFuture(responseStream);

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMethods.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcMethods.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.GoodbyeMessage;
+import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.RpcRequest;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.artemis.networking.p2p.jvmlibp2p.PeerLookup;
 import tech.pegasys.artemis.util.sos.SimpleOffsetSerializable;
@@ -54,7 +55,7 @@ public class RpcMethods {
     return builder.build();
   }
 
-  public <I extends SimpleOffsetSerializable, O extends SimpleOffsetSerializable>
+  public <I extends RpcRequest, O extends SimpleOffsetSerializable>
       CompletableFuture<ResponseStream<O>> invoke(
           final RpcMethod<I, O> method, final Connection connection, final I request) {
     return getHandler(method).invokeRemote(connection, request);
@@ -65,7 +66,7 @@ public class RpcMethods {
   }
 
   @SuppressWarnings("unchecked")
-  private <I extends SimpleOffsetSerializable, O extends SimpleOffsetSerializable>
+  private <I extends RpcRequest, O extends SimpleOffsetSerializable>
       RpcMessageHandler<I, O> getHandler(final RpcMethod<I, O> method) {
     return (RpcMessageHandler<I, O>) methods.get(method);
   }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcResponseCallback.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcResponseCallback.java
@@ -47,7 +47,7 @@ class RpcResponseCallback<TResponse extends SimpleOffsetSerializable>
 
   @Override
   public void completeSuccessfully() {
-    ctx.disconnect();
+    ctx.channel().disconnect();
     if (closeNotification) {
       connection.getNettyChannel().close();
     }
@@ -57,7 +57,7 @@ class RpcResponseCallback<TResponse extends SimpleOffsetSerializable>
   public void completeWithError(final RpcException error) {
     LOG.debug("Responding to RPC request with error: {}", error.getErrorMessage());
     writeResponse(ctx, rpcEncoder.encodeErrorResponse(error));
-    ctx.disconnect();
+    ctx.channel().disconnect();
   }
 
   private void writeResponse(final ChannelHandlerContext ctx, final Bytes encoded) {

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcResponseCallback.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcResponseCallback.java
@@ -47,7 +47,7 @@ class RpcResponseCallback<TResponse extends SimpleOffsetSerializable>
 
   @Override
   public void completeSuccessfully() {
-    ctx.close();
+    ctx.disconnect();
     if (closeNotification) {
       connection.getNettyChannel().close();
     }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcResponseCallback.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcResponseCallback.java
@@ -47,7 +47,7 @@ class RpcResponseCallback<TResponse extends SimpleOffsetSerializable>
 
   @Override
   public void completeSuccessfully() {
-    ctx.channel().disconnect();
+    ctx.disconnect();
     if (closeNotification) {
       connection.getNettyChannel().close();
     }
@@ -57,7 +57,7 @@ class RpcResponseCallback<TResponse extends SimpleOffsetSerializable>
   public void completeWithError(final RpcException error) {
     LOG.debug("Responding to RPC request with error: {}", error.getErrorMessage());
     writeResponse(ctx, rpcEncoder.encodeErrorResponse(error));
-    ctx.channel().disconnect();
+    ctx.disconnect();
   }
 
   private void writeResponse(final ChannelHandlerContext ctx, final Bytes encoded) {

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcResponseCallback.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/jvmlibp2p/rpc/RpcResponseCallback.java
@@ -47,7 +47,7 @@ class RpcResponseCallback<TResponse extends SimpleOffsetSerializable>
 
   @Override
   public void completeSuccessfully() {
-    ctx.disconnect();
+    ctx.close();
     if (closeNotification) {
       connection.getNettyChannel().close();
     }


### PR DESCRIPTION
## PR Description
For req/resp requests like `STATUS` where a single response chunk is expected, the requester is responsible for closing the stream once it's received and the responder does not.

For requests that can have multiple responses, while the responder will close the stream after sending all response chunks, we have a known upper bound on the number of responses we expect (typically the number of blocks we requested) and should enforce that as a limit to avoid processing a never ending stream of responses from the remote peer.