### PR TITLE
Only post processed annotation and aggregate events after successful processing

### DIFF
--- a/sync/src/main/java/tech/pegasys/artemis/sync/DelayableAttestation.java
+++ b/sync/src/main/java/tech/pegasys/artemis/sync/DelayableAttestation.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.sync;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.Collection;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.artemis.datastructures.operations.Attestation;
+
+public class DelayableAttestation {
+  private final Attestation attestation;
+  private final Runnable onSuccessfulProcessing;
+
+  public DelayableAttestation(
+      final Attestation attestation, final Runnable onSuccessfulProcessing) {
+    this.attestation = attestation;
+    this.onSuccessfulProcessing = onSuccessfulProcessing;
+  }
+
+  Attestation getAttestation() {
+    return attestation;
+  }
+
+  void onAttestationProcessedSuccessfully() {
+    onSuccessfulProcessing.run();
+  }
+
+  public UnsignedLong getEarliestSlotForProcessing() {
+    return attestation.getEarliestSlotForProcessing();
+  }
+
+  public Collection<Bytes32> getDependentBlockRoots() {
+    return attestation.getDependentBlockRoots();
+  }
+
+  public Bytes32 hash_tree_root() {
+    return attestation.hash_tree_root();
+  }
+}

--- a/sync/src/main/java/tech/pegasys/artemis/sync/PendingPool.java
+++ b/sync/src/main/java/tech/pegasys/artemis/sync/PendingPool.java
@@ -31,7 +31,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.artemis.datastructures.operations.Attestation;
 import tech.pegasys.artemis.service.serviceutils.Service;
 import tech.pegasys.artemis.storage.events.FinalizedCheckpointEvent;
 import tech.pegasys.artemis.storage.events.SlotEvent;
@@ -94,14 +93,14 @@ class PendingPool<T> extends Service {
         SignedBeaconBlock::getSlot);
   }
 
-  public static PendingPool<Attestation> createForAttestations(final EventBus eventBus) {
+  public static PendingPool<DelayableAttestation> createForAttestations(final EventBus eventBus) {
     return new PendingPool<>(
         eventBus,
         DEFAULT_HISTORICAL_SLOT_TOLERANCE,
         DEFAULT_FUTURE_SLOT_TOLERANCE,
-        Attestation::hash_tree_root,
-        Attestation::getDependentBlockRoots,
-        Attestation::getEarliestSlotForProcessing);
+        DelayableAttestation::hash_tree_root,
+        DelayableAttestation::getDependentBlockRoots,
+        DelayableAttestation::getEarliestSlotForProcessing);
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Previously `ProcessedAttestationEvent` and `ProcessedAggregateEvent` were sent once the `AggregationManager` received an attestation, regardless of whether it was successfully processed or not.  Now the events are delayed if the processing is delayed and not sent at all if the attestation is invalid.