### PR TITLE
Modify BeaconBlocksByRange to treat count as the number of slots to check

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -108,7 +108,9 @@ public class BeaconBlocksByRangeMessageHandler
         final ResponseCallback<SignedBeaconBlock> callback) {
       this.headBlockRoot = message.getHeadBlockRoot();
       this.currentSlot = message.getStartSlot();
-      this.remainingBlocks = message.getCount();
+      // Minus 1 to account for sending the block at startSlot.
+      // We only decrement this when moving to the next slot but we're already at the first slot
+      this.remainingBlocks = message.getCount().minus(ONE);
       this.step = message.getStep();
       this.headSlot = headSlot;
       this.callback = callback;
@@ -127,11 +129,11 @@ public class BeaconBlocksByRangeMessageHandler
     }
 
     void sendBlock(final SignedBeaconBlock block) {
-      remainingBlocks = remainingBlocks.minus(ONE);
       callback.respond(block);
     }
 
     void incrementCurrentSlot() {
+      remainingBlocks = remainingBlocks.minus(ONE);
       currentSlot = currentSlot.plus(step);
     }
   }


### PR DESCRIPTION
## PR Description
Change the behaviour of our BeaconBlocksByRange responses when there are skipped slots so that the skipped slot is counted.  Thus if we have blocks in slots 1, 2, 3, 5, 6 (skipping 4) and get a request start=1, count=5, skip=1 we'll return 1, 2, 3, 5 (we checked for blocks in 5 slots and found 4). Previously we would have return 1, 2, 3, 5, 6 (we continued searching until we found 5 blocks to return, regardless of how many slots we had to check).