### PR TITLE
[BC-289] Fix overzealous connection logic

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/connection/ConnectionManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/connection/ConnectionManager.java
@@ -125,15 +125,34 @@ public class ConnectionManager extends Service {
   }
 
   private SafeFuture<Peer> maintainPersistentConnection(final String peerAddress) {
+    if (!isRunning()) {
+      // We've been stopped so halt the process.
+      return new SafeFuture<>();
+    }
+
     LOG.debug("Connecting to peer {}", peerAddress);
     return network
         .connect(peerAddress)
+        .thenApply(
+            peer -> {
+              LOG.debug("Connection to peer {} was successful", peer.getId());
+              peer.subscribeDisconnect(
+                  () -> {
+                    LOG.debug(
+                        "Peer {} disconnected. Will try to reconnect in {} sec",
+                        peerAddress,
+                        RECONNECT_TIMEOUT.toSeconds());
+                    asyncRunner
+                        .runAfterDelay(
+                            () -> maintainPersistentConnection(peerAddress),
+                            RECONNECT_TIMEOUT.toMillis(),
+                            TimeUnit.MILLISECONDS)
+                        .reportExceptions();
+                  });
+              return peer;
+            })
         .exceptionallyCompose(
             error -> {
-              if (!isRunning()) {
-                // We've been stopped so halt the process.
-                return new SafeFuture<>();
-              }
               LOG.debug(
                   "Connection to {} failed: {}. Will retry in {} sec",
                   peerAddress,
@@ -143,12 +162,6 @@ public class ConnectionManager extends Service {
                   () -> maintainPersistentConnection(peerAddress),
                   RECONNECT_TIMEOUT.toMillis(),
                   TimeUnit.MILLISECONDS);
-            })
-        .thenApply(
-            peer -> {
-              LOG.debug("Connection to peer {} was successful", peer.getId());
-              peer.subscribeDisconnect(() -> createPersistentConnection(peerAddress));
-              return peer;
             });
   }
 }

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/discovery/ConnectionManagerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/discovery/ConnectionManagerTest.java
@@ -92,6 +92,8 @@ class ConnectionManagerTest {
     verify(network).connect("peer1");
     peer.disconnect();
 
+    assertThat(asyncRunner.hasDelayedActions()).isTrue();
+    asyncRunner.executeQueuedActions();
     verify(network, times(2)).connect("peer1");
   }
 
@@ -110,6 +112,8 @@ class ConnectionManagerTest {
     verify(network).connect("peer1");
     peer.disconnect();
 
+    assertThat(asyncRunner.hasDelayedActions()).isTrue();
+    asyncRunner.executeQueuedActions();
     verify(network, times(2)).connect("peer1");
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Fix a few issues causing us to initiate connection requests too frequently:
- Add a timeout before reconnecting after a disconnection
- Change the ordering of the connection logic so that we only handle successful connections once
