### PR TITLE
Handle duplicate peers

### DIFF
--- a/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/GoodbyeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/GoodbyeIntegrationTest.java
@@ -27,13 +27,11 @@ public class GoodbyeIntegrationTest {
   private final Eth2NetworkFactory networkFactory = new Eth2NetworkFactory();
   private Eth2Peer peer1;
   private Eth2Peer peer2;
-  private Eth2Network network1;
-  private Eth2Network network2;
 
   @BeforeEach
   public void setUp() throws Exception {
-    network1 = networkFactory.builder().startNetwork();
-    network2 = networkFactory.builder().peer(network1).startNetwork();
+    final Eth2Network network1 = networkFactory.builder().startNetwork();
+    final Eth2Network network2 = networkFactory.builder().peer(network1).startNetwork();
     peer1 = network2.getPeer(network1.getNodeId()).orElseThrow();
     peer2 = network1.getPeer(network2.getNodeId()).orElseThrow();
   }
@@ -48,7 +46,5 @@ public class GoodbyeIntegrationTest {
     waitFor(peer1.sendGoodbye(GoodbyeMessage.REASON_CLIENT_SHUT_DOWN));
     Waiter.waitFor(() -> assertThat(peer1.isConnected()).isFalse());
     Waiter.waitFor(() -> assertThat(peer2.isConnected()).isFalse());
-    assertThat(network1.getPeerCount()).isZero();
-    assertThat(network2.getPeerCount()).isZero();
   }
 }

--- a/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/DiscoveryNetworkIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/DiscoveryNetworkIntegrationTest.java
@@ -47,6 +47,24 @@ public class DiscoveryNetworkIntegrationTest {
   }
 
   @Test
+  public void shouldReconnectToStaticPeersWhenAlreadyConnected() throws Exception {
+    final DiscoveryNetwork<Peer> network1 = discoveryNetworkFactory.builder().buildAndStart();
+    final DiscoveryNetwork<Peer> network2 =
+        discoveryNetworkFactory.builder().staticPeer(network1.getNodeAddress()).buildAndStart();
+    assertConnected(network1, network2);
+
+    // Already connected, but now tell network1 to maintain a persistent connection to network2.
+    network1.addStaticPeer(network2.getNodeAddress());
+
+    network1.getPeer(network2.getNodeId()).orElseThrow().disconnect();
+    assertConnected(network1, network2);
+
+    // Check we remain connected and didn't just briefly reconnect.
+    Thread.sleep(1000);
+    assertConnected(network1, network2);
+  }
+
+  @Test
   public void shouldConnectToBootnodes() throws Exception {
     final DiscoveryNetwork<Peer> network1 = discoveryNetworkFactory.builder().buildAndStart();
     final DiscoveryNetwork<Peer> network2 =

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/DiscoveryNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/DiscoveryNetwork.java
@@ -102,6 +102,10 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
             });
   }
 
+  public void addStaticPeer(final String peer) {
+    connectionManager.addStaticPeer(peer);
+  }
+
   @Override
   public Optional<String> getEnr() {
     return discoveryService.getEnr();

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PPeer.java
@@ -89,7 +89,7 @@ public class LibP2PPeer implements Peer {
   }
 
   private void handleConnectionClosed() {
-    LOG.debug("Disconnected from peer {}", this);
+    LOG.debug("Disconnected from peer {}", nodeId);
     connected.set(false);
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/P2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/P2PNetwork.java
@@ -31,7 +31,8 @@ public interface P2PNetwork<T extends Peer> extends GossipNetwork {
 
   /**
    * Connects to a Peer using a user supplied address. The address format is specific to the network
-   * implementation.
+   * implementation. If a connection already exists for this peer, the future completes with the
+   * existing peer.
    *
    * @param peer Peer to connect to.
    * @return A future which completes when the connection is establish, containing the newly
@@ -40,7 +41,8 @@ public interface P2PNetwork<T extends Peer> extends GossipNetwork {
   SafeFuture<Peer> connect(String peer);
 
   /**
-   * Connects to a peer identified via discovery.
+   * Connects to a peer identified via discovery. If a connection already exists for this peer, the
+   * future completes with the existing peer.
    *
    * @param peer the peer to connect to.
    * @return A future which completes when the connection is establish, containing the newly


### PR DESCRIPTION
## PR Description
Ensure that we only have a single connection to each peer ID.

Builds on #1239. Last commit has all the changes specific to this PR.