### PR TITLE
Provide meaningful type of peer addresses instead of just String

### DIFF
--- a/compatibility-tests/multiclient/src/compatibility-test/java/tech/pegasys/artemis/compatibility/multiclient/StatusMessageCompatibilityTest.java
+++ b/compatibility-tests/multiclient/src/compatibility-test/java/tech/pegasys/artemis/compatibility/multiclient/StatusMessageCompatibilityTest.java
@@ -50,7 +50,7 @@ class StatusMessageCompatibilityTest {
 
   @Test
   public void shouldExchangeStatusWhenArtemisConnectsToPrysm() throws Exception {
-    waitFor(artemis.connect(PRYSM_NODE.getMultiAddr()));
+    waitFor(artemis.connect(artemis.createPeerAddress(PRYSM_NODE.getMultiAddr())));
     waitFor(() -> assertThat(artemis.getPeerCount()).isEqualTo(1));
     final Eth2Peer prysm = artemis.getPeer(PRYSM_NODE.getId()).orElseThrow();
     final PeerStatus status = prysm.getStatus();

--- a/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/GossipMessageHandlerIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/GossipMessageHandlerIntegrationTest.java
@@ -63,8 +63,8 @@ public class GossipMessageHandlerIntegrationTest {
     node2.chainUtil().setSlot(blockSlot);
 
     // Connect networks 1 -> 2 -> 3
-    waitFor(node1.network().connect(node2.network().getNodeAddress()));
-    waitFor(node2.network().connect(node3.network().getNodeAddress()));
+    waitFor(node1.connect(node2));
+    waitFor(node2.connect(node3));
     // Wait for connections to get set up
     Waiter.waitFor(
         () -> {
@@ -108,8 +108,8 @@ public class GossipMessageHandlerIntegrationTest {
     node2.chainUtil().setSlot(blockSlot);
 
     // Connect networks 1 -> 2 -> 3
-    waitFor(node1.network().connect(node2.network().getNodeAddress()));
-    waitFor(node2.network().connect(node3.network().getNodeAddress()));
+    waitFor(node1.connect(node2));
+    waitFor(node2.connect(node3));
     // Wait for connections to get set up
     Waiter.waitFor(
         () -> {
@@ -145,7 +145,7 @@ public class GossipMessageHandlerIntegrationTest {
     final Eth2Network network2 = node2.network();
 
     // Connect networks 1 -> 2
-    waitFor(network1.connect(network2.getNodeAddress()));
+    waitFor(node1.connect(node2));
     // Wait for connections to get set up
     Waiter.waitFor(
         () -> {
@@ -175,7 +175,7 @@ public class GossipMessageHandlerIntegrationTest {
     final Eth2Network network2 = node2.network();
 
     // Connect networks 1 -> 2
-    waitFor(network1.connect(network2.getNodeAddress()));
+    waitFor(node1.connect(node2));
     // Wait for connections to get set up
     Waiter.waitFor(
         () -> {
@@ -220,7 +220,7 @@ public class GossipMessageHandlerIntegrationTest {
     final Eth2Network network2 = node2.network();
 
     // Connect networks 1 -> 2
-    waitFor(network1.connect(network2.getNodeAddress()));
+    waitFor(node1.connect(node2));
     // Wait for connections to get set up
     Waiter.waitFor(
         () -> {

--- a/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/PeerStatusIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/PeerStatusIntegrationTest.java
@@ -52,7 +52,7 @@ public class PeerStatusIntegrationTest {
             .chainStorageClient(storageClient2)
             .startNetwork();
 
-    Waiter.waitFor(network1.connect(network2.getNodeAddress()));
+    Waiter.waitFor(network1.connect(network1.createPeerAddress(network2.getNodeAddress())));
     Waiter.waitFor(
         () -> {
           assertThat(network1.getPeerCount()).isEqualTo(1);

--- a/networking/eth2/src/test-support/java/tech/pegasys/artemis/networking/eth2/NodeManager.java
+++ b/networking/eth2/src/test-support/java/tech/pegasys/artemis/networking/eth2/NodeManager.java
@@ -17,8 +17,11 @@ import com.google.common.eventbus.EventBus;
 import java.util.List;
 import java.util.function.Consumer;
 import tech.pegasys.artemis.networking.eth2.Eth2NetworkFactory.Eth2P2PNetworkBuilder;
+import tech.pegasys.artemis.networking.p2p.network.PeerAddress;
+import tech.pegasys.artemis.networking.p2p.peer.Peer;
 import tech.pegasys.artemis.statetransition.BeaconChainUtil;
 import tech.pegasys.artemis.storage.ChainStorageClient;
+import tech.pegasys.artemis.util.async.SafeFuture;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
 
 public class NodeManager {
@@ -61,6 +64,11 @@ public class NodeManager {
     chainUtil.initializeStorage();
 
     return new NodeManager(eventBus, storageClient, chainUtil, eth2Network);
+  }
+
+  public SafeFuture<Peer> connect(final NodeManager peer) {
+    final PeerAddress peerAddress = eth2Network.createPeerAddress(peer.network().getNodeAddress());
+    return eth2Network.connect(peerAddress);
   }
 
   public EventBus eventBus() {

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/DiscoveryNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/DiscoveryNetwork.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.artemis.networking.p2p;
 
+import static java.util.stream.Collectors.toList;
+
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
@@ -55,7 +57,7 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
             discoveryService,
             DelayedExecutorAsyncRunner.create(),
             p2pNetwork,
-            p2pConfig.getStaticPeers(),
+            p2pConfig.getStaticPeers().stream().map(p2pNetwork::parse).collect(toList()),
             p2pConfig.getTargetPeerRange());
     return new DiscoveryNetwork<>(p2pNetwork, discoveryService, connectionManager);
   }
@@ -103,8 +105,8 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
             });
   }
 
-  public void addStaticPeer(final String peer) {
-    connectionManager.addStaticPeer(peer);
+  public void addStaticPeer(final String peerAddress) {
+    connectionManager.addStaticPeer(p2pNetwork.parse(peerAddress));
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/DiscoveryNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/DiscoveryNetwork.java
@@ -57,7 +57,9 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
             discoveryService,
             DelayedExecutorAsyncRunner.create(),
             p2pNetwork,
-            p2pConfig.getStaticPeers().stream().map(p2pNetwork::parse).collect(toList()),
+            p2pConfig.getStaticPeers().stream()
+                .map(p2pNetwork::createPeerAddress)
+                .collect(toList()),
             p2pConfig.getTargetPeerRange());
     return new DiscoveryNetwork<>(p2pNetwork, discoveryService, connectionManager);
   }
@@ -106,7 +108,7 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
   }
 
   public void addStaticPeer(final String peerAddress) {
-    connectionManager.addStaticPeer(p2pNetwork.parse(peerAddress));
+    connectionManager.addStaticPeer(p2pNetwork.createPeerAddress(peerAddress));
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/connection/ConnectionManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/connection/ConnectionManager.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.artemis.networking.p2p.discovery.DiscoveryPeer;
 import tech.pegasys.artemis.networking.p2p.discovery.DiscoveryService;
 import tech.pegasys.artemis.networking.p2p.network.P2PNetwork;
+import tech.pegasys.artemis.networking.p2p.network.PeerAddress;
 import tech.pegasys.artemis.networking.p2p.peer.Peer;
 import tech.pegasys.artemis.service.serviceutils.Service;
 import tech.pegasys.artemis.util.async.AsyncRunner;
@@ -34,7 +35,7 @@ public class ConnectionManager extends Service {
   private static final Duration DISCOVERY_INTERVAL = Duration.ofSeconds(30);
   private final AsyncRunner asyncRunner;
   private final P2PNetwork<? extends Peer> network;
-  private final Set<String> staticPeers;
+  private final Set<PeerAddress> staticPeers;
   private final DiscoveryService discoveryService;
   private final TargetPeerRange targetPeerCountRange;
 
@@ -44,11 +45,11 @@ public class ConnectionManager extends Service {
       final DiscoveryService discoveryService,
       final AsyncRunner asyncRunner,
       final P2PNetwork<? extends Peer> network,
-      final List<String> staticPeers,
+      final List<PeerAddress> peerAddresses,
       final TargetPeerRange targetPeerCountRange) {
     this.asyncRunner = asyncRunner;
     this.network = network;
-    this.staticPeers = new HashSet<>(staticPeers);
+    this.staticPeers = new HashSet<>(peerAddresses);
     this.discoveryService = discoveryService;
     this.targetPeerCountRange = targetPeerCountRange;
   }
@@ -113,18 +114,18 @@ public class ConnectionManager extends Service {
     return SafeFuture.COMPLETE;
   }
 
-  public synchronized void addStaticPeer(final String peerAddress) {
+  public synchronized void addStaticPeer(final PeerAddress peerAddress) {
     if (!staticPeers.contains(peerAddress)) {
       staticPeers.add(peerAddress);
       createPersistentConnection(peerAddress);
     }
   }
 
-  private void createPersistentConnection(final String peerAddress) {
+  private void createPersistentConnection(final PeerAddress peerAddress) {
     maintainPersistentConnection(peerAddress).reportExceptions();
   }
 
-  private SafeFuture<Peer> maintainPersistentConnection(final String peerAddress) {
+  private SafeFuture<Peer> maintainPersistentConnection(final PeerAddress peerAddress) {
     LOG.debug("Connecting to peer {}", peerAddress);
     return network
         .connect(peerAddress)

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PNetwork.java
@@ -51,6 +51,7 @@ import tech.pegasys.artemis.networking.p2p.libp2p.gossip.LibP2PGossipNetwork;
 import tech.pegasys.artemis.networking.p2p.libp2p.rpc.RpcHandler;
 import tech.pegasys.artemis.networking.p2p.network.NetworkConfig;
 import tech.pegasys.artemis.networking.p2p.network.P2PNetwork;
+import tech.pegasys.artemis.networking.p2p.network.PeerAddress;
 import tech.pegasys.artemis.networking.p2p.network.PeerHandler;
 import tech.pegasys.artemis.networking.p2p.peer.NodeId;
 import tech.pegasys.artemis.networking.p2p.peer.Peer;
@@ -159,8 +160,15 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
   }
 
   @Override
-  public SafeFuture<Peer> connect(final String peer) {
-    return peerManager.connect(new Multiaddr(peer), host.getNetwork());
+  public SafeFuture<Peer> connect(final PeerAddress peer) {
+    return peer.as(MultiaddrPeerAddress.class)
+        .thenCompose(
+            staticPeer -> peerManager.connect(staticPeer.getMultiaddr(), host.getNetwork()));
+  }
+
+  @Override
+  public PeerAddress parse(final String peerAddress) {
+    return MultiaddrPeerAddress.parse(peerAddress);
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PNetwork.java
@@ -14,6 +14,7 @@
 package tech.pegasys.artemis.networking.p2p.libp2p;
 
 import static tech.pegasys.artemis.util.alogger.ALogger.STDOUT;
+import static tech.pegasys.artemis.util.async.SafeFuture.failedFuture;
 import static tech.pegasys.artemis.util.async.SafeFuture.reportExceptions;
 
 import identify.pb.IdentifyOuterClass;
@@ -161,8 +162,12 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
   @Override
   public SafeFuture<Peer> connect(final PeerAddress peer) {
     return peer.as(MultiaddrPeerAddress.class)
-        .thenCompose(
-            staticPeer -> peerManager.connect(staticPeer.getMultiaddr(), host.getNetwork()));
+        .map(staticPeer -> peerManager.connect(staticPeer.getMultiaddr(), host.getNetwork()))
+        .orElseGet(
+            () ->
+                failedFuture(
+                    new IllegalArgumentException(
+                        "Unsupported peer address: " + peer.getClass().getName())));
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PNetwork.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.artemis.networking.p2p.libp2p;
 
-import static tech.pegasys.artemis.networking.p2p.libp2p.DiscoveryPeerToMultiaddrConverter.convertToMultiAddr;
 import static tech.pegasys.artemis.util.alogger.ALogger.STDOUT;
 import static tech.pegasys.artemis.util.async.SafeFuture.reportExceptions;
 
@@ -167,13 +166,13 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
   }
 
   @Override
-  public PeerAddress parse(final String peerAddress) {
-    return MultiaddrPeerAddress.parse(peerAddress);
+  public PeerAddress createPeerAddress(final String peerAddress) {
+    return MultiaddrPeerAddress.fromAddress(peerAddress);
   }
 
   @Override
-  public SafeFuture<Peer> connect(final DiscoveryPeer peer) {
-    return peerManager.connect(convertToMultiAddr(peer), host.getNetwork());
+  public PeerAddress createPeerAddress(final DiscoveryPeer discoveryPeer) {
+    return MultiaddrPeerAddress.fromDiscoveryPeer(discoveryPeer);
   }
 
   @Override
@@ -187,10 +186,8 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
   }
 
   @Override
-  public boolean isConnected(final DiscoveryPeer discoveryPeer) {
-    return peerManager
-        .getPeer(DiscoveryPeerToMultiaddrConverter.getNodeId(discoveryPeer))
-        .isPresent();
+  public boolean isConnected(final PeerAddress peerAddress) {
+    return peerManager.getPeer(peerAddress.getId()).isPresent();
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/MultiaddrPeerAddress.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/MultiaddrPeerAddress.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.p2p.libp2p;
+
+import io.libp2p.core.PeerId;
+import io.libp2p.core.multiformats.Multiaddr;
+import io.libp2p.core.multiformats.Protocol;
+import tech.pegasys.artemis.networking.p2p.network.PeerAddress;
+import tech.pegasys.artemis.networking.p2p.peer.NodeId;
+
+public class MultiaddrPeerAddress extends PeerAddress {
+
+  private final Multiaddr multiaddr;
+
+  private MultiaddrPeerAddress(
+      final NodeId nodeId, final Multiaddr multiaddr, final String sourceAddress) {
+    super(nodeId, sourceAddress);
+    this.multiaddr = multiaddr;
+  }
+
+  public static MultiaddrPeerAddress parse(final String address) {
+    final Multiaddr multiaddr = Multiaddr.fromString(address);
+    final String p2pComponent = multiaddr.getStringComponent(Protocol.P2P);
+    if (p2pComponent == null) {
+      throw new IllegalArgumentException("No peer ID present in multiaddr: " + address);
+    }
+    final LibP2PNodeId nodeId = new LibP2PNodeId(PeerId.fromBase58(p2pComponent));
+    return new MultiaddrPeerAddress(nodeId, multiaddr, address);
+  }
+
+  public Multiaddr getMultiaddr() {
+    return multiaddr;
+  }
+}

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/MultiaddrPeerAddress.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/MultiaddrPeerAddress.java
@@ -16,6 +16,7 @@ package tech.pegasys.artemis.networking.p2p.libp2p;
 import io.libp2p.core.PeerId;
 import io.libp2p.core.multiformats.Multiaddr;
 import io.libp2p.core.multiformats.Protocol;
+import tech.pegasys.artemis.networking.p2p.discovery.DiscoveryPeer;
 import tech.pegasys.artemis.networking.p2p.network.PeerAddress;
 import tech.pegasys.artemis.networking.p2p.peer.NodeId;
 
@@ -23,20 +24,28 @@ public class MultiaddrPeerAddress extends PeerAddress {
 
   private final Multiaddr multiaddr;
 
-  private MultiaddrPeerAddress(
-      final NodeId nodeId, final Multiaddr multiaddr, final String sourceAddress) {
-    super(nodeId, sourceAddress);
+  private MultiaddrPeerAddress(final NodeId nodeId, final Multiaddr multiaddr) {
+    super(nodeId);
     this.multiaddr = multiaddr;
   }
 
-  public static MultiaddrPeerAddress parse(final String address) {
+  public static MultiaddrPeerAddress fromAddress(final String address) {
     final Multiaddr multiaddr = Multiaddr.fromString(address);
+    return fromMultiaddr(multiaddr);
+  }
+
+  public static MultiaddrPeerAddress fromDiscoveryPeer(final DiscoveryPeer discoveryPeer) {
+    final Multiaddr multiaddr = DiscoveryPeerToMultiaddrConverter.convertToMultiAddr(discoveryPeer);
+    return fromMultiaddr(multiaddr);
+  }
+
+  private static MultiaddrPeerAddress fromMultiaddr(final Multiaddr multiaddr) {
     final String p2pComponent = multiaddr.getStringComponent(Protocol.P2P);
     if (p2pComponent == null) {
-      throw new IllegalArgumentException("No peer ID present in multiaddr: " + address);
+      throw new IllegalArgumentException("No peer ID present in multiaddr: " + multiaddr);
     }
     final LibP2PNodeId nodeId = new LibP2PNodeId(PeerId.fromBase58(p2pComponent));
-    return new MultiaddrPeerAddress(nodeId, multiaddr, address);
+    return new MultiaddrPeerAddress(nodeId, multiaddr);
   }
 
   public Multiaddr getMultiaddr() {

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/mock/MockP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/mock/MockP2PNetwork.java
@@ -40,13 +40,13 @@ public class MockP2PNetwork<P extends Peer> implements P2PNetwork<P> {
   }
 
   @Override
-  public PeerAddress parse(final String peerAddress) {
-    return new PeerAddress(new MockNodeId(peerAddress.hashCode()), peerAddress);
+  public PeerAddress createPeerAddress(final String peerAddress) {
+    return new PeerAddress(new MockNodeId(peerAddress.hashCode()));
   }
 
   @Override
-  public SafeFuture<Peer> connect(final DiscoveryPeer peer) {
-    return SafeFuture.failedFuture(new UnsupportedOperationException());
+  public PeerAddress createPeerAddress(final DiscoveryPeer discoveryPeer) {
+    throw new UnsupportedOperationException();
   }
 
   @Override
@@ -60,7 +60,7 @@ public class MockP2PNetwork<P extends Peer> implements P2PNetwork<P> {
   }
 
   @Override
-  public boolean isConnected(final DiscoveryPeer discoveryPeer) {
+  public boolean isConnected(final PeerAddress peerAddress) {
     return false;
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/mock/MockP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/mock/MockP2PNetwork.java
@@ -20,6 +20,7 @@ import tech.pegasys.artemis.networking.p2p.discovery.DiscoveryPeer;
 import tech.pegasys.artemis.networking.p2p.gossip.TopicChannel;
 import tech.pegasys.artemis.networking.p2p.gossip.TopicHandler;
 import tech.pegasys.artemis.networking.p2p.network.P2PNetwork;
+import tech.pegasys.artemis.networking.p2p.network.PeerAddress;
 import tech.pegasys.artemis.networking.p2p.peer.NodeId;
 import tech.pegasys.artemis.networking.p2p.peer.Peer;
 import tech.pegasys.artemis.networking.p2p.peer.PeerConnectedSubscriber;
@@ -34,8 +35,13 @@ public class MockP2PNetwork<P extends Peer> implements P2PNetwork<P> {
   }
 
   @Override
-  public SafeFuture<Peer> connect(String peer) {
+  public SafeFuture<Peer> connect(PeerAddress peer) {
     return SafeFuture.failedFuture(new UnsupportedOperationException());
+  }
+
+  @Override
+  public PeerAddress parse(final String peerAddress) {
+    return new PeerAddress(new MockNodeId(peerAddress.hashCode()), peerAddress);
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/DelegatingP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/DelegatingP2PNetwork.java
@@ -34,18 +34,18 @@ public abstract class DelegatingP2PNetwork<T extends Peer> implements P2PNetwork
   }
 
   @Override
-  public SafeFuture<Peer> connect(final DiscoveryPeer peer) {
-    return network.connect(peer);
+  public PeerAddress createPeerAddress(final DiscoveryPeer discoveryPeer) {
+    return network.createPeerAddress(discoveryPeer);
   }
 
   @Override
-  public boolean isConnected(final DiscoveryPeer discoveryPeer) {
-    return network.isConnected(discoveryPeer);
+  public boolean isConnected(final PeerAddress peerAddress) {
+    return network.isConnected(peerAddress);
   }
 
   @Override
-  public PeerAddress parse(final String peerAddress) {
-    return network.parse(peerAddress);
+  public PeerAddress createPeerAddress(final String peerAddress) {
+    return network.createPeerAddress(peerAddress);
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/DelegatingP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/DelegatingP2PNetwork.java
@@ -29,7 +29,7 @@ public abstract class DelegatingP2PNetwork<T extends Peer> implements P2PNetwork
   }
 
   @Override
-  public SafeFuture<Peer> connect(final String peer) {
+  public SafeFuture<Peer> connect(final PeerAddress peer) {
     return network.connect(peer);
   }
 
@@ -41,6 +41,11 @@ public abstract class DelegatingP2PNetwork<T extends Peer> implements P2PNetwork
   @Override
   public boolean isConnected(final DiscoveryPeer discoveryPeer) {
     return network.isConnected(discoveryPeer);
+  }
+
+  @Override
+  public PeerAddress parse(final String peerAddress) {
+    return network.parse(peerAddress);
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/P2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/P2PNetwork.java
@@ -35,11 +35,23 @@ public interface P2PNetwork<T extends Peer> extends GossipNetwork {
    * implementation. If a connection already exists for this peer, the future completes with the
    * existing peer.
    *
+   * <p>The {@link PeerAddress} must have been created using the {@link #parse(String)} method of
+   * this same implementation.
+   *
    * @param peer Peer to connect to.
    * @return A future which completes when the connection is establish, containing the newly
    *     connected peer.
    */
-  SafeFuture<Peer> connect(String peer);
+  SafeFuture<Peer> connect(PeerAddress peer);
+
+  /**
+   * Parses a peer address in any of this networks supported formats.
+   *
+   * @param peerAddress the address to parse
+   * @return a {@link PeerAddress} which is supported by {@link #connect(PeerAddress)} for
+   *     initiating connections
+   */
+  PeerAddress parse(String peerAddress);
 
   /**
    * Connects to a peer identified via discovery. If a connection already exists for this peer, the

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/P2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/P2PNetwork.java
@@ -35,8 +35,8 @@ public interface P2PNetwork<T extends Peer> extends GossipNetwork {
    * implementation. If a connection already exists for this peer, the future completes with the
    * existing peer.
    *
-   * <p>The {@link PeerAddress} must have been created using the {@link #parse(String)} method of
-   * this same implementation.
+   * <p>The {@link PeerAddress} must have been created using the {@link #createPeerAddress(String)}
+   * method of this same implementation.
    *
    * @param peer Peer to connect to.
    * @return A future which completes when the connection is establish, containing the newly
@@ -51,23 +51,23 @@ public interface P2PNetwork<T extends Peer> extends GossipNetwork {
    * @return a {@link PeerAddress} which is supported by {@link #connect(PeerAddress)} for
    *     initiating connections
    */
-  PeerAddress parse(String peerAddress);
+  PeerAddress createPeerAddress(String peerAddress);
 
   /**
-   * Connects to a peer identified via discovery. If a connection already exists for this peer, the
-   * future completes with the existing peer.
+   * Converts a {@link DiscoveryPeer} to a {@link PeerAddress} which can be used with this network's
+   * {@link #connect(PeerAddress)} method.
    *
-   * @param peer the peer to connect to.
-   * @return A future which completes when the connection is establish, containing the newly
-   *     connected peer.
+   * @param discoveryPeer the discovery peer to convert
+   * @return a {@link PeerAddress} which is supported by {@link #connect(PeerAddress)} for
+   *     initiating connections
    */
-  SafeFuture<Peer> connect(DiscoveryPeer peer);
+  PeerAddress createPeerAddress(DiscoveryPeer discoveryPeer);
 
   long subscribeConnect(PeerConnectedSubscriber<T> subscriber);
 
   void unsubscribeConnect(long subscriptionId);
 
-  boolean isConnected(DiscoveryPeer discoveryPeer);
+  boolean isConnected(PeerAddress peerAddress);
 
   Optional<T> getPeer(NodeId id);
 

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/PeerAddress.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/PeerAddress.java
@@ -19,11 +19,9 @@ import tech.pegasys.artemis.util.async.SafeFuture;
 
 public class PeerAddress {
   private final NodeId id;
-  private final String sourceAddress;
 
-  public PeerAddress(final NodeId id, final String sourceAddress) {
+  public PeerAddress(final NodeId id) {
     this.id = id;
-    this.sourceAddress = sourceAddress;
   }
 
   public NodeId getId() {
@@ -42,7 +40,7 @@ public class PeerAddress {
 
   @Override
   public String toString() {
-    return sourceAddress;
+    return id.toString();
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/PeerAddress.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/PeerAddress.java
@@ -14,8 +14,8 @@
 package tech.pegasys.artemis.networking.p2p.network;
 
 import java.util.Objects;
+import java.util.Optional;
 import tech.pegasys.artemis.networking.p2p.peer.NodeId;
-import tech.pegasys.artemis.util.async.SafeFuture;
 
 public class PeerAddress {
   private final NodeId id;
@@ -29,12 +29,11 @@ public class PeerAddress {
   }
 
   @SuppressWarnings("unchecked")
-  public <T> SafeFuture<T> as(final Class<T> clazz) {
+  public <T> Optional<T> as(final Class<T> clazz) {
     if (clazz.isInstance(this)) {
-      return SafeFuture.completedFuture((T) this);
+      return Optional.of((T) this);
     } else {
-      return SafeFuture.failedFuture(
-          new IllegalArgumentException("Unsupported static peer type: " + getClass().getName()));
+      return Optional.empty();
     }
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/PeerAddress.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/PeerAddress.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.p2p.network;
+
+import java.util.Objects;
+import tech.pegasys.artemis.networking.p2p.peer.NodeId;
+import tech.pegasys.artemis.util.async.SafeFuture;
+
+public class PeerAddress {
+  private final NodeId id;
+  private final String sourceAddress;
+
+  public PeerAddress(final NodeId id, final String sourceAddress) {
+    this.id = id;
+    this.sourceAddress = sourceAddress;
+  }
+
+  public NodeId getId() {
+    return id;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T> SafeFuture<T> as(final Class<T> clazz) {
+    if (clazz.isInstance(this)) {
+      return SafeFuture.completedFuture((T) this);
+    } else {
+      return SafeFuture.failedFuture(
+          new IllegalArgumentException("Unsupported static peer type: " + getClass().getName()));
+    }
+  }
+
+  @Override
+  public String toString() {
+    return sourceAddress;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PeerAddress that = (PeerAddress) o;
+    return id.equals(that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+}

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/discovery/ConnectionManagerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/discovery/ConnectionManagerTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.artemis.networking.p2p.discovery;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -34,12 +33,16 @@ import tech.pegasys.artemis.networking.p2p.connection.ConnectionManager;
 import tech.pegasys.artemis.networking.p2p.connection.TargetPeerRange;
 import tech.pegasys.artemis.networking.p2p.mock.MockNodeId;
 import tech.pegasys.artemis.networking.p2p.network.P2PNetwork;
+import tech.pegasys.artemis.networking.p2p.network.PeerAddress;
 import tech.pegasys.artemis.networking.p2p.peer.Peer;
 import tech.pegasys.artemis.networking.p2p.peer.PeerConnectedSubscriber;
 import tech.pegasys.artemis.util.async.SafeFuture;
 import tech.pegasys.artemis.util.async.StubAsyncRunner;
 
 class ConnectionManagerTest {
+  private static final PeerAddress PEER1 = new PeerAddress(new MockNodeId(1), "peer1");
+  private static final PeerAddress PEER2 = new PeerAddress(new MockNodeId(2), "peer2");
+
   @SuppressWarnings("unchecked")
   private final P2PNetwork<Peer> network = mock(P2PNetwork.class);
 
@@ -54,45 +57,45 @@ class ConnectionManagerTest {
 
   @Test
   public void shouldConnectToStaticPeersOnStart() {
-    final ConnectionManager manager = createManager("peer1", "peer2");
-    when(network.connect(anyString())).thenReturn(SafeFuture.completedFuture(null));
+    final ConnectionManager manager = createManager(PEER1, PEER2);
+    when(network.connect(any(PeerAddress.class))).thenReturn(SafeFuture.completedFuture(null));
     manager.start().join();
 
-    verify(network).connect("peer1");
-    verify(network).connect("peer2");
+    verify(network).connect(PEER1);
+    verify(network).connect(PEER2);
   }
 
   @Test
   public void shouldRetryConnectionToStaticPeerAfterDelayWhenInitialAttemptFails() {
-    final ConnectionManager manager = createManager("peer1");
+    final ConnectionManager manager = createManager(PEER1);
 
     final SafeFuture<Peer> connectionFuture1 = new SafeFuture<>();
     final SafeFuture<Peer> connectionFuture2 = new SafeFuture<>();
-    when(network.connect("peer1")).thenReturn(connectionFuture1).thenReturn(connectionFuture2);
+    when(network.connect(PEER1)).thenReturn(connectionFuture1).thenReturn(connectionFuture2);
     manager.start().join();
-    verify(network).connect("peer1");
+    verify(network).connect(PEER1);
 
     connectionFuture1.completeExceptionally(new RuntimeException("Nope"));
 
     assertThat(asyncRunner.hasDelayedActions()).isTrue();
     asyncRunner.executeQueuedActions();
-    verify(network, times(2)).connect("peer1");
+    verify(network, times(2)).connect(PEER1);
   }
 
   @Test
   public void shouldReconnectWhenPersistentPeerDisconnects() {
-    final ConnectionManager manager = createManager("peer1");
+    final ConnectionManager manager = createManager(PEER1);
 
     final MockNodeId peerId = new MockNodeId();
     final StubPeer peer = new StubPeer(peerId);
-    when(network.connect("peer1"))
+    when(network.connect(PEER1))
         .thenReturn(SafeFuture.completedFuture(peer))
         .thenReturn(new SafeFuture<>());
     manager.start().join();
-    verify(network).connect("peer1");
+    verify(network).connect(PEER1);
     peer.disconnect();
 
-    verify(network, times(2)).connect("peer1");
+    verify(network, times(2)).connect(PEER1);
   }
 
   @Test
@@ -101,34 +104,34 @@ class ConnectionManagerTest {
 
     final MockNodeId peerId = new MockNodeId();
     final StubPeer peer = new StubPeer(peerId);
-    when(network.connect("peer1"))
+    when(network.connect(PEER1))
         .thenReturn(SafeFuture.completedFuture(peer))
         .thenReturn(new SafeFuture<>());
     manager.start().join();
 
-    manager.addStaticPeer("peer1");
-    verify(network).connect("peer1");
+    manager.addStaticPeer(PEER1);
+    verify(network).connect(PEER1);
     peer.disconnect();
 
-    verify(network, times(2)).connect("peer1");
+    verify(network, times(2)).connect(PEER1);
   }
 
   @Test
   public void shouldNotAddDuplicatePeerToStaticList() {
-    final ConnectionManager manager = createManager("peer1");
+    final ConnectionManager manager = createManager(PEER1);
 
     final MockNodeId peerId = new MockNodeId();
     final StubPeer peer = new StubPeer(peerId);
-    when(network.connect("peer1"))
+    when(network.connect(PEER1))
         .thenReturn(SafeFuture.completedFuture(peer))
         .thenReturn(new SafeFuture<>());
     manager.start().join();
 
-    verify(network).connect("peer1");
+    verify(network).connect(PEER1);
 
-    manager.addStaticPeer("peer1");
+    manager.addStaticPeer(PEER1);
     // Doesn't attempt to connect a second time.
-    verify(network, times(1)).connect("peer1");
+    verify(network, times(1)).connect(PEER1);
   }
 
   @Test
@@ -335,12 +338,12 @@ class ConnectionManagerTest {
     return captor.getValue();
   }
 
-  private ConnectionManager createManager(final String... peers) {
+  private ConnectionManager createManager(final PeerAddress... peers) {
     return createManager(new TargetPeerRange(5, 10), peers);
   }
 
   private ConnectionManager createManager(
-      final TargetPeerRange targetPeerCount, final String... peers) {
+      final TargetPeerRange targetPeerCount, final PeerAddress... peers) {
     return new ConnectionManager(
         discoveryService, asyncRunner, network, Arrays.asList(peers), targetPeerCount);
   }

--- a/sync/src/integration-test/java/tech/pegasys/artemis/sync/BlockPropagationIntegrationTest.java
+++ b/sync/src/integration-test/java/tech/pegasys/artemis/sync/BlockPropagationIntegrationTest.java
@@ -58,7 +58,7 @@ public class BlockPropagationIntegrationTest {
     SyncingNodeManager node2 = SyncingNodeManager.create(networkFactory, validatorKeys);
 
     // Connect networks
-    Waiter.waitFor(node1.network().connect(node2.network().getNodeAddress()));
+    Waiter.waitFor(node1.connect(node2));
     // Wait for connections to get set up
     Waiter.waitFor(
         () -> {

--- a/sync/src/test-support/java/tech/pegasys/artemis/sync/SyncingNodeManager.java
+++ b/sync/src/test-support/java/tech/pegasys/artemis/sync/SyncingNodeManager.java
@@ -20,10 +20,13 @@ import java.util.function.Consumer;
 import tech.pegasys.artemis.networking.eth2.Eth2Network;
 import tech.pegasys.artemis.networking.eth2.Eth2NetworkFactory;
 import tech.pegasys.artemis.networking.eth2.Eth2NetworkFactory.Eth2P2PNetworkBuilder;
+import tech.pegasys.artemis.networking.p2p.network.PeerAddress;
+import tech.pegasys.artemis.networking.p2p.peer.Peer;
 import tech.pegasys.artemis.statetransition.BeaconChainUtil;
 import tech.pegasys.artemis.statetransition.blockimport.BlockImporter;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.storage.events.SlotEvent;
+import tech.pegasys.artemis.util.async.SafeFuture;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
 
 public class SyncingNodeManager {
@@ -74,6 +77,11 @@ public class SyncingNodeManager {
     syncService.start().join();
 
     return new SyncingNodeManager(eventBus, storageClient, chainUtil, eth2Network, syncService);
+  }
+
+  public SafeFuture<Peer> connect(final SyncingNodeManager peer) {
+    final PeerAddress peerAddress = eth2Network.createPeerAddress(peer.network().getNodeAddress());
+    return eth2Network.connect(peerAddress);
   }
 
   public EventBus eventBus() {


### PR DESCRIPTION
## PR Description
Introduces a `PeerAddress` class which represents an address of a peer.  The implementation details and parsing format are network type specific but it allows the node ID to be extracted without any further knowledge of the address type and provides static type checking.

Both static and discovery peers are now converted into PeerAddress instances which are then used to connect.