### PR TITLE
Split pre-genesis deposit handling out of StateProcessor

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateProcessor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateProcessor.java
@@ -13,38 +13,19 @@
 
 package tech.pegasys.artemis.statetransition;
 
-import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.initialize_beacon_state_from_eth1;
-import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.is_valid_genesis_state;
-import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.is_valid_genesis_stateSim;
 import static tech.pegasys.artemis.statetransition.util.ForkChoiceUtil.get_head;
-import static tech.pegasys.artemis.util.alogger.ALogger.STDOUT;
-import static tech.pegasys.artemis.util.config.Constants.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT;
-import static tech.pegasys.artemis.util.config.Constants.MIN_GENESIS_TIME;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
-import com.google.common.primitives.UnsignedLong;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
-import tech.pegasys.artemis.datastructures.operations.DepositWithIndex;
-import tech.pegasys.artemis.datastructures.state.BeaconState;
-import tech.pegasys.artemis.datastructures.state.BeaconStateWithCache;
-import tech.pegasys.artemis.datastructures.util.DepositUtil;
-import tech.pegasys.artemis.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.artemis.statetransition.blockimport.BlockImportResult;
 import tech.pegasys.artemis.statetransition.blockimport.BlockImporter;
 import tech.pegasys.artemis.statetransition.events.BlockProposedEvent;
-import tech.pegasys.artemis.statetransition.events.GenesisEvent;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.storage.Store;
-import tech.pegasys.artemis.util.config.ArtemisConfiguration;
-import tech.pegasys.artemis.util.config.Constants;
 
 /** Class to manage the state tree and initiate state transitions */
 public class StateProcessor {
@@ -52,25 +33,11 @@ public class StateProcessor {
 
   private final BlockImporter blockImporter;
   private final ChainStorageClient chainStorageClient;
-  private final ArtemisConfiguration config;
-  private final DepositQueue depositQueue = new DepositQueue(this::onOrderedDeposit);
-  private final List<DepositWithIndex> deposits = new ArrayList<>();
 
-  public StateProcessor(
-      EventBus eventBus, ChainStorageClient chainStorageClient, ArtemisConfiguration config) {
-    this.config = config;
+  public StateProcessor(EventBus eventBus, ChainStorageClient chainStorageClient) {
     this.chainStorageClient = chainStorageClient;
     this.blockImporter = new BlockImporter(chainStorageClient, eventBus);
     eventBus.register(this);
-  }
-
-  public void eth2Genesis(GenesisEvent genesisEvent) {
-    STDOUT.log(Level.INFO, "******* Eth2Genesis Event******* : ");
-    final BeaconStateWithCache initialState = genesisEvent.getBeaconState();
-    chainStorageClient.initializeFromGenesis(initialState);
-    Bytes32 genesisBlockRoot = chainStorageClient.getBestBlockRoot();
-    STDOUT.log(Level.INFO, "Initial state root is " + initialState.hash_tree_root().toHexString());
-    STDOUT.log(Level.INFO, "Genesis block root is " + genesisBlockRoot.toHexString());
   }
 
   public Bytes32 processHead() {
@@ -79,49 +46,6 @@ public class StateProcessor {
     BeaconBlock headBlock = store.getBlock(headBlockRoot);
     chainStorageClient.updateBestBlock(headBlockRoot, headBlock.getSlot());
     return headBlockRoot;
-  }
-
-  @Subscribe
-  public void onDeposits(DepositsFromBlockEvent event) {
-    depositQueue.onDeposit(event);
-  }
-
-  private void onOrderedDeposit(final DepositsFromBlockEvent event) {
-    STDOUT.log(Level.DEBUG, "New deposits received");
-    event.getDeposits().stream()
-        .map(DepositUtil::convertDepositEventToOperationDeposit)
-        .forEach(deposits::add);
-
-    final Bytes32 eth1BlockHash = event.getBlockHash();
-    final UnsignedLong eth1_timestamp = event.getBlockTimestamp();
-
-    // Approximation to save CPU cycles of creating new BeaconState on every Deposit captured
-    if (isGenesisReasonable(
-        eth1_timestamp, deposits, config.getDepositMode().equals(Constants.DEPOSIT_SIM))) {
-      if (config.getDepositMode().equals(Constants.DEPOSIT_SIM)) {
-        BeaconStateWithCache candidate_state =
-            initialize_beacon_state_from_eth1(eth1BlockHash, eth1_timestamp, deposits);
-        if (is_valid_genesis_stateSim(candidate_state)) {
-          setSimulationGenesisTime(candidate_state);
-          eth2Genesis(new GenesisEvent(candidate_state));
-        }
-
-      } else {
-        BeaconStateWithCache candidate_state =
-            initialize_beacon_state_from_eth1(eth1BlockHash, eth1_timestamp, deposits);
-        if (is_valid_genesis_state(candidate_state)) {
-          eth2Genesis(new GenesisEvent(candidate_state));
-        }
-      }
-    }
-  }
-
-  public boolean isGenesisReasonable(
-      UnsignedLong eth1_timestamp, List<DepositWithIndex> deposits, boolean isSimulation) {
-    final boolean sufficientValidators = deposits.size() >= MIN_GENESIS_ACTIVE_VALIDATOR_COUNT;
-    if (isSimulation) return sufficientValidators;
-    final boolean afterMinGenesisTime = eth1_timestamp.compareTo(MIN_GENESIS_TIME) >= 0;
-    return afterMinGenesisTime && sufficientValidators;
   }
 
   @Subscribe
@@ -139,11 +63,5 @@ public class StateProcessor {
               + blockProposedEvent,
           result.getFailureCause().orElse(null));
     }
-  }
-
-  private void setSimulationGenesisTime(BeaconState state) {
-    Date date = new Date();
-    state.setGenesis_time(
-        UnsignedLong.valueOf((date.getTime() / 1000)).plus(Constants.GENESIS_START_DELAY));
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/genesis/PreGenesisDepositHandler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/genesis/PreGenesisDepositHandler.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.statetransition.genesis;
+
+import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.initialize_beacon_state_from_eth1;
+import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.is_valid_genesis_state;
+import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.is_valid_genesis_stateSim;
+import static tech.pegasys.artemis.util.alogger.ALogger.STDOUT;
+import static tech.pegasys.artemis.util.config.Constants.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT;
+import static tech.pegasys.artemis.util.config.Constants.MIN_GENESIS_TIME;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import org.apache.logging.log4j.Level;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.artemis.datastructures.operations.DepositWithIndex;
+import tech.pegasys.artemis.datastructures.state.BeaconState;
+import tech.pegasys.artemis.datastructures.state.BeaconStateWithCache;
+import tech.pegasys.artemis.datastructures.util.DepositUtil;
+import tech.pegasys.artemis.pow.event.DepositsFromBlockEvent;
+import tech.pegasys.artemis.statetransition.DepositQueue;
+import tech.pegasys.artemis.statetransition.events.GenesisEvent;
+import tech.pegasys.artemis.storage.ChainStorageClient;
+import tech.pegasys.artemis.util.config.ArtemisConfiguration;
+import tech.pegasys.artemis.util.config.Constants;
+
+public class PreGenesisDepositHandler {
+
+  private final ArtemisConfiguration config;
+  private final ChainStorageClient chainStorageClient;
+  private final DepositQueue depositQueue = new DepositQueue(this::onOrderedDeposit);
+  private final List<DepositWithIndex> deposits = new ArrayList<>();
+
+  public PreGenesisDepositHandler(
+      final ArtemisConfiguration config, final ChainStorageClient chainStorageClient) {
+    this.config = config;
+    this.chainStorageClient = chainStorageClient;
+  }
+
+  @Subscribe
+  public void onDeposits(DepositsFromBlockEvent event) {
+    if (!chainStorageClient.isPreGenesis()) {
+      return;
+    }
+    depositQueue.onDeposit(event);
+  }
+
+  private void eth2Genesis(GenesisEvent genesisEvent) {
+    STDOUT.log(Level.INFO, "******* Eth2Genesis Event******* : ");
+    final BeaconStateWithCache initialState = genesisEvent.getBeaconState();
+    chainStorageClient.initializeFromGenesis(initialState);
+    Bytes32 genesisBlockRoot = chainStorageClient.getBestBlockRoot();
+    STDOUT.log(Level.INFO, "Initial state root is " + initialState.hash_tree_root().toHexString());
+    STDOUT.log(Level.INFO, "Genesis block root is " + genesisBlockRoot.toHexString());
+  }
+
+  private void onOrderedDeposit(final DepositsFromBlockEvent event) {
+    STDOUT.log(Level.DEBUG, "New deposits received");
+    event.getDeposits().stream()
+        .map(DepositUtil::convertDepositEventToOperationDeposit)
+        .forEach(deposits::add);
+
+    final Bytes32 eth1BlockHash = event.getBlockHash();
+    final UnsignedLong eth1_timestamp = event.getBlockTimestamp();
+
+    // Approximation to save CPU cycles of creating new BeaconState on every Deposit captured
+    if (isGenesisReasonable(
+        eth1_timestamp, deposits, config.getDepositMode().equals(Constants.DEPOSIT_SIM))) {
+      if (config.getDepositMode().equals(Constants.DEPOSIT_SIM)) {
+        BeaconStateWithCache candidate_state =
+            initialize_beacon_state_from_eth1(eth1BlockHash, eth1_timestamp, deposits);
+        if (is_valid_genesis_stateSim(candidate_state)) {
+          setSimulationGenesisTime(candidate_state);
+          eth2Genesis(new GenesisEvent(candidate_state));
+        }
+
+      } else {
+        BeaconStateWithCache candidate_state =
+            initialize_beacon_state_from_eth1(eth1BlockHash, eth1_timestamp, deposits);
+        if (is_valid_genesis_state(candidate_state)) {
+          eth2Genesis(new GenesisEvent(candidate_state));
+        }
+      }
+    }
+  }
+
+  public boolean isGenesisReasonable(
+      UnsignedLong eth1_timestamp, List<DepositWithIndex> deposits, boolean isSimulation) {
+    final boolean sufficientValidators = deposits.size() >= MIN_GENESIS_ACTIVE_VALIDATOR_COUNT;
+    if (isSimulation) return sufficientValidators;
+    final boolean afterMinGenesisTime = eth1_timestamp.compareTo(MIN_GENESIS_TIME) >= 0;
+    return afterMinGenesisTime && sufficientValidators;
+  }
+
+  private void setSimulationGenesisTime(BeaconState state) {
+    Date date = new Date();
+    state.setGenesis_time(
+        UnsignedLong.valueOf((date.getTime() / 1000)).plus(Constants.GENESIS_START_DELAY));
+  }
+}

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -51,6 +51,7 @@ import tech.pegasys.artemis.statetransition.StateProcessor;
 import tech.pegasys.artemis.statetransition.blockimport.BlockImporter;
 import tech.pegasys.artemis.statetransition.events.BroadcastAggregatesEvent;
 import tech.pegasys.artemis.statetransition.events.BroadcastAttestationEvent;
+import tech.pegasys.artemis.statetransition.genesis.PreGenesisDepositHandler;
 import tech.pegasys.artemis.statetransition.util.StartupUtil;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.storage.Store;
@@ -107,6 +108,7 @@ public class BeaconChainController {
     initAttestationAggregator();
     initBlockAttestationsPool();
     initValidatorCoordinator();
+    initDepositHandler();
     initStateProcessor();
     initAttestationPropagationManager();
     initP2PNetwork();
@@ -157,7 +159,12 @@ public class BeaconChainController {
 
   public void initStateProcessor() {
     STDOUT.log(Level.DEBUG, "BeaconChainController.initStateProcessor()");
-    this.stateProcessor = new StateProcessor(eventBus, chainStorageClient, config);
+    this.stateProcessor = new StateProcessor(eventBus, chainStorageClient);
+  }
+
+  private void initDepositHandler() {
+    STDOUT.log(Level.DEBUG, "BeaconChainController.initDepositHandler()");
+    eventBus.register(new PreGenesisDepositHandler(config, chainStorageClient));
   }
 
   private void initAttestationPropagationManager() {


### PR DESCRIPTION
## PR Description
Split the deposit handling out of StateProcessor into a new `PreGenesisDepositHandler` class and set it up to ignore deposits once we have a genesis events.

We'll later need a `PostGenesisDepositHandler` that takes over once we have a genesis event and possibly something smarter to handle the switch between the two without losing deposits. For now though this avoids us generating multiple genesis events as new deposits come in.