### PR TITLE
Remove validator_test_data.json and git-lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,6 @@
 *.bat -text
 *.pcap binary
 *.blocks binary
-validator_test_data.json filter=lfs diff=lfs merge=lfs -text
 *.dylib binary
 *.so binary
 *.gz binary

--- a/validator_test_data.json
+++ b/validator_test_data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e5b269d986e7fdd40f2d2dadca06313199cef1cf4e09c11628e9bf494ab98906
-size 72614072


### PR DESCRIPTION
## PR Description
Git LFS makes life difficult people when checking out the repo resulting in various obscure errors. The only file we use git-lfs for is validator_test_data.json which is rarely actually needed.  Arguably we should remove the simulation deposit mode entirely as it's actually easier to run a real ETH1 chain and send deposits to it these days.