### PR TITLE
Add disk querying to beacon/block rest API

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApi.java
@@ -15,6 +15,7 @@ package tech.pegasys.artemis.beaconrestapi;
 
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
+import com.google.common.eventbus.EventBus;
 import io.javalin.Javalin;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +42,7 @@ public class BeaconRestApi {
   public BeaconRestApi(
       ChainStorageClient chainStorageClient,
       P2PNetwork<?> p2pNetwork,
+      EventBus eventBus,
       final int requestedPortNumber) {
     app = Javalin.create();
     app.server().setServerPort(requestedPortNumber);
@@ -48,7 +50,7 @@ public class BeaconRestApi {
     handlers.add(new GenesisTimeHandler(chainStorageClient));
     handlers.add(new BeaconHeadHandler(chainStorageClient));
     handlers.add(new BeaconChainHeadHandler(chainStorageClient));
-    handlers.add(new BeaconBlockHandler(chainStorageClient));
+    handlers.add(new BeaconBlockHandler(chainStorageClient, eventBus));
     handlers.add(new BeaconStateHandler(chainStorageClient));
     handlers.add(new FinalizedCheckpointHandler(chainStorageClient));
     handlers.add(new PeerIdHandler(p2pNetwork));

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApi.java
@@ -15,7 +15,6 @@ package tech.pegasys.artemis.beaconrestapi;
 
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
-import com.google.common.eventbus.EventBus;
 import io.javalin.Javalin;
 import java.util.ArrayList;
 import java.util.List;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApi.java
@@ -33,6 +33,7 @@ import tech.pegasys.artemis.beaconrestapi.networkhandlers.PeersHandler;
 import tech.pegasys.artemis.networking.p2p.network.P2PNetwork;
 import tech.pegasys.artemis.provider.JsonProvider;
 import tech.pegasys.artemis.storage.ChainStorageClient;
+import tech.pegasys.artemis.storage.HistoricalChainData;
 
 public class BeaconRestApi {
 
@@ -42,7 +43,7 @@ public class BeaconRestApi {
   public BeaconRestApi(
       ChainStorageClient chainStorageClient,
       P2PNetwork<?> p2pNetwork,
-      EventBus eventBus,
+      HistoricalChainData historicalChainData,
       final int requestedPortNumber) {
     app = Javalin.create();
     app.server().setServerPort(requestedPortNumber);
@@ -50,7 +51,7 @@ public class BeaconRestApi {
     handlers.add(new GenesisTimeHandler(chainStorageClient));
     handlers.add(new BeaconHeadHandler(chainStorageClient));
     handlers.add(new BeaconChainHeadHandler(chainStorageClient));
-    handlers.add(new BeaconBlockHandler(chainStorageClient, eventBus));
+    handlers.add(new BeaconBlockHandler(chainStorageClient, historicalChainData));
     handlers.add(new BeaconStateHandler(chainStorageClient));
     handlers.add(new FinalizedCheckpointHandler(chainStorageClient));
     handlers.add(new PeerIdHandler(p2pNetwork));

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconBlockHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconBlockHandler.java
@@ -16,13 +16,10 @@ package tech.pegasys.artemis.beaconrestapi.beaconhandlers;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.eventbus.EventBus;
 import com.google.common.primitives.UnsignedLong;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.artemis.beaconrestapi.handlerinterfaces.BeaconRestApiHandler;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
@@ -63,16 +60,18 @@ public class BeaconBlockHandler implements BeaconRestApiHandler {
     }
 
     return getBlockBySlot(slot)
-            .map(block -> ImmutableMap.of("block", block, "blockRoot", block.hash_tree_root()))
-            .orElse(null);
+        .map(block -> ImmutableMap.of("block", block, "blockRoot", block.hash_tree_root()))
+        .orElse(null);
   }
 
   private Optional<BeaconBlock> getBlockBySlot(UnsignedLong slot) {
-    return client.getBlockRootBySlot(slot)
-            .map(root -> client.getStore().getBlock(root))
-            .or(() -> {
+    return client
+        .getBlockRootBySlot(slot)
+        .map(root -> client.getStore().getBlock(root))
+        .or(
+            () -> {
               Optional<SignedBeaconBlock> signedBeaconBlock =
-                      historicalChainData.getFinalizedBlockAtSlot(slot).join();
+                  historicalChainData.getFinalizedBlockAtSlot(slot).join();
               return signedBeaconBlock.map(SignedBeaconBlock::getMessage);
             });
   };

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconBlockHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconBlockHandler.java
@@ -60,7 +60,7 @@ public class BeaconBlockHandler implements BeaconRestApiHandler {
     }
 
     return getBlockBySlot(slot)
-        .map(block -> ImmutableMap.of("block", block, "blockRoot", block.hash_tree_root()))
+        .map(block -> ImmutableMap.of("block", block, "blockRoot", block.hash_tree_root().toHexString()))
         .orElse(null);
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconBlockHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconBlockHandler.java
@@ -60,7 +60,9 @@ public class BeaconBlockHandler implements BeaconRestApiHandler {
     }
 
     return getBlockBySlot(slot)
-        .map(block -> ImmutableMap.of("block", block, "blockRoot", block.hash_tree_root().toHexString()))
+        .map(
+            block ->
+                ImmutableMap.of("block", block, "blockRoot", block.hash_tree_root().toHexString()))
         .orElse(null);
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -221,7 +221,8 @@ public class BeaconChainController {
   public void initRestAPI() {
     STDOUT.log(Level.DEBUG, "BeaconChainController.initRestAPI()");
     beaconRestAPI =
-        new BeaconRestApi(chainStorageClient, p2pNetwork, config.getBeaconRestAPIPortNumber());
+        new BeaconRestApi(
+            chainStorageClient, p2pNetwork, eventBus, config.getBeaconRestAPIPortNumber());
   }
 
   public void initSyncManager() {

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -56,6 +56,7 @@ import tech.pegasys.artemis.statetransition.events.BroadcastAttestationEvent;
 import tech.pegasys.artemis.statetransition.genesis.PreGenesisDepositHandler;
 import tech.pegasys.artemis.statetransition.util.StartupUtil;
 import tech.pegasys.artemis.storage.ChainStorageClient;
+import tech.pegasys.artemis.storage.HistoricalChainData;
 import tech.pegasys.artemis.storage.Store;
 import tech.pegasys.artemis.storage.events.NodeStartEvent;
 import tech.pegasys.artemis.storage.events.SlotEvent;
@@ -222,7 +223,10 @@ public class BeaconChainController {
     STDOUT.log(Level.DEBUG, "BeaconChainController.initRestAPI()");
     beaconRestAPI =
         new BeaconRestApi(
-            chainStorageClient, p2pNetwork, eventBus, config.getBeaconRestAPIPortNumber());
+            chainStorageClient,
+            p2pNetwork,
+            new HistoricalChainData(eventBus),
+            config.getBeaconRestAPIPortNumber());
   }
 
   public void initSyncManager() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Previously our beacon/block API was unable to return information on blocks that were pruned from memory but kept on the disk, so this PR fixes that.