### PR TITLE
Introduce a generic EventSink to make it easier for tests to capture specific event types

### DIFF
--- a/sync/src/test/java/tech/pegasys/artemis/sync/AttestationManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/artemis/sync/AttestationManagerTest.java
@@ -24,9 +24,7 @@ import static tech.pegasys.artemis.statetransition.attestation.AttestationProces
 import static tech.pegasys.artemis.statetransition.attestation.AttestationProcessingResult.SUCCESSFUL;
 
 import com.google.common.eventbus.EventBus;
-import com.google.common.eventbus.Subscribe;
 import com.google.common.primitives.UnsignedLong;
-import java.util.ArrayList;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.AfterEach;
@@ -44,6 +42,7 @@ import tech.pegasys.artemis.statetransition.events.BlockImportedEvent;
 import tech.pegasys.artemis.statetransition.events.ProcessedAggregateEvent;
 import tech.pegasys.artemis.statetransition.events.ProcessedAttestationEvent;
 import tech.pegasys.artemis.storage.events.SlotEvent;
+import tech.pegasys.artemis.util.EventSink;
 import tech.pegasys.artemis.util.SSZTypes.Bitlist;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
@@ -56,7 +55,10 @@ class AttestationManagerTest {
 
   private final ForkChoiceAttestationProcessor attestationProcessor =
       mock(ForkChoiceAttestationProcessor.class);
-  private final EventCapture events = new EventCapture();
+  private final List<ProcessedAttestationEvent> processedAttestationEvents =
+      EventSink.capture(eventBus, ProcessedAttestationEvent.class);
+  private final List<ProcessedAggregateEvent> processedAggregateEvents =
+      EventSink.capture(eventBus, ProcessedAggregateEvent.class);
 
   private final AttestationManager attestationManager =
       new AttestationManager(
@@ -67,7 +69,6 @@ class AttestationManagerTest {
   @BeforeEach
   public void setup() {
     assertThat(attestationManager.start()).isCompleted();
-    eventBus.register(events);
   }
 
   @AfterEach
@@ -84,9 +85,9 @@ class AttestationManagerTest {
     verify(attestationProcessor).processAttestation(attestation);
     assertThat(futureAttestations.size()).isZero();
     assertThat(pendingAttestations.size()).isZero();
-    assertThat(events.processedAttestationEvents)
+    assertThat(processedAttestationEvents)
         .containsExactly(new ProcessedAttestationEvent(attestation));
-    assertThat(events.processedAggregateEvents).isEmpty();
+    assertThat(processedAggregateEvents).isEmpty();
   }
 
   @Test
@@ -99,9 +100,9 @@ class AttestationManagerTest {
     verify(attestationProcessor).processAttestation(aggregateAndProof.getAggregate());
     assertThat(futureAttestations.size()).isZero();
     assertThat(pendingAttestations.size()).isZero();
-    assertThat(events.processedAggregateEvents)
+    assertThat(processedAggregateEvents)
         .containsExactly(new ProcessedAggregateEvent(aggregateAndProof.getAggregate()));
-    assertThat(events.processedAttestationEvents).isEmpty();
+    assertThat(processedAttestationEvents).isEmpty();
   }
 
   @Test
@@ -127,7 +128,7 @@ class AttestationManagerTest {
     verify(attestationProcessor, times(2)).processAttestation(attestation);
     assertThat(futureAttestations.size()).isZero();
     assertThat(pendingAttestations.size()).isZero();
-    assertThat(events.processedAttestationEvents)
+    assertThat(processedAttestationEvents)
         .containsExactly(new ProcessedAttestationEvent(attestation));
   }
 
@@ -162,7 +163,7 @@ class AttestationManagerTest {
     verify(attestationProcessor, times(2)).processAttestation(attestation);
     assertThat(futureAttestations.size()).isZero();
     assertThat(pendingAttestations.size()).isZero();
-    assertThat(events.processedAttestationEvents)
+    assertThat(processedAttestationEvents)
         .containsExactly(new ProcessedAttestationEvent(attestation));
   }
 
@@ -220,14 +221,14 @@ class AttestationManagerTest {
     verify(attestationProcessor, times(2)).processAttestation(attestation);
     assertThat(futureAttestations.size()).isZero();
     assertThat(pendingAttestations.size()).isZero();
-    assertThat(events.processedAttestationEvents).isEmpty();
-    assertThat(events.processedAggregateEvents)
+    assertThat(processedAttestationEvents).isEmpty();
+    assertThat(processedAggregateEvents)
         .containsExactly(new ProcessedAggregateEvent(attestation));
   }
 
   private void assertNoProcessedEvents() {
-    assertThat(events.processedAttestationEvents).isEmpty();
-    assertThat(events.processedAggregateEvents).isEmpty();
+    assertThat(processedAttestationEvents).isEmpty();
+    assertThat(processedAggregateEvents).isEmpty();
   }
 
   private Attestation attestationFromSlot(final long slot) {
@@ -244,20 +245,5 @@ class AttestationManagerTest {
             new Checkpoint(UnsignedLong.ZERO, Bytes32.ZERO),
             new Checkpoint(UnsignedLong.ZERO, targetRoot)),
         BLSSignature.empty());
-  }
-
-  private static class EventCapture {
-    private final List<ProcessedAttestationEvent> processedAttestationEvents = new ArrayList<>();
-    private final List<ProcessedAggregateEvent> processedAggregateEvents = new ArrayList<>();
-
-    @Subscribe
-    public void onAttestationProcessed(final ProcessedAttestationEvent event) {
-      processedAttestationEvents.add(event);
-    }
-
-    @Subscribe
-    public void onAggregateProcessed(final ProcessedAggregateEvent event) {
-      processedAggregateEvents.add(event);
-    }
   }
 }

--- a/sync/src/test/java/tech/pegasys/artemis/sync/AttestationManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/artemis/sync/AttestationManagerTest.java
@@ -222,8 +222,7 @@ class AttestationManagerTest {
     assertThat(futureAttestations.size()).isZero();
     assertThat(pendingAttestations.size()).isZero();
     assertThat(processedAttestationEvents).isEmpty();
-    assertThat(processedAggregateEvents)
-        .containsExactly(new ProcessedAggregateEvent(attestation));
+    assertThat(processedAggregateEvents).containsExactly(new ProcessedAggregateEvent(attestation));
   }
 
   private void assertNoProcessedEvents() {

--- a/util/src/test-support/java/tech/pegasys/artemis/util/EventSink.java
+++ b/util/src/test-support/java/tech/pegasys/artemis/util/EventSink.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.util;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import java.util.ArrayList;
+import java.util.List;
+
+public class EventSink<T> {
+
+  private final List<T> events = new ArrayList<>();
+  private final Class<T> eventType;
+
+  private EventSink(final Class<T> eventType) {
+    this.eventType = eventType;
+  }
+
+  public static <T> List<T> capture(final EventBus eventBus, Class<T> eventType) {
+    final EventSink<T> eventSink = new EventSink<>(eventType);
+    eventBus.register(eventSink);
+    return eventSink.events;
+  }
+
+  @Subscribe
+  public void onEvent(final Object event) {
+    if (eventType.isInstance(event)) {
+      events.add(eventType.cast(event));
+    }
+  }
+}

--- a/util/src/test/java/tech/pegasys/artemis/util/EventSinkTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/EventSinkTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.eventbus.EventBus;
+import java.math.BigInteger;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class EventSinkTest {
+  private final EventBus eventBus = new EventBus();
+
+  @Test
+  public void shouldCaptureOnlyTheDeclaredEventType() {
+    final List<String> capturedEvents = EventSink.capture(eventBus, String.class);
+
+    eventBus.post("Hello");
+    eventBus.post(BigInteger.ZERO);
+    eventBus.post("World");
+
+    assertThat(capturedEvents).containsExactly("Hello", "World");
+  }
+
+  @Test
+  public void shouldCaptureSubclassesOfDeclaredType() {
+    final List<Exception> capturedEvents = EventSink.capture(eventBus, Exception.class);
+
+    final Exception sameClass = new Exception();
+    final RuntimeException subclass = new RuntimeException();
+    final Throwable superClass = new Throwable();
+    eventBus.post(sameClass);
+    eventBus.post(subclass);
+    eventBus.post(superClass);
+
+    assertThat(capturedEvents).containsExactly(sameClass, subclass);
+  }
+}


### PR DESCRIPTION
## PR Description
Introduce `EventSink` test util to make it easy for tests to capture specific types of events from the event bus without having to create custom classes.