### PR TITLE
Preserve log level

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
@@ -70,8 +70,10 @@ public class BeaconNode {
     }
 
     // set log level per CLI flags
-    System.out.println("Setting logging level to " + loggingLevel.name());
-    Configurator.setAllLevels("", loggingLevel);
+    if (loggingLevel != null) {
+      System.out.println("Setting logging level to " + loggingLevel.name());
+      Configurator.setAllLevels("", loggingLevel);
+    }
   }
 
   public void start() {

--- a/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
@@ -22,6 +22,7 @@ import com.google.common.eventbus.SubscriberExceptionContext;
 import com.google.common.eventbus.SubscriberExceptionHandler;
 import io.vertx.core.Vertx;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.logging.log4j.Level;
@@ -53,7 +54,7 @@ public class BeaconNode {
   private EventBus eventBus;
   private MetricsEndpoint metricsEndpoint;
 
-  BeaconNode(Level loggingLevel, ArtemisConfiguration config) {
+  BeaconNode(Optional<Level> loggingLevel, ArtemisConfiguration config) {
     System.setProperty("logPath", config.getLogPath());
     System.setProperty("rollingFile", config.getLogFile());
 
@@ -70,10 +71,11 @@ public class BeaconNode {
     }
 
     // set log level per CLI flags
-    if (loggingLevel != null) {
-      System.out.println("Setting logging level to " + loggingLevel.name());
-      Configurator.setAllLevels("", loggingLevel);
-    }
+    loggingLevel.ifPresent(
+        level -> {
+          System.out.println("Setting logging level to " + level.name());
+          Configurator.setAllLevels("", level);
+        });
   }
 
   public void start() {

--- a/artemis/src/main/java/tech/pegasys/artemis/BeaconNodeCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/BeaconNodeCommand.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.artemis;
 
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import org.apache.logging.log4j.Level;
 import picocli.CommandLine.Command;
@@ -49,8 +50,8 @@ public class BeaconNodeCommand implements Callable<Integer> {
       description = "Path/filename of the config file")
   private String configFile = "./config/config.toml";
 
-  public Level getLoggingLevel() {
-    return this.logLevel;
+  public Optional<Level> getLoggingLevel() {
+    return Optional.ofNullable(this.logLevel);
   }
 
   public String getConfigFile() {

--- a/artemis/src/main/java/tech/pegasys/artemis/BeaconNodeCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/BeaconNodeCommand.java
@@ -41,7 +41,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
       paramLabel = "<LOG VERBOSITY LEVEL>",
       description =
           "Logging verbosity levels: OFF, FATAL, WARN, INFO, DEBUG, TRACE, ALL (default: INFO).")
-  private Level logLevel = Level.INFO;
+  private Level logLevel;
 
   @Option(
       names = {"-c", "--config"},

--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/ValidatorClient.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/ValidatorClient.java
@@ -51,18 +51,7 @@ public class ValidatorClient {
         port,
         keypair.getPublicKey());
 
-    Runtime.getRuntime()
-        .addShutdownHook(
-            new Thread() {
-              @Override
-              public void run() {
-                // Use stderr here since the logger may have been reset by its JVM shutdown hook.
-                System.err.println(
-                    "*** Shutting down Validator Client gRPC server since JVM is shutting down");
-                stopServer();
-                System.err.println("*** Server shut down");
-              }
-            });
+    Runtime.getRuntime().addShutdownHook(new Thread(this::stopServer));
   }
 
   private void stopServer() {


### PR DESCRIPTION
## PR Description
Only set the log level if it is explicitly set on the command line. Otherwise allow the log4j configuration to control it.  By default this is still INFO level, but if the user sets a custom log4j configuration (e.g. via the log4j.configurationFile system property) the custom config has full control of logging without being overridden.

Also remove the scary looking System.err.println calls when `ValidatorClient` is shutting down so it does look like the world is ending as Artemis shuts down.