### PR TITLE
Use gradle root project build dir in check-license

### DIFF
--- a/gradle/check-licenses.gradle
+++ b/gradle/check-licenses.gradle
@@ -173,7 +173,7 @@ task checkLicenses {
 
   def bads = ""
   doLast {
-    def xml = new XmlParser().parse('build/reports/license/license-dependency.xml')
+    def xml = new XmlParser().parse("${rootProject.buildDir}/reports/license/license-dependency.xml")
     xml.each { license ->
       if (!acceptedLicenses.contains((license.@name).toLowerCase())) {
         def depStrings = []


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description

Fixed check-license to use root project's build dir property instead of relative path which resolves to user.dir.
This was stopping me from building locally

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->