### PR TITLE
Improve rpc logging, only close outgoing rpc stream once

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/AsyncResponseProcessor.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/AsyncResponseProcessor.java
@@ -92,6 +92,7 @@ class AsyncResponseProcessor<TResponse> {
     if (!cancelled.get() && !isProcessing.get() && !queuedResponses.isEmpty()) {
       processNextResponse();
     } else if (allResponsesDelivered.get() && !isProcessing.get() && queuedResponses.isEmpty()) {
+      LOG.trace("Finished processing responses.");
       finishedProcessing.complete(null);
     }
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Improve rpc logging by ensuring that we only close our outgoing rpc streams once.  Previously, our timeout code could run after the stream had already been closed, which made the logs a bit confusing.
