### PR TITLE
Add acceptance test that checks generated genesis states match

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -3,6 +3,7 @@ dependencies {
   testSupportImplementation project(path: ':data:provider')
   testSupportImplementation 'com.google.code.gson:gson'
   testSupportImplementation 'com.squareup.okhttp3:okhttp'
+  testSupportImplementation 'io.libp2p:jvm-libp2p-minimal'
   testSupportImplementation 'org.apache.tuweni:tuweni-toml'
   testSupportImplementation 'org.assertj:assertj-core'
   testSupportImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/artemis/test/acceptance/GenesisStateAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/artemis/test/acceptance/GenesisStateAcceptanceTest.java
@@ -20,7 +20,7 @@ import tech.pegasys.artemis.test.acceptance.dsl.ArtemisNode;
 import tech.pegasys.artemis.test.acceptance.dsl.BesuNode;
 
 @Disabled("Genesis generation does not yet match")
-public class GenesisEventAcceptanceTest extends AcceptanceTestBase {
+public class GenesisStateAcceptanceTest extends AcceptanceTestBase {
 
   @Test
   public void shouldCreateTheSameGenesisState() throws Exception {

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/artemis/test/acceptance/SyncAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/artemis/test/acceptance/SyncAcceptanceTest.java
@@ -20,7 +20,7 @@ import tech.pegasys.artemis.test.acceptance.dsl.ArtemisNode;
 import tech.pegasys.artemis.test.acceptance.dsl.BesuNode;
 
 @Disabled("Genesis generation does not yet match")
-public class SyncAcceptanceTest extends AcceptanceTestBase {
+public class GenesisEventAcceptanceTest extends AcceptanceTestBase {
 
   @Test
   public void shouldCreateTheSameGenesisState() throws Exception {

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/artemis/test/acceptance/SyncAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/artemis/test/acceptance/SyncAcceptanceTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.test.acceptance;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.test.acceptance.dsl.AcceptanceTestBase;
+import tech.pegasys.artemis.test.acceptance.dsl.ArtemisNode;
+import tech.pegasys.artemis.test.acceptance.dsl.BesuNode;
+
+@Disabled("Genesis generation does not yet match")
+public class SyncAcceptanceTest extends AcceptanceTestBase {
+
+  @Test
+  public void shouldCreateTheSameGenesisState() throws Exception {
+    final BesuNode eth1Node = createBesuNode();
+    eth1Node.start();
+
+    final String validatorKeys = createArtemisDepositSender().sendValidatorDeposits(eth1Node, 64);
+
+    final ArtemisNode firstArtemis =
+        createArtemisNode(
+            config -> config.withDepositsFrom(eth1Node).withValidatorKeys(validatorKeys));
+    firstArtemis.start();
+    firstArtemis.waitForGenesis();
+
+    final ArtemisNode lateJoinArtemis =
+        createArtemisNode(config -> config.withDepositsFrom(eth1Node));
+    lateJoinArtemis.start();
+    lateJoinArtemis.waitForGenesis();
+
+    // Even though the nodes aren't connected to each other they should generate the same genesis
+    // state because they processed the same deposits from the same ETH1 chain.
+    lateJoinArtemis.waitUntilInSyncWith(firstArtemis);
+  }
+}

--- a/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisDepositSender.java
+++ b/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisDepositSender.java
@@ -27,7 +27,7 @@ public class ArtemisDepositSender extends Node {
     super(network, ArtemisNode.ARTEMIS_DOCKER_IMAGE, LOG);
   }
 
-  public void sendValidatorDeposits(final BesuNode eth1Node, final int numberOfValidators) {
+  public String sendValidatorDeposits(final BesuNode eth1Node, final int numberOfValidators) {
     container.setCommand(
         "validator",
         "generate",
@@ -39,8 +39,11 @@ public class ArtemisDepositSender extends Node {
         eth1Node.getRichBenefactorKey(),
         "--node-url",
         eth1Node.getInternalJsonRpcUrl());
+    final StringBuilder validatorKeys = new StringBuilder();
+    container.withLogConsumer(outputFrame -> validatorKeys.append(outputFrame.getUtf8String()));
     container.start();
     Waiter.waitFor(() -> assertThat(container.isRunning()).isFalse());
     container.stop();
+    return validatorKeys.toString();
   }
 }

--- a/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
+++ b/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
@@ -13,10 +13,16 @@
 
 package tech.pegasys.artemis.test.acceptance.dsl;
 
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
 import static org.apache.tuweni.toml.Toml.tomlEscape;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.primitives.UnsignedLong;
+import io.libp2p.core.PeerId;
+import io.libp2p.core.crypto.KEY_TYPE;
+import io.libp2p.core.crypto.KeyKt;
+import io.libp2p.core.crypto.PrivKey;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -27,9 +33,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
@@ -44,12 +53,13 @@ public class ArtemisNode extends Node {
   public static final String ARTEMIS_DOCKER_IMAGE = "pegasyseng/artemis:develop";
   private static final int REST_API_PORT = 9051;
   private static final String CONFIG_FILE_PATH = "/config.toml";
+  private static final int P2P_PORT = 9000;
 
   private final SimpleHttpClient httpClient;
   private final Config config = new Config();
 
   private boolean started = false;
-  private File configFile;
+  private Set<File> configFiles;
 
   ArtemisNode(
       final SimpleHttpClient httpClient,
@@ -67,13 +77,13 @@ public class ArtemisNode extends Node {
   public void start() throws Exception {
     assertThat(started).isFalse();
     started = true;
-    configFile = File.createTempFile("config", ".toml");
-    configFile.deleteOnExit();
-    config.writeTo(configFile);
-    container
-        .withCopyFileToContainer(
-            MountableFile.forHostPath(configFile.getAbsolutePath()), CONFIG_FILE_PATH)
-        .start();
+    final Map<File, String> configFiles = config.write();
+    this.configFiles = configFiles.keySet();
+    configFiles.forEach(
+        (localFile, targetPath) ->
+            container.withCopyFileToContainer(
+                MountableFile.forHostPath(localFile.getAbsolutePath()), targetPath));
+    container.start();
   }
 
   public void waitForGenesis() {
@@ -108,6 +118,10 @@ public class ArtemisNode extends Node {
         540);
   }
 
+  public void waitUntilInSyncWith(final ArtemisNode targetNode) {
+    waitFor(() -> assertThat(getCurrentBeaconHead()).isEqualTo(targetNode.getCurrentBeaconHead()));
+  }
+
   private BeaconHead getCurrentBeaconHead() throws IOException {
     final BeaconHead beaconHead =
         JsonProvider.jsonToObject(
@@ -137,6 +151,10 @@ public class ArtemisNode extends Node {
         MountableFile.forHostPath(databaseFile.getAbsolutePath()), "/artemis.db");
   }
 
+  String getMultiAddr() {
+    return "/dns4/" + nodeAlias + "/tcp/" + P2P_PORT + "/p2p/" + config.getPeerId();
+  }
+
   private URI getRestApiUrl() {
     return URI.create("http://127.0.0.1:" + container.getMappedPort(REST_API_PORT));
   }
@@ -147,27 +165,37 @@ public class ArtemisNode extends Node {
       return;
     }
     LOG.debug("Shutting down");
-    if (!configFile.delete() && configFile.exists()) {
-      throw new RuntimeException("Failed to delete config file: " + configFile);
-    }
+    configFiles.forEach(
+        configFile -> {
+          if (!configFile.delete() && configFile.exists()) {
+            throw new RuntimeException("Failed to delete config file: " + configFile);
+          }
+        });
     container.stop();
   }
 
   public static class Config {
+
+    private final PrivKey privateKey = KeyKt.generateKeyPair(KEY_TYPE.SECP256K1).component1();
+    private final PeerId peerId = PeerId.fromPubKey(privateKey.publicKey());
 
     private static final String DATABASE_SECTION = "database";
     private static final String BEACONRESTAPI_SECTION = "beaconrestapi";
     private static final String DEPOSIT_SECTION = "deposit";
     private static final String INTEROP_SECTION = "interop";
     private static final String NODE_SECTION = "node";
+    private static final String VALIDATOR_SECTION = "validator";
+    private static final String VALIDATORS_FILE_PATH = "/validators.yml";
     private Map<String, Map<String, Object>> options = new HashMap<>();
     private static final int DEFAULT_VALIDATOR_COUNT = 64;
 
+    private Optional<String> validatorKeys = Optional.empty();
+
     public Config() {
       final Map<String, Object> node = getSection(NODE_SECTION);
-      node.put("networkMode", "mock");
-      node.put("networkInterface", "127.0.0.1");
-      node.put("port", 9000);
+      setNetworkMode("mock");
+      node.put("networkInterface", "0.0.0.0");
+      node.put("port", P2P_PORT);
       node.put("discovery", "static");
       node.put("constants", "minimal");
 
@@ -184,26 +212,70 @@ public class ArtemisNode extends Node {
       beaconRestApi.put("portNumber", REST_API_PORT);
     }
 
-    public void withDepositsFrom(final BesuNode eth1Node) {
+    public Config withDepositsFrom(final BesuNode eth1Node) {
       setDepositMode("normal");
       final Map<String, Object> depositSection = getSection(DEPOSIT_SECTION);
       depositSection.put("contractAddr", eth1Node.getDepositContractAddress());
       depositSection.put("nodeUrl", eth1Node.getInternalJsonRpcUrl());
+      return this;
     }
 
-    public void startFromDisk() {
+    public Config startFromDisk() {
       getSection(DATABASE_SECTION).put("startFromDisk", true);
+      return this;
+    }
+
+    public Config withValidatorKeys(final String validatorKeys) {
+      this.validatorKeys = Optional.of(validatorKeys);
+      return this;
+    }
+
+    public Config withRealNetwork() {
+      setNetworkMode("jvmlibp2p");
+      getSection(INTEROP_SECTION).put("privateKey", Bytes.wrap(privateKey.bytes()).toHexString());
+      return this;
+    }
+
+    public Config withPeers(final ArtemisNode... nodes) {
+      getSection(NODE_SECTION)
+          .put("peers", asList(nodes).stream().map(ArtemisNode::getMultiAddr).collect(toList()));
+      return this;
     }
 
     private void setDepositMode(final String mode) {
       getSection(DEPOSIT_SECTION).put("mode", mode);
     }
 
+    private void setNetworkMode(final String mode) {
+      getSection(NODE_SECTION).put("networkMode", mode);
+    }
+
     private Map<String, Object> getSection(final String interop) {
       return options.computeIfAbsent(interop, key -> new HashMap<>());
     }
 
-    public void writeTo(final File configFile) throws Exception {
+    public String getPeerId() {
+      return peerId.toBase58();
+    }
+
+    public Map<File, String> write() throws Exception {
+      final Map<File, String> configFiles = new HashMap<>();
+      if (validatorKeys.isPresent()) {
+        final File validatorsFile = Files.createTempFile("validators", ".yml").toFile();
+        validatorsFile.deleteOnExit();
+        Files.writeString(validatorsFile.toPath(), validatorKeys.get());
+        configFiles.put(validatorsFile, VALIDATORS_FILE_PATH);
+        getSection(VALIDATOR_SECTION).put("validatorsKeyFile", VALIDATORS_FILE_PATH);
+      }
+
+      final File configFile = File.createTempFile("config", ".toml");
+      configFile.deleteOnExit();
+      writeTo(configFile);
+      configFiles.put(configFile, CONFIG_FILE_PATH);
+      return configFiles;
+    }
+
+    private void writeTo(final File configFile) throws Exception {
       try (PrintWriter out =
           new PrintWriter(Files.newBufferedWriter(configFile.toPath(), StandardCharsets.UTF_8))) {
         for (Entry<String, Map<String, Object>> entry : options.entrySet()) {


### PR DESCRIPTION
## PR Description
AT to check that the generated genesis states match when created from the same ETH1 chain. Disabled as currently they don't appear to.

Also adds initial DSL support for connecting two nodes in ATs.