### PR TITLE
Ensure Eth1DataCache and ValidatorCoordinator process slots in sync

### DIFF
--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/Eth1DataCache.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/Eth1DataCache.java
@@ -73,7 +73,7 @@ public class Eth1DataCache {
     prune();
   }
 
-  @Subscribe
+  // Called by ValidatorCoordinator not the event bus to ensure we process slot events in sync
   public void onSlot(SlotEvent slotEvent) {
     if (genesisTime.isEmpty()) {
       return;

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinator.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinator.java
@@ -193,6 +193,7 @@ public class ValidatorCoordinator {
         chainStorageClient.getStore().getBlockState(chainStorageClient.getBestBlockRoot());
     BeaconBlock headBlock =
         chainStorageClient.getStore().getBlock(chainStorageClient.getBestBlockRoot());
+    eth1DataCache.onSlot(slotEvent);
 
     // Copy state so that state transition during block creation
     // does not manipulate headState in storage

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinator.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinator.java
@@ -117,50 +117,6 @@ public class ValidatorCoordinator {
     this.eventBus.register(this);
   }
 
-  /*
-  @Subscribe
-  public void checkIfIncomingBlockObeysSlashingConditions(BeaconBlock block) {
-
-    int proposerIndex =
-        BeaconStateUtil.get_beacon_proposer_index(headState);
-    Validator proposer = headState.getValidator_registry().get(proposerIndex);
-
-    checkArgument(
-        bls_verify(
-            proposer.getPubkey(),
-            block.signing_root("signature"),
-            block.getSignature(),
-            get_domain(
-                headState,
-                Constants.DOMAIN_BEACON_PROPOSER,
-                get_current_epoch(headState))),
-        "Proposer signature is invalid");
-
-    BeaconBlockHeader blockHeader =
-        new BeaconBlockHeader(
-            block.getSlot(),
-            block.getParent_root(),
-            block.getState_root(),
-            block.getBody().hash_tree_root(),
-            block.getSignature());
-    UnsignedLong headerSlot = blockHeader.getSlot();
-    if (store.getBeaconBlockHeaders(proposerIndex).isPresent()) {
-      List<BeaconBlockHeader> headers = store.getBeaconBlockHeaders(proposerIndex).get();
-      headers.forEach(
-          (header) -> {
-            if (header.getSlot().equals(headerSlot)
-                && !header.hash_tree_root().equals(blockHeader.hash_tree_root())
-                && !proposer.isSlashed()) {
-              ProposerSlashing slashing =
-                  new ProposerSlashing(UnsignedLong.valueOf(proposerIndex), blockHeader, header);
-              slashings.add(slashing);
-            }
-          });
-    }
-    this.store.addUnprocessedBlockHeader(proposerIndex, blockHeader);
-  }
-  */
-
   @Subscribe
   public void onStoreInitializedEvent(final StoreInitializedEvent event) {
     // Any deposits pre-genesis can be ignored.

--- a/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/Eth1DataCacheTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/Eth1DataCacheTest.java
@@ -81,12 +81,12 @@ public class Eth1DataCacheTest {
   @Test
   void checkTimeValues() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eventBus.post(new SlotEvent(START_SLOT));
+    eth1DataCache.onSlot(new SlotEvent(START_SLOT));
     assertThat(eth1DataCache.getSpecRangeLowerBound())
         .isEqualByComparingTo(UnsignedLong.valueOf(354));
     assertThat(eth1DataCache.getSpecRangeUpperBound())
         .isEqualByComparingTo(UnsignedLong.valueOf(369));
-    eventBus.post(new SlotEvent(NEXT_VOTING_PERIOD_SLOT));
+    eth1DataCache.onSlot(new SlotEvent(NEXT_VOTING_PERIOD_SLOT));
     assertThat(eth1DataCache.getSpecRangeLowerBound())
         .isEqualByComparingTo(UnsignedLong.valueOf(378));
   }
@@ -94,7 +94,7 @@ public class Eth1DataCacheTest {
   @Test
   void majorityVoteWins() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eventBus.post(new SlotEvent(START_SLOT));
+    eth1DataCache.onSlot(new SlotEvent(START_SLOT));
 
     // Both Eth1Data timestamp inside the spec range
     CacheEth1BlockEvent cacheEth1BlockEvent1 =
@@ -118,7 +118,7 @@ public class Eth1DataCacheTest {
   @Test
   void smallestDistanceWinsIfNoMajority() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eventBus.post(new SlotEvent(START_SLOT));
+    eth1DataCache.onSlot(new SlotEvent(START_SLOT));
 
     // Both Eth1Data timestamp inside the spec range
     CacheEth1BlockEvent cacheEth1BlockEvent1 =
@@ -143,7 +143,7 @@ public class Eth1DataCacheTest {
   @Test
   void oldVoteDoesNotCount() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eventBus.post(new SlotEvent(START_SLOT));
+    eth1DataCache.onSlot(new SlotEvent(START_SLOT));
 
     // Eth1Data inside the range
     CacheEth1BlockEvent cacheEth1BlockEvent1 =
@@ -168,7 +168,7 @@ public class Eth1DataCacheTest {
   @Test
   void tooRecentVoteDoesNotCount() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eventBus.post(new SlotEvent(START_SLOT));
+    eth1DataCache.onSlot(new SlotEvent(START_SLOT));
 
     // Eth1Data inside the range
     CacheEth1BlockEvent cacheEth1BlockEvent1 =
@@ -193,7 +193,7 @@ public class Eth1DataCacheTest {
   @Test
   void noValidVotesInThisPeriod_eth1ChainLive() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eventBus.post(new SlotEvent(START_SLOT));
+    eth1DataCache.onSlot(new SlotEvent(START_SLOT));
 
     // Both Eth1Data timestamp inside the spec range
     CacheEth1BlockEvent cacheEth1BlockEvent1 =
@@ -216,7 +216,7 @@ public class Eth1DataCacheTest {
   @Test
   void noValidVotesInThisPeriod_eth1ChainNotLive() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eventBus.post(new SlotEvent(START_SLOT));
+    eth1DataCache.onSlot(new SlotEvent(START_SLOT));
 
     Eth1Data eth1Data = DataStructureUtil.randomEth1Data(10);
 
@@ -252,7 +252,7 @@ public class Eth1DataCacheTest {
   @Test
   void pruneAfterGenesis() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eventBus.post(new SlotEvent(START_SLOT));
+    eth1DataCache.onSlot(new SlotEvent(START_SLOT));
 
     // First two Eth1Data timestamps inside the spec range for this voting period
     CacheEth1BlockEvent cacheEth1BlockEvent1 =
@@ -268,7 +268,7 @@ public class Eth1DataCacheTest {
     eventBus.post(cacheEth1BlockEvent2);
     eventBus.post(cacheEth1BlockEvent3);
 
-    eventBus.post(new SlotEvent(NEXT_VOTING_PERIOD_SLOT));
+    eth1DataCache.onSlot(new SlotEvent(NEXT_VOTING_PERIOD_SLOT));
 
     Eth1Data eth1Data3 = Eth1DataCache.createEth1Data(cacheEth1BlockEvent3);
 


### PR DESCRIPTION
The order that slot events were delivered to Eth1DataCache and ValidatorCoordinator was not guaranteed which may result in ValidatorCoordinator producing blocks with incorrect ETH1 data or Eth1DataCache not having the information ValidatorCoordinator needed.

It also led to intermittency in `ValidatorCoordinatorTest` when `Eth1DataCache` had not received a `SlotEvent` and initialised its `currentVotingPeriodStartTime` before `ValidatorCoordinator` asked it for an ETH1 data vote, resulting in `java.lang.IllegalArgumentException: inconsistent range` from the sorted map when retrieving votes.

`ValidatorCoordinator` now directly passes slot events to Eth1DataCache to ensure it has processed the slot event prior to starting to create blocks.