### PR TITLE
Publish poms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,8 +253,9 @@ jobs:
           at: ~/project
       - run:
           name: Publish
+          # binTray plugin doesn't publish pom artifacts if configure-on-demand is used
           command: |
-            ./gradlew --no-daemon --parallel bintrayUpload
+            ./gradlew --no-daemon --parallel -no-configure-on-demand bintrayUpload
 
   publishDocker:
     executor: medium_executor

--- a/build.gradle
+++ b/build.gradle
@@ -83,11 +83,6 @@ allprojects {
     from sourceSets.main.allSource
   }
 
-  task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-  }
-
   sourceCompatibility = '11'
   targetCompatibility = '11'
 
@@ -379,7 +374,6 @@ subprojects {
     options.fork = true
     options.incremental = true
   }
-  apply plugin: 'maven-publish'
 
   sourceSets {
     // test-support can be consumed as a library by other projects in their tests
@@ -447,7 +441,6 @@ subprojects {
           if (sourceSetIsPopulated("main")) {
             from components.java
             artifact sourcesJar
-            artifact javadocJar
           }
 
           if (sourceSetIsPopulated("testSupport")) {
@@ -458,7 +451,7 @@ subprojects {
             usage('java-runtime') { fromResolutionResult() }
           }
           pom {
-            name = "Besu - ${project.name}"
+            name = "Teku - ${project.name}"
             url = 'https://github.com/PegaSysEng/teku'
             licenses {
               license {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Fixes the publishing poms and source artifacts to binTray.

* Disables for the configure-on-demand option when using the binTrayUpload as the plugin doesn't work correctly with this option enabled
* Remove javadoc jars as well as Teku doesn't currently have valid Javadoc

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
