### PR TITLE
Support testnet configs

### DIFF
--- a/compatibility-tests/multiclient/src/compatibility-test/java/tech/pegasys/artemis/compatibility/multiclient/StatusMessageCompatibilityTest.java
+++ b/compatibility-tests/multiclient/src/compatibility-test/java/tech/pegasys/artemis/compatibility/multiclient/StatusMessageCompatibilityTest.java
@@ -24,11 +24,11 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import tech.pegasys.artemis.compatibility.multiclient.clients.Prysm;
-import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.networking.eth2.Eth2Network;
 import tech.pegasys.artemis.networking.eth2.Eth2NetworkFactory;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.artemis.networking.eth2.peers.PeerStatus;
+import tech.pegasys.artemis.util.config.Constants;
 
 @Testcontainers
 class StatusMessageCompatibilityTest {
@@ -55,7 +55,7 @@ class StatusMessageCompatibilityTest {
     final Eth2Peer prysm = artemis.getPeer(PRYSM_NODE.getId()).orElseThrow();
     final PeerStatus status = prysm.getStatus();
     assertThat(status).isNotNull();
-    assertThat(status.getHeadForkVersion()).isEqualTo(Fork.VERSION_ZERO);
+    assertThat(status.getHeadForkVersion()).isEqualTo(Constants.GENESIS_FORK_VERSION);
 
     // No validators so nothing should get finalised.
     assertThat(status.getFinalizedEpoch()).isEqualTo(UnsignedLong.ZERO);

--- a/data/provider/src/test/java/tech/pegasys/artemis/provider/JsonProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/artemis/provider/JsonProviderTest.java
@@ -19,13 +19,11 @@ import com.google.common.primitives.UnsignedLong;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
-import tech.pegasys.artemis.util.config.Constants;
 
 class JsonProviderTest {
 
   @Test
   void beaconStateJsonTest() {
-    Constants.setConstants("minimal");
     BeaconState state = DataStructureUtil.randomBeaconState(UnsignedLong.valueOf(16), 100);
     String jsonState = JsonProvider.objectToJSON(state);
     assertTrue(jsonState.length() > 0);

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/BeaconState.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/BeaconState.java
@@ -159,7 +159,9 @@ public class BeaconState implements Merkleizable, SimpleOffsetSerializable, SSZC
     this.slot = UnsignedLong.valueOf(Constants.GENESIS_SLOT);
     this.fork =
         new Fork(
-            Fork.VERSION_ZERO, Fork.VERSION_ZERO, UnsignedLong.valueOf(Constants.GENESIS_EPOCH));
+            Constants.GENESIS_FORK_VERSION,
+            Constants.GENESIS_FORK_VERSION,
+            UnsignedLong.valueOf(Constants.GENESIS_EPOCH));
 
     // History
     this.latest_block_header = new BeaconBlockHeader();

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/Fork.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/Fork.java
@@ -31,7 +31,6 @@ public class Fork implements Merkleizable, SimpleOffsetSerializable, SSZContaine
 
   // The number of SimpleSerialize basic types in this SSZ Container/POJO.
   public static final int SSZ_FIELD_COUNT = 3;
-  public static final Bytes4 VERSION_ZERO = new Bytes4(Bytes.of(0, 0, 0, 0));
 
   private final Bytes4 previous_version; // This is a Version type, aliased as a Bytes4
   private final Bytes4 current_version; // This is a Version type, aliased as a Bytes4

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -299,7 +299,7 @@ public class BeaconStateUtil {
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#compute_domain</a>
    */
   public static Bytes compute_domain(Bytes4 domain_type) {
-    return compute_domain(domain_type, new Bytes4(Bytes.wrap(new byte[4])));
+    return compute_domain(domain_type, Constants.GENESIS_FORK_VERSION);
   }
 
   /**

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -299,7 +299,7 @@ public class BeaconStateUtil {
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#compute_domain</a>
    */
   public static Bytes compute_domain(Bytes4 domain_type) {
-    return compute_domain(domain_type, Constants.GENESIS_FORK_VERSION);
+    return compute_domain(domain_type, new Bytes4(Bytes.wrap(new byte[4])));
   }
 
   /**

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/GenesisGenerator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/GenesisGenerator.java
@@ -18,6 +18,7 @@ import static tech.pegasys.artemis.util.alogger.ALogger.STDOUT;
 import static tech.pegasys.artemis.util.config.Constants.DEPOSIT_CONTRACT_TREE_DEPTH;
 import static tech.pegasys.artemis.util.config.Constants.EFFECTIVE_BALANCE_INCREMENT;
 import static tech.pegasys.artemis.util.config.Constants.GENESIS_EPOCH;
+import static tech.pegasys.artemis.util.config.Constants.GENESIS_FORK_VERSION;
 import static tech.pegasys.artemis.util.config.Constants.MAX_EFFECTIVE_BALANCE;
 import static tech.pegasys.artemis.util.config.Constants.SECONDS_PER_DAY;
 
@@ -36,6 +37,7 @@ import tech.pegasys.artemis.datastructures.operations.Deposit;
 import tech.pegasys.artemis.datastructures.operations.DepositData;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.state.BeaconStateWithCache;
+import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.datastructures.state.Validator;
 import tech.pegasys.artemis.util.SSZTypes.SSZList;
 import tech.pegasys.artemis.util.bls.BLSPublicKey;
@@ -55,6 +57,8 @@ public class GenesisGenerator {
     Bytes32 latestBlockRoot = new BeaconBlockBody().hash_tree_root();
     beaconBlockHeader.setBody_root(latestBlockRoot);
     state.setLatest_block_header(beaconBlockHeader);
+    state.setFork(
+        new Fork(GENESIS_FORK_VERSION, GENESIS_FORK_VERSION, UnsignedLong.valueOf(GENESIS_EPOCH)));
   }
 
   public void addDepositsFromBlock(

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/StatusMessageTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/StatusMessageTest.java
@@ -19,15 +19,15 @@ import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
+import tech.pegasys.artemis.util.config.Constants;
 
 class StatusMessageTest {
   @Test
   public void shouldRoundTripViaSsz() {
     final StatusMessage message =
         new StatusMessage(
-            Fork.VERSION_ZERO,
+            Constants.GENESIS_FORK_VERSION,
             Bytes32.fromHexStringLenient("0x01"),
             UnsignedLong.valueOf(2),
             Bytes32.fromHexStringLenient("0x03"),

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
@@ -44,7 +44,6 @@ import tech.pegasys.artemis.datastructures.state.BeaconStateWithCache;
 import tech.pegasys.artemis.datastructures.state.Committee;
 import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.datastructures.state.Validator;
-import tech.pegasys.artemis.util.SSZTypes.Bytes4;
 import tech.pegasys.artemis.util.SSZTypes.SSZList;
 import tech.pegasys.artemis.util.bls.BLSPublicKey;
 import tech.pegasys.artemis.util.bls.BLSSignature;
@@ -281,8 +280,8 @@ class BeaconStateUtilTest {
     beaconState.setSlot(randomUnsignedLong(100));
     beaconState.setFork(
         new Fork(
-            new Bytes4(Bytes.ofUnsignedInt(0)),
-            new Bytes4(Bytes.ofUnsignedInt(0)),
+            Constants.GENESIS_FORK_VERSION,
+            Constants.GENESIS_FORK_VERSION,
             UnsignedLong.valueOf(Constants.GENESIS_EPOCH)));
 
     List<Validator> validatorList =

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/MockStartBeaconStateGeneratorTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/MockStartBeaconStateGeneratorTest.java
@@ -54,7 +54,6 @@ import tech.pegasys.artemis.util.SSZTypes.Bitvector;
 import tech.pegasys.artemis.util.SSZTypes.Bytes4;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
 import tech.pegasys.artemis.util.bls.BLSPublicKey;
-import tech.pegasys.artemis.util.config.Constants;
 
 class MockStartBeaconStateGeneratorTest {
   private static final Logger LOG = LogManager.getLogger();
@@ -162,10 +161,7 @@ class MockStartBeaconStateGeneratorTest {
 
   @Test
   @Disabled
-  @SuppressWarnings({"rawtypes"})
   public void printBeaconState() throws Exception {
-    Constants.setConstants("minimal");
-
     final UnsignedLong genesisTime = UnsignedLong.valueOf(1567719788L);
     final int validatorCount = 16;
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtilTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtilTest.java
@@ -22,7 +22,6 @@ import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomV
 import com.google.common.primitives.UnsignedLong;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.junit.BouncyCastleExtension;
 import org.junit.jupiter.api.Disabled;
@@ -35,7 +34,6 @@ import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.state.BeaconStateWithCache;
 import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.datastructures.state.Validator;
-import tech.pegasys.artemis.util.SSZTypes.Bytes4;
 import tech.pegasys.artemis.util.SSZTypes.SSZList;
 import tech.pegasys.artemis.util.bls.BLSPublicKey;
 import tech.pegasys.artemis.util.config.Constants;
@@ -140,8 +138,8 @@ class BlockProcessorUtilTest {
     beaconState.setSlot(randomUnsignedLong(100));
     beaconState.setFork(
         new Fork(
-            new Bytes4(Bytes.ofUnsignedInt(0)),
-            new Bytes4(Bytes.ofUnsignedInt(0)),
+            Constants.GENESIS_FORK_VERSION,
+            Constants.GENESIS_FORK_VERSION,
             UnsignedLong.valueOf(Constants.GENESIS_EPOCH)));
 
     SSZList<Validator> validatorList =

--- a/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/ErrorConditionsIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/ErrorConditionsIntegrationTest.java
@@ -23,13 +23,13 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.StatusMessage;
-import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.artemis.networking.eth2.rpc.core.Eth2RpcMethod;
 import tech.pegasys.artemis.networking.eth2.rpc.core.ResponseStream;
 import tech.pegasys.artemis.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.artemis.util.Waiter;
 import tech.pegasys.artemis.util.async.SafeFuture;
+import tech.pegasys.artemis.util.config.Constants;
 
 public class ErrorConditionsIntegrationTest {
 
@@ -63,7 +63,12 @@ public class ErrorConditionsIntegrationTest {
   private static class InvalidStatusMessage extends StatusMessage {
 
     public InvalidStatusMessage() {
-      super(Fork.VERSION_ZERO, Bytes32.ZERO, UnsignedLong.ZERO, Bytes32.ZERO, UnsignedLong.ZERO);
+      super(
+          Constants.GENESIS_FORK_VERSION,
+          Bytes32.ZERO,
+          UnsignedLong.ZERO,
+          Bytes32.ZERO,
+          UnsignedLong.ZERO);
     }
 
     @Override

--- a/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/PeerStatusIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/PeerStatusIntegrationTest.java
@@ -20,7 +20,6 @@ import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.artemis.networking.eth2.peers.PeerStatus;
 import tech.pegasys.artemis.statetransition.BeaconChainUtil;
@@ -29,6 +28,7 @@ import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.storage.Store;
 import tech.pegasys.artemis.util.SSZTypes.Bytes4;
 import tech.pegasys.artemis.util.Waiter;
+import tech.pegasys.artemis.util.config.Constants;
 
 public class PeerStatusIntegrationTest {
 
@@ -101,7 +101,7 @@ public class PeerStatusIntegrationTest {
   }
 
   private void assertPreGenesisStatus(final PeerStatus status) {
-    assertThat(PeerStatus.isPreGenesisStatus(status, Fork.VERSION_ZERO)).isTrue();
+    assertThat(PeerStatus.isPreGenesisStatus(status, Constants.GENESIS_FORK_VERSION)).isTrue();
   }
 
   private void assertStatusMatchesStorage(

--- a/networking/eth2/src/test-support/java/tech/pegasys/artemis/networking/eth2/peers/PeerStatusFactory.java
+++ b/networking/eth2/src/test-support/java/tech/pegasys/artemis/networking/eth2/peers/PeerStatusFactory.java
@@ -16,7 +16,6 @@ package tech.pegasys.artemis.networking.eth2.peers;
 import com.google.common.primitives.UnsignedLong;
 import java.util.Random;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.util.SSZTypes.Bytes4;
 import tech.pegasys.artemis.util.config.Constants;
 
@@ -33,7 +32,7 @@ public class PeerStatusFactory {
   }
 
   public PeerStatus random() {
-    final Bytes4 fork = Fork.VERSION_ZERO;
+    final Bytes4 fork = Constants.GENESIS_FORK_VERSION;
     final Bytes32 finalizedRoot = randomBytes32();
     final UnsignedLong finalizedEpoch = randomLong(0, 10);
     final Bytes32 headRoot = randomBytes32();

--- a/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
@@ -37,6 +37,7 @@ import tech.pegasys.artemis.storage.events.StoreGenesisDiskUpdateEvent;
 import tech.pegasys.artemis.storage.events.StoreInitializedEvent;
 import tech.pegasys.artemis.util.SSZTypes.Bytes4;
 import tech.pegasys.artemis.util.alogger.ALogger;
+import tech.pegasys.artemis.util.config.Constants;
 
 /** This class is the ChainStorage client-side logic */
 public class ChainStorageClient implements ChainStorage, StoreUpdateHandler {
@@ -44,7 +45,6 @@ public class ChainStorageClient implements ChainStorage, StoreUpdateHandler {
   protected final EventBus eventBus;
   private final TransactionPrecommit transactionPrecommit;
 
-  private final Bytes4 genesisFork = Fork.VERSION_ZERO;
   private volatile Store store;
   private volatile Bytes32 bestBlockRoot =
       Bytes32.ZERO; // block chosen by lmd ghost to build and attest on
@@ -140,7 +140,7 @@ public class ChainStorageClient implements ChainStorage, StoreUpdateHandler {
     // TODO - add better fork configuration management
     if (isPreGenesis()) {
       // We don't have anywhere to look for fork data, so just return the initial fork
-      return genesisFork;
+      return Constants.GENESIS_FORK_VERSION;
     }
     // For now, we don't have any forks, so just use the latest
     Fork latestFork = getBestBlockRootState().getFork();

--- a/storage/src/test/java/tech/pegasys/artemis/storage/ChainStorageClientTest.java
+++ b/storage/src/test/java/tech/pegasys/artemis/storage/ChainStorageClientTest.java
@@ -24,7 +24,6 @@ import static tech.pegasys.artemis.storage.Store.get_genesis_store;
 import com.google.common.eventbus.EventBus;
 import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
@@ -43,11 +42,6 @@ class ChainStorageClientTest {
   private final Store store = mock(Store.class);
   private final ChainStorageClient storageClient = ChainStorageClient.memoryOnlyClient(eventBus);
   private int seed = 428942;
-
-  @BeforeAll
-  public static void beforeAll() {
-    Constants.setConstants("minimal");
-  }
 
   @Test
   public void initialize_setupInitialState() {

--- a/sync/src/test/java/tech/pegasys/artemis/sync/PeerSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/artemis/sync/PeerSyncTest.java
@@ -36,7 +36,6 @@ import tech.pegasys.artemis.data.BlockProcessingRecord;
 import tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.GoodbyeMessage;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.StatusMessage;
-import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.artemis.networking.eth2.peers.PeerStatus;
@@ -62,7 +61,7 @@ public class PeerSyncTest {
   private static final PeerStatus PEER_STATUS =
       PeerStatus.fromStatusMessage(
           new StatusMessage(
-              Fork.VERSION_ZERO,
+              Constants.GENESIS_FORK_VERSION,
               Bytes32.ZERO,
               PEER_FINALIZED_EPOCH,
               PEER_HEAD_BLOCK_ROOT,
@@ -263,7 +262,7 @@ public class PeerSyncTest {
     final PeerStatus peer_status =
         PeerStatus.fromStatusMessage(
             new StatusMessage(
-                Fork.VERSION_ZERO,
+                Constants.GENESIS_FORK_VERSION,
                 Bytes32.ZERO,
                 PEER_FINALIZED_EPOCH,
                 PEER_HEAD_BLOCK_ROOT,

--- a/sync/src/test/java/tech/pegasys/artemis/sync/SyncManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/artemis/sync/SyncManagerTest.java
@@ -27,13 +27,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.StatusMessage;
-import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.networking.eth2.Eth2Network;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.artemis.networking.eth2.peers.PeerStatus;
 import tech.pegasys.artemis.networking.p2p.peer.PeerConnectedSubscriber;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.util.async.SafeFuture;
+import tech.pegasys.artemis.util.config.Constants;
 
 public class SyncManagerTest {
 
@@ -49,7 +49,7 @@ public class SyncManagerTest {
   private static final PeerStatus PEER_STATUS =
       PeerStatus.fromStatusMessage(
           new StatusMessage(
-              Fork.VERSION_ZERO,
+              Constants.GENESIS_FORK_VERSION,
               Bytes32.ZERO,
               PEER_FINALIZED_EPOCH,
               PEER_HEAD_BLOCK_ROOT,

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 
   implementation 'info.picocli:picocli'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
+  implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   implementation 'com.google.guava:guava'
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-config'

--- a/util/src/main/java/tech/pegasys/artemis/util/SSZTypes/Bytes4.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/SSZTypes/Bytes4.java
@@ -29,6 +29,10 @@ public class Bytes4 {
     this.bytes = bytes;
   }
 
+  public static Bytes4 fromHexString(String value) {
+    return new Bytes4(Bytes.fromHexString(value));
+  }
+
   /**
    * Left pad a {@link Bytes} value with zero bytes to create a {@link Bytes4}.
    *

--- a/util/src/main/java/tech/pegasys/artemis/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/Constants.java
@@ -49,7 +49,7 @@ public class Constants {
   public static long EFFECTIVE_BALANCE_INCREMENT;
 
   // Initial values
-  public static Bytes4 GENESIS_FORK_VERSION;
+  public static Bytes4 GENESIS_FORK_VERSION = Bytes4.fromHexString("0x00000000");
   public static long GENESIS_SLOT;
   public static long GENESIS_EPOCH;
   public static Bytes BLS_WITHDRAWAL_PREFIX;

--- a/util/src/main/java/tech/pegasys/artemis/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/Constants.java
@@ -14,10 +14,14 @@
 package tech.pegasys.artemis.util.config;
 
 import com.google.common.primitives.UnsignedLong;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.artemis.util.SSZTypes.Bytes4;
-import tech.pegasys.artemis.util.bls.BLSSignature;
 
 public class Constants {
 
@@ -27,7 +31,6 @@ public class Constants {
   public static int DEPOSIT_CONTRACT_TREE_DEPTH = 32;
   public static int SECONDS_PER_DAY = 86400;
   public static int JUSTIFICATION_BITS_LENGTH = 4;
-  public static String ENDIANNESS = "little";
 
   // Misc
   public static int MAX_COMMITTEES_PER_SLOT;
@@ -62,6 +65,9 @@ public class Constants {
   public static int MIN_VALIDATOR_WITHDRAWABILITY_DELAY;
   public static int PERSISTENT_COMMITTEE_PERIOD;
   public static int MIN_EPOCHS_TO_INACTIVITY_PENALTY;
+  public static int MAX_EPOCHS_PER_CROSSLINK;
+  public static int EPOCHS_PER_CUSTODY_PERIOD;
+  public static int CUSTODY_PERIOD_TO_RANDAO_PADDING;
 
   // State list lengths
   public static int EPOCHS_PER_HISTORICAL_VECTOR;
@@ -89,6 +95,9 @@ public class Constants {
   public static Bytes4 DOMAIN_RANDAO = new Bytes4(Bytes.fromHexString("0x02000000"));
   public static Bytes4 DOMAIN_DEPOSIT = new Bytes4(Bytes.fromHexString("0x03000000"));
   public static Bytes4 DOMAIN_VOLUNTARY_EXIT = new Bytes4(Bytes.fromHexString("0x04000000"));
+  public static Bytes4 DOMAIN_CUSTODY_BIT_CHALLENGE = Bytes4.fromHexString("0x06000000");
+  public static Bytes4 DOMAIN_SHARD_PROPOSER = Bytes4.fromHexString("0x80000000");
+  public static Bytes4 DOMAIN_SHARD_ATTESTER = Bytes4.fromHexString("0x81000000");
 
   // Honest Validator
   public static UnsignedLong TARGET_AGGREGATORS_PER_COMMITTEE = UnsignedLong.valueOf(16);
@@ -114,14 +123,11 @@ public class Constants {
 
   public static int EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS;
 
-  public static BLSSignature EMPTY_SIGNATURE = BLSSignature.empty();
   public static UnsignedLong BYTES_PER_LENGTH_OFFSET = UnsignedLong.valueOf(4L);
 
   public static UnsignedLong ETH1_FOLLOW_DISTANCE = UnsignedLong.valueOf(1024);
 
   // Artemis specific
-  public static String SIM_DEPOSIT_VALUE = "1000000000000000000";
-  public static int DEPOSIT_DATA_SIZE = 512; //
   public static int VALIDATOR_CLIENT_PORT_BASE = 50000;
   public static Bytes32 ZERO_HASH = Bytes32.ZERO;
   public static double TIME_TICKER_REFRESH_RATE = 2; // per sec
@@ -136,122 +142,22 @@ public class Constants {
   }
 
   @SuppressWarnings("rawtypes")
-  public static void setConstants(String Constants) {
-    if (Constants.equals("mainnet")) {
+  public static void setConstants(final String source) {
+    try (final InputStream input = createInputStream(source)) {
+      ConstantsReader.loadConstantsFrom(input);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Failed to load constants from " + source, e);
+    }
+  }
 
-      // Mainnet settings
-
-      // Misc
-      MAX_COMMITTEES_PER_SLOT = 64;
-      TARGET_COMMITTEE_SIZE = 128;
-      MAX_VALIDATORS_PER_COMMITTEE = 2048;
-      MIN_PER_EPOCH_CHURN_LIMIT = 4;
-      CHURN_LIMIT_QUOTIENT = 65536;
-      SHUFFLE_ROUND_COUNT = 90;
-      MIN_GENESIS_ACTIVE_VALIDATOR_COUNT = 16384;
-      MIN_GENESIS_TIME = UnsignedLong.valueOf(1578009600);
-
-      // Gwei values
-      MIN_DEPOSIT_AMOUNT = 1000000000L;
-      MAX_EFFECTIVE_BALANCE = 32000000000L;
-      EJECTION_BALANCE = 16000000000L;
-      EFFECTIVE_BALANCE_INCREMENT = 1000000000L;
-
-      // Initial values
-      GENESIS_FORK_VERSION = new Bytes4(Bytes.fromHexString("0x00000000"));
-      GENESIS_SLOT = 0;
-      GENESIS_EPOCH = 0;
-      BLS_WITHDRAWAL_PREFIX = Bytes.wrap(new byte[1]);
-
-      // Time parameters
-      MIN_ATTESTATION_INCLUSION_DELAY = 1;
-      SLOTS_PER_EPOCH = 32;
-      MIN_SEED_LOOKAHEAD = 1;
-      MAX_SEED_LOOKAHEAD = 4;
-      SLOTS_PER_ETH1_VOTING_PERIOD = 1024;
-      SLOTS_PER_HISTORICAL_ROOT = 8192;
-      MIN_VALIDATOR_WITHDRAWABILITY_DELAY = 256;
-      PERSISTENT_COMMITTEE_PERIOD = 2048;
-      MIN_EPOCHS_TO_INACTIVITY_PENALTY = 4;
-      EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS = 16384;
-
-      // State list lengths
-      EPOCHS_PER_HISTORICAL_VECTOR = 65536;
-      EPOCHS_PER_SLASHINGS_VECTOR = 8192;
-      HISTORICAL_ROOTS_LIMIT = 16777216;
-      VALIDATOR_REGISTRY_LIMIT = 1099511627776L;
-
-      // Reward and penalty quotients
-      BASE_REWARD_FACTOR = 64;
-      WHISTLEBLOWER_REWARD_QUOTIENT = 512;
-      PROPOSER_REWARD_QUOTIENT = 8;
-      INACTIVITY_PENALTY_QUOTIENT = 33554432;
-      MIN_SLASHING_PENALTY_QUOTIENT = 32;
-
-      // Max transactions per block
-      MAX_PROPOSER_SLASHINGS = 16;
-      MAX_ATTESTER_SLASHINGS = 1;
-      MAX_ATTESTATIONS = 128;
-      MAX_DEPOSITS = 16;
-      MAX_VOLUNTARY_EXITS = 16;
-
+  private static InputStream createInputStream(final String source) throws IOException {
+    if (source.contains(":")) {
+      return new URL(source).openStream();
+    } else if ("mainnet".equals(source) || "minimal".equals(source)) {
+      return Constants.class.getResourceAsStream(source + ".yaml");
     } else {
-
-      // Minimal settings
-
-      // Misc
-      MAX_COMMITTEES_PER_SLOT = 4;
-      TARGET_COMMITTEE_SIZE = 4;
-      MAX_VALIDATORS_PER_COMMITTEE = 2048;
-      MIN_PER_EPOCH_CHURN_LIMIT = 4;
-      CHURN_LIMIT_QUOTIENT = 65536;
-      SHUFFLE_ROUND_COUNT = 10;
-      MIN_GENESIS_ACTIVE_VALIDATOR_COUNT = 64;
-      MIN_GENESIS_TIME = UnsignedLong.ONE;
-
-      // Gwei values
-      MIN_DEPOSIT_AMOUNT = 1000000000L;
-      MAX_EFFECTIVE_BALANCE = 32000000000L;
-      EJECTION_BALANCE = 16000000000L;
-      EFFECTIVE_BALANCE_INCREMENT = 1000000000L;
-
-      // Initial values
-      GENESIS_FORK_VERSION = new Bytes4(Bytes.fromHexString("0x00000000"));
-      GENESIS_SLOT = 0;
-      GENESIS_EPOCH = 0;
-      BLS_WITHDRAWAL_PREFIX = Bytes.wrap(new byte[1]);
-
-      // Time parameters
-      MIN_ATTESTATION_INCLUSION_DELAY = 1;
-      SLOTS_PER_EPOCH = 8;
-      MIN_SEED_LOOKAHEAD = 1;
-      MAX_SEED_LOOKAHEAD = 4;
-      SLOTS_PER_ETH1_VOTING_PERIOD = 16;
-      SLOTS_PER_HISTORICAL_ROOT = 64;
-      MIN_VALIDATOR_WITHDRAWABILITY_DELAY = 256;
-      PERSISTENT_COMMITTEE_PERIOD = 2048;
-      MIN_EPOCHS_TO_INACTIVITY_PENALTY = 4;
-      EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS = 4096;
-
-      // State list lengths
-      EPOCHS_PER_HISTORICAL_VECTOR = 64;
-      EPOCHS_PER_SLASHINGS_VECTOR = 64;
-      HISTORICAL_ROOTS_LIMIT = 16777216;
-      VALIDATOR_REGISTRY_LIMIT = 1099511627776L;
-
-      // Reward and penalty quotients
-      BASE_REWARD_FACTOR = 64;
-      WHISTLEBLOWER_REWARD_QUOTIENT = 512;
-      PROPOSER_REWARD_QUOTIENT = 8;
-      INACTIVITY_PENALTY_QUOTIENT = 33554432;
-      MIN_SLASHING_PENALTY_QUOTIENT = 32;
-
-      // Max transactions per block
-      MAX_PROPOSER_SLASHINGS = 16;
-      MAX_ATTESTER_SLASHINGS = 1;
-      MAX_ATTESTATIONS = 128;
-      MAX_DEPOSITS = 16;
-      MAX_VOLUNTARY_EXITS = 16;
+      // Treat it as a file
+      return Files.newInputStream(Path.of(source));
     }
   }
 }

--- a/util/src/main/java/tech/pegasys/artemis/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/Constants.java
@@ -46,6 +46,7 @@ public class Constants {
   public static long EFFECTIVE_BALANCE_INCREMENT;
 
   // Initial values
+  public static Bytes4 GENESIS_FORK_VERSION;
   public static long GENESIS_SLOT;
   public static long GENESIS_EPOCH;
   public static Bytes BLS_WITHDRAWAL_PREFIX;
@@ -157,6 +158,7 @@ public class Constants {
       EFFECTIVE_BALANCE_INCREMENT = 1000000000L;
 
       // Initial values
+      GENESIS_FORK_VERSION = new Bytes4(Bytes.fromHexString("0x00000000"));
       GENESIS_SLOT = 0;
       GENESIS_EPOCH = 0;
       BLS_WITHDRAWAL_PREFIX = Bytes.wrap(new byte[1]);
@@ -214,6 +216,7 @@ public class Constants {
       EFFECTIVE_BALANCE_INCREMENT = 1000000000L;
 
       // Initial values
+      GENESIS_FORK_VERSION = new Bytes4(Bytes.fromHexString("0x00000000"));
       GENESIS_SLOT = 0;
       GENESIS_EPOCH = 0;
       BLS_WITHDRAWAL_PREFIX = Bytes.wrap(new byte[1]);

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ConstantsReader.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ConstantsReader.java
@@ -29,7 +29,7 @@ import tech.pegasys.artemis.util.SSZTypes.Bytes4;
 
 class ConstantsReader {
 
-  private static final Map<Class<?>, Function<String, ?>> PARSERS =
+  private static final ImmutableMap<Class<?>, Function<String, ?>> PARSERS =
       ImmutableMap.<Class<?>, Function<String, ?>>builder()
           .put(Integer.TYPE, ConstantsReader::parseInt)
           .put(Long.TYPE, Long::valueOf)

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ConstantsReader.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ConstantsReader.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.util.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.UnsignedLong;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.ByteOrder;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.artemis.util.SSZTypes.Bytes4;
+
+class ConstantsReader {
+
+  private static final Map<Class<?>, Function<String, ?>> PARSERS =
+      ImmutableMap.<Class<?>, Function<String, ?>>builder()
+          .put(Integer.TYPE, ConstantsReader::parseInt)
+          .put(Long.TYPE, Long::valueOf)
+          .put(UnsignedLong.class, UnsignedLong::valueOf)
+          .put(String.class, Function.identity())
+          .put(Bytes.class, Bytes::fromHexString)
+          .put(Bytes4.class, Bytes4::fromHexString)
+          .build();
+
+  @SuppressWarnings("unchecked")
+  public static void loadConstantsFrom(final InputStream source) throws IOException {
+    final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    final Map<String, String> values =
+        (Map<String, String>)
+            mapper
+                .readerFor(
+                    mapper.getTypeFactory().constructMapType(Map.class, String.class, String.class))
+                .readValues(source)
+                .next();
+    values.forEach(ConstantsReader::setField);
+  }
+
+  private static void setField(final String key, final String value) {
+    try {
+      final Field field = Constants.class.getField(key);
+      if (!Modifier.isStatic(field.getModifiers())) {
+        throw new IllegalArgumentException("Unknown constant: " + key);
+      }
+      field.set(null, parseValue(field, value));
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new IllegalArgumentException("Unknown constant: " + key, e);
+    }
+  }
+
+  private static Object parseValue(final Field field, final String value) {
+    final Function<String, ?> parser = PARSERS.get(field.getType());
+    if (parser == null) {
+      throw new IllegalArgumentException("Unknown constant type: " + field.getType());
+    }
+    try {
+      return parser.apply(value);
+    } catch (final IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Failed to parse value '" + value + "' for constant '" + field.getName() + "'");
+    }
+  }
+
+  private static Integer parseInt(final String value) {
+    if (value.startsWith("0x")) {
+      return Bytes.fromHexString(value)
+          .toUnsignedBigInteger(ByteOrder.LITTLE_ENDIAN)
+          .intValueExact();
+    } else {
+      return Integer.valueOf(value);
+    }
+  }
+}

--- a/util/src/main/resources/tech/pegasys/artemis/util/config/mainnet.yaml
+++ b/util/src/main/resources/tech/pegasys/artemis/util/config/mainnet.yaml
@@ -1,0 +1,147 @@
+# Mainnet preset
+# Note: the intention of this file (for now) is to illustrate what a mainnet configuration could look like.
+# Some of these constants may still change before the launch of Phase 0.
+
+
+# Misc
+# ---------------------------------------------------------------
+# 2**6 (= 64)
+MAX_COMMITTEES_PER_SLOT: 64
+# 2**7 (= 128)
+TARGET_COMMITTEE_SIZE: 128
+# 2**11 (= 2,048)
+MAX_VALIDATORS_PER_COMMITTEE: 2048
+# 2**2 (= 4)
+MIN_PER_EPOCH_CHURN_LIMIT: 4
+# 2**16 (= 65,536)
+CHURN_LIMIT_QUOTIENT: 65536
+# See issue 563
+SHUFFLE_ROUND_COUNT: 90
+# `2**14` (= 16,384)
+MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 16384
+# Jan 3, 2020
+MIN_GENESIS_TIME: 1578009600
+
+
+# Fork Choice
+# ---------------------------------------------------------------
+# 2**3 (= 8)
+SAFE_SLOTS_TO_UPDATE_JUSTIFIED: 8
+
+
+# Validator
+# ---------------------------------------------------------------
+# 2**10 (= 1,024)
+ETH1_FOLLOW_DISTANCE: 1024
+# 2**4 (= 16)
+TARGET_AGGREGATORS_PER_COMMITTEE: 16
+# 2**0 (= 1)
+RANDOM_SUBNETS_PER_VALIDATOR: 1
+# 2**8 (= 256)
+EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION: 256
+
+
+# Deposit contract
+# ---------------------------------------------------------------
+# **TBD**
+DEPOSIT_CONTRACT_ADDRESS: 0x1234567890123456789012345678901234567890
+
+
+# Gwei values
+# ---------------------------------------------------------------
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
+MIN_DEPOSIT_AMOUNT: 1000000000
+# 2**5 * 10**9 (= 32,000,000,000) Gwei
+MAX_EFFECTIVE_BALANCE: 32000000000
+# 2**4 * 10**9 (= 16,000,000,000) Gwei
+EJECTION_BALANCE: 16000000000
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
+EFFECTIVE_BALANCE_INCREMENT: 1000000000
+
+
+# Initial values
+# ---------------------------------------------------------------
+# 0, GENESIS_EPOCH is derived from this constant
+GENESIS_SLOT: 0
+BLS_WITHDRAWAL_PREFIX: 0x00
+
+
+# Time parameters
+# ---------------------------------------------------------------
+# 12 seconds
+SECONDS_PER_SLOT: 12
+# 2**0 (= 1) slots 12 seconds
+MIN_ATTESTATION_INCLUSION_DELAY: 1
+# 2**5 (= 32) slots 6.4 minutes
+SLOTS_PER_EPOCH: 32
+# 2**0 (= 1) epochs 6.4 minutes
+MIN_SEED_LOOKAHEAD: 1
+# 2**2 (= 4) epochs 25.6 minutes
+MAX_SEED_LOOKAHEAD: 4
+# 2**10 (= 1,024) slots ~1.7 hours
+SLOTS_PER_ETH1_VOTING_PERIOD: 1024
+# 2**13 (= 8,192) slots ~13 hours
+SLOTS_PER_HISTORICAL_ROOT: 8192
+# 2**8 (= 256) epochs ~27 hours
+MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256
+# 2**11 (= 2,048) epochs 9 days
+PERSISTENT_COMMITTEE_PERIOD: 2048
+# 2**6 (= 64) epochs ~7 hours
+MAX_EPOCHS_PER_CROSSLINK: 64
+# 2**2 (= 4) epochs 25.6 minutes
+MIN_EPOCHS_TO_INACTIVITY_PENALTY: 4
+# 2**14 (= 16,384) epochs ~73 days
+EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS: 16384
+
+
+
+# State vector lengths
+# ---------------------------------------------------------------
+# 2**16 (= 65,536) epochs ~0.8 years
+EPOCHS_PER_HISTORICAL_VECTOR: 65536
+# 2**13 (= 8,192) epochs ~36 days
+EPOCHS_PER_SLASHINGS_VECTOR: 8192
+# 2**24 (= 16,777,216) historical roots, ~26,131 years
+HISTORICAL_ROOTS_LIMIT: 16777216
+# 2**40 (= 1,099,511,627,776) validator spots
+VALIDATOR_REGISTRY_LIMIT: 1099511627776
+
+
+# Reward and penalty quotients
+# ---------------------------------------------------------------
+# 2**6 (= 64)
+BASE_REWARD_FACTOR: 64
+# 2**9 (= 512)
+WHISTLEBLOWER_REWARD_QUOTIENT: 512
+# 2**3 (= 8)
+PROPOSER_REWARD_QUOTIENT: 8
+# 2**25 (= 33,554,432)
+INACTIVITY_PENALTY_QUOTIENT: 33554432
+# 2**5 (= 32)
+MIN_SLASHING_PENALTY_QUOTIENT: 32
+
+
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**4 (= 16)
+MAX_PROPOSER_SLASHINGS: 16
+# 2**0 (= 1)
+MAX_ATTESTER_SLASHINGS: 1
+# 2**7 (= 128)
+MAX_ATTESTATIONS: 128
+# 2**4 (= 16)
+MAX_DEPOSITS: 16
+# 2**4 (= 16)
+MAX_VOLUNTARY_EXITS: 16
+
+
+# Signature domains
+# ---------------------------------------------------------------
+DOMAIN_BEACON_PROPOSER: 0x00000000
+DOMAIN_BEACON_ATTESTER: 0x01000000
+DOMAIN_RANDAO: 0x02000000
+DOMAIN_DEPOSIT: 0x03000000
+DOMAIN_VOLUNTARY_EXIT: 0x04000000
+DOMAIN_CUSTODY_BIT_CHALLENGE: 0x06000000
+DOMAIN_SHARD_PROPOSER: 0x80000000
+DOMAIN_SHARD_ATTESTER: 0x81000000

--- a/util/src/main/resources/tech/pegasys/artemis/util/config/minimal.yaml
+++ b/util/src/main/resources/tech/pegasys/artemis/util/config/minimal.yaml
@@ -1,0 +1,150 @@
+# Minimal preset
+
+
+# Misc
+# ---------------------------------------------------------------
+
+# [customized] Just 4 committees for slot for testing purposes
+MAX_COMMITTEES_PER_SLOT: 4
+# [customized] unsecure, but fast
+TARGET_COMMITTEE_SIZE: 4
+# 2**11 (= 2,048)
+MAX_VALIDATORS_PER_COMMITTEE: 2048
+# 2**2 (= 4)
+MIN_PER_EPOCH_CHURN_LIMIT: 4
+# 2**16 (= 65,536)
+CHURN_LIMIT_QUOTIENT: 65536
+# [customized] Faster, but unsecure.
+SHUFFLE_ROUND_COUNT: 10
+# [customized]
+MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 64
+# Jan 3, 2020
+MIN_GENESIS_TIME: 1578009600
+
+#
+#
+# Fork Choice
+# ---------------------------------------------------------------
+# 2**1 (= 1)
+SAFE_SLOTS_TO_UPDATE_JUSTIFIED: 2
+
+#
+# Validator
+# ---------------------------------------------------------------
+# [customized] process deposits more quickly, but insecure
+ETH1_FOLLOW_DISTANCE: 16
+# 2**4 (= 16)
+TARGET_AGGREGATORS_PER_COMMITTEE: 16
+# 2**0 (= 1)
+RANDOM_SUBNETS_PER_VALIDATOR: 1
+# 2**8 (= 256)
+EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION: 256
+
+
+# Deposit contract
+# ---------------------------------------------------------------
+# **TBD**
+DEPOSIT_CONTRACT_ADDRESS: 0x1234567890123456789012345678901234567890
+
+
+# Gwei values
+# ---------------------------------------------------------------
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
+MIN_DEPOSIT_AMOUNT: 1000000000
+# 2**5 * 10**9 (= 32,000,000,000) Gwei
+MAX_EFFECTIVE_BALANCE: 32000000000
+# 2**4 * 10**9 (= 16,000,000,000) Gwei
+EJECTION_BALANCE: 16000000000
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
+EFFECTIVE_BALANCE_INCREMENT: 1000000000
+
+
+# Initial values
+# ---------------------------------------------------------------
+# 0, GENESIS_EPOCH is derived from this constant
+GENESIS_SLOT: 0
+BLS_WITHDRAWAL_PREFIX: 0x00
+
+
+# Time parameters
+# ---------------------------------------------------------------
+# [customized] Faster for testing purposes
+SECONDS_PER_SLOT: 6
+# 2**0 (= 1) slots 6 seconds
+MIN_ATTESTATION_INCLUSION_DELAY: 1
+# [customized] fast epochs
+SLOTS_PER_EPOCH: 8
+# 2**0 (= 1) epochs
+MIN_SEED_LOOKAHEAD: 1
+# 2**2 (= 4) epochs
+MAX_SEED_LOOKAHEAD: 4
+# [customized] higher frequency new deposits from eth1 for testing
+SLOTS_PER_ETH1_VOTING_PERIOD: 16
+# [customized] smaller state
+SLOTS_PER_HISTORICAL_ROOT: 64
+# 2**8 (= 256) epochs
+MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256
+# 2**11 (= 2,048) epochs
+PERSISTENT_COMMITTEE_PERIOD: 2048
+# [customized] fast catchup crosslinks
+MAX_EPOCHS_PER_CROSSLINK: 4
+# 2**2 (= 4) epochs
+MIN_EPOCHS_TO_INACTIVITY_PENALTY: 4
+# [customized] 2**12 (= 4,096) epochs
+EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS: 4096
+# 2**2 (= 4) epochs
+EPOCHS_PER_CUSTODY_PERIOD: 4
+# 2**2 (= 4) epochs
+CUSTODY_PERIOD_TO_RANDAO_PADDING: 4
+
+
+# State vector lengths
+# ---------------------------------------------------------------
+# [customized] smaller state
+EPOCHS_PER_HISTORICAL_VECTOR: 64
+# [customized] smaller state
+EPOCHS_PER_SLASHINGS_VECTOR: 64
+# 2**24 (= 16,777,216) historical roots
+HISTORICAL_ROOTS_LIMIT: 16777216
+# 2**40 (= 1,099,511,627,776) validator spots
+VALIDATOR_REGISTRY_LIMIT: 1099511627776
+
+
+# Reward and penalty quotients
+# ---------------------------------------------------------------
+# 2**6 (= 64)
+BASE_REWARD_FACTOR: 64
+# 2**9 (= 512)
+WHISTLEBLOWER_REWARD_QUOTIENT: 512
+# 2**3 (= 8)
+PROPOSER_REWARD_QUOTIENT: 8
+# 2**25 (= 33,554,432)
+INACTIVITY_PENALTY_QUOTIENT: 33554432
+# 2**5 (= 32)
+MIN_SLASHING_PENALTY_QUOTIENT: 32
+
+
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**4 (= 16)
+MAX_PROPOSER_SLASHINGS: 16
+# 2**0 (= 1)
+MAX_ATTESTER_SLASHINGS: 1
+# 2**7 (= 128)
+MAX_ATTESTATIONS: 128
+# 2**4 (= 16)
+MAX_DEPOSITS: 16
+# 2**4 (= 16)
+MAX_VOLUNTARY_EXITS: 16
+
+
+# Signature domains
+# ---------------------------------------------------------------
+DOMAIN_BEACON_PROPOSER: 0x00000000
+DOMAIN_BEACON_ATTESTER: 0x01000000
+DOMAIN_RANDAO: 0x02000000
+DOMAIN_DEPOSIT: 0x03000000
+DOMAIN_VOLUNTARY_EXIT: 0x04000000
+DOMAIN_CUSTODY_BIT_CHALLENGE: 0x06000000
+DOMAIN_SHARD_PROPOSER: 0x80000000
+DOMAIN_SHARD_ATTESTER: 0x81000000

--- a/util/src/test/java/tech/pegasys/artemis/util/config/ArtemisConfigurationTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/config/ArtemisConfigurationTest.java
@@ -16,9 +16,15 @@ package tech.pegasys.artemis.util.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 final class ArtemisConfigurationTest {
+
+  @AfterEach
+  public void tearDown() {
+    Constants.setConstants("minimal");
+  }
 
   @Test
   void validMinimum() {

--- a/util/src/test/java/tech/pegasys/artemis/util/config/ConstantsReaderTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/config/ConstantsReaderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.util.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class ConstantsReaderTest {
+
+  @AfterEach
+  public void tearDown() {
+    Constants.setConstants("minimal");
+  }
+
+  @Test
+  public void shouldLoadConstants() throws Exception {
+    final String config =
+        "MAX_COMMITTEES_PER_SLOT: 68\n" + "# 2**7 (= 128)\n" + "TARGET_COMMITTEE_SIZE: 129";
+    ConstantsReader.loadConstantsFrom(
+        new ByteArrayInputStream(config.getBytes(StandardCharsets.UTF_8)));
+
+    // Sanity check a couple of values
+    assertThat(Constants.MAX_COMMITTEES_PER_SLOT).isEqualTo(68);
+    assertThat(Constants.TARGET_COMMITTEE_SIZE).isEqualTo(129);
+  }
+
+  @Test
+  public void shouldLoadMainnetConstants() {
+    Constants.setConstants("mainnet");
+
+    // Sanity check a couple of values
+    assertThat(Constants.MAX_COMMITTEES_PER_SLOT).isEqualTo(64);
+    assertThat(Constants.TARGET_COMMITTEE_SIZE).isEqualTo(128);
+  }
+
+  @Test
+  public void shouldLoadMinimalConstants() {
+    Constants.setConstants("minimal");
+
+    assertThat(Constants.MAX_COMMITTEES_PER_SLOT).isEqualTo(4);
+    assertThat(Constants.TARGET_COMMITTEE_SIZE).isEqualTo(4);
+  }
+
+  @Test
+  public void shouldLoadFromUrl() {
+    Constants.setConstants(
+        "https://github.com/eth2-clients/eth2-testnets/raw/master/prysm/Sapphire(v0.9.4)/config.yaml");
+    assertThat(Constants.TARGET_COMMITTEE_SIZE).isEqualTo(128);
+    assertThat(Constants.JUSTIFICATION_BITS_LENGTH).isEqualTo(4);
+  }
+}


### PR DESCRIPTION
## PR Description
* Make genesis fork version a constant. This is essentially a backport from v0.10 to make it easier to setup testnet configs that don't use 0 as the fork version.
* Support loading constants definitions from presets (mainnet or minimal), a YAML file or a URL.

For example to run the Prysm sapphire testnet use the config:
```
constants = https://github.com/eth2-clients/eth2-testnets/raw/master/prysm/Sapphire(v0.9.4)/config.yaml
```