### PR TITLE
Implement and test Proto's getProofWithViewBoundary

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/GenesisGenerator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/GenesisGenerator.java
@@ -71,13 +71,10 @@ public class GenesisGenerator {
     // Process deposits
     deposits.forEach(
         deposit -> {
-          if (BeaconStateUtil.DEPOSIT_PROOFS_ENABLED) {
-            calculateDepositProof(deposit);
-          }
           STDOUT.log(Level.DEBUG, "About to process deposit: " + depositDataList.size());
           depositDataList.add(deposit.getData());
 
-          // Skip verifing the merkle proof as we'll only generate one at the end
+          // Skip verifying the merkle proof as these deposits come directly from an Eth1 event.
           // We do still verify the signature
           process_deposit_without_checking_merkle_proof(state, deposit, keyCache);
 
@@ -136,12 +133,6 @@ public class GenesisGenerator {
         .setDeposit_root(
             HashTreeUtil.hash_tree_root(
                 HashTreeUtil.SSZTypes.LIST_OF_COMPOSITE, depositListLength, depositDataList));
-  }
-
-  private void calculateDepositProof(final Deposit deposit) {
-    final Bytes32 value = deposit.getData().hash_tree_root();
-    depositMerkleTree.add(value);
-    deposit.setProof(depositMerkleTree.getProofTreeByValue(value));
   }
 
   private void updateGenesisTime(final UnsignedLong eth1Timestamp) {

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/GenesisGenerator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/GenesisGenerator.java
@@ -44,7 +44,6 @@ import tech.pegasys.artemis.util.bls.BLSPublicKey;
 import tech.pegasys.artemis.util.hashtree.HashTreeUtil;
 
 public class GenesisGenerator {
-  private final MerkleTree depositMerkleTree = new OptimizedMerkleTree(DEPOSIT_CONTRACT_TREE_DEPTH);
   private final BeaconState state = new BeaconState();
   private final Map<BLSPublicKey, Integer> keyCache = new HashMap<>();
   private final long depositListLength = ((long) 1) << DEPOSIT_CONTRACT_TREE_DEPTH;

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/MerkleTree.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/MerkleTree.java
@@ -52,12 +52,12 @@ public abstract class MerkleTree {
     return zeroHashes;
   }
 
-  public SSZVector<Bytes32> getProofTreeByValue(Bytes32 value) {
+  public SSZVector<Bytes32> getProof(Bytes32 value) {
     int index = tree.get(0).indexOf(value);
-    return getProofTreeByIndex(index);
+    return getProof(index);
   }
 
-  public SSZVector<Bytes32> getProofTreeByIndex(int index) {
+  public SSZVector<Bytes32> getProof(int index) {
     List<Bytes32> proof = new ArrayList<>();
     for (int i = 0; i < treeDepth; i++) {
       index = index % 2 == 1 ? index - 1 : index + 1;

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/MerkleTree.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/MerkleTree.java
@@ -23,7 +23,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.Hash;
 import tech.pegasys.artemis.util.SSZTypes.SSZVector;
 
-abstract class MerkleTree {
+public abstract class MerkleTree {
   protected final List<List<Bytes32>> tree;
   protected final List<Bytes32> zeroHashes;
   protected final int treeDepth;
@@ -38,17 +38,16 @@ abstract class MerkleTree {
     zeroHashes = generateZeroHashes(treeDepth);
   }
 
-  abstract void add(Bytes32 leaf);
+  public abstract void add(Bytes32 leaf);
 
-  protected abstract int getNumberOfLeaves();
+  public abstract int getNumberOfLeaves();
 
   protected static List<Bytes32> generateZeroHashes(int height) {
     List<Bytes32> zeroHashes = new ArrayList<>();
-    for (int i = 0; i < height; i++) {
-      zeroHashes.add(Bytes32.ZERO);
-    }
-    for (int i = 0; i < height - 1; i++) {
-      zeroHashes.set(i + 1, Hash.sha2_256(Bytes.concatenate(zeroHashes.get(i), zeroHashes.get(i))));
+    zeroHashes.add(Bytes32.ZERO);
+    for (int i = 1; i < height; i++) {
+      zeroHashes.add(
+          i, Hash.sha2_256(Bytes.concatenate(zeroHashes.get(i - 1), zeroHashes.get(i - 1))));
     }
     return zeroHashes;
   }
@@ -62,21 +61,87 @@ abstract class MerkleTree {
     List<Bytes32> proof = new ArrayList<>();
     for (int i = 0; i < treeDepth; i++) {
       index = index % 2 == 1 ? index - 1 : index + 1;
-      if (index < tree.get(i).size()) proof.add(tree.get(i).get(index));
-      else proof.add(zeroHashes.get(i));
+      if (index < tree.get(i).size()) {
+        proof.add(tree.get(i).get(index));
+      } else {
+        proof.add(zeroHashes.get(i));
+      }
       index /= 2;
     }
     proof.add(calcMixInValue());
     return new SSZVector<>(proof, Bytes32.class);
   }
 
-  private Bytes32 calcMixInValue() {
+  private Bytes32 calcViewBoundaryRoot(int depth, int viewLimit) {
+    if (depth == 0) {
+      return zeroHashes.get(0);
+    }
+    depth -= 1;
+    Bytes32 deeperRoot = calcViewBoundaryRoot(depth, viewLimit);
+    if ((viewLimit & (1 << depth)) != 0) {
+      return Hash.sha2_256(Bytes.concatenate(tree.get(depth).get(viewLimit >> depth), deeperRoot));
+    } else {
+      return Hash.sha2_256(Bytes.concatenate(deeperRoot, zeroHashes.get(depth)));
+    }
+  }
+
+  public SSZVector<Bytes32> getProofWithViewBoundary(Bytes32 value, int viewLimit) {
+    return getProofWithViewBoundary(tree.get(0).indexOf(value), viewLimit);
+  }
+
+  public SSZVector<Bytes32> getProofWithViewBoundary(int index, int viewLimit) {
+    checkArgument(index < viewLimit, "MerkleTree: Index must be within view limit");
+
+    List<Bytes32> proof = new ArrayList<>();
+    for (int i = 0; i < treeDepth; i++) {
+      // Get index of sibling node
+      index = index % 2 == 1 ? index - 1 : index + 1;
+
+      // Check how much of the tree at this level is strictly within the view limit.
+      int limit = viewLimit >> i;
+
+      checkArgument(
+          limit <= tree.get(i).size(), "MerkleTree: Tree is too small for given limit at height");
+
+      // If the index (sibling node to be put in the proof) is equal to the limit,
+      if (index == limit) {
+        // At:
+        // Go deeper to partially merkleize in zero-hashes.
+        proof.add(calcViewBoundaryRoot(i, viewLimit));
+      } else if (index > limit) {
+        // Beyond:
+        // Just use a zero-hash as effective sibling.
+        proof.add(zeroHashes.get(i));
+      } else {
+        // Within:
+        // Return the tree node as-is without modifications
+        proof.add(tree.get(i).get(index));
+      }
+      index /= 2;
+    }
+    proof.add(calcMixInValue(viewLimit));
+    return new SSZVector<>(proof, Bytes32.class);
+  }
+
+  private Bytes32 calcMixInValue(int viewLimit) {
     return (Bytes32)
-        Bytes.concatenate(
-            Bytes.ofUnsignedLong(getNumberOfLeaves(), LITTLE_ENDIAN), Bytes.wrap(new byte[24]));
+        Bytes.concatenate(Bytes.ofUnsignedLong(viewLimit, LITTLE_ENDIAN), Bytes.wrap(new byte[24]));
+  }
+
+  private Bytes32 calcMixInValue() {
+    return calcMixInValue(getNumberOfLeaves());
   }
 
   public Bytes32 getRoot() {
-    return tree.get(treeDepth).get(0);
+    return Hash.sha2_256(Bytes.concatenate(tree.get(treeDepth).get(0), calcMixInValue()));
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder returnString = new StringBuilder();
+    for (int i = treeDepth; i >= 0; i--) {
+      returnString.append("\n").append(tree.get(i));
+    }
+    return "MerkleTree{" + "tree=" + returnString + ", treeDepth=" + treeDepth + '}';
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/OptimizedMerkleTree.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/OptimizedMerkleTree.java
@@ -56,7 +56,7 @@ public class OptimizedMerkleTree extends MerkleTree {
   }
 
   @Override
-  protected int getNumberOfLeaves() {
+  public int getNumberOfLeaves() {
     int lastLeafIndex = tree.get(0).size() - 1;
     if (tree.get(0).get(lastLeafIndex).equals(Bytes32.ZERO)) {
       return tree.get(0).size() - 1;

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/SimpleMerkleTree.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/SimpleMerkleTree.java
@@ -48,7 +48,7 @@ public class SimpleMerkleTree extends MerkleTree {
   }
 
   @Override
-  protected int getNumberOfLeaves() {
+  public int getNumberOfLeaves() {
     return tree.get(0).size();
   }
 
@@ -56,6 +56,18 @@ public class SimpleMerkleTree extends MerkleTree {
   public SSZVector<Bytes32> getProofTreeByIndex(int index) {
     if (dirty) calcBranches();
     return super.getProofTreeByIndex(index);
+  }
+
+  @Override
+  public SSZVector<Bytes32> getProofWithViewBoundary(Bytes32 leaf, int viewLimit) {
+    if (dirty) calcBranches();
+    return super.getProofWithViewBoundary(leaf, viewLimit);
+  }
+
+  @Override
+  public SSZVector<Bytes32> getProofWithViewBoundary(int index, int viewLimit) {
+    if (dirty) calcBranches();
+    return super.getProofWithViewBoundary(index, viewLimit);
   }
 
   @Override

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/SimpleMerkleTree.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/SimpleMerkleTree.java
@@ -53,9 +53,9 @@ public class SimpleMerkleTree extends MerkleTree {
   }
 
   @Override
-  public SSZVector<Bytes32> getProofTreeByIndex(int index) {
+  public SSZVector<Bytes32> getProof(int index) {
     if (dirty) calcBranches();
-    return super.getProofTreeByIndex(index);
+    return super.getProof(index);
   }
 
   @Override

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/merkletree/MerkleTreeTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/merkletree/MerkleTreeTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.merkletree;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.is_valid_merkle_branch;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
+import tech.pegasys.artemis.datastructures.util.MerkleTree;
+import tech.pegasys.artemis.datastructures.util.OptimizedMerkleTree;
+import tech.pegasys.artemis.datastructures.util.SimpleMerkleTree;
+
+public class MerkleTreeTest {
+
+  private MerkleTree merkleTree1;
+  private MerkleTree merkleTree2;
+  private final int treeDepth = 32;
+  private int seed = 0;
+  private int numDeposits = 1000;
+
+  private final List<Bytes32> leaves =
+      IntStream.range(0, numDeposits)
+          .mapToObj(i -> DataStructureUtil.randomBytes32(++seed))
+          .collect(Collectors.toList());
+
+  @Test
+  void ifProofsMerkleValidSimpleTree() {
+    merkleTree1 = new SimpleMerkleTree(treeDepth);
+
+    for (int index = 0; index < numDeposits; index++) {
+      Bytes32 leaf = leaves.get(index);
+      merkleTree1.add(leaf);
+      Bytes32 root = merkleTree1.getRoot();
+
+      assertThat(
+              is_valid_merkle_branch(
+                  leaf,
+                  merkleTree1.getProofTreeByValue(leaf),
+                  treeDepth + 1, // Add 1 for the `List` length mix-in
+                  index,
+                  root))
+          .isTrue();
+    }
+  }
+
+  @Test
+  void ifProofsMerkleValidOptimizedTree() {
+    merkleTree1 = new OptimizedMerkleTree(treeDepth);
+
+    for (int index = 0; index < numDeposits; index++) {
+      Bytes32 leaf = leaves.get(index);
+      merkleTree1.add(leaf);
+      Bytes32 root = merkleTree1.getRoot();
+
+      assertThat(
+              is_valid_merkle_branch(
+                  leaf,
+                  merkleTree1.getProofTreeByValue(leaf),
+                  treeDepth + 1, // Add 1 for the `List` length mix-in
+                  index,
+                  root))
+          .isTrue();
+    }
+  }
+
+  @Test
+  void ifProofsWithViewBoundaryIsMerkleValidBranchSimpleTree() {
+    merkleTree1 = new SimpleMerkleTree(treeDepth);
+    merkleTree2 = new SimpleMerkleTree(treeDepth);
+
+    for (int i = 0; i < numDeposits; i++) {
+      merkleTree2.add(leaves.get(i));
+    }
+
+    for (int index = 0; index < numDeposits - 1; index++) {
+      Bytes32 leaf = leaves.get(index);
+      merkleTree1.add(leaf);
+      Bytes32 root = merkleTree1.getRoot();
+
+      assertThat(
+              is_valid_merkle_branch(
+                  leaf,
+                  merkleTree2.getProofWithViewBoundary(leaf, index + 1),
+                  treeDepth + 1, // Add 1 for the `List` length mix-in
+                  index,
+                  root))
+          .isTrue();
+    }
+  }
+
+  @Test
+  void ifProofsWithViewBoundaryIsMerkleValidBranchOptimizedTree() {
+    merkleTree1 = new OptimizedMerkleTree(treeDepth);
+    merkleTree2 = new OptimizedMerkleTree(treeDepth);
+
+    for (int i = 0; i < numDeposits; i++) {
+      merkleTree2.add(leaves.get(i));
+    }
+
+    for (int index = 0; index < numDeposits - 1; index++) {
+      Bytes32 leaf = leaves.get(index);
+      merkleTree1.add(leaf);
+      Bytes32 root = merkleTree1.getRoot();
+
+      assertThat(
+              is_valid_merkle_branch(
+                  leaf,
+                  merkleTree2.getProofWithViewBoundary(leaf, index + 1),
+                  treeDepth + 1, // Add 1 for the `List` length mix-in
+                  index,
+                  root))
+          .isTrue();
+    }
+  }
+}

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/merkletree/MerkleTreeTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/merkletree/MerkleTreeTest.java
@@ -96,7 +96,7 @@ public class MerkleTreeTest {
       assertThat(
               is_valid_merkle_branch(
                   leaf,
-                  merkleTree2.getProofWithViewBoundary(leaf, index + 1),
+                  merkleTree2.getProofWithViewBoundary(leaf, index),
                   treeDepth + 1, // Add 1 for the `List` length mix-in
                   index,
                   root))
@@ -121,7 +121,7 @@ public class MerkleTreeTest {
       assertThat(
               is_valid_merkle_branch(
                   leaf,
-                  merkleTree2.getProofWithViewBoundary(leaf, index + 1),
+                  merkleTree2.getProofWithViewBoundary(leaf, index),
                   treeDepth + 1, // Add 1 for the `List` length mix-in
                   index,
                   root))

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/merkletree/MerkleTreeTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/merkletree/MerkleTreeTest.java
@@ -40,7 +40,7 @@ public class MerkleTreeTest {
           .collect(Collectors.toList());
 
   @Test
-  void ifProofsMerkleValidSimpleTree() {
+  void ProofSimpleTree() {
     merkleTree1 = new SimpleMerkleTree(treeDepth);
 
     for (int index = 0; index < numDeposits; index++) {
@@ -51,7 +51,7 @@ public class MerkleTreeTest {
       assertThat(
               is_valid_merkle_branch(
                   leaf,
-                  merkleTree1.getProofTreeByValue(leaf),
+                  merkleTree1.getProof(leaf),
                   treeDepth + 1, // Add 1 for the `List` length mix-in
                   index,
                   root))
@@ -60,7 +60,7 @@ public class MerkleTreeTest {
   }
 
   @Test
-  void ifProofsMerkleValidOptimizedTree() {
+  void ProofOptimizedTree() {
     merkleTree1 = new OptimizedMerkleTree(treeDepth);
 
     for (int index = 0; index < numDeposits; index++) {
@@ -71,7 +71,7 @@ public class MerkleTreeTest {
       assertThat(
               is_valid_merkle_branch(
                   leaf,
-                  merkleTree1.getProofTreeByValue(leaf),
+                  merkleTree1.getProof(leaf),
                   treeDepth + 1, // Add 1 for the `List` length mix-in
                   index,
                   root))
@@ -80,7 +80,7 @@ public class MerkleTreeTest {
   }
 
   @Test
-  void ifProofsWithViewBoundaryIsMerkleValidBranchSimpleTree() {
+  void ProofsWithViewBoundarySimpleTree() {
     merkleTree1 = new SimpleMerkleTree(treeDepth);
     merkleTree2 = new SimpleMerkleTree(treeDepth);
 
@@ -105,7 +105,7 @@ public class MerkleTreeTest {
   }
 
   @Test
-  void ifProofsWithViewBoundaryIsMerkleValidBranchOptimizedTree() {
+  void ProofsWithViewBoundaryOptimizedTree() {
     merkleTree1 = new OptimizedMerkleTree(treeDepth);
     merkleTree2 = new OptimizedMerkleTree(treeDepth);
 

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/merkletree/OptimizedMerkleTreeTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/merkletree/OptimizedMerkleTreeTest.java
@@ -44,7 +44,7 @@ public class OptimizedMerkleTreeTest {
     Bytes32 leaf = DataStructureUtil.randomBytes32(seed);
     optimizedMT.add(leaf);
     simpleMT.add(leaf);
-    assertThat(optimizedMT.getProofTreeByValue(leaf)).isEqualTo(simpleMT.getProofTreeByValue(leaf));
+    assertThat(optimizedMT.getProof(leaf)).isEqualTo(simpleMT.getProof(leaf));
   }
 
   @Test
@@ -64,8 +64,6 @@ public class OptimizedMerkleTreeTest {
             .collect(Collectors.toList());
 
     leaves.forEach(
-        (leaf) ->
-            assertThat(optimizedMT.getProofTreeByValue(leaf))
-                .isEqualTo(simpleMT.getProofTreeByValue(leaf)));
+        (leaf) -> assertThat(optimizedMT.getProof(leaf)).isEqualTo(simpleMT.getProof(leaf)));
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/GenesisGeneratorTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/GenesisGeneratorTest.java
@@ -121,9 +121,6 @@ class GenesisGeneratorTest {
     genesisGenerator.addDepositsFromBlock(Bytes32.ZERO, UnsignedLong.ZERO, INITIAL_DEPOSITS);
     final BeaconStateWithCache state = genesisGenerator.getGenesisState();
 
-    // All deposits should have a proof
-    INITIAL_DEPOSITS.forEach(deposit -> assertThat(deposit.getProof()).isNotEmpty());
-
     // All deposits should have been added into the state
     assertThat(state.getEth1_deposit_index())
         .isEqualTo(UnsignedLong.valueOf(INITIAL_DEPOSITS.size()));

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/GenesisGeneratorTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/GenesisGeneratorTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.artemis.datastructures.util;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.is_valid_merkle_branch;
 import static tech.pegasys.artemis.datastructures.util.ValidatorsUtil.get_active_validator_indices;
 import static tech.pegasys.artemis.datastructures.util.ValidatorsUtil.is_active_validator;
 
@@ -114,29 +113,6 @@ class GenesisGeneratorTest {
     // And caching should be enabled on the final generated state.
     assertThat(BeaconStateWithCache.getTransitionCaches(state.get()))
         .isNotSameAs(TransitionCaches.getNoOp());
-  }
-
-  @Test
-  public void shouldGenerateValidDepositRoot() {
-    genesisGenerator.addDepositsFromBlock(Bytes32.ZERO, UnsignedLong.ZERO, INITIAL_DEPOSITS);
-    final BeaconStateWithCache state = genesisGenerator.getGenesisState();
-
-    // All deposits should have been added into the state
-    assertThat(state.getEth1_deposit_index())
-        .isEqualTo(UnsignedLong.valueOf(INITIAL_DEPOSITS.size()));
-
-    // The deposit root is only generated for the last deposit so that's the only one we can
-    // actually check
-    final Deposit deposit = INITIAL_DEPOSITS.get(INITIAL_DEPOSITS.size() - 1);
-    final boolean isProofValid =
-        is_valid_merkle_branch(
-            deposit.getData().hash_tree_root(),
-            deposit.getProof(),
-            Constants.DEPOSIT_CONTRACT_TREE_DEPTH + 1, // Add 1 for the `List` length mix-in
-            // -1 because we'd normally check this before incrementing the deposit index
-            INITIAL_DEPOSITS.size() - 1,
-            state.getEth1_data().getDeposit_root());
-    assertThat(isProofValid).isTrue();
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
- Implements @protolambda's `getProofWithViewBoundary` algorithm so that we can look up the proofs of deposits back in time. 
- Fixes the `getRoot` method of `MerkleTree` so that it returns the root hashed with the length mix-in.
- Adds tests for proof returning methods of `MerkleTree`. 
- Skips adding proofs to deposits during genesis creation since they don't get checked (and these deposits are produced from Eth1 events).

Thanks, @protolambda: https://github.com/PegaSysEng/artemis/pull/1127#issuecomment-583783914
