### PR TITLE
[BC-176] Add initial HistoricalChainData class and events to retrieve blocks by slot from storage

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateProcessor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateProcessor.java
@@ -51,7 +51,6 @@ import tech.pegasys.artemis.statetransition.events.ProcessedBlockEvent;
 import tech.pegasys.artemis.statetransition.util.EpochProcessingException;
 import tech.pegasys.artemis.statetransition.util.SlotProcessingException;
 import tech.pegasys.artemis.storage.ChainStorageClient;
-import tech.pegasys.artemis.storage.HistoricalChainData;
 import tech.pegasys.artemis.storage.Store;
 import tech.pegasys.artemis.storage.events.StoreDiskUpdateEvent;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateProcessor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateProcessor.java
@@ -51,6 +51,7 @@ import tech.pegasys.artemis.statetransition.events.ProcessedBlockEvent;
 import tech.pegasys.artemis.statetransition.util.EpochProcessingException;
 import tech.pegasys.artemis.statetransition.util.SlotProcessingException;
 import tech.pegasys.artemis.storage.ChainStorageClient;
+import tech.pegasys.artemis.storage.HistoricalChainData;
 import tech.pegasys.artemis.storage.Store;
 import tech.pegasys.artemis.storage.events.StoreDiskUpdateEvent;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
@@ -190,6 +191,15 @@ public class StateProcessor {
       //  this.eventBus.post(new BlockProcessingRecord(preState, block, new BeaconState()));
       STDOUT.log(Level.WARN, "Exception in onBlock: " + e.toString());
     }
+    System.out.println("Requesting");
+    new HistoricalChainData(eventBus)
+        .getBlockBySlot(block.getSlot().minus(UnsignedLong.ONE))
+        .thenAccept(b -> System.out.println(b))
+        .exceptionally(
+            t -> {
+              t.printStackTrace();
+              return null;
+            });
   }
 
   private void onAttestation(Attestation attestation) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateProcessor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateProcessor.java
@@ -191,15 +191,6 @@ public class StateProcessor {
       //  this.eventBus.post(new BlockProcessingRecord(preState, block, new BeaconState()));
       STDOUT.log(Level.WARN, "Exception in onBlock: " + e.toString());
     }
-    System.out.println("Requesting");
-    new HistoricalChainData(eventBus)
-        .getBlockBySlot(block.getSlot().minus(UnsignedLong.ONE))
-        .thenAccept(b -> System.out.println(b))
-        .exceptionally(
-            t -> {
-              t.printStackTrace();
-              return null;
-            });
   }
 
   private void onAttestation(Attestation attestation) {

--- a/storage/src/main/java/tech/pegasys/artemis/storage/Database.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/Database.java
@@ -283,6 +283,14 @@ public class Database {
     return blockContained ? Optional.of(latest_messages.get(validatorIndex)) : Optional.empty();
   }
 
+  public Optional<BeaconBlock> getBlockBySlot(UnsignedLong slot) {
+    final Bytes32 root = block_root_references.get(slot);
+    if (root == null) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(blocks.get(root));
+  }
+
   public void close() {
     db.close();
   }

--- a/storage/src/main/java/tech/pegasys/artemis/storage/HistoricalChainData.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/HistoricalChainData.java
@@ -44,7 +44,7 @@ public class HistoricalChainData {
   @Subscribe
   public void onResponse(final GetBlockBySlotResponse response) {
     final CompletableFuture<Optional<BeaconBlock>> future =
-        blockBySlotRequests.remove(response.getRoot());
+        blockBySlotRequests.remove(response.getSlot());
     if (future != null) {
       future.complete(response.getBlock());
     }

--- a/storage/src/main/java/tech/pegasys/artemis/storage/events/GetBlockBySlotRequest.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/events/GetBlockBySlotRequest.java
@@ -17,14 +17,14 @@ import com.google.common.primitives.UnsignedLong;
 import java.util.Objects;
 
 public class GetBlockBySlotRequest {
-  private final UnsignedLong root;
+  private final UnsignedLong slot;
 
-  public GetBlockBySlotRequest(final UnsignedLong root) {
-    this.root = root;
+  public GetBlockBySlotRequest(final UnsignedLong slot) {
+    this.slot = slot;
   }
 
   public UnsignedLong getSlot() {
-    return root;
+    return slot;
   }
 
   @Override
@@ -36,11 +36,11 @@ public class GetBlockBySlotRequest {
       return false;
     }
     final GetBlockBySlotRequest that = (GetBlockBySlotRequest) o;
-    return Objects.equals(root, that.root);
+    return Objects.equals(slot, that.slot);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(root);
+    return Objects.hash(slot);
   }
 }

--- a/storage/src/main/java/tech/pegasys/artemis/storage/events/GetBlockBySlotRequest.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/events/GetBlockBySlotRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.storage.events;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.Objects;
+
+public class GetBlockBySlotRequest {
+  private final UnsignedLong root;
+
+  public GetBlockBySlotRequest(final UnsignedLong root) {
+    this.root = root;
+  }
+
+  public UnsignedLong getSlot() {
+    return root;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final GetBlockBySlotRequest that = (GetBlockBySlotRequest) o;
+    return Objects.equals(root, that.root);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(root);
+  }
+}

--- a/storage/src/main/java/tech/pegasys/artemis/storage/events/GetBlockBySlotResponse.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/events/GetBlockBySlotResponse.java
@@ -18,16 +18,16 @@ import java.util.Optional;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 
 public class GetBlockBySlotResponse {
-  private final UnsignedLong root;
+  private final UnsignedLong slot;
   private final Optional<BeaconBlock> block;
 
-  public GetBlockBySlotResponse(final UnsignedLong root, final Optional<BeaconBlock> block) {
-    this.root = root;
+  public GetBlockBySlotResponse(final UnsignedLong slot, final Optional<BeaconBlock> block) {
+    this.slot = slot;
     this.block = block;
   }
 
-  public UnsignedLong getRoot() {
-    return root;
+  public UnsignedLong getSlot() {
+    return slot;
   }
 
   public Optional<BeaconBlock> getBlock() {

--- a/storage/src/main/java/tech/pegasys/artemis/storage/events/GetBlockBySlotResponse.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/events/GetBlockBySlotResponse.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.storage.events;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.Optional;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
+
+public class GetBlockBySlotResponse {
+  private final UnsignedLong root;
+  private final Optional<BeaconBlock> block;
+
+  public GetBlockBySlotResponse(final UnsignedLong root, final Optional<BeaconBlock> block) {
+    this.root = root;
+    this.block = block;
+  }
+
+  public UnsignedLong getRoot() {
+    return root;
+  }
+
+  public Optional<BeaconBlock> getBlock() {
+    return block;
+  }
+}

--- a/storage/src/test/java/tech/pegasys/artemis/storage/HistoricalChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/artemis/storage/HistoricalChainDataTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.storage;
+
+import static com.google.common.primitives.UnsignedLong.ONE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.eventbus.EventBus;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
+import tech.pegasys.artemis.storage.events.GetBlockBySlotRequest;
+import tech.pegasys.artemis.storage.events.GetBlockBySlotResponse;
+
+class HistoricalChainDataTest {
+  private static final Optional<BeaconBlock> BLOCK =
+      Optional.of(DataStructureUtil.randomBeaconBlock(1, 100));
+  private final EventBus eventBus = mock(EventBus.class);
+  private final HistoricalChainData historicalChainData = new HistoricalChainData(eventBus);
+
+  @Test
+  public void shouldRegisterWithEventBus() {
+    verify(eventBus).register(historicalChainData);
+  }
+
+  @Test
+  public void shouldRetrieveBlockBySlot() {
+    final CompletableFuture<Optional<BeaconBlock>> result = historicalChainData.getBlockBySlot(ONE);
+    verify(eventBus).post(new GetBlockBySlotRequest(ONE));
+    assertThat(result).isNotDone();
+
+    historicalChainData.onResponse(new GetBlockBySlotResponse(ONE, BLOCK));
+    assertThat(result).isCompletedWithValue(BLOCK);
+  }
+
+  @Test
+  public void shouldResolveWithEmptyOptionalWhenBlockNotAvailable() {
+    final CompletableFuture<Optional<BeaconBlock>> result = historicalChainData.getBlockBySlot(ONE);
+
+    historicalChainData.onResponse(new GetBlockBySlotResponse(ONE, Optional.empty()));
+    assertThat(result).isCompletedWithValue(Optional.empty());
+  }
+
+  @Test
+  public void shouldIgnoreBlocksThatDoNotMatchOutstandingRequests() {
+    historicalChainData.onResponse(new GetBlockBySlotResponse(ONE, BLOCK));
+  }
+
+  @Test
+  public void shouldResolveMultipleRequestsForTheSameSlotWithFirstAvailableData() {
+    final CompletableFuture<Optional<BeaconBlock>> result1 =
+        historicalChainData.getBlockBySlot(ONE);
+    final CompletableFuture<Optional<BeaconBlock>> result2 =
+        historicalChainData.getBlockBySlot(ONE);
+
+    assertThat(result1).isNotDone();
+    assertThat(result2).isNotDone();
+
+    historicalChainData.onResponse(new GetBlockBySlotResponse(ONE, BLOCK));
+
+    assertThat(result1).isCompletedWithValue(BLOCK);
+    assertThat(result2).isCompletedWithValue(BLOCK);
+  }
+}


### PR DESCRIPTION
## PR Description
This is intended to provide the minimum possible functionality to allow https://pegasys1.atlassian.net/browse/BC-150 to progress.  Using `HistoricalChainData` blocks can be requested by slot. For finalised blocks this will work out great, for slots that haven't been finalised it doesn't provide any guarantee about which fork the block will be from.

https://pegasys1.atlassian.net/browse/BC-177 will expand this functionality further to handle non-finalised blocks and generally meet the requirements of beacon_block_by_slot. That will also include support for pulling blocks from memory when available and falling back to storage if not (but finalised blocks shouldn't be in memory so going straight to storage makes more sense).