### PR TITLE
added test and fixed NPE

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandler.java
@@ -96,6 +96,10 @@ public class BeaconStateHandler implements Handler {
         future = queryByRootHash(validateQueryParameter(parameters, ROOT));
       } else if (parameters.containsKey(SLOT)) {
         future = queryBySlot(validateQueryParameter(parameters, SLOT));
+      } else {
+        ctx.result(jsonProvider.objectToJSON(new BadRequest("expected one of " + SLOT + " or " + ROOT)));
+        ctx.status(SC_BAD_REQUEST);
+        return;
       }
       ctx.result(
           future.thenApplyChecked(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandler.java
@@ -97,7 +97,8 @@ public class BeaconStateHandler implements Handler {
       } else if (parameters.containsKey(SLOT)) {
         future = queryBySlot(validateQueryParameter(parameters, SLOT));
       } else {
-        ctx.result(jsonProvider.objectToJSON(new BadRequest("expected one of " + SLOT + " or " + ROOT)));
+        ctx.result(
+            jsonProvider.objectToJSON(new BadRequest("expected one of " + SLOT + " or " + ROOT)));
         ctx.status(SC_BAD_REQUEST);
         return;
       }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandlerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandlerTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.artemis.beaconrestapi.RestApiConstants.EPOCH;
 import static tech.pegasys.artemis.beaconrestapi.RestApiConstants.ROOT;
 import static tech.pegasys.artemis.beaconrestapi.RestApiConstants.SLOT;
 import static tech.pegasys.artemis.util.async.SafeFuture.completedFuture;
@@ -100,6 +101,17 @@ public class BeaconStateHandlerTest {
     final BeaconStateHandler handler =
         new BeaconStateHandler(combinedChainDataClient, jsonProvider);
     when(context.queryParamMap()).thenReturn(Map.of(SLOT, List.of("not-an-int")));
+
+    handler.handle(context);
+
+    verify(context).status(SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenBadParamSpecified() throws Exception {
+    final BeaconStateHandler handler =
+        new BeaconStateHandler(combinedChainDataClient, jsonProvider);
+    when(context.queryParamMap()).thenReturn(Map.of(EPOCH, List.of("not-an-int")));
 
     handler.handle(context);
 


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Added a test that supplies an EPOCH param to an endpoint that expects either SLOT or ROOT. 
