### PR TITLE
[BC-220] Don't drop unattached blocks

### DIFF
--- a/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/GossipMessageHandlerIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/GossipMessageHandlerIntegrationTest.java
@@ -24,11 +24,12 @@ import com.google.common.primitives.UnsignedLong;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.artemis.datastructures.operations.Attestation;
-import tech.pegasys.artemis.datastructures.util.MockStartValidatorKeyPairFactory;
+import tech.pegasys.artemis.networking.eth2.Eth2NetworkFactory.Eth2P2PNetworkBuilder;
 import tech.pegasys.artemis.statetransition.AttestationGenerator;
 import tech.pegasys.artemis.statetransition.BeaconChainUtil;
 import tech.pegasys.artemis.statetransition.events.BlockProposedEvent;
@@ -36,10 +37,12 @@ import tech.pegasys.artemis.statetransition.events.CommitteeAssignmentEvent;
 import tech.pegasys.artemis.statetransition.events.CommitteeDismissalEvent;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.util.Waiter;
+import tech.pegasys.artemis.util.bls.BLSKeyGenerator;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
 
 public class GossipMessageHandlerIntegrationTest {
 
+  private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(3);
   private final Eth2NetworkFactory networkFactory = new Eth2NetworkFactory();
 
   @AfterEach
@@ -49,60 +52,40 @@ public class GossipMessageHandlerIntegrationTest {
 
   @Test
   public void shouldGossipBlocksAcrossToIndirectlyConnectedPeers() throws Exception {
+    final UnsignedLong blockSlot = UnsignedLong.valueOf(2L);
+
     // Setup network 1
-    final EventBus eventBus1 = new EventBus();
-    final ChainStorageClient storageClient1 = ChainStorageClient.memoryOnlyClient(eventBus1);
-    final Eth2Network network1 =
-        networkFactory
-            .builder()
-            .eventBus(eventBus1)
-            .chainStorageClient(storageClient1)
-            .startNetwork();
-    final BeaconChainUtil chainUtil = BeaconChainUtil.create(12, storageClient1);
-    chainUtil.initializeStorage();
+    NodeManager node1 = NodeManager.build(networkFactory, validatorKeys);
+    node1.chainUtil().setSlot(blockSlot);
 
     // Setup network 2
-    final EventBus eventBus2 = new EventBus();
-    final ChainStorageClient storageClient2 = ChainStorageClient.memoryOnlyClient(eventBus2);
-    final Eth2Network network2 =
-        networkFactory
-            .builder()
-            .eventBus(eventBus2)
-            .chainStorageClient(storageClient2)
-            .startNetwork();
-    chainUtil.initializeStorage(storageClient2);
+    NodeManager node2 = NodeManager.build(networkFactory, validatorKeys);
+    node2.chainUtil().setSlot(blockSlot);
 
     // Setup network 3
-    final EventBus eventBus3 = new EventBus();
-    final ChainStorageClient storageClient3 = ChainStorageClient.memoryOnlyClient(eventBus3);
-    final Eth2Network network3 =
-        networkFactory
-            .builder()
-            .eventBus(eventBus3)
-            .chainStorageClient(storageClient3)
-            .startNetwork();
-    chainUtil.initializeStorage(storageClient3);
+    NodeManager node3 = NodeManager.build(networkFactory, validatorKeys);
+    node2.chainUtil().setSlot(blockSlot);
 
     // Connect networks 1 -> 2 -> 3
-    waitFor(network1.connect(network2.getNodeAddress()));
-    waitFor(network2.connect(network3.getNodeAddress()));
+    waitFor(node1.network().connect(node2.network().getNodeAddress()));
+    waitFor(node2.network().connect(node3.network().getNodeAddress()));
     // Wait for connections to get set up
     Waiter.waitFor(
         () -> {
-          assertThat(network1.getPeerCount()).isEqualTo(1);
-          assertThat(network2.getPeerCount()).isEqualTo(2);
-          assertThat(network3.getPeerCount()).isEqualTo(1);
+          assertThat(node1.network().getPeerCount()).isEqualTo(1);
+          assertThat(node2.network().getPeerCount()).isEqualTo(2);
+          assertThat(node3.network().getPeerCount()).isEqualTo(1);
         });
     // TODO: debug this - we shouldn't have to wait here
     Thread.sleep(2000);
 
     // Propagate block from network 1
-    final SignedBeaconBlock newBlock = chainUtil.createBlockAtSlot(UnsignedLong.valueOf(2L));
-    eventBus1.post(new BlockProposedEvent(newBlock));
+    final SignedBeaconBlock newBlock = node1.chainUtil().createBlockAtSlot(blockSlot);
+    node1.eventBus().post(new BlockProposedEvent(newBlock));
 
     // Listen for new block event to arrive on networks 2 and 3
-    final GossipedBlockCollector network2Blocks = new GossipedBlockCollector(eventBus2);
-    final GossipedBlockCollector network3Blocks = new GossipedBlockCollector(eventBus3);
+    final GossipedBlockCollector network2Blocks = new GossipedBlockCollector(node2.eventBus());
+    final GossipedBlockCollector network3Blocks = new GossipedBlockCollector(node2.eventBus());
 
     // Verify the expected block was gossiped across the network
     Waiter.waitFor(
@@ -114,61 +97,41 @@ public class GossipMessageHandlerIntegrationTest {
 
   @Test
   public void shouldNotGossipInvalidBlocks() throws Exception {
+    final UnsignedLong blockSlot = UnsignedLong.valueOf(2L);
+
     // Setup network 1
-    final EventBus eventBus1 = new EventBus();
-    final ChainStorageClient storageClient1 = ChainStorageClient.memoryOnlyClient(eventBus1);
-    final Eth2Network network1 =
-        networkFactory
-            .builder()
-            .eventBus(eventBus1)
-            .chainStorageClient(storageClient1)
-            .startNetwork();
-    final BeaconChainUtil chainUtil = BeaconChainUtil.create(12, storageClient1);
-    chainUtil.initializeStorage();
+    NodeManager node1 = NodeManager.build(networkFactory, validatorKeys);
+    node1.chainUtil().setSlot(blockSlot);
 
     // Setup network 2
-    final EventBus eventBus2 = new EventBus();
-    final ChainStorageClient storageClient2 = ChainStorageClient.memoryOnlyClient(eventBus2);
-    final Eth2Network network2 =
-        networkFactory
-            .builder()
-            .eventBus(eventBus2)
-            .chainStorageClient(storageClient2)
-            .startNetwork();
-    chainUtil.initializeStorage(storageClient2);
+    NodeManager node2 = NodeManager.build(networkFactory, validatorKeys);
+    node2.chainUtil().setSlot(blockSlot);
 
     // Setup network 3
-    final EventBus eventBus3 = new EventBus();
-    final ChainStorageClient storageClient3 = ChainStorageClient.memoryOnlyClient(eventBus3);
-    final Eth2Network network3 =
-        networkFactory
-            .builder()
-            .eventBus(eventBus3)
-            .chainStorageClient(storageClient3)
-            .startNetwork();
-    chainUtil.initializeStorage(storageClient3);
+    NodeManager node3 = NodeManager.build(networkFactory, validatorKeys);
+    node2.chainUtil().setSlot(blockSlot);
 
     // Connect networks 1 -> 2 -> 3
-    waitFor(network1.connect(network2.getNodeAddress()));
-    waitFor(network2.connect(network3.getNodeAddress()));
+    waitFor(node1.network().connect(node2.network().getNodeAddress()));
+    waitFor(node2.network().connect(node3.network().getNodeAddress()));
     // Wait for connections to get set up
     Waiter.waitFor(
         () -> {
-          assertThat(network1.getPeerCount()).isEqualTo(1);
-          assertThat(network2.getPeerCount()).isEqualTo(2);
-          assertThat(network3.getPeerCount()).isEqualTo(1);
+          assertThat(node1.network().getPeerCount()).isEqualTo(1);
+          assertThat(node2.network().getPeerCount()).isEqualTo(2);
+          assertThat(node3.network().getPeerCount()).isEqualTo(1);
         });
     // TODO: debug this - we shouldn't have to wait here
     Thread.sleep(2000);
 
-    // Propagate block from network 1
+    // Propagate invalid block from network 1
     final SignedBeaconBlock newBlock =
-        chainUtil.createBlockAtSlotFromInvalidProposer(UnsignedLong.valueOf(2L));
-    eventBus1.post(new BlockProposedEvent(newBlock));
+        node1.chainUtil().createBlockAtSlotFromInvalidProposer(blockSlot);
+    node1.eventBus().post(new BlockProposedEvent(newBlock));
 
     // Listen for new block event to arrive on networks 2 and 3
-    final GossipedBlockCollector network2Blocks = new GossipedBlockCollector(eventBus2);
-    final GossipedBlockCollector network3Blocks = new GossipedBlockCollector(eventBus3);
+    final GossipedBlockCollector network2Blocks = new GossipedBlockCollector(node2.eventBus());
+    final GossipedBlockCollector network3Blocks = new GossipedBlockCollector(node2.eventBus());
 
     // Wait for blocks to propagate
     ensureConditionRemainsMet(() -> assertThat(network2Blocks.getBlocks()).isEmpty(), 10000);
@@ -178,29 +141,12 @@ public class GossipMessageHandlerIntegrationTest {
   @Test
   public void shouldNotGossipAttestationsAcrossPeersThatAreNotOnTheSameSubnet() throws Exception {
     // Setup network 1
-    final EventBus eventBus1 = new EventBus();
-    final ChainStorageClient storageClient1 = ChainStorageClient.memoryOnlyClient(eventBus1);
-    final Eth2Network network1 =
-        networkFactory
-            .builder()
-            .eventBus(eventBus1)
-            .chainStorageClient(storageClient1)
-            .startNetwork();
-    List<BLSKeyPair> blsKeyPairList =
-        new MockStartValidatorKeyPairFactory().generateKeyPairs(0, 12);
-    final BeaconChainUtil chainUtil = BeaconChainUtil.create(storageClient1, blsKeyPairList);
-    chainUtil.initializeStorage();
+    final NodeManager node1 = NodeManager.build(networkFactory, validatorKeys);
+    final Eth2Network network1 = node1.network();
 
     // Setup network 2
-    final EventBus eventBus2 = new EventBus();
-    final ChainStorageClient storageClient2 = ChainStorageClient.memoryOnlyClient(eventBus2);
-    final Eth2Network network2 =
-        networkFactory
-            .builder()
-            .eventBus(eventBus2)
-            .chainStorageClient(storageClient2)
-            .startNetwork();
-    chainUtil.initializeStorage(storageClient2);
+    final NodeManager node2 = NodeManager.build(networkFactory, validatorKeys);
+    final Eth2Network network2 = node2.network();
 
     // Connect networks 1 -> 2
     waitFor(network1.connect(network2.getNodeAddress()));
@@ -212,12 +158,12 @@ public class GossipMessageHandlerIntegrationTest {
         });
 
     // Listen for new attestation event to arrive on network 2
-    final AttestationCollector network2Attestations = new AttestationCollector(eventBus2);
+    final AttestationCollector network2Attestations = new AttestationCollector(node2.eventBus());
 
     // Propagate attestation from network 1
-    AttestationGenerator attestationGenerator = new AttestationGenerator(blsKeyPairList);
-    Attestation validAttestation = attestationGenerator.validAttestation(storageClient1);
-    eventBus1.post(validAttestation);
+    AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
+    Attestation validAttestation = attestationGenerator.validAttestation(node1.storageClient());
+    node1.eventBus().post(validAttestation);
 
     ensureConditionRemainsMet(() -> assertThat(network2Attestations.getAttestations()).isEmpty());
   }
@@ -225,29 +171,12 @@ public class GossipMessageHandlerIntegrationTest {
   @Test
   public void shouldGossipAttestationsAcrossPeersThatAreOnTheSameSubnet() throws Exception {
     // Setup network 1
-    final EventBus eventBus1 = new EventBus();
-    final ChainStorageClient storageClient1 = ChainStorageClient.memoryOnlyClient(eventBus1);
-    final Eth2Network network1 =
-        networkFactory
-            .builder()
-            .eventBus(eventBus1)
-            .chainStorageClient(storageClient1)
-            .startNetwork();
-    List<BLSKeyPair> blsKeyPairList =
-        new MockStartValidatorKeyPairFactory().generateKeyPairs(0, 12);
-    final BeaconChainUtil chainUtil = BeaconChainUtil.create(storageClient1, blsKeyPairList);
-    chainUtil.initializeStorage();
+    final NodeManager node1 = NodeManager.build(networkFactory, validatorKeys);
+    final Eth2Network network1 = node1.network();
 
     // Setup network 2
-    final EventBus eventBus2 = new EventBus();
-    final ChainStorageClient storageClient2 = ChainStorageClient.memoryOnlyClient(eventBus2);
-    final Eth2Network network2 =
-        networkFactory
-            .builder()
-            .eventBus(eventBus2)
-            .chainStorageClient(storageClient2)
-            .startNetwork();
-    chainUtil.initializeStorage(storageClient2);
+    final NodeManager node2 = NodeManager.build(networkFactory, validatorKeys);
+    final Eth2Network network2 = node2.network();
 
     // Connect networks 1 -> 2
     waitFor(network1.connect(network2.getNodeAddress()));
@@ -259,20 +188,26 @@ public class GossipMessageHandlerIntegrationTest {
         });
 
     // Listen for new attestation event to arrive on network 2
-    final AttestationCollector network2Attestations = new AttestationCollector(eventBus2);
+    final AttestationCollector network2Attestations = new AttestationCollector(node2.eventBus());
 
     // Propagate attestation from network 1
-    AttestationGenerator attestationGenerator = new AttestationGenerator(blsKeyPairList);
-    Attestation validAttestation = attestationGenerator.validAttestation(storageClient1);
+    AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
+    Attestation validAttestation = attestationGenerator.validAttestation(node1.storageClient());
 
-    eventBus1.post(
-        new CommitteeAssignmentEvent(List.of(validAttestation.getData().getIndex().intValue())));
-    eventBus2.post(
-        new CommitteeAssignmentEvent(List.of(validAttestation.getData().getIndex().intValue())));
+    node1
+        .eventBus()
+        .post(
+            new CommitteeAssignmentEvent(
+                List.of(validAttestation.getData().getIndex().intValue())));
+    node2
+        .eventBus()
+        .post(
+            new CommitteeAssignmentEvent(
+                List.of(validAttestation.getData().getIndex().intValue())));
 
     waitForTopicRegistration();
 
-    eventBus1.post(validAttestation);
+    node1.eventBus().post(validAttestation);
 
     Waiter.waitFor(
         () -> assertThat(network2Attestations.getAttestations()).containsExactly(validAttestation));
@@ -281,29 +216,12 @@ public class GossipMessageHandlerIntegrationTest {
   @Test
   public void shouldNotGossipAttestationsWhenPeerDeregistersFromTopic() throws Exception {
     // Setup network 1
-    final EventBus eventBus1 = new EventBus();
-    final ChainStorageClient storageClient1 = ChainStorageClient.memoryOnlyClient(eventBus1);
-    final Eth2Network network1 =
-        networkFactory
-            .builder()
-            .eventBus(eventBus1)
-            .chainStorageClient(storageClient1)
-            .startNetwork();
-    List<BLSKeyPair> blsKeyPairList =
-        new MockStartValidatorKeyPairFactory().generateKeyPairs(0, 12);
-    final BeaconChainUtil chainUtil = BeaconChainUtil.create(storageClient1, blsKeyPairList);
-    chainUtil.initializeStorage();
+    final NodeManager node1 = NodeManager.build(networkFactory, validatorKeys);
+    final Eth2Network network1 = node1.network();
 
     // Setup network 2
-    final EventBus eventBus2 = new EventBus();
-    final ChainStorageClient storageClient2 = ChainStorageClient.memoryOnlyClient(eventBus2);
-    final Eth2Network network2 =
-        networkFactory
-            .builder()
-            .eventBus(eventBus2)
-            .chainStorageClient(storageClient2)
-            .startNetwork();
-    chainUtil.initializeStorage(storageClient2);
+    final NodeManager node2 = NodeManager.build(networkFactory, validatorKeys);
+    final Eth2Network network2 = node2.network();
 
     // Connect networks 1 -> 2
     waitFor(network1.connect(network2.getNodeAddress()));
@@ -315,35 +233,45 @@ public class GossipMessageHandlerIntegrationTest {
         });
 
     // Listen for new attestation event to arrive on network 2
-    final AttestationCollector network2Attestations = new AttestationCollector(eventBus2);
+    final AttestationCollector network2Attestations = new AttestationCollector(node2.eventBus());
 
     // Propagate attestation from network 1
-    AttestationGenerator attestationGenerator = new AttestationGenerator(blsKeyPairList);
-    Attestation validAttestation = attestationGenerator.validAttestation(storageClient1);
+    AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
+    Attestation validAttestation = attestationGenerator.validAttestation(node1.storageClient());
 
-    eventBus1.post(
-        new CommitteeAssignmentEvent(List.of(validAttestation.getData().getIndex().intValue())));
-    eventBus2.post(
-        new CommitteeAssignmentEvent(List.of(validAttestation.getData().getIndex().intValue())));
+    node1
+        .eventBus()
+        .post(
+            new CommitteeAssignmentEvent(
+                List.of(validAttestation.getData().getIndex().intValue())));
+    node2
+        .eventBus()
+        .post(
+            new CommitteeAssignmentEvent(
+                List.of(validAttestation.getData().getIndex().intValue())));
 
     waitForTopicRegistration();
 
-    eventBus1.post(validAttestation);
+    node1.eventBus().post(validAttestation);
 
     waitForMessageToBeDelivered();
 
     assertTrue(network2Attestations.getAttestations().contains(validAttestation));
 
-    eventBus1.post(
-        new CommitteeDismissalEvent(List.of(validAttestation.getData().getIndex().intValue())));
-    eventBus2.post(
-        new CommitteeDismissalEvent(List.of(validAttestation.getData().getIndex().intValue())));
+    node1
+        .eventBus()
+        .post(
+            new CommitteeDismissalEvent(List.of(validAttestation.getData().getIndex().intValue())));
+    node2
+        .eventBus()
+        .post(
+            new CommitteeDismissalEvent(List.of(validAttestation.getData().getIndex().intValue())));
 
     waitForTopicDeregistration();
 
     // Listen if the new attestation arrives on network 2
     final AttestationCollector network2AttestationsAfterDeregistration =
-        new AttestationCollector(eventBus2);
+        new AttestationCollector(node2.eventBus());
 
     ensureConditionRemainsMet(
         () -> assertThat(network2AttestationsAfterDeregistration.getAttestations()).isEmpty());
@@ -376,5 +304,64 @@ public class GossipMessageHandlerIntegrationTest {
 
   private void waitForMessageToBeDelivered() throws Exception {
     Thread.sleep(1000);
+  }
+
+  private static class NodeManager {
+    private final EventBus eventBus;
+    private final ChainStorageClient storageClient;
+    private final BeaconChainUtil chainUtil;
+    private final Eth2Network eth2Network;
+
+    private NodeManager(
+        final EventBus eventBus,
+        final ChainStorageClient storageClient,
+        final BeaconChainUtil chainUtil,
+        final Eth2Network eth2Network) {
+      this.eventBus = eventBus;
+      this.storageClient = storageClient;
+      this.chainUtil = chainUtil;
+      this.eth2Network = eth2Network;
+    }
+
+    public static NodeManager build(
+        Eth2NetworkFactory networkFactory, final List<BLSKeyPair> validatorKeys) throws Exception {
+      return build(networkFactory, validatorKeys, c -> {});
+    }
+
+    public static NodeManager build(
+        Eth2NetworkFactory networkFactory,
+        final List<BLSKeyPair> validatorKeys,
+        Consumer<Eth2P2PNetworkBuilder> configureNetwork)
+        throws Exception {
+      final EventBus eventBus = new EventBus();
+      final ChainStorageClient storageClient = ChainStorageClient.memoryOnlyClient(eventBus);
+      final Eth2P2PNetworkBuilder networkBuilder =
+          networkFactory.builder().eventBus(eventBus).chainStorageClient(storageClient);
+
+      configureNetwork.accept(networkBuilder);
+
+      final Eth2Network eth2Network = networkBuilder.startNetwork();
+
+      final BeaconChainUtil chainUtil = BeaconChainUtil.create(storageClient, validatorKeys);
+      chainUtil.initializeStorage();
+
+      return new NodeManager(eventBus, storageClient, chainUtil, eth2Network);
+    }
+
+    public EventBus eventBus() {
+      return eventBus;
+    }
+
+    public BeaconChainUtil chainUtil() {
+      return chainUtil;
+    }
+
+    public Eth2Network network() {
+      return eth2Network;
+    }
+
+    public ChainStorageClient storageClient() {
+      return storageClient;
+    }
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/topics/BlockTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/topics/BlockTopicHandler.java
@@ -79,15 +79,15 @@ public class BlockTopicHandler extends Eth2TopicHandler<SignedBeaconBlock> {
       return false;
     }
 
+    if (!isBlockSignatureValid(block, preState)) {
+      LOG.trace("Dropping gossiped block with invalid signature: {}", block);
+      return false;
+    }
+
     final UnsignedLong currentSlot = get_current_slot(chainStorageClient.getStore());
     if (block.getSlot().compareTo(currentSlot) > 0) {
       // Don't gossip future blocks
       eventBus.post(createEvent(block));
-      return false;
-    }
-
-    if (!isBlockSignatureValid(block, preState)) {
-      LOG.trace("Dropping gossiped block with invalid signature: {}", block);
       return false;
     }
 

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/BlockTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/BlockTopicHandlerTest.java
@@ -59,7 +59,7 @@ public class BlockTopicHandlerTest {
 
     final boolean result = topicHandler.handleMessage(serialized);
     assertThat(result).isEqualTo(false);
-    verify(eventBus, never()).post(new GossipedBlockEvent(block));
+    verify(eventBus).post(new GossipedBlockEvent(block));
   }
 
   @Test

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/BlockTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/BlockTopicHandlerTest.java
@@ -46,9 +46,22 @@ public class BlockTopicHandlerTest {
     final UnsignedLong nextSlot = storageClient.getBestSlot().plus(UnsignedLong.ONE);
     final SignedBeaconBlock block = beaconChainUtil.createBlockAtSlot(nextSlot);
     Bytes serialized = SimpleOffsetSerializer.serialize(block);
+    beaconChainUtil.setSlot(nextSlot);
 
     final boolean result = topicHandler.handleMessage(serialized);
     assertThat(result).isEqualTo(true);
+    verify(eventBus).post(new GossipedBlockEvent(block));
+  }
+
+  @Test
+  public void handleMessage_validFutureBlock() throws Exception {
+    final UnsignedLong nextSlot = storageClient.getBestSlot().plus(UnsignedLong.ONE);
+    final SignedBeaconBlock block = beaconChainUtil.createBlockAtSlot(nextSlot);
+    Bytes serialized = SimpleOffsetSerializer.serialize(block);
+    beaconChainUtil.setSlot(storageClient.getBestSlot());
+
+    final boolean result = topicHandler.handleMessage(serialized);
+    assertThat(result).isEqualTo(false);
     verify(eventBus).post(new GossipedBlockEvent(block));
   }
 
@@ -75,6 +88,7 @@ public class BlockTopicHandlerTest {
     final UnsignedLong nextSlot = storageClient.getBestSlot().plus(UnsignedLong.ONE);
     final SignedBeaconBlock block = beaconChainUtil.createBlockAtSlotFromInvalidProposer(nextSlot);
     Bytes serialized = SimpleOffsetSerializer.serialize(block);
+    beaconChainUtil.setSlot(nextSlot);
 
     final boolean result = topicHandler.handleMessage(serialized);
     assertThat(result).isEqualTo(false);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
When a block is gossiped and we don't have the pre-state associated with this block, don't re-gossip the block but do post an event so that `BlockPropagationManager` can track the block.  Also add some extra validation to prevent us from re-gossiping future blocks (see: https://github.com/ethereum/eth2.0-specs/blob/v0.10.0/specs/phase0/p2p-interface.md#global-topics).