### PR TITLE
bootnodes as empty string does not work, needs to be a list

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -9,7 +9,7 @@ port = 9000
 # "static" - no discovery, only connect to static peers
 # "discv5" - Enable discovery v5
 discovery = "static"
-bootnodes = ""
+#bootnodes = ""
 advertisedPort = 9000
 constants = "minimal"
 


### PR DESCRIPTION
comment out node.bootnodes="" since it needs to be a list 