### PR TITLE
Use getters in SyncStatus instead of public fields

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/SyncingResponse.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/schema/SyncingResponse.java
@@ -30,7 +30,7 @@ public class SyncingResponse {
   }
 
   public SyncingResponse(SyncingStatus syncStatus) {
-    this.is_syncing = syncStatus.is_syncing;
-    this.sync_status = syncStatus.sync_status;
+    this.is_syncing = syncStatus.isSyncing();
+    this.sync_status = syncStatus.getSyncStatus();
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -331,7 +331,7 @@ public class BeaconChainController extends Service {
   @Subscribe
   @SuppressWarnings("unused")
   private void onTick(Date date) {
-    if (chainStorageClient.isPreGenesis() || syncService.getSyncStatus().is_syncing) {
+    if (chainStorageClient.isPreGenesis() || syncService.getSyncStatus().isSyncing()) {
       return;
     }
     final UnsignedLong currentTime = UnsignedLong.valueOf(date.getTime() / 1000);

--- a/sync/src/main/java/tech/pegasys/artemis/sync/SyncingStatus.java
+++ b/sync/src/main/java/tech/pegasys/artemis/sync/SyncingStatus.java
@@ -13,12 +13,30 @@
 
 package tech.pegasys.artemis.sync;
 
-public class SyncingStatus {
-  public final boolean is_syncing;
-  public final SyncStatus sync_status;
+import com.google.common.base.MoreObjects;
 
-  public SyncingStatus(final boolean is_syncing, final SyncStatus sync_status) {
-    this.is_syncing = is_syncing;
-    this.sync_status = sync_status;
+public class SyncingStatus {
+  private final boolean syncing;
+  private final SyncStatus syncStatus;
+
+  public SyncingStatus(final boolean syncing, final SyncStatus syncStatus) {
+    this.syncing = syncing;
+    this.syncStatus = syncStatus;
+  }
+
+  public boolean isSyncing() {
+    return syncing;
+  }
+
+  public SyncStatus getSyncStatus() {
+    return syncStatus;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("syncing", syncing)
+        .add("syncStatus", syncStatus)
+        .toString();
   }
 }

--- a/sync/src/test/java/tech/pegasys/artemis/sync/SyncManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/artemis/sync/SyncManagerTest.java
@@ -208,7 +208,7 @@ public class SyncManagerTest {
     UnsignedLong currentSlot = UnsignedLong.valueOf(17);
     when(storageClient.getBestSlot()).thenReturn(currentSlot);
 
-    SyncStatus syncStatus = syncManager.getSyncStatus().sync_status;
+    SyncStatus syncStatus = syncManager.getSyncStatus().getSyncStatus();
     assertThat(syncStatus.getCurrent_slot()).isEqualTo(currentSlot);
     assertThat(syncStatus.getStarting_slot()).isEqualTo(startingSlot);
     assertThat(syncStatus.getHighest_slot()).isEqualTo(PEER_HEAD_SLOT);
@@ -228,7 +228,7 @@ public class SyncManagerTest {
     verifyNoInteractions(peerSync);
 
     // verify that getSyncStatus completes even when no peers
-    assertThat(syncManager.getSyncStatus().sync_status).isNull();
+    assertThat(syncManager.getSyncStatus().getSyncStatus()).isNull();
     assertThat(syncManager.isSyncQueued()).isFalse();
   }
 }


### PR DESCRIPTION
## PR Description
Follow code style in SyncStatus now that it's not being used directly in REST API responses.