### PR TITLE
Disconnect cleanly

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/GoodbyeMessage.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/networking/libp2p/rpc/GoodbyeMessage.java
@@ -35,6 +35,7 @@ public final class GoodbyeMessage implements RpcRequest, SimpleOffsetSerializabl
 
   // Custom reasons
   public static final UnsignedLong REASON_UNABLE_TO_VERIFY_NETWORK = UnsignedLong.valueOf(128);
+  public static final UnsignedLong REASON_TOO_MANY_PEERS = UnsignedLong.valueOf(129);
 
   public GoodbyeMessage(UnsignedLong reason) {
     checkArgument(

--- a/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/GoodbyeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/GoodbyeIntegrationTest.java
@@ -14,13 +14,12 @@
 package tech.pegasys.artemis.networking.eth2;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.artemis.util.Waiter.waitFor;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.GoodbyeMessage;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.artemis.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
 import tech.pegasys.artemis.util.Waiter;
 
 public class GoodbyeIntegrationTest {
@@ -42,8 +41,8 @@ public class GoodbyeIntegrationTest {
   }
 
   @Test
-  public void shouldCloseConnectionAfterGoodbyeReceived() throws Exception {
-    waitFor(peer1.sendGoodbye(GoodbyeMessage.REASON_CLIENT_SHUT_DOWN));
+  public void shouldCloseConnectionAfterGoodbyeReceived() {
+    peer1.disconnectCleanly(DisconnectReason.SHUTTING_DOWN);
     Waiter.waitFor(() -> assertThat(peer1.isConnected()).isFalse());
     Waiter.waitFor(() -> assertThat(peer2.isConnected()).isFalse());
   }

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2Peer.java
@@ -101,7 +101,7 @@ public class Eth2Peer extends DelegatingPeer implements Peer {
             });
   }
 
-  public SafeFuture<Void> sendGoodbye(final UnsignedLong reason) {
+  SafeFuture<Void> sendGoodbye(final UnsignedLong reason) {
     final Eth2RpcMethod<GoodbyeMessage, GoodbyeMessage> goodByeMethod = rpcMethods.goodBye();
     return sendMessage(goodByeMethod, new GoodbyeMessage(reason));
   }

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2PeerManager.java
@@ -114,6 +114,12 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
         return GoodbyeMessage.REASON_TOO_MANY_PEERS;
       case SHUTTING_DOWN:
         return GoodbyeMessage.REASON_CLIENT_SHUT_DOWN;
+      case REMOTE_FAULT:
+        return GoodbyeMessage.REASON_FAULT_ERROR;
+      case IRRELEVANT_NETWORK:
+        return GoodbyeMessage.REASON_IRRELEVANT_NETWORK;
+      case UNABLE_TO_VERIFY_NETWORK:
+        return GoodbyeMessage.REASON_UNABLE_TO_VERIFY_NETWORK;
       default:
         LOG.warn("Unknown disconnect reason: " + reason);
         return GoodbyeMessage.REASON_FAULT_ERROR;

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2PeerManager.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.artemis.networking.eth2.peers;
 
+import com.google.common.primitives.UnsignedLong;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
@@ -20,9 +21,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.jetbrains.annotations.NotNull;
+import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.GoodbyeMessage;
 import tech.pegasys.artemis.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.artemis.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
 import tech.pegasys.artemis.networking.p2p.network.PeerHandler;
+import tech.pegasys.artemis.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
 import tech.pegasys.artemis.networking.p2p.peer.NodeId;
 import tech.pegasys.artemis.networking.p2p.peer.Peer;
 import tech.pegasys.artemis.networking.p2p.peer.PeerConnectedSubscriber;
@@ -48,7 +51,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
       final ChainStorageClient storageClient,
       final MetricsSystem metricsSystem,
       final PeerValidatorFactory peerValidatorFactory) {
-    statusMessageFactory = new StatusMessageFactory(storageClient);
+    this.statusMessageFactory = new StatusMessageFactory(storageClient);
     this.peerValidatorFactory = peerValidatorFactory;
     this.rpcMethods =
         BeaconChainMethods.create(
@@ -75,7 +78,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
   }
 
   @Override
-  public void onConnect(@NotNull final Peer peer) {
+  public void onConnect(final Peer peer) {
     Eth2Peer eth2Peer = new Eth2Peer(peer, rpcMethods, statusMessageFactory);
     final boolean wasAdded = connectedPeerMap.putIfAbsent(peer.getId(), eth2Peer) == null;
     if (!wasAdded) {
@@ -83,6 +86,8 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
       return;
     }
 
+    peer.setDisconnectRequestHandler(
+        reason -> eth2Peer.sendGoodbye(convertToEth2DisconnectReason(reason)));
     if (peer.connectionInitiatedLocally()) {
       eth2Peer
           .sendStatus()
@@ -101,6 +106,18 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
                         connectSubscribers.forEach(c -> c.onConnected(eth2Peer));
                       }
                     }));
+  }
+
+  private UnsignedLong convertToEth2DisconnectReason(final DisconnectReason reason) {
+    switch (reason) {
+      case TOO_MANY_PEERS:
+        return GoodbyeMessage.REASON_TOO_MANY_PEERS;
+      case SHUTTING_DOWN:
+        return GoodbyeMessage.REASON_CLIENT_SHUT_DOWN;
+      default:
+        LOG.warn("Unknown disconnect reason: " + reason);
+        return GoodbyeMessage.REASON_FAULT_ERROR;
+    }
   }
 
   public long subscribeConnect(final PeerConnectedSubscriber<Eth2Peer> subscriber) {

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/PeerChainValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/PeerChainValidator.java
@@ -24,8 +24,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.GoodbyeMessage;
 import tech.pegasys.artemis.datastructures.state.Checkpoint;
+import tech.pegasys.artemis.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.storage.HistoricalChainData;
 import tech.pegasys.artemis.util.SSZTypes.Bytes4;
@@ -76,7 +76,7 @@ public class PeerChainValidator {
               if (!isValid) {
                 // We are not on the same chain
                 LOG.trace("Disconnecting peer on different chain: {}", peer);
-                peer.sendGoodbye(GoodbyeMessage.REASON_IRRELEVANT_NETWORK).reportExceptions();
+                peer.disconnectCleanly(DisconnectReason.IRRELEVANT_NETWORK);
               } else {
                 LOG.trace("Validated peer's chain: {}", peer);
                 peer.markChainValidated();
@@ -86,7 +86,7 @@ public class PeerChainValidator {
         .exceptionally(
             err -> {
               LOG.debug("Unable to validate peer's chain, disconnecting: " + peer, err);
-              peer.sendGoodbye(GoodbyeMessage.REASON_UNABLE_TO_VERIFY_NETWORK).reportExceptions();
+              peer.disconnectCleanly(DisconnectReason.UNABLE_TO_VERIFY_NETWORK);
               return false;
             });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/GoodbyeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/GoodbyeMessageHandler.java
@@ -46,7 +46,7 @@ public class GoodbyeMessageHandler implements LocalMessageHandler<GoodbyeMessage
       final ResponseCallback<GoodbyeMessage> callback) {
     LOG.trace("Peer {} said goodbye.", peer.getId());
     goodbyeCounter.labels(labelForReason(message.getReason())).inc();
-    peer.disconnect();
+    peer.disconnectImmediately();
     callback.completeSuccessfully();
   }
 

--- a/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/DiscoveryNetworkIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/artemis/networking/p2p/DiscoveryNetworkIntegrationTest.java
@@ -40,7 +40,7 @@ public class DiscoveryNetworkIntegrationTest {
     assertConnected(network1, network2);
 
     // Peers disconnect
-    network1.getPeer(network2.getNodeId()).orElseThrow().disconnect();
+    network1.getPeer(network2.getNodeId()).orElseThrow().disconnectImmediately();
 
     // But are automatically reconnected
     assertConnected(network1, network2);
@@ -56,7 +56,7 @@ public class DiscoveryNetworkIntegrationTest {
     // Already connected, but now tell network1 to maintain a persistent connection to network2.
     network1.addStaticPeer(network2.getNodeAddress());
 
-    network1.getPeer(network2.getNodeId()).orElseThrow().disconnect();
+    network1.getPeer(network2.getNodeId()).orElseThrow().disconnectImmediately();
     assertConnected(network1, network2);
 
     // Check we remain connected and didn't just briefly reconnect.

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/connection/ConnectionManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/connection/ConnectionManager.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.artemis.networking.p2p.discovery.DiscoveryPeer;
 import tech.pegasys.artemis.networking.p2p.discovery.DiscoveryService;
 import tech.pegasys.artemis.networking.p2p.network.P2PNetwork;
+import tech.pegasys.artemis.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
 import tech.pegasys.artemis.networking.p2p.peer.Peer;
 import tech.pegasys.artemis.service.serviceutils.Service;
 import tech.pegasys.artemis.util.async.AsyncRunner;
@@ -104,7 +105,10 @@ public class ConnectionManager extends Service {
 
   private void onPeerConnected(final Peer peer) {
     final int peersToDrop = targetPeerCountRange.getPeersToDrop(network.getPeerCount());
-    network.streamPeers().limit(peersToDrop).forEach(Peer::disconnect);
+    network
+        .streamPeers()
+        .limit(peersToDrop)
+        .forEach(peerToDrop -> peerToDrop.disconnectCleanly(DisconnectReason.TOO_MANY_PEERS));
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PPeer.java
@@ -76,7 +76,7 @@ public class LibP2PPeer implements Peer {
     disconnectRequestHandler
         .requestDisconnect(reason)
         .finish(
-            () -> LOG.trace("Disconnected peer {} cleanly", nodeId),
+            this::disconnectImmediately, // Request sent now close our side
             error -> {
               LOG.debug("Failed to disconnect from " + nodeId + " cleanly.", error);
               disconnectImmediately();

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PPeer.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.artemis.networking.p2p.libp2p.rpc.RpcHandler;
+import tech.pegasys.artemis.networking.p2p.peer.DisconnectRequestHandler;
 import tech.pegasys.artemis.networking.p2p.peer.NodeId;
 import tech.pegasys.artemis.networking.p2p.peer.Peer;
 import tech.pegasys.artemis.networking.p2p.peer.PeerDisconnectedSubscriber;
@@ -36,6 +37,12 @@ public class LibP2PPeer implements Peer {
   private final Connection connection;
   private final NodeId nodeId;
   private final AtomicBoolean connected = new AtomicBoolean(true);
+
+  private volatile DisconnectRequestHandler disconnectRequestHandler =
+      reason -> {
+        disconnectImmediately();
+        return SafeFuture.COMPLETE;
+      };
 
   public LibP2PPeer(final Connection connection, final Map<RpcMethod, RpcHandler> rpcHandlers) {
     this.connection = connection;
@@ -58,9 +65,27 @@ public class LibP2PPeer implements Peer {
 
   @Override
   @SuppressWarnings("FutureReturnValueIgnored")
-  public void disconnect() {
+  public void disconnectImmediately() {
     connected.set(false);
     connection.close();
+  }
+
+  @Override
+  public void disconnectCleanly(final DisconnectRequestHandler.DisconnectReason reason) {
+    connected.set(false);
+    disconnectRequestHandler
+        .requestDisconnect(reason)
+        .finish(
+            () -> LOG.trace("Disconnected peer {} cleanly", nodeId),
+            error -> {
+              LOG.debug("Failed to disconnect from " + nodeId + " cleanly.", error);
+              disconnectImmediately();
+            });
+  }
+
+  @Override
+  public void setDisconnectRequestHandler(final DisconnectRequestHandler handler) {
+    this.disconnectRequestHandler = handler;
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/peer/DelegatingPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/peer/DelegatingPeer.java
@@ -15,6 +15,7 @@ package tech.pegasys.artemis.networking.p2p.peer;
 
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.artemis.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
 import tech.pegasys.artemis.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.artemis.networking.p2p.rpc.RpcRequestHandler;
 import tech.pegasys.artemis.networking.p2p.rpc.RpcStream;
@@ -54,8 +55,18 @@ public class DelegatingPeer implements Peer {
   }
 
   @Override
-  public void disconnect() {
-    peer.disconnect();
+  public void disconnectImmediately() {
+    peer.disconnectImmediately();
+  }
+
+  @Override
+  public void disconnectCleanly(final DisconnectReason reason) {
+    peer.disconnectCleanly(reason);
+  }
+
+  @Override
+  public void setDisconnectRequestHandler(final DisconnectRequestHandler handler) {
+    peer.setDisconnectRequestHandler(handler);
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/peer/DisconnectRequestHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/peer/DisconnectRequestHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.p2p.peer;
+
+import tech.pegasys.artemis.util.async.SafeFuture;
+
+public interface DisconnectRequestHandler {
+
+  SafeFuture<Void> requestDisconnect(DisconnectReason reason);
+
+  enum DisconnectReason {
+    TOO_MANY_PEERS,
+    SHUTTING_DOWN
+  }
+}

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/peer/DisconnectRequestHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/peer/DisconnectRequestHandler.java
@@ -20,7 +20,10 @@ public interface DisconnectRequestHandler {
   SafeFuture<Void> requestDisconnect(DisconnectReason reason);
 
   enum DisconnectReason {
+    IRRELEVANT_NETWORK,
+    UNABLE_TO_VERIFY_NETWORK,
     TOO_MANY_PEERS,
+    REMOTE_FAULT,
     SHUTTING_DOWN
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/peer/Peer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/peer/Peer.java
@@ -15,6 +15,7 @@ package tech.pegasys.artemis.networking.p2p.peer;
 
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.artemis.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
 import tech.pegasys.artemis.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.artemis.networking.p2p.rpc.RpcRequestHandler;
 import tech.pegasys.artemis.networking.p2p.rpc.RpcStream;
@@ -26,7 +27,11 @@ public interface Peer {
 
   boolean isConnected();
 
-  void disconnect();
+  void disconnectImmediately();
+
+  void disconnectCleanly(DisconnectReason reason);
+
+  void setDisconnectRequestHandler(DisconnectRequestHandler handler);
 
   void subscribeDisconnect(PeerDisconnectedSubscriber subscriber);
 

--- a/networking/p2p/src/test-support/java/tech/pegasys/artemis/network/p2p/peer/StubPeer.java
+++ b/networking/p2p/src/test-support/java/tech/pegasys/artemis/network/p2p/peer/StubPeer.java
@@ -13,8 +13,11 @@
 
 package tech.pegasys.artemis.network.p2p.peer;
 
+import java.util.Optional;
 import javax.naming.OperationNotSupportedException;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.artemis.networking.p2p.peer.DisconnectRequestHandler;
+import tech.pegasys.artemis.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
 import tech.pegasys.artemis.networking.p2p.peer.NodeId;
 import tech.pegasys.artemis.networking.p2p.peer.Peer;
 import tech.pegasys.artemis.networking.p2p.peer.PeerDisconnectedSubscriber;
@@ -29,6 +32,7 @@ public class StubPeer implements Peer {
       Subscribers.create(false);
   private final NodeId nodeId;
   private boolean connected = true;
+  private Optional<DisconnectReason> disconnectReason = Optional.empty();
 
   public StubPeer(final NodeId nodeId) {
     this.nodeId = nodeId;
@@ -45,9 +49,25 @@ public class StubPeer implements Peer {
   }
 
   @Override
-  public void disconnect() {
+  public void disconnectImmediately() {
     disconnectedSubscribers.forEach(PeerDisconnectedSubscriber::onDisconnected);
     connected = false;
+  }
+
+  @Override
+  public void disconnectCleanly(final DisconnectReason reason) {
+    disconnectReason = Optional.of(reason);
+    disconnectedSubscribers.forEach(PeerDisconnectedSubscriber::onDisconnected);
+    connected = false;
+  }
+
+  public Optional<DisconnectReason> getDisconnectReason() {
+    return disconnectReason;
+  }
+
+  @Override
+  public void setDisconnectRequestHandler(final DisconnectRequestHandler handler) {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/sync/src/main/java/tech/pegasys/artemis/sync/PeerSync.java
+++ b/sync/src/main/java/tech/pegasys/artemis/sync/PeerSync.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.artemis.sync;
 
-import static tech.pegasys.artemis.datastructures.networking.libp2p.rpc.GoodbyeMessage.REASON_FAULT_ERROR;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 import static tech.pegasys.artemis.util.config.Constants.MAX_BLOCK_BY_RANGE_REQUEST_SIZE;
 
@@ -28,6 +27,7 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.artemis.networking.eth2.peers.PeerStatus;
+import tech.pegasys.artemis.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
 import tech.pegasys.artemis.statetransition.blockimport.BlockImportResult;
 import tech.pegasys.artemis.statetransition.blockimport.BlockImportResult.FailureReason;
 import tech.pegasys.artemis.statetransition.blockimport.BlockImporter;
@@ -187,7 +187,7 @@ public class PeerSync {
   }
 
   private void disconnectFromPeer(Eth2Peer peer) {
-    peer.sendGoodbye(REASON_FAULT_ERROR).reportExceptions();
+    peer.disconnectCleanly(DisconnectReason.REMOTE_FAULT);
   }
 
   public UnsignedLong getStartingSlot() {

--- a/sync/src/test/java/tech/pegasys/artemis/sync/SyncManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/artemis/sync/SyncManagerTest.java
@@ -66,7 +66,6 @@ public class SyncManagerTest {
     when(network.subscribeConnect(any())).thenReturn(SUBSCRIPTION_ID);
     when(storageClient.getFinalizedEpoch()).thenReturn(UnsignedLong.ZERO);
     when(peer.getStatus()).thenReturn(PEER_STATUS);
-    when(peer.sendGoodbye(any())).thenReturn(new SafeFuture<>());
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Support sending a GOODBYE message when peers are disconnected. To maintain the clear separation between Eth2 and LibP2P layers, `Peer` supports a custom `DisconnectRequestHandler` which by default just disconnects, but is set by the ETH2 network to send a goodbye request.

Also found that when we sent a goodbye request we were depending on the other side closing the connection - a misbehaving peer could wind up holding the connection open. To avoid this once we've sent the goodbye message we now disconnect.