### PR TITLE
Moving dataPath option to database config section

### DIFF
--- a/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
+++ b/acceptance-tests/src/test-support/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
@@ -275,7 +275,9 @@ public class ArtemisNode extends Node {
       final Map<String, Object> output = getSection(OUTPUT_SECTION);
       output.put("transitionRecordDir", ARTIFACTS_PATH + "transitions/");
       output.put("logDir", ARTIFACTS_PATH + "logs/");
-      output.put("dataDir", ARTIFACTS_PATH + "data/");
+
+      final Map<String, Object> database = getSection(DATABASE_SECTION);
+      database.put("dataDir", ARTIFACTS_PATH + "data/");
     }
 
     public Config withDepositsFrom(final BesuNode eth1Node) {

--- a/config/config.toml
+++ b/config/config.toml
@@ -35,7 +35,6 @@ contractAddr = "0x77f7bED277449F51505a4C54550B074030d989bC"
 nodeUrl = "http://localhost:8545"
 
 [output]
-dataPath="."
 #transitionRecordDir = "/tmp/teku"
 
 [metrics]
@@ -45,6 +44,7 @@ metricsNetworkInterface = "127.0.0.1"
 #metricsCategories = [ "BEACONCHAIN", "JVM", "PROCESS" ]
 
 [database]
+dataPath="."
 startFromDisk = false
 
 [beaconrestapi]

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
@@ -104,13 +104,12 @@ public class ArtemisConfiguration {
         asList("JVM", "PROCESS", "BEACONCHAIN", "EVENTBUS", "NETWORK"),
         "Metric categories to enable",
         null);
+
     // Outputs
     builder.addString(
         "output.logPath", ".", "Path to output the log file", PropertyValidator.isPresent());
     builder.addString(
         "output.logFile", "artemis.log", "Log file name", PropertyValidator.isPresent());
-    builder.addString(
-        "output.dataPath", ".", "Path to output data files", PropertyValidator.isPresent());
     builder.addString(
         "output.transitionRecordDir",
         "",
@@ -119,6 +118,8 @@ public class ArtemisConfiguration {
 
     // Database
     builder.addBoolean("database.startFromDisk", false, "Start from the disk if set to true", null);
+    builder.addString(
+        "database.dataPath", ".", "Path to output data files", PropertyValidator.isPresent());
 
     // Beacon Rest API
     builder.addInteger("beaconrestapi.portNumber", 5051, "Port number of Beacon Rest API", null);
@@ -316,7 +317,7 @@ public class ArtemisConfiguration {
   }
 
   public String getDataPath() {
-    return config.getString("output.dataPath");
+    return config.getString("database.dataPath");
   }
 
   public boolean startFromDisk() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
The `dataPath` determines the path to the datasource, which is a concept with greater alignment to the `[database]` section of the config rather than `[output]`.
