### PR TITLE
Optimize: parallel attestations validation on block import 

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/artemis/benchmarks/gen/Generator.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/artemis/benchmarks/gen/Generator.java
@@ -89,7 +89,7 @@ public class Generator {
           // localStorage.getBlockByRoot(localStorage.getBestBlockRoot());
           BlockProcessingRecord record =
               localChain.createAndImportBlockAtSlot(
-                  currentSlot, Utils.groupAndAggregateAttestations(attestations));
+                  currentSlot, AttestationGenerator.groupAndAggregateAttestations(attestations));
 
           final SignedBeaconBlock block = record.getBlock();
           writer.accept(block);

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/artemis/benchmarks/gen/Utils.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/artemis/benchmarks/gen/Utils.java
@@ -13,57 +13,11 @@
 
 package tech.pegasys.artemis.benchmarks.gen;
 
-import com.google.common.base.Preconditions;
-import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import tech.pegasys.artemis.datastructures.operations.Attestation;
-import tech.pegasys.artemis.util.SSZTypes.Bitlist;
-import tech.pegasys.artemis.util.bls.BLSAggregate;
-import tech.pegasys.artemis.util.bls.BLSSignature;
-import tech.pegasys.artemis.util.config.Constants;
 
 public class Utils {
-  /**
-   * Groups passed attestations by their {@link
-   * tech.pegasys.artemis.datastructures.operations.AttestationData} and aggregates attestations in
-   * every group to a single {@link Attestation}
-   *
-   * @return a list of aggregated {@link Attestation}s with distinct {@link
-   *     tech.pegasys.artemis.datastructures.operations.AttestationData}
-   */
-  public static List<Attestation> groupAndAggregateAttestations(List<Attestation> srcAttestations) {
-    Collection<List<Attestation>> groupedAtt =
-        srcAttestations.stream().collect(Collectors.groupingBy(Attestation::getData)).values();
-    return groupedAtt.stream().map(Utils::aggregateAttestations).collect(Collectors.toList());
-  }
-
-  /**
-   * Aggregates passed attestations
-   *
-   * @param srcAttestations attestations which should have the same {@link Attestation#getData()}
-   */
-  public static Attestation aggregateAttestations(List<Attestation> srcAttestations) {
-    Preconditions.checkArgument(!srcAttestations.isEmpty(), "Expected at least one attestation");
-
-    int targetBitlistSize =
-        srcAttestations.stream()
-            .mapToInt(a -> a.getAggregation_bits().getCurrentSize())
-            .max()
-            .getAsInt();
-    Bitlist targetBitlist = new Bitlist(targetBitlistSize, Constants.MAX_VALIDATORS_PER_COMMITTEE);
-    srcAttestations.forEach(a -> targetBitlist.setAllBits(a.getAggregation_bits()));
-    BLSSignature targetSig =
-        BLSAggregate.bls_aggregate_signatures(
-            srcAttestations.stream()
-                .map(Attestation::getAggregate_signature)
-                .collect(Collectors.toList()));
-
-    return new Attestation(targetBitlist, srcAttestations.get(0).getData(), targetSig);
-  }
 
   static <T> Iterator<T> fromSupplier(Supplier<T> supplier) {
     return new Iterator<T>() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
@@ -388,12 +388,18 @@ public final class BlockProcessorUtil {
               "process_attestations: Attestation source error 2");
           state.getPrevious_epoch_attestations().add(pendingAttestation);
         }
-
-        // Check signature
-        checkArgument(
-            is_valid_indexed_attestation(state, get_indexed_attestation(state, attestation)),
-            "process_attestations: Check signature");
       }
+
+      attestations.stream()
+          .parallel()
+          .forEach(
+              attestation -> {
+                // Check signature
+                checkArgument(
+                    is_valid_indexed_attestation(
+                        state, get_indexed_attestation(state, attestation)),
+                    "process_attestations: Check signature");
+              });
     } catch (IllegalArgumentException e) {
       STDOUT.log(Level.WARN, e.getMessage());
       throw new BlockProcessingException(e);


### PR DESCRIPTION
## PR Description

BLS signature validation is heavy and takes ~95% of block import. The most easy and straightforward optimization is to parallelize block attestations validation 

Also add a couple of tests to check blocks with attestations import 

## Results
Blocks import speed increased on ~50% 

#### Before
```
Benchmark                              (validatorsCount)  Mode  Cnt  Score   Error  Units
TransitionBenchmark.Block.importBlock               1024    ss   50  0,351 ± 0,009   s/op
TransitionBenchmark.Block.importBlock               3072    ss   50  0,529 ± 0,005   s/op
```

#### After
```
Benchmark                              (validatorsCount)  Mode  Cnt  Score   Error  Units
TransitionBenchmark.Block.importBlock               1024    ss   50  0,226 ± 0,009   s/op
TransitionBenchmark.Block.importBlock               3072    ss   50  0,352 ± 0,004   s/op
```