### PR TITLE
Retrieve block timestamp in PoW service

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/DepositWithIndex.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/DepositWithIndex.java
@@ -21,39 +21,42 @@ import tech.pegasys.artemis.util.SSZTypes.SSZVector;
 
 public class DepositWithIndex extends Deposit implements Comparable<DepositWithIndex> {
 
-  private UnsignedLong index;
-  private Log log;
+  private final UnsignedLong index;
+  private final Log log;
+  private final UnsignedLong blockTimestamp;
 
   public DepositWithIndex(SSZVector<Bytes32> proof, DepositData data, UnsignedLong index) {
     super(proof, data);
     this.index = index;
+    log = null;
+    blockTimestamp = null;
   }
 
   public DepositWithIndex(DepositData data, UnsignedLong index) {
     super(data);
     this.index = index;
+    log = null;
+    blockTimestamp = null;
   }
 
-  public DepositWithIndex(DepositData data, UnsignedLong index, Log log) {
+  public DepositWithIndex(
+      DepositData data, UnsignedLong index, Log log, UnsignedLong blockTimestamp) {
     super(data);
     this.index = index;
     this.log = log;
+    this.blockTimestamp = blockTimestamp;
   }
 
   public UnsignedLong getIndex() {
     return index;
   }
 
-  public void setIndex(UnsignedLong index) {
-    this.index = index;
-  }
-
   public Log getLog() {
     return log;
   }
 
-  public void setLog(Log log) {
-    this.log = log;
+  public UnsignedLong getBlockTimestamp() {
+    return blockTimestamp;
   }
 
   @Override

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DepositUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/DepositUtil.java
@@ -19,15 +19,12 @@ import static tech.pegasys.artemis.util.config.Constants.MIN_DEPOSIT_AMOUNT;
 
 import com.google.common.primitives.UnsignedLong;
 import com.google.gson.JsonElement;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.Hash;
-import org.web3j.protocol.Web3j;
-import org.web3j.protocol.http.HttpService;
 import tech.pegasys.artemis.datastructures.operations.Deposit;
 import tech.pegasys.artemis.datastructures.operations.DepositData;
 import tech.pegasys.artemis.datastructures.operations.DepositWithIndex;
@@ -176,7 +173,8 @@ public class DepositUtil {
             event.getWithdrawal_credentials(),
             event.getAmount(),
             event.getSignature());
-    return new DepositWithIndex(data, event.getMerkle_tree_index(), event.getResponse().log);
+    return new DepositWithIndex(
+        data, event.getMerkle_tree_index(), event.getResponse().log, event.getBlockTimestamp());
   }
 
   // deprecated, being used until a new validators_test_data.json can be generated
@@ -193,13 +191,6 @@ public class DepositUtil {
     response.amount = Arrays.copyOfRange(data, 80, 88);
     response.signature = Arrays.copyOfRange(data, 88, 184);
     response.index = index;
-    return new tech.pegasys.artemis.pow.event.Deposit(response);
-  }
-
-  public static UnsignedLong getEpochBlockTimeByDepositBlockHash(Bytes32 blockHash, String provider)
-      throws IOException {
-    Web3j web3 = Web3j.build(new HttpService(provider));
-    return UnsignedLong.valueOf(
-        web3.ethGetBlockByHash(blockHash.toHexString(), false).send().getBlock().getTimestamp());
+    return new tech.pegasys.artemis.pow.event.Deposit(response, UnsignedLong.ZERO);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateProcessor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateProcessor.java
@@ -24,7 +24,6 @@ import static tech.pegasys.artemis.util.config.Constants.MIN_GENESIS_TIME;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.primitives.UnsignedLong;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -91,14 +90,7 @@ public class StateProcessor {
     deposits.add(deposit);
 
     final Bytes32 eth1BlockHash = Bytes32.fromHexString(deposit.getLog().getBlockHash());
-    final UnsignedLong eth1_timestamp;
-    try {
-      eth1_timestamp =
-          DepositUtil.getEpochBlockTimeByDepositBlockHash(eth1BlockHash, config.getNodeUrl());
-    } catch (IOException e) {
-      STDOUT.log(Level.FATAL, e.toString());
-      return;
-    }
+    final UnsignedLong eth1_timestamp = deposit.getBlockTimestamp();
 
     // Approximation to save CPU cycles of creating new BeaconState on every Deposit captured
     if (isGenesisReasonable(

--- a/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListener.java
+++ b/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListener.java
@@ -58,11 +58,11 @@ public class DepositContractListener {
   }
 
   private Flowable<Deposit> convertToDeposit(final DepositEventEventResponse event) {
-    return getBlockByHash(web3j, event.log.getBlockHash())
+    return getBlockByHash(event.log.getBlockHash())
         .map(block -> new Deposit(event, UnsignedLong.valueOf(block.getTimestamp())));
   }
 
-  private Flowable<Block> getBlockByHash(final Web3j web3j, final String blockHash) {
+  private Flowable<Block> getBlockByHash(final String blockHash) {
     return cachedBlock
         .filter(block -> block.getHash().equals(blockHash))
         .map(Flowable::just)

--- a/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListener.java
+++ b/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListener.java
@@ -16,19 +16,25 @@ package tech.pegasys.artemis.pow;
 import static tech.pegasys.artemis.pow.contract.DepositContract.DEPOSITEVENT_EVENT;
 
 import com.google.common.eventbus.EventBus;
+import com.google.common.primitives.UnsignedLong;
+import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.web3j.abi.EventEncoder;
+import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.methods.request.EthFilter;
 import tech.pegasys.artemis.pow.contract.DepositContract;
+import tech.pegasys.artemis.pow.contract.DepositContract.DepositEventEventResponse;
 import tech.pegasys.artemis.pow.event.Deposit;
 
 public class DepositContractListener {
-
+  private static final Logger LOG = LogManager.getLogger();
   private final Disposable subscriptionNewDeposit;
   private DepositContract contract;
 
-  public DepositContractListener(EventBus eventBus, DepositContract contract) {
+  public DepositContractListener(Web3j web3j, EventBus eventBus, DepositContract contract) {
     this.contract = contract;
 
     // Filter by the contract address and by begin/end blocks
@@ -44,11 +50,17 @@ public class DepositContractListener {
     subscriptionNewDeposit =
         contract
             .depositEventEventFlowable(depositEventFilter)
-            .subscribe(
-                response -> {
-                  Deposit deposit = new Deposit(response);
-                  eventBus.post(deposit);
-                });
+            .flatMap(event -> getBlockTimestamp(web3j, event))
+            .subscribe(eventBus::post);
+  }
+
+  private Flowable<Deposit> getBlockTimestamp(
+      final Web3j web3j, final DepositEventEventResponse event) {
+    LOG.debug("Getting timestamp for deposit event in block {}", event.log.getBlockNumber());
+    return web3j
+        .ethGetBlockByHash(event.log.getBlockHash(), false)
+        .flowable()
+        .map(block -> new Deposit(event, UnsignedLong.valueOf(block.getBlock().getTimestamp())));
   }
 
   public DepositContract getContract() {

--- a/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListener.java
+++ b/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListener.java
@@ -19,12 +19,15 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.primitives.UnsignedLong;
 import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.web3j.abi.EventEncoder;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.methods.request.EthFilter;
+import org.web3j.protocol.core.methods.response.EthBlock;
+import org.web3j.protocol.core.methods.response.EthBlock.Block;
 import tech.pegasys.artemis.pow.contract.DepositContract;
 import tech.pegasys.artemis.pow.contract.DepositContract.DepositEventEventResponse;
 import tech.pegasys.artemis.pow.event.Deposit;
@@ -33,6 +36,7 @@ public class DepositContractListener {
   private static final Logger LOG = LogManager.getLogger();
   private final Disposable subscriptionNewDeposit;
   private DepositContract contract;
+  private volatile Optional<EthBlock.Block> cachedBlock = Optional.empty();
 
   public DepositContractListener(Web3j web3j, EventBus eventBus, DepositContract contract) {
     this.contract = contract;
@@ -57,10 +61,24 @@ public class DepositContractListener {
   private Flowable<Deposit> getBlockTimestamp(
       final Web3j web3j, final DepositEventEventResponse event) {
     LOG.debug("Getting timestamp for deposit event in block {}", event.log.getBlockNumber());
-    return web3j
-        .ethGetBlockByHash(event.log.getBlockHash(), false)
-        .flowable()
-        .map(block -> new Deposit(event, UnsignedLong.valueOf(block.getBlock().getTimestamp())));
+    return getBlockByHash(web3j, event.log.getBlockHash())
+        .map(block -> new Deposit(event, UnsignedLong.valueOf(block.getTimestamp())));
+  }
+
+  private Flowable<Block> getBlockByHash(final Web3j web3j, final String blockHash) {
+    return cachedBlock
+        .filter(block -> block.getHash().equals(blockHash))
+        .map(Flowable::just)
+        .orElseGet(
+            () ->
+                web3j
+                    .ethGetBlockByHash(blockHash, false)
+                    .flowable()
+                    .map(
+                        blockResponse -> {
+                          cachedBlock = Optional.of(blockResponse.getBlock());
+                          return blockResponse.getBlock();
+                        }));
   }
 
   public DepositContract getContract() {

--- a/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListener.java
+++ b/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListener.java
@@ -51,11 +51,11 @@ public class DepositContractListener {
     subscriptionNewDeposit =
         contract
             .depositEventEventFlowable(depositEventFilter)
-            .flatMap(event -> getBlockTimestamp(web3j, event))
+            .flatMap(event -> convertToDeposit(web3j, event))
             .subscribe(eventBus::post);
   }
 
-  private Flowable<Deposit> getBlockTimestamp(
+  private Flowable<Deposit> convertToDeposit(
       final Web3j web3j, final DepositEventEventResponse event) {
     return getBlockByHash(web3j, event.log.getBlockHash())
         .map(block -> new Deposit(event, UnsignedLong.valueOf(block.getTimestamp())));

--- a/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListener.java
+++ b/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListener.java
@@ -20,8 +20,6 @@ import com.google.common.primitives.UnsignedLong;
 import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
 import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.web3j.abi.EventEncoder;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameterName;
@@ -33,7 +31,6 @@ import tech.pegasys.artemis.pow.contract.DepositContract.DepositEventEventRespon
 import tech.pegasys.artemis.pow.event.Deposit;
 
 public class DepositContractListener {
-  private static final Logger LOG = LogManager.getLogger();
   private final Disposable subscriptionNewDeposit;
   private DepositContract contract;
   private volatile Optional<EthBlock.Block> cachedBlock = Optional.empty();
@@ -60,7 +57,6 @@ public class DepositContractListener {
 
   private Flowable<Deposit> getBlockTimestamp(
       final Web3j web3j, final DepositEventEventResponse event) {
-    LOG.debug("Getting timestamp for deposit event in block {}", event.log.getBlockNumber());
     return getBlockByHash(web3j, event.log.getBlockHash())
         .map(block -> new Deposit(event, UnsignedLong.valueOf(block.getTimestamp())));
   }

--- a/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListenerFactory.java
+++ b/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListenerFactory.java
@@ -40,7 +40,7 @@ public class DepositContractListenerFactory {
           "DepositContractListenerFactory.simulationDeployDepositContract: DepositContract failed to deploy in the simulation environment",
           e);
     }
-    return new DepositContractListener(eventBus, contract);
+    return new DepositContractListener(web3j, eventBus, contract);
   }
 
   public static DepositContractListener eth1DepositContract(
@@ -49,6 +49,6 @@ public class DepositContractListenerFactory {
     DepositContract contract =
         DepositContract.load(
             address, web3j, new ClientTransactionManager(web3j, address), new DefaultGasProvider());
-    return new DepositContractListener(eventBus, contract);
+    return new DepositContractListener(web3j, eventBus, contract);
   }
 }

--- a/pow/src/main/java/tech/pegasys/artemis/pow/event/Deposit.java
+++ b/pow/src/main/java/tech/pegasys/artemis/pow/event/Deposit.java
@@ -34,19 +34,22 @@ public class Deposit extends AbstractEvent<DepositContract.DepositEventEventResp
   private Bytes32 withdrawal_credentials;
   private BLSSignature signature;
   private UnsignedLong amount;
+  private final UnsignedLong blockTimestamp;
   private UnsignedLong merkle_tree_index;
 
   private static final ObjectMapper mapper = new ObjectMapper();
 
   private Map<String, Object> outputFieldMap = new HashMap<>();
 
-  public Deposit(DepositContract.DepositEventEventResponse response) {
+  public Deposit(
+      DepositContract.DepositEventEventResponse response, final UnsignedLong blockTimestamp) {
     super(response);
     this.merkle_tree_index = UnsignedLong.valueOf(Bytes.wrap(response.index).reverse().toLong());
     this.pubkey = BLSPublicKey.fromBytesCompressed(Bytes.wrap(response.pubkey));
     this.withdrawal_credentials = Bytes32.wrap(response.withdrawal_credentials);
     this.signature = BLSSignature.fromBytes(Bytes.wrap(response.signature));
     this.amount = UnsignedLong.valueOf(Bytes.wrap(response.amount).reverse().toLong());
+    this.blockTimestamp = blockTimestamp;
   }
 
   public UnsignedLong getMerkle_tree_index() {
@@ -63,6 +66,10 @@ public class Deposit extends AbstractEvent<DepositContract.DepositEventEventResp
 
   public UnsignedLong getAmount() {
     return amount;
+  }
+
+  public UnsignedLong getBlockTimestamp() {
+    return blockTimestamp;
   }
 
   public void setPubkey(BLSPublicKey pubkey) {


### PR DESCRIPTION
## PR Description
Moves retrieval of the block timestamp for deposits from `StateProcessor` back up into the proof of work service which is actually responsible for communications with the ETH1 node.  This also better balances processing time for deposits so the queue in the event bus doesn't build up as badly.