### PR TITLE
Renaming ALogger to StatusLogger

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/BeaconNode.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.artemis;
 
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.AsyncEventBus;
@@ -43,8 +43,8 @@ import tech.pegasys.artemis.services.powchain.PowchainService;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
 import tech.pegasys.artemis.util.config.Constants;
 import tech.pegasys.artemis.util.time.SystemTimeProvider;
-import tech.pegasys.teku.logging.ALogger;
-import tech.pegasys.teku.logging.ALogger.Color;
+import tech.pegasys.teku.logging.StatusLogger;
+import tech.pegasys.teku.logging.StatusLogger.Color;
 
 public class BeaconNode {
 
@@ -117,9 +117,10 @@ public class BeaconNode {
 @VisibleForTesting
 final class EventBusExceptionHandler
     implements SubscriberExceptionHandler, ChannelExceptionHandler {
-  private final ALogger logger;
 
-  EventBusExceptionHandler(final ALogger logger) {
+  private final StatusLogger logger;
+
+  EventBusExceptionHandler(final StatusLogger logger) {
     this.logger = logger;
   }
 

--- a/artemis/src/main/java/tech/pegasys/artemis/DepositCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/DepositCommand.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.artemis;
 
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.primitives.UnsignedLong;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;

--- a/artemis/src/main/java/tech/pegasys/artemis/GenesisCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/GenesisCommand.java
@@ -14,7 +14,7 @@
 package tech.pegasys.artemis;
 
 import static tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer.serialize;
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/artemis/src/test/java/tech/pegasys/artemis/EventBusExceptionHandlerTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/EventBusExceptionHandlerTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.util.Waiter;
 import tech.pegasys.artemis.util.async.SafeFuture;
-import tech.pegasys.teku.logging.ALogger;
+import tech.pegasys.teku.logging.StatusLogger;
 
 class EventBusExceptionHandlerTest {
 
@@ -55,7 +55,7 @@ class EventBusExceptionHandlerTest {
   void setupBus() {
 
     final var recordingLogger =
-        new ALogger("stdout") {
+        new StatusLogger("stdout") {
           @Override
           public void log(final Level level, final String message) {
             logLevelFuture.complete(level);

--- a/data/recorder/src/main/java/tech/pegasys/artemis/data/recorder/SSZTransitionRecorder.java
+++ b/data/recorder/src/main/java/tech/pegasys/artemis/data/recorder/SSZTransitionRecorder.java
@@ -14,7 +14,7 @@
 package tech.pegasys.artemis.data.recorder;
 
 import static tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer.serialize;
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.common.primitives.UnsignedLong;

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
@@ -21,7 +21,7 @@ import static tech.pegasys.artemis.datastructures.util.CommitteeUtil.get_beacon_
 import static tech.pegasys.artemis.util.bls.BLSAggregate.bls_aggregate_pubkeys;
 import static tech.pegasys.artemis.util.config.Constants.DOMAIN_BEACON_ATTESTER;
 import static tech.pegasys.artemis.util.config.Constants.MAX_VALIDATORS_PER_COMMITTEE;
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/BlockProposalUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/BlockProposalUtil.java
@@ -15,7 +15,7 @@ package tech.pegasys.artemis.statetransition;
 
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_domain;
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.primitives.UnsignedLong;
 import org.apache.logging.log4j.Level;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/StateTransition.java
@@ -32,7 +32,7 @@ import static tech.pegasys.artemis.util.config.Constants.FAR_FUTURE_EPOCH;
 import static tech.pegasys.artemis.util.config.Constants.SLOTS_PER_EPOCH;
 import static tech.pegasys.artemis.util.config.Constants.SLOTS_PER_HISTORICAL_ROOT;
 import static tech.pegasys.artemis.util.config.Constants.ZERO_HASH;
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.Optional;
@@ -51,7 +51,7 @@ import tech.pegasys.artemis.statetransition.util.BlockProcessingException;
 import tech.pegasys.artemis.statetransition.util.EpochProcessingException;
 import tech.pegasys.artemis.statetransition.util.SlotProcessingException;
 import tech.pegasys.artemis.util.bls.BLSVerify;
-import tech.pegasys.teku.logging.ALogger;
+import tech.pegasys.teku.logging.StatusLogger;
 
 public class StateTransition {
 
@@ -112,7 +112,8 @@ public class StateTransition {
         | BlockProcessingException
         | EpochProcessingException
         | IllegalArgumentException e) {
-      STDOUT.log(Level.WARN, "  State Transition error: " + e, printEnabled, ALogger.Color.RED);
+      STDOUT.log(
+          Level.WARN, "  State Transition error: " + e, printEnabled, StatusLogger.Color.RED);
       throw new StateTransitionException(e);
     }
   }
@@ -225,7 +226,8 @@ public class StateTransition {
             .plus(UnsignedLong.ONE)
             .mod(UnsignedLong.valueOf(SLOTS_PER_EPOCH))
             .equals(UnsignedLong.ZERO)) {
-          STDOUT.log(Level.INFO, "******* Epoch Event *******", printEnabled, ALogger.Color.BLUE);
+          STDOUT.log(
+              Level.INFO, "******* Epoch Event *******", printEnabled, StatusLogger.Color.BLUE);
           process_epoch(state);
           reportExceptions(CompletableFuture.runAsync(() -> recordMetrics(state)));
         }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/genesis/GenesisHandler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/genesis/GenesisHandler.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.artemis.statetransition.genesis;
 
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.List;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
@@ -41,7 +41,7 @@ import static tech.pegasys.artemis.util.config.Constants.MAX_DEPOSITS;
 import static tech.pegasys.artemis.util.config.Constants.PERSISTENT_COMMITTEE_PERIOD;
 import static tech.pegasys.artemis.util.config.Constants.SLOTS_PER_EPOCH;
 import static tech.pegasys.artemis.util.config.Constants.SLOTS_PER_ETH1_VOTING_PERIOD;
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.collect.Sets;
 import com.google.common.primitives.UnsignedLong;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/StartupUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/StartupUtil.java
@@ -15,7 +15,7 @@ package tech.pegasys.artemis.statetransition.util;
 
 import static tech.pegasys.artemis.util.config.Constants.SLOTS_PER_EPOCH;
 import static tech.pegasys.artemis.util.config.Constants.SLOTS_PER_ETH1_VOTING_PERIOD;
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.primitives.UnsignedLong;
 import java.io.File;
@@ -37,8 +37,8 @@ import tech.pegasys.artemis.datastructures.util.MockStartValidatorKeyPairFactory
 import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
-import tech.pegasys.teku.logging.ALogger;
-import tech.pegasys.teku.logging.ALogger.Color;
+import tech.pegasys.teku.logging.StatusLogger;
+import tech.pegasys.teku.logging.StatusLogger.Color;
 
 public final class StartupUtil {
 
@@ -91,7 +91,8 @@ public final class StartupUtil {
     BeaconState initialState;
     if (startState != null) {
       try {
-        STDOUT.log(Level.INFO, "Loading initial state from " + startState, ALogger.Color.GREEN);
+        STDOUT.log(
+            Level.INFO, "Loading initial state from " + startState, StatusLogger.Color.GREEN);
         initialState = StartupUtil.loadBeaconStateFromFile(startState);
       } catch (final IOException e) {
         throw new IllegalStateException("Failed to load initial state", e);

--- a/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
@@ -17,9 +17,9 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class ALogger {
+public class StatusLogger {
 
-  public static final ALogger STDOUT = new ALogger("stdout");
+  public static final StatusLogger STDOUT = new StatusLogger("stdout");
 
   public enum Color {
     RED,
@@ -33,7 +33,7 @@ public class ALogger {
 
   private final Logger logger;
 
-  protected ALogger(String className) {
+  protected StatusLogger(String className) {
     this.logger = LogManager.getLogger(className);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/Eth2OutgoingRequestHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/Eth2OutgoingRequestHandler.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.artemis.networking.eth2.rpc.core;
 
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import io.netty.buffer.ByteBuf;
 import java.time.Duration;

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PNetwork.java
@@ -15,7 +15,7 @@ package tech.pegasys.artemis.networking.p2p.libp2p;
 
 import static tech.pegasys.artemis.util.async.SafeFuture.failedFuture;
 import static tech.pegasys.artemis.util.async.SafeFuture.reportExceptions;
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import identify.pb.IdentifyOuterClass;
 import io.libp2p.core.Host;

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/PeerManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/PeerManager.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.artemis.networking.p2p.libp2p;
 
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -18,7 +18,7 @@ import static tech.pegasys.artemis.statetransition.util.ForkChoiceUtil.get_head;
 import static tech.pegasys.artemis.statetransition.util.ForkChoiceUtil.on_tick;
 import static tech.pegasys.artemis.util.config.Constants.DEPOSIT_TEST;
 import static tech.pegasys.artemis.util.config.Constants.SECONDS_PER_SLOT;
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
@@ -72,7 +72,7 @@ import tech.pegasys.artemis.util.time.TimeProvider;
 import tech.pegasys.artemis.util.time.Timer;
 import tech.pegasys.artemis.validator.coordinator.DepositProvider;
 import tech.pegasys.artemis.validator.coordinator.ValidatorCoordinator;
-import tech.pegasys.teku.logging.ALogger;
+import tech.pegasys.teku.logging.StatusLogger;
 
 public class BeaconChainController {
   private final ExecutorService networkExecutor = Executors.newSingleThreadExecutor();
@@ -322,7 +322,8 @@ public class BeaconChainController {
       currentSlot = deltaTime.dividedBy(UnsignedLong.valueOf(SECONDS_PER_SLOT));
     } else {
       UnsignedLong timeUntilGenesis = genesisTime.minus(currentTime);
-      STDOUT.log(Level.INFO, timeUntilGenesis + " seconds until genesis.", ALogger.Color.GREEN);
+      STDOUT.log(
+          Level.INFO, timeUntilGenesis + " seconds until genesis.", StatusLogger.Color.GREEN);
     }
     nodeSlot = currentSlot;
   }
@@ -351,7 +352,7 @@ public class BeaconChainController {
       this.eventBus.post(new SlotEvent(nodeSlot));
       this.currentSlotGauge.set(nodeSlot.longValue());
       this.currentEpochGauge.set(compute_epoch_at_slot(nodeSlot).longValue());
-      STDOUT.log(Level.INFO, "******* Slot Event *******", ALogger.Color.WHITE);
+      STDOUT.log(Level.INFO, "******* Slot Event *******", StatusLogger.Color.WHITE);
       STDOUT.log(Level.INFO, "Node slot:                             " + nodeSlot);
       Thread.sleep(SECONDS_PER_SLOT * 1000 / 3);
       Bytes32 headBlockRoot = this.stateProcessor.processHead();
@@ -383,6 +384,6 @@ public class BeaconChainController {
   public void setNodeSlotAccordingToDBStore(Store store) {
     Bytes32 headBlockRoot = get_head(store);
     chainStorageClient.initializeFromStore(store, headBlockRoot);
-    STDOUT.log(Level.INFO, "Node being started from database.", ALogger.Color.GREEN);
+    STDOUT.log(Level.INFO, "Node being started from database.", StatusLogger.Color.GREEN);
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainService.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainService.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.artemis.services.beaconchain;
 
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import java.util.Objects;
 import org.apache.logging.log4j.Level;

--- a/services/chainstorage/src/main/java/tech/pegasys/artemis/services/chainstorage/ChainStorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/artemis/services/chainstorage/ChainStorageService.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.artemis.services.chainstorage;
 
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import org.apache.logging.log4j.Level;
 import tech.pegasys.artemis.service.serviceutils.ServiceConfig;

--- a/services/powchain/src/main/java/tech/pegasys/artemis/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/artemis/services/powchain/PowchainService.java
@@ -14,7 +14,7 @@
 package tech.pegasys.artemis.services.powchain;
 
 import static tech.pegasys.artemis.util.config.Constants.MAXIMUM_CONCURRENT_ETH1_REQUESTS;
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import org.apache.logging.log4j.Level;
 import org.web3j.protocol.Web3j;

--- a/services/serviceutils/src/main/java/tech/pegasys/artemis/service/serviceutils/ServiceController.java
+++ b/services/serviceutils/src/main/java/tech/pegasys/artemis/service/serviceutils/ServiceController.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.artemis.service.serviceutils;
 
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;

--- a/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageClient.java
@@ -14,7 +14,7 @@
 package tech.pegasys.artemis.storage;
 
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
@@ -37,7 +37,7 @@ import tech.pegasys.artemis.storage.events.StoreGenesisDiskUpdateEvent;
 import tech.pegasys.artemis.storage.events.StoreInitializedEvent;
 import tech.pegasys.artemis.util.SSZTypes.Bytes4;
 import tech.pegasys.artemis.util.config.Constants;
-import tech.pegasys.teku.logging.ALogger;
+import tech.pegasys.teku.logging.StatusLogger;
 
 /** This class is the ChainStorage client-side logic */
 public class ChainStorageClient implements ChainStorage, StoreUpdateHandler {
@@ -181,7 +181,7 @@ public class ChainStorageClient implements ChainStorage, StoreUpdateHandler {
     STDOUT.log(
         Level.INFO,
         "New BeaconBlock with state root:  " + block.getState_root().toHexString() + " detected.",
-        ALogger.Color.GREEN);
+        StatusLogger.Color.GREEN);
   }
 
   @Subscribe
@@ -191,7 +191,7 @@ public class ChainStorageClient implements ChainStorage, StoreUpdateHandler {
         "New Attestation with block root:  "
             + attestation.getData().getBeacon_block_root()
             + " detected.",
-        ALogger.Color.GREEN);
+        StatusLogger.Color.GREEN);
   }
 
   @Subscribe
@@ -201,7 +201,7 @@ public class ChainStorageClient implements ChainStorage, StoreUpdateHandler {
         "New AggregateAndProof with block root:  "
             + attestation.getAggregate().getData().getBeacon_block_root()
             + " detected.",
-        ALogger.Color.BLUE);
+        StatusLogger.Color.BLUE);
   }
 
   public boolean containsBlock(final Bytes32 root) {

--- a/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageServer.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageServer.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.artemis.storage;
 
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.eventbus.AllowConcurrentEvents;
 import com.google.common.eventbus.EventBus;

--- a/storage/src/main/java/tech/pegasys/artemis/storage/MapDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/MapDbDatabase.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.artemis.storage;
 
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.primitives.UnsignedLong;
 import java.io.File;

--- a/sync/src/main/java/tech/pegasys/artemis/sync/AttestationManager.java
+++ b/sync/src/main/java/tech/pegasys/artemis/sync/AttestationManager.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.artemis.sync;
 
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/KeystoresValidatorKeyProvider.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/KeystoresValidatorKeyProvider.java
@@ -18,7 +18,7 @@ import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.io.Files;
 import java.io.FileNotFoundException;

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/MockStartValidatorKeyProvider.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/MockStartValidatorKeyProvider.java
@@ -13,14 +13,14 @@
 
 package tech.pegasys.artemis.validator.coordinator;
 
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import java.util.List;
 import org.apache.logging.log4j.Level;
 import tech.pegasys.artemis.datastructures.util.MockStartValidatorKeyPairFactory;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
-import tech.pegasys.teku.logging.ALogger.Color;
+import tech.pegasys.teku.logging.StatusLogger.Color;
 
 class MockStartValidatorKeyProvider implements ValidatorKeyProvider {
 

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinator.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinator.java
@@ -22,7 +22,7 @@ import static tech.pegasys.artemis.util.config.Constants.GENESIS_EPOCH;
 import static tech.pegasys.artemis.validator.coordinator.ValidatorCoordinatorUtil.isEpochStart;
 import static tech.pegasys.artemis.validator.coordinator.ValidatorCoordinatorUtil.isGenesis;
 import static tech.pegasys.artemis.validator.coordinator.ValidatorLoader.initializeValidators;
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorLoader.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorLoader.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.artemis.validator.coordinator;
 
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.google.common.collect.Streams;
 import java.util.Collection;

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/YamlValidatorKeyProvider.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/YamlValidatorKeyProvider.java
@@ -14,7 +14,7 @@
 package tech.pegasys.artemis.validator.coordinator;
 
 import static java.util.stream.Collectors.toList;
-import static tech.pegasys.teku.logging.ALogger.STDOUT;
+import static tech.pegasys.teku.logging.StatusLogger.STDOUT;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -30,7 +30,7 @@ import tech.pegasys.artemis.util.bls.BLSKeyPair;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
 import tech.pegasys.artemis.util.mikuli.KeyPair;
 import tech.pegasys.artemis.util.mikuli.SecretKey;
-import tech.pegasys.teku.logging.ALogger.Color;
+import tech.pegasys.teku.logging.StatusLogger.Color;
 
 public class YamlValidatorKeyProvider implements ValidatorKeyProvider {
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
The first part of the transition of the colourful console logger from being a utility to actually encapsulating the status updates and their display (which will be a colourful console for the time being) is renaming the `ALogger`.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
