### PR TITLE
Add config to run compatibility tests nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,12 @@ executors:
       JAVA_TOOL_OPTIONS: -Xmx3g
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
 
+  machine_executor:
+    machine:
+      image: ubuntu-1604:201903-01 #Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
+      docker_layer_caching: true
+    working_directory: ~/project
+
 commands:
   prepare:
     description: "Prepare"
@@ -159,7 +165,7 @@ jobs:
       - capture_test_results
 
   compatibilityTests:
-    executor: medium_executor
+    executor: machine_executor
     steps:
       - prepare
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,8 @@ jobs:
     executor: machine_executor
     steps:
       - prepare
+      - attach_workspace:
+          at: ~/project
       - run:
           name: Install Packages - Java 11
           command: |
@@ -241,7 +243,9 @@ workflows:
           requires:
             - assemble
             - spotless
-      - compatibilityTests
+      - compatibilityTests:
+          requires:
+            - assemble
       - docker:
           requires:
             - assemble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,7 @@ jobs:
       - prepare
       - attach_workspace:
           at: ~/project
+      - setup_remote_docker
       - run:
           name: CompatibilityTests
           no_output_timeout: 20m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,8 +168,6 @@ jobs:
     executor: machine_executor
     steps:
       - prepare
-      - attach_workspace:
-          at: ~/project
       - run:
           name: CompatibilityTests
           no_output_timeout: 20m
@@ -236,10 +234,7 @@ workflows:
           requires:
             - assemble
             - spotless
-      - compatibilityTests:
-          requires:
-            - assemble
-            - spotless
+      - compatibilityTests
       - docker:
           requires:
             - assemble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,13 @@ jobs:
     steps:
       - prepare
       - run:
+          name: Install Packages - Java 11
+          command: |
+            sudo add-apt-repository -y ppa:openjdk-r/ppa
+            sudo apt update
+            sudo apt install -y openjdk-11-jdk
+            sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
+      - run:
           name: CompatibilityTests
           no_output_timeout: 20m
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,19 @@ jobs:
             - eth-reference-tests/src/referenceTest/resources/eth2.0-spec-tests/
       - capture_test_results
 
+  compatibilityTests:
+    executor: medium_executor
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: CompatibilityTests
+          no_output_timeout: 20m
+          command: |
+            ./gradlew --no-daemon --parallel compatibilityTest
+      - capture_test_results
+
   docker:
     executor: medium_executor
     steps:
@@ -244,3 +257,16 @@ workflows:
             - integrationTests
             - referenceTests
             - docker
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - assemble
+      - compatibilityTests:
+          requires:
+            - assemble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,6 +230,10 @@ workflows:
           requires:
             - assemble
             - spotless
+      - compatibilityTests:
+          requires:
+            - assemble
+            - spotless
       - docker:
           requires:
             - assemble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,6 @@ jobs:
       - prepare
       - attach_workspace:
           at: ~/project
-      - setup_remote_docker
       - run:
           name: CompatibilityTests
           no_output_timeout: 20m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,9 +243,6 @@ workflows:
           requires:
             - assemble
             - spotless
-      - compatibilityTests:
-          requires:
-            - assemble
       - docker:
           requires:
             - assemble

--- a/compatibility-tests/multiclient/src/compatibility-test/java/tech/pegasys/artemis/compatibility/multiclient/StatusMessageCompatibilityTest.java
+++ b/compatibility-tests/multiclient/src/compatibility-test/java/tech/pegasys/artemis/compatibility/multiclient/StatusMessageCompatibilityTest.java
@@ -20,7 +20,6 @@ import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -50,7 +49,6 @@ class StatusMessageCompatibilityTest {
   }
 
   @Test
-  @Disabled("Prysm doesn't prefix responses with the status code")
   public void shouldExchangeStatusWhenArtemisConnectsToPrysm() throws Exception {
     waitFor(artemis.connect(PRYSM_NODE.getMultiAddr()));
     waitFor(() -> assertThat(artemis.getPeerManager().getAvailablePeerCount()).isEqualTo(1));


### PR DESCRIPTION
## PR Description
Setup circle ci to run compatibility tests nightly. These tests pull in the latest versions of other clients so may fail even if Artemis doesn't change but we want regular feedback on if they're passing or not.

Prysm status test now passes so enable that.