### PR TITLE
Fix compilation on JDK 13

### DIFF
--- a/util/src/main/java/tech/pegasys/artemis/util/async/SafeFuture.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/async/SafeFuture.java
@@ -133,9 +133,9 @@ public class SafeFuture<T> extends CompletableFuture<T> {
    * @param errorHandler the function returning a new CompletionStage
    * @return the SafeFuture
    */
-  @SuppressWarnings("FutureReturnValueIgnored")
+  @SuppressWarnings({"FutureReturnValueIgnored", "MissingOverride"})
   public SafeFuture<T> exceptionallyCompose(
-      final Function<Throwable, CompletionStage<T>> errorHandler) {
+      final Function<Throwable, ? extends CompletionStage<T>> errorHandler) {
     final SafeFuture<T> result = new SafeFuture<>();
     whenComplete(
         (value, error) -> {


### PR DESCRIPTION
## PR Description
JDK 13 added a new `exceptionallyCompose` method to `CompatibleFuture` with a slightly different API (more forgiving of subclasses).  Fix `SafeFuture` to use the same API so the method is available on any JDK without conflicting.