### PR TITLE
[BC-283] Don't persist time to db

### DIFF
--- a/storage/src/main/java/tech/pegasys/artemis/storage/DatabaseUpdateResult.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/DatabaseUpdateResult.java
@@ -29,6 +29,10 @@ public interface DatabaseUpdateResult {
     return new SuccessfulDatabaseUpdateResult(prunedBlockRoots, prunedCheckpoints);
   }
 
+  static DatabaseUpdateResult successfulWithNothingPruned() {
+    return new SuccessfulDatabaseUpdateResult(Collections.emptySet(), Collections.emptySet());
+  }
+
   /** @return {@code true} if the update was successfully processed */
   boolean isSuccessful();
 

--- a/storage/src/main/java/tech/pegasys/artemis/storage/MapDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/MapDbDatabase.java
@@ -270,6 +270,13 @@ public class MapDbDatabase implements Database {
 
   private Set<Bytes32> pruneHotBlocks(final Checkpoint newFinalizedCheckpoint) {
     SignedBeaconBlock newlyFinalizedBlock = hotBlocksByRoot.get(newFinalizedCheckpoint.getRoot());
+    if (newlyFinalizedBlock == null) {
+      LOG.error(
+          "Missing finalized block {} for epoch {}",
+          newFinalizedCheckpoint.getRoot(),
+          newFinalizedCheckpoint.getEpoch());
+      return Collections.emptySet();
+    }
     final UnsignedLong finalizedSlot = newlyFinalizedBlock.getSlot();
     final ConcurrentNavigableMap<UnsignedLong, Set<Bytes32>> toRemove =
         hotRootsBySlotCache.headMap(finalizedSlot);

--- a/storage/src/main/java/tech/pegasys/artemis/storage/Store.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/Store.java
@@ -324,7 +324,6 @@ public class Store implements ReadOnlyStore {
       final StoreDiskUpdateEvent updateEvent =
           new StoreDiskUpdateEvent(
               id,
-              time,
               genesis_time,
               justified_checkpoint,
               finalized_checkpoint,

--- a/storage/src/main/java/tech/pegasys/artemis/storage/TransactionPrecommit.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/TransactionPrecommit.java
@@ -14,7 +14,6 @@
 package tech.pegasys.artemis.storage;
 
 import com.google.common.eventbus.EventBus;
-import java.util.Collections;
 import javax.annotation.CheckReturnValue;
 import tech.pegasys.artemis.storage.events.StoreDiskUpdateEvent;
 import tech.pegasys.artemis.util.async.SafeFuture;
@@ -22,9 +21,7 @@ import tech.pegasys.artemis.util.async.SafeFuture;
 public interface TransactionPrecommit {
 
   static TransactionPrecommit memoryOnly() {
-    return event ->
-        SafeFuture.completedFuture(
-            DatabaseUpdateResult.successful(Collections.emptySet(), Collections.emptySet()));
+    return event -> SafeFuture.completedFuture(DatabaseUpdateResult.successfulWithNothingPruned());
   }
 
   static TransactionPrecommit storageEnabled(final EventBus eventBus) {

--- a/storage/src/main/java/tech/pegasys/artemis/storage/events/StoreDiskUpdateEvent.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/events/StoreDiskUpdateEvent.java
@@ -24,7 +24,6 @@ import tech.pegasys.artemis.datastructures.state.Checkpoint;
 public class StoreDiskUpdateEvent {
 
   private final long transactionId;
-  private final Optional<UnsignedLong> time;
   private final Optional<UnsignedLong> genesisTime;
   private final Optional<Checkpoint> justifiedCheckpoint;
   private final Optional<Checkpoint> finalizedCheckpoint;
@@ -36,7 +35,6 @@ public class StoreDiskUpdateEvent {
 
   public StoreDiskUpdateEvent(
       final long transactionId,
-      final Optional<UnsignedLong> time,
       final Optional<UnsignedLong> genesisTime,
       final Optional<Checkpoint> justifiedCheckpoint,
       final Optional<Checkpoint> finalizedCheckpoint,
@@ -46,7 +44,6 @@ public class StoreDiskUpdateEvent {
       final Map<Checkpoint, BeaconState> checkpointStates,
       final Map<UnsignedLong, Checkpoint> latestMessages) {
     this.transactionId = transactionId;
-    this.time = time;
     this.genesisTime = genesisTime;
     this.justifiedCheckpoint = justifiedCheckpoint;
     this.finalizedCheckpoint = finalizedCheckpoint;
@@ -57,12 +54,19 @@ public class StoreDiskUpdateEvent {
     this.latestMessages = latestMessages;
   }
 
-  public long getTransactionId() {
-    return transactionId;
+  public boolean isEmpty() {
+    return genesisTime.isEmpty()
+        && justifiedCheckpoint.isEmpty()
+        && finalizedCheckpoint.isEmpty()
+        && bestJustifiedCheckpoint.isEmpty()
+        && blocks.isEmpty()
+        && blockStates.isEmpty()
+        && checkpointStates.isEmpty()
+        && latestMessages.isEmpty();
   }
 
-  public Optional<UnsignedLong> getTime() {
-    return time;
+  public long getTransactionId() {
+    return transactionId;
   }
 
   public Optional<UnsignedLong> getGenesisTime() {

--- a/storage/src/test/java/tech/pegasys/artemis/storage/MapDbDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/artemis/storage/MapDbDatabaseTest.java
@@ -95,7 +95,7 @@ class MapDbDatabaseTest {
   @Test
   public void shouldRecreateOriginalGenesisStore() {
     final Store memoryStore = database.createMemoryStore();
-    assertThat(memoryStore).isEqualToIgnoringGivenFields(store, "lock", "readLock");
+    assertThat(memoryStore).isEqualToIgnoringGivenFields(store, "time", "lock", "readLock");
   }
 
   @Test
@@ -140,7 +140,6 @@ class MapDbDatabaseTest {
 
     final Transaction transaction = store.startTransaction(databaseTransactionPrecommit);
     transaction.setGenesis_time(UnsignedLong.valueOf(3));
-    transaction.setTime(UnsignedLong.valueOf(5));
     transaction.setFinalizedCheckpoint(checkpoint1);
     transaction.setJustifiedCheckpoint(checkpoint2);
     transaction.setBestJustifiedCheckpoint(checkpoint3);
@@ -149,7 +148,6 @@ class MapDbDatabaseTest {
 
     final Store result = database.createMemoryStore();
 
-    assertThat(result.getTime()).isEqualTo(transaction.getTime());
     assertThat(result.getGenesisTime()).isEqualTo(transaction.getGenesisTime());
     assertThat(result.getFinalizedCheckpoint()).isEqualTo(transaction.getFinalizedCheckpoint());
     assertThat(result.getJustifiedCheckpoint()).isEqualTo(transaction.getJustifiedCheckpoint());

--- a/storage/src/test/java/tech/pegasys/artemis/storage/MapDbDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/artemis/storage/MapDbDatabaseTest.java
@@ -156,6 +156,122 @@ class MapDbDatabaseTest {
   }
 
   @Test
+  public void shouldStoreSingleValue_genesisTime() {
+    final UnsignedLong newGenesisTime = UnsignedLong.valueOf(3);
+    // Sanity check
+    assertThat(store.getGenesisTime()).isNotEqualTo(newGenesisTime);
+
+    final Transaction transaction = store.startTransaction(databaseTransactionPrecommit);
+    transaction.setGenesis_time(newGenesisTime);
+    commit(transaction);
+
+    final Store result = database.createMemoryStore();
+    assertThat(result.getGenesisTime()).isEqualTo(transaction.getGenesisTime());
+  }
+
+  @Test
+  public void shouldStoreSingleValue_justifiedCheckpoint() {
+    final Checkpoint newValue = checkpoint3;
+    // Sanity check
+    assertThat(store.getJustifiedCheckpoint()).isNotEqualTo(checkpoint3);
+
+    final Transaction transaction = store.startTransaction(databaseTransactionPrecommit);
+    transaction.setJustifiedCheckpoint(newValue);
+    commit(transaction);
+
+    final Store result = database.createMemoryStore();
+    assertThat(result.getJustifiedCheckpoint()).isEqualTo(newValue);
+  }
+
+  @Test
+  public void shouldStoreSingleValue_finalizedCheckpoint() {
+    final Checkpoint newValue = checkpoint3;
+    // Sanity check
+    assertThat(store.getFinalizedCheckpoint()).isNotEqualTo(checkpoint3);
+
+    final Transaction transaction = store.startTransaction(databaseTransactionPrecommit);
+    transaction.setFinalizedCheckpoint(newValue);
+    commit(transaction);
+
+    final Store result = database.createMemoryStore();
+    assertThat(result.getFinalizedCheckpoint()).isEqualTo(newValue);
+  }
+
+  @Test
+  public void shouldStoreSingleValue_bestJustifiedCheckpoint() {
+    final Checkpoint newValue = checkpoint3;
+    // Sanity check
+    assertThat(store.getBestJustifiedCheckpoint()).isNotEqualTo(checkpoint3);
+
+    final Transaction transaction = store.startTransaction(databaseTransactionPrecommit);
+    transaction.setBestJustifiedCheckpoint(newValue);
+    commit(transaction);
+
+    final Store result = database.createMemoryStore();
+    assertThat(result.getBestJustifiedCheckpoint()).isEqualTo(newValue);
+  }
+
+  @Test
+  public void shouldStoreSingleValue_singleBlock() {
+    final SignedBeaconBlock newBlock = checkpoint3Block;
+    final Bytes32 newBlockRoot = newBlock.getMessage().hash_tree_root();
+    // Sanity check
+    assertThat(store.getBlock(newBlockRoot)).isNull();
+
+    final Transaction transaction = store.startTransaction(databaseTransactionPrecommit);
+    transaction.putBlock(newBlockRoot, newBlock);
+    commit(transaction);
+
+    final Store result = database.createMemoryStore();
+    assertThat(result.getBlock(newBlockRoot)).isEqualTo(newBlock.getMessage());
+  }
+
+  @Test
+  public void shouldStoreSingleValue_singleBlockState() {
+    final BeaconState newState = DataStructureUtil.randomBeaconState(999);
+    final Bytes32 blockRoot = DataStructureUtil.randomBytes32(999L);
+    // Sanity check
+    assertThat(store.getBlockState(blockRoot)).isNull();
+
+    final Transaction transaction = store.startTransaction(databaseTransactionPrecommit);
+    transaction.putBlockState(blockRoot, newState);
+    commit(transaction);
+
+    final Store result = database.createMemoryStore();
+    assertThat(result.getBlockState(blockRoot)).isEqualTo(newState);
+  }
+
+  @Test
+  public void shouldStoreSingleValue_singleCheckpointState() {
+    final Checkpoint checkpoint = checkpoint3;
+    final BeaconState newState = DataStructureUtil.randomBeaconState(999);
+    // Sanity check
+    assertThat(store.getCheckpointState(checkpoint)).isNull();
+
+    final Transaction transaction = store.startTransaction(databaseTransactionPrecommit);
+    transaction.putCheckpointState(checkpoint, newState);
+    commit(transaction);
+
+    final Store result = database.createMemoryStore();
+    assertThat(result.getCheckpointState(checkpoint)).isEqualTo(newState);
+  }
+
+  @Test
+  public void shouldStoreSingleValue_latestMessage() {
+    final UnsignedLong validatorIndex = UnsignedLong.valueOf(999);
+    final Checkpoint latestMessage = checkpoint3;
+    // Sanity check
+    assertThat(store.getLatestMessage(validatorIndex)).isNull();
+
+    final Transaction transaction = store.startTransaction(databaseTransactionPrecommit);
+    transaction.putLatestMessage(validatorIndex, latestMessage);
+    commit(transaction);
+
+    final Store result = database.createMemoryStore();
+    assertThat(result.getLatestMessage(validatorIndex)).isEqualTo(latestMessage);
+  }
+
+  @Test
   public void shouldStoreLatestMessageFromEachValidator() {
     final UnsignedLong validator1 = UnsignedLong.valueOf(1);
     final UnsignedLong validator2 = UnsignedLong.valueOf(2);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Time is updated very frequently.  In this PR, the database is modified so that we no longer track time at the storage layer.  This means we're committing less frequently to the database, which should help with contention around database updates.