### PR TITLE
Remove mockito-junit-jupiter dependency and be consistent in how we create mocks

### DIFF
--- a/data/beaconrestapi/build.gradle
+++ b/data/beaconrestapi/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     testImplementation 'org.assertj:assertj-core'
 
     testCompile 'io.libp2p:jvm-libp2p-minimal'
-    testCompile 'org.mockito:mockito-junit-jupiter:3.2.4'
 }
 
 test {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/CacheControlUtilsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/CacheControlUtilsTest.java
@@ -15,24 +15,21 @@ package tech.pegasys.artemis.beaconrestapi;
 
 import static com.google.common.primitives.UnsignedLong.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.artemis.beaconrestapi.CacheControlUtils.CACHE_FINALIZED;
 import static tech.pegasys.artemis.beaconrestapi.CacheControlUtils.CACHE_NONE;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import tech.pegasys.artemis.api.ChainDataProvider;
 import tech.pegasys.artemis.api.schema.SignedBeaconBlock;
 import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 
-@ExtendWith(MockitoExtension.class)
 public class CacheControlUtilsTest {
 
   SignedBeaconBlock signedBlock =
       new SignedBeaconBlock(DataStructureUtil.randomSignedBeaconBlock(1, 1));
-  @Mock private ChainDataProvider provider;
+  private final ChainDataProvider provider = mock(ChainDataProvider.class);
 
   @Test
   void getMaxAgeForSignedBlock_shouldSetCacheNoneIfNotFinalized() {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandlerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/beaconhandlers/BeaconStateHandlerTest.java
@@ -36,10 +36,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.junit.jupiter.MockitoExtension;
 import tech.pegasys.artemis.api.ChainDataProvider;
 import tech.pegasys.artemis.api.schema.BeaconState;
 import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
@@ -47,7 +44,6 @@ import tech.pegasys.artemis.provider.JsonProvider;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.util.async.SafeFuture;
 
-@ExtendWith(MockitoExtension.class)
 public class BeaconStateHandlerTest {
   private static tech.pegasys.artemis.datastructures.state.BeaconState beaconStateInternal;
   private static BeaconState beaconState;
@@ -58,8 +54,6 @@ public class BeaconStateHandlerTest {
   private final Context context = mock(Context.class);
   private final String missingRoot = Bytes32.leftPad(Bytes.fromHexString("0xff")).toHexString();
   private final ChainDataProvider dataProvider = mock(ChainDataProvider.class);
-
-  @Captor private ArgumentCaptor<SafeFuture<String>> args;
 
   @BeforeAll
   public static void setup() {
@@ -132,6 +126,8 @@ public class BeaconStateHandlerTest {
 
     handler.handle(context);
 
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<SafeFuture<String>> args = ArgumentCaptor.forClass(SafeFuture.class);
     verify(context).result(args.capture());
     SafeFuture<String> data = args.getValue();
     assertEquals(data.get(), jsonProvider.objectToJSON(beaconState));
@@ -184,6 +180,8 @@ public class BeaconStateHandlerTest {
 
     handler.handle(context);
 
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<SafeFuture<String>> args = ArgumentCaptor.forClass(SafeFuture.class);
     verify(context).result(args.capture());
     SafeFuture<String> data = args.getValue();
     assertEquals(data.get(), jsonProvider.objectToJSON(beaconState));

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetBlockTest.java
@@ -17,6 +17,7 @@ import static com.google.common.primitives.UnsignedLong.ONE;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.artemis.beaconrestapi.CacheControlUtils.CACHE_NONE;
@@ -38,11 +39,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import tech.pegasys.artemis.api.ChainDataProvider;
 import tech.pegasys.artemis.api.schema.SignedBeaconBlock;
 import tech.pegasys.artemis.beaconrestapi.schema.BadRequest;
@@ -50,11 +47,12 @@ import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.provider.JsonProvider;
 import tech.pegasys.artemis.util.async.SafeFuture;
 
-@ExtendWith(MockitoExtension.class)
 public class GetBlockTest {
-  @Captor private ArgumentCaptor<SafeFuture<String>> args;
-  @Mock private Context context;
-  @Mock private ChainDataProvider provider;
+  @SuppressWarnings("unchecked")
+  private final ArgumentCaptor<SafeFuture<String>> args = ArgumentCaptor.forClass(SafeFuture.class);
+
+  private final Context context = mock(Context.class);
+  private final ChainDataProvider provider = mock(ChainDataProvider.class);
 
   private final JsonProvider jsonProvider = new JsonProvider();
   private GetBlock handler;

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetCommitteesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetCommitteesTest.java
@@ -36,11 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import tech.pegasys.artemis.api.ChainDataProvider;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
@@ -51,7 +47,6 @@ import tech.pegasys.artemis.storage.HistoricalChainData;
 import tech.pegasys.artemis.storage.Store;
 import tech.pegasys.artemis.util.async.SafeFuture;
 
-@ExtendWith(MockitoExtension.class)
 public class GetCommitteesTest {
   private static BeaconState beaconState;
   private static Bytes32 blockRoot;
@@ -63,9 +58,10 @@ public class GetCommitteesTest {
 
   private final JsonProvider jsonProvider = new JsonProvider();
   private final Context context = mock(Context.class);
-  @Mock private ChainDataProvider provider;
+  private final ChainDataProvider provider = mock(ChainDataProvider.class);
 
-  @Captor private ArgumentCaptor<SafeFuture<String>> args;
+  @SuppressWarnings("unchecked")
+  private final ArgumentCaptor<SafeFuture<String>> args = ArgumentCaptor.forClass(SafeFuture.class);
 
   @BeforeAll
   public static void setup() {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetHeadTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetHeadTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.artemis.beaconrestapi.handlers.beacon;
 
 import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.artemis.beaconrestapi.CacheControlUtils.CACHE_NONE;
@@ -24,19 +25,15 @@ import io.javalin.http.Context;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import tech.pegasys.artemis.api.ChainDataProvider;
 import tech.pegasys.artemis.api.schema.BeaconHead;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.provider.JsonProvider;
 
-@ExtendWith(MockitoExtension.class)
 public class GetHeadTest {
-  @Mock private ChainDataProvider provider;
-  @Mock private Context context;
+  private final ChainDataProvider provider = mock(ChainDataProvider.class);
+  private final Context context = mock(Context.class);
   private final JsonProvider jsonProvider = new JsonProvider();
   private BeaconState rootState = DataStructureUtil.randomBeaconState(1);
   private final UnsignedLong bestSlot = UnsignedLong.valueOf(51234);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetStateRootTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetStateRootTest.java
@@ -35,10 +35,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.junit.jupiter.MockitoExtension;
 import tech.pegasys.artemis.api.ChainDataProvider;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
@@ -46,7 +43,6 @@ import tech.pegasys.artemis.provider.JsonProvider;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.util.async.SafeFuture;
 
-@ExtendWith(MockitoExtension.class)
 public class GetStateRootTest {
   public static BeaconState beaconStateInternal;
   private static Bytes32 blockRoot;
@@ -56,7 +52,8 @@ public class GetStateRootTest {
   private final JsonProvider jsonProvider = new JsonProvider();
   private final Context context = mock(Context.class);
 
-  @Captor private ArgumentCaptor<SafeFuture<String>> args;
+  @SuppressWarnings("unchecked")
+  private ArgumentCaptor<SafeFuture<String>> args = ArgumentCaptor.forClass(SafeFuture.class);
 
   @BeforeAll
   public static void setup() {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetValidatorsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetValidatorsTest.java
@@ -34,10 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.junit.jupiter.MockitoExtension;
 import tech.pegasys.artemis.api.ChainDataProvider;
 import tech.pegasys.artemis.api.schema.BeaconState;
 import tech.pegasys.artemis.api.schema.BeaconValidators;
@@ -52,7 +49,6 @@ import tech.pegasys.artemis.util.SSZTypes.SSZList;
 import tech.pegasys.artemis.util.async.SafeFuture;
 import tech.pegasys.artemis.util.config.Constants;
 
-@ExtendWith(MockitoExtension.class)
 public class GetValidatorsTest {
   private Context context = mock(Context.class);
   private final UnsignedLong epoch = DataStructureUtil.randomUnsignedLong(99);
@@ -64,7 +60,8 @@ public class GetValidatorsTest {
 
   private final ChainDataProvider provider = mock(ChainDataProvider.class);
 
-  @Captor private ArgumentCaptor<SafeFuture<String>> args;
+  @SuppressWarnings("unchecked")
+  private final ArgumentCaptor<SafeFuture<String>> args = ArgumentCaptor.forClass(SafeFuture.class);
 
   @Test
   public void shouldReturnNoContentWhenNoBlockRoot() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/network/GetEthereumNameRecordTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/network/GetEthereumNameRecordTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.artemis.beaconrestapi.handlers.network;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.artemis.beaconrestapi.CacheControlUtils.CACHE_NONE;
@@ -21,20 +22,19 @@ import io.javalin.core.util.Header;
 import io.javalin.http.Context;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import tech.pegasys.artemis.api.NetworkDataProvider;
 import tech.pegasys.artemis.networking.p2p.network.P2PNetwork;
 import tech.pegasys.artemis.networking.p2p.peer.Peer;
 import tech.pegasys.artemis.provider.JsonProvider;
 
-@ExtendWith(MockitoExtension.class)
 public class GetEthereumNameRecordTest {
-  @Mock Context context;
-  @Mock P2PNetwork<Peer> p2pNetwork;
+  private static final String ENR = "enr:-";
+  private final Context context = mock(Context.class);
+
+  @SuppressWarnings("unchecked")
+  private final P2PNetwork<Peer> p2pNetwork = mock(P2PNetwork.class);
+
   private final JsonProvider jsonProvider = new JsonProvider();
-  private String ENR = "enr:-";
 
   @Test
   public void shouldReturnEmptyStringWhenDiscoveryNotInUse() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/network/GetPeerCountTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/network/GetPeerCountTest.java
@@ -19,15 +19,11 @@ import static org.mockito.Mockito.when;
 
 import io.javalin.http.Context;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import tech.pegasys.artemis.api.NetworkDataProvider;
 import tech.pegasys.artemis.provider.JsonProvider;
 
-@ExtendWith(MockitoExtension.class)
 public class GetPeerCountTest {
-  @Mock Context context;
+  private final Context context = mock(Context.class);
   private final JsonProvider jsonProvider = new JsonProvider();
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/network/GetPeerIdTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/network/GetPeerIdTest.java
@@ -22,9 +22,6 @@ import io.javalin.core.util.Header;
 import io.javalin.http.Context;
 import io.libp2p.core.PeerId;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import tech.pegasys.artemis.api.NetworkDataProvider;
 import tech.pegasys.artemis.networking.p2p.libp2p.LibP2PNodeId;
 import tech.pegasys.artemis.networking.p2p.network.P2PNetwork;
@@ -32,11 +29,13 @@ import tech.pegasys.artemis.networking.p2p.peer.NodeId;
 import tech.pegasys.artemis.networking.p2p.peer.Peer;
 import tech.pegasys.artemis.provider.JsonProvider;
 
-@ExtendWith(MockitoExtension.class)
 public class GetPeerIdTest {
   private Context context = mock(Context.class);
-  @Mock P2PNetwork<Peer> p2pNetwork;
-  @Mock private JsonProvider jsonProvider;
+
+  @SuppressWarnings("unchecked")
+  private final P2PNetwork<Peer> p2pNetwork = mock(P2PNetwork.class);
+
+  private final JsonProvider jsonProvider = mock(JsonProvider.class);
 
   @Test
   public void shouldReturnPeerId() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/network/GetPeersTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/network/GetPeersTest.java
@@ -23,9 +23,6 @@ import io.javalin.http.Context;
 import io.libp2p.core.PeerId;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import tech.pegasys.artemis.api.NetworkDataProvider;
 import tech.pegasys.artemis.networking.p2p.libp2p.LibP2PNodeId;
 import tech.pegasys.artemis.networking.p2p.network.P2PNetwork;
@@ -33,11 +30,12 @@ import tech.pegasys.artemis.networking.p2p.peer.NodeId;
 import tech.pegasys.artemis.networking.p2p.peer.Peer;
 import tech.pegasys.artemis.provider.JsonProvider;
 
-@ExtendWith(MockitoExtension.class)
 public class GetPeersTest {
   private final JsonProvider jsonProvider = new JsonProvider();
-  @Mock Context context;
-  @Mock P2PNetwork<Peer> p2pNetwork;
+  private final Context context = mock(Context.class);
+
+  @SuppressWarnings("unchecked")
+  private final P2PNetwork<Peer> p2pNetwork = mock(P2PNetwork.class);
 
   @Test
   public void shouldReturnArrayOfPeersIfPresent() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/validator/GetAttestationTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/validator/GetAttestationTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.artemis.beaconrestapi.handlers.validator;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.artemis.beaconrestapi.RestApiConstants.COMMITTEE_INDEX;
@@ -28,19 +29,15 @@ import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import tech.pegasys.artemis.api.ChainDataProvider;
 import tech.pegasys.artemis.api.schema.Attestation;
 import tech.pegasys.artemis.beaconrestapi.schema.BadRequest;
 import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.provider.JsonProvider;
 
-@ExtendWith(MockitoExtension.class)
 public class GetAttestationTest {
-  @Mock private Context context;
-  @Mock private ChainDataProvider provider;
+  private Context context = mock(Context.class);
+  private ChainDataProvider provider = mock(ChainDataProvider.class);
   private final JsonProvider jsonProvider = new JsonProvider();
   private GetAttestation handler;
   private Attestation attestation = new Attestation(DataStructureUtil.randomAttestation(1111));

--- a/data/provider/build.gradle
+++ b/data/provider/build.gradle
@@ -15,8 +15,7 @@ dependencies {
     runtime 'org.apache.logging.log4j:log4j-core'
 
     testImplementation project(path: ':ethereum:datastructures', configuration: 'testSupportArtifacts')
-
-    testCompile 'org.mockito:mockito-junit-jupiter:3.2.4'
+    testImplementation 'org.mockito:mockito-core'
 }
 
 test {

--- a/data/provider/src/test/java/tech/pegasys/artemis/api/NetworkDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/artemis/api/NetworkDataProviderTest.java
@@ -20,15 +20,12 @@ import static org.mockito.Mockito.when;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import tech.pegasys.artemis.networking.p2p.network.P2PNetwork;
 import tech.pegasys.artemis.networking.p2p.peer.Peer;
 
-@ExtendWith(MockitoExtension.class)
 public class NetworkDataProviderTest {
-  @Mock private P2PNetwork<Peer> p2pNetwork;
+  @SuppressWarnings("unchecked")
+  private P2PNetwork<Peer> p2pNetwork = mock(P2PNetwork.class);
 
   @Test
   void getPeerCount_shouldReturnTotalPeers() {

--- a/sync/build.gradle
+++ b/sync/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     testImplementation project(path: ':ethereum:datastructures', configuration: 'testSupportArtifacts')
     testImplementation project(path: ':ethereum:statetransition', configuration: 'testSupportArtifacts')
     testImplementation project(path: ':util', configuration: 'testSupportArtifacts')
-    testCompile 'org.mockito:mockito-junit-jupiter:3.2.4'
 
     integrationTestImplementation 'org.mockito:mockito-core'
     integrationTestImplementation project(path: ':networking:eth2', configuration: 'testSupportArtifacts')

--- a/sync/src/test/java/tech/pegasys/artemis/sync/FetchRecentBlocksServiceTest.java
+++ b/sync/src/test/java/tech/pegasys/artemis/sync/FetchRecentBlocksServiceTest.java
@@ -26,10 +26,7 @@ import java.util.List;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.networking.eth2.Eth2Network;
@@ -39,12 +36,14 @@ import tech.pegasys.artemis.sync.FetchRecentBlocksService.FetchBlockTaskFactory;
 import tech.pegasys.artemis.util.async.SafeFuture;
 import tech.pegasys.artemis.util.async.StubAsyncRunner;
 
-@ExtendWith(MockitoExtension.class)
 public class FetchRecentBlocksServiceTest {
 
-  @Mock private Eth2Network eth2Network;
-  @Mock private PendingPool<SignedBeaconBlock> pendingBlocksPool;
-  @Mock private FetchBlockTaskFactory fetchBlockTaskFactory;
+  private Eth2Network eth2Network = mock(Eth2Network.class);
+
+  @SuppressWarnings("unchecked")
+  private PendingPool<SignedBeaconBlock> pendingBlocksPool = mock(PendingPool.class);
+
+  private FetchBlockTaskFactory fetchBlockTaskFactory = mock(FetchBlockTaskFactory.class);
 
   private final int maxConcurrentRequests = 2;
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();


### PR DESCRIPTION
## PR Description
Aim to be consistent in how we create and work with mocks - Teku is nearly entirely using the `Mockito.mock` static method instead of `@Mock` annotations but a few places have moved to annotations.  Make everything consistent again and remove the dependency that provides the `MockitoExtension` which does the annotation processing.

I know different people have different preferences, but the key is consistency.