### PR TITLE
#1162 add openApi documentation to beacon state handler

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApi.java
@@ -132,12 +132,12 @@ public class BeaconRestApi {
 
   private void addBeaconHandlers(
       ChainStorageClient chainStorageClient, HistoricalChainData historicalChainData) {
+    app.get(BeaconStateHandler.ROUTE, new BeaconStateHandler(chainStorageClient));
     // TODO: not in Minimal or optional specified set - some are similar to lighthouse
     // implementation
     handlers.add(new BeaconBlockHandler(chainStorageClient, historicalChainData));
     handlers.add(new BeaconChainHeadHandler(chainStorageClient));
     handlers.add(new BeaconHeadHandler(chainStorageClient));
-    handlers.add(new BeaconStateHandler(chainStorageClient));
     handlers.add(new FinalizedCheckpointHandler(chainStorageClient));
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/README.md
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/README.md
@@ -4,7 +4,8 @@
 
 * [Prysm API]("https://api.prylabs.net/#")
 * [Lighthouse API]("https://lighthouse-book.sigmaprime.io/http.html")
-* [eth2-api]("https://github.com/ethereum/eth2.0-specs")
+* [eth2 specs]("https://github.com/ethereum/eth2.0-specs")
+* [eth2-api]("https://ethereum.github.io/eth2.0-APIs/") - [github]("https://github.com/ethereum/eth2.0-APIs")
 
 ## /node/genesis_time
 
@@ -19,6 +20,6 @@ genesis time set. For this reason, it was deemed more appropriate to return:
 
 ## /beacon/state
 
-In [Lighthouse]("https://lighthouse-book.sigmaprime.io/http_beacon.html#beaconstate") the beacon state can 
-be queried by slot or root, and only root search is currently implemented in Teku. eth2-api also suggests
-searching by slot.
+In [Lighthouse]("https://lighthouse-book.sigmaprime.io/http_beacon.html#beaconstate") 
+and [eth2-api]("https://github.com/ethereum/eth2.0-APIs/blob/master/apis/beacon/basic.md#beacon-state"), 
+the beacon state can be queried by slot or root, and only root search is currently implemented in Teku.

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/README.md
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/README.md
@@ -16,3 +16,9 @@ Any time a beacon node is in a pre-genesis state, it will be a valid condition t
 genesis time set. For this reason, it was deemed more appropriate to return:
 * 200 code and a numeric
 * 204 (no content)
+
+## /beacon/state
+
+In [Lighthouse]("https://lighthouse-book.sigmaprime.io/http_beacon.html#beaconstate") the beacon state can 
+be queried by slot or root, and only root search is currently implemented in Teku. eth2-api also suggests
+searching by slot.

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandler.java
@@ -49,7 +49,9 @@ public class BeaconStateHandler implements Handler {
       method = HttpMethod.GET,
       summary = "Get the beacon chain state that matches the specified tree hash root.",
       tags = {"beacon"},
-      queryParams = {@OpenApiParam(name = "root")},
+      queryParams = {
+        @OpenApiParam(name = "root", description = "Tree hash root to query (Bytes32)")
+      },
       description =
           "Request that the node return a beacon chain state that matches the provided criteria.",
       responses = {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandler.java
@@ -13,26 +13,60 @@
 
 package tech.pegasys.artemis.beaconrestapi.beaconhandlers;
 
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+
+import io.javalin.http.Context;
+import io.javalin.http.Handler;
+import io.javalin.plugin.openapi.annotations.HttpMethod;
+import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiContent;
+import io.javalin.plugin.openapi.annotations.OpenApiParam;
+import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.artemis.beaconrestapi.handlerinterfaces.BeaconRestApiHandler;
+import tech.pegasys.artemis.beaconrestapi.schema.BeaconStateResponse;
+import tech.pegasys.artemis.datastructures.state.BeaconState;
+import tech.pegasys.artemis.provider.JsonProvider;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 
-public class BeaconStateHandler implements BeaconRestApiHandler {
-
+public class BeaconStateHandler implements Handler {
+  public static final String ROUTE = "/beacon/state/";
+  private final Logger LOG = LogManager.getLogger();
   private final ChainStorageClient client;
 
   public BeaconStateHandler(ChainStorageClient client) {
     this.client = client;
   }
 
-  @Override
-  public String getPath() {
-    return "/beacon/state";
+  private BeaconState queryByRootHash(String root) {
+    Bytes32 root32 = Bytes32.fromHexString(root);
+    return client.getStore().getBlockState(root32);
   }
 
+  @OpenApi(
+      path = BeaconStateHandler.ROUTE,
+      method = HttpMethod.GET,
+      summary = "Get the beacon chain state that matches the specified tree hash root.",
+      tags = {"beacon"},
+      queryParams = {@OpenApiParam(name = "root")},
+      description =
+          "Request that the node return a beacon chain state that matches the provided criteria.",
+      responses = {
+        @OpenApiResponse(
+            status = "200",
+            content = @OpenApiContent(from = BeaconStateResponse.class)),
+        @OpenApiResponse(status = "404")
+      })
   @Override
-  public Object handleRequest(RequestParams params) {
-    Bytes32 root = Bytes32.fromHexString(params.getQueryParam("root"));
-    return client.getStore() != null ? client.getStore().getBlockState(root) : null;
+  public void handle(Context ctx) throws Exception {
+    String rootParam = ctx.queryParam("root");
+    BeaconState result = queryByRootHash(rootParam);
+    if (result == null) {
+      ctx.status(SC_NOT_FOUND);
+    } else {
+      LOG.debug("Block root {} not found", rootParam);
+      ctx.result(JsonProvider.objectToJSON(result));
+    }
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandler.java
@@ -63,9 +63,9 @@ public class BeaconStateHandler implements Handler {
     String rootParam = ctx.queryParam("root");
     BeaconState result = queryByRootHash(rootParam);
     if (result == null) {
+      LOG.debug("Block root {} not found", rootParam);
       ctx.status(SC_NOT_FOUND);
     } else {
-      LOG.debug("Block root {} not found", rootParam);
       ctx.result(JsonProvider.objectToJSON(result));
     }
   }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/AttestationData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/AttestationData.java
@@ -16,12 +16,15 @@ package tech.pegasys.artemis.beaconrestapi.schema;
 import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes32;
 
-public class Checkpoint {
-  public UnsignedLong epoch;
-  public Bytes32 root;
+public class AttestationData {
+  public UnsignedLong slot;
+  public UnsignedLong index;
 
-  public Checkpoint(tech.pegasys.artemis.datastructures.state.Checkpoint checkpoint) {
-    this.epoch = checkpoint.getEpoch();
-    this.root = checkpoint.getRoot();
+  public Bytes32 beacon_block_root;
+
+  public AttestationData(tech.pegasys.artemis.datastructures.operations.AttestationData data) {
+    this.slot = data.getSlot();
+    this.index = data.getIndex();
+    this.beacon_block_root = data.getBeacon_block_root();
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/BeaconBlockHeader.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/BeaconBlockHeader.java
@@ -13,10 +13,21 @@
 
 package tech.pegasys.artemis.beaconrestapi.schema;
 
-@SuppressWarnings("UnusedVariable")
+import com.google.common.primitives.UnsignedLong;
+import org.apache.tuweni.bytes.Bytes32;
+
 public class BeaconBlockHeader {
-  public Long slot;
-  public String parent_root;
-  public String state_root;
-  public String body_root;
+  public final UnsignedLong slot;
+
+  public final Bytes32 parent_root;
+  public final Bytes32 state_root;
+  public final Bytes32 body_root;
+
+  public BeaconBlockHeader(
+      tech.pegasys.artemis.datastructures.blocks.BeaconBlockHeader blockHeader) {
+    this.slot = blockHeader.getSlot();
+    this.parent_root = blockHeader.getParent_root();
+    this.state_root = blockHeader.getState_root();
+    this.body_root = blockHeader.getBody_root();
+  }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/BeaconBlockHeader.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/BeaconBlockHeader.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.beaconrestapi.schema;
+
+@SuppressWarnings("UnusedVariable")
+public class BeaconBlockHeader {
+  public Long slot;
+  public String parent_root;
+  public String state_root;
+  public String body_root;
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/BeaconStateResponse.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/BeaconStateResponse.java
@@ -13,36 +13,76 @@
 
 package tech.pegasys.artemis.beaconrestapi.schema;
 
-import java.util.ArrayList;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
-@SuppressWarnings("UnusedVariable")
+import com.google.common.primitives.UnsignedLong;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.artemis.datastructures.state.BeaconState;
+
 public class BeaconStateResponse {
 
-  public Long genesis_time;
-  public Long slot;
-  public Fork fork; // For versioning hard forks
+  public UnsignedLong genesis_time;
+  public UnsignedLong slot;
+  public Fork fork;
 
   public BeaconBlockHeader latest_block_header;
-  public ArrayList<String> block_roots;
-  public ArrayList<String> state_roots;
-  public ArrayList<String> historical_roots;
+  public List<Bytes32> block_roots;
+  public List<Bytes32> state_roots;
+  public List<Bytes32> historical_roots;
 
   public Eth1Data eth1_data;
-  public ArrayList<Eth1Data> eth1_data_votes;
-  public Long eth1_deposit_index;
+  public List<Eth1Data> eth1_data_votes;
+  public UnsignedLong eth1_deposit_index;
 
-  public ArrayList<Validator> validators;
-  public ArrayList<Long> balances;
+  public List<Validator> validators;
+  public List<UnsignedLong> balances;
 
-  public ArrayList<String> randao_mixes;
+  public List<Bytes32> randao_mixes;
 
-  public ArrayList<Long> slashings;
+  public List<UnsignedLong> slashings;
 
-  public ArrayList<PendingAttestation> previous_epoch_attestations;
-  public ArrayList<PendingAttestation> current_epoch_attestations;
+  public List<PendingAttestation> previous_epoch_attestations;
+  public List<PendingAttestation> current_epoch_attestations;
 
   public String justification_bits;
   public Checkpoint previous_justified_checkpoint;
   public Checkpoint current_justified_checkpoint;
   public Checkpoint finalized_checkpoint;
+
+  public BeaconStateResponse(BeaconState beaconState) {
+    this.genesis_time = beaconState.getGenesis_time();
+    this.slot = beaconState.getSlot();
+    this.fork = new Fork(beaconState.getFork());
+    this.latest_block_header = new BeaconBlockHeader(beaconState.getLatest_block_header());
+    this.block_roots = beaconState.getBlock_roots();
+    this.state_roots = beaconState.getState_roots();
+    this.historical_roots = beaconState.getHistorical_roots();
+
+    this.eth1_data = new Eth1Data(beaconState.getEth1_data());
+    this.eth1_data_votes =
+        beaconState.getEth1_data_votes().stream().map(Eth1Data::new).collect(toUnmodifiableList());
+    this.eth1_deposit_index = beaconState.getEth1_deposit_index();
+
+    this.validators =
+        beaconState.getValidators().stream().map(Validator::new).collect(toUnmodifiableList());
+    this.balances = beaconState.getBalances();
+    this.randao_mixes = beaconState.getRandao_mixes();
+    this.slashings = beaconState.getSlashings();
+    this.previous_epoch_attestations =
+        beaconState.getPrevious_epoch_attestations().stream()
+            .map(PendingAttestation::new)
+            .collect(toUnmodifiableList());
+    this.current_epoch_attestations =
+        beaconState.getCurrent_epoch_attestations().stream()
+            .map(PendingAttestation::new)
+            .collect(toUnmodifiableList());
+
+    this.justification_bits = beaconState.getJustification_bits().toString();
+    this.previous_justified_checkpoint =
+        new Checkpoint(beaconState.getPrevious_justified_checkpoint());
+    this.current_justified_checkpoint =
+        new Checkpoint(beaconState.getCurrent_justified_checkpoint());
+    this.finalized_checkpoint = new Checkpoint(beaconState.getFinalized_checkpoint());
+  }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/BeaconStateResponse.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/BeaconStateResponse.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.beaconrestapi.schema;
+
+import java.util.ArrayList;
+
+@SuppressWarnings("UnusedVariable")
+public class BeaconStateResponse {
+
+  public Long genesis_time;
+  public Long slot;
+  public Fork fork; // For versioning hard forks
+
+  public BeaconBlockHeader latest_block_header;
+  public ArrayList<String> block_roots;
+  public ArrayList<String> state_roots;
+  public ArrayList<String> historical_roots;
+
+  public Eth1Data eth1_data;
+  public ArrayList<Eth1Data> eth1_data_votes;
+  public Long eth1_deposit_index;
+
+  public ArrayList<Validator> validators;
+  public ArrayList<Long> balances;
+
+  public ArrayList<String> randao_mixes;
+
+  public ArrayList<Long> slashings;
+
+  public ArrayList<PendingAttestation> previous_epoch_attestations;
+  public ArrayList<PendingAttestation> current_epoch_attestations;
+
+  public String justification_bits;
+  public Checkpoint previous_justified_checkpoint;
+  public Checkpoint current_justified_checkpoint;
+  public Checkpoint finalized_checkpoint;
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/Checkpoint.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/Checkpoint.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.beaconrestapi.schema;
+
+@SuppressWarnings("UnusedVariable")
+public class Checkpoint {
+  public Long epoch;
+  public String root;
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/Eth1Data.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/Eth1Data.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.beaconrestapi.schema;
+
+@SuppressWarnings("UnusedVariable")
+public class Eth1Data {
+  public String deposit_root;
+  public Long deposit_count;
+  public String block_hash;
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/Eth1Data.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/Eth1Data.java
@@ -13,9 +13,17 @@
 
 package tech.pegasys.artemis.beaconrestapi.schema;
 
-@SuppressWarnings("UnusedVariable")
+import com.google.common.primitives.UnsignedLong;
+import org.apache.tuweni.bytes.Bytes32;
+
 public class Eth1Data {
-  public String deposit_root;
-  public Long deposit_count;
-  public String block_hash;
+  public Bytes32 deposit_root;
+  public UnsignedLong deposit_count;
+  public Bytes32 block_hash;
+
+  public Eth1Data(tech.pegasys.artemis.datastructures.blocks.Eth1Data eth1Data) {
+    this.deposit_root = eth1Data.getDeposit_root();
+    this.deposit_count = eth1Data.getDeposit_count();
+    this.block_hash = eth1Data.getBlock_hash();
+  }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/Fork.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/Fork.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.beaconrestapi.schema;
+
+@SuppressWarnings("UnusedVariable")
+public class Fork {
+  public Long epoch;
+  public String previous_version;
+  public String current_version;
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/Fork.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/Fork.java
@@ -13,9 +13,16 @@
 
 package tech.pegasys.artemis.beaconrestapi.schema;
 
-@SuppressWarnings("UnusedVariable")
+import com.google.common.primitives.UnsignedLong;
+
 public class Fork {
-  public Long epoch;
+  public UnsignedLong epoch;
   public String previous_version;
   public String current_version;
+
+  public Fork(tech.pegasys.artemis.datastructures.state.Fork fork) {
+    this.epoch = fork.getEpoch();
+    this.previous_version = fork.getPrevious_version().toString();
+    this.current_version = fork.getCurrent_version().toString();
+  }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/PendingAttestation.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/PendingAttestation.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.beaconrestapi.schema;
+
+@SuppressWarnings("UnusedVariable")
+public class PendingAttestation {
+  public String aggregation_bits;
+  public String data;
+  public Long inclusion_delay;
+  public Long proposer_index;
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/PendingAttestation.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/PendingAttestation.java
@@ -13,10 +13,19 @@
 
 package tech.pegasys.artemis.beaconrestapi.schema;
 
-@SuppressWarnings("UnusedVariable")
+import com.google.common.primitives.UnsignedLong;
+
 public class PendingAttestation {
   public String aggregation_bits;
-  public String data;
-  public Long inclusion_delay;
-  public Long proposer_index;
+  public AttestationData data;
+  public UnsignedLong inclusion_delay;
+  public UnsignedLong proposer_index;
+
+  public PendingAttestation(
+      tech.pegasys.artemis.datastructures.state.PendingAttestation pendingAttestation) {
+    this.aggregation_bits = pendingAttestation.getAggregation_bits().toString();
+    this.data = new AttestationData(pendingAttestation.getData());
+    this.inclusion_delay = pendingAttestation.getInclusion_delay();
+    this.proposer_index = pendingAttestation.getProposer_index();
+  }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/Validator.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/Validator.java
@@ -13,14 +13,27 @@
 
 package tech.pegasys.artemis.beaconrestapi.schema;
 
-@SuppressWarnings("UnusedVariable")
+import com.google.common.primitives.UnsignedLong;
+import org.apache.tuweni.bytes.Bytes32;
+
 public class Validator {
   public String pubkey;
-  public String withdrawal_credentials;
-  public Long effective_balance;
+  public Bytes32 withdrawal_credentials;
+  public UnsignedLong effective_balance;
   public boolean slashed;
-  public Long activation_eligibility_epoch;
-  public Long activation_epoch;
-  public Long exit_epoch;
-  public Long withdrawable_epoch;
+  public UnsignedLong activation_eligibility_epoch;
+  public UnsignedLong activation_epoch;
+  public UnsignedLong exit_epoch;
+  public UnsignedLong withdrawable_epoch;
+
+  public Validator(tech.pegasys.artemis.datastructures.state.Validator validator) {
+    this.pubkey = validator.getPubkey().toString();
+    this.withdrawal_credentials = validator.getWithdrawal_credentials();
+    this.effective_balance = validator.getEffective_balance();
+    this.slashed = validator.isSlashed();
+    this.activation_eligibility_epoch = validator.getActivation_eligibility_epoch();
+    this.activation_epoch = validator.getActivation_epoch();
+    this.exit_epoch = validator.getExit_epoch();
+    this.withdrawable_epoch = validator.getWithdrawable_epoch();
+  }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/Validator.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/Validator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.beaconrestapi.schema;
+
+@SuppressWarnings("UnusedVariable")
+public class Validator {
+  public String pubkey;
+  public String withdrawal_credentials;
+  public Long effective_balance;
+  public boolean slashed;
+  public Long activation_eligibility_epoch;
+  public Long activation_epoch;
+  public Long exit_epoch;
+  public Long withdrawable_epoch;
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApiTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApiTest.java
@@ -22,7 +22,9 @@ import static org.mockito.Mockito.when;
 import com.google.common.eventbus.EventBus;
 import io.javalin.Javalin;
 import io.javalin.core.JavalinServer;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.beaconrestapi.beaconhandlers.BeaconStateHandler;
 import tech.pegasys.artemis.beaconrestapi.beaconhandlers.GenesisTimeHandler;
 import tech.pegasys.artemis.beaconrestapi.beaconhandlers.VersionHandler;
 import tech.pegasys.artemis.storage.ChainStorageClient;
@@ -56,5 +58,14 @@ class BeaconRestApiTest {
     new BeaconRestApi(storageClient, null, null, THE_PORT, mockApp);
 
     verify(mockApp).get(eq(VersionHandler.ROUTE), any(VersionHandler.class));
+  }
+
+  @Test
+  @Disabled
+  public void RestApiShouldHavBeaconStateEndpoint() throws Exception {
+    when(mockApp.server()).thenReturn(mockServer);
+    new BeaconRestApi(storageClient, null, null, THE_PORT, mockApp);
+
+    verify(mockApp).get(eq(BeaconStateHandler.ROUTE), any(BeaconStateHandler.class));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApiTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApiTest.java
@@ -31,39 +31,39 @@ import tech.pegasys.artemis.storage.ChainStorageClient;
 class BeaconRestApiTest {
   private final ChainStorageClient storageClient =
       ChainStorageClient.memoryOnlyClient(new EventBus());
-  private final JavalinServer mockServer = mock(JavalinServer.class);
-  private final Javalin mockApp = mock(Javalin.class);
+  private final JavalinServer server = mock(JavalinServer.class);
+  private final Javalin app = mock(Javalin.class);
   private static final Integer THE_PORT = 12345;
 
   @Test
   public void RestApiShouldHaveServerPortSet() {
-    when(mockApp.server()).thenReturn(mockServer);
-    new BeaconRestApi(storageClient, null, null, THE_PORT, mockApp);
+    when(app.server()).thenReturn(server);
+    new BeaconRestApi(storageClient, null, null, THE_PORT, app);
 
-    verify(mockServer).setServerPort(THE_PORT);
+    verify(server).setServerPort(THE_PORT);
   }
 
   @Test
   public void RestApiShouldHaveGenesisTimeEndpoint() throws Exception {
-    when(mockApp.server()).thenReturn(mockServer);
-    new BeaconRestApi(storageClient, null, null, THE_PORT, mockApp);
+    when(app.server()).thenReturn(server);
+    new BeaconRestApi(storageClient, null, null, THE_PORT, app);
 
-    verify(mockApp).get(eq(GenesisTimeHandler.ROUTE), any(GenesisTimeHandler.class));
+    verify(app).get(eq(GenesisTimeHandler.ROUTE), any(GenesisTimeHandler.class));
   }
 
   @Test
   public void RestApiShouldHaveVersionEndpoint() throws Exception {
-    when(mockApp.server()).thenReturn(mockServer);
-    new BeaconRestApi(storageClient, null, null, THE_PORT, mockApp);
+    when(app.server()).thenReturn(server);
+    new BeaconRestApi(storageClient, null, null, THE_PORT, app);
 
-    verify(mockApp).get(eq(VersionHandler.ROUTE), any(VersionHandler.class));
+    verify(app).get(eq(VersionHandler.ROUTE), any(VersionHandler.class));
   }
 
   @Test
   public void RestApiShouldHavBeaconStateEndpoint() throws Exception {
-    when(mockApp.server()).thenReturn(mockServer);
-    new BeaconRestApi(storageClient, null, null, THE_PORT, mockApp);
+    when(app.server()).thenReturn(server);
+    new BeaconRestApi(storageClient, null, null, THE_PORT, app);
 
-    verify(mockApp).get(eq(BeaconStateHandler.ROUTE), any(BeaconStateHandler.class));
+    verify(app).get(eq(BeaconStateHandler.ROUTE), any(BeaconStateHandler.class));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApiTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApiTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.when;
 import com.google.common.eventbus.EventBus;
 import io.javalin.Javalin;
 import io.javalin.core.JavalinServer;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.beaconrestapi.beaconhandlers.BeaconStateHandler;
 import tech.pegasys.artemis.beaconrestapi.beaconhandlers.GenesisTimeHandler;
@@ -61,7 +60,6 @@ class BeaconRestApiTest {
   }
 
   @Test
-  @Disabled
   public void RestApiShouldHavBeaconStateEndpoint() throws Exception {
     when(mockApp.server()).thenReturn(mockServer);
     new BeaconRestApi(storageClient, null, null, THE_PORT, mockApp);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandlerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandlerTest.java
@@ -28,35 +28,35 @@ import tech.pegasys.artemis.storage.Store;
 
 public class BeaconStateHandlerTest {
 
-  private final ChainStorageClient mockStorageClient = mock(ChainStorageClient.class);
-  private final Store mockStore = mock(Store.class);
+  private final ChainStorageClient storageClient = mock(ChainStorageClient.class);
+  private final Store store = mock(Store.class);
   private final Bytes32 blockRoot = Bytes32.random();
-  private final Context mockContext = mock(Context.class);
-  private final BeaconState mockBeaconState = mock(BeaconState.class);
+  private final Context context = mock(Context.class);
+  private final BeaconState beaconState = mock(BeaconState.class);
 
   @Test
   public void shouldReturnNotFoundWhenQueryAgainstMissingRootObject() throws Exception {
-    BeaconStateHandler handler = new BeaconStateHandler(mockStorageClient);
+    BeaconStateHandler handler = new BeaconStateHandler(storageClient);
 
-    when(mockStorageClient.getStore()).thenReturn(mockStore);
-    when(mockStore.getBlockState(blockRoot)).thenReturn(null);
-    when(mockContext.queryParam("root")).thenReturn(blockRoot.toHexString());
+    when(storageClient.getStore()).thenReturn(store);
+    when(store.getBlockState(blockRoot)).thenReturn(null);
+    when(context.queryParam("root")).thenReturn(blockRoot.toHexString());
 
-    handler.handle(mockContext);
+    handler.handle(context);
 
-    verify(mockContext).status(SC_NOT_FOUND);
+    verify(context).status(SC_NOT_FOUND);
   }
 
   @Test
   public void shouldReturnBeaconStateObjectWhenFound() throws Exception {
-    BeaconStateHandler handler = new BeaconStateHandler(mockStorageClient);
+    BeaconStateHandler handler = new BeaconStateHandler(storageClient);
 
-    when(mockStorageClient.getStore()).thenReturn(mockStore);
-    when(mockStore.getBlockState(blockRoot)).thenReturn(mockBeaconState);
-    when(mockContext.queryParam("root")).thenReturn(blockRoot.toHexString());
+    when(storageClient.getStore()).thenReturn(store);
+    when(store.getBlockState(blockRoot)).thenReturn(beaconState);
+    when(context.queryParam("root")).thenReturn(blockRoot.toHexString());
 
-    handler.handle(mockContext);
+    handler.handle(context);
 
-    verify(mockContext).result(JsonProvider.objectToJSON(mockBeaconState));
+    verify(context).result(JsonProvider.objectToJSON(beaconState));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandlerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandlerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.beaconrestapi.beaconhandlers;
+
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.javalin.http.Context;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.state.BeaconState;
+import tech.pegasys.artemis.provider.JsonProvider;
+import tech.pegasys.artemis.storage.ChainStorageClient;
+import tech.pegasys.artemis.storage.Store;
+
+public class BeaconStateHandlerTest {
+
+  private final ChainStorageClient mockStorageClient = mock(ChainStorageClient.class);
+  private final Store mockStore = mock(Store.class);
+  private final Bytes32 blockRoot = Bytes32.random();
+  private final Context mockContext = mock(Context.class);
+  private final BeaconState mockBeaconState = mock(BeaconState.class);
+
+  @Test
+  public void shouldReturnNotFoundWhenQueryAgainstMissingRootObject() throws Exception {
+    BeaconStateHandler handler = new BeaconStateHandler(mockStorageClient);
+
+    when(mockStorageClient.getStore()).thenReturn(mockStore);
+    when(mockStore.getBlockState(blockRoot)).thenReturn(null);
+    when(mockContext.queryParam("root")).thenReturn(blockRoot.toHexString());
+
+    handler.handle(mockContext);
+
+    verify(mockContext).status(SC_NOT_FOUND);
+  }
+
+  @Test
+  public void shouldReturnBeaconStateObjectWhenFound() throws Exception {
+    BeaconStateHandler handler = new BeaconStateHandler(mockStorageClient);
+
+    when(mockStorageClient.getStore()).thenReturn(mockStore);
+    when(mockStore.getBlockState(blockRoot)).thenReturn(mockBeaconState);
+    when(mockContext.queryParam("root")).thenReturn(blockRoot.toHexString());
+
+    handler.handle(mockContext);
+
+    verify(mockContext).result(JsonProvider.objectToJSON(mockBeaconState));
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/GenesisTimeHandlerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/GenesisTimeHandlerTest.java
@@ -25,7 +25,7 @@ import tech.pegasys.artemis.provider.JsonProvider;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 
 public class GenesisTimeHandlerTest {
-  private Context mockContext = mock(Context.class);
+  private Context context = mock(Context.class);
   private final UnsignedLong genesisTime = UnsignedLong.valueOf(51234);
 
   private final ChainStorageClient storageClient =
@@ -34,17 +34,17 @@ public class GenesisTimeHandlerTest {
   @Test
   public void shouldReturnNoContentWhenGenesisTimeIsNotSet() throws Exception {
     GenesisTimeHandler handler = new GenesisTimeHandler(null);
-    handler.handle(mockContext);
+    handler.handle(context);
 
-    verify(mockContext).status(SC_NO_CONTENT);
+    verify(context).status(SC_NO_CONTENT);
   }
 
   @Test
   public void shouldReturnGenesisTimeWhenSet() throws Exception {
     storageClient.setGenesisTime(genesisTime);
     GenesisTimeHandler handler = new GenesisTimeHandler(storageClient);
-    handler.handle(mockContext);
+    handler.handle(context);
 
-    verify(mockContext).result(JsonProvider.objectToJSON(genesisTime));
+    verify(context).result(JsonProvider.objectToJSON(genesisTime));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/VersionHandlerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/VersionHandlerTest.java
@@ -22,13 +22,13 @@ import tech.pegasys.artemis.provider.JsonProvider;
 import tech.pegasys.artemis.util.cli.VersionProvider;
 
 public class VersionHandlerTest {
-  private Context mockContext = Mockito.mock(Context.class);
+  private Context context = Mockito.mock(Context.class);
 
   @Test
   public void shouldReturnVersionString() throws Exception {
     VersionHandler handler = new VersionHandler();
-    handler.handle(mockContext);
+    handler.handle(context);
 
-    verify(mockContext).result(JsonProvider.objectToJSON(VersionProvider.VERSION));
+    verify(context).result(JsonProvider.objectToJSON(VersionProvider.VERSION));
   }
 }


### PR DESCRIPTION
Add an object level abstraction for the response object, so that openApi can render what the response will be similar to.

 - The openApi was not able to handle SZVector or SZList.
 - It also defined Byte32 in a messy way, and our representation of Byte32 is actually String
 - UnsignedLong was coming out as an empty object, not any kind of numeric representation.

 The one messy thing about these objects is they're all 'public', because private members don't get rendered in openApi.  This means we have objects that are 'similar' and just used for documentation, which I'm not the hugest fan of, but it does look like we don't have a lot of choices.

Signed-off-by: Paul Harris <paul.harris@consensys.net>
