### PR TITLE
[BC-275] Prune in memory store

### DIFF
--- a/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageServer.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageServer.java
@@ -18,8 +18,6 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import java.io.File;
 import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.artemis.storage.events.GetFinalizedBlockAtSlotRequest;
 import tech.pegasys.artemis.storage.events.GetFinalizedBlockAtSlotResponse;
@@ -31,7 +29,6 @@ import tech.pegasys.artemis.storage.events.StoreGenesisDiskUpdateEvent;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
 
 public class ChainStorageServer {
-  private static final Logger LOG = LogManager.getLogger();
   private final Database database;
   private final EventBus eventBus;
 
@@ -47,14 +44,8 @@ public class ChainStorageServer {
 
   @Subscribe
   public void onStoreDiskUpdate(final StoreDiskUpdateEvent event) {
-    try {
-      database.insert(event);
-
-      eventBus.post(new StoreDiskUpdateCompleteEvent(event.getTransactionId(), Optional.empty()));
-    } catch (final RuntimeException e) {
-      LOG.debug("Transaction " + event.getTransactionId() + " failed", e);
-      eventBus.post(new StoreDiskUpdateCompleteEvent(event.getTransactionId(), Optional.of(e)));
-    }
+    final DatabaseUpdateResult result = database.update(event);
+    eventBus.post(new StoreDiskUpdateCompleteEvent(event.getTransactionId(), result));
   }
 
   @Subscribe

--- a/storage/src/main/java/tech/pegasys/artemis/storage/Database.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/Database.java
@@ -25,7 +25,7 @@ public interface Database extends Closeable {
 
   void storeGenesis(Store store);
 
-  void insert(StoreDiskUpdateEvent event);
+  DatabaseUpdateResult update(StoreDiskUpdateEvent event);
 
   Store createMemoryStore();
 

--- a/storage/src/main/java/tech/pegasys/artemis/storage/DatabaseUpdateResult.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/DatabaseUpdateResult.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.storage;
+
+import java.util.Collections;
+import java.util.Set;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.artemis.datastructures.state.Checkpoint;
+
+public interface DatabaseUpdateResult {
+
+  static DatabaseUpdateResult failed(final RuntimeException error) {
+    return new FailedDatabaseUpdateResult(error);
+  }
+
+  static DatabaseUpdateResult successful(
+      final Set<Bytes32> prunedBlockRoots, final Set<Checkpoint> prunedCheckpoints) {
+    return new SuccessfulDatabaseUpdateResult(prunedBlockRoots, prunedCheckpoints);
+  }
+
+  /** @return {@code true} if the update was successfully processed */
+  boolean isSuccessful();
+
+  /** @return If the result is unsuccessful, returns the error, otherwise null. */
+  RuntimeException getError();
+
+  /**
+   * @return If the update was successful returns the set of block roots that were pruned from
+   *     storage. Otherwise, returns an empty collection.
+   */
+  Set<Bytes32> getPrunedBlockRoots();
+  /**
+   * @return If the update was successful returns the set of checkpoints that were pruned from
+   *     storage. Otherwise, returns an empty collection.
+   */
+  Set<Checkpoint> getPrunedCheckpoints();
+
+  class SuccessfulDatabaseUpdateResult implements DatabaseUpdateResult {
+    private final Set<Bytes32> prunedBlockRoots;
+    private final Set<Checkpoint> prunedCheckpoints;
+
+    SuccessfulDatabaseUpdateResult(
+        final Set<Bytes32> prunedBlockRoots, final Set<Checkpoint> prunedCheckpoints) {
+      this.prunedBlockRoots = prunedBlockRoots;
+      this.prunedCheckpoints = prunedCheckpoints;
+    }
+
+    @Override
+    public boolean isSuccessful() {
+      return true;
+    }
+
+    @Override
+    public RuntimeException getError() {
+      return null;
+    }
+
+    @Override
+    public Set<Checkpoint> getPrunedCheckpoints() {
+      return prunedCheckpoints;
+    }
+
+    @Override
+    public Set<Bytes32> getPrunedBlockRoots() {
+      return prunedBlockRoots;
+    }
+  }
+
+  class FailedDatabaseUpdateResult implements DatabaseUpdateResult {
+    private final RuntimeException error;
+
+    FailedDatabaseUpdateResult(final RuntimeException error) {
+      this.error = error;
+    }
+
+    @Override
+    public boolean isSuccessful() {
+      return false;
+    }
+
+    @Override
+    public RuntimeException getError() {
+      return error;
+    }
+
+    @Override
+    public Set<Bytes32> getPrunedBlockRoots() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public Set<Checkpoint> getPrunedCheckpoints() {
+      return Collections.emptySet();
+    }
+  }
+}

--- a/storage/src/main/java/tech/pegasys/artemis/storage/FailedPrecommitException.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/FailedPrecommitException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.storage;
+
+public class FailedPrecommitException extends RuntimeException {
+
+  public FailedPrecommitException(final DatabaseUpdateResult result) {
+    super(result.getError());
+  }
+}

--- a/storage/src/main/java/tech/pegasys/artemis/storage/Store.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/Store.java
@@ -335,11 +335,15 @@ public class Store implements ReadOnlyStore {
               latest_messages);
       return transactionPrecommit
           .precommit(updateEvent)
-          .thenRun(
-              () -> {
+          .thenAccept(
+              updateResult -> {
+                if (!updateResult.isSuccessful()) {
+                  throw new FailedPrecommitException(updateResult);
+                }
                 final Lock writeLock = Store.this.lock.writeLock();
                 writeLock.lock();
                 try {
+                  // Add new data
                   time.ifPresent(value -> Store.this.time = value);
                   genesis_time.ifPresent(value -> Store.this.genesis_time = value);
                   justified_checkpoint.ifPresent(value -> Store.this.justified_checkpoint = value);
@@ -350,6 +354,15 @@ public class Store implements ReadOnlyStore {
                   Store.this.block_states.putAll(block_states);
                   Store.this.checkpoint_states.putAll(checkpoint_states);
                   Store.this.latest_messages.putAll(latest_messages);
+                  // Prune old data
+                  updateResult.getPrunedBlockRoots().forEach(Store.this.checkpoint_states::remove);
+                  updateResult
+                      .getPrunedBlockRoots()
+                      .forEach(
+                          prunedRoot -> {
+                            Store.this.blocks.remove(prunedRoot);
+                            Store.this.block_states.remove(prunedRoot);
+                          });
                 } finally {
                   writeLock.unlock();
                 }

--- a/storage/src/main/java/tech/pegasys/artemis/storage/Store.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/Store.java
@@ -355,7 +355,7 @@ public class Store implements ReadOnlyStore {
                   Store.this.checkpoint_states.putAll(checkpoint_states);
                   Store.this.latest_messages.putAll(latest_messages);
                   // Prune old data
-                  updateResult.getPrunedBlockRoots().forEach(Store.this.checkpoint_states::remove);
+                  updateResult.getPrunedCheckpoints().forEach(Store.this.checkpoint_states::remove);
                   updateResult
                       .getPrunedBlockRoots()
                       .forEach(

--- a/storage/src/main/java/tech/pegasys/artemis/storage/StoreToDiskTransactionPrecommit.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/StoreToDiskTransactionPrecommit.java
@@ -17,7 +17,6 @@ import com.google.common.eventbus.AllowConcurrentEvents;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import java.time.Duration;
-import java.util.Optional;
 import javax.annotation.CheckReturnValue;
 import tech.pegasys.artemis.storage.events.StoreDiskUpdateCompleteEvent;
 import tech.pegasys.artemis.storage.events.StoreDiskUpdateEvent;
@@ -26,7 +25,7 @@ import tech.pegasys.artemis.util.async.SafeFuture;
 
 public class StoreToDiskTransactionPrecommit implements TransactionPrecommit {
   private static final Duration COMMIT_TIMEOUT = Duration.ofMinutes(1);
-  private final AsyncEventTracker<Long, Optional<RuntimeException>> tracker;
+  private final AsyncEventTracker<Long, DatabaseUpdateResult> tracker;
 
   public StoreToDiskTransactionPrecommit(final EventBus eventBus) {
     this.tracker = new AsyncEventTracker<>(eventBus);
@@ -35,21 +34,13 @@ public class StoreToDiskTransactionPrecommit implements TransactionPrecommit {
 
   @Override
   @CheckReturnValue
-  public SafeFuture<Void> precommit(final StoreDiskUpdateEvent updateEvent) {
-    return tracker
-        .sendRequest(updateEvent.getTransactionId(), updateEvent, COMMIT_TIMEOUT)
-        .thenApply(
-            error -> {
-              if (error.isPresent()) {
-                throw error.get();
-              }
-              return null;
-            });
+  public SafeFuture<DatabaseUpdateResult> precommit(final StoreDiskUpdateEvent updateEvent) {
+    return tracker.sendRequest(updateEvent.getTransactionId(), updateEvent, COMMIT_TIMEOUT);
   }
 
   @Subscribe
   @AllowConcurrentEvents
   void onResponse(final StoreDiskUpdateCompleteEvent event) {
-    tracker.onResponse(event.getTransactionId(), event.getError());
+    tracker.onResponse(event.getTransactionId(), event.getResult());
   }
 }

--- a/storage/src/main/java/tech/pegasys/artemis/storage/TransactionPrecommit.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/TransactionPrecommit.java
@@ -14,6 +14,7 @@
 package tech.pegasys.artemis.storage;
 
 import com.google.common.eventbus.EventBus;
+import java.util.Collections;
 import javax.annotation.CheckReturnValue;
 import tech.pegasys.artemis.storage.events.StoreDiskUpdateEvent;
 import tech.pegasys.artemis.util.async.SafeFuture;
@@ -21,7 +22,9 @@ import tech.pegasys.artemis.util.async.SafeFuture;
 public interface TransactionPrecommit {
 
   static TransactionPrecommit memoryOnly() {
-    return event -> SafeFuture.completedFuture(null);
+    return event ->
+        SafeFuture.completedFuture(
+            DatabaseUpdateResult.successful(Collections.emptySet(), Collections.emptySet()));
   }
 
   static TransactionPrecommit storageEnabled(final EventBus eventBus) {

--- a/storage/src/main/java/tech/pegasys/artemis/storage/TransactionPrecommit.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/TransactionPrecommit.java
@@ -29,5 +29,5 @@ public interface TransactionPrecommit {
   }
 
   @CheckReturnValue
-  SafeFuture<Void> precommit(StoreDiskUpdateEvent updateEvent);
+  SafeFuture<DatabaseUpdateResult> precommit(StoreDiskUpdateEvent updateEvent);
 }

--- a/storage/src/main/java/tech/pegasys/artemis/storage/events/StoreDiskUpdateCompleteEvent.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/events/StoreDiskUpdateCompleteEvent.java
@@ -13,23 +13,22 @@
 
 package tech.pegasys.artemis.storage.events;
 
-import java.util.Optional;
+import tech.pegasys.artemis.storage.DatabaseUpdateResult;
 
 public class StoreDiskUpdateCompleteEvent {
   private final long transactionId;
-  private final Optional<RuntimeException> error;
+  private final DatabaseUpdateResult result;
 
-  public StoreDiskUpdateCompleteEvent(
-      final long transactionId, final Optional<RuntimeException> error) {
+  public StoreDiskUpdateCompleteEvent(final long transactionId, final DatabaseUpdateResult result) {
     this.transactionId = transactionId;
-    this.error = error;
+    this.result = result;
   }
 
   public long getTransactionId() {
     return transactionId;
   }
 
-  public Optional<RuntimeException> getError() {
-    return error;
+  public DatabaseUpdateResult getResult() {
+    return result;
   }
 }

--- a/storage/src/test/java/tech/pegasys/artemis/storage/MapDbDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/artemis/storage/MapDbDatabaseTest.java
@@ -57,7 +57,7 @@ class MapDbDatabaseTest {
   private Database database = MapDbDatabase.createInMemory();
   private final TransactionPrecommit databaseTransactionPrecommit =
       updateEvent -> {
-        database.insert(updateEvent);
+        database.update(updateEvent);
         return SafeFuture.completedFuture(null);
       };
   private final Store store = Store.get_genesis_store(GENESIS_STATE);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Modify `Database.update()` to return a `DatabaseUpdateResult` object with pruning information.  Propagate result to `Store` via `TransactionPrecommit` so that in-memory data can be pruned as well. 