### PR TITLE
Fix SSZ_FIELD_COUNT for Attestation.

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/Attestation.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/Attestation.java
@@ -36,7 +36,7 @@ import tech.pegasys.artemis.util.sos.SimpleOffsetSerializable;
 public class Attestation implements Merkleizable, SimpleOffsetSerializable, SSZContainer {
 
   // The number of SimpleSerialize basic types in this SSZ Container/POJO.
-  public static final int SSZ_FIELD_COUNT = 2;
+  public static final int SSZ_FIELD_COUNT = 1;
 
   private Bitlist aggregation_bits; // Bitlist bounded by MAX_VALIDATORS_PER_COMMITTEE
   private AttestationData data;


### PR DESCRIPTION
Attestation only has 1 direct field that is an SSZ primitive object.

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description

SSZ_FIELD_COUNT is intended to enumerate the number of primitive SSZ fields directly in a container.

Attestation only has 1 such field (`Bitlist aggregation_bits`).

As `get_fixed_parts()` and `get_variable_parts()` are both overridden for Attestation, I think the inaccurate `getSSZFieldCount()` would only affect a SimpleOffsetSerializable that contains an Attestation and uses a default `get_XXX_parts()` implementation.
Such a class is not currently defined so the bug is not triggered.
