### PR TITLE
Support blocks by range queries prior to finalised checkpoint

### DIFF
--- a/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
@@ -79,12 +79,12 @@ public class BeaconBlocksByRangeIntegrationTest {
   }
 
   @Test
-  public void shouldSendEmptyResponseWhenHeadBlockRootIsNotOnCanonicalChain() throws Exception {
+  public void shouldRespondWithBlocksWhenHeadBlockRootIsNotOnCanonicalChain() throws Exception {
     beaconChainUtil.initializeStorage();
     final BeaconBlock nonCanonicalBlock = beaconChainUtil.createAndImportBlockAtSlot(1).getBlock();
     storageClient1.updateBestBlock(nonCanonicalBlock.getParent_root(), UnsignedLong.ZERO);
     final List<BeaconBlock> response = requestBlocks(nonCanonicalBlock.signing_root("signature"));
-    assertThat(response).isEmpty();
+    assertThat(response).containsExactly(nonCanonicalBlock);
   }
 
   @Test

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2PeerManager.java
@@ -28,6 +28,7 @@ import tech.pegasys.artemis.networking.p2p.peer.NodeId;
 import tech.pegasys.artemis.networking.p2p.peer.Peer;
 import tech.pegasys.artemis.networking.p2p.peer.PeerConnectedSubscriber;
 import tech.pegasys.artemis.storage.ChainStorageClient;
+import tech.pegasys.artemis.storage.CombinedChainDataClient;
 import tech.pegasys.artemis.storage.HistoricalChainData;
 import tech.pegasys.artemis.util.events.Subscribers;
 
@@ -43,6 +44,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
   private final PeerValidatorFactory peerValidatorFactory;
 
   Eth2PeerManager(
+      final CombinedChainDataClient combinedChainDataClient,
       final ChainStorageClient storageClient,
       final MetricsSystem metricsSystem,
       final PeerValidatorFactory peerValidatorFactory) {
@@ -50,7 +52,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
     this.peerValidatorFactory = peerValidatorFactory;
     this.rpcMethods =
         BeaconChainMethods.createRpcMethods(
-            this, storageClient, metricsSystem, statusMessageFactory);
+            this, combinedChainDataClient, storageClient, metricsSystem, statusMessageFactory);
   }
 
   public static Eth2PeerManager create(
@@ -60,7 +62,11 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
     final PeerValidatorFactory peerValidatorFactory =
         (peer, status) ->
             PeerChainValidator.create(storageClient, historicalChainData, peer, status);
-    return new Eth2PeerManager(storageClient, metricsSystem, peerValidatorFactory);
+    return new Eth2PeerManager(
+        new CombinedChainDataClient(storageClient, historicalChainData),
+        storageClient,
+        metricsSystem,
+        peerValidatorFactory);
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -30,6 +30,7 @@ import tech.pegasys.artemis.networking.eth2.rpc.core.RpcMethod;
 import tech.pegasys.artemis.networking.eth2.rpc.core.RpcMethods;
 import tech.pegasys.artemis.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.artemis.storage.ChainStorageClient;
+import tech.pegasys.artemis.storage.CombinedChainDataClient;
 
 public class BeaconChainMethods {
   public static final RpcMethod<StatusMessage, StatusMessage> STATUS =
@@ -61,6 +62,7 @@ public class BeaconChainMethods {
 
   public static RpcMethods createRpcMethods(
       PeerLookup peerLookup,
+      final CombinedChainDataClient combinedChainDataClient,
       final ChainStorageClient chainStorageClient,
       final MetricsSystem metricsSystem,
       final StatusMessageFactory statusMessageFactory) {
@@ -69,7 +71,7 @@ public class BeaconChainMethods {
     final BeaconBlocksByRootMessageHandler beaconBlocksByRootHandler =
         new BeaconBlocksByRootMessageHandler(chainStorageClient);
     final BeaconBlocksByRangeMessageHandler beaconBlocksByRangeHandler =
-        new BeaconBlocksByRangeMessageHandler(chainStorageClient);
+        new BeaconBlocksByRangeMessageHandler(combinedChainDataClient);
     return new RpcMethods(
         new RpcMessageHandler<>(STATUS, peerLookup, statusHandler),
         new RpcMessageHandler<>(GOODBYE, peerLookup, goodbyeHandler).setCloseNotification(),

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -101,10 +101,6 @@ public class BeaconBlocksByRangeMessageHandler
   }
 
   private CompletableFuture<RequestState> sendNextBlock(final RequestState requestState) {
-    LOG.trace(
-        "Requesting block at slot {} for head block root {}",
-        requestState.currentSlot,
-        requestState.headBlockRoot);
     return storageClient
         .getBlockAtSlot(requestState.currentSlot, requestState.headBlockRoot)
         .thenCompose(
@@ -122,7 +118,6 @@ public class BeaconBlocksByRangeMessageHandler
                         requestState.callback.respond(block);
                       });
               if (requestState.isComplete()) {
-                LOG.trace("Request is complete {}", requestState);
                 return completedFuture(requestState);
               }
               requestState.incrementCurrentSlot();

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -15,26 +15,31 @@ package tech.pegasys.artemis.networking.eth2.rpc.beaconchain.methods;
 
 import static com.google.common.primitives.UnsignedLong.ONE;
 import static com.google.common.primitives.UnsignedLong.ZERO;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.primitives.UnsignedLong;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.LogManager;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage;
+import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.artemis.networking.eth2.rpc.core.LocalMessageHandler;
 import tech.pegasys.artemis.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.artemis.networking.eth2.rpc.core.RpcException;
-import tech.pegasys.artemis.storage.ChainStorageClient;
-import tech.pegasys.artemis.storage.Store;
+import tech.pegasys.artemis.storage.CombinedChainDataClient;
 
 public class BeaconBlocksByRangeMessageHandler
     implements LocalMessageHandler<BeaconBlocksByRangeRequestMessage, BeaconBlock> {
   private static final org.apache.logging.log4j.Logger LOG = LogManager.getLogger();
 
-  private final ChainStorageClient storageClient;
+  private final CombinedChainDataClient storageClient;
 
-  public BeaconBlocksByRangeMessageHandler(final ChainStorageClient storageClient) {
+  public BeaconBlocksByRangeMessageHandler(final CombinedChainDataClient storageClient) {
     this.storageClient = storageClient;
   }
 
@@ -50,43 +55,133 @@ public class BeaconBlocksByRangeMessageHandler
         message.getStartSlot(),
         message.getCount(),
         message.getStep());
-    try {
-      if (message.getStep().compareTo(ONE) < 0) {
-        callback.completeWithError(RpcException.INVALID_STEP);
-        return;
-      }
-      sendMatchingBlocks(message, callback);
-      callback.completeSuccessfully();
-    } catch (final RpcException e) {
-      callback.completeWithError(e);
+    if (message.getStep().compareTo(ONE) < 0) {
+      callback.completeWithError(RpcException.INVALID_STEP);
+      return;
     }
+    sendMatchingBlocks(message, callback)
+        .thenAccept(success -> callback.completeSuccessfully())
+        .exceptionally(
+            error -> {
+              if (error instanceof RpcException) {
+                LOG.trace("Rejecting beacon blocks by range request", error);
+                callback.completeWithError((RpcException) error);
+              } else {
+                LOG.error("Failed to process blocks by range request", error);
+                callback.completeWithError(RpcException.SERVER_ERROR);
+              }
+              return null;
+            });
   }
 
-  private void sendMatchingBlocks(
-      final BeaconBlocksByRangeRequestMessage message, final ResponseCallback<BeaconBlock> callback)
-      throws RpcException {
-    final Store store = storageClient.getStore();
-    if (store == null) {
-      return;
+  private CompletableFuture<?> sendMatchingBlocks(
+      final BeaconBlocksByRangeRequestMessage message,
+      final ResponseCallback<BeaconBlock> callback) {
+    final Optional<BeaconState> headState =
+        storageClient.getNonfinalizedBlockState(message.getHeadBlockRoot());
+    if (headState.isEmpty()) {
+      LOG.trace("Not sending blocks by range because head block state is unknown");
+      return completedFuture(null);
     }
-    if (!storageClient.isIncludedInBestState(message.getHeadBlockRoot())) {
-      return;
-    }
-    final UnsignedLong bestSlot = storageClient.getBestSlot();
+    final UnsignedLong bestSlot = headState.get().getSlot();
     if (bestSlot == null) {
       LOG.error("No best slot present despite having at least one canonical block");
-      throw RpcException.SERVER_ERROR;
+      return failedFuture(RpcException.SERVER_ERROR);
     }
 
-    UnsignedLong remainingBlocks = message.getCount();
-    for (UnsignedLong slot = message.getStartSlot();
-        !remainingBlocks.equals(ZERO) && slot.compareTo(bestSlot) <= 0;
-        slot = slot.plus(message.getStep())) {
-      final Optional<BeaconBlock> maybeBlock = storageClient.getBlockBySlot(slot);
-      if (maybeBlock.isPresent()) {
-        remainingBlocks = remainingBlocks.minus(ONE);
-        callback.respond(maybeBlock.get());
-      }
+    final RequestState requestState =
+        new RequestState(
+            message.getHeadBlockRoot(),
+            message.getStartSlot(),
+            message.getStep(),
+            message.getCount(),
+            bestSlot,
+            callback);
+    return sendNextBlock(requestState);
+  }
+
+  private CompletableFuture<RequestState> sendNextBlock(final RequestState requestState) {
+    LOG.trace(
+        "Requesting block at slot {} for head block root {}",
+        requestState.currentSlot,
+        requestState.headBlockRoot);
+    return storageClient
+        .getBlockAtSlot(requestState.currentSlot, requestState.headBlockRoot)
+        .thenCompose(
+            maybeBlock -> {
+              maybeBlock
+                  .filter(block -> block.getSlot().equals(requestState.currentSlot))
+                  .ifPresent(
+                      block -> {
+                        LOG.trace(
+                            "Responding with block slot {} for slot {}. Remaining {}",
+                            block.getSlot(),
+                            requestState.currentSlot,
+                            requestState.remainingBlocks);
+                        requestState.decrementRemainingBlocks();
+                        requestState.callback.respond(block);
+                      });
+              if (requestState.isComplete()) {
+                LOG.trace("Request is complete {}", requestState);
+                return completedFuture(requestState);
+              }
+              requestState.incrementCurrentSlot();
+              return sendNextBlock(requestState);
+            });
+  }
+
+  private static class RequestState {
+    private final UnsignedLong headSlot;
+    private final ResponseCallback<BeaconBlock> callback;
+    private final Bytes32 headBlockRoot;
+    private final UnsignedLong step;
+    private UnsignedLong currentSlot;
+    private UnsignedLong remainingBlocks;
+
+    public RequestState(
+        final Bytes32 headBlockRoot,
+        final UnsignedLong currentSlot,
+        final UnsignedLong step,
+        final UnsignedLong remainingBlocks,
+        final UnsignedLong headSlot,
+        final ResponseCallback<BeaconBlock> callback) {
+      this.headBlockRoot = headBlockRoot;
+      this.currentSlot = currentSlot;
+      this.remainingBlocks = remainingBlocks;
+      this.headSlot = headSlot;
+      this.step = step;
+      this.callback = callback;
+    }
+
+    boolean needsMoreBlocks() {
+      return !remainingBlocks.equals(ZERO);
+    }
+
+    boolean hasReachedHeadSlot() {
+      return currentSlot.compareTo(headSlot) >= 0;
+    }
+
+    boolean isComplete() {
+      return !needsMoreBlocks() || hasReachedHeadSlot();
+    }
+
+    void decrementRemainingBlocks() {
+      remainingBlocks = remainingBlocks.minus(ONE);
+    }
+
+    void incrementCurrentSlot() {
+      currentSlot = currentSlot.plus(step);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("headSlot", headSlot)
+          .add("callback", callback)
+          .add("headBlockRoot", headBlockRoot)
+          .add("currentSlot", currentSlot)
+          .add("remainingBlocks", remainingBlocks)
+          .toString();
     }
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/peers/Eth2PeerManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/peers/Eth2PeerManagerTest.java
@@ -28,10 +28,13 @@ import tech.pegasys.artemis.networking.eth2.rpc.beaconchain.methods.StatusMessag
 import tech.pegasys.artemis.networking.p2p.mock.MockNodeId;
 import tech.pegasys.artemis.networking.p2p.peer.Peer;
 import tech.pegasys.artemis.storage.ChainStorageClient;
+import tech.pegasys.artemis.storage.CombinedChainDataClient;
 
 public class Eth2PeerManagerTest {
 
   private final PeerStatusFactory statusFactory = PeerStatusFactory.create(1L);
+  private final CombinedChainDataClient combinedChainDataClient =
+      mock(CombinedChainDataClient.class);
   private final ChainStorageClient storageClient = mock(ChainStorageClient.class);
   private final StatusMessageFactory statusMessageFactory = new StatusMessageFactory(storageClient);
 
@@ -40,7 +43,8 @@ public class Eth2PeerManagerTest {
   private final CompletableFuture<Boolean> peerValidationResult = new CompletableFuture<>();
 
   private final Eth2PeerManager peerManager =
-      new Eth2PeerManager(storageClient, new NoOpMetricsSystem(), peerValidatorFactory);
+      new Eth2PeerManager(
+          combinedChainDataClient, storageClient, new NoOpMetricsSystem(), peerValidatorFactory);
 
   @BeforeEach
   public void setup() {

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -66,7 +66,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
         new BeaconBlocksByRangeRequestMessage(headBlockRoot, UnsignedLong.ZERO, ONE, ONE),
         listener);
 
-    verify(storageClient, never()).getBlockAtSlot(any(), any());
+    verify(storageClient, never()).getBlockAtSlotExact(any(), any());
     verifyNoBlocksReturned();
   }
 
@@ -79,7 +79,8 @@ class BeaconBlocksByRangeMessageHandlerTest {
     // Series of empty blocks leading up to our best slot.
     withCanonicalHeadBlock(headBlock, UnsignedLong.valueOf(20));
 
-    when(storageClient.getBlockAtSlot(any(), any())).thenReturn(completedFuture(Optional.empty()));
+    when(storageClient.getBlockAtSlotExact(any(), any()))
+        .thenReturn(completedFuture(Optional.empty()));
 
     handler.onIncomingMessage(
         peer,
@@ -105,7 +106,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
 
     BLOCKS.forEach(
         block ->
-            when(storageClient.getBlockAtSlot(block.getSlot(), headBlockRoot))
+            when(storageClient.getBlockAtSlotExact(block.getSlot(), headBlockRoot))
                 .thenReturn(completedFuture(Optional.of(block))));
 
     handler.onIncomingMessage(
@@ -132,7 +133,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
 
     BLOCKS.forEach(
         block ->
-            when(storageClient.getBlockAtSlot(block.getSlot(), headBlockRoot))
+            when(storageClient.getBlockAtSlotExact(block.getSlot(), headBlockRoot))
                 .thenReturn(completedFuture(Optional.of(block))));
 
     handler.onIncomingMessage(
@@ -232,9 +233,9 @@ class BeaconBlocksByRangeMessageHandlerTest {
         listener);
 
     verifyNoBlocksReturned();
-    verify(storageClient).getBlockAtSlot(UnsignedLong.valueOf(15), headBlockRoot);
-    verify(storageClient).getBlockAtSlot(UnsignedLong.valueOf(20), headBlockRoot);
-    verify(storageClient, never()).getBlockAtSlot(greaterThan(bestSlot), any());
+    verify(storageClient).getBlockAtSlotExact(UnsignedLong.valueOf(15), headBlockRoot);
+    verify(storageClient).getBlockAtSlotExact(UnsignedLong.valueOf(20), headBlockRoot);
+    verify(storageClient, never()).getBlockAtSlotExact(greaterThan(bestSlot), any());
   }
 
   @Test
@@ -285,12 +286,12 @@ class BeaconBlocksByRangeMessageHandlerTest {
   }
 
   private void withBlockAtSlot(final int slot, final Bytes32 headBlockRoot) {
-    when(storageClient.getBlockAtSlot(UnsignedLong.valueOf(slot), headBlockRoot))
+    when(storageClient.getBlockAtSlotExact(UnsignedLong.valueOf(slot), headBlockRoot))
         .thenReturn(completedFuture(Optional.of(BLOCKS.get(slot))));
   }
 
   private void withEmptySlot(final int slot, final Bytes32 headBlockRoot) {
-    when(storageClient.getBlockAtSlot(UnsignedLong.valueOf(slot), headBlockRoot))
+    when(storageClient.getBlockAtSlotExact(UnsignedLong.valueOf(slot), headBlockRoot))
         .thenReturn(completedFuture(Optional.empty()));
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.artemis.networking.eth2.rpc.beaconchain.methods;
 
 import static com.google.common.primitives.UnsignedLong.ONE;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -37,8 +38,7 @@ import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.artemis.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.artemis.networking.eth2.rpc.core.RpcException;
-import tech.pegasys.artemis.storage.ChainStorageClient;
-import tech.pegasys.artemis.storage.Store;
+import tech.pegasys.artemis.storage.CombinedChainDataClient;
 
 class BeaconBlocksByRangeMessageHandlerTest {
   private final Eth2Peer peer = mock(Eth2Peer.class);
@@ -51,54 +51,23 @@ class BeaconBlocksByRangeMessageHandlerTest {
   @SuppressWarnings("unchecked")
   private final ResponseCallback<BeaconBlock> listener = mock(ResponseCallback.class);
 
-  private final ChainStorageClient storageClient = mock(ChainStorageClient.class);
-  private final Store store = mock(Store.class);
+  private final CombinedChainDataClient storageClient = mock(CombinedChainDataClient.class);
 
   private final BeaconBlocksByRangeMessageHandler handler =
       new BeaconBlocksByRangeMessageHandler(storageClient);
 
   @Test
-  public void shouldReturnNoBlocksWhenStoreIsNotPresent() {
-    when(storageClient.getStore()).thenReturn(null);
-
-    handler.onIncomingMessage(
-        peer,
-        new BeaconBlocksByRangeRequestMessage(Bytes32.ZERO, UnsignedLong.ZERO, ONE, ONE),
-        listener);
-
-    verifyNoBlocksReturned();
-  }
-
-  @Test
   public void shouldReturnNoBlocksWhenHeadBlockIsNotInStore() {
     final Bytes32 headBlockRoot = Bytes32.fromHexStringLenient("0x123456");
-    when(storageClient.getStore()).thenReturn(store);
-    when(store.getBlock(headBlockRoot)).thenReturn(null);
+    when(storageClient.getNonfinalizedBlockState(headBlockRoot)).thenReturn(Optional.empty());
 
     handler.onIncomingMessage(
         peer,
         new BeaconBlocksByRangeRequestMessage(headBlockRoot, UnsignedLong.ZERO, ONE, ONE),
         listener);
 
-    verify(storageClient, never()).isIncludedInBestState(null);
+    verify(storageClient, never()).getBlockAtSlot(any(), any());
     verifyNoBlocksReturned();
-  }
-
-  @Test
-  public void shouldReturnNoBlocksWhenHeadIsNotCanonical() {
-    final BeaconBlock headBlock = BLOCKS.get(1);
-    final Bytes32 headBlockRoot = headBlock.hash_tree_root();
-    when(storageClient.getStore()).thenReturn(store);
-    when(store.getBlock(headBlockRoot)).thenReturn(headBlock);
-    when(storageClient.isIncludedInBestState(headBlockRoot)).thenReturn(false);
-
-    handler.onIncomingMessage(
-        peer,
-        new BeaconBlocksByRangeRequestMessage(headBlockRoot, UnsignedLong.ZERO, ONE, ONE),
-        listener);
-
-    verifyNoBlocksReturned();
-    verify(storageClient, never()).getBlockBySlot(any());
   }
 
   @Test
@@ -110,7 +79,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
     // Series of empty blocks leading up to our best slot.
     withCanonicalHeadBlock(headBlock, UnsignedLong.valueOf(20));
 
-    when(storageClient.getBlockBySlot(any())).thenReturn(Optional.empty());
+    when(storageClient.getBlockAtSlot(any(), any())).thenReturn(completedFuture(Optional.empty()));
 
     handler.onIncomingMessage(
         peer,
@@ -130,18 +99,19 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final int count = 5;
     final int skip = 1;
     final BeaconBlock headBlock = BLOCKS.get(10);
+    final Bytes32 headBlockRoot = headBlock.hash_tree_root();
 
     withCanonicalHeadBlock(headBlock);
-    when(storageClient.getBestSlot()).thenReturn(headBlock.getSlot());
 
     BLOCKS.forEach(
         block ->
-            when(storageClient.getBlockBySlot(block.getSlot())).thenReturn(Optional.of(block)));
+            when(storageClient.getBlockAtSlot(block.getSlot(), headBlockRoot))
+                .thenReturn(completedFuture(Optional.of(block))));
 
     handler.onIncomingMessage(
         peer,
         new BeaconBlocksByRangeRequestMessage(
-            headBlock.hash_tree_root(),
+            headBlockRoot,
             UnsignedLong.valueOf(startBlock),
             UnsignedLong.valueOf(count),
             UnsignedLong.valueOf(skip)),
@@ -157,16 +127,18 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final int count = 5;
     final int skip = 2;
     final BeaconBlock headBlock = BLOCKS.get(10);
+    final Bytes32 headBlockRoot = headBlock.hash_tree_root();
     withCanonicalHeadBlock(headBlock);
 
     BLOCKS.forEach(
         block ->
-            when(storageClient.getBlockBySlot(block.getSlot())).thenReturn(Optional.of(block)));
+            when(storageClient.getBlockAtSlot(block.getSlot(), headBlockRoot))
+                .thenReturn(completedFuture(Optional.of(block))));
 
     handler.onIncomingMessage(
         peer,
         new BeaconBlocksByRangeRequestMessage(
-            headBlock.hash_tree_root(),
+            headBlockRoot,
             UnsignedLong.valueOf(startBlock),
             UnsignedLong.valueOf(count),
             UnsignedLong.valueOf(skip)),
@@ -182,20 +154,21 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final int count = 5;
     final int skip = 1;
     final BeaconBlock headBlock = BLOCKS.get(10);
+    final Bytes32 headBlockRoot = headBlock.hash_tree_root();
 
     withCanonicalHeadBlock(headBlock);
 
-    withBlockAtSlot(2);
-    withBlockAtSlot(3);
-    withEmptySlot(4);
-    withBlockAtSlot(5);
-    withBlockAtSlot(6);
-    withBlockAtSlot(7);
+    withBlockAtSlot(2, headBlockRoot);
+    withBlockAtSlot(3, headBlockRoot);
+    withEmptySlot(4, headBlockRoot);
+    withBlockAtSlot(5, headBlockRoot);
+    withBlockAtSlot(6, headBlockRoot);
+    withBlockAtSlot(7, headBlockRoot);
 
     handler.onIncomingMessage(
         peer,
         new BeaconBlocksByRangeRequestMessage(
-            headBlock.hash_tree_root(),
+            headBlockRoot,
             UnsignedLong.valueOf(startBlock),
             UnsignedLong.valueOf(count),
             UnsignedLong.valueOf(skip)),
@@ -211,22 +184,23 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final int count = 4;
     final int skip = 2;
     final BeaconBlock headBlock = BLOCKS.get(10);
+    final Bytes32 headBlockRoot = headBlock.hash_tree_root();
 
     withCanonicalHeadBlock(headBlock);
 
-    withBlockAtSlot(2);
-    withBlockAtSlot(3);
-    withEmptySlot(4);
-    withBlockAtSlot(5);
-    withBlockAtSlot(6);
-    withEmptySlot(7);
-    withBlockAtSlot(8);
-    withBlockAtSlot(10);
+    withBlockAtSlot(2, headBlockRoot);
+    withBlockAtSlot(3, headBlockRoot);
+    withEmptySlot(4, headBlockRoot);
+    withBlockAtSlot(5, headBlockRoot);
+    withBlockAtSlot(6, headBlockRoot);
+    withEmptySlot(7, headBlockRoot);
+    withBlockAtSlot(8, headBlockRoot);
+    withBlockAtSlot(10, headBlockRoot);
 
     handler.onIncomingMessage(
         peer,
         new BeaconBlocksByRangeRequestMessage(
-            headBlock.hash_tree_root(),
+            headBlockRoot,
             UnsignedLong.valueOf(startBlock),
             UnsignedLong.valueOf(count),
             UnsignedLong.valueOf(skip)),
@@ -243,23 +217,24 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final int skip = 5;
 
     final BeaconBlock headBlock = BLOCKS.get(5);
+    final Bytes32 headBlockRoot = headBlock.hash_tree_root();
 
     final UnsignedLong bestSlot = UnsignedLong.valueOf(20);
     withCanonicalHeadBlock(headBlock, bestSlot);
 
+    withEmptySlot(15, headBlockRoot);
+    withEmptySlot(20, headBlockRoot);
+
     handler.onIncomingMessage(
         peer,
         new BeaconBlocksByRangeRequestMessage(
-            headBlock.hash_tree_root(),
-            UnsignedLong.valueOf(startBlock),
-            count,
-            UnsignedLong.valueOf(skip)),
+            headBlockRoot, UnsignedLong.valueOf(startBlock), count, UnsignedLong.valueOf(skip)),
         listener);
 
     verifyNoBlocksReturned();
-    verify(storageClient).getBlockBySlot(UnsignedLong.valueOf(15));
-    verify(storageClient).getBlockBySlot(UnsignedLong.valueOf(20));
-    verify(storageClient, never()).getBlockBySlot(greaterThan(bestSlot));
+    verify(storageClient).getBlockAtSlot(UnsignedLong.valueOf(15), headBlockRoot);
+    verify(storageClient).getBlockAtSlot(UnsignedLong.valueOf(20), headBlockRoot);
+    verify(storageClient, never()).getBlockAtSlot(greaterThan(bestSlot), any());
   }
 
   @Test
@@ -305,18 +280,18 @@ class BeaconBlocksByRangeMessageHandlerTest {
   }
 
   private void withCanonicalHeadBlock(final BeaconBlock headBlock, final UnsignedLong bestSlot) {
-    when(storageClient.getStore()).thenReturn(store);
-    when(storageClient.isIncludedInBestState(headBlock.hash_tree_root())).thenReturn(true);
-    when(storageClient.getBestSlot()).thenReturn(bestSlot);
+    when(storageClient.getNonfinalizedBlockState(headBlock.hash_tree_root()))
+        .thenReturn(Optional.of(DataStructureUtil.randomBeaconState(bestSlot, 1)));
   }
 
-  private void withBlockAtSlot(final int slot) {
-    when(storageClient.getBlockBySlot(UnsignedLong.valueOf(slot)))
-        .thenReturn(Optional.of(BLOCKS.get(slot)));
+  private void withBlockAtSlot(final int slot, final Bytes32 headBlockRoot) {
+    when(storageClient.getBlockAtSlot(UnsignedLong.valueOf(slot), headBlockRoot))
+        .thenReturn(completedFuture(Optional.of(BLOCKS.get(slot))));
   }
 
-  private void withEmptySlot(final int slot) {
-    when(storageClient.getBlockBySlot(UnsignedLong.valueOf(slot))).thenReturn(Optional.empty());
+  private void withEmptySlot(final int slot, final Bytes32 headBlockRoot) {
+    when(storageClient.getBlockAtSlot(UnsignedLong.valueOf(slot), headBlockRoot))
+        .thenReturn(completedFuture(Optional.empty()));
   }
 
   private UnsignedLong greaterThan(final UnsignedLong bestSlot) {

--- a/storage/src/main/java/tech/pegasys/artemis/storage/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/CombinedChainDataClient.java
@@ -98,4 +98,8 @@ public class CombinedChainDataClient {
     final UnsignedLong finalizedSlot = compute_start_slot_at_epoch(finalizedEpoch);
     return finalizedSlot.compareTo(slot) >= 0;
   }
+
+  public Optional<BeaconState> getNonfinalizedBlockState(final Bytes32 blockRoot) {
+    return recentChainData.getBlockState(blockRoot);
+  }
 }

--- a/storage/src/main/java/tech/pegasys/artemis/storage/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/CombinedChainDataClient.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.storage;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_block_root_at_slot;
+import static tech.pegasys.artemis.util.config.Constants.SLOTS_PER_HISTORICAL_ROOT;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
+import tech.pegasys.artemis.datastructures.state.BeaconState;
+import tech.pegasys.artemis.datastructures.util.BeaconStateUtil;
+
+public class CombinedChainDataClient {
+  private static final Logger LOG = LogManager.getLogger();
+
+  private static final CompletableFuture<Optional<BeaconBlock>> BLOCK_NOT_AVAILABLE =
+      completedFuture(Optional.empty());
+  private final ChainStorageClient recentChainData;
+  private final HistoricalChainData historicalChainData;
+
+  public CombinedChainDataClient(
+      final ChainStorageClient recentChainData, final HistoricalChainData historicalChainData) {
+    this.recentChainData = recentChainData;
+    this.historicalChainData = historicalChainData;
+  }
+
+  public CompletableFuture<Optional<BeaconBlock>> getBlockAtSlot(
+      final UnsignedLong slot, final Bytes32 headBlockRoot) {
+    final Store store = recentChainData.getStore();
+    if (store == null) {
+      LOG.trace("No block at slot {} because the store is not set", slot);
+      return BLOCK_NOT_AVAILABLE;
+    }
+    final BeaconState headState = store.getBlockState(headBlockRoot);
+    if (headState == null) {
+      LOG.trace("No block at slot {} because head block root {} is unknown", slot, headBlockRoot);
+      return BLOCK_NOT_AVAILABLE;
+    }
+    if (headState.getSlot().compareTo(slot) < 0) {
+      LOG.trace(
+          "No block at slot {} because it is after the referenced head state slot {}",
+          slot,
+          headState.getSlot());
+      return BLOCK_NOT_AVAILABLE;
+    }
+    if (headState.getSlot().equals(slot)) {
+      LOG.trace("Block root at slot {} is the specified head block root", slot);
+      return completedFuture(Optional.ofNullable(store.getBlock(headBlockRoot)));
+    }
+    if (isFinalized(slot)) {
+      LOG.trace("Block at slot {} is in a finalized epoch. Retrieving from historical data", slot);
+      return historicalChainData.getFinalizedBlockAtSlot(slot);
+    }
+
+    return getBlockAtSlotFormHistoricalBlockRoots(slot, store, headState);
+  }
+
+  private CompletableFuture<Optional<BeaconBlock>> getBlockAtSlotFormHistoricalBlockRoots(
+      final UnsignedLong slot, final Store store, final BeaconState headState) {
+    final UnsignedLong slotsPerHistoricalRoot = UnsignedLong.valueOf(SLOTS_PER_HISTORICAL_ROOT);
+    BeaconState state = headState;
+    while (state != null && !BeaconStateUtil.isBlockRootAvailableFromState(state, slot)) {
+      checkState(
+          state.getSlot().compareTo(slotsPerHistoricalRoot) >= 0,
+          "Can't get earlier state because the historical roots already extends to genesis");
+      final UnsignedLong earliestAvailableSlot = state.getSlot().minus(slotsPerHistoricalRoot);
+      LOG.trace(
+          "Slot {} is before the current historical root. Retrieving state from slot {}",
+          slot,
+          earliestAvailableSlot);
+      state = store.getBlockState(get_block_root_at_slot(state, earliestAvailableSlot));
+    }
+    return completedFuture(
+        Optional.ofNullable(store.getBlock(get_block_root_at_slot(state, slot))));
+  }
+
+  private boolean isFinalized(final UnsignedLong slot) {
+    final UnsignedLong finalizedEpoch = recentChainData.getFinalizedEpoch();
+    final UnsignedLong finalizedSlot = compute_start_slot_at_epoch(finalizedEpoch);
+    return finalizedSlot.compareTo(slot) >= 0;
+  }
+}

--- a/storage/src/test/java/tech/pegasys/artemis/storage/CombinedChainDataClientTest.java
+++ b/storage/src/test/java/tech/pegasys/artemis/storage/CombinedChainDataClientTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.storage;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
+import tech.pegasys.artemis.datastructures.state.BeaconState;
+import tech.pegasys.artemis.datastructures.util.BeaconStateUtil;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
+import tech.pegasys.artemis.util.config.Constants;
+
+class CombinedChainDataClientTest {
+
+  private final ChainStorageClient recentChainData = mock(ChainStorageClient.class);
+  private final HistoricalChainData historicalChainData = mock(HistoricalChainData.class);
+  private final Store store = mock(Store.class);
+  private final CombinedChainDataClient client =
+      new CombinedChainDataClient(recentChainData, historicalChainData);
+
+  private int seed = 242842;
+
+  @BeforeEach
+  public void setUp() {
+    when(recentChainData.getStore()).thenReturn(store);
+    when(recentChainData.getFinalizedEpoch()).thenReturn(UnsignedLong.ZERO);
+  }
+
+  @Test
+  public void getBlockBySlot_shouldReturnEmptyWhenRecentDataHasNoStore() {
+    when(recentChainData.getStore()).thenReturn(null);
+    assertThat(client.getBlockAtSlot(UnsignedLong.ONE, Bytes32.ZERO))
+        .isCompletedWithValue(Optional.empty());
+  }
+
+  @Test
+  public void getBlockBySlot_returnEmptyWhenHeadRootUnknown() {
+    when(store.getBlockState(Bytes32.ZERO)).thenReturn(null);
+    assertThat(client.getBlockAtSlot(UnsignedLong.ONE, Bytes32.ZERO))
+        .isCompletedWithValue(Optional.empty());
+  }
+
+  @Test
+  public void getBlockBySlot_returnEmptyWhenHeadRootUnknownAndSlotFinalized() {
+    final UnsignedLong slot = UnsignedLong.ONE;
+    when(store.getBlockState(Bytes32.ZERO)).thenReturn(null);
+    when(recentChainData.getFinalizedEpoch()).thenReturn(UnsignedLong.valueOf(10));
+
+    assertThat(client.getBlockAtSlot(slot, Bytes32.ZERO)).isCompletedWithValue(Optional.empty());
+  }
+
+  @Test
+  public void getBlockBySlot_returnBlockFromHistoricalDataWhenHeadRootKnownAndSlotFinalized() {
+    final UnsignedLong slot = UnsignedLong.ONE;
+    final BeaconBlock block = block(slot);
+    when(store.getBlockState(Bytes32.ZERO)).thenReturn(beaconState(UnsignedLong.valueOf(100)));
+    when(recentChainData.getFinalizedEpoch()).thenReturn(UnsignedLong.valueOf(10));
+    when(historicalChainData.getFinalizedBlockAtSlot(slot))
+        .thenReturn(completedFuture(Optional.of(block)));
+
+    assertThat(client.getBlockAtSlot(slot, Bytes32.ZERO)).isCompletedWithValue(Optional.of(block));
+  }
+
+  @Test
+  public void getBlockBySlot_returnEmptyWhenFinalizedSlotDidNotHaveABlock() {}
+
+  @Test
+  public void getBlockBySlot_returnBlockInHeadSlot() {
+    final UnsignedLong slot = UnsignedLong.ONE;
+    final BeaconBlock block = block(slot);
+    final Bytes32 headBlockRoot = Bytes32.ZERO;
+    when(store.getBlockState(headBlockRoot)).thenReturn(beaconState(slot));
+    when(store.getBlock(headBlockRoot)).thenReturn(block);
+
+    assertThat(client.getBlockAtSlot(slot, headBlockRoot)).isCompletedWithValue(Optional.of(block));
+  }
+
+  @Test
+  public void getBlockBySlot_slotAfterHeadRootReturnsEmpty() {
+    final UnsignedLong slot = UnsignedLong.ONE;
+    final Bytes32 headBlockRoot = Bytes32.ZERO;
+    when(store.getBlockState(headBlockRoot)).thenReturn(beaconState(UnsignedLong.ZERO));
+
+    assertThat(client.getBlockAtSlot(slot, headBlockRoot)).isCompletedWithValue(Optional.empty());
+  }
+
+  @Test
+  public void getBlockBySlot_returnCorrectBlockFromHistoricalWindow() {
+    // We've wrapped around a lot of times and are 5 slots into the next "loop"
+    final int historicalIndex = 5;
+    final UnsignedLong requestedSlot =
+        UnsignedLong.valueOf(Constants.SLOTS_PER_HISTORICAL_ROOT)
+            .times(UnsignedLong.valueOf(900000000))
+            .plus(UnsignedLong.valueOf(historicalIndex));
+    // Avoid the simple case where the requested slot is the head block slot
+    final UnsignedLong headSlot = requestedSlot.plus(UnsignedLong.ONE);
+
+    final BeaconBlock block = block(requestedSlot);
+    final Bytes32 blockRoot = block.signing_root("signature");
+    final Bytes32 headBlockRoot = Bytes32.fromHexString("0x1234");
+    final BeaconState bestState = beaconState(headSlot);
+    // At the start of the chain, the slot number is the index into historical roots
+    bestState.getBlock_roots().set(historicalIndex, blockRoot);
+    when(store.getBlockState(headBlockRoot)).thenReturn(bestState);
+    when(store.getBlock(blockRoot)).thenReturn(block);
+
+    assertThat(client.getBlockAtSlot(requestedSlot, headBlockRoot))
+        .isCompletedWithValue(Optional.of(block));
+  }
+
+  @Test
+  public void getBlockBySlot_returnCorrectBlockFromBeforeBestStateHistoricalWindow() {
+    // We've wrapped around a lot of times and are 5 slots into the next "loop"
+    final int historicalIndex = 5;
+    final UnsignedLong requestedSlot =
+        UnsignedLong.valueOf(Constants.SLOTS_PER_HISTORICAL_ROOT)
+            .times(UnsignedLong.valueOf(900000000))
+            .plus(UnsignedLong.valueOf(historicalIndex));
+    // Avoid the simple case where the requested slot is the head block slot
+    final UnsignedLong lastSlotInHistoricalWindow = requestedSlot.plus(UnsignedLong.ONE);
+    final UnsignedLong headSlot =
+        lastSlotInHistoricalWindow.plus(UnsignedLong.valueOf(Constants.SLOTS_PER_HISTORICAL_ROOT));
+
+    final BeaconBlock block = block(requestedSlot);
+    final Bytes32 blockRoot = block.signing_root("signature");
+    final Bytes32 headBlockRoot = Bytes32.fromHexString("0x1234");
+    final BeaconState headState = beaconState(headSlot);
+    final Bytes32 olderBlockRoot = Bytes32.fromHexString("0x8976");
+    headState.getBlock_roots().set(historicalIndex + 1, olderBlockRoot);
+    assertThat(BeaconStateUtil.get_block_root_at_slot(headState, lastSlotInHistoricalWindow))
+        .isEqualTo(olderBlockRoot);
+
+    final BeaconState olderState = beaconState(lastSlotInHistoricalWindow);
+    olderState.getBlock_roots().set(historicalIndex, blockRoot);
+
+    when(store.getBlockState(headBlockRoot)).thenReturn(headState);
+    when(store.getBlockState(olderBlockRoot)).thenReturn(olderState);
+    when(store.getBlock(blockRoot)).thenReturn(block);
+
+    assertThat(client.getBlockAtSlot(requestedSlot, headBlockRoot))
+        .isCompletedWithValue(Optional.of(block));
+  }
+
+  @Test
+  public void getBlockBySlot_returnPreviousBlockWhenSlotWasEmpty() {
+    // We've wrapped around a lot of times and are 5 slots into the next "loop"
+    final int historicalIndex = 5;
+    final UnsignedLong requestedSlot = UnsignedLong.valueOf(historicalIndex);
+    // Avoid the simple case where the requested slot is the head block slot
+    final UnsignedLong headSlot = requestedSlot.plus(UnsignedLong.ONE);
+
+    // Block is actually from the block before the requested slot
+    final BeaconBlock block = block(requestedSlot.minus(UnsignedLong.ONE));
+    final Bytes32 blockRoot = block.signing_root("signature");
+    final Bytes32 headBlockRoot = Bytes32.fromHexString("0x1234");
+    final BeaconState bestState = beaconState(headSlot);
+    // At the start of the chain, the slot number is the index into historical roots
+    bestState.getBlock_roots().set(historicalIndex, blockRoot);
+    when(store.getBlockState(headBlockRoot)).thenReturn(bestState);
+    when(store.getBlock(blockRoot)).thenReturn(block);
+
+    assertThat(client.getBlockAtSlot(requestedSlot, headBlockRoot))
+        .isCompletedWithValue(Optional.of(block));
+  }
+
+  private BeaconBlock block(final UnsignedLong slot) {
+    return DataStructureUtil.randomBeaconBlock(slot.longValue(), seed++);
+  }
+
+  private BeaconState beaconState(final UnsignedLong slot) {
+    return DataStructureUtil.randomBeaconState(slot, seed++);
+  }
+}


### PR DESCRIPTION
## PR Description
Beacon blocks by range requests now support:
* returning finalised blocks
* returning blocks from non-canonical chains
* returning blocks from before the historical window
