### PR TITLE
Throw error when Eth1Node cache is stale

### DIFF
--- a/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListener.java
+++ b/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListener.java
@@ -91,9 +91,9 @@ public class DepositContractListener {
                 String value = ethCall.getValue();
                 if (value == null) {
                   throw new Eth1RequestException(
-                      "Eth1 call on state of block number "
+                      "Eth1 call has failed: data at block number "
                           + blockHeight
-                          + " seems to be outdated on the node cache.");
+                          + " is unavailable.");
                 }
                 return value;
               }

--- a/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListener.java
+++ b/pow/src/main/java/tech/pegasys/artemis/pow/DepositContractListener.java
@@ -88,7 +88,14 @@ public class DepositContractListener {
                 throw new Eth1RequestException(
                     "Eth1 call has failed:" + ethCall.getError().getMessage());
               } else {
-                return ethCall.getValue();
+                String value = ethCall.getValue();
+                if (value == null) {
+                  throw new Eth1RequestException(
+                      "Eth1 call on state of block number "
+                          + blockHeight
+                          + " seems to be outdated on the node cache.");
+                }
+                return value;
               }
             });
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Throws descriptive error to report when Eth1 Node's archival cache is not big enough to serve our needs in filling the Eth1DataCache. For example with the new defaults, a Besu node will have an archival cache of about 4.5 hours whereas we need 8 hours of past information to correctly provide Eth1Data to beacon chain.  

https://pegasys1.atlassian.net/browse/BC-266