### PR TITLE
[BC-290] Fix outgoing request error handling

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/AsyncResponseProcessor.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/AsyncResponseProcessor.java
@@ -70,9 +70,10 @@ class AsyncResponseProcessor<TResponse> {
   }
 
   /** Stop processing and clear any pending requests */
-  private void cancel() {
+  private void cancel(Throwable error) {
     cancelled.set(true);
     queuedResponses.clear();
+    finishedProcessing.completeExceptionally(error);
   }
 
   /**
@@ -110,7 +111,7 @@ class AsyncResponseProcessor<TResponse> {
         .exceptionally(
             (err) -> {
               LOG.trace("Failed to process response: " + response, err);
-              cancel();
+              cancel(err);
               onError.accept(err);
               return null;
             })

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/Eth2OutgoingRequestHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/Eth2OutgoingRequestHandler.java
@@ -42,7 +42,6 @@ public class Eth2OutgoingRequestHandler<TRequest extends RpcRequest, TResponse>
   private final AtomicBoolean hasReceivedInitialBytes = new AtomicBoolean(false);
   private final AtomicInteger currentChunkCount = new AtomicInteger(0);
   private final AtomicBoolean isClosed = new AtomicBoolean(false);
-  private final AtomicBoolean isCancelled = new AtomicBoolean(false);
 
   private final ResponseRpcDecoder<TResponse> responseHandler;
   private final AsyncResponseProcessor<TResponse> responseProcessor;
@@ -152,10 +151,6 @@ public class Eth2OutgoingRequestHandler<TRequest extends RpcRequest, TResponse>
   private void cancelRequest(
       final RpcStream rpcStream, Throwable error, final boolean forceCancel) {
     if (!isClosed.compareAndSet(false, true) && !forceCancel) {
-      return;
-    }
-    if (!isCancelled.compareAndSet(false, true)) {
-      // Even if we're force cancelling, we don't want to cancel more than once
       return;
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
This PR adds proper handling for the case where all responses to an outgoing request have been delivered and then an error occurs during response processing.  Previously, we would complete the `ResponseStream` successfully in this case.  We now propagate the error up to `ResponseStream`.