### PR TITLE
test for passing in config as a toml file

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/BeaconNodeCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/BeaconNodeCommand.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.artemis;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import org.apache.logging.log4j.Level;
@@ -56,6 +57,8 @@ public class BeaconNodeCommand implements Callable<Integer> {
       description = "Path/filename of the config file")
   private String configFile = "./config/config.toml";
 
+  private ArtemisConfiguration artemisConfiguration;
+
   public Optional<Level> getLoggingLevel() {
     return Optional.ofNullable(this.logLevel);
   }
@@ -64,11 +67,16 @@ public class BeaconNodeCommand implements Callable<Integer> {
     return configFile;
   }
 
+  @VisibleForTesting
+  public ArtemisConfiguration getArtemisConfiguration() {
+    return artemisConfiguration;
+  }
+
   @Override
   public Integer call() {
     try {
-      BeaconNode node =
-          new BeaconNode(getLoggingLevel(), ArtemisConfiguration.fromFile(getConfigFile()));
+      artemisConfiguration = ArtemisConfiguration.fromFile(getConfigFile());
+      BeaconNode node = new BeaconNode(getLoggingLevel(), artemisConfiguration);
       node.start();
       // Detect SIGTERM
       Runtime.getRuntime()

--- a/artemis/src/test/java/tech/pegasys/artemis/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/BeaconNodeCommandTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+import tech.pegasys.artemis.util.config.ArtemisConfiguration;
+
+public class BeaconNodeCommandTest {
+
+  @Test
+  public void overrideDefaultValuesIfKeyIsPresentInConfigFile() throws IOException {
+    final URL configFile = this.getClass().getResource("/complete_config.toml");
+    final String updatedConfig = Resources.toString(configFile, UTF_8);
+    final Path toml = createTempFile("toml", updatedConfig.getBytes(UTF_8));
+
+    final BeaconNodeCommand app = new BeaconNodeCommand();
+    final CommandLine cmd = new CommandLine(app);
+    cmd.execute("--config", toml.toString());
+
+    final ArtemisConfiguration artemisConfiguration = app.getArtemisConfiguration();
+
+    assertThat(artemisConfiguration.isMetricsEnabled()).isFalse();
+    assertThat(artemisConfiguration.getAdvertisedIp()).isEqualTo("127.0.0.1");
+    assertThat(artemisConfiguration.getAdvertisedPort()).isEqualTo(9000);
+    assertThat(artemisConfiguration.getBeaconRestAPIEnableSwagger()).isFalse();
+    assertThat(artemisConfiguration.getBeaconRestAPIPortNumber()).isEqualTo(5051);
+    assertThat(artemisConfiguration.getBootnodes()).isEqualTo(Collections.emptyList());
+    assertThat(artemisConfiguration.getConstants()).isEqualTo("minimal");
+    assertThat(artemisConfiguration.getContractAddr())
+        .isEqualTo("0x77f7bED277449F51505a4C54550B074030d989bC");
+    assertThat(artemisConfiguration.getDataPath()).isEqualTo(".");
+    assertThat(artemisConfiguration.getDepositMode()).isEqualTo("test");
+    assertThat(artemisConfiguration.getDiscovery()).isEqualTo("static");
+
+    // hard to test - depends on System.currentTime
+    // assertThat(artemisConfiguration.getGenesisTime()).isEqualTo();
+
+    // dev option used for simulation
+    // assertThat(artemisConfiguration.getInputFile()).isEqualTo(null);
+
+    assertThat(artemisConfiguration.getInteropOwnedValidatorCount()).isEqualTo(64);
+    assertThat(artemisConfiguration.getInteropOwnedValidatorStartIndex()).isEqualTo(0);
+    assertThat(artemisConfiguration.getInteropPrivateKey())
+        .isEqualTo("0x08021221008166B8EF20C11F3A18F8774BF834173B07F64BAEDA981766896B4A8F53B52EDF");
+    assertThat(artemisConfiguration.getMetricCategories())
+        .isEqualTo(Arrays.asList("JVM", "PROCESS", "BEACONCHAIN", "EVENTBUS", "NETWORK"));
+    assertThat(artemisConfiguration.getMetricsNetworkInterface()).isEqualTo("127.0.0.1");
+    assertThat(artemisConfiguration.getMetricsPort()).isEqualTo(8008);
+    assertThat(artemisConfiguration.getNetworkID()).isEqualTo(1);
+    assertThat(artemisConfiguration.getNetworkInterface()).isEqualTo("0.0.0.0");
+    assertThat(artemisConfiguration.getNetworkMode()).isEqualTo("mock");
+    assertThat(artemisConfiguration.getNodeUrl()).isEqualTo("http://localhost:8545");
+    assertThat(artemisConfiguration.getNumValidators()).isEqualTo(64);
+    assertThat(artemisConfiguration.getPort()).isEqualTo(9000);
+
+    // property does not exist
+    // assertThat(artemisConfiguration.getProviderType()).isEqualTo("");
+
+    // most likely a dev option
+    assertThat(artemisConfiguration.getStartState()).isEqualTo(null);
+
+    assertThat(artemisConfiguration.getTargetPeerCountRangeLowerBound()).isEqualTo(20);
+    assertThat(artemisConfiguration.getTargetPeerCountRangeUpperBound()).isEqualTo(30);
+
+    // property does not exist
+    // assertThat(artemisConfiguration.getTimer()).isEqualTo(null);
+
+    // most likely a dev option for debugging
+    assertThat(artemisConfiguration.getTransitionRecordDir()).isEqualTo(null);
+
+    // application uses mock for testing if this is not set
+    assertThat(artemisConfiguration.getValidatorsKeyFile()).isEqualTo(null);
+
+    assertThat(artemisConfiguration.startFromDisk()).isFalse();
+  }
+
+  private Path createTempFile(final String filename, final byte[] contents) throws IOException {
+    final Path file = Files.createTempFile(filename, "");
+    Files.write(file, contents);
+    file.toFile().deleteOnExit();
+    return file;
+  }
+}

--- a/artemis/src/test/java/tech/pegasys/artemis/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/BeaconNodeCommandTest.java
@@ -81,6 +81,7 @@ public class BeaconNodeCommandTest {
     // most likely a dev option
     assertThat(artemisConfiguration.getStartState()).isEqualTo(null);
 
+    assertThat(artemisConfiguration.getStateStorageMode()).isEqualTo("prune");
     assertThat(artemisConfiguration.getTargetPeerCountRangeLowerBound()).isEqualTo(20);
     assertThat(artemisConfiguration.getTargetPeerCountRangeUpperBound()).isEqualTo(30);
 

--- a/artemis/src/test/java/tech/pegasys/artemis/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/BeaconNodeCommandTest.java
@@ -53,13 +53,7 @@ public class BeaconNodeCommandTest {
     assertThat(artemisConfiguration.getDataPath()).isEqualTo(".");
     assertThat(artemisConfiguration.getDepositMode()).isEqualTo("test");
     assertThat(artemisConfiguration.getDiscovery()).isEqualTo("static");
-
-    // hard to test - depends on System.currentTime
-    // assertThat(artemisConfiguration.getGenesisTime()).isEqualTo();
-
-    // dev option used for simulation
-    // assertThat(artemisConfiguration.getInputFile()).isEqualTo(null);
-
+    assertThat(artemisConfiguration.getGenesisTime()).isEqualTo(1);
     assertThat(artemisConfiguration.getInteropOwnedValidatorCount()).isEqualTo(64);
     assertThat(artemisConfiguration.getInteropOwnedValidatorStartIndex()).isEqualTo(0);
     assertThat(artemisConfiguration.getInteropPrivateKey())
@@ -74,27 +68,24 @@ public class BeaconNodeCommandTest {
     assertThat(artemisConfiguration.getNodeUrl()).isEqualTo("http://localhost:8545");
     assertThat(artemisConfiguration.getNumValidators()).isEqualTo(64);
     assertThat(artemisConfiguration.getPort()).isEqualTo(9000);
-
-    // property does not exist
-    // assertThat(artemisConfiguration.getProviderType()).isEqualTo("");
-
-    // most likely a dev option
-    assertThat(artemisConfiguration.getStartState()).isEqualTo(null);
-
     assertThat(artemisConfiguration.getStateStorageMode()).isEqualTo("prune");
     assertThat(artemisConfiguration.getTargetPeerCountRangeLowerBound()).isEqualTo(20);
     assertThat(artemisConfiguration.getTargetPeerCountRangeUpperBound()).isEqualTo(30);
-
-    // property does not exist
-    // assertThat(artemisConfiguration.getTimer()).isEqualTo(null);
-
-    // most likely a dev option for debugging
-    assertThat(artemisConfiguration.getTransitionRecordDir()).isEqualTo(null);
-
     // application uses mock for testing if this is not set
     assertThat(artemisConfiguration.getValidatorsKeyFile()).isEqualTo(null);
 
-    assertThat(artemisConfiguration.startFromDisk()).isFalse();
+    // the following are likely to change or be removed
+
+    // dev option used for simulation
+    // assertThat(artemisConfiguration.getInputFile()).isEqualTo(null);
+    // property does not exist
+    // assertThat(artemisConfiguration.getProviderType()).isEqualTo("");
+    // most likely a dev option
+    assertThat(artemisConfiguration.getStartState()).isEqualTo(null);
+    // property does not exist
+    // assertThat(artemisConfiguration.getTimer()).isEqualTo(null);
+    // most likely a dev option for debugging
+    assertThat(artemisConfiguration.getTransitionRecordDir()).isEqualTo(null);
   }
 
   private Path createTempFile(final String filename, final byte[] contents) throws IOException {

--- a/artemis/src/test/resources/complete_config.toml
+++ b/artemis/src/test/resources/complete_config.toml
@@ -1,0 +1,110 @@
+## CURRENT VALID TOML FILE
+
+[node]
+# networkMode options:
+# "mock": use MockP2PNetwork
+# "jvmlibp2p" : use JvmLibP2PNetwork
+networkMode = "mock"
+networkInterface = "0.0.0.0"
+port = 9000
+advertisedIp = "127.0.0.1"
+# discovery options:
+# "static" - no discovery, only connect to static peers
+# "discv5" - Enable discovery v5
+discovery = "static"
+bootnodes=[]
+advertisedPort = 9000
+constants = "minimal"
+
+[interop]
+# when genesis time is set to 0, artemis takes genesis time as currentTime + 5 seconds.
+genesisTime = 0
+ownedValidatorStartIndex = 0
+ownedValidatorCount = 64
+startState = ""
+#this.privKey.bytes().toHexString() who's corresponding sha2(publicKey) == 16Uiu2HAm8cQB9DcwMtaSVuHNiJEPSq9mXM6FHho7c55M6XN2P3EQ
+privateKey = "0x08021221008166B8EF20C11F3A18F8774BF834173B07F64BAEDA981766896B4A8F53B52EDF"
+
+[validator]
+#validatorsKeyFile = "keys.yaml"
+
+[deposit]
+# normal, test
+# "test" pre-production
+# "normal" production, must include contractAddr and nodeUrl
+mode = "test"
+inputFile = "" #"validator_test_data.json"
+numValidators = 64
+contractAddr = "0x77f7bED277449F51505a4C54550B074030d989bC"
+nodeUrl = "http://localhost:8545"
+
+[output]
+#transitionRecordDir = "/tmp/teku"
+
+[metrics]
+enabled = false
+port = 8008
+metricsNetworkInterface = "127.0.0.1"
+#metricsCategories = [ "BEACONCHAIN", "JVM", "PROCESS" ]
+
+[database]
+dataPath="."
+startFromDisk = false
+
+[beaconrestapi]
+portNumber = 5051
+enableSwagger = false
+
+## This is the TOML config we want in the future
+#
+## network
+#network="minimal"
+#
+## p2p
+#p2p-enabled=false
+#p2p-interface="1.2.3.4"
+#p2p-port=1234
+#p2p-discovery-enabled=false
+#p2p-discovery-bootnodes=[
+#  "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.1:4567",
+#  "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.1:4567",
+#  "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.1:4567"
+#]
+#p2p-advertised-port=2345
+#p2p-private-key="path/to/file"
+##p2p-target-peer-range= (probably should be two values denoting min/max)
+#
+## interop
+#X-interop-genesis-time=0
+#X-interop-owned-validator-start-index= 0
+#X-interop-owned-validator-count=64
+#X-interop-start-state=""
+#X-interop-number-of-validators=64
+#X-interop-enabled=false
+#
+## validator
+#validators-key-file="path/to/keys.yaml"
+#
+## deposit
+#eth1-deposit-contract-address="0x77f7bED277449F51505a4C54550B074030d989bC"
+#eth1-endpoint="http://localhost:8545"
+#
+## output
+#X-transaction-record-directory="path/to/directory"
+#
+## metrics
+#metrics-enabled=false
+#metrics-port=8008
+#metrics-interface="127.0.0.1"
+#metrics-categories=["beaconchain", "jvm", "process"]
+#
+## database
+#data-path="path/to/directory"
+#
+## beacon rest api
+#rest-api-port=false
+#rest-api-docs-enabled=false
+#rest-api-enabled=false
+#rest-api-interface="127.0.0.1"
+#
+## validator subcommand (probably not needed here)

--- a/artemis/src/test/resources/complete_config.toml
+++ b/artemis/src/test/resources/complete_config.toml
@@ -18,7 +18,7 @@ constants = "minimal"
 
 [interop]
 # when genesis time is set to 0, artemis takes genesis time as currentTime + 5 seconds.
-genesisTime = 0
+genesisTime = 1
 ownedValidatorStartIndex = 0
 ownedValidatorCount = 64
 startState = ""
@@ -49,7 +49,6 @@ metricsNetworkInterface = "127.0.0.1"
 
 [database]
 dataPath="."
-startFromDisk = false
 stateStorageMode = "prune"
 
 [beaconrestapi]

--- a/artemis/src/test/resources/complete_config.toml
+++ b/artemis/src/test/resources/complete_config.toml
@@ -50,6 +50,7 @@ metricsNetworkInterface = "127.0.0.1"
 [database]
 dataPath="."
 startFromDisk = false
+stateStorageMode = "prune"
 
 [beaconrestapi]
 portNumber = 5051


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description

Tests that value from a toml file are correctly parsed into `ArtemisConfiguration`

**N.B.** need feedback on how to handle some options - see comments in the test.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
