### PR TITLE
Default to not signing deposits in tests

### DIFF
--- a/ethereum/datastructures/build.gradle
+++ b/ethereum/datastructures/build.gradle
@@ -12,6 +12,8 @@ dependencies {
   runtime 'org.apache.logging.log4j:log4j-core'
   testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+
+  testSupportImplementation 'org.junit.jupiter:junit-jupiter-api'
   
   test {
     testLogging.showStandardStreams = true

--- a/ethereum/datastructures/src/test-support/java/tech/pegasys/artemis/datastructures/util/DisableDepositValidation.java
+++ b/ethereum/datastructures/src/test-support/java/tech/pegasys/artemis/datastructures/util/DisableDepositValidation.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.util;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class DisableDepositValidation implements BeforeAllCallback, AfterAllCallback {
+
+  @Override
+  public void beforeAll(final ExtensionContext context) throws Exception {
+    BeaconStateUtil.BLS_VERIFY_DEPOSIT = false;
+    BeaconStateUtil.DEPOSIT_PROOFS_ENABLED = false;
+  }
+
+  @Override
+  public void afterAll(final ExtensionContext context) throws Exception {
+    BeaconStateUtil.BLS_VERIFY_DEPOSIT = true;
+    BeaconStateUtil.DEPOSIT_PROOFS_ENABLED = true;
+  }
+}

--- a/ethereum/statetransition/build.gradle
+++ b/ethereum/statetransition/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   testImplementation 'org.mockito:mockito-core'
 
   testImplementation project(path: ':util', configuration: 'testSupportArtifacts')
+  testImplementation project(path: ':ethereum:datastructures', configuration: 'testSupportArtifacts')
   testSupportImplementation project(path: ':util', configuration: 'testSupportArtifacts')
 
   test {

--- a/ethereum/statetransition/src/test-support/java/tech/pegasys/artemis/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/test-support/java/tech/pegasys/artemis/statetransition/BeaconChainUtil.java
@@ -62,8 +62,16 @@ public class BeaconChainUtil {
   }
 
   public static BeaconChainUtil create(
+      final int validatorCount,
+      final ChainStorageClient storageClient,
+      final boolean signDeposits) {
+    final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(validatorCount);
+    return create(storageClient, validatorKeys, signDeposits);
+  }
+
+  public static BeaconChainUtil create(
       final ChainStorageClient storageClient, final List<BLSKeyPair> validatorKeys) {
-    return create(storageClient, validatorKeys, true);
+    return create(storageClient, validatorKeys, false);
   }
 
   public static BeaconChainUtil create(
@@ -75,7 +83,7 @@ public class BeaconChainUtil {
 
   public static void initializeStorage(
       final ChainStorageClient chainStorageClient, final List<BLSKeyPair> validatorKeys) {
-    initializeStorage(chainStorageClient, validatorKeys, true);
+    initializeStorage(chainStorageClient, validatorKeys, false);
   }
 
   public static void initializeStorage(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/AttestationAggregatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/AttestationAggregatorTest.java
@@ -25,7 +25,9 @@ import java.util.List;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tech.pegasys.artemis.datastructures.operations.Attestation;
+import tech.pegasys.artemis.datastructures.util.DisableDepositValidation;
 import tech.pegasys.artemis.datastructures.validator.AggregatorInformation;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.util.bls.BLSAggregate;
@@ -33,6 +35,7 @@ import tech.pegasys.artemis.util.bls.BLSKeyGenerator;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
+@ExtendWith(DisableDepositValidation.class)
 class AttestationAggregatorTest {
 
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(12);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/blockimport/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/blockimport/BlockImporterTest.java
@@ -24,8 +24,10 @@ import java.util.List;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.state.Checkpoint;
+import tech.pegasys.artemis.datastructures.util.DisableDepositValidation;
 import tech.pegasys.artemis.statetransition.BeaconChainUtil;
 import tech.pegasys.artemis.statetransition.blockimport.BlockImportResult.FailureReason;
 import tech.pegasys.artemis.storage.ChainStorageClient;
@@ -34,6 +36,7 @@ import tech.pegasys.artemis.util.bls.BLSKeyGenerator;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
 import tech.pegasys.artemis.util.config.Constants;
 
+@ExtendWith(DisableDepositValidation.class)
 public class BlockImporterTest {
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(2);
   private final EventBus localEventBus = mock(EventBus.class);

--- a/networking/eth2/build.gradle
+++ b/networking/eth2/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   testImplementation 'org.mockito:mockito-core'
   testImplementation project(path: ':ethereum:statetransition', configuration: 'testSupportArtifacts')
   testImplementation project(path: ':util', configuration: 'testSupportArtifacts')
+  testImplementation project(path: ':ethereum:datastructures', configuration: 'testSupportArtifacts')
   testImplementation 'org.hyperledger.besu.internal:metrics-core'
 
   integrationTestImplementation project(path: ':ethereum:statetransition', configuration: 'testSupportArtifacts')

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/AttestationTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/AttestationTopicHandlerTest.java
@@ -25,7 +25,9 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tech.pegasys.artemis.datastructures.operations.Attestation;
+import tech.pegasys.artemis.datastructures.util.DisableDepositValidation;
 import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
 import tech.pegasys.artemis.statetransition.AttestationGenerator;
 import tech.pegasys.artemis.statetransition.BeaconChainUtil;
@@ -34,6 +36,7 @@ import tech.pegasys.artemis.storage.Store;
 import tech.pegasys.artemis.util.bls.BLSKeyGenerator;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
 
+@ExtendWith(DisableDepositValidation.class)
 public class AttestationTopicHandlerTest {
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(12);
   private final EventBus eventBus = mock(EventBus.class);

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/BlockTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/BlockTopicHandlerTest.java
@@ -23,13 +23,16 @@ import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
+import tech.pegasys.artemis.datastructures.util.DisableDepositValidation;
 import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
 import tech.pegasys.artemis.networking.eth2.gossip.events.GossipedBlockEvent;
 import tech.pegasys.artemis.statetransition.BeaconChainUtil;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 
+@ExtendWith(DisableDepositValidation.class)
 public class BlockTopicHandlerTest {
   private final EventBus eventBus = mock(EventBus.class);
   private final ChainStorageClient storageClient = ChainStorageClient.memoryOnlyClient(eventBus);

--- a/sync/build.gradle
+++ b/sync/build.gradle
@@ -11,5 +11,6 @@ dependencies {
 
     testImplementation 'org.mockito:mockito-core'
     testImplementation project(path: ':networking:eth2', configuration: 'testSupportArtifacts')
+    testImplementation project(path: ':ethereum:datastructures', configuration: 'testSupportArtifacts')
     testImplementation project(path: ':ethereum:statetransition', configuration: 'testSupportArtifacts')
 }

--- a/sync/src/test/java/tech/pegasys/artemis/sync/BlockPropagationManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/artemis/sync/BlockPropagationManagerTest.java
@@ -22,7 +22,9 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
+import tech.pegasys.artemis.datastructures.util.DisableDepositValidation;
 import tech.pegasys.artemis.networking.eth2.gossip.events.GossipedBlockEvent;
 import tech.pegasys.artemis.statetransition.BeaconChainUtil;
 import tech.pegasys.artemis.statetransition.ImportedBlocks;
@@ -33,6 +35,7 @@ import tech.pegasys.artemis.util.bls.BLSKeyGenerator;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
 import tech.pegasys.artemis.util.config.Constants;
 
+@ExtendWith(DisableDepositValidation.class)
 public class BlockPropagationManagerTest {
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(2);
   private final EventBus localEventBus = new EventBus();

--- a/validator/coordinator/build.gradle
+++ b/validator/coordinator/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 
   testImplementation 'org.mockito:mockito-core'
   testImplementation project(path: ':util', configuration: 'testSupportArtifacts')
+  testImplementation project(path: ':ethereum:datastructures', configuration: 'testSupportArtifacts')
   testImplementation project(path: ':ethereum:statetransition', configuration: 'testSupportArtifacts')
 }
 

--- a/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinatorTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinatorTest.java
@@ -29,6 +29,8 @@ import com.google.common.primitives.UnsignedLong;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tech.pegasys.artemis.datastructures.util.DisableDepositValidation;
 import tech.pegasys.artemis.datastructures.util.MockStartValidatorKeyPairFactory;
 import tech.pegasys.artemis.statetransition.AttestationAggregator;
 import tech.pegasys.artemis.statetransition.BeaconChainUtil;
@@ -40,6 +42,7 @@ import tech.pegasys.artemis.storage.events.SlotEvent;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
 
+@ExtendWith(DisableDepositValidation.class)
 public class ValidatorCoordinatorTest {
 
   private BlockAttestationsPool blockAttestationsPool;


### PR DESCRIPTION
## PR Description
Since signing and verifying deposits is slow, disable signing of deposits by default.  Most tests never even run through the code that would verify them.  Disable verification in a few tests that do use the real deposit processing code to setup the state they need (but aren't actually testing deposit validation).

Validation is disabled with `@ExtendsWith(DisableDepositValidation.class)` so it always gets re-enabled again at the end of the test.