### PR TITLE
[BC-311] Introduce config option for pruning finalized state

### DIFF
--- a/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageServer.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/ChainStorageServer.java
@@ -71,7 +71,11 @@ public class ChainStorageServer {
     LOG.info("Data directory set to: {}", dataStoragePath);
     preflightCheck(databaseStoragePath, databaseVersionPath);
 
-    this.database = MapDbDatabase.createOnDisk(databaseStoragePath, configuration.startFromDisk());
+    final StateStorageMode stateStorageMode =
+        StateStorageMode.fromString(configuration.getStateStorageMode());
+    this.database =
+        MapDbDatabase.createOnDisk(
+            databaseStoragePath, configuration.startFromDisk(), stateStorageMode);
     eventBus.register(this);
 
     final Optional<Store> store = getStore();

--- a/storage/src/main/java/tech/pegasys/artemis/storage/MapDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/MapDbDatabase.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.artemis.storage;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.UnsignedLong;
 import java.io.File;
 import java.io.IOException;
@@ -66,8 +67,10 @@ public class MapDbDatabase implements Database {
   // In memory only
   private final ConcurrentNavigableMap<UnsignedLong, Set<Bytes32>> hotRootsBySlotCache =
       new ConcurrentSkipListMap<>();
+  private final StateStorageMode stateStorageMode;
 
-  public static Database createOnDisk(final File directory, final boolean startFromDisk) {
+  public static Database createOnDisk(
+      final File directory, final boolean startFromDisk, final StateStorageMode stateStorageMode) {
     final File databaseFile = new File(directory, "teku.db");
     try {
       if (!startFromDisk) {
@@ -76,14 +79,16 @@ public class MapDbDatabase implements Database {
     } catch (IOException e) {
       LOG.error("Failed to clear old database");
     }
-    return new MapDbDatabase(DBMaker.fileDB(databaseFile));
+    return new MapDbDatabase(DBMaker.fileDB(databaseFile), stateStorageMode);
   }
 
-  public static Database createInMemory() {
-    return new MapDbDatabase(DBMaker.memoryDB());
+  @VisibleForTesting
+  static Database createInMemory(final StateStorageMode stateStorageMode) {
+    return new MapDbDatabase(DBMaker.memoryDB(), stateStorageMode);
   }
 
-  private MapDbDatabase(final Maker dbMaker) {
+  private MapDbDatabase(final Maker dbMaker, final StateStorageMode stateStorageMode) {
+    this.stateStorageMode = stateStorageMode;
     db = dbMaker.transactionEnable().make();
     genesisTime = db.atomicVar("genesisTime", new UnsignedLongSerializer()).createOrOpen();
     justifiedCheckpoint =
@@ -158,7 +163,7 @@ public class MapDbDatabase implements Database {
                 hotStatesByRoot.put(root, state);
                 finalizedRootsBySlot.put(block.getSlot(), root);
                 finalizedBlocksByRoot.put(root, block);
-                finalizedStatesByRoot.put(root, state);
+                putFinalizedState(root, state);
               });
       checkpointStates.put(
           store.getJustifiedCheckpoint(),
@@ -214,6 +219,17 @@ public class MapDbDatabase implements Database {
     }
   }
 
+  private void putFinalizedState(final Bytes32 blockRoot, final BeaconState state) {
+    switch (stateStorageMode) {
+      case ARCHIVE:
+        finalizedStatesByRoot.put(blockRoot, state);
+        break;
+      case PRUNE:
+        // Don't persist finalized state
+        break;
+    }
+  }
+
   private void addHotBlock(final Bytes32 root, final SignedBeaconBlock block) {
     hotBlocksByRoot.put(root, block);
     addToHotRootsBySlotCache(root, block);
@@ -238,7 +254,7 @@ public class MapDbDatabase implements Database {
       finalizedBlocksByRoot.put(newlyFinalizedBlockRoot, newlyFinalizedBlock);
       final Optional<BeaconState> finalizedState = getState(newlyFinalizedBlockRoot);
       if (finalizedState.isPresent()) {
-        finalizedStatesByRoot.put(newlyFinalizedBlockRoot, finalizedState.get());
+        putFinalizedState(newlyFinalizedBlockRoot, finalizedState.get());
       } else {
         LOG.error(
             "Missing finalized state {} for epoch {}",

--- a/storage/src/main/java/tech/pegasys/artemis/storage/StateStorageMode.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/StateStorageMode.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.storage;
+
+import java.util.Objects;
+
+public enum StateStorageMode {
+  // All historical state is available to query in archive mode
+  ARCHIVE,
+  // No historical state is available to query in mode "prune"
+  PRUNE;
+
+  static StateStorageMode fromString(final String value) {
+    final String normalizedValue = value.trim().toUpperCase();
+    for (StateStorageMode mode : StateStorageMode.values()) {
+      if (Objects.equals(mode.name(), normalizedValue)) {
+        return mode;
+      }
+    }
+    throw new IllegalArgumentException("Unknown value supplied: " + value);
+  }
+}

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
@@ -134,6 +134,11 @@ public class ArtemisConfiguration {
     builder.addBoolean("database.startFromDisk", false, "Start from the disk if set to true", null);
     builder.addString(
         "database.dataPath", ".", "Path to output data files", PropertyValidator.isPresent());
+    builder.addString(
+        "database.stateStorageMode",
+        "prune",
+        "Sets the strategy for handling historical chain state.  Supported values include: 'prune', and 'archive'",
+        null);
 
     // Beacon Rest API
     builder.addInteger("beaconrestapi.portNumber", 5051, "Port number of Beacon Rest API", null);
@@ -370,6 +375,10 @@ public class ArtemisConfiguration {
 
   public boolean startFromDisk() {
     return config.getBoolean("database.startFromDisk");
+  }
+
+  public String getStateStorageMode() {
+    return config.getString("database.stateStorageMode");
   }
 
   public void validateConfig() throws IllegalArgumentException {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
This PR introduces an option `database.stateStorageMode` which can be configured so that we drop finalized states ("prune") or keep finalized states ("archive").  This change should be safe since `Database.getState()` already returns an `Optional`.  However, I will follow up with another PR to make sure that missing state is properly handled by REST API's.  