### PR TITLE
Use a single TimeProvider instance across the system

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
@@ -23,7 +23,6 @@ import com.google.common.eventbus.SubscriberExceptionHandler;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.vertx.core.Vertx;
 import java.nio.file.Path;
-import java.time.Clock;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -40,8 +39,7 @@ import tech.pegasys.artemis.util.alogger.ALogger;
 import tech.pegasys.artemis.util.alogger.ALogger.Color;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
 import tech.pegasys.artemis.util.config.Constants;
-import tech.pegasys.artemis.util.time.ClockTimeProvider;
-import tech.pegasys.artemis.util.time.TimeProvider;
+import tech.pegasys.artemis.util.time.SystemTimeProvider;
 
 public class BeaconNode {
 
@@ -61,10 +59,10 @@ public class BeaconNode {
 
     this.eventBus = new AsyncEventBus(threadPool, new EventBusExceptionHandler(STDOUT));
 
-    final TimeProvider timeProvider = new ClockTimeProvider(Clock.systemUTC());
     metricsEndpoint = new MetricsEndpoint(config, vertx);
     this.serviceConfig =
-        new ServiceConfig(timeProvider, eventBus, metricsEndpoint.getMetricsSystem(), config);
+        new ServiceConfig(
+            new SystemTimeProvider(), eventBus, metricsEndpoint.getMetricsSystem(), config);
     Constants.setConstants(config.getConstants());
 
     final String transitionRecordDir = config.getTransitionRecordDir();

--- a/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
@@ -23,6 +23,7 @@ import com.google.common.eventbus.SubscriberExceptionHandler;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.vertx.core.Vertx;
 import java.nio.file.Path;
+import java.time.Clock;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -39,6 +40,8 @@ import tech.pegasys.artemis.util.alogger.ALogger;
 import tech.pegasys.artemis.util.alogger.ALogger.Color;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
 import tech.pegasys.artemis.util.config.Constants;
+import tech.pegasys.artemis.util.time.ClockTimeProvider;
+import tech.pegasys.artemis.util.time.TimeProvider;
 
 public class BeaconNode {
 
@@ -58,9 +61,10 @@ public class BeaconNode {
 
     this.eventBus = new AsyncEventBus(threadPool, new EventBusExceptionHandler(STDOUT));
 
+    final TimeProvider timeProvider = new ClockTimeProvider(Clock.systemUTC());
     metricsEndpoint = new MetricsEndpoint(config, vertx);
     this.serviceConfig =
-        new ServiceConfig(eventBus, vertx, metricsEndpoint.getMetricsSystem(), config);
+        new ServiceConfig(timeProvider, eventBus, metricsEndpoint.getMetricsSystem(), config);
     Constants.setConstants(config.getConstants());
 
     final String transitionRecordDir = config.getTransitionRecordDir();

--- a/pow/src/test/java/tech/pegasys/artemis/pow/Eth1DataManagerTest.java
+++ b/pow/src/test/java/tech/pegasys/artemis/pow/Eth1DataManagerTest.java
@@ -92,7 +92,7 @@ public class Eth1DataManagerTest {
   void setUp() {
     eventBus = new EventBus();
     eventSink = EventSink.capture(eventBus, CacheEth1BlockEvent.class);
-    timeProvider = new StubTimeProvider(testStartTime);
+    timeProvider = StubTimeProvider.withTimeInSeconds(testStartTime);
 
     when(depositContractListener.getDepositCount(any()))
         .thenReturn(SafeFuture.completedFuture(UnsignedLong.valueOf(1234)));

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -62,6 +62,7 @@ import tech.pegasys.artemis.sync.SyncService;
 import tech.pegasys.artemis.util.alogger.ALogger;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
 import tech.pegasys.artemis.util.config.Constants;
+import tech.pegasys.artemis.util.time.TimeProvider;
 import tech.pegasys.artemis.util.time.Timer;
 import tech.pegasys.artemis.validator.coordinator.ValidatorCoordinator;
 
@@ -69,6 +70,7 @@ public class BeaconChainController {
   private final ExecutorService networkExecutor = Executors.newSingleThreadExecutor();
   private Runnable networkTask;
   private final ArtemisConfiguration config;
+  private final TimeProvider timeProvider;
   private EventBus eventBus;
   private Timer timer;
   private ChainStorageClient chainStorageClient;
@@ -86,7 +88,11 @@ public class BeaconChainController {
   private AttestationManager attestationManager;
 
   public BeaconChainController(
-      EventBus eventBus, MetricsSystem metricsSystem, ArtemisConfiguration config) {
+      TimeProvider timeProvider,
+      EventBus eventBus,
+      MetricsSystem metricsSystem,
+      ArtemisConfiguration config) {
+    this.timeProvider = timeProvider;
     this.eventBus = eventBus;
     this.config = config;
     this.metricsSystem = metricsSystem;
@@ -141,7 +147,12 @@ public class BeaconChainController {
   public void initValidatorCoordinator() {
     STDOUT.log(Level.DEBUG, "BeaconChainController.initValidatorCoordinator()");
     new ValidatorCoordinator(
-        eventBus, chainStorageClient, attestationAggregator, blockAttestationsPool, config);
+        timeProvider,
+        eventBus,
+        chainStorageClient,
+        attestationAggregator,
+        blockAttestationsPool,
+        config);
   }
 
   public void initStateProcessor() {

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainService.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainService.java
@@ -26,11 +26,13 @@ public class BeaconChainService implements ServiceInterface {
   public BeaconChainService() {}
 
   @Override
-  @SuppressWarnings("rawtypes")
   public void init(ServiceConfig config) {
     this.controller =
         new BeaconChainController(
-            config.getEventBus(), config.getMetricsSystem(), config.getConfig());
+            config.getTimeProvider(),
+            config.getEventBus(),
+            config.getMetricsSystem(),
+            config.getConfig());
     this.controller.initAll();
   }
 

--- a/services/powchain/src/main/java/tech/pegasys/artemis/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/artemis/services/powchain/PowchainService.java
@@ -62,11 +62,13 @@ public class PowchainService implements ServiceInterface {
   private String provider;
 
   private String depositSimFile;
+  private TimeProvider timeProvider;
 
   public PowchainService() {}
 
   @Override
   public void init(ServiceConfig config) {
+    timeProvider = config.getTimeProvider();
     this.eventBus = config.getEventBus();
     this.eventBus.register(this);
     this.depositMode = config.getConfig().getDepositMode();
@@ -116,7 +118,7 @@ public class PowchainService implements ServiceInterface {
               eventBus,
               depositContractListener,
               new DelayedExecutorAsyncRunner(),
-              new TimeProvider());
+              timeProvider);
       eth1DataManager.start();
     } else if (depositMode.equals(DEPOSIT_SIM)) {
       try {
@@ -146,7 +148,7 @@ public class PowchainService implements ServiceInterface {
               eventBus,
               depositContractListener,
               new DelayedExecutorAsyncRunner(),
-              new TimeProvider());
+              timeProvider);
       eth1DataManager.start();
     }
   }

--- a/services/powchain/src/main/java/tech/pegasys/artemis/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/artemis/services/powchain/PowchainService.java
@@ -68,7 +68,7 @@ public class PowchainService implements ServiceInterface {
 
   @Override
   public void init(ServiceConfig config) {
-    timeProvider = config.getTimeProvider();
+    this.timeProvider = config.getTimeProvider();
     this.eventBus = config.getEventBus();
     this.eventBus.register(this);
     this.depositMode = config.getConfig().getDepositMode();

--- a/services/serviceutils/src/main/java/tech/pegasys/artemis/service/serviceutils/ServiceConfig.java
+++ b/services/serviceutils/src/main/java/tech/pegasys/artemis/service/serviceutils/ServiceConfig.java
@@ -14,62 +14,41 @@
 package tech.pegasys.artemis.service.serviceutils;
 
 import com.google.common.eventbus.EventBus;
-import io.vertx.core.Vertx;
-import java.util.Objects;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
+import tech.pegasys.artemis.util.time.TimeProvider;
 
 public class ServiceConfig {
-  Vertx vertx;
-  EventBus eventBus;
-  MetricsSystem metricsSystem;
-  ArtemisConfiguration config;
+
+  private final TimeProvider timeProvider;
+  private final EventBus eventBus;
+  private final MetricsSystem metricsSystem;
+  private final ArtemisConfiguration config;
 
   public ServiceConfig(
-      EventBus eventBus, Vertx vertx, MetricsSystem metricsSystem, ArtemisConfiguration config) {
+      final TimeProvider timeProvider,
+      final EventBus eventBus,
+      final MetricsSystem metricsSystem,
+      final ArtemisConfiguration config) {
+    this.timeProvider = timeProvider;
     this.eventBus = eventBus;
-    this.vertx = vertx;
     this.metricsSystem = metricsSystem;
     this.config = config;
+  }
+
+  public TimeProvider getTimeProvider() {
+    return timeProvider;
   }
 
   public EventBus getEventBus() {
     return this.eventBus;
   }
 
-  public void setEventBus(EventBus eventBus) {
-    this.eventBus = eventBus;
-  }
-
-  public Vertx getVertx() {
-    return this.vertx;
-  }
-
   public ArtemisConfiguration getConfig() {
     return this.config;
   }
 
-  public void setConfig(ArtemisConfiguration config) {
-    this.config = config;
-  }
-
   public MetricsSystem getMetricsSystem() {
     return metricsSystem;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (o == this) return true;
-    if (!(o instanceof ServiceConfig)) {
-      return false;
-    }
-    ServiceConfig serviceConfig = (ServiceConfig) o;
-    return Objects.equals(eventBus, serviceConfig.eventBus)
-        && Objects.equals(config, serviceConfig.config);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(eventBus, config);
   }
 }

--- a/util/src/main/java/tech/pegasys/artemis/util/time/ClockTimeProvider.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/time/ClockTimeProvider.java
@@ -14,14 +14,18 @@
 package tech.pegasys.artemis.util.time;
 
 import com.google.common.primitives.UnsignedLong;
+import java.time.Clock;
 
-public interface TimeProvider {
+public class ClockTimeProvider implements TimeProvider {
 
-  UnsignedLong MILLIS_PER_SECOND = UnsignedLong.valueOf(1000);
+  private final Clock clock;
 
-  UnsignedLong getTimeInMillis();
+  public ClockTimeProvider(final Clock clock) {
+    this.clock = clock;
+  }
 
-  default UnsignedLong getTimeInSeconds() {
-    return getTimeInMillis().dividedBy(MILLIS_PER_SECOND);
+  @Override
+  public UnsignedLong getTimeInMillis() {
+    return UnsignedLong.valueOf(clock.millis());
   }
 }

--- a/util/src/main/java/tech/pegasys/artemis/util/time/SystemTimeProvider.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/time/SystemTimeProvider.java
@@ -16,12 +16,12 @@ package tech.pegasys.artemis.util.time;
 import com.google.common.primitives.UnsignedLong;
 import java.time.Clock;
 
-public class ClockTimeProvider implements TimeProvider {
+public class SystemTimeProvider implements TimeProvider {
 
   private final Clock clock;
 
-  public ClockTimeProvider(final Clock clock) {
-    this.clock = clock;
+  public SystemTimeProvider() {
+    this.clock = Clock.systemUTC();
   }
 
   @Override

--- a/util/src/test-support/java/tech/pegasys/artemis/util/time/StubTimeProvider.java
+++ b/util/src/test-support/java/tech/pegasys/artemis/util/time/StubTimeProvider.java
@@ -25,15 +25,19 @@ public class StubTimeProvider implements TimeProvider {
   }
 
   public static StubTimeProvider withTimeInSeconds(final long timeInSeconds) {
-    return withTimeInMillis(TimeUnit.SECONDS.toMillis(timeInSeconds));
+    return withTimeInSeconds(UnsignedLong.valueOf(timeInSeconds));
   }
 
   public static StubTimeProvider withTimeInSeconds(final UnsignedLong timeInSeconds) {
-    return withTimeInMillis(timeInSeconds.longValue());
+    return withTimeInMillis(timeInSeconds.times(MILLIS_PER_SECOND));
   }
 
   public static StubTimeProvider withTimeInMillis(final long timeInMillis) {
-    return new StubTimeProvider(UnsignedLong.valueOf(timeInMillis));
+    return withTimeInMillis(UnsignedLong.valueOf(timeInMillis));
+  }
+
+  public static StubTimeProvider withTimeInMillis(final UnsignedLong timeInMillis) {
+    return new StubTimeProvider(timeInMillis);
   }
 
   public void advanceTimeBySeconds(final long seconds) {

--- a/util/src/test-support/java/tech/pegasys/artemis/util/time/StubTimeProvider.java
+++ b/util/src/test-support/java/tech/pegasys/artemis/util/time/StubTimeProvider.java
@@ -14,29 +14,34 @@
 package tech.pegasys.artemis.util.time;
 
 import com.google.common.primitives.UnsignedLong;
+import java.util.concurrent.TimeUnit;
 
-public class StubTimeProvider extends TimeProvider {
+public class StubTimeProvider implements TimeProvider {
 
-  private UnsignedLong timeInSeconds;
+  private UnsignedLong timeInMillis;
 
-  public StubTimeProvider() {
-    this(UnsignedLong.valueOf(29842948));
+  private StubTimeProvider(final UnsignedLong timeInMillis) {
+    this.timeInMillis = timeInMillis;
   }
 
-  public StubTimeProvider(final long timeInSeconds) {
-    this(UnsignedLong.valueOf(timeInSeconds));
+  public static StubTimeProvider withTimeInSeconds(final long timeInSeconds) {
+    return withTimeInMillis(TimeUnit.SECONDS.toMillis(timeInSeconds));
   }
 
-  public StubTimeProvider(final UnsignedLong timeInSeconds) {
-    this.timeInSeconds = timeInSeconds;
+  public static StubTimeProvider withTimeInSeconds(final UnsignedLong timeInSeconds) {
+    return withTimeInMillis(timeInSeconds.longValue());
+  }
+
+  public static StubTimeProvider withTimeInMillis(final long timeInMillis) {
+    return new StubTimeProvider(UnsignedLong.valueOf(timeInMillis));
   }
 
   public void advanceTimeBySeconds(final long seconds) {
-    this.timeInSeconds = timeInSeconds.plus(UnsignedLong.valueOf(seconds));
+    this.timeInMillis = timeInMillis.plus(UnsignedLong.valueOf(TimeUnit.SECONDS.toMillis(seconds)));
   }
 
   @Override
-  public UnsignedLong getTimeInSeconds() {
-    return timeInSeconds;
+  public UnsignedLong getTimeInMillis() {
+    return timeInMillis;
   }
 }

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinator.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinator.java
@@ -101,6 +101,7 @@ public class ValidatorCoordinator {
   private LinkedBlockingQueue<ProposerSlashing> slashings = new LinkedBlockingQueue<>();
 
   public ValidatorCoordinator(
+      TimeProvider timeProvider,
       EventBus eventBus,
       ChainStorageClient chainStorageClient,
       AttestationAggregator attestationAggregator,
@@ -113,7 +114,7 @@ public class ValidatorCoordinator {
     this.validators = initializeValidators(config);
     this.attestationAggregator = attestationAggregator;
     this.blockAttestationsPool = blockAttestationsPool;
-    this.eth1DataCache = new Eth1DataCache(eventBus, new TimeProvider());
+    this.eth1DataCache = new Eth1DataCache(eventBus, timeProvider);
     this.eventBus.register(this);
   }
 

--- a/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/Eth1DataCacheTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/Eth1DataCacheTest.java
@@ -73,7 +73,7 @@ public class Eth1DataCacheTest {
         .thenReturn(testStartTime.minus(UnsignedLong.valueOf(1000)));
     when(genesisState.getSlot()).thenReturn(UnsignedLong.ZERO);
 
-    timeProvider = new StubTimeProvider(testStartTime);
+    timeProvider = StubTimeProvider.withTimeInSeconds(testStartTime);
     eth1DataCache = new Eth1DataCache(eventBus, timeProvider);
   }
 

--- a/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinatorTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinatorTest.java
@@ -39,9 +39,11 @@ import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.storage.events.SlotEvent;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
+import tech.pegasys.artemis.util.time.StubTimeProvider;
 
 public class ValidatorCoordinatorTest {
 
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(1000);
   private BlockAttestationsPool blockAttestationsPool;
   private AttestationAggregator attestationAggregator;
   private EventBus eventBus;
@@ -114,7 +116,12 @@ public class ValidatorCoordinatorTest {
     when(config.getInteropOwnedValidatorCount()).thenReturn(ownedValidatorCount);
     ValidatorCoordinator vc =
         new ValidatorCoordinator(
-            eventBus, storageClient, attestationAggregator, blockAttestationsPool, config);
+            timeProvider,
+            eventBus,
+            storageClient,
+            attestationAggregator,
+            blockAttestationsPool,
+            config);
 
     chainUtil.initializeStorage();
     return vc;


### PR DESCRIPTION
## PR Description
Pulls the creation of `TimeProvider` right up to the top level `BeaconNode` and share the same instance everywhere it's needed.

Support millis in `TimeProvider` since I'll be needing that precision next.  Also made it an interface with two separate implementations which actually just boiled down to personal preference (I initially thought it would be required but turned out not to be).  One advantage of interfaces is that you can't accidentally add a method to the "real" implementation and forget to override it in the stub so I figure it's worth keeping the change.