### PR TITLE
[BC-268] Only prune hot blocks prior to latest finalized block

### DIFF
--- a/storage/src/main/java/tech/pegasys/artemis/storage/MapDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/MapDbDatabase.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.artemis.storage;
 
-import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 import static tech.pegasys.artemis.util.alogger.ALogger.STDOUT;
 
 import com.google.common.primitives.UnsignedLong;
@@ -257,10 +256,10 @@ public class MapDbDatabase implements Database {
 
   private void pruneHotBlocks(final Checkpoint newFinalizedCheckpoint) {
     // TODO: Can we prune blocks from in the finalized epoch as well?
-    final UnsignedLong startOfFinalizedEpoch =
-        compute_start_slot_at_epoch(newFinalizedCheckpoint.getEpoch());
+    SignedBeaconBlock newlyFinalizedBlock = hotBlocksByRoot.get(newFinalizedCheckpoint.getRoot());
+    final UnsignedLong finalizedSlot = newlyFinalizedBlock.getSlot();
     final ConcurrentNavigableMap<UnsignedLong, Set<Bytes32>> toRemove =
-        hotRootsBySlotCache.headMap(startOfFinalizedEpoch);
+        hotRootsBySlotCache.headMap(finalizedSlot);
     LOG.trace("Pruning slots {} from non-finalized pool", toRemove::keySet);
     toRemove
         .values()

--- a/storage/src/main/java/tech/pegasys/artemis/storage/MapDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/MapDbDatabase.java
@@ -255,7 +255,6 @@ public class MapDbDatabase implements Database {
   }
 
   private void pruneHotBlocks(final Checkpoint newFinalizedCheckpoint) {
-    // TODO: Can we prune blocks from in the finalized epoch as well?
     SignedBeaconBlock newlyFinalizedBlock = hotBlocksByRoot.get(newFinalizedCheckpoint.getRoot());
     final UnsignedLong finalizedSlot = newlyFinalizedBlock.getSlot();
     final ConcurrentNavigableMap<UnsignedLong, Set<Bytes32>> toRemove =

--- a/storage/src/test/java/tech/pegasys/artemis/storage/MapDbDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/artemis/storage/MapDbDatabaseTest.java
@@ -45,12 +45,14 @@ import tech.pegasys.artemis.util.config.Constants;
 class MapDbDatabaseTest {
   private static final BeaconState GENESIS_STATE =
       DataStructureUtil.randomBeaconState(UnsignedLong.ZERO, 1);
-  private static final Checkpoint CHECKPOINT1 =
-      new Checkpoint(UnsignedLong.valueOf(6), Bytes32.fromHexString("0x1234"));
-  private static final Checkpoint CHECKPOINT2 =
-      new Checkpoint(UnsignedLong.valueOf(7), Bytes32.fromHexString("0x5678"));
-  private static final Checkpoint CHECKPOINT3 =
-      new Checkpoint(UnsignedLong.valueOf(8), Bytes32.fromHexString("0x9012"));
+
+  private SignedBeaconBlock checkpoint1Block;
+  private SignedBeaconBlock checkpoint2Block;
+  private SignedBeaconBlock checkpoint3Block;
+
+  private Checkpoint checkpoint1;
+  private Checkpoint checkpoint2;
+  private Checkpoint checkpoint3;
 
   private Database database = MapDbDatabase.createInMemory();
   private final TransactionPrecommit databaseTransactionPrecommit =
@@ -65,6 +67,17 @@ class MapDbDatabaseTest {
   @BeforeEach
   public void recordGenesis() {
     database.storeGenesis(store);
+
+    checkpoint1Block = blockAtEpoch(6);
+    checkpoint2Block = blockAtEpoch(7);
+    checkpoint3Block = blockAtEpoch(8);
+
+    checkpoint1 =
+        new Checkpoint(UnsignedLong.valueOf(6), checkpoint1Block.getMessage().hash_tree_root());
+    checkpoint2 =
+        new Checkpoint(UnsignedLong.valueOf(7), checkpoint2Block.getMessage().hash_tree_root());
+    checkpoint3 =
+        new Checkpoint(UnsignedLong.valueOf(8), checkpoint3Block.getMessage().hash_tree_root());
   }
 
   @Test
@@ -111,12 +124,14 @@ class MapDbDatabaseTest {
 
   @Test
   public void shouldStoreSingleValueFields() {
+    addBlocks(checkpoint1Block, checkpoint2Block, checkpoint3Block);
+
     final Transaction transaction = store.startTransaction(databaseTransactionPrecommit);
     transaction.setGenesis_time(UnsignedLong.valueOf(3));
     transaction.setTime(UnsignedLong.valueOf(5));
-    transaction.setFinalizedCheckpoint(CHECKPOINT1);
-    transaction.setJustifiedCheckpoint(CHECKPOINT2);
-    transaction.setBestJustifiedCheckpoint(CHECKPOINT3);
+    transaction.setFinalizedCheckpoint(checkpoint1);
+    transaction.setJustifiedCheckpoint(checkpoint2);
+    transaction.setBestJustifiedCheckpoint(checkpoint3);
 
     commit(transaction);
 
@@ -136,57 +151,58 @@ class MapDbDatabaseTest {
     final UnsignedLong validator2 = UnsignedLong.valueOf(2);
     final UnsignedLong validator3 = UnsignedLong.valueOf(3);
 
+    addBlocks(checkpoint1Block, checkpoint2Block, checkpoint3Block);
+
     final Transaction transaction = store.startTransaction(databaseTransactionPrecommit);
-    transaction.putLatestMessage(validator1, CHECKPOINT1);
-    transaction.putLatestMessage(validator2, CHECKPOINT2);
-    transaction.putLatestMessage(validator3, CHECKPOINT1);
+    transaction.putLatestMessage(validator1, checkpoint1);
+    transaction.putLatestMessage(validator2, checkpoint2);
+    transaction.putLatestMessage(validator3, checkpoint1);
     commit(transaction);
 
     final Store result1 = database.createMemoryStore();
-    assertThat(result1.getLatestMessage(validator1)).isEqualTo(CHECKPOINT1);
-    assertThat(result1.getLatestMessage(validator2)).isEqualTo(CHECKPOINT2);
-    assertThat(result1.getLatestMessage(validator3)).isEqualTo(CHECKPOINT1);
+    assertThat(result1.getLatestMessage(validator1)).isEqualTo(checkpoint1);
+    assertThat(result1.getLatestMessage(validator2)).isEqualTo(checkpoint2);
+    assertThat(result1.getLatestMessage(validator3)).isEqualTo(checkpoint1);
 
     // Should overwrite when later changes are made.
     final Transaction transaction2 = store.startTransaction(databaseTransactionPrecommit);
-    transaction2.putLatestMessage(validator3, CHECKPOINT2);
+    transaction2.putLatestMessage(validator3, checkpoint2);
     commit(transaction2);
 
     final Store result2 = database.createMemoryStore();
-    assertThat(result2.getLatestMessage(validator1)).isEqualTo(CHECKPOINT1);
-    assertThat(result2.getLatestMessage(validator2)).isEqualTo(CHECKPOINT2);
-    assertThat(result2.getLatestMessage(validator3)).isEqualTo(CHECKPOINT2);
+    assertThat(result2.getLatestMessage(validator1)).isEqualTo(checkpoint1);
+    assertThat(result2.getLatestMessage(validator2)).isEqualTo(checkpoint2);
+    assertThat(result2.getLatestMessage(validator3)).isEqualTo(checkpoint2);
   }
 
   @Test
   public void shouldStoreCheckpointStates() {
     final Transaction transaction = store.startTransaction(databaseTransactionPrecommit);
 
+    addBlocks(checkpoint1Block, checkpoint2Block, checkpoint3Block);
+
     final Checkpoint forkCheckpoint =
-        new Checkpoint(CHECKPOINT1.getEpoch(), Bytes32.fromHexString("0x88677727"));
-    transaction.putCheckpointState(CHECKPOINT1, GENESIS_STATE);
-    transaction.putCheckpointState(CHECKPOINT2, DataStructureUtil.randomBeaconState(seed++));
+        new Checkpoint(checkpoint1.getEpoch(), Bytes32.fromHexString("0x88677727"));
+    transaction.putCheckpointState(checkpoint1, GENESIS_STATE);
+    transaction.putCheckpointState(checkpoint2, DataStructureUtil.randomBeaconState(seed++));
     transaction.putCheckpointState(forkCheckpoint, DataStructureUtil.randomBeaconState(seed++));
 
     commit(transaction);
 
     final Store result = database.createMemoryStore();
-    assertThat(result.getCheckpointState(CHECKPOINT1))
-        .isEqualTo(transaction.getCheckpointState(CHECKPOINT1));
-    assertThat(result.getCheckpointState(CHECKPOINT2))
-        .isEqualTo(transaction.getCheckpointState(CHECKPOINT2));
+    assertThat(result.getCheckpointState(checkpoint1))
+        .isEqualTo(transaction.getCheckpointState(checkpoint1));
+    assertThat(result.getCheckpointState(checkpoint2))
+        .isEqualTo(transaction.getCheckpointState(checkpoint2));
     assertThat(result.getCheckpointState(forkCheckpoint))
         .isEqualTo(transaction.getCheckpointState(forkCheckpoint));
   }
 
   @Test
   public void shouldRemoveCheckpointStatesPriorToFinalizedCheckpoint() {
-    final Checkpoint earlyCheckpoint =
-        new Checkpoint(UnsignedLong.ONE, Bytes32.fromHexString("0x01"));
-    final Checkpoint middleCheckpoint =
-        new Checkpoint(UnsignedLong.valueOf(2), Bytes32.fromHexString("0x02"));
-    final Checkpoint laterCheckpoint =
-        new Checkpoint(UnsignedLong.valueOf(3), Bytes32.fromHexString("0x03"));
+    final Checkpoint earlyCheckpoint = createCheckpoint(1);
+    final Checkpoint middleCheckpoint = createCheckpoint(2);
+    final Checkpoint laterCheckpoint = createCheckpoint(3);
 
     // First store the initial checkpoints.
     final Transaction transaction1 = store.startTransaction(databaseTransactionPrecommit);
@@ -241,14 +257,17 @@ class MapDbDatabaseTest {
     final SignedBeaconBlock block2 = blockAtSlot(2);
     final SignedBeaconBlock unfinalizedBlock =
         blockAtSlot(compute_start_slot_at_epoch(UnsignedLong.valueOf(2)).longValue());
+
     final BeaconState state1 = DataStructureUtil.randomBeaconState(UnsignedLong.valueOf(1), seed++);
     final BeaconState state2 = DataStructureUtil.randomBeaconState(UnsignedLong.valueOf(2), seed++);
     final BeaconState unfinalizedState =
         DataStructureUtil.randomBeaconState(
             compute_start_slot_at_epoch(UnsignedLong.valueOf(2)), seed++);
+
     final Bytes32 block1Root = block1.getMessage().hash_tree_root();
     final Bytes32 block2Root = block2.getMessage().hash_tree_root();
     final Bytes32 unfinalizedBlockRoot = unfinalizedBlock.getMessage().hash_tree_root();
+
     transaction.putBlock(block1Root, block1);
     transaction.putBlock(block2Root, block2);
     transaction.putBlock(unfinalizedBlockRoot, unfinalizedBlock);
@@ -262,12 +281,12 @@ class MapDbDatabaseTest {
 
     final Store result = database.createMemoryStore();
     assertThat(result.getSignedBlock(block1Root)).isNull();
-    assertThat(result.getSignedBlock(block2Root)).isNull();
+    assertThat(result.getSignedBlock(block2Root)).isEqualTo(block2);
     assertThat(result.getSignedBlock(unfinalizedBlockRoot)).isEqualTo(unfinalizedBlock);
     assertThat(result.getBlockState(block1Root)).isNull();
-    assertThat(result.getBlockState(block2Root)).isNull();
+    assertThat(result.getBlockState(block2Root)).isEqualTo(state2);
     assertThat(result.getBlockState(unfinalizedBlockRoot)).isEqualTo(unfinalizedState);
-    assertThat(result.getBlockRoots()).containsOnly(unfinalizedBlockRoot);
+    assertThat(result.getBlockRoots()).containsOnly(block2Root, unfinalizedBlockRoot);
   }
 
   @Test
@@ -301,7 +320,7 @@ class MapDbDatabaseTest {
 
     finalizeEpoch(UnsignedLong.ONE, block7.getMessage().hash_tree_root());
 
-    assertOnlyHotBlocks(block8, block9, forkBlock8, forkBlock9);
+    assertOnlyHotBlocks(block7, block8, block9, forkBlock7, forkBlock8, forkBlock9);
     assertBlocksFinalized(block1, block2, block3, block7);
     assertGetLatestFinalizedRootAtSlotReturnsFinalizedBlocks(block1, block2, block3, block7);
 
@@ -346,7 +365,7 @@ class MapDbDatabaseTest {
     // Close and re-read from disk store.
     database.close();
     database = MapDbDatabase.createOnDisk(tempDir.toFile(), true);
-    assertOnlyHotBlocks(block8, block9, forkBlock8, forkBlock9);
+    assertOnlyHotBlocks(block7, block8, block9, forkBlock7, forkBlock8, forkBlock9);
     assertBlocksFinalized(block1, block2, block3, block7);
     assertGetLatestFinalizedRootAtSlotReturnsFinalizedBlocks(block1, block2, block3, block7);
 
@@ -416,6 +435,17 @@ class MapDbDatabaseTest {
     final Transaction transaction = store.startTransaction(databaseTransactionPrecommit);
     transaction.setFinalizedCheckpoint(new Checkpoint(epoch, root));
     commit(transaction);
+  }
+
+  private Checkpoint createCheckpoint(final long epoch) {
+    final SignedBeaconBlock block = blockAtEpoch(epoch);
+    addBlocks(block);
+    return new Checkpoint(UnsignedLong.valueOf(epoch), block.getMessage().hash_tree_root());
+  }
+
+  private SignedBeaconBlock blockAtEpoch(final long epoch) {
+    final UnsignedLong slot = compute_start_slot_at_epoch(UnsignedLong.valueOf(epoch));
+    return blockAtSlot(slot.longValue(), DataStructureUtil.randomBytes32(epoch));
   }
 
   private SignedBeaconBlock blockAtSlot(final long slot) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Currently, we're pruning our [hotStatesByRoot](https://github.com/PegaSysEng/artemis/blob/cb5d35e69b4577eb3d3904ffdbbab23a20a33e19/storage/src/main/java/tech/pegasys/artemis/storage/MapDbDatabase.java#L60) collection using the epoch boundary of the latest finalized block.  If the epoch boundary is a skipped slot (the finalized block for this epoch is from a slot prior to the epoch boundary slot), this means that we'll end up pruning the finalized state.  Upon restarting the client, we'll hydrate our Store from the database and end up with no finalized state corresponding to our finalized block.  This prevents us from importing new blocks on top of our latest finalized block.

In this PR, the hot block pruning logic has been updated to only prune blocks that are prior to the slot of the latest finalized block.


