### PR TITLE
Don't report errors handled via finish as unhandled

### DIFF
--- a/util/src/main/java/tech/pegasys/artemis/util/async/SafeFuture.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/async/SafeFuture.java
@@ -97,13 +97,14 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   }
 
   public void finish(final Consumer<T> onSuccess, final Consumer<Throwable> onError) {
-    whenComplete(
+    handle(
             (result, error) -> {
               if (error != null) {
                 onError.accept(error);
               } else {
                 onSuccess.accept(result);
               }
+              return null;
             })
         .reportExceptions();
   }

--- a/util/src/test/java/tech/pegasys/artemis/util/async/SafeFutureTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/async/SafeFutureTest.java
@@ -240,6 +240,17 @@ class SafeFutureTest {
   }
 
   @Test
+  public void finish_shouldReportExceptionsWhenNoErrorHandlerProvided() {
+    final CountingNoOpAppender logCounter = startCountingReportedUnhandledExceptions();
+
+    final SafeFuture<Object> safeFuture = new SafeFuture<>();
+    safeFuture.finish(() -> {});
+    safeFuture.completeExceptionally(new RuntimeException("Not handled"));
+
+    assertThat(logCounter.getCount()).isEqualTo(1);
+  }
+
+  @Test
   public void reportExceptions_shouldLogUnhandledExceptions() {
     final CountingNoOpAppender logCounter = startCountingReportedUnhandledExceptions();
 


### PR DESCRIPTION
## PR Description
`SafeFuture` was using the `whenComplete` method to implement `finish` but `whenComplete` does not consider the exception handled - only `handle` actually does that. As a result, it was incorrectly reporting the exception as unhandled, even though the `onError` condition had been called and already successfully handled the exception.