### PR TITLE
Enable docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ jobs:
       - prepare
       - attach_workspace:
           at: ~/project
-      - setup_remote_docker
+      - setup_remote_docker:
           docker_layer_caching: true
       - run:
           name: Docker
@@ -246,7 +246,7 @@ jobs:
       - prepare
       - attach_workspace:
           at: ~/project
-      - setup_remote_docker
+      - setup_remote_docker:
           docker_layer_caching: true
       - run:
           name: Publish Docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,6 +218,7 @@ jobs:
       - attach_workspace:
           at: ~/project
       - setup_remote_docker
+          docker_layer_caching: true
       - run:
           name: Docker
           command: |
@@ -246,6 +247,7 @@ jobs:
       - attach_workspace:
           at: ~/project
       - setup_remote_docker
+          docker_layer_caching: true
       - run:
           name: Publish Docker
           command: |


### PR DESCRIPTION
## PR Description
Enable docker layer caching when using remote docker executors so we don't have to rebuild images or base layers that haven't changed.