### PR TITLE
Use docker for acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,16 @@ commands:
             - deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
             - deps-{{ checksum "build.gradle" }}
             - deps-
+  install_java:
+    description: "Install Java"
+    steps:
+      - run:
+          name: Install Packages - Java 11
+          command: |
+            sudo add-apt-repository -y ppa:openjdk-r/ppa
+            sudo apt update
+            sudo apt install -y openjdk-11-jdk
+            sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
   capture_test_results:
     description: "Capture test results"
     steps:
@@ -133,6 +143,7 @@ jobs:
       - prepare
       - attach_workspace:
           at: ~/project
+      - install_java
       - run:
           name: AcceptanceTests
           command: |
@@ -192,13 +203,7 @@ jobs:
       - prepare
       - attach_workspace:
           at: ~/project
-      - run:
-          name: Install Packages - Java 11
-          command: |
-            sudo add-apt-repository -y ppa:openjdk-r/ppa
-            sudo apt update
-            sudo apt install -y openjdk-11-jdk
-            sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
+      - install_java
       - run:
           name: CompatibilityTests
           no_output_timeout: 20m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
 
   acceptanceTests:
     parallelism: 1
-    executor: large_executor
+    executor: machine_executor
     steps:
       - prepare
       - attach_workspace:
@@ -145,7 +145,7 @@ jobs:
             # Format the arguments to "./gradlew test"
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
             echo "Prepared arguments for Gradle: $GRADLE_ARGS"
-            ./gradlew --no-daemon --no-parallel acceptanceTest $GRADLE_ARGS
+            ./gradlew --no-daemon --parallel acceptanceTest $GRADLE_ARGS
       - capture_test_results
 
   referenceTests:

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -6,4 +6,5 @@ dependencies {
   testSupportImplementation 'org.apache.tuweni:tuweni-toml'
   testSupportImplementation 'org.assertj:assertj-core'
   testSupportImplementation 'org.junit.jupiter:junit-jupiter-api'
+  testSupportImplementation "org.testcontainers:testcontainers"
 }

--- a/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/AcceptanceTestBase.java
+++ b/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/AcceptanceTestBase.java
@@ -45,9 +45,14 @@ public class AcceptanceTestBase {
   }
 
   protected ArtemisNode createArtemisNode() {
-    final String ip = SUBNET_PREFIX + (nextAllocation++);
-    final ArtemisNode artemisNode = new ArtemisNode(httpClient, networkSupplier.get(), ip);
+    final ArtemisNode artemisNode =
+        new ArtemisNode(httpClient, networkSupplier.get(), allocateNextIp());
     nodes.add(artemisNode);
     return artemisNode;
+  }
+
+  private String allocateNextIp() {
+    final int allocation = nextAllocation++;
+    return SUBNET_PREFIX + allocation;
   }
 }

--- a/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/AcceptanceTestBase.java
+++ b/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/AcceptanceTestBase.java
@@ -23,7 +23,7 @@ import org.testcontainers.containers.Network;
 
 public class AcceptanceTestBase {
 
-  private static final String SUBNET_PREFIX = "172.20.0.";
+  private static final String SUBNET_PREFIX = "10.105.47.";
   private final SimpleHttpClient httpClient = new SimpleHttpClient();
   private final List<ArtemisNode> nodes = new ArrayList<>();
   private int nextAllocation = 2;

--- a/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
+++ b/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.MountableFile;
 import tech.pegasys.artemis.provider.JsonProvider;
@@ -43,19 +44,22 @@ public class ArtemisNode {
   private final SimpleHttpClient httpClient;
   private final Config config = new Config();
 
-  private final GenericContainer<?> container =
-      new GenericContainer<>("pegasyseng/artemis:develop")
-          .withExposedPorts(REST_API_PORT)
-          .withLogConsumer(frame -> LOG.debug(frame.getUtf8String().trim()))
-          .waitingFor(
-              new HttpWaitStrategy()
-                  .forPort(config.getRestApiPortNumber())
-                  .forPath("/network/peer_id"));
+  private final GenericContainer<?> container;
   private boolean started = false;
   private File configFile;
 
-  ArtemisNode(final SimpleHttpClient httpClient) {
+  ArtemisNode(final SimpleHttpClient httpClient, final Network network, final String ipAddress) {
     this.httpClient = httpClient;
+    container =
+        new GenericContainer<>("pegasyseng/artemis:develop")
+            .withExposedPorts(REST_API_PORT)
+            .withNetwork(network)
+            .withCreateContainerCmdModifier(modifier -> modifier.withIpv4Address(ipAddress))
+            .withLogConsumer(frame -> LOG.debug(frame.getUtf8String().trim()))
+            .waitingFor(
+                new HttpWaitStrategy()
+                    .forPort(config.getRestApiPortNumber())
+                    .forPath("/network/peer_id"));
   }
 
   public void start() throws Exception {

--- a/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
+++ b/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.artemis.test.acceptance.dsl;
 
-import static org.apache.tuweni.io.file.Files.deleteRecursively;
 import static org.apache.tuweni.toml.Toml.tomlEscape;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.artemis.util.Waiter.waitFor;
@@ -24,53 +23,51 @@ import java.io.PrintWriter;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.utility.MountableFile;
 import tech.pegasys.artemis.provider.JsonProvider;
 import tech.pegasys.artemis.test.acceptance.dsl.data.BeaconHead;
 
 public class ArtemisNode {
+  private static final int REST_API_PORT = 9051;
   private static final Logger LOG = LogManager.getLogger();
-  private static final String ARTEMIS_BINARY =
-      new File(System.getProperty("artemis.binary.path", "../build/install/artemis/bin/artemis"))
-          .getAbsolutePath();
 
   private final SimpleHttpClient httpClient;
-  private final Config config;
+  private final Config config = new Config();
 
+  private final GenericContainer<?> container =
+      new GenericContainer<>("pegasyseng/artemis:develop")
+          .withExposedPorts(REST_API_PORT)
+          .withLogConsumer(frame -> LOG.debug(frame.getUtf8String().trim()))
+          .waitingFor(
+              new HttpWaitStrategy()
+                  .forPort(config.getRestApiPortNumber())
+                  .forPath("/network/peer_id"));
   private boolean started = false;
   private File configFile;
-  private Process process;
-  private Path workDir;
 
   ArtemisNode(final SimpleHttpClient httpClient) {
     this.httpClient = httpClient;
-    config = new Config();
   }
 
   public void start() throws Exception {
     assertThat(started).isFalse();
     started = true;
-    workDir = Files.createTempDirectory("artemis");
     configFile = File.createTempFile("config", ".toml");
     configFile.deleteOnExit();
     config.writeTo(configFile);
-    LOG.info(
-        "Starting artemis from {} with config file {}",
-        ARTEMIS_BINARY,
-        configFile.getAbsolutePath());
-    process =
-        new ProcessBuilder(ARTEMIS_BINARY, "--config", configFile.getAbsolutePath())
-            .directory(workDir.toFile())
-            .inheritIO()
-            .start();
+    container.withCopyFileToContainer(
+        MountableFile.forHostPath(configFile.getAbsolutePath()), "/config.toml");
+    container.setCommand("--config", "/config.toml");
+    container.start();
   }
 
   public void waitForGenesis() {
@@ -92,7 +89,7 @@ public class ArtemisNode {
   }
 
   private URI getRestApiUrl() {
-    return URI.create("http://127.0.0.1:" + config.getRestApiPortNumber());
+    return URI.create("http://127.0.0.1:" + container.getMappedPort(config.getRestApiPortNumber()));
   }
 
   public void stop() {
@@ -100,20 +97,10 @@ public class ArtemisNode {
       return;
     }
     LOG.debug("Shutting down");
-    try {
-      process.destroy();
-      if (!process.waitFor(1, TimeUnit.MINUTES)) {
-        LOG.warn("Didn't shutdown in a timely fashion, being more aggressive");
-        process.destroyForcibly();
-      }
-
-      if (!configFile.delete() && configFile.exists()) {
-        throw new IOException("Failed to delete config file: " + configFile);
-      }
-      deleteRecursively(workDir);
-    } catch (final IOException | InterruptedException e) {
-      throw new RuntimeException(e);
+    if (!configFile.delete() && configFile.exists()) {
+      throw new RuntimeException("Failed to delete config file: " + configFile);
     }
+    container.stop();
   }
 
   private static class Config {
@@ -143,7 +130,7 @@ public class ArtemisNode {
       deposit.put("numValidators", DEFAULT_VALIDATOR_COUNT);
 
       final Map<String, Object> beaconRestApi = getSection(BEACONRESTAPI_SECTION);
-      beaconRestApi.put("portNumber", 9051);
+      beaconRestApi.put("portNumber", REST_API_PORT);
     }
 
     public int getRestApiPortNumber() {

--- a/build.gradle
+++ b/build.gradle
@@ -383,11 +383,10 @@ subprojects {
     classpath = sourceSets.integrationTest.runtimeClasspath
   }
 
-  task acceptanceTest(type: Test, dependsOn:["compileAcceptanceTestJava", rootProject.installDist]){
+  task acceptanceTest(type: Test, dependsOn:["compileAcceptanceTestJava", "rootProject.distDocker"]){
     group = "verification"
     description = "Runs the Artemis acceptance tests"
 
-    systemProperty("artemis.binary.path", ("${rootProject.buildDir}/install/artemis/bin/artemis" as File).absolutePath)
     testClassesDirs = sourceSets.acceptanceTest.output.classesDirs
     classpath = sourceSets.acceptanceTest.runtimeClasspath
   }

--- a/build.gradle
+++ b/build.gradle
@@ -499,7 +499,7 @@ task distDocker(type: Exec) {
   dependsOn dockerDistUntar
 
   def dockerBuildVersion = project.hasProperty('release.releaseVersion') ? project.property('release.releaseVersion') : "${rootProject.version}"
-  def image = project.hasProperty('release.releaseVersion') ? "pegasyseng/artemis:" + project.property('release.releaseVersion') : "pegasyseng/artemis:${project.version}"
+  def image = "pegasyseng/artemis:develop"
   def dockerBuildDir = "build/docker-artemis/"
   workingDir "${dockerBuildDir}"
 
@@ -658,9 +658,10 @@ task dockerUpload(type: Exec) {
   dependsOn([distDocker, distDockerWhiteblock])
   def imageRepos = 'pegasyseng'
   def imageName = "${imageRepos}/artemis"
-  def image = "${imageName}:${rootProject.version}"
-  def cmd = "docker push '${image}'"
+  def image = "${imageName}:develop"
+  def cmd = "docker push ${imageName}:whiteblock"
   def additionalTags = []
+  additionalTags.add("${imageName}:${rootProject.version}")
   if (project.hasProperty('branch') && project.property('branch') == 'master') {
     additionalTags.add('develop')
   }

--- a/build.gradle
+++ b/build.gradle
@@ -661,7 +661,7 @@ task dockerUpload(type: Exec) {
   def image = "${imageName}:develop"
   def cmd = "docker push ${imageName}:whiteblock"
   def additionalTags = []
-  additionalTags.add("${imageName}:${rootProject.version}")
+  additionalTags.add("${rootProject.version}")
   if (project.hasProperty('branch') && project.property('branch') == 'master') {
     additionalTags.add('develop')
   }

--- a/build.gradle
+++ b/build.gradle
@@ -231,6 +231,94 @@ task cleanRefTests(dependsOn: [cleanRefTestsGeneral, cleanRefTestsMainnet, clean
 
 task deploy() {}
 
+
+installDist { }
+
+distTar {
+  dependsOn checkLicenses
+  doFirst {
+    delete fileTree(dir: 'build/distributions', include: '*.tar.gz')
+  }
+  compression = Compression.GZIP
+  extension = 'tar.gz'
+}
+
+distZip {
+  dependsOn checkLicenses
+  doFirst {
+    delete fileTree(dir: 'build/distributions', include: '*.zip')
+  }
+}
+
+// rename the top level dir from artemis-<version> to artemis and this makes it really
+// simple for use in docker
+tasks.register("dockerDistUntar") {
+  dependsOn distTar
+  def dockerBuildDir = "build/docker-artemis/"
+  def distTarFile = distTar.outputs.files.singleFile
+  def distTarFileName = distTar.outputs.files.singleFile.name.replace(".tar.gz", "")
+
+  doFirst {
+    new File(dockerBuildDir).mkdir()
+    copy {
+      from tarTree(distTarFile)
+      into(dockerBuildDir)
+    }
+    file("${dockerBuildDir}/${distTarFileName}").renameTo("${dockerBuildDir}/artemis")
+  }
+}
+
+task distDocker(type: Exec) {
+  dependsOn dockerDistUntar
+
+  def dockerBuildVersion = project.hasProperty('release.releaseVersion') ? project.property('release.releaseVersion') : "${rootProject.version}"
+  def image = "pegasyseng/artemis:develop"
+  def dockerBuildDir = "build/docker-artemis/"
+  workingDir "${dockerBuildDir}"
+
+  doFirst {
+    copy {
+      from file("${projectDir}/docker/Dockerfile")
+      into(workingDir)
+    }
+  }
+
+  executable "sh"
+  args "-c", "docker build --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
+}
+
+task distDockerWhiteblock(type: Exec) {
+  dependsOn installDist
+
+  def dockerBuildVersion = project.hasProperty('release.releaseVersion') ? project.property('release.releaseVersion') : "${rootProject.version}"
+  def image = "pegasyseng/artemis:whiteblock"
+  def dockerBuildDir = "build/docker-artemis-whiteblock/"
+  workingDir "${dockerBuildDir}"
+
+  doFirst {
+    new File(dockerBuildDir).mkdir()
+    copy {
+      from fileTree("${projectDir}/docker/whiteblock/")
+      into(workingDir)
+    }
+    copy {
+      from fileTree("${projectDir}/build/install/")
+      into(workingDir)
+    }
+    copy {
+      from fileTree("${projectDir}/scripts/")
+      into("${workingDir}/scripts")
+    }
+    copy {
+      from fileTree("${projectDir}/config/")
+      into("${workingDir}/config")
+    }
+  }
+
+  executable "sh"
+  args "-c", "docker build --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
+}
+
 subprojects {
   tasks.withType(Test) {
     // If GRADLE_MAX_TEST_FORKS is not set, use half the available processors
@@ -336,7 +424,7 @@ subprojects {
   dependencies {
     implementation 'org.apache.logging.log4j:log4j-core'
     runtime 'org.apache.logging.log4j:log4j-slf4j-impl'
-    
+
     testImplementation sourceSets.testSupport.output
     integrationTestImplementation sourceSets.testSupport.output
 
@@ -383,7 +471,7 @@ subprojects {
     classpath = sourceSets.integrationTest.runtimeClasspath
   }
 
-  task acceptanceTest(type: Test, dependsOn:["compileAcceptanceTestJava", "rootProject.distDocker"]){
+  task acceptanceTest(type: Test, dependsOn:["compileAcceptanceTestJava", rootProject.distDocker]){
     group = "verification"
     description = "Runs the Artemis acceptance tests"
 
@@ -456,93 +544,6 @@ distributions {
       from("libs") { into "native" }
     }
   }
-}
-
-installDist { }
-
-distTar {
-  dependsOn checkLicenses
-  doFirst {
-    delete fileTree(dir: 'build/distributions', include: '*.tar.gz')
-  }
-  compression = Compression.GZIP
-  extension = 'tar.gz'
-}
-
-distZip {
-  dependsOn checkLicenses
-  doFirst {
-    delete fileTree(dir: 'build/distributions', include: '*.zip')
-  }
-}
-
-// rename the top level dir from artemis-<version> to artemis and this makes it really
-// simple for use in docker
-tasks.register("dockerDistUntar") {
-  dependsOn distTar
-  def dockerBuildDir = "build/docker-artemis/"
-  def distTarFile = distTar.outputs.files.singleFile
-  def distTarFileName = distTar.outputs.files.singleFile.name.replace(".tar.gz", "")
-
-  doFirst {
-    new File(dockerBuildDir).mkdir()
-    copy {
-      from tarTree(distTarFile)
-      into(dockerBuildDir)
-    }
-    file("${dockerBuildDir}/${distTarFileName}").renameTo("${dockerBuildDir}/artemis")
-  }
-}
-
-task distDocker(type: Exec) {
-  dependsOn dockerDistUntar
-
-  def dockerBuildVersion = project.hasProperty('release.releaseVersion') ? project.property('release.releaseVersion') : "${rootProject.version}"
-  def image = "pegasyseng/artemis:develop"
-  def dockerBuildDir = "build/docker-artemis/"
-  workingDir "${dockerBuildDir}"
-
-  doFirst {
-    copy {
-      from file("${projectDir}/docker/Dockerfile")
-      into(workingDir)
-    }
-  }
-
-  executable "sh"
-  args "-c", "docker build --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
-}
-
-task distDockerWhiteblock(type: Exec) {
-  dependsOn installDist
-
-  def dockerBuildVersion = project.hasProperty('release.releaseVersion') ? project.property('release.releaseVersion') : "${rootProject.version}"
-  def image = "pegasyseng/artemis:whiteblock"
-  def dockerBuildDir = "build/docker-artemis-whiteblock/"
-  workingDir "${dockerBuildDir}"
-
-  doFirst {
-    new File(dockerBuildDir).mkdir()
-    copy {
-      from fileTree("${projectDir}/docker/whiteblock/")
-      into(workingDir)
-    }
-    copy {
-      from fileTree("${projectDir}/build/install/")
-      into(workingDir)
-    }
-    copy {
-      from fileTree("${projectDir}/scripts/")
-      into("${workingDir}/scripts")
-    }
-    copy {
-      from fileTree("${projectDir}/config/")
-      into("${workingDir}/config")
-    }
-  }
-
-  executable "sh"
-  args "-c", "docker build --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
 }
 
 // http://label-schema.org/rc1/


### PR DESCRIPTION
## PR Description
To avoid port conflicts when running acceptance tests in parallel, run artemis inside a docker image.  Docker will also be required to add other node types like besu for an eth1 chain and potentially other clients in the future.

Note that we're using a specific docker network and assigning static IPs to make internode communication easier (the IPs are internal to the docker network so only need to be unique for a single test).

Builds on #1048 as we need the built artemis image to be tagged with a simple label (develop).