### PR TITLE
refactor BeaconChainHeadHandler to do a single call to storage client

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconChainHeadHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconChainHeadHandler.java
@@ -69,11 +69,6 @@ public class BeaconChainHeadHandler implements Handler {
     Checkpoint finalizedCheckpoint = beaconState.getFinalized_checkpoint();
     Checkpoint justifiedCheckpoint = beaconState.getCurrent_justified_checkpoint();
 
-    if (finalizedCheckpoint.getRoot() == null || justifiedCheckpoint.getRoot() == null) {
-      ctx.status(SC_NO_CONTENT);
-      return;
-    }
-
     BeaconChainHeadResponse chainHeadResponse =
         new BeaconChainHeadResponse(
             beaconState.getSlot(),

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconChainHeadHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconChainHeadHandler.java
@@ -57,7 +57,7 @@ public class BeaconChainHeadHandler implements Handler {
             content = @OpenApiContent(from = BeaconChainHeadResponse.class)),
         @OpenApiResponse(
             status = "204",
-            description = "No Content will be returned if any of the block roots are null")
+            description = "No Content will be returned if pre Genesis state")
       })
   @Override
   public void handle(Context ctx) throws JsonProcessingException {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconChainHeadHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconChainHeadHandler.java
@@ -15,9 +15,7 @@ package tech.pegasys.artemis.beaconrestapi.beaconhandlers;
 
 import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
-import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 
-import com.google.common.primitives.UnsignedLong;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
@@ -26,6 +24,8 @@ import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.artemis.beaconrestapi.schema.BeaconChainHeadResponse;
+import tech.pegasys.artemis.datastructures.state.BeaconState;
+import tech.pegasys.artemis.datastructures.state.Checkpoint;
 import tech.pegasys.artemis.provider.JsonProvider;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 
@@ -59,29 +59,32 @@ public class BeaconChainHeadHandler implements Handler {
   @Override
   public void handle(Context ctx) {
     Bytes32 head_block_root = client.getBestBlockRoot();
+    if (head_block_root == null) {
+      ctx.status(SC_NO_CONTENT);
+      return;
+    }
 
-    UnsignedLong head_block_slot = client.getBestSlot();
-    UnsignedLong finalized_epoch = client.getFinalizedEpoch();
-    Bytes32 finalized_root = client.getFinalizedRoot();
-    UnsignedLong justified_epoch = client.getJustifiedEpoch();
-    Bytes32 justified_root = client.getJustifiedRoot();
+    // derive all other state from the head_block_root
+    BeaconState beaconState = client.getStore().getBlockState(head_block_root);
+    Checkpoint finalizedCheckpoint = beaconState.getFinalized_checkpoint();
+    Checkpoint justifiedCheckpoint = beaconState.getCurrent_justified_checkpoint();
 
-    if (head_block_root == null || finalized_root == null || justified_root == null) {
+    if (finalizedCheckpoint.getRoot() == null || justifiedCheckpoint.getRoot() == null) {
       ctx.status(SC_NO_CONTENT);
       return;
     }
 
     BeaconChainHeadResponse chainHeadResponse =
         new BeaconChainHeadResponse(
-            head_block_slot,
-            compute_epoch_at_slot(head_block_slot),
+            beaconState.getSlot(),
+            compute_epoch_at_slot(beaconState.getSlot()),
             head_block_root,
-            compute_start_slot_at_epoch(finalized_epoch),
-            finalized_epoch,
-            finalized_root,
-            compute_start_slot_at_epoch(justified_epoch),
-            justified_epoch,
-            justified_root);
+            finalizedCheckpoint.getEpochSlot(),
+            finalizedCheckpoint.getEpoch(),
+            finalizedCheckpoint.getRoot(),
+            justifiedCheckpoint.getEpochSlot(),
+            justifiedCheckpoint.getEpoch(),
+            justifiedCheckpoint.getRoot());
 
     ctx.result(JsonProvider.objectToJSON(chainHeadResponse));
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconChainHeadHandlerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconChainHeadHandlerTest.java
@@ -35,13 +35,13 @@ public class BeaconChainHeadHandlerTest {
   private Context context = mock(Context.class);
   private ChainStorageClient storageClient = mock(ChainStorageClient.class);
   private Store store = mock(Store.class);
-  private BeaconState beaconState = mock(BeaconState.class);
+  private BeaconState beaconState = DataStructureUtil.randomBeaconState(77);
 
-  private Checkpoint finalizedCheckpoint = DataStructureUtil.randomCheckpoint(99);
-  private Checkpoint justifiedCheckpoint = DataStructureUtil.randomCheckpoint(98);
+  private Checkpoint finalizedCheckpoint = beaconState.getFinalized_checkpoint();
+  private Checkpoint justifiedCheckpoint = beaconState.getCurrent_justified_checkpoint();
 
   private final Bytes32 headBlockRoot = DataStructureUtil.randomBytes32(91);
-  private final UnsignedLong headBlockSlot = DataStructureUtil.randomUnsignedLong(92);
+  private final UnsignedLong headBlockSlot = beaconState.getSlot();
   private final UnsignedLong headBlockEpoch = compute_epoch_at_slot(headBlockSlot);
 
   @Test
@@ -50,10 +50,6 @@ public class BeaconChainHeadHandlerTest {
     when(storageClient.getStore()).thenReturn(store);
 
     when(store.getBlockState(headBlockRoot)).thenReturn(beaconState);
-
-    when(beaconState.getSlot()).thenReturn(headBlockSlot);
-    when(beaconState.getFinalized_checkpoint()).thenReturn(finalizedCheckpoint);
-    when(beaconState.getCurrent_justified_checkpoint()).thenReturn(justifiedCheckpoint);
 
     BeaconChainHeadHandler handler = new BeaconChainHeadHandler(storageClient);
     handler.handle(context);


### PR DESCRIPTION
Make a single call to the storage client and derive all else from the state at that point, rather than doing multiple calls.

Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>