### PR TITLE
[BC-203] Drop pending blocks from finalized slots

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/Checkpoint.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/Checkpoint.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.artemis.datastructures.state;
 
+import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.primitives.UnsignedLong;
 import java.util.Arrays;
@@ -109,6 +111,10 @@ public class Checkpoint implements Merkleizable, SimpleOffsetSerializable, SSZCo
 
   public Bytes32 getRoot() {
     return root;
+  }
+
+  public UnsignedLong getEpochSlot() {
+    return compute_start_slot_at_epoch(getEpoch());
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/ForkChoiceUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/ForkChoiceUtil.java
@@ -120,8 +120,7 @@ public class ForkChoiceUtil {
   public static Bytes32 get_head(Store store) {
     // Execute the LMD-GHOST fork choice
     Bytes32 head = store.getJustifiedCheckpoint().getRoot();
-    UnsignedLong justified_slot =
-        compute_start_slot_at_epoch(store.getJustifiedCheckpoint().getEpoch());
+    UnsignedLong justified_slot = store.getJustifiedCheckpoint().getEpochSlot();
 
     while (true) {
       final Bytes32 head_in_filter = head;
@@ -170,9 +169,7 @@ public class ForkChoiceUtil {
     }
 
     BeaconBlock new_justified_block = store.getBlock(new_justified_checkpoint.getRoot());
-    if (new_justified_block
-            .getSlot()
-            .compareTo(compute_start_slot_at_epoch(store.getJustifiedCheckpoint().getEpoch()))
+    if (new_justified_block.getSlot().compareTo(store.getJustifiedCheckpoint().getEpochSlot())
         <= 0) {
       return false;
     }
@@ -311,8 +308,7 @@ public class ForkChoiceUtil {
     final Checkpoint finalizedCheckpoint = store.getFinalizedCheckpoint();
 
     // Make sure this block's slot is after the latest finalized slot
-    final UnsignedLong finalizedEpochStartSlot =
-        compute_start_slot_at_epoch(finalizedCheckpoint.getEpoch());
+    final UnsignedLong finalizedEpochStartSlot = finalizedCheckpoint.getEpochSlot();
     if (block.getSlot().compareTo(finalizedEpochStartSlot) <= 0) {
       return false;
     }
@@ -377,9 +373,7 @@ public class ForkChoiceUtil {
         unixTimeStamp.compareTo(
                 base_state
                     .getGenesis_time()
-                    .plus(
-                        compute_start_slot_at_epoch(target.getEpoch())
-                            .times(UnsignedLong.valueOf(SECONDS_PER_SLOT))))
+                    .plus(target.getEpochSlot().times(UnsignedLong.valueOf(SECONDS_PER_SLOT))))
             >= 0,
         "on_attestation: Attestations cannot be from the future epochs");
 
@@ -397,8 +391,7 @@ public class ForkChoiceUtil {
 
     // Store target checkpoint state if not yet seen
     if (!store.containsCheckpointState(target)) {
-      stateTransition.process_slots(
-          base_state, compute_start_slot_at_epoch(target.getEpoch()), false);
+      stateTransition.process_slots(base_state, target.getEpochSlot(), false);
       store.putCheckpointState(target, base_state);
     }
     BeaconState target_state = store.getCheckpointState(target);

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/PeerChainValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/PeerChainValidator.java
@@ -145,8 +145,7 @@ public class PeerChainValidator {
 
   private SafeFuture<Boolean> verifyPeerAgreesWithOurFinalizedCheckpoint(
       Checkpoint finalizedCheckpoint) {
-    final UnsignedLong finalizedEpochSlot =
-        compute_start_slot_at_epoch(finalizedCheckpoint.getEpoch());
+    final UnsignedLong finalizedEpochSlot = finalizedCheckpoint.getEpochSlot();
 
     return historicalChainData
         .getFinalizedBlockAtSlot(finalizedEpochSlot)

--- a/storage/src/main/java/tech/pegasys/artemis/storage/events/FinalizedCheckpointEvent.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/events/FinalizedCheckpointEvent.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.storage.events;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.Objects;
+import tech.pegasys.artemis.datastructures.state.Checkpoint;
+
+public class FinalizedCheckpointEvent {
+  private final Checkpoint finalizedCheckpoint;
+
+  public FinalizedCheckpointEvent(final Checkpoint finalizedCheckpoint) {
+    this.finalizedCheckpoint = finalizedCheckpoint;
+  }
+
+  public Checkpoint getCheckpoint() {
+    return finalizedCheckpoint;
+  }
+
+  public UnsignedLong getFinalizedSlot() {
+    return finalizedCheckpoint.getEpochSlot();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof FinalizedCheckpointEvent)) {
+      return false;
+    }
+    final FinalizedCheckpointEvent that = (FinalizedCheckpointEvent) o;
+    return Objects.equals(finalizedCheckpoint, that.finalizedCheckpoint);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(finalizedCheckpoint);
+  }
+}

--- a/storage/src/test/java/tech/pegasys/artemis/storage/ChainStorageClientTest.java
+++ b/storage/src/test/java/tech/pegasys/artemis/storage/ChainStorageClientTest.java
@@ -259,7 +259,6 @@ class ChainStorageClientTest {
     tx.commit().reportExceptions();
     verify(eventBus, never()).post(argThat(this::isFinalizedCheckpointEvent));
 
-    // Check that store was updated
     final Checkpoint currentCheckpoint = storageClient.getStore().getFinalizedCheckpoint();
     assertThat(currentCheckpoint).isEqualTo(originalCheckpoint);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Add a `FinalizedCheckpointEvent` to signal that a new block has been finalized.  Use this event to update constraints on `PendingBlocks`, so we can drop blocks that are from a finalized slot.