### PR TITLE
Store genesis data to disk

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/artemis/test/acceptance/StartupAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/artemis/test/acceptance/StartupAcceptanceTest.java
@@ -13,8 +13,8 @@
 
 package tech.pegasys.artemis.test.acceptance;
 
+import com.google.common.primitives.UnsignedLong;
 import java.io.File;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.test.acceptance.dsl.AcceptanceTestBase;
 import tech.pegasys.artemis.test.acceptance.dsl.ArtemisNode;
@@ -30,22 +30,19 @@ public class StartupAcceptanceTest extends AcceptanceTestBase {
     node.waitForNewBlock();
   }
 
-  @Disabled
   @Test
   public void shouldProgressChainAfterStartingFromDisk() throws Exception {
     final ArtemisNode node1 = createArtemisNode();
     node1.start();
-    node1.waitForGenesis();
-    node1.waitForNewFinalization();
+    final UnsignedLong genesisTime = node1.getGenesisTime();
     File tempDatabaseFile = node1.getDatabaseFileFromContainer();
     node1.stop();
 
     final ArtemisNode node2 = createArtemisNode(ArtemisNode.Config::startFromDisk);
     node2.copyDatabaseFileToContainer(tempDatabaseFile);
     node2.start();
-    node1.waitForGenesis();
-    node2.waitForNewFinalization();
-    node2.stop();
+    node2.waitForGenesisTime(genesisTime);
+    node2.waitForNewBlock();
   }
 
   @Test

--- a/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
+++ b/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
@@ -77,7 +77,20 @@ public class ArtemisNode extends Node {
   }
 
   public void waitForGenesis() {
-    waitFor(() -> httpClient.get(getRestApiUrl(), "/node/genesis_time"));
+    waitFor(this::fetchGenesisTime);
+  }
+
+  public void waitForGenesisTime(final UnsignedLong expectedGenesisTime) {
+    waitFor(() -> assertThat(fetchGenesisTime()).isEqualTo(expectedGenesisTime));
+  }
+
+  private UnsignedLong fetchGenesisTime() throws IOException {
+    return UnsignedLong.valueOf(httpClient.get(getRestApiUrl(), "/node/genesis_time"));
+  }
+
+  public UnsignedLong getGenesisTime() throws IOException {
+    waitForGenesis();
+    return fetchGenesisTime();
   }
 
   public void waitForNewBlock() throws IOException {

--- a/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
@@ -28,6 +28,7 @@ import tech.pegasys.artemis.datastructures.operations.Attestation;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.datastructures.util.BeaconStateUtil;
+import tech.pegasys.artemis.storage.events.StoreGenesisDiskUpdateEvent;
 import tech.pegasys.artemis.storage.events.StoreInitializedEvent;
 import tech.pegasys.artemis.util.SSZTypes.Bytes4;
 import tech.pegasys.artemis.util.alogger.ALogger;
@@ -55,6 +56,7 @@ public class ChainStorageClient implements ChainStorage {
     setGenesisTime(initialState.getGenesis_time());
     final Store store = Store.get_genesis_store(initialState);
     setStore(store);
+    eventBus.post(new StoreGenesisDiskUpdateEvent(store));
 
     // The genesis state is by definition finalised so just get the root from there.
     Bytes32 headBlockRoot = store.getFinalizedCheckpoint().getRoot();

--- a/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageServer.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageServer.java
@@ -21,6 +21,7 @@ import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.storage.events.GetFinalizedBlockAtSlotRequest;
 import tech.pegasys.artemis.storage.events.GetFinalizedBlockAtSlotResponse;
 import tech.pegasys.artemis.storage.events.StoreDiskUpdateEvent;
+import tech.pegasys.artemis.storage.events.StoreGenesisDiskUpdateEvent;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
 
 public class ChainStorageServer {
@@ -38,8 +39,13 @@ public class ChainStorageServer {
   }
 
   @Subscribe
-  public void onStoreDiskUpdate(StoreDiskUpdateEvent storeDiskUpdateEvent) {
+  public void onStoreDiskUpdate(final StoreDiskUpdateEvent storeDiskUpdateEvent) {
     database.insert(storeDiskUpdateEvent);
+  }
+
+  @Subscribe
+  public void onStoreGenesis(final StoreGenesisDiskUpdateEvent event) {
+    database.storeGenesis(event.getStore());
   }
 
   @Subscribe

--- a/storage/src/main/java/tech/pegasys/artemis/storage/events/StoreGenesisDiskUpdateEvent.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/events/StoreGenesisDiskUpdateEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.storage.events;
+
+import tech.pegasys.artemis.storage.Store;
+
+public class StoreGenesisDiskUpdateEvent {
+
+  private final Store store;
+
+  public StoreGenesisDiskUpdateEvent(final Store store) {
+    this.store = store;
+  }
+
+  public Store getStore() {
+    return store;
+  }
+}


### PR DESCRIPTION
## PR Description
Fixes disk storage so that the genesis state is correctly stored.  Enables `StartupAcceptanceTest. shouldProgressChainAfterStartingFromDisk` as it no longer needs to wait for epoch's to finalize.