### PR TITLE
Sync should be set active when we start running it

### DIFF
--- a/sync/src/main/java/tech/pegasys/artemis/sync/SyncManager.java
+++ b/sync/src/main/java/tech/pegasys/artemis/sync/SyncManager.java
@@ -77,6 +77,7 @@ public class SyncManager extends Service {
   @Override
   protected SafeFuture<?> doStart() {
     LOG.trace("Start {}", this.getClass().getSimpleName());
+    syncActive = true;
     peerConnectSubscriptionId = network.subscribeConnect(this::onNewPeer);
     startOrScheduleSync();
     return completedFuture(null);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
This PR builds upon this PR: https://github.com/PegaSysEng/teku/pull/1405/files. Sync should be set to active when we start running so that the client doesn't do redundant processing when it's waiting to connect to another peer with higher finalized epoch.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
