### PR TITLE
Setup initial state if genesis state is provided

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -110,7 +110,8 @@ public class BeaconChainController {
     this.eventChannels = eventChannels;
     this.config = config;
     this.metricsSystem = metricsSystem;
-    this.setupInitialState = config.getDepositMode().equals(DEPOSIT_TEST);
+    this.setupInitialState =
+        config.getDepositMode().equals(DEPOSIT_TEST) || config.getStartState() != null;
     this.eventBus.register(this);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
If a genesis state is configured, we should try to import it regardless of the deposit mode flag.  