### PR TITLE
Switch DataStructureUtil to use instance methods

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/artemis/beaconrestapi/beacon/GetHeadIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/artemis/beaconrestapi/beacon/GetHeadIntegrationTest.java
@@ -28,6 +28,8 @@ import tech.pegasys.artemis.storage.Store;
 
 public class GetHeadIntegrationTest extends AbstractBeaconRestAPIIntegrationTest {
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+
   @Test
   public void shouldReturnNoContentIfStoreNotDefined() throws Exception {
     when(chainStorageClient.getStore()).thenReturn(null);
@@ -48,7 +50,7 @@ public class GetHeadIntegrationTest extends AbstractBeaconRestAPIIntegrationTest
 
   @Test
   public void shouldReturnNoContentIfBestBlockIsMissing() throws Exception {
-    final Bytes32 headRoot = DataStructureUtil.randomBytes32(1);
+    final Bytes32 headRoot = dataStructureUtil.randomBytes32();
     when(chainStorageClient.getBestBlockRoot()).thenReturn(Optional.of(headRoot));
     when(chainStorageClient.getBlockByRoot(headRoot)).thenReturn(Optional.empty());
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/CacheControlUtilsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/CacheControlUtilsTest.java
@@ -27,8 +27,9 @@ import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 
 public class CacheControlUtilsTest {
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   SignedBeaconBlock signedBlock =
-      new SignedBeaconBlock(DataStructureUtil.randomSignedBeaconBlock(1, 1));
+      new SignedBeaconBlock(dataStructureUtil.randomSignedBeaconBlock(1));
   private final ChainDataProvider provider = mock(ChainDataProvider.class);
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetBlockTest.java
@@ -48,6 +48,8 @@ import tech.pegasys.artemis.provider.JsonProvider;
 import tech.pegasys.artemis.util.async.SafeFuture;
 
 public class GetBlockTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+
   @SuppressWarnings("unchecked")
   private final ArgumentCaptor<SafeFuture<String>> args = ArgumentCaptor.forClass(SafeFuture.class);
 
@@ -58,7 +60,7 @@ public class GetBlockTest {
   private GetBlock handler;
   private Bytes32 blockRoot = Bytes32.random();
   private tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlock signedBeaconBlock =
-      DataStructureUtil.randomSignedBeaconBlock(1, 1);
+      dataStructureUtil.randomSignedBeaconBlock(1);
 
   @BeforeEach
   public void setup() {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetCommitteesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetCommitteesTest.java
@@ -47,6 +47,7 @@ import tech.pegasys.artemis.storage.Store;
 import tech.pegasys.artemis.util.async.SafeFuture;
 
 public class GetCommitteesTest {
+  private static final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private static BeaconState beaconState;
   private static Bytes32 blockRoot;
   private static UnsignedLong slot;
@@ -66,7 +67,7 @@ public class GetCommitteesTest {
   public static void setup() {
     final EventBus localEventBus = new EventBus();
     final ChainStorageClient storageClient = ChainStorageClient.memoryOnlyClient(localEventBus);
-    beaconState = DataStructureUtil.randomBeaconState(11233);
+    beaconState = dataStructureUtil.randomBeaconState();
     storageClient.initializeFromGenesis(beaconState);
     combinedChainDataClient = new CombinedChainDataClient(storageClient, historicalChainData);
     blockRoot = storageClient.getBestBlockRoot().orElseThrow();

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetHeadTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetHeadTest.java
@@ -30,10 +30,11 @@ import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.provider.JsonProvider;
 
 public class GetHeadTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final ChainDataProvider provider = mock(ChainDataProvider.class);
   private final Context context = mock(Context.class);
   private final JsonProvider jsonProvider = new JsonProvider();
-  private BeaconState rootState = DataStructureUtil.randomBeaconState(1);
+  private BeaconState rootState = dataStructureUtil.randomBeaconState();
   private final UnsignedLong bestSlot = UnsignedLong.valueOf(51234);
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetStateRootTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetStateRootTest.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -43,9 +42,10 @@ import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.util.async.SafeFuture;
 
 public class GetStateRootTest {
-  public static BeaconState beaconStateInternal;
-  private static Bytes32 blockRoot;
-  private static UnsignedLong slot;
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  public BeaconState beaconStateInternal;
+  private Bytes32 blockRoot;
+  private UnsignedLong slot;
   private ChainDataProvider provider = mock(ChainDataProvider.class);
 
   private final JsonProvider jsonProvider = new JsonProvider();
@@ -54,14 +54,14 @@ public class GetStateRootTest {
   @SuppressWarnings("unchecked")
   private ArgumentCaptor<SafeFuture<String>> args = ArgumentCaptor.forClass(SafeFuture.class);
 
-  @BeforeAll
-  public static void setup() {
+  @BeforeEach
+  public void setup() {
     final EventBus localEventBus = new EventBus();
     final ChainStorageClient storageClient = ChainStorageClient.memoryOnlyClient(localEventBus);
-    beaconStateInternal = DataStructureUtil.randomBeaconState(11233);
+    beaconStateInternal = dataStructureUtil.randomBeaconState();
     storageClient.initializeFromGenesis(beaconStateInternal);
     blockRoot = storageClient.getBestBlockRoot().orElseThrow();
-    slot = DataStructureUtil.randomUnsignedLong(99);
+    slot = dataStructureUtil.randomUnsignedLong();
   }
 
   @BeforeEach

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetStateTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetStateTest.java
@@ -44,6 +44,7 @@ import tech.pegasys.artemis.storage.ChainStorageClient;
 import tech.pegasys.artemis.util.async.SafeFuture;
 
 public class GetStateTest {
+  private static final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private static tech.pegasys.artemis.datastructures.state.BeaconState beaconStateInternal;
   private static BeaconState beaconState;
   private static Bytes32 blockRoot;
@@ -58,7 +59,7 @@ public class GetStateTest {
   public static void setup() {
     final EventBus localEventBus = new EventBus();
     final ChainStorageClient storageClient = ChainStorageClient.memoryOnlyClient(localEventBus);
-    beaconStateInternal = DataStructureUtil.randomBeaconState(11233);
+    beaconStateInternal = dataStructureUtil.randomBeaconState();
     storageClient.initializeFromGenesis(beaconStateInternal);
     blockRoot = storageClient.getBestBlockRoot().orElseThrow();
     slot = beaconStateInternal.getSlot();

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetValidatorsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/beacon/GetValidatorsTest.java
@@ -47,12 +47,13 @@ import tech.pegasys.artemis.util.async.SafeFuture;
 import tech.pegasys.artemis.util.config.Constants;
 
 public class GetValidatorsTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private Context context = mock(Context.class);
-  private final UnsignedLong epoch = DataStructureUtil.randomUnsignedLong(99);
+  private final UnsignedLong epoch = dataStructureUtil.randomUnsignedLong();
   private final JsonProvider jsonProvider = new JsonProvider();
-  private final Bytes32 blockRoot = DataStructureUtil.randomBytes32(99);
+  private final Bytes32 blockRoot = dataStructureUtil.randomBytes32();
   private final tech.pegasys.artemis.datastructures.state.BeaconState beaconStateInternal =
-      DataStructureUtil.randomBeaconState(98);
+      dataStructureUtil.randomBeaconState();
   private final BeaconState beaconState = new BeaconState(beaconStateInternal);
 
   private final ChainDataProvider provider = mock(ChainDataProvider.class);
@@ -305,7 +306,7 @@ public class GetValidatorsTest {
     MutableBeaconState beaconStateW = beaconState.createWritableCopy();
 
     // create an ACTIVE validator and add it to the list
-    MutableValidator v = DataStructureUtil.randomValidator(88).createWritableCopy();
+    MutableValidator v = dataStructureUtil.randomValidator().createWritableCopy();
     v.setActivation_eligibility_epoch(UnsignedLong.ZERO);
     v.setActivation_epoch(UnsignedLong.valueOf(Constants.GENESIS_EPOCH));
     assertThat(

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/node/GetForkTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/node/GetForkTest.java
@@ -27,8 +27,9 @@ import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.provider.JsonProvider;
 
 public class GetForkTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private Context context = mock(Context.class);
-  private final Fork fork = new Fork(DataStructureUtil.randomFork(51234));
+  private final Fork fork = new Fork(dataStructureUtil.randomFork());
   private final JsonProvider jsonProvider = new JsonProvider();
   private final ChainDataProvider provider = mock(ChainDataProvider.class);
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/validator/GetAttestationTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/artemis/beaconrestapi/handlers/validator/GetAttestationTest.java
@@ -35,11 +35,12 @@ import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.provider.JsonProvider;
 
 public class GetAttestationTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private Context context = mock(Context.class);
   private ChainDataProvider provider = mock(ChainDataProvider.class);
   private final JsonProvider jsonProvider = new JsonProvider();
   private GetAttestation handler;
-  private Attestation attestation = new Attestation(DataStructureUtil.randomAttestation(1111));
+  private Attestation attestation = new Attestation(dataStructureUtil.randomAttestation());
 
   @BeforeEach
   public void setup() {

--- a/data/provider/src/test/java/tech/pegasys/artemis/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/artemis/api/ChainDataProviderTest.java
@@ -64,6 +64,7 @@ import tech.pegasys.artemis.util.async.SafeFuture;
 import tech.pegasys.artemis.util.bls.BLSPublicKey;
 
 public class ChainDataProviderTest {
+  private static final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private static CombinedChainDataClient combinedChainDataClient;
   private static HistoricalChainData historicalChainData = mock(HistoricalChainData.class);
   private static tech.pegasys.artemis.datastructures.state.BeaconState beaconStateInternal;
@@ -73,7 +74,7 @@ public class ChainDataProviderTest {
   private static EventBus localEventBus;
   private static ChainStorageClient chainStorageClient;
   private final tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlock signedBeaconBlock =
-      DataStructureUtil.randomSignedBeaconBlock(999, 999);
+      dataStructureUtil.randomSignedBeaconBlock(999);
   private CombinedChainDataClient mockCombinedChainDataClient = mock(CombinedChainDataClient.class);
   private ChainStorageClient mockChainStorageClient = mock(ChainStorageClient.class);
 
@@ -81,7 +82,7 @@ public class ChainDataProviderTest {
   public static void setup() {
     localEventBus = new EventBus();
     chainStorageClient = ChainStorageClient.memoryOnlyClient(localEventBus);
-    beaconStateInternal = DataStructureUtil.randomBeaconState(11233);
+    beaconStateInternal = dataStructureUtil.randomBeaconState();
     beaconState = new BeaconState(beaconStateInternal);
     chainStorageClient.initializeFromGenesis(beaconStateInternal);
     combinedChainDataClient = new CombinedChainDataClient(chainStorageClient, historicalChainData);
@@ -431,7 +432,7 @@ public class ChainDataProviderTest {
 
   @Test
   void getValidatorIndex_shouldReturnNotFoundIfNotFound() {
-    BLSPubKey pubKey = new BLSPubKey(DataStructureUtil.randomPublicKey(88).toBytes());
+    BLSPubKey pubKey = new BLSPubKey(dataStructureUtil.randomPublicKey().toBytes());
     Integer validatorIndex = ChainDataProvider.getValidatorIndex(List.of(), pubKey);
     assertThat(validatorIndex).isEqualTo(null);
   }
@@ -439,7 +440,7 @@ public class ChainDataProviderTest {
   @Test
   void getValidatorIndex_shouldReturnIndexIfFound() {
     tech.pegasys.artemis.datastructures.state.BeaconState beaconStateInternal =
-        DataStructureUtil.randomBeaconState(99);
+        dataStructureUtil.randomBeaconState();
     BeaconState state = new BeaconState(beaconStateInternal);
     // all the validators are the same so the first one will match
     int expectedValidatorIndex = 0;
@@ -461,7 +462,7 @@ public class ChainDataProviderTest {
   void getCommitteeIndex_shouldReturnIndexIfFound() {
     ChainDataProvider provider =
         new ChainDataProvider(chainStorageClient, mockCombinedChainDataClient);
-    UnsignedLong committeeIndex = DataStructureUtil.randomUnsignedLong(888);
+    UnsignedLong committeeIndex = dataStructureUtil.randomUnsignedLong();
     CommitteeAssignment committeeAssignment1 =
         new CommitteeAssignment(List.of(4, 5, 6), committeeIndex, slot);
     CommitteeAssignment committeeAssignment2 =
@@ -474,11 +475,11 @@ public class ChainDataProviderTest {
   @Test
   void getValidatorDutiesFromState() {
     tech.pegasys.artemis.datastructures.state.BeaconState beaconStateInternal =
-        DataStructureUtil.randomBeaconState(77);
+        dataStructureUtil.randomBeaconState();
     ChainDataProvider provider =
         new ChainDataProvider(chainStorageClient, mockCombinedChainDataClient);
-    BLSPublicKey pubKey1 = DataStructureUtil.randomPublicKey(99);
-    BLSPublicKey pubKey2 = DataStructureUtil.randomPublicKey(98);
+    BLSPublicKey pubKey1 = dataStructureUtil.randomPublicKey();
+    BLSPublicKey pubKey2 = dataStructureUtil.randomPublicKey();
     List<ValidatorDuties> dutiesList =
         provider.getValidatorDutiesFromState(
             beaconStateInternal,
@@ -550,10 +551,9 @@ public class ChainDataProviderTest {
     assertThat(validatorDuties.get(0))
         .usingRecursiveComparison()
         .isEqualTo(new ValidatorDuties(alteredState.validators.get(0).pubkey, 0, 0));
-    // even though we used key 11 it will come out as 0 since the default keys are all equal
     assertThat(validatorDuties.get(1))
         .usingRecursiveComparison()
-        .isEqualTo(new ValidatorDuties(alteredState.validators.get(11).pubkey, 0, 0));
+        .isEqualTo(new ValidatorDuties(alteredState.validators.get(11).pubkey, 11, 1));
     assertThat(validatorDuties.get(2))
         .usingRecursiveComparison()
         .isEqualTo(
@@ -599,7 +599,7 @@ public class ChainDataProviderTest {
       final tech.pegasys.artemis.datastructures.state.BeaconState beaconState) {
     MutableBeaconState beaconStateW = beaconState.createWritableCopy();
     // create a validator and add it to the list
-    MutableValidator v = DataStructureUtil.randomValidator(88).createWritableCopy();
+    MutableValidator v = dataStructureUtil.randomValidator().createWritableCopy();
     beaconStateW.getValidators().add(v);
     return beaconStateW.commitChanges();
   }

--- a/data/provider/src/test/java/tech/pegasys/artemis/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/artemis/api/ValidatorDataProviderTest.java
@@ -31,10 +31,11 @@ import tech.pegasys.artemis.statetransition.util.SlotProcessingException;
 import tech.pegasys.artemis.validator.coordinator.ValidatorCoordinator;
 
 public class ValidatorDataProviderTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final ValidatorCoordinator validatorCoordinator = mock(ValidatorCoordinator.class);
   private ValidatorDataProvider provider = new ValidatorDataProvider(validatorCoordinator);;
   private final tech.pegasys.artemis.datastructures.blocks.BeaconBlock blockInternal =
-      DataStructureUtil.randomBeaconBlock(123, 456);
+      dataStructureUtil.randomBeaconBlock(123);
   private final BeaconBlock block = new BeaconBlock(blockInternal);
   private final tech.pegasys.artemis.util.bls.BLSSignature signatureInternal =
       tech.pegasys.artemis.util.bls.BLSSignature.random(1234);

--- a/data/provider/src/test/java/tech/pegasys/artemis/api/schema/BeaconValidatorsTest.java
+++ b/data/provider/src/test/java/tech/pegasys/artemis/api/schema/BeaconValidatorsTest.java
@@ -30,10 +30,11 @@ import tech.pegasys.artemis.util.SSZTypes.SSZList;
 import tech.pegasys.artemis.util.config.Constants;
 
 class BeaconValidatorsTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
 
   @Test
   public void validatorsResponseShouldConformToDefaults() {
-    BeaconState beaconState = DataStructureUtil.randomBeaconState(99);
+    BeaconState beaconState = dataStructureUtil.randomBeaconState();
     SSZList<Validator> validatorList = beaconState.getValidators();
     BeaconValidators response = new BeaconValidators(beaconState);
     assertThat(response.total_size).isEqualTo(beaconState.getValidators().size());
@@ -49,7 +50,7 @@ class BeaconValidatorsTest {
 
   @Test
   public void activeValidatorsResponseShouldConformToDefaults() {
-    BeaconState beaconState = DataStructureUtil.randomBeaconState(98);
+    BeaconState beaconState = dataStructureUtil.randomBeaconState();
     BeaconValidators validators =
         new BeaconValidators(
             beaconState,
@@ -72,7 +73,7 @@ class BeaconValidatorsTest {
 
   @Test
   public void suppliedPageSizeParamIsUsed() {
-    BeaconState beaconState = DataStructureUtil.randomBeaconState(97);
+    BeaconState beaconState = dataStructureUtil.randomBeaconState();
     final int suppliedPageSizeParam = 10;
 
     BeaconValidators beaconValidators =
@@ -89,7 +90,7 @@ class BeaconValidatorsTest {
 
   @Test
   public void suppliedPageParamsAreUsed() {
-    BeaconState beaconState = DataStructureUtil.randomBeaconState(97);
+    BeaconState beaconState = dataStructureUtil.randomBeaconState();
     final int suppliedPageSizeParam = 9;
     final int suppliedPageTokenParam = 2;
 
@@ -107,7 +108,7 @@ class BeaconValidatorsTest {
 
   @Test
   public void returnEmptyListIfPageParamsOutOfBounds() {
-    BeaconState beaconState = DataStructureUtil.randomBeaconState(97);
+    BeaconState beaconState = dataStructureUtil.randomBeaconState();
     final int suppliedPageSizeParam = 1000;
     final int suppliedPageTokenParam = 1000;
 
@@ -127,7 +128,7 @@ class BeaconValidatorsTest {
 
   @Test
   public void returnRemainderIfEdgeCasePageParams() {
-    BeaconState beaconState = DataStructureUtil.randomBeaconState(97);
+    BeaconState beaconState = dataStructureUtil.randomBeaconState();
     final SSZList<Validator> validators = beaconState.getValidators();
     final int validatorsSize = validators.size();
     final int suppliedPageSizeParam = validatorsSize / 10 - 1;
@@ -151,7 +152,7 @@ class BeaconValidatorsTest {
 
   @Test
   public void getActiveValidatorsCount() {
-    BeaconState beaconState = DataStructureUtil.randomBeaconState(23);
+    BeaconState beaconState = dataStructureUtil.randomBeaconState();
     MutableBeaconState beaconStateW = beaconState.createWritableCopy();
 
     SSZList<Validator> allValidators = beaconState.getValidators();
@@ -166,7 +167,7 @@ class BeaconValidatorsTest {
         .isLessThanOrEqualTo(beaconStateW.getValidators().size());
 
     // create one validator which IS active and add it to the list
-    MutableValidator v = DataStructureUtil.randomValidator(77).createWritableCopy();
+    MutableValidator v = dataStructureUtil.randomValidator().createWritableCopy();
     v.setActivation_eligibility_epoch(UnsignedLong.ZERO);
     v.setActivation_epoch(UnsignedLong.valueOf(Constants.GENESIS_EPOCH));
     beaconStateW.getValidators().add(v);

--- a/data/provider/src/test/java/tech/pegasys/artemis/provider/JsonProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/artemis/provider/JsonProviderTest.java
@@ -32,6 +32,7 @@ import tech.pegasys.artemis.util.SSZTypes.SSZList;
 import tech.pegasys.artemis.util.SSZTypes.SSZVector;
 
 class JsonProviderTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final JsonProvider jsonProvider = new JsonProvider();
   private static final String Q = "\"";
 
@@ -47,7 +48,7 @@ class JsonProviderTest {
 
   @Test
   public void unsignedLongShouldSerializeToJson() throws JsonProcessingException {
-    UnsignedLong data = DataStructureUtil.randomUnsignedLong(1111);
+    UnsignedLong data = dataStructureUtil.randomUnsignedLong();
     String serialized = jsonProvider.objectToJSON(data);
     assertEquals(serialized, data.toString());
   }
@@ -98,7 +99,7 @@ class JsonProviderTest {
   @Test
   void beaconStateJsonTest() throws JsonProcessingException {
     tech.pegasys.artemis.datastructures.state.BeaconState stateInternal =
-        DataStructureUtil.randomBeaconState(UnsignedLong.valueOf(16), 100);
+        dataStructureUtil.randomBeaconState(UnsignedLong.valueOf(16));
     BeaconState state = new BeaconState(stateInternal);
     String jsonState = jsonProvider.objectToJSON(state);
     assertTrue(jsonState.length() > 0);

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/artemis/benchmarks/SSZBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/artemis/benchmarks/SSZBenchmark.java
@@ -13,18 +13,18 @@
 
 package tech.pegasys.artemis.benchmarks;
 
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBeaconState;
 import static tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer.serialize;
 
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Warmup;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.util.sos.SimpleOffsetSerializable;
 
 public class SSZBenchmark {
 
-  private static SimpleOffsetSerializable state = randomBeaconState(100);
+  private static SimpleOffsetSerializable state = new DataStructureUtil().randomBeaconState();
 
   @Benchmark
   @Warmup(iterations = 2, time = 100, timeUnit = TimeUnit.MILLISECONDS)

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/FixedPartSSZSOSTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/FixedPartSSZSOSTest.java
@@ -14,8 +14,6 @@
 package tech.pegasys.artemis.datastructures;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomEth1Data;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.Random;
@@ -29,12 +27,14 @@ import tech.pegasys.artemis.datastructures.blocks.Eth1DataVote;
 import tech.pegasys.artemis.datastructures.operations.DepositData;
 import tech.pegasys.artemis.datastructures.state.Checkpoint;
 import tech.pegasys.artemis.datastructures.state.Validator;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
 import tech.pegasys.artemis.util.bls.BLSPublicKey;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
 @SuppressWarnings("unused")
 class FixedPartSSZSOSTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
 
   public static Bytes validatorToBytes(Validator v) {
     return SSZ.encode(
@@ -105,12 +105,12 @@ class FixedPartSSZSOSTest {
   void testValidatorSOS() {
     BLSPublicKey pubkey = BLSPublicKey.random(100);
     Bytes32 withdrawal_credentials = Bytes32.random(new Random(100));
-    UnsignedLong effective_balance = randomUnsignedLong(100);
+    UnsignedLong effective_balance = dataStructureUtil.randomUnsignedLong();
     boolean slashed = true;
-    UnsignedLong activation_eligibility_epoch = randomUnsignedLong(101);
-    UnsignedLong activation_epoch = randomUnsignedLong(102);
-    UnsignedLong exit_epoch = randomUnsignedLong(103);
-    UnsignedLong withdrawable_epoch = randomUnsignedLong(104);
+    UnsignedLong activation_eligibility_epoch = dataStructureUtil.randomUnsignedLong();
+    UnsignedLong activation_epoch = dataStructureUtil.randomUnsignedLong();
+    UnsignedLong exit_epoch = dataStructureUtil.randomUnsignedLong();
+    UnsignedLong withdrawable_epoch = dataStructureUtil.randomUnsignedLong();
 
     Validator validator =
         Validator.create(
@@ -133,7 +133,7 @@ class FixedPartSSZSOSTest {
   void testDepositDataSOS() {
     BLSPublicKey pubkey = BLSPublicKey.random(100);
     Bytes32 withdrawalCredentials = Bytes32.random(new Random(100));
-    UnsignedLong amount = randomUnsignedLong(100);
+    UnsignedLong amount = dataStructureUtil.randomUnsignedLong();
     BLSSignature signature = BLSSignature.random(100);
 
     DepositData depositData = new DepositData(pubkey, withdrawalCredentials, amount, signature);
@@ -147,8 +147,8 @@ class FixedPartSSZSOSTest {
 
   @Test
   void testEth1DataVoteSOS() {
-    Eth1Data eth1Data = randomEth1Data(100);
-    UnsignedLong voteCount = randomUnsignedLong(100);
+    Eth1Data eth1Data = dataStructureUtil.randomEth1Data();
+    UnsignedLong voteCount = dataStructureUtil.randomUnsignedLong();
 
     Eth1DataVote eth1DataVote = new Eth1DataVote(eth1Data, voteCount);
 
@@ -161,7 +161,7 @@ class FixedPartSSZSOSTest {
 
   @Test
   void testCheckpointSOS() {
-    UnsignedLong epoch = randomUnsignedLong(100);
+    UnsignedLong epoch = dataStructureUtil.randomUnsignedLong();
     Bytes32 root = Bytes32.random(new Random(100));
 
     Checkpoint checkpoint = new Checkpoint(epoch, root);

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockBodyTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockBodyTest.java
@@ -15,13 +15,6 @@ package tech.pegasys.artemis.datastructures.blocks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomAttestation;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomAttesterSlashing;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBytes32;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomDeposits;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomEth1Data;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomProposerSlashing;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomSignedVoluntaryExit;
 import static tech.pegasys.artemis.util.config.Constants.MAX_ATTESTATIONS;
 import static tech.pegasys.artemis.util.config.Constants.MAX_ATTESTER_SLASHINGS;
 import static tech.pegasys.artemis.util.config.Constants.MAX_DEPOSITS;
@@ -35,15 +28,16 @@ import tech.pegasys.artemis.datastructures.operations.AttesterSlashing;
 import tech.pegasys.artemis.datastructures.operations.Deposit;
 import tech.pegasys.artemis.datastructures.operations.ProposerSlashing;
 import tech.pegasys.artemis.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.util.SSZTypes.SSZList;
 import tech.pegasys.artemis.util.SSZTypes.SSZMutableList;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
 class BeaconBlockBodyTest {
-  private int seed = 100;
-  private BLSSignature blsSignature = BLSSignature.random(seed);
-  private Eth1Data eth1Data = randomEth1Data(seed++);
-  private Bytes32 graffiti = randomBytes32(seed++);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private BLSSignature blsSignature = dataStructureUtil.randomSignature();
+  private Eth1Data eth1Data = dataStructureUtil.randomEth1Data();
+  private Bytes32 graffiti = dataStructureUtil.randomBytes32();
   private SSZMutableList<ProposerSlashing> proposerSlashings =
       SSZList.createMutable(ProposerSlashing.class, MAX_PROPOSER_SLASHINGS);
   private SSZMutableList<AttesterSlashing> attesterSlashings =
@@ -55,17 +49,17 @@ class BeaconBlockBodyTest {
       SSZList.createMutable(SignedVoluntaryExit.class, MAX_VOLUNTARY_EXITS);
 
   {
-    proposerSlashings.add(randomProposerSlashing(seed++));
-    proposerSlashings.add(randomProposerSlashing(seed++));
-    proposerSlashings.add(randomProposerSlashing(seed++));
-    attesterSlashings.add(randomAttesterSlashing(seed++));
-    attestations.add(randomAttestation(seed++));
-    attestations.add(randomAttestation(seed++));
-    attestations.add(randomAttestation(seed++));
-    deposits.addAll(randomDeposits(MAX_DEPOSITS, seed++));
-    voluntaryExits.add(randomSignedVoluntaryExit(seed++));
-    voluntaryExits.add(randomSignedVoluntaryExit(seed++));
-    voluntaryExits.add(randomSignedVoluntaryExit(seed++));
+    proposerSlashings.add(dataStructureUtil.randomProposerSlashing());
+    proposerSlashings.add(dataStructureUtil.randomProposerSlashing());
+    proposerSlashings.add(dataStructureUtil.randomProposerSlashing());
+    attesterSlashings.add(dataStructureUtil.randomAttesterSlashing());
+    attestations.add(dataStructureUtil.randomAttestation());
+    attestations.add(dataStructureUtil.randomAttestation());
+    attestations.add(dataStructureUtil.randomAttestation());
+    deposits.addAll(dataStructureUtil.randomDeposits(MAX_DEPOSITS));
+    voluntaryExits.add(dataStructureUtil.randomSignedVoluntaryExit());
+    voluntaryExits.add(dataStructureUtil.randomSignedVoluntaryExit());
+    voluntaryExits.add(dataStructureUtil.randomSignedVoluntaryExit());
   }
 
   private BeaconBlockBody beaconBlockBody =
@@ -125,7 +119,8 @@ class BeaconBlockBodyTest {
   void equalsReturnsFalseWhenAttesterSlashingsAreDifferent() {
     // Create copy of attesterSlashings and change the element to ensure it is different.
     SSZMutableList<AttesterSlashing> otherAttesterSlashings =
-        SSZList.concat(SSZList.singleton(randomAttesterSlashing(seed++)), attesterSlashings);
+        SSZList.concat(
+            SSZList.singleton(dataStructureUtil.randomAttesterSlashing()), attesterSlashings);
 
     BeaconBlockBody testBeaconBlockBody =
         new BeaconBlockBody(

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockHeaderTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockHeaderTest.java
@@ -15,8 +15,6 @@ package tech.pegasys.artemis.datastructures.blocks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBytes32;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes;
@@ -25,11 +23,11 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 
 class BeaconBlockHeaderTest {
-  private int seed = 100;
-  private UnsignedLong slot = randomUnsignedLong(seed);
-  private Bytes32 previous_block_root = randomBytes32(seed++);
-  private Bytes32 state_root = randomBytes32(seed++);
-  private Bytes32 block_body_root = randomBytes32(seed++);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private UnsignedLong slot = dataStructureUtil.randomUnsignedLong();
+  private Bytes32 previous_block_root = dataStructureUtil.randomBytes32();
+  private Bytes32 state_root = dataStructureUtil.randomBytes32();
+  private Bytes32 block_body_root = dataStructureUtil.randomBytes32();
 
   private BeaconBlockHeader beaconBlockHeader =
       new BeaconBlockHeader(slot, previous_block_root, state_root, block_body_root);
@@ -53,7 +51,7 @@ class BeaconBlockHeaderTest {
   void equalsReturnsFalseWhenSlotsAreDifferent() {
     BeaconBlockHeader testBeaconBlockHeader =
         new BeaconBlockHeader(
-            slot.plus(randomUnsignedLong(seed++)),
+            slot.plus(dataStructureUtil.randomUnsignedLong()),
             previous_block_root,
             state_root,
             block_body_root);
@@ -93,7 +91,7 @@ class BeaconBlockHeaderTest {
 
   @Test
   void blockRootHeaderRootMatchingTests() {
-    BeaconBlock block = DataStructureUtil.randomBeaconBlock(90000000, seed++);
+    BeaconBlock block = dataStructureUtil.randomBeaconBlock(90000000);
     BeaconBlockHeader blockHeader =
         new BeaconBlockHeader(
             block.getSlot(),

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/BeaconBlockTest.java
@@ -16,23 +16,22 @@ package tech.pegasys.artemis.datastructures.blocks;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBeaconBlockBody;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.Objects;
-import java.util.Random;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
 
 class BeaconBlockTest {
 
-  private UnsignedLong slot = randomUnsignedLong(100);
-  private Bytes32 previous_root = Bytes32.random(new Random(100));
-  private Bytes32 state_root = Bytes32.random(new Random(101));
-  private BeaconBlockBody body = randomBeaconBlockBody(100);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private UnsignedLong slot = dataStructureUtil.randomUnsignedLong();
+  private Bytes32 previous_root = dataStructureUtil.randomBytes32();
+  private Bytes32 state_root = dataStructureUtil.randomBytes32();
+  private BeaconBlockBody body = dataStructureUtil.randomBeaconBlockBody();
 
   private BeaconBlock beaconBlock = new BeaconBlock(slot, previous_root, state_root, body);
 
@@ -77,9 +76,9 @@ class BeaconBlockTest {
     // BeaconBlockBody is rather involved to create. Just create a random one until it is not the
     // same
     // as the original.
-    BeaconBlockBody otherBody = randomBeaconBlockBody(100);
+    BeaconBlockBody otherBody = dataStructureUtil.randomBeaconBlockBody();
     while (Objects.equals(otherBody, body)) {
-      otherBody = randomBeaconBlockBody(101);
+      otherBody = dataStructureUtil.randomBeaconBlockBody();
     }
 
     BeaconBlock testBeaconBlock = new BeaconBlock(slot, previous_root, state_root, otherBody);

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/Eth1DataVoteTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/Eth1DataVoteTest.java
@@ -15,19 +15,18 @@ package tech.pegasys.artemis.datastructures.blocks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomEth1Data;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 
 class Eth1DataVoteTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
 
-  private int seed = 100;
-  private Eth1Data eth1Data = randomEth1Data(seed);
-  private UnsignedLong voteCount = randomUnsignedLong(seed++);
+  private Eth1Data eth1Data = dataStructureUtil.randomEth1Data();
+  private UnsignedLong voteCount = dataStructureUtil.randomUnsignedLong();
 
   private Eth1DataVote eth1DataVote = new Eth1DataVote(eth1Data, voteCount);
 
@@ -49,9 +48,9 @@ class Eth1DataVoteTest {
   void equalsReturnsFalseWhenEth1DataIsDifferent() {
     // Eth1Data is rather involved to create. Just create a random one until it is not the same
     // as the original.
-    Eth1Data otherEth1Data = randomEth1Data(seed++);
+    Eth1Data otherEth1Data = dataStructureUtil.randomEth1Data();
     while (Objects.equals(otherEth1Data, eth1Data)) {
-      otherEth1Data = randomEth1Data(seed++);
+      otherEth1Data = dataStructureUtil.randomEth1Data();
     }
     Eth1DataVote testEth1DataVote = new Eth1DataVote(otherEth1Data, voteCount);
 
@@ -61,7 +60,7 @@ class Eth1DataVoteTest {
   @Test
   void equalsReturnsFalseWhenVoteCountsAreDifferent() {
     Eth1DataVote testEth1DataVote =
-        new Eth1DataVote(eth1Data, voteCount.plus(randomUnsignedLong(seed++)));
+        new Eth1DataVote(eth1Data, voteCount.plus(dataStructureUtil.randomUnsignedLong()));
 
     assertNotEquals(eth1DataVote, testEth1DataVote);
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/SignedBeaconBlockHeaderTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/SignedBeaconBlockHeaderTest.java
@@ -14,23 +14,22 @@
 package tech.pegasys.artemis.datastructures.blocks;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBytes32;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
 class SignedBeaconBlockHeaderTest {
-  private int seed = 100;
-  private UnsignedLong slot = randomUnsignedLong(seed);
-  private Bytes32 previous_block_root = randomBytes32(seed++);
-  private Bytes32 state_root = randomBytes32(seed++);
-  private Bytes32 block_body_root = randomBytes32(seed++);
-  private BLSSignature signature = BLSSignature.random(seed++);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private UnsignedLong slot = dataStructureUtil.randomUnsignedLong();
+  private Bytes32 previous_block_root = dataStructureUtil.randomBytes32();
+  private Bytes32 state_root = dataStructureUtil.randomBytes32();
+  private Bytes32 block_body_root = dataStructureUtil.randomBytes32();
+  private BLSSignature signature = dataStructureUtil.randomSignature();
 
   private SignedBeaconBlockHeader signedBlockHeader =
       new SignedBeaconBlockHeader(

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/SignedBeaconBlockTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/blocks/SignedBeaconBlockTest.java
@@ -23,7 +23,7 @@ import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
 class SignedBeaconBlockTest {
   @Test
   public void shouldRoundTripViaSsz() {
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(1, 1);
+    final SignedBeaconBlock block = new DataStructureUtil().randomSignedBeaconBlock(1);
     final Bytes ssz = SimpleOffsetSerializer.serialize(block);
     final SignedBeaconBlock result =
         SimpleOffsetSerializer.deserialize(ssz, SignedBeaconBlock.class);

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationDataTest.java
@@ -15,25 +15,24 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBytes32;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.state.Checkpoint;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
 
 class AttestationDataTest {
-  private int seed = 100;
-  private UnsignedLong slot = randomUnsignedLong(seed++);
-  private UnsignedLong index = randomUnsignedLong(seed++);
-  private Bytes32 beaconBlockRoot = randomBytes32(seed++);
-  private UnsignedLong source_epoch = randomUnsignedLong(seed++);
-  private Bytes32 source_root = randomBytes32(seed++);
-  private UnsignedLong target_epoch = randomUnsignedLong(seed++);
-  private Bytes32 target_root = randomBytes32(seed++);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private UnsignedLong slot = dataStructureUtil.randomUnsignedLong();
+  private UnsignedLong index = dataStructureUtil.randomUnsignedLong();
+  private Bytes32 beaconBlockRoot = dataStructureUtil.randomBytes32();
+  private UnsignedLong source_epoch = dataStructureUtil.randomUnsignedLong();
+  private Bytes32 source_root = dataStructureUtil.randomBytes32();
+  private UnsignedLong target_epoch = dataStructureUtil.randomUnsignedLong();
+  private Bytes32 target_root = dataStructureUtil.randomBytes32();
   private Checkpoint source = new Checkpoint(source_epoch, source_root);
   private Checkpoint target = new Checkpoint(target_epoch, target_root);
 
@@ -65,7 +64,7 @@ class AttestationDataTest {
 
   @Test
   void equalsReturnsFalseWhenSourceEpochsAreDifferent() {
-    Checkpoint newSource = new Checkpoint(randomUnsignedLong(seed++), source.getRoot());
+    Checkpoint newSource = new Checkpoint(dataStructureUtil.randomUnsignedLong(), source.getRoot());
     AttestationData testAttestationData =
         new AttestationData(slot, index, beaconBlockRoot, newSource, target);
 
@@ -83,7 +82,7 @@ class AttestationDataTest {
 
   @Test
   void equalsReturnsFalseWhenTargetEpochsAreDifferent() {
-    Checkpoint newTarget = new Checkpoint(randomUnsignedLong(seed++), target.getRoot());
+    Checkpoint newTarget = new Checkpoint(dataStructureUtil.randomUnsignedLong(), target.getRoot());
     AttestationData testAttestationData =
         new AttestationData(slot, index, beaconBlockRoot, source, newTarget);
 

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttestationTest.java
@@ -16,22 +16,21 @@ package tech.pegasys.artemis.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomAttestationData;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBitlist;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.state.Checkpoint;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.util.SSZTypes.Bitlist;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
 class AttestationTest {
-  private int seed = 100;
-  private Bitlist aggregationBitfield = randomBitlist(seed);
-  private AttestationData data = randomAttestationData(seed++);
-  private BLSSignature aggregateSignature = BLSSignature.random(seed++);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private Bitlist aggregationBitfield = dataStructureUtil.randomBitlist();
+  private AttestationData data = dataStructureUtil.randomAttestationData();
+  private BLSSignature aggregateSignature = dataStructureUtil.randomSignature();
 
   private Attestation attestation = new Attestation(aggregationBitfield, data, aggregateSignature);
 
@@ -122,7 +121,8 @@ class AttestationTest {
 
   @Test
   void equalsReturnsFalseWhenAggregationBitfieldsAreDifferent() {
-    Attestation testAttestation = new Attestation(randomBitlist(seed++), data, aggregateSignature);
+    Attestation testAttestation =
+        new Attestation(dataStructureUtil.randomBitlist(), data, aggregateSignature);
 
     assertNotEquals(attestation, testAttestation);
   }
@@ -131,9 +131,9 @@ class AttestationTest {
   void equalsReturnsFalseWhenAttestationDataIsDifferent() {
     // AttestationData is rather involved to create. Just create a random one until it is not the
     // same as the original.
-    AttestationData otherData = randomAttestationData(seed++);
+    AttestationData otherData = dataStructureUtil.randomAttestationData();
     while (Objects.equals(otherData, data)) {
-      otherData = randomAttestationData(seed++);
+      otherData = dataStructureUtil.randomAttestationData();
     }
 
     Attestation testAttestation =

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttesterSlashingTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/AttesterSlashingTest.java
@@ -15,16 +15,16 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomIndexedAttestation;
 
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 
 class AttesterSlashingTest {
 
-  private int seed = 100;
-  private IndexedAttestation indexedAttestation1 = randomIndexedAttestation(seed);
-  private IndexedAttestation indexedAttestation2 = randomIndexedAttestation(seed++);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private IndexedAttestation indexedAttestation1 = dataStructureUtil.randomIndexedAttestation();
+  private IndexedAttestation indexedAttestation2 = dataStructureUtil.randomIndexedAttestation();
 
   private AttesterSlashing attesterSlashing =
       new AttesterSlashing(indexedAttestation1, indexedAttestation2);
@@ -48,9 +48,9 @@ class AttesterSlashingTest {
   void equalsReturnsFalseWhenIndexedAttestation1IsDifferent() {
     // IndexedAttestation is rather involved to create. Just create a random one until it is not
     // the same as the original.
-    IndexedAttestation otherIndexedAttestation1 = randomIndexedAttestation(seed++);
+    IndexedAttestation otherIndexedAttestation1 = dataStructureUtil.randomIndexedAttestation();
     while (Objects.equals(otherIndexedAttestation1, indexedAttestation1)) {
-      otherIndexedAttestation1 = randomIndexedAttestation(seed++);
+      otherIndexedAttestation1 = dataStructureUtil.randomIndexedAttestation();
     }
 
     AttesterSlashing testAttesterSlashing =
@@ -63,9 +63,9 @@ class AttesterSlashingTest {
   void equalsReturnsFalseWhenIndexedAttestation2IsDifferent() {
     // IndexedAttestation is rather involved to create. Just create a random one until it is not
     // the ame as the original.
-    IndexedAttestation otherIndexedAttestation2 = randomIndexedAttestation(seed++);
+    IndexedAttestation otherIndexedAttestation2 = dataStructureUtil.randomIndexedAttestation();
     while (Objects.equals(otherIndexedAttestation2, indexedAttestation2)) {
-      otherIndexedAttestation2 = randomIndexedAttestation(seed++);
+      otherIndexedAttestation2 = dataStructureUtil.randomIndexedAttestation();
     }
 
     AttesterSlashing testAttesterSlashing =

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositDataTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositDataTest.java
@@ -15,22 +15,21 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBytes32;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.util.bls.BLSPublicKey;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
 class DepositDataTest {
-  private int seed = 100;
-  private BLSPublicKey pubkey = BLSPublicKey.random(seed++);
-  private Bytes32 withdrawalCredentials = randomBytes32(seed++);
-  private UnsignedLong amount = randomUnsignedLong(seed++);
-  private BLSSignature signature = BLSSignature.random(seed++);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private BLSPublicKey pubkey = dataStructureUtil.randomPublicKey();
+  private Bytes32 withdrawalCredentials = dataStructureUtil.randomBytes32();
+  private UnsignedLong amount = dataStructureUtil.randomUnsignedLong();
+  private BLSSignature signature = dataStructureUtil.randomSignature();
 
   private DepositData depositData =
       new DepositData(pubkey, withdrawalCredentials, amount, signature);
@@ -52,7 +51,7 @@ class DepositDataTest {
 
   @Test
   void equalsReturnsFalseWhenPubkeysAreDifferent() {
-    BLSPublicKey differentPublicKey = BLSPublicKey.random(99);
+    BLSPublicKey differentPublicKey = dataStructureUtil.randomPublicKey();
     DepositData testDepositInput =
         new DepositData(differentPublicKey, withdrawalCredentials, amount, signature);
 
@@ -70,7 +69,7 @@ class DepositDataTest {
 
   @Test
   void equalsReturnsFalseWhenProofsOfPosessionAreDifferent() {
-    BLSSignature differentSignature = BLSSignature.random(99);
+    BLSSignature differentSignature = dataStructureUtil.randomSignature();
     DepositData testDepositInput =
         new DepositData(pubkey, withdrawalCredentials, amount, differentSignature);
 

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositMessageTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositMessageTest.java
@@ -14,21 +14,20 @@
 package tech.pegasys.artemis.datastructures.operations;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBytes32;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
 import tech.pegasys.artemis.util.bls.BLSPublicKey;
 
 class DepositMessageTest {
-  private int seed = 94385;
-  private BLSPublicKey pubkey = BLSPublicKey.random(seed++);
-  private Bytes32 withdrawalCredentials = randomBytes32(seed++);
-  private UnsignedLong amount = randomUnsignedLong(seed++);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private BLSPublicKey pubkey = dataStructureUtil.randomPublicKey();
+  private Bytes32 withdrawalCredentials = dataStructureUtil.randomBytes32();
+  private UnsignedLong amount = dataStructureUtil.randomUnsignedLong();
 
   @Test
   public void shouldRoundTripViaSsz() {

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/DepositTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomDepositData;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,6 +24,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.junit.BouncyCastleExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
 import tech.pegasys.artemis.util.SSZTypes.SSZMutableVector;
 import tech.pegasys.artemis.util.SSZTypes.SSZVector;
@@ -32,9 +32,9 @@ import tech.pegasys.artemis.util.config.Constants;
 
 @ExtendWith(BouncyCastleExtension.class)
 class DepositTest {
-  private int seed = 100;
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private SSZVector<Bytes32> branch = setupMerkleBranch();
-  private DepositData depositData = randomDepositData(seed);
+  private DepositData depositData = dataStructureUtil.randomDepositData();
 
   private Deposit deposit = new Deposit(branch, depositData);
 
@@ -68,9 +68,9 @@ class DepositTest {
   void equalsReturnsFalseWhenDepositDataIsDifferent() {
     // DepositData is rather involved to create. Just create a random one until it is not the same
     // as the original.
-    DepositData otherDepositData = randomDepositData(seed++);
+    DepositData otherDepositData = dataStructureUtil.randomDepositData();
     while (Objects.equals(otherDepositData, depositData)) {
-      otherDepositData = randomDepositData(seed++);
+      otherDepositData = dataStructureUtil.randomDepositData();
     }
 
     Deposit testDeposit = new Deposit(branch, otherDepositData);

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ProposerSlashingTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/ProposerSlashingTest.java
@@ -15,21 +15,20 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomSignedBeaconBlockHeader;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlockHeader;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
 
 class ProposerSlashingTest {
-  private int seed = 100;
-  private UnsignedLong proposerIndex = randomUnsignedLong(seed);
-  private SignedBeaconBlockHeader proposal1 = randomSignedBeaconBlockHeader(seed++);
-  private SignedBeaconBlockHeader proposal2 = randomSignedBeaconBlockHeader(seed++);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private UnsignedLong proposerIndex = dataStructureUtil.randomUnsignedLong();
+  private SignedBeaconBlockHeader proposal1 = dataStructureUtil.randomSignedBeaconBlockHeader();
+  private SignedBeaconBlockHeader proposal2 = dataStructureUtil.randomSignedBeaconBlockHeader();
 
   private ProposerSlashing proposerSlashing =
       new ProposerSlashing(proposerIndex, proposal1, proposal2);
@@ -52,7 +51,8 @@ class ProposerSlashingTest {
   @Test
   void equalsReturnsFalseWhenProposerIndicesAreDifferent() {
     ProposerSlashing testProposerSlashing =
-        new ProposerSlashing(proposerIndex.plus(randomUnsignedLong(seed++)), proposal1, proposal2);
+        new ProposerSlashing(
+            proposerIndex.plus(dataStructureUtil.randomUnsignedLong()), proposal1, proposal2);
 
     assertNotEquals(proposerSlashing, testProposerSlashing);
   }
@@ -61,9 +61,9 @@ class ProposerSlashingTest {
   void equalsReturnsFalseWhenProposalData1IsDifferent() {
     // Proposal is rather involved to create. Just create a random one until it is not the
     // same as the original.
-    SignedBeaconBlockHeader otherProposal1 = randomSignedBeaconBlockHeader(seed++);
+    SignedBeaconBlockHeader otherProposal1 = dataStructureUtil.randomSignedBeaconBlockHeader();
     while (Objects.equals(otherProposal1, proposal1)) {
-      otherProposal1 = randomSignedBeaconBlockHeader(seed++);
+      otherProposal1 = dataStructureUtil.randomSignedBeaconBlockHeader();
     }
 
     ProposerSlashing testProposerSlashing =
@@ -76,9 +76,9 @@ class ProposerSlashingTest {
   void equalsReturnsFalseWhenProposalData2IsDifferent() {
     // Proposal is rather involved to create. Just create a random one until it is not the
     // same as the original.
-    SignedBeaconBlockHeader otherProposal2 = randomSignedBeaconBlockHeader(seed++);
+    SignedBeaconBlockHeader otherProposal2 = dataStructureUtil.randomSignedBeaconBlockHeader();
     while (Objects.equals(otherProposal2, proposal2)) {
-      otherProposal2 = randomSignedBeaconBlockHeader(seed++);
+      otherProposal2 = dataStructureUtil.randomSignedBeaconBlockHeader();
     }
 
     ProposerSlashing testProposerSlashing =

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/VoluntaryExitTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/operations/VoluntaryExitTest.java
@@ -15,17 +15,17 @@ package tech.pegasys.artemis.datastructures.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
 
 class VoluntaryExitTest {
-  private int seed = 100;
-  private UnsignedLong epoch = randomUnsignedLong(seed);
-  private UnsignedLong validatorIndex = randomUnsignedLong(seed++);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private UnsignedLong epoch = dataStructureUtil.randomUnsignedLong();
+  private UnsignedLong validatorIndex = dataStructureUtil.randomUnsignedLong();
 
   private VoluntaryExit voluntaryExit = new VoluntaryExit(epoch, validatorIndex);
 
@@ -46,7 +46,7 @@ class VoluntaryExitTest {
   @Test
   void equalsReturnsFalseWhenEpochsAreDifferent() {
     VoluntaryExit testVoluntaryExit =
-        new VoluntaryExit(epoch.plus(randomUnsignedLong(seed++)), validatorIndex);
+        new VoluntaryExit(epoch.plus(dataStructureUtil.randomUnsignedLong()), validatorIndex);
 
     assertNotEquals(voluntaryExit, testVoluntaryExit);
   }
@@ -54,7 +54,7 @@ class VoluntaryExitTest {
   @Test
   void equalsReturnsFalseWhenValidatorIndicesAreDifferent() {
     VoluntaryExit testVoluntaryExit =
-        new VoluntaryExit(epoch, validatorIndex.plus(randomUnsignedLong(seed++)));
+        new VoluntaryExit(epoch, validatorIndex.plus(dataStructureUtil.randomUnsignedLong()));
 
     assertNotEquals(voluntaryExit, testVoluntaryExit);
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/sostests/DeserializationTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/sostests/DeserializationTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.artemis.datastructures.sostests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.int_to_bytes;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBeaconState;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.stream.IntStream;
@@ -50,9 +49,11 @@ import tech.pegasys.artemis.util.SSZTypes.SSZVector;
 import tech.pegasys.artemis.util.config.Constants;
 
 public class DeserializationTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+
   @Test
   void BeaconBlockBodyTest() {
-    BeaconBlockBody beaconBlockBody = DataStructureUtil.randomBeaconBlockBody(100);
+    BeaconBlockBody beaconBlockBody = dataStructureUtil.randomBeaconBlockBody();
     BeaconBlockBody newBeaconBlockBody =
         SimpleOffsetSerializer.deserialize(
             SimpleOffsetSerializer.serialize(beaconBlockBody), BeaconBlockBody.class);
@@ -61,7 +62,7 @@ public class DeserializationTest {
 
   @Test
   void BeaconBlockHeaderTest() {
-    BeaconBlockHeader beaconBlockHeader = DataStructureUtil.randomBeaconBlockHeader(100);
+    BeaconBlockHeader beaconBlockHeader = dataStructureUtil.randomBeaconBlockHeader();
     Bytes beaconBlockSerialized = SimpleOffsetSerializer.serialize(beaconBlockHeader);
     BeaconBlockHeader newBeaconBlockHeader =
         SimpleOffsetSerializer.deserialize(beaconBlockSerialized, BeaconBlockHeader.class);
@@ -70,7 +71,7 @@ public class DeserializationTest {
 
   @Test
   void BeaconBlockTest() {
-    BeaconBlock beaconBlock = DataStructureUtil.randomBeaconBlock(100, 100);
+    BeaconBlock beaconBlock = dataStructureUtil.randomBeaconBlock(100);
     Bytes serialized = SimpleOffsetSerializer.serialize(beaconBlock);
     BeaconBlock newBeaconBlock = SimpleOffsetSerializer.deserialize(serialized, BeaconBlock.class);
     assertEquals(beaconBlock, newBeaconBlock);
@@ -78,7 +79,7 @@ public class DeserializationTest {
 
   @Test
   void Eth1DataTest() {
-    Eth1Data eth1Data = DataStructureUtil.randomEth1Data(100);
+    Eth1Data eth1Data = dataStructureUtil.randomEth1Data();
     Bytes eth1DataSerialized = SimpleOffsetSerializer.serialize(eth1Data);
     Eth1Data newEth1Data = SimpleOffsetSerializer.deserialize(eth1DataSerialized, Eth1Data.class);
     assertEquals(eth1Data, newEth1Data);
@@ -86,7 +87,7 @@ public class DeserializationTest {
 
   @Test
   void AttestationDataTest() {
-    AttestationData attestationData = DataStructureUtil.randomAttestationData(100);
+    AttestationData attestationData = dataStructureUtil.randomAttestationData();
     assertEquals(
         attestationData,
         SimpleOffsetSerializer.deserialize(
@@ -95,7 +96,7 @@ public class DeserializationTest {
 
   @Test
   void AttestationTest() {
-    Attestation attestation = DataStructureUtil.randomAttestation(100);
+    Attestation attestation = dataStructureUtil.randomAttestation();
     Attestation newAttestation =
         SimpleOffsetSerializer.deserialize(
             SimpleOffsetSerializer.serialize(attestation), Attestation.class);
@@ -104,7 +105,7 @@ public class DeserializationTest {
 
   @Test
   void AttesterSlashingTest() {
-    AttesterSlashing attesterSlashing = DataStructureUtil.randomAttesterSlashing(100);
+    AttesterSlashing attesterSlashing = dataStructureUtil.randomAttesterSlashing();
     AttesterSlashing newAttesterSlashing =
         SimpleOffsetSerializer.deserialize(
             SimpleOffsetSerializer.serialize(attesterSlashing), AttesterSlashing.class);
@@ -113,7 +114,7 @@ public class DeserializationTest {
 
   @Test
   void DepositDataTest() {
-    DepositData depositData = DataStructureUtil.randomDepositData(100);
+    DepositData depositData = dataStructureUtil.randomDepositData();
     assertEquals(
         depositData,
         SimpleOffsetSerializer.deserialize(
@@ -122,7 +123,7 @@ public class DeserializationTest {
 
   @Test
   void DepositTest() {
-    Deposit deposit = DataStructureUtil.randomDeposit(100);
+    Deposit deposit = dataStructureUtil.randomDeposit();
     Bytes serialized = SimpleOffsetSerializer.serialize(deposit);
     Deposit newDeposit = SimpleOffsetSerializer.deserialize(serialized, Deposit.class);
     // TODO
@@ -132,7 +133,7 @@ public class DeserializationTest {
 
   @Test
   void IndexedAttestationTest() {
-    IndexedAttestation indexedAttestation = DataStructureUtil.randomIndexedAttestation(100);
+    IndexedAttestation indexedAttestation = dataStructureUtil.randomIndexedAttestation();
     IndexedAttestation newIndexedAttestation =
         SimpleOffsetSerializer.deserialize(
             SimpleOffsetSerializer.serialize(indexedAttestation), IndexedAttestation.class);
@@ -141,7 +142,7 @@ public class DeserializationTest {
 
   @Test
   void ProposerSlashingTest() {
-    ProposerSlashing proposerSlashing = DataStructureUtil.randomProposerSlashing(100);
+    ProposerSlashing proposerSlashing = dataStructureUtil.randomProposerSlashing();
     assertEquals(
         proposerSlashing,
         SimpleOffsetSerializer.deserialize(
@@ -150,7 +151,7 @@ public class DeserializationTest {
 
   @Test
   void VoluntaryExitTest() {
-    VoluntaryExit voluntaryExit = DataStructureUtil.randomVoluntaryExit(100);
+    VoluntaryExit voluntaryExit = dataStructureUtil.randomVoluntaryExit();
     assertEquals(
         voluntaryExit,
         SimpleOffsetSerializer.deserialize(
@@ -159,7 +160,7 @@ public class DeserializationTest {
 
   @Test
   void BeaconStateTest() {
-    BeaconState beaconState = randomBeaconState(100);
+    BeaconState beaconState = dataStructureUtil.randomBeaconState();
     Bytes bytes = SimpleOffsetSerializer.serialize(beaconState);
     BeaconStateImpl state = SimpleOffsetSerializer.deserialize(bytes, BeaconStateImpl.class);
     assertEquals(beaconState, state);
@@ -167,7 +168,7 @@ public class DeserializationTest {
 
   @Test
   void CheckpointTest() {
-    Checkpoint checkpoint = DataStructureUtil.randomCheckpoint(100);
+    Checkpoint checkpoint = dataStructureUtil.randomCheckpoint();
     Bytes checkpointSerialized = SimpleOffsetSerializer.serialize(checkpoint);
     Checkpoint newCheckpoint =
         SimpleOffsetSerializer.deserialize(checkpointSerialized, Checkpoint.class);
@@ -195,8 +196,8 @@ public class DeserializationTest {
     IntStream.range(0, Constants.SLOTS_PER_HISTORICAL_ROOT)
         .forEach(
             i -> {
-              block_roots.set(i, DataStructureUtil.randomBytes32(i));
-              state_roots.set(i, DataStructureUtil.randomBytes32(i));
+              block_roots.set(i, dataStructureUtil.randomBytes32());
+              state_roots.set(i, dataStructureUtil.randomBytes32());
             });
     HistoricalBatch deposit = new HistoricalBatch(block_roots, state_roots);
     Bytes serialized = SimpleOffsetSerializer.serialize(deposit);
@@ -213,7 +214,7 @@ public class DeserializationTest {
 
   @Test
   void ValidatorTest() {
-    Validator validator = DataStructureUtil.randomValidator(100);
+    Validator validator = dataStructureUtil.randomValidator();
     assertEquals(
         validator,
         SimpleOffsetSerializer.deserialize(
@@ -222,7 +223,7 @@ public class DeserializationTest {
 
   @Test
   void AggregateAndProofTest() {
-    AggregateAndProof aggregateAndProof = DataStructureUtil.randomAggregateAndProof(100);
+    AggregateAndProof aggregateAndProof = dataStructureUtil.randomAggregateAndProof();
     assertEquals(
         aggregateAndProof,
         SimpleOffsetSerializer.deserialize(

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/ForkTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/ForkTest.java
@@ -15,18 +15,18 @@ package tech.pegasys.artemis.datastructures.state;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.util.SSZTypes.Bytes4;
 
 class ForkTest {
-  private int seed = 100;
-  private Bytes4 previousVersion = new Bytes4(Bytes.random(4));
-  private Bytes4 currentVersion = new Bytes4(Bytes.random(4));
-  private UnsignedLong epoch = randomUnsignedLong(seed++);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private Bytes4 previousVersion = new Bytes4(Bytes.of(1, 2, 3, 4));
+  private Bytes4 currentVersion = new Bytes4(Bytes.of(5, 6, 7, 8));
+  private UnsignedLong epoch = dataStructureUtil.randomUnsignedLong();
 
   private Fork fork = new Fork(previousVersion, currentVersion, epoch);
 
@@ -63,7 +63,8 @@ class ForkTest {
   @Test
   void equalsReturnsFalseWhenEpochsAreDifferent() {
     Fork testFork =
-        new Fork(previousVersion, currentVersion, epoch.plus(randomUnsignedLong(seed++)));
+        new Fork(
+            previousVersion, currentVersion, epoch.plus(dataStructureUtil.randomUnsignedLong()));
 
     assertNotEquals(fork, testFork);
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/PendingAttestationTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/PendingAttestationTest.java
@@ -15,22 +15,20 @@ package tech.pegasys.artemis.datastructures.state;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomAttestationData;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBitlist;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.operations.AttestationData;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.util.SSZTypes.Bitlist;
 
 class PendingAttestationTest {
-  private int seed = 100;
-  private Bitlist participationBitfield = randomBitlist(seed);
-  private AttestationData data = randomAttestationData(seed++);
-  private UnsignedLong inclusionDelay = randomUnsignedLong(seed++);
-  private UnsignedLong proposerIndex = randomUnsignedLong(seed++);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private Bitlist participationBitfield = dataStructureUtil.randomBitlist();
+  private AttestationData data = dataStructureUtil.randomAttestationData();
+  private UnsignedLong inclusionDelay = dataStructureUtil.randomUnsignedLong();
+  private UnsignedLong proposerIndex = dataStructureUtil.randomUnsignedLong();
 
   private PendingAttestation pendingAttestation =
       new PendingAttestation(participationBitfield, data, inclusionDelay, proposerIndex);
@@ -54,9 +52,9 @@ class PendingAttestationTest {
   void equalsReturnsFalseWhenAttestationDataIsDifferent() {
     // BeaconBlock is rather involved to create. Just create a random one until it is not the same
     // as the original.
-    AttestationData otherAttestationData = randomAttestationData(seed++);
+    AttestationData otherAttestationData = dataStructureUtil.randomAttestationData();
     while (Objects.equals(otherAttestationData, data)) {
-      otherAttestationData = randomAttestationData(seed++);
+      otherAttestationData = dataStructureUtil.randomAttestationData();
     }
     PendingAttestation testPendingAttestation =
         new PendingAttestation(
@@ -68,7 +66,8 @@ class PendingAttestationTest {
   @Test
   void equalsReturnsFalseWhenParticipationBitfieldsAreDifferent() {
     PendingAttestation testPendingAttestation =
-        new PendingAttestation(randomBitlist(seed++), data, inclusionDelay, proposerIndex);
+        new PendingAttestation(
+            dataStructureUtil.randomBitlist(), data, inclusionDelay, proposerIndex);
 
     assertNotEquals(pendingAttestation, testPendingAttestation);
   }
@@ -79,7 +78,7 @@ class PendingAttestationTest {
         new PendingAttestation(
             participationBitfield,
             data,
-            inclusionDelay.plus(randomUnsignedLong(seed++)),
+            inclusionDelay.plus(dataStructureUtil.randomUnsignedLong()),
             proposerIndex);
 
     assertNotEquals(pendingAttestation, testPendingAttestation);
@@ -92,7 +91,7 @@ class PendingAttestationTest {
             participationBitfield,
             data,
             inclusionDelay,
-            proposerIndex.plus(randomUnsignedLong(seed++)));
+            proposerIndex.plus(dataStructureUtil.randomUnsignedLong()));
 
     assertNotEquals(pendingAttestation, testPendingAttestation);
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/ValidatorTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/state/ValidatorTest.java
@@ -15,17 +15,17 @@ package tech.pegasys.artemis.datastructures.state;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBytes32;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
 
 import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.ssz.SSZ;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.util.bls.BLSPublicKey;
 
 class ValidatorTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
 
   public static Validator validatorFromBytes(Bytes bytes) {
     return SSZ.decode(
@@ -58,13 +58,13 @@ class ValidatorTest {
 
   private int seed = 100;
   private BLSPublicKey pubkey = BLSPublicKey.random(seed);
-  private Bytes32 withdrawalCredentials = randomBytes32(seed++);
-  private UnsignedLong activationEligibilityEpoch = randomUnsignedLong(seed++);
-  private UnsignedLong activationEpoch = randomUnsignedLong(seed++);
-  private UnsignedLong exitEpoch = randomUnsignedLong(seed++);
-  private UnsignedLong withdrawalEpoch = randomUnsignedLong(seed++);
+  private Bytes32 withdrawalCredentials = dataStructureUtil.randomBytes32();
+  private UnsignedLong activationEligibilityEpoch = dataStructureUtil.randomUnsignedLong();
+  private UnsignedLong activationEpoch = dataStructureUtil.randomUnsignedLong();
+  private UnsignedLong exitEpoch = dataStructureUtil.randomUnsignedLong();
+  private UnsignedLong withdrawalEpoch = dataStructureUtil.randomUnsignedLong();
   private boolean slashed = false;
-  private UnsignedLong effectiveBalance = randomUnsignedLong(seed++);
+  private UnsignedLong effectiveBalance = dataStructureUtil.randomUnsignedLong();
 
   private Validator validator =
       Validator.create(
@@ -143,7 +143,7 @@ class ValidatorTest {
             effectiveBalance,
             slashed,
             activationEligibilityEpoch,
-            activationEpoch.plus(randomUnsignedLong(seed++)),
+            activationEpoch.plus(dataStructureUtil.randomUnsignedLong()),
             exitEpoch,
             withdrawalEpoch);
 
@@ -160,7 +160,7 @@ class ValidatorTest {
             slashed,
             activationEligibilityEpoch,
             activationEpoch,
-            exitEpoch.plus(randomUnsignedLong(seed++)),
+            exitEpoch.plus(dataStructureUtil.randomUnsignedLong()),
             withdrawalEpoch);
 
     assertNotEquals(validator, testValidator);
@@ -177,7 +177,7 @@ class ValidatorTest {
             activationEligibilityEpoch,
             activationEpoch,
             exitEpoch,
-            withdrawalEpoch.plus(randomUnsignedLong(seed++)));
+            withdrawalEpoch.plus(dataStructureUtil.randomUnsignedLong()));
 
     assertNotEquals(validator, testValidator);
   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtilTest.java
@@ -20,10 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_signing_root;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.initialize_beacon_state_from_eth1;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.newDeposits;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomDeposits;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomValidator;
 import static tech.pegasys.artemis.util.hashtree.HashTreeUtil.is_power_of_two;
 
 import com.google.common.primitives.UnsignedLong;
@@ -54,6 +50,8 @@ import tech.pegasys.artemis.util.config.Constants;
 
 @ExtendWith(BouncyCastleExtension.class)
 class BeaconStateUtilTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+
   @Test
   void minReturnsMin() {
     UnsignedLong actual = BeaconStateUtil.min(UnsignedLong.valueOf(13L), UnsignedLong.valueOf(12L));
@@ -105,7 +103,7 @@ class BeaconStateUtilTest {
 
   @Test
   void validateProofOfPossessionReturnsTrueIfTheBLSSignatureIsValidForGivenDepositInputData() {
-    Deposit deposit = newDeposits(1).get(0);
+    Deposit deposit = dataStructureUtil.newDeposits(1).get(0);
     BLSPublicKey pubkey = deposit.getData().getPubkey();
     DepositData depositData = deposit.getData();
     DepositMessage depositMessage =
@@ -125,7 +123,7 @@ class BeaconStateUtilTest {
 
   @Test
   void validateProofOfPossessionReturnsFalseIfTheBLSSignatureIsNotValidForGivenDepositInputData() {
-    Deposit deposit = newDeposits(1).get(0);
+    Deposit deposit = dataStructureUtil.newDeposits(1).get(0);
     BLSPublicKey pubkey = BLSPublicKey.random(42);
     DepositData depositData = deposit.getData();
     DepositMessage depositMessage =
@@ -282,7 +280,7 @@ class BeaconStateUtilTest {
   private BeaconState createBeaconState(
       boolean addToList, UnsignedLong amount, Validator knownValidator) {
     MutableBeaconState beaconState = BeaconState.createEmpty().createWritableCopy();
-    beaconState.setSlot(randomUnsignedLong(100));
+    beaconState.setSlot(dataStructureUtil.randomUnsignedLong());
     beaconState.setFork(
         new Fork(
             Constants.GENESIS_FORK_VERSION,
@@ -291,7 +289,10 @@ class BeaconStateUtilTest {
 
     List<Validator> validatorList =
         new ArrayList<>(
-            Arrays.asList(randomValidator(101), randomValidator(102), randomValidator(103)));
+            Arrays.asList(
+                dataStructureUtil.randomValidator(),
+                dataStructureUtil.randomValidator(),
+                dataStructureUtil.randomValidator()));
     List<UnsignedLong> balanceList =
         new ArrayList<>(
             Collections.nCopies(3, UnsignedLong.valueOf(Constants.MAX_EFFECTIVE_BALANCE)));
@@ -348,7 +349,7 @@ class BeaconStateUtilTest {
 
   @Test
   void processDepositsShouldIgnoreInvalidSignedDeposits() {
-    ArrayList<DepositWithIndex> deposits = randomDeposits(3, 100);
+    ArrayList<DepositWithIndex> deposits = dataStructureUtil.randomDeposits(3);
     deposits.get(1).getData().setSignature(BLSSignature.empty());
     BeaconState state =
         initialize_beacon_state_from_eth1(Bytes32.ZERO, UnsignedLong.ZERO, deposits);

--- a/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/GenesisGeneratorTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/artemis/datastructures/util/GenesisGeneratorTest.java
@@ -56,13 +56,13 @@ class GenesisGeneratorTest {
           .collect(toList());
   public static final UnsignedLong GENESIS_EPOCH = UnsignedLong.valueOf(Constants.GENESIS_EPOCH);
 
-  private int seed = 2489232;
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final GenesisGenerator genesisGenerator = new GenesisGenerator();
 
   @Test
   public void shouldGenerateSameGenesisAsSpecMethodForSingleDeposit() {
-    final Bytes32 eth1BlockHash1 = DataStructureUtil.randomBytes32(seed++);
-    final Bytes32 eth1BlockHash2 = DataStructureUtil.randomBytes32(seed++);
+    final Bytes32 eth1BlockHash1 = dataStructureUtil.randomBytes32();
+    final Bytes32 eth1BlockHash2 = dataStructureUtil.randomBytes32();
 
     final UnsignedLong genesisTime = UnsignedLong.valueOf(982928293223232L);
 

--- a/ethereum/statetransition/src/test-support/java/tech/pegasys/artemis/statetransition/AttestationGenerator.java
+++ b/ethereum/statetransition/src/test-support/java/tech/pegasys/artemis/statetransition/AttestationGenerator.java
@@ -68,7 +68,7 @@ public class AttestationGenerator {
   }
 
   public static Attestation aggregateAttestation(int numAttesters) {
-    Attestation attestation = DataStructureUtil.randomAttestation(1);
+    Attestation attestation = new DataStructureUtil(1).randomAttestation();
     withNewAttesterBits(attestation, numAttesters);
     return attestation;
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/BlockAttestationsPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/BlockAttestationsPoolTest.java
@@ -30,6 +30,7 @@ import tech.pegasys.artemis.util.SSZTypes.Bitlist;
 
 class BlockAttestationsPoolTest {
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private BlockAttestationsPool pool;
 
   @BeforeEach
@@ -116,7 +117,7 @@ class BlockAttestationsPoolTest {
   @Test
   void getAggregatedAttestations_DoesNotReturnAttestationsMoreThanMaxAttestations() {
     for (int i = 0; i < MAX_ATTESTATIONS + 1; i++) {
-      Attestation attestation = DataStructureUtil.randomAttestation(i);
+      Attestation attestation = dataStructureUtil.randomAttestation();
       attestation.setData(diffSlotAttestationData(UnsignedLong.valueOf(i), attestation.getData()));
       pool.addUnprocessedAggregateAttestationToQueue(attestation);
     }
@@ -128,7 +129,7 @@ class BlockAttestationsPoolTest {
   void getAggregatedAttestations_DoesNotReturnAttestationsWithSlotsHigherThanGivenSlot() {
     int SLOT = 10;
     for (int i = 0; i < SLOT; i++) {
-      Attestation attestation = DataStructureUtil.randomAttestation(i);
+      Attestation attestation = dataStructureUtil.randomAttestation();
       attestation.setData(diffSlotAttestationData(UnsignedLong.valueOf(i), attestation.getData()));
       pool.addUnprocessedAggregateAttestationToQueue(attestation);
     }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtilTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtilTest.java
@@ -15,9 +15,6 @@ package tech.pegasys.artemis.statetransition.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.newDeposits;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomUnsignedLong;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomValidator;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.Arrays;
@@ -34,6 +31,7 @@ import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.datastructures.state.MutableBeaconState;
 import tech.pegasys.artemis.datastructures.state.Validator;
 import tech.pegasys.artemis.datastructures.state.ValidatorImpl;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.util.SSZTypes.SSZList;
 import tech.pegasys.artemis.util.SSZTypes.SSZMutableList;
 import tech.pegasys.artemis.util.bls.BLSPublicKey;
@@ -41,12 +39,14 @@ import tech.pegasys.artemis.util.config.Constants;
 
 @ExtendWith(BouncyCastleExtension.class)
 class BlockProcessorUtilTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+
   @Test
   @Disabled
   void processDepositAddsNewValidatorWhenPubkeyIsNotFoundInRegistry()
       throws BlockProcessingException {
     // Data Setup
-    SSZList<DepositWithIndex> deposits = newDeposits(1);
+    SSZList<DepositWithIndex> deposits = dataStructureUtil.newDeposits(1);
     Deposit deposit = deposits.get(0);
     DepositData depositInput = deposit.getData();
     BLSPublicKey pubkey = depositInput.getPubkey();
@@ -86,7 +86,7 @@ class BlockProcessorUtilTest {
   void processDepositTopsUpValidatorBalanceWhenPubkeyIsFoundInRegistry()
       throws BlockProcessingException {
     // Data Setup
-    SSZList<DepositWithIndex> deposits = newDeposits(1);
+    SSZList<DepositWithIndex> deposits = dataStructureUtil.newDeposits(1);
     Deposit deposit = deposits.get(0);
     DepositData depositInput = deposit.getData();
     BLSPublicKey pubkey = depositInput.getPubkey();
@@ -136,7 +136,7 @@ class BlockProcessorUtilTest {
   private BeaconState createBeaconState(
       boolean addToList, UnsignedLong amount, Validator knownValidator) {
     MutableBeaconState beaconState = BeaconState.createEmpty().createWritableCopy();
-    beaconState.setSlot(randomUnsignedLong(100));
+    beaconState.setSlot(dataStructureUtil.randomUnsignedLong());
     beaconState.setFork(
         new Fork(
             Constants.GENESIS_FORK_VERSION,
@@ -145,13 +145,18 @@ class BlockProcessorUtilTest {
 
     SSZMutableList<Validator> validatorList =
         SSZList.createMutable(
-            Arrays.asList(randomValidator(101), randomValidator(102), randomValidator(103)),
+            Arrays.asList(
+                dataStructureUtil.randomValidator(),
+                dataStructureUtil.randomValidator(),
+                dataStructureUtil.randomValidator()),
             Constants.VALIDATOR_REGISTRY_LIMIT,
             ValidatorImpl.class);
     SSZMutableList<UnsignedLong> balanceList =
         SSZList.createMutable(
             Arrays.asList(
-                randomUnsignedLong(104), randomUnsignedLong(105), randomUnsignedLong(106)),
+                dataStructureUtil.randomUnsignedLong(),
+                dataStructureUtil.randomUnsignedLong(),
+                dataStructureUtil.randomUnsignedLong()),
             Constants.VALIDATOR_REGISTRY_LIMIT,
             UnsignedLong.class);
 

--- a/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/BeaconBlocksByRootIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/BeaconBlocksByRootIntegrationTest.java
@@ -41,8 +41,8 @@ import tech.pegasys.artemis.util.async.SafeFuture;
 
 public class BeaconBlocksByRootIntegrationTest {
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final Eth2NetworkFactory networkFactory = new Eth2NetworkFactory();
-  private int seed = 1000;
   private Eth2Peer peer1;
   private ChainStorageClient storageClient1;
 
@@ -180,7 +180,7 @@ public class BeaconBlocksByRootIntegrationTest {
   }
 
   private SignedBeaconBlock addBlock() {
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(seed, seed++);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
     final Bytes32 blockRoot = block.getMessage().hash_tree_root();
     final Transaction transaction = storageClient1.startStoreTransaction();
     transaction.putBlock(blockRoot, block);

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/AggregateGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/AggregateGossipManagerTest.java
@@ -33,6 +33,7 @@ import tech.pegasys.artemis.storage.ChainStorageClient;
 
 public class AggregateGossipManagerTest {
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final EventBus eventBus = new EventBus();
   private final ChainStorageClient storageClient = ChainStorageClient.memoryOnlyClient(eventBus);
   private final GossipNetwork gossipNetwork = mock(GossipNetwork.class);
@@ -46,7 +47,7 @@ public class AggregateGossipManagerTest {
 
   @Test
   public void onNewAggregate() {
-    final AggregateAndProof aggregate = DataStructureUtil.randomAggregateAndProof(1);
+    final AggregateAndProof aggregate = dataStructureUtil.randomAggregateAndProof();
     final Bytes serialized = SimpleOffsetSerializer.serialize(aggregate);
 
     eventBus.post(aggregate);

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationGossipManagerTest.java
@@ -40,6 +40,7 @@ import tech.pegasys.artemis.storage.ChainStorageClient;
 
 public class AttestationGossipManagerTest {
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final String topicRegex = "/eth2/index\\d+_beacon_attestation/ssz";
   private final EventBus eventBus = new EventBus();
   private final ChainStorageClient storageClient = ChainStorageClient.memoryOnlyClient(eventBus);
@@ -64,7 +65,7 @@ public class AttestationGossipManagerTest {
     eventBus.post(assignment);
 
     // Post new attestation
-    final Attestation attestation = DataStructureUtil.randomAttestation(1);
+    final Attestation attestation = dataStructureUtil.randomAttestation();
     attestation.setData(attestation.getData().withIndex(UnsignedLong.valueOf(committeeIndex)));
     final Bytes serialized = SimpleOffsetSerializer.serialize(attestation);
     eventBus.post(attestation);
@@ -81,7 +82,7 @@ public class AttestationGossipManagerTest {
     eventBus.post(assignment);
 
     // Post new attestation
-    final Attestation attestation = DataStructureUtil.randomAttestation(1);
+    final Attestation attestation = dataStructureUtil.randomAttestation();
     attestation.setData(attestation.getData().withIndex(UnsignedLong.valueOf(committeeIndex + 1)));
     eventBus.post(attestation);
 
@@ -103,14 +104,14 @@ public class AttestationGossipManagerTest {
     eventBus.post(dismissalEvent);
 
     // Attestation for dismissed assignment should be ignored
-    final Attestation attestation = DataStructureUtil.randomAttestation(1);
+    final Attestation attestation = dataStructureUtil.randomAttestation();
     attestation.setData(attestation.getData().withIndex(UnsignedLong.valueOf(dismissedIndex)));
     final Bytes serialized = SimpleOffsetSerializer.serialize(attestation);
     eventBus.post(attestation);
     verify(topicChannel, never()).gossip(serialized);
 
     // Attestation for remaining assignment should be processed
-    final Attestation attestation2 = DataStructureUtil.randomAttestation(1);
+    final Attestation attestation2 = dataStructureUtil.randomAttestation();
     attestation2.setData(attestation.getData().withIndex(UnsignedLong.valueOf(committeeIndex)));
     final Bytes serialized2 = SimpleOffsetSerializer.serialize(attestation2);
     eventBus.post(attestation2);

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/BlockGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/BlockGossipManagerTest.java
@@ -34,6 +34,7 @@ import tech.pegasys.artemis.storage.ChainStorageClient;
 
 public class BlockGossipManagerTest {
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final EventBus eventBus = new EventBus();
   private final ChainStorageClient storageClient = ChainStorageClient.memoryOnlyClient(eventBus);
   private final GossipNetwork gossipNetwork = mock(GossipNetwork.class);
@@ -48,7 +49,7 @@ public class BlockGossipManagerTest {
   @Test
   public void onBlockProposed() {
     // Should gossip new blocks received from event bus
-    SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(1, 100);
+    SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
     Bytes serialized = SimpleOffsetSerializer.serialize(block);
     eventBus.post(new ProposedBlockEvent(block));
 

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/AggregateTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/AggregateTopicHandlerTest.java
@@ -29,6 +29,7 @@ import tech.pegasys.artemis.statetransition.BeaconChainUtil;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 
 public class AggregateTopicHandlerTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final EventBus eventBus = mock(EventBus.class);
   private final ChainStorageClient storageClient = ChainStorageClient.memoryOnlyClient(eventBus);
   private final AggregateTopicHandler topicHandler =
@@ -42,7 +43,7 @@ public class AggregateTopicHandlerTest {
 
   @Test
   public void handleMessage_invalidAttestation_badState() throws Exception {
-    final AggregateAndProof aggregate = DataStructureUtil.randomAggregateAndProof(1);
+    final AggregateAndProof aggregate = dataStructureUtil.randomAggregateAndProof();
     final Bytes serialized = SimpleOffsetSerializer.serialize(aggregate);
 
     final boolean result = topicHandler.handleMessage(serialized);

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/AttestationTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/AttestationTopicHandlerTest.java
@@ -33,6 +33,7 @@ import tech.pegasys.artemis.util.bls.BLSKeyGenerator;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
 
 public class AttestationTopicHandlerTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(12);
   private final EventBus eventBus = mock(EventBus.class);
   private final ChainStorageClient storageClient = ChainStorageClient.memoryOnlyClient(eventBus);
@@ -83,7 +84,7 @@ public class AttestationTopicHandlerTest {
 
     // Set up state to be missing
     final ChainStorageClient storageClient = ChainStorageClient.memoryOnlyClient(eventBus);
-    storageClient.initializeFromGenesis(DataStructureUtil.randomBeaconState(1));
+    storageClient.initializeFromGenesis(dataStructureUtil.randomBeaconState());
     final AttestationTopicHandler topicHandler =
         new AttestationTopicHandler(eventBus, storageClient, 1);
 

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/BlockTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/BlockTopicHandlerTest.java
@@ -31,6 +31,7 @@ import tech.pegasys.artemis.statetransition.BeaconChainUtil;
 import tech.pegasys.artemis.storage.ChainStorageClient;
 
 public class BlockTopicHandlerTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final EventBus eventBus = mock(EventBus.class);
   private final ChainStorageClient storageClient = ChainStorageClient.memoryOnlyClient(eventBus);
   private final BeaconChainUtil beaconChainUtil = BeaconChainUtil.create(2, storageClient);
@@ -67,7 +68,7 @@ public class BlockTopicHandlerTest {
 
   @Test
   public void handleMessage_invalidBlock_unknownPreState() {
-    SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(1, 100);
+    SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
     Bytes serialized = SimpleOffsetSerializer.serialize(block);
 
     final boolean result = topicHandler.handleMessage(serialized);

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/Eth2TopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/Eth2TopicHandlerTest.java
@@ -32,11 +32,12 @@ import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 public class Eth2TopicHandlerTest {
   private static final String TOPIC = "testing";
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final EventBus eventBus = mock(EventBus.class);
   private final MockTopicHandler topicHandler = spy(new MockTopicHandler(eventBus));
   private final Bytes message = Bytes.fromHexString("0x01");
 
-  private final Attestation deserialized = DataStructureUtil.randomAttestation(1);
+  private final Attestation deserialized = dataStructureUtil.randomAttestation();
   private Supplier<Attestation> deserializer = Suppliers.ofInstance(deserialized);
   private Supplier<Boolean> validator = Suppliers.ofInstance(true);
 

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/peers/PeerChainValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/peers/PeerChainValidatorTest.java
@@ -41,6 +41,7 @@ import tech.pegasys.artemis.util.config.Constants;
 
 public class PeerChainValidatorTest {
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final Eth2Peer peer = mock(Eth2Peer.class);
   private final Store store = mock(Store.class);
   private final ChainStorageClient storageClient = mock(ChainStorageClient.class);
@@ -68,13 +69,13 @@ public class PeerChainValidatorTest {
   private final UnsignedLong laterBlockSlot = laterEpochSlot.minus(UnsignedLong.ONE);
 
   private final SignedBeaconBlock genesisBlock =
-      DataStructureUtil.randomSignedBeaconBlock(genesisSlot.longValue(), 1);
+      dataStructureUtil.randomSignedBeaconBlock(genesisSlot.longValue());
   private final SignedBeaconBlock remoteFinalizedBlock =
-      DataStructureUtil.randomSignedBeaconBlock(remoteFinalizedBlockSlot.longValue(), 1);
+      dataStructureUtil.randomSignedBeaconBlock(remoteFinalizedBlockSlot.longValue());
   private final SignedBeaconBlock earlierBlock =
-      DataStructureUtil.randomSignedBeaconBlock(earlierBlockSlot.longValue(), 2);
+      dataStructureUtil.randomSignedBeaconBlock(earlierBlockSlot.longValue());
   private final SignedBeaconBlock laterBlock =
-      DataStructureUtil.randomSignedBeaconBlock(laterBlockSlot.longValue(), 3);
+      dataStructureUtil.randomSignedBeaconBlock(laterBlockSlot.longValue());
 
   private final Checkpoint genesisCheckpoint =
       new Checkpoint(genesisEpoch, genesisBlock.getMessage().hash_tree_root());
@@ -373,7 +374,7 @@ public class PeerChainValidatorTest {
   }
 
   private SignedBeaconBlock randomBlock(UnsignedLong slot) {
-    return DataStructureUtil.randomSignedBeaconBlock(slot.longValue(), slot.intValue());
+    return dataStructureUtil.randomSignedBeaconBlock(slot.longValue());
   }
 
   private Checkpoint getFinalizedCheckpoint(final PeerStatus status) {

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -41,11 +41,12 @@ import tech.pegasys.artemis.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.artemis.storage.CombinedChainDataClient;
 
 class BeaconBlocksByRangeMessageHandlerTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final Eth2Peer peer = mock(Eth2Peer.class);
 
   private static final List<SignedBeaconBlock> BLOCKS =
       IntStream.rangeClosed(0, 10)
-          .mapToObj(slot -> DataStructureUtil.randomSignedBeaconBlock(slot, slot))
+          .mapToObj(slot -> new DataStructureUtil(slot).randomSignedBeaconBlock(slot))
           .collect(Collectors.toList());
 
   @SuppressWarnings("unchecked")
@@ -310,7 +311,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
   private void withCanonicalHeadBlock(
       final SignedBeaconBlock headBlock, final UnsignedLong bestSlot) {
     when(storageClient.getNonfinalizedBlockState(headBlock.getMessage().hash_tree_root()))
-        .thenReturn(Optional.of(DataStructureUtil.randomBeaconState(bestSlot, 1)));
+        .thenReturn(Optional.of(dataStructureUtil.randomBeaconState(bestSlot)));
   }
 
   private void withBlockAtSlot(final int slot, final Bytes32 headBlockRoot) {

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
@@ -44,6 +44,7 @@ import tech.pegasys.artemis.util.async.SafeFuture;
 import tech.pegasys.artemis.util.async.StubAsyncRunner;
 
 public class Eth2IncomingRequestHandlerTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final PeerLookup peerLookup = mock(PeerLookup.class);
   private final CombinedChainDataClient combinedChainDataClient =
@@ -71,7 +72,7 @@ public class Eth2IncomingRequestHandlerTest {
   private final BeaconState state = mock(BeaconState.class);
   private final BeaconBlocksByRangeRequestMessage request =
       new BeaconBlocksByRangeRequestMessage(
-          DataStructureUtil.randomBytes32(1), UnsignedLong.ONE, UnsignedLong.ONE, UnsignedLong.ONE);
+          dataStructureUtil.randomBytes32(), UnsignedLong.ONE, UnsignedLong.ONE, UnsignedLong.ONE);
   private final Bytes requestData = blocksByRangeMethod.encodeRequest(request);
 
   @BeforeEach
@@ -90,8 +91,7 @@ public class Eth2IncomingRequestHandlerTest {
   }
 
   private SafeFuture<Optional<SignedBeaconBlock>> getBlockAtSlot(final UnsignedLong slot) {
-    final SignedBeaconBlock block =
-        DataStructureUtil.randomSignedBeaconBlock(slot.longValue(), slot.intValue());
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot.longValue());
     return SafeFuture.completedFuture(Optional.of(block));
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
@@ -47,6 +47,7 @@ import tech.pegasys.artemis.util.async.StubAsyncRunner;
 
 public class Eth2OutgoingRequestHandlerTest {
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final StubAsyncRunner asyncRequestRunner = new StubAsyncRunner();
   private final StubAsyncRunner timeoutRunner = new StubAsyncRunner();
 
@@ -266,7 +267,7 @@ public class Eth2OutgoingRequestHandlerTest {
   }
 
   private Bytes chunkBytes(final int chunk) {
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(chunk, chunk);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(chunk);
     return rpcEncoder.encodeSuccessfulResponse(block);
   }
 

--- a/storage/src/test/java/tech/pegasys/artemis/storage/CombinedChainDataClientTest.java
+++ b/storage/src/test/java/tech/pegasys/artemis/storage/CombinedChainDataClientTest.java
@@ -40,13 +40,12 @@ import tech.pegasys.artemis.util.config.Constants;
 
 class CombinedChainDataClientTest {
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final ChainStorageClient recentChainData = mock(ChainStorageClient.class);
   private final HistoricalChainData historicalChainData = mock(HistoricalChainData.class);
   private final Store store = mock(Store.class);
   private final CombinedChainDataClient client =
       spy(new CombinedChainDataClient(recentChainData, historicalChainData));
-
-  private int seed = 242842;
 
   @BeforeEach
   public void setUp() {
@@ -243,7 +242,7 @@ class CombinedChainDataClientTest {
 
   @Test
   public void getCommitteesFromStateWithCache_shouldReturnCommitteeAssignments() {
-    BeaconState state = DataStructureUtil.randomBeaconState(11233);
+    BeaconState state = dataStructureUtil.randomBeaconState();
     List<CommitteeAssignment> data = client.getCommitteesFromState(state, state.getSlot());
     assertThat(data.size()).isEqualTo(SLOTS_PER_EPOCH);
   }
@@ -252,7 +251,7 @@ class CombinedChainDataClientTest {
   public void getBlockBySlot_blockByBlockRoot() throws ExecutionException, InterruptedException {
     final UnsignedLong slotParam = UnsignedLong.ONE;
     final SignedBeaconBlock signedBeaconBlock =
-        DataStructureUtil.randomSignedBeaconBlock(slotParam.longValue(), 7);
+        dataStructureUtil.randomSignedBeaconBlock(slotParam.longValue());
 
     doReturn(Optional.of(signedBeaconBlock.getParent_root()))
         .when(client)
@@ -274,7 +273,7 @@ class CombinedChainDataClientTest {
       throws ExecutionException, InterruptedException {
     final UnsignedLong slotParam = UnsignedLong.ONE;
     final SignedBeaconBlock signedBeaconBlock =
-        DataStructureUtil.randomSignedBeaconBlock(slotParam.longValue(), 7);
+        dataStructureUtil.randomSignedBeaconBlock(slotParam.longValue());
 
     doReturn(Optional.empty()).when(client).getBlockRootBySlot(any());
     doReturn(Optional.of(signedBeaconBlock.getParent_root())).when(client).getBestBlockRoot();
@@ -300,10 +299,10 @@ class CombinedChainDataClientTest {
   }
 
   private SignedBeaconBlock block(final UnsignedLong slot) {
-    return DataStructureUtil.randomSignedBeaconBlock(slot.longValue(), seed++);
+    return dataStructureUtil.randomSignedBeaconBlock(slot.longValue());
   }
 
   private BeaconState beaconState(final UnsignedLong slot) {
-    return DataStructureUtil.randomBeaconState(slot, seed++);
+    return dataStructureUtil.randomBeaconState(slot);
   }
 }

--- a/storage/src/test/java/tech/pegasys/artemis/storage/HistoricalChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/artemis/storage/HistoricalChainDataTest.java
@@ -39,10 +39,11 @@ import tech.pegasys.artemis.storage.events.GetLatestFinalizedBlockAtSlotResponse
 import tech.pegasys.artemis.util.async.SafeFuture;
 
 class HistoricalChainDataTest {
+  private static final DataStructureUtil DATA_STRUCTURE_UTIL = new DataStructureUtil();
   private static final Optional<SignedBeaconBlock> BLOCK =
-      Optional.of(DataStructureUtil.randomSignedBeaconBlock(1, 100));
+      Optional.of(DATA_STRUCTURE_UTIL.randomSignedBeaconBlock(1));
   private static final Optional<BeaconState> STATE =
-      Optional.of(DataStructureUtil.randomBeaconState(UnsignedLong.valueOf(1), 100));
+      Optional.of(DATA_STRUCTURE_UTIL.randomBeaconState(UnsignedLong.valueOf(1)));
   private final EventBus eventBus = mock(EventBus.class);
   private final HistoricalChainData historicalChainData = new HistoricalChainData(eventBus);
 

--- a/storage/src/test/java/tech/pegasys/artemis/storage/MapDbDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/artemis/storage/MapDbDatabaseTest.java
@@ -53,8 +53,9 @@ import tech.pegasys.artemis.util.config.Constants;
 @ExtendWith(TempDirectoryExtension.class)
 class MapDbDatabaseTest {
   private static final BeaconState GENESIS_STATE =
-      DataStructureUtil.randomBeaconState(UnsignedLong.ZERO, 1);
+      new DataStructureUtil().randomBeaconState(UnsignedLong.ZERO);
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private SignedBeaconBlock checkpoint1Block;
   private SignedBeaconBlock checkpoint2Block;
   private SignedBeaconBlock checkpoint3Block;
@@ -79,8 +80,6 @@ class MapDbDatabaseTest {
           .findFirst()
           .get();
   private final Checkpoint genesisCheckpoint = store.getFinalizedCheckpoint();
-
-  private int seed = 498242;
 
   @BeforeEach
   public void recordGenesis(@TempDirectory final Path tempDir) {
@@ -140,8 +139,8 @@ class MapDbDatabaseTest {
   @Test
   public void shouldGetHotStateByRoot() {
     final Transaction transaction = store.startTransaction(databaseTransactionPrecommit);
-    final BeaconState state1 = DataStructureUtil.randomBeaconState(seed++);
-    final BeaconState state2 = DataStructureUtil.randomBeaconState(seed++);
+    final BeaconState state1 = dataStructureUtil.randomBeaconState();
+    final BeaconState state2 = dataStructureUtil.randomBeaconState();
     final Bytes32 block1Root = Bytes32.fromHexString("0x1234");
     final Bytes32 block2Root = Bytes32.fromHexString("0x5822");
     transaction.putBlockState(block1Root, state1);
@@ -247,8 +246,8 @@ class MapDbDatabaseTest {
 
   @Test
   public void shouldStoreSingleValue_singleBlockState() {
-    final BeaconState newState = DataStructureUtil.randomBeaconState(999);
-    final Bytes32 blockRoot = DataStructureUtil.randomBytes32(999L);
+    final BeaconState newState = dataStructureUtil.randomBeaconState();
+    final Bytes32 blockRoot = dataStructureUtil.randomBytes32();
     // Sanity check
     assertThat(store.getBlockState(blockRoot)).isNull();
 
@@ -263,7 +262,7 @@ class MapDbDatabaseTest {
   @Test
   public void shouldStoreSingleValue_singleCheckpointState() {
     final Checkpoint checkpoint = checkpoint3;
-    final BeaconState newState = DataStructureUtil.randomBeaconState(999);
+    final BeaconState newState = dataStructureUtil.randomBeaconState();
     // Sanity check
     assertThat(store.getCheckpointState(checkpoint)).isNull();
 
@@ -329,8 +328,8 @@ class MapDbDatabaseTest {
     final Checkpoint forkCheckpoint =
         new Checkpoint(checkpoint1.getEpoch(), Bytes32.fromHexString("0x88677727"));
     transaction.putCheckpointState(checkpoint1, GENESIS_STATE);
-    transaction.putCheckpointState(checkpoint2, DataStructureUtil.randomBeaconState(seed++));
-    transaction.putCheckpointState(forkCheckpoint, DataStructureUtil.randomBeaconState(seed++));
+    transaction.putCheckpointState(checkpoint2, dataStructureUtil.randomBeaconState());
+    transaction.putCheckpointState(forkCheckpoint, dataStructureUtil.randomBeaconState());
 
     commit(transaction);
 
@@ -351,9 +350,9 @@ class MapDbDatabaseTest {
 
     // First store the initial checkpoints.
     final Transaction transaction1 = store.startTransaction(databaseTransactionPrecommit);
-    transaction1.putCheckpointState(earlyCheckpoint, DataStructureUtil.randomBeaconState(seed++));
-    transaction1.putCheckpointState(middleCheckpoint, DataStructureUtil.randomBeaconState(seed++));
-    transaction1.putCheckpointState(laterCheckpoint, DataStructureUtil.randomBeaconState(seed++));
+    transaction1.putCheckpointState(earlyCheckpoint, dataStructureUtil.randomBeaconState());
+    transaction1.putCheckpointState(middleCheckpoint, dataStructureUtil.randomBeaconState());
+    transaction1.putCheckpointState(laterCheckpoint, dataStructureUtil.randomBeaconState());
     commit(transaction1);
     assertLatestUpdateResultPrunedCollectionsAreEmpty();
 
@@ -387,8 +386,8 @@ class MapDbDatabaseTest {
     final Transaction transaction = store.startTransaction(databaseTransactionPrecommit);
     final SignedBeaconBlock block1 = blockAtSlot(1);
     final SignedBeaconBlock block2 = blockAtSlot(2);
-    final BeaconState state1 = DataStructureUtil.randomBeaconState(seed++);
-    final BeaconState state2 = DataStructureUtil.randomBeaconState(seed++);
+    final BeaconState state1 = dataStructureUtil.randomBeaconState();
+    final BeaconState state2 = dataStructureUtil.randomBeaconState();
     final Bytes32 block1Root = block1.getMessage().hash_tree_root();
     final Bytes32 block2Root = block2.getMessage().hash_tree_root();
     transaction.putBlock(block1Root, block1);
@@ -415,11 +414,10 @@ class MapDbDatabaseTest {
     final SignedBeaconBlock unfinalizedBlock =
         blockAtSlot(compute_start_slot_at_epoch(UnsignedLong.valueOf(2)).longValue());
 
-    final BeaconState state1 = DataStructureUtil.randomBeaconState(UnsignedLong.valueOf(1), seed++);
-    final BeaconState state2 = DataStructureUtil.randomBeaconState(UnsignedLong.valueOf(2), seed++);
+    final BeaconState state1 = dataStructureUtil.randomBeaconState(UnsignedLong.valueOf(1));
+    final BeaconState state2 = dataStructureUtil.randomBeaconState(UnsignedLong.valueOf(2));
     final BeaconState unfinalizedState =
-        DataStructureUtil.randomBeaconState(
-            compute_start_slot_at_epoch(UnsignedLong.valueOf(2)), seed++);
+        dataStructureUtil.randomBeaconState(compute_start_slot_at_epoch(UnsignedLong.valueOf(2)));
 
     final Bytes32 block1Root = block1.getMessage().hash_tree_root();
     final Bytes32 block2Root = block2.getMessage().hash_tree_root();
@@ -476,12 +474,10 @@ class MapDbDatabaseTest {
 
     // Create States
     final Map<Bytes32, BeaconState> states = new HashMap<>();
-    final BeaconState block3State = DataStructureUtil.randomBeaconState(block3.getSlot(), 3);
-    final BeaconState block7State = DataStructureUtil.randomBeaconState(block7.getSlot(), 7);
-    final BeaconState forkBlock6State =
-        DataStructureUtil.randomBeaconState(forkBlock6.getSlot(), 16);
-    final BeaconState forkBlock7State =
-        DataStructureUtil.randomBeaconState(forkBlock7.getSlot(), 17);
+    final BeaconState block3State = dataStructureUtil.randomBeaconState(block3.getSlot());
+    final BeaconState block7State = dataStructureUtil.randomBeaconState(block7.getSlot());
+    final BeaconState forkBlock6State = dataStructureUtil.randomBeaconState(forkBlock6.getSlot());
+    final BeaconState forkBlock7State = dataStructureUtil.randomBeaconState(forkBlock7.getSlot());
     // Store states in map
     states.put(block3.getMessage().hash_tree_root(), block3State);
     states.put(block7.getMessage().hash_tree_root(), block7State);
@@ -577,12 +573,10 @@ class MapDbDatabaseTest {
 
       // Create States
       final Map<Bytes32, BeaconState> states = new HashMap<>();
-      final BeaconState block3State = DataStructureUtil.randomBeaconState(block3.getSlot(), 3);
-      final BeaconState block7State = DataStructureUtil.randomBeaconState(block7.getSlot(), 7);
-      final BeaconState forkBlock6State =
-          DataStructureUtil.randomBeaconState(forkBlock6.getSlot(), 16);
-      final BeaconState forkBlock7State =
-          DataStructureUtil.randomBeaconState(forkBlock7.getSlot(), 17);
+      final BeaconState block3State = dataStructureUtil.randomBeaconState(block3.getSlot());
+      final BeaconState block7State = dataStructureUtil.randomBeaconState(block7.getSlot());
+      final BeaconState forkBlock6State = dataStructureUtil.randomBeaconState(forkBlock6.getSlot());
+      final BeaconState forkBlock7State = dataStructureUtil.randomBeaconState(forkBlock7.getSlot());
       // Store states in map
       states.put(block3.getMessage().hash_tree_root(), block3State);
       states.put(block7.getMessage().hash_tree_root(), block7State);
@@ -791,7 +785,7 @@ class MapDbDatabaseTest {
 
   private SignedBeaconBlock blockAtEpoch(final long epoch) {
     final UnsignedLong slot = compute_start_slot_at_epoch(UnsignedLong.valueOf(epoch));
-    return blockAtSlot(slot.longValue(), DataStructureUtil.randomBytes32(epoch));
+    return blockAtSlot(slot.longValue(), dataStructureUtil.randomBytes32());
   }
 
   private SignedBeaconBlock blockAtSlot(final long slot) {

--- a/storage/src/test/java/tech/pegasys/artemis/storage/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/artemis/storage/StoreTest.java
@@ -16,9 +16,6 @@ package tech.pegasys.artemis.storage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBeaconState;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomBytes32;
-import static tech.pegasys.artemis.datastructures.util.DataStructureUtil.randomSignedBeaconBlock;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.HashMap;
@@ -31,13 +28,13 @@ import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
 import tech.pegasys.artemis.storage.Store.Transaction;
 
 class StoreTest {
-
-  private static final int SEED = 12424242;
-  private static final Checkpoint INITIAL_JUSTIFIED_CHECKPOINT =
-      new Checkpoint(UnsignedLong.valueOf(50), randomBytes32(SEED - 1));
-  private static final Checkpoint INITIAL_BEST_JUSTIFIED_CHECKPOINT =
-      new Checkpoint(UnsignedLong.valueOf(33), randomBytes32(SEED - 2));
   private static final Checkpoint INITIAL_FINALIZED_CHECKPOINT = new Checkpoint();
+
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Checkpoint initialJustifiedCheckpoint =
+      new Checkpoint(UnsignedLong.valueOf(50), dataStructureUtil.randomBytes32());
+  private final Checkpoint initialBestJustifiedCheckpoint =
+      new Checkpoint(UnsignedLong.valueOf(33), dataStructureUtil.randomBytes32());
   private UnsignedLong INITIAL_GENESIS_TIME = UnsignedLong.ZERO;
   private UnsignedLong INITIAL_TIME = UnsignedLong.ONE;
   private final TransactionPrecommit transactionPrecommit = TransactionPrecommit.memoryOnly();
@@ -45,9 +42,9 @@ class StoreTest {
       new Store(
           INITIAL_TIME,
           INITIAL_GENESIS_TIME,
-          INITIAL_JUSTIFIED_CHECKPOINT,
+          initialJustifiedCheckpoint,
           INITIAL_FINALIZED_CHECKPOINT,
-          INITIAL_BEST_JUSTIFIED_CHECKPOINT,
+          initialBestJustifiedCheckpoint,
           new HashMap<>(),
           new HashMap<>(),
           new HashMap<>(),
@@ -56,12 +53,12 @@ class StoreTest {
   @Test
   public void shouldApplyChangesWhenTransactionCommits() {
     final Transaction transaction = store.startTransaction(transactionPrecommit);
-    final Bytes32 blockRoot = DataStructureUtil.randomBytes32(SEED);
+    final Bytes32 blockRoot = dataStructureUtil.randomBytes32();
     final Checkpoint justifiedCheckpoint = new Checkpoint(UnsignedLong.valueOf(2), blockRoot);
     final Checkpoint finalizedCheckpoint = new Checkpoint(UnsignedLong.ONE, blockRoot);
     final Checkpoint bestJustifiedCheckpoint = new Checkpoint(UnsignedLong.valueOf(3), blockRoot);
-    final SignedBeaconBlock block = randomSignedBeaconBlock(10, 100);
-    final BeaconState state = randomBeaconState(100);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(10);
+    final BeaconState state = dataStructureUtil.randomBeaconState();
     final UnsignedLong genesisTime = UnsignedLong.valueOf(1);
     final UnsignedLong time = UnsignedLong.valueOf(3);
     transaction.putBlock(blockRoot, block);
@@ -79,8 +76,8 @@ class StoreTest {
     assertEquals(INITIAL_TIME, store.getTime());
     assertEquals(INITIAL_GENESIS_TIME, store.getGenesisTime());
     assertEquals(INITIAL_FINALIZED_CHECKPOINT, store.getFinalizedCheckpoint());
-    assertEquals(INITIAL_JUSTIFIED_CHECKPOINT, store.getJustifiedCheckpoint());
-    assertEquals(INITIAL_BEST_JUSTIFIED_CHECKPOINT, store.getBestJustifiedCheckpoint());
+    assertEquals(initialJustifiedCheckpoint, store.getJustifiedCheckpoint());
+    assertEquals(initialBestJustifiedCheckpoint, store.getBestJustifiedCheckpoint());
 
     assertEquals(block, transaction.getSignedBlock(blockRoot));
     assertEquals(state, transaction.getBlockState(blockRoot));

--- a/sync/src/test/java/tech/pegasys/artemis/sync/AttestationManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/artemis/sync/AttestationManagerTest.java
@@ -47,6 +47,7 @@ import tech.pegasys.artemis.util.SSZTypes.Bitlist;
 import tech.pegasys.artemis.util.bls.BLSSignature;
 
 class AttestationManagerTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final EventBus eventBus = new EventBus();
   private final PendingPool<DelayableAttestation> pendingAttestations =
       PendingPool.createForAttestations(eventBus);
@@ -64,8 +65,6 @@ class AttestationManagerTest {
       new AttestationManager(
           eventBus, attestationProcessor, pendingAttestations, futureAttestations);
 
-  private int seed = 482942;
-
   @BeforeEach
   public void setup() {
     assertThat(attestationManager.start()).isCompleted();
@@ -78,7 +77,7 @@ class AttestationManagerTest {
 
   @Test
   public void shouldProcessAttestationsThatAreReadyImmediately() {
-    final Attestation attestation = DataStructureUtil.randomAttestation(seed++);
+    final Attestation attestation = dataStructureUtil.randomAttestation();
     when(attestationProcessor.processAttestation(attestation)).thenReturn(SUCCESSFUL);
     eventBus.post(attestation);
 
@@ -92,7 +91,7 @@ class AttestationManagerTest {
 
   @Test
   public void shouldProcessAggregatesThatAreReadyImmediately() {
-    final AggregateAndProof aggregateAndProof = DataStructureUtil.randomAggregateAndProof(seed++);
+    final AggregateAndProof aggregateAndProof = dataStructureUtil.randomAggregateAndProof();
     when(attestationProcessor.processAttestation(aggregateAndProof.getAggregate()))
         .thenReturn(SUCCESSFUL);
     eventBus.post(aggregateAndProof);
@@ -134,7 +133,7 @@ class AttestationManagerTest {
 
   @Test
   public void shouldDeferProcessingForAttestationsThatAreMissingBlockDependencies() {
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(1, seed++);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
     final Bytes32 requiredBlockRoot = block.getMessage().hash_tree_root();
     final Attestation attestation = attestationFromSlot(1, requiredBlockRoot);
     when(attestationProcessor.processAttestation(attestation))
@@ -155,7 +154,7 @@ class AttestationManagerTest {
     assertNoProcessedEvents();
 
     // Importing a different block shouldn't cause the attestation to be processed
-    eventBus.post(new ImportedBlockEvent(DataStructureUtil.randomSignedBeaconBlock(2, seed++)));
+    eventBus.post(new ImportedBlockEvent(dataStructureUtil.randomSignedBeaconBlock(2)));
     verifyNoMoreInteractions(attestationProcessor);
     assertNoProcessedEvents();
 
@@ -169,7 +168,7 @@ class AttestationManagerTest {
 
   @Test
   public void shouldNotPublishProcessedAttestationEventWhenAttestationIsInvalid() {
-    final Attestation attestation = DataStructureUtil.randomAttestation(seed++);
+    final Attestation attestation = dataStructureUtil.randomAttestation();
     when(attestationProcessor.processAttestation(attestation))
         .thenReturn(AttestationProcessingResult.invalid("Seems fishy"));
 
@@ -183,7 +182,7 @@ class AttestationManagerTest {
 
   @Test
   public void shouldNotPublishProcessedAggregationEventWhenAttestationIsInvalid() {
-    final AggregateAndProof aggregateAndProof = DataStructureUtil.randomAggregateAndProof(seed++);
+    final AggregateAndProof aggregateAndProof = dataStructureUtil.randomAggregateAndProof();
     final Attestation attestation = aggregateAndProof.getAggregate();
     when(attestationProcessor.processAttestation(attestation))
         .thenReturn(AttestationProcessingResult.invalid("Seems fishy"));

--- a/sync/src/test/java/tech/pegasys/artemis/sync/BlockPropagationManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/artemis/sync/BlockPropagationManagerTest.java
@@ -39,6 +39,7 @@ import tech.pegasys.artemis.util.bls.BLSKeyPair;
 import tech.pegasys.artemis.util.config.Constants;
 
 public class BlockPropagationManagerTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(2);
   private final EventBus localEventBus = new EventBus();
   private final EventBus remoteEventBus = new EventBus();
@@ -177,7 +178,7 @@ public class BlockPropagationManagerTest {
     for (int i = 0; i < invalidChainDepth; i++) {
       final UnsignedLong nextSlot = incrementSlot();
       final SignedBeaconBlock block =
-          DataStructureUtil.randomSignedBeaconBlock(nextSlot.longValue(), parentBlockRoot, i);
+          dataStructureUtil.randomSignedBeaconBlock(nextSlot.longValue(), parentBlockRoot);
       invalidBlockDescendants.add(block);
       parentBlockRoot = block.getMessage().hash_tree_root();
     }
@@ -209,7 +210,7 @@ public class BlockPropagationManagerTest {
     for (int i = 0; i < invalidChainDepth; i++) {
       final UnsignedLong nextSlot = incrementSlot();
       final SignedBeaconBlock block =
-          DataStructureUtil.randomSignedBeaconBlock(nextSlot.longValue(), parentBlockRoot, i);
+          dataStructureUtil.randomSignedBeaconBlock(nextSlot.longValue(), parentBlockRoot);
       invalidBlockDescendants.add(block);
       parentBlockRoot = block.getMessage().hash_tree_root();
     }

--- a/sync/src/test/java/tech/pegasys/artemis/sync/FetchBlockTaskTest.java
+++ b/sync/src/test/java/tech/pegasys/artemis/sync/FetchBlockTaskTest.java
@@ -33,6 +33,7 @@ import tech.pegasys.artemis.util.async.SafeFuture;
 
 public class FetchBlockTaskTest {
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   final Eth2Network eth2Network = mock(Eth2Network.class);
   final List<Eth2Peer> peers = new ArrayList<>();
 
@@ -43,7 +44,7 @@ public class FetchBlockTaskTest {
 
   @Test
   public void run_successful() {
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(10, 1);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(10);
     final Bytes32 blockRoot = block.getMessage().hash_tree_root();
     FetchBlockTask task = FetchBlockTask.create(eth2Network, blockRoot);
     assertThat(task.getBlockRoot()).isEqualTo(blockRoot);
@@ -60,7 +61,7 @@ public class FetchBlockTaskTest {
 
   @Test
   public void run_noPeers() {
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(10, 1);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(10);
     final Bytes32 blockRoot = block.getMessage().hash_tree_root();
     FetchBlockTask task = FetchBlockTask.create(eth2Network, blockRoot);
 
@@ -73,7 +74,7 @@ public class FetchBlockTaskTest {
 
   @Test
   public void run_failAndRetryWithNoNewPeers() {
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(10, 1);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(10);
     final Bytes32 blockRoot = block.getMessage().hash_tree_root();
     FetchBlockTask task = FetchBlockTask.create(eth2Network, blockRoot);
 
@@ -99,7 +100,7 @@ public class FetchBlockTaskTest {
 
   @Test
   public void run_failAndRetryWithNewPeer() {
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(10, 1);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(10);
     final Bytes32 blockRoot = block.getMessage().hash_tree_root();
     FetchBlockTask task = FetchBlockTask.create(eth2Network, blockRoot);
 
@@ -129,7 +130,7 @@ public class FetchBlockTaskTest {
 
   @Test
   public void run_withMultiplesPeersAvailable() {
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(10, 1);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(10);
     final Bytes32 blockRoot = block.getMessage().hash_tree_root();
     FetchBlockTask task = FetchBlockTask.create(eth2Network, blockRoot);
 
@@ -152,7 +153,7 @@ public class FetchBlockTaskTest {
 
   @Test
   public void cancel() {
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(10, 1);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(10);
     final Bytes32 blockRoot = block.getMessage().hash_tree_root();
     FetchBlockTask task = FetchBlockTask.create(eth2Network, blockRoot);
 

--- a/sync/src/test/java/tech/pegasys/artemis/sync/FetchRecentBlocksServiceTest.java
+++ b/sync/src/test/java/tech/pegasys/artemis/sync/FetchRecentBlocksServiceTest.java
@@ -38,6 +38,7 @@ import tech.pegasys.artemis.util.async.StubAsyncRunner;
 
 public class FetchRecentBlocksServiceTest {
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private Eth2Network eth2Network = mock(Eth2Network.class);
 
   @SuppressWarnings("unchecked")
@@ -85,14 +86,14 @@ public class FetchRecentBlocksServiceTest {
 
   @Test
   public void fetchSingleBlockSuccessfully() {
-    final Bytes32 root = DataStructureUtil.randomBytes32(1);
+    final Bytes32 root = dataStructureUtil.randomBytes32();
     recentBlockFetcher.requestRecentBlock(root);
 
     assertTaskCounts(1, 1, 0);
     assertThat(importedBlocks).isEmpty();
 
     final SafeFuture<FetchBlockResult> future = taskFutures.get(0);
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(1, 1);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
     future.complete(FetchBlockResult.createSuccessful(block));
 
     assertThat(importedBlocks).containsExactly(block);
@@ -101,7 +102,7 @@ public class FetchRecentBlocksServiceTest {
 
   @Test
   public void handleDuplicateRequiredBlocks() {
-    final Bytes32 root = DataStructureUtil.randomBytes32(1);
+    final Bytes32 root = dataStructureUtil.randomBytes32();
     recentBlockFetcher.requestRecentBlock(root);
     recentBlockFetcher.requestRecentBlock(root);
 
@@ -109,7 +110,7 @@ public class FetchRecentBlocksServiceTest {
     assertThat(importedBlocks).isEmpty();
 
     final SafeFuture<FetchBlockResult> future = taskFutures.get(0);
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(1, 1);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
     future.complete(FetchBlockResult.createSuccessful(block));
 
     assertThat(importedBlocks).containsExactly(block);
@@ -118,7 +119,7 @@ public class FetchRecentBlocksServiceTest {
 
   @Test
   public void ignoreKnownBlock() {
-    final Bytes32 root = DataStructureUtil.randomBytes32(1);
+    final Bytes32 root = dataStructureUtil.randomBytes32();
     when(pendingBlocksPool.contains(root)).thenReturn(true);
     recentBlockFetcher.requestRecentBlock(root);
 
@@ -128,7 +129,7 @@ public class FetchRecentBlocksServiceTest {
 
   @Test
   public void cancelBlockRequest() {
-    final Bytes32 root = DataStructureUtil.randomBytes32(1);
+    final Bytes32 root = dataStructureUtil.randomBytes32();
     recentBlockFetcher.requestRecentBlock(root);
     recentBlockFetcher.cancelRecentBlockRequest(root);
 
@@ -143,7 +144,7 @@ public class FetchRecentBlocksServiceTest {
 
   @Test
   public void fetchSingleBlockWithRetry() {
-    final Bytes32 root = DataStructureUtil.randomBytes32(1);
+    final Bytes32 root = dataStructureUtil.randomBytes32();
     recentBlockFetcher.requestRecentBlock(root);
 
     assertTaskCounts(1, 1, 0);
@@ -165,7 +166,7 @@ public class FetchRecentBlocksServiceTest {
 
   @Test
   public void cancelTaskWhileWaitingToRetry() {
-    final Bytes32 root = DataStructureUtil.randomBytes32(1);
+    final Bytes32 root = dataStructureUtil.randomBytes32();
     recentBlockFetcher.requestRecentBlock(root);
 
     assertTaskCounts(1, 1, 0);
@@ -192,7 +193,7 @@ public class FetchRecentBlocksServiceTest {
 
   @Test
   public void handlesPeersUnavailable() {
-    final Bytes32 root = DataStructureUtil.randomBytes32(1);
+    final Bytes32 root = dataStructureUtil.randomBytes32();
     recentBlockFetcher.requestRecentBlock(root);
 
     assertTaskCounts(1, 1, 0);
@@ -216,7 +217,7 @@ public class FetchRecentBlocksServiceTest {
   public void queueFetchTaskWhenConcurrencyLimitReached() {
     final int taskCount = maxConcurrentRequests + 1;
     for (int i = 0; i < taskCount; i++) {
-      final Bytes32 root = DataStructureUtil.randomBytes32(i);
+      final Bytes32 root = dataStructureUtil.randomBytes32();
       recentBlockFetcher.requestRecentBlock(root);
     }
 
@@ -224,7 +225,7 @@ public class FetchRecentBlocksServiceTest {
 
     // Complete first task
     final SafeFuture<FetchBlockResult> future = taskFutures.get(0);
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(1, 1);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
     future.complete(FetchBlockResult.createSuccessful(block));
 
     // After first task completes, remaining pending count should become active

--- a/sync/src/test/java/tech/pegasys/artemis/sync/PeerSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/artemis/sync/PeerSyncTest.java
@@ -54,7 +54,7 @@ public class PeerSyncTest {
   private BlockImporter blockImporter = mock(BlockImporter.class);
   private ChainStorageClient storageClient = mock(ChainStorageClient.class);
 
-  private static final SignedBeaconBlock BLOCK = DataStructureUtil.randomSignedBeaconBlock(1, 100);
+  private static final SignedBeaconBlock BLOCK = new DataStructureUtil().randomSignedBeaconBlock(1);
   private static final Bytes32 PEER_HEAD_BLOCK_ROOT = Bytes32.fromHexString("0x1234");
   private static final UnsignedLong PEER_HEAD_SLOT = UnsignedLong.valueOf(30);
   private static final UnsignedLong PEER_FINALIZED_EPOCH = UnsignedLong.valueOf(3);
@@ -68,6 +68,7 @@ public class PeerSyncTest {
               PEER_HEAD_BLOCK_ROOT,
               PEER_HEAD_SLOT));
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private PeerSync peerSync;
 
@@ -436,7 +437,7 @@ public class PeerSyncTest {
       final ResponseStream.ResponseListener<SignedBeaconBlock> responseListener, int... slots) {
     List<SignedBeaconBlock> blocks = new ArrayList<>();
     for (int slot : slots) {
-      final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(slot, slot);
+      final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot);
       blocks.add(block);
       responseListener.onResponse(block);
     }

--- a/sync/src/test/java/tech/pegasys/artemis/sync/PendingPoolTest.java
+++ b/sync/src/test/java/tech/pegasys/artemis/sync/PendingPoolTest.java
@@ -31,6 +31,7 @@ import tech.pegasys.artemis.storage.events.FinalizedCheckpointEvent;
 import tech.pegasys.artemis.storage.events.SlotEvent;
 
 public class PendingPoolTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final EventBus eventBus = new EventBus();
   private final UnsignedLong historicalTolerance = UnsignedLong.valueOf(5);
   private final UnsignedLong futureTolerance = UnsignedLong.valueOf(2);
@@ -66,7 +67,7 @@ public class PendingPoolTest {
   @Test
   public void add_blockForCurrentSlot() {
     final SignedBeaconBlock block =
-        DataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue(), 1);
+        dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
     pendingPool.add(block);
 
     assertThat(pendingPool.contains(block)).isTrue();
@@ -80,7 +81,7 @@ public class PendingPoolTest {
   @Test
   public void add_historicalBlockWithinWindow() {
     final UnsignedLong slot = currentSlot.minus(historicalTolerance);
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(slot.longValue(), 1);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot.longValue());
     pendingPool.add(block);
 
     assertThat(pendingPool.contains(block)).isTrue();
@@ -94,7 +95,7 @@ public class PendingPoolTest {
   @Test
   public void add_historicalBlockOutsideWindow() {
     final UnsignedLong slot = currentSlot.minus(historicalTolerance).minus(UnsignedLong.ONE);
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(slot.longValue(), 1);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot.longValue());
     pendingPool.add(block);
 
     assertThat(pendingPool.contains(block)).isFalse();
@@ -107,7 +108,7 @@ public class PendingPoolTest {
   @Test
   public void add_futureBlockWithinWindow() {
     final UnsignedLong slot = currentSlot.plus(futureTolerance);
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(slot.longValue(), 1);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot.longValue());
     pendingPool.add(block);
 
     assertThat(pendingPool.contains(block)).isTrue();
@@ -121,7 +122,7 @@ public class PendingPoolTest {
   @Test
   public void add_futureBlockOutsideWindow() {
     final UnsignedLong slot = currentSlot.plus(futureTolerance).plus(UnsignedLong.ONE);
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(slot.longValue(), 1);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot.longValue());
     pendingPool.add(block);
 
     assertThat(pendingPool.contains(block)).isFalse();
@@ -133,13 +134,13 @@ public class PendingPoolTest {
 
   @Test
   public void add_nonFinalizedBlock() {
-    final SignedBeaconBlock finalizedBlock = DataStructureUtil.randomSignedBeaconBlock(10, 1);
+    final SignedBeaconBlock finalizedBlock = dataStructureUtil.randomSignedBeaconBlock(10);
     final Checkpoint checkpoint = finalizedCheckpoint(finalizedBlock);
     eventBus.post(new FinalizedCheckpointEvent(checkpoint));
 
     final UnsignedLong slot = checkpoint.getEpochStartSlot().plus(UnsignedLong.ONE);
     setSlot(slot);
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(slot.longValue(), 1);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot.longValue());
 
     pendingPool.add(block);
     assertThat(pendingPool.contains(block)).isTrue();
@@ -152,14 +153,14 @@ public class PendingPoolTest {
 
   @Test
   public void add_finalizedBlock() {
-    final SignedBeaconBlock finalizedBlock = DataStructureUtil.randomSignedBeaconBlock(10, 1);
+    final SignedBeaconBlock finalizedBlock = dataStructureUtil.randomSignedBeaconBlock(10);
     final Checkpoint checkpoint = finalizedCheckpoint(finalizedBlock);
     eventBus.post(new FinalizedCheckpointEvent(checkpoint));
     final long slot = checkpoint.getEpochStartSlot().longValue() + 10;
     setSlot(slot);
 
     final long blockSlot = checkpoint.getEpochStartSlot().longValue();
-    final SignedBeaconBlock block = DataStructureUtil.randomSignedBeaconBlock(blockSlot, 1);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(blockSlot);
 
     pendingPool.add(block);
     assertThat(pendingPool.contains(block)).isFalse();
@@ -179,7 +180,7 @@ public class PendingPoolTest {
   @Test
   public void add_duplicateBlock() {
     final SignedBeaconBlock block =
-        DataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue(), 1);
+        dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
     final Bytes32 parentRoot = block.getParent_root();
     pendingPool.add(block);
     pendingPool.add(block);
@@ -195,10 +196,10 @@ public class PendingPoolTest {
   @Test
   public void add_siblingBlocks() {
     final SignedBeaconBlock blockA =
-        DataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue(), 1);
+        dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
     final Bytes32 parentRoot = blockA.getParent_root();
     final SignedBeaconBlock blockB =
-        DataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue(), parentRoot, 3);
+        dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue(), parentRoot);
     pendingPool.add(blockA);
     pendingPool.add(blockB);
 
@@ -214,7 +215,7 @@ public class PendingPoolTest {
   @Test
   public void remove_existingBlock() {
     final SignedBeaconBlock block =
-        DataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue(), 1);
+        dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
     pendingPool.add(block);
     pendingPool.remove(block);
 
@@ -228,7 +229,7 @@ public class PendingPoolTest {
   @Test
   public void remove_unknownBlock() {
     final SignedBeaconBlock block =
-        DataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue(), 1);
+        dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
     pendingPool.remove(block);
 
     assertThat(pendingPool.contains(block)).isFalse();
@@ -241,10 +242,10 @@ public class PendingPoolTest {
   @Test
   public void remove_siblingBlock() {
     final SignedBeaconBlock blockA =
-        DataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue(), 1);
+        dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
     final Bytes32 parentRoot = blockA.getParent_root();
     final SignedBeaconBlock blockB =
-        DataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue(), parentRoot, 3);
+        dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue(), parentRoot);
     pendingPool.add(blockA);
     pendingPool.add(blockB);
     pendingPool.remove(blockA);
@@ -259,19 +260,17 @@ public class PendingPoolTest {
 
   @Test
   public void getItemsDependingOn_includeIndirect() {
-    int seed = 9248294;
     final int chainDepth = 2;
     final int descendentChainCount = 2;
     final List<SignedBeaconBlock> directDescendents = new ArrayList<>();
     final List<SignedBeaconBlock> indirectDescendents = new ArrayList<>();
 
-    final Bytes32 commonAncestorRoot = DataStructureUtil.randomBytes32(1);
+    final Bytes32 commonAncestorRoot = dataStructureUtil.randomBytes32();
     for (int chainIndex = 0; chainIndex < descendentChainCount; chainIndex++) {
       Bytes32 parentRoot = commonAncestorRoot;
       for (int depth = 0; depth < chainDepth; depth++) {
         final long slot = currentSlot.longValue() + 1 + depth;
-        final SignedBeaconBlock block =
-            DataStructureUtil.randomSignedBeaconBlock(slot, parentRoot, seed++);
+        final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot, parentRoot);
         final List<SignedBeaconBlock> blockSet =
             depth == 0 ? directDescendents : indirectDescendents;
         blockSet.add(block);
@@ -293,19 +292,17 @@ public class PendingPoolTest {
 
   @Test
   public void getItemsDependingOn_directOnly() {
-    int seed = 48929482;
     final int chainDepth = 2;
     final int descendentChainCount = 2;
     final List<SignedBeaconBlock> directDescendents = new ArrayList<>();
     final List<SignedBeaconBlock> indirectDescendents = new ArrayList<>();
 
-    final Bytes32 commonAncestorRoot = DataStructureUtil.randomBytes32(1);
+    final Bytes32 commonAncestorRoot = dataStructureUtil.randomBytes32();
     for (int chainIndex = 0; chainIndex < descendentChainCount; chainIndex++) {
       Bytes32 parentRoot = commonAncestorRoot;
       for (int depth = 0; depth < chainDepth; depth++) {
         final long slot = currentSlot.longValue() + 1 + depth;
-        final SignedBeaconBlock block =
-            DataStructureUtil.randomSignedBeaconBlock(slot, parentRoot, seed++);
+        final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot, parentRoot);
         final List<SignedBeaconBlock> blockSet =
             depth == 0 ? directDescendents : indirectDescendents;
         blockSet.add(block);
@@ -324,18 +321,18 @@ public class PendingPoolTest {
 
   @Test
   public void prune_finalizedBlocks() {
-    final SignedBeaconBlock finalizedBlock = DataStructureUtil.randomSignedBeaconBlock(10, 1);
+    final SignedBeaconBlock finalizedBlock = dataStructureUtil.randomSignedBeaconBlock(10);
     final Checkpoint checkpoint = finalizedCheckpoint(finalizedBlock);
     final long finalizedSlot = checkpoint.getEpochStartSlot().longValue();
     setSlot(finalizedSlot);
 
     // Add a bunch of blocks
     List<SignedBeaconBlock> nonFinalBlocks =
-        List.of(DataStructureUtil.randomSignedBeaconBlock(finalizedSlot + 1, 1));
+        List.of(dataStructureUtil.randomSignedBeaconBlock(finalizedSlot + 1));
     List<SignedBeaconBlock> finalizedBlocks =
         List.of(
-            DataStructureUtil.randomSignedBeaconBlock(finalizedSlot, 2),
-            DataStructureUtil.randomSignedBeaconBlock(finalizedSlot - 1, 3));
+            dataStructureUtil.randomSignedBeaconBlock(finalizedSlot),
+            dataStructureUtil.randomSignedBeaconBlock(finalizedSlot - 1));
     List<SignedBeaconBlock> allBlocks = new ArrayList<>();
     allBlocks.addAll(nonFinalBlocks);
     allBlocks.addAll(finalizedBlocks);
@@ -362,9 +359,9 @@ public class PendingPoolTest {
   @Test
   public void onSlot_prunesOldBlocks() {
     final SignedBeaconBlock blockA =
-        DataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue() - 1L, 1);
+        dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue() - 1L);
     final SignedBeaconBlock blockB =
-        DataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue(), 1);
+        dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
     pendingPool.add(blockA);
     pendingPool.add(blockB);
 

--- a/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/DepositProviderTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/DepositProviderTest.java
@@ -45,8 +45,7 @@ import tech.pegasys.artemis.util.config.Constants;
 
 public class DepositProviderTest {
 
-  private int seed = 0;
-
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private List<tech.pegasys.artemis.pow.event.Deposit> allSeenDepositsList;
   private DepositProvider depositProvider;
   private ChainStorageClient chainStorageClient;
@@ -136,7 +135,7 @@ public class DepositProviderTest {
   private void createDepositEvents(int n) {
     allSeenDepositsList =
         IntStream.range(0, n)
-            .mapToObj(i -> DataStructureUtil.randomDepositEvent(seed++, UnsignedLong.valueOf(i)))
+            .mapToObj(i -> dataStructureUtil.randomDepositEvent(UnsignedLong.valueOf(i)))
             .collect(Collectors.toList());
   }
 

--- a/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/Eth1DataCacheTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/Eth1DataCacheTest.java
@@ -39,6 +39,7 @@ import tech.pegasys.artemis.util.time.StubTimeProvider;
 
 public class Eth1DataCacheTest {
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final EventBus eventBus = new EventBus();
   private final BeaconStateImpl genesisState = mock(BeaconStateImpl.class);
 
@@ -228,7 +229,7 @@ public class Eth1DataCacheTest {
     eth1DataCache.startBeaconChainMode(genesisState);
     eth1DataCache.onSlot(new SlotEvent(START_SLOT));
 
-    Eth1Data eth1Data = DataStructureUtil.randomEth1Data(10);
+    Eth1Data eth1Data = dataStructureUtil.randomEth1Data();
 
     SSZMutableList<Eth1Data> eth1DataVotes =
         SSZList.createMutable(List.of(eth1Data), 10, Eth1Data.class);
@@ -316,12 +317,11 @@ public class Eth1DataCacheTest {
   }
 
   private CacheEth1BlockEvent createRandomCacheEth1BlockEvent(UnsignedLong timestamp) {
-    long seed = 0;
     return new CacheEth1BlockEvent(
-        DataStructureUtil.randomUnsignedLong(++seed),
-        DataStructureUtil.randomBytes32(++seed),
+        dataStructureUtil.randomUnsignedLong(),
+        dataStructureUtil.randomBytes32(),
         timestamp,
-        DataStructureUtil.randomBytes32(++seed),
-        DataStructureUtil.randomUnsignedLong(++seed));
+        dataStructureUtil.randomBytes32(),
+        dataStructureUtil.randomUnsignedLong());
   }
 }


### PR DESCRIPTION
## PR Description
DataStructureUtil now uses instance methods instead of static so it can encapsulate the seed value and ensure it increments for each call.  Fixes an issue where the `BeaconState` it generated actually had the same public key for every validator in the state because the seed wasn't being updated correctly.