### PR TITLE
[BC-263] Increase async event timeouts

### DIFF
--- a/storage/src/main/java/tech/pegasys/artemis/storage/HistoricalChainData.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/HistoricalChainData.java
@@ -17,6 +17,7 @@ import com.google.common.eventbus.AllowConcurrentEvents;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.primitives.UnsignedLong;
+import java.time.Duration;
 import java.util.Optional;
 import tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.artemis.storage.events.GetFinalizedBlockAtSlotRequest;
@@ -27,6 +28,7 @@ import tech.pegasys.artemis.util.async.AsyncEventTracker;
 import tech.pegasys.artemis.util.async.SafeFuture;
 
 public class HistoricalChainData {
+  private static final Duration QUERY_TIMEOUT = Duration.ofSeconds(10);
   private final AsyncEventTracker<UnsignedLong, Optional<SignedBeaconBlock>> blockAtSlotRequests;
   private final AsyncEventTracker<UnsignedLong, Optional<SignedBeaconBlock>>
       latestBlockAtSlotRequests;
@@ -38,13 +40,14 @@ public class HistoricalChainData {
   }
 
   public SafeFuture<Optional<SignedBeaconBlock>> getFinalizedBlockAtSlot(final UnsignedLong slot) {
-    return blockAtSlotRequests.sendRequest(slot, new GetFinalizedBlockAtSlotRequest(slot));
+    return blockAtSlotRequests.sendRequest(
+        slot, new GetFinalizedBlockAtSlotRequest(slot), QUERY_TIMEOUT);
   }
 
   public SafeFuture<Optional<SignedBeaconBlock>> getLatestFinalizedBlockAtSlot(
       final UnsignedLong slot) {
     return latestBlockAtSlotRequests.sendRequest(
-        slot, new GetLatestFinalizedBlockAtSlotRequest(slot));
+        slot, new GetLatestFinalizedBlockAtSlotRequest(slot), QUERY_TIMEOUT);
   }
 
   @Subscribe

--- a/storage/src/main/java/tech/pegasys/artemis/storage/StoreToDiskTransactionPrecommit.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/StoreToDiskTransactionPrecommit.java
@@ -16,6 +16,7 @@ package tech.pegasys.artemis.storage;
 import com.google.common.eventbus.AllowConcurrentEvents;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import java.time.Duration;
 import java.util.Optional;
 import javax.annotation.CheckReturnValue;
 import tech.pegasys.artemis.storage.events.StoreDiskUpdateCompleteEvent;
@@ -24,6 +25,7 @@ import tech.pegasys.artemis.util.async.AsyncEventTracker;
 import tech.pegasys.artemis.util.async.SafeFuture;
 
 public class StoreToDiskTransactionPrecommit implements TransactionPrecommit {
+  private static final Duration COMMIT_TIMEOUT = Duration.ofMinutes(1);
   private final AsyncEventTracker<Long, Optional<RuntimeException>> tracker;
 
   public StoreToDiskTransactionPrecommit(final EventBus eventBus) {
@@ -35,7 +37,7 @@ public class StoreToDiskTransactionPrecommit implements TransactionPrecommit {
   @CheckReturnValue
   public SafeFuture<Void> precommit(final StoreDiskUpdateEvent updateEvent) {
     return tracker
-        .sendRequest(updateEvent.getTransactionId(), updateEvent)
+        .sendRequest(updateEvent.getTransactionId(), updateEvent, COMMIT_TIMEOUT)
         .thenApply(
             error -> {
               if (error.isPresent()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Require explicit timeouts in `AsyncEventTracker`, increase timeouts, make sure to clean up tracking when events time out.
