### PR TITLE
Default advertisedPort to port

### DIFF
--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
@@ -31,6 +31,8 @@ import org.apache.tuweni.config.SchemaBuilder;
 /** Configuration of an instance of Artemis. */
 public class ArtemisConfiguration {
 
+  private static final int NO_VALUE = -1;
+
   @SuppressWarnings({"DoubleBraceInitialization"})
   static final Schema createSchema() {
     SchemaBuilder builder =
@@ -45,7 +47,7 @@ public class ArtemisConfiguration {
     builder.addInteger("node.port", 9000, "Peer to peer port", PropertyValidator.inRange(0, 65535));
     builder.addInteger(
         "node.advertisedPort",
-        9000,
+        NO_VALUE,
         "Peer to peer advertised port",
         PropertyValidator.inRange(0, 65535));
     builder.addString("node.discovery", "", "static or discv5", null);
@@ -195,7 +197,8 @@ public class ArtemisConfiguration {
 
   /** @return the port this node will advertise as its own */
   public int getAdvertisedPort() {
-    return config.getInteger("node.advertisedPort");
+    final int advertisedPort = config.getInteger("node.advertisedPort");
+    return advertisedPort == NO_VALUE ? getPort() : advertisedPort;
   }
 
   /** @return the network interface this node will bind to */

--- a/util/src/test/java/tech/pegasys/artemis/util/config/ArtemisConfigurationTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/config/ArtemisConfigurationTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.artemis.util.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,12 @@ final class ArtemisConfigurationTest {
         IllegalArgumentException.class,
         () ->
             ArtemisConfiguration.fromString("node.identity=\"2345\"\nnode.advertisedPort=100000"));
+  }
+
+  @Test
+  void advertisedPortDefaultsToPort() {
+    final ArtemisConfiguration config = ArtemisConfiguration.fromString("node.port=1234");
+    assertThat(config.getAdvertisedPort()).isEqualTo(1234);
   }
 
   @Test


### PR DESCRIPTION
## PR Description
If node.advertisedPort is not specified in the config, the advertised port should be the same as node.port.