### PR TITLE
Restore grpc runtime dependencies

### DIFF
--- a/proto/build.gradle
+++ b/proto/build.gradle
@@ -11,8 +11,8 @@ buildscript {
 }
 
 dependencies {
-    compileOnly 'io.grpc:grpc-netty-shaded'
-    compileOnly 'io.grpc:grpc-protobuf'
+    implementation 'io.grpc:grpc-netty-shaded'
+    implementation 'io.grpc:grpc-protobuf'
     compileOnly 'io.grpc:grpc-stub'
     compileOnly 'javax.annotation:javax.annotation-api'
 }


### PR DESCRIPTION
## PR Description
Artemis was failing to start because a couple of grpc dependencies had become compileOnly instead of implementation.