### PR TITLE
Updating the deprecated Gradle dependency keywords

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -516,7 +516,7 @@ subprojects {
 
   dependencies {
     implementation 'org.apache.logging.log4j:log4j-core'
-    runtime 'org.apache.logging.log4j:log4j-slf4j-impl'
+    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
 
     testImplementation sourceSets.testSupport.output
     integrationTestImplementation sourceSets.testSupport.output
@@ -617,7 +617,7 @@ startScripts {
 }
 
 dependencies {
-  compile project(':artemis')
+  implementation project(':artemis')
   errorprone 'com.google.errorprone:error_prone_core'
 }
 

--- a/data/beaconrestapi/build.gradle
+++ b/data/beaconrestapi/build.gradle
@@ -1,6 +1,4 @@
 dependencies {
-    compile 'io.javalin:javalin'
-
     implementation project(':data')
     implementation project(':data:provider')
     implementation project(':ethereum:datastructures')
@@ -15,27 +13,29 @@ dependencies {
     implementation 'com.google.guava:guava'
     implementation 'io.swagger.core.v3:swagger-core'
     implementation 'io.github.classgraph:classgraph'
+    implementation 'io.javalin:javalin'
     implementation 'org.apache.commons:commons-lang3'
     implementation 'org.apache.logging.log4j:log4j-api'
     implementation 'org.apache.tuweni:tuweni-crypto'
     implementation 'org.apache.tuweni:tuweni-units'
     implementation 'org.webjars:swagger-ui'
 
-    runtime 'org.apache.logging.log4j:log4j-core'
+    runtimeOnly 'org.apache.logging.log4j:log4j-core'
 
     testImplementation project(path: ':ethereum:datastructures', configuration: 'testSupportArtifacts')
 
-    testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.assertj:assertj-core'
-    testCompile 'io.libp2p:jvm-libp2p-minimal'
+    testImplementation 'org.mockito:mockito-core'
 
-    integrationTestImplementation project(path: ':ethereum:datastructures', configuration: 'testSupportArtifacts')
+    testCompileOnly 'io.libp2p:jvm-libp2p-minimal'
+
     integrationTestImplementation project(path: ':bls', configuration: 'testSupportArtifacts')
-    integrationTestImplementation 'org.mockito:mockito-core'
     integrationTestImplementation project(path: ':ethereum:datastructures', configuration: 'testSupportArtifacts')
-    integrationTestImplementation 'org.assertj:assertj-core'
-    integrationTestImplementation 'com.squareup.okhttp3:okhttp'
+    integrationTestImplementation project(path: ':ethereum:datastructures', configuration: 'testSupportArtifacts')
 
+    integrationTestImplementation 'com.squareup.okhttp3:okhttp'
+    integrationTestImplementation 'org.mockito:mockito-core'
+    integrationTestImplementation 'org.assertj:assertj-core'
 }
 
 test {

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -10,7 +10,7 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-units'
   implementation 'org.apache.tuweni:tuweni-ssz'
 
-  runtime 'org.apache.logging.log4j:log4j-core'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
 }
 
 

--- a/data/metrics/build.gradle
+++ b/data/metrics/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'org.hyperledger.besu.internal:metrics-core'
     implementation 'org.hyperledger.besu:plugin-api'
 
-    runtime 'org.apache.logging.log4j:log4j-core'
+    runtimeOnly 'org.apache.logging.log4j:log4j-core'
 
     test {
         testLogging.showStandardStreams = true

--- a/data/provider/build.gradle
+++ b/data/provider/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-api'
     implementation 'org.apache.tuweni:tuweni-units'
 
-    runtime 'org.apache.logging.log4j:log4j-core'
+    runtimeOnly 'org.apache.logging.log4j:log4j-core'
 
     testImplementation project(path: ':ethereum:datastructures', configuration: 'testSupportArtifacts')
 

--- a/data/recorder/build.gradle
+++ b/data/recorder/build.gradle
@@ -14,7 +14,7 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation 'org.apache.commons:commons-lang3'
 
-  runtime 'org.apache.logging.log4j:log4j-core'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
 
   test {
     testLogging.showStandardStreams = true

--- a/ethereum/datastructures/build.gradle
+++ b/ethereum/datastructures/build.gradle
@@ -18,6 +18,9 @@ dependencies {
 
   testImplementation project(path: ':bls', configuration: 'testSupportArtifacts')
   testImplementation project(path: ':util', configuration: 'testSupportArtifacts')
+
+  testImplementation 'com.googlecode.json-simple:json-simple'
+
   test {
     testLogging.showStandardStreams = true
   }

--- a/ethereum/datastructures/build.gradle
+++ b/ethereum/datastructures/build.gradle
@@ -14,7 +14,7 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-units'
   implementation 'org.apache.tuweni:tuweni-ssz'
 
-  runtime 'org.apache.logging.log4j:log4j-core'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
 
   testImplementation project(path: ':bls', configuration: 'testSupportArtifacts')
   testImplementation project(path: ':util', configuration: 'testSupportArtifacts')

--- a/ethereum/statetransition/build.gradle
+++ b/ethereum/statetransition/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-ssz'
   implementation 'org.hyperledger.besu:plugin-api'
 
-  runtime 'org.apache.logging.log4j:log4j-core'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
 
   testImplementation 'org.mockito:mockito-core'
 

--- a/networking/eth2/build.gradle
+++ b/networking/eth2/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation 'org.hyperledger.besu:plugin-api'
   implementation 'org.xerial.snappy:snappy-java'
 
-  runtime 'org.apache.logging.log4j:log4j-core'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
 
   testImplementation project(path: ':ethereum:datastructures', configuration: 'testSupportArtifacts')
   testImplementation project(path: ':ethereum:statetransition', configuration: 'testSupportArtifacts')

--- a/networking/p2p/build.gradle
+++ b/networking/p2p/build.gradle
@@ -25,7 +25,7 @@ dependencies {
   implementation 'org.hyperledger.besu:plugin-api'
   implementation 'tech.pegasys.discovery:discovery'
 
-  runtime 'org.apache.logging.log4j:log4j-core'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
 
   testImplementation project(path: ':ethereum:statetransition', configuration: 'testSupportArtifacts')
   testImplementation project(path: ':util', configuration: 'testSupportArtifacts')

--- a/pow/build.gradle
+++ b/pow/build.gradle
@@ -9,8 +9,7 @@ dependencies {
   implementation project(':util')
 
   api 'org.web3j:core'
-
-
+  
   implementation 'com.googlecode.json-simple:json-simple'
   implementation 'com.google.code.gson:gson'
   implementation 'com.google.guava:guava'

--- a/pow/build.gradle
+++ b/pow/build.gradle
@@ -13,8 +13,8 @@ dependencies {
   api 'org.web3j:abi'
   api 'org.web3j:crypto'
 
-  compile 'com.googlecode.json-simple:json-simple'
 
+  implementation 'com.googlecode.json-simple:json-simple'
   implementation 'com.google.code.gson:gson'
   implementation 'com.google.guava:guava'
   implementation 'org.apache.commons:commons-lang3'
@@ -22,7 +22,7 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-crypto'
   implementation 'org.apache.tuweni:tuweni-units'
 
-  runtime 'org.apache.logging.log4j:log4j-core'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
 
   testImplementation project(path: ':util', configuration: 'testSupportArtifacts')
 

--- a/services/beaconchain/build.gradle
+++ b/services/beaconchain/build.gradle
@@ -27,5 +27,5 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-crypto'
   implementation 'org.hyperledger.besu:plugin-api'
 
-  runtime 'org.apache.logging.log4j:log4j-core'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
 }

--- a/services/chainstorage/build.gradle
+++ b/services/chainstorage/build.gradle
@@ -8,5 +8,5 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation 'org.apache.tuweni:tuweni-config'
 
-  runtime 'org.apache.logging.log4j:log4j-core'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
  }

--- a/services/powchain/build.gradle
+++ b/services/powchain/build.gradle
@@ -16,5 +16,5 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-crypto'
   implementation 'org.apache.tuweni:tuweni-units'
 
-  runtime 'org.apache.logging.log4j:log4j-core'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
 }

--- a/services/serviceutils/build.gradle
+++ b/services/serviceutils/build.gradle
@@ -12,5 +12,5 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-crypto'
   implementation 'org.hyperledger.besu:plugin-api'
 
-  runtime 'org.apache.logging.log4j:log4j-core'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
 }

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -5,16 +5,15 @@ dependencies {
   implementation project(':ssz')
   implementation project(':util')
 
-  compile 'org.mapdb:mapdb'
-
   implementation 'com.google.guava:guava'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-kv'
   implementation 'org.apache.tuweni:tuweni-ssz'
+  implementation 'org.mapdb:mapdb'
 
-  runtime 'org.apache.logging.log4j:log4j-core'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
 
   testImplementation project(path: ':ethereum:datastructures', configuration: 'testSupportArtifacts')
   testImplementation project(path: ':util', configuration: 'testSupportArtifacts')

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     exclude group: 'com.mchange'
   }
   
-  runtime 'org.apache.logging.log4j:log4j-core'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
 
   testImplementation 'org.mockito:mockito-core'
 

--- a/validator/coordinator/build.gradle
+++ b/validator/coordinator/build.gradle
@@ -18,14 +18,14 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-crypto'
   implementation 'org.apache.tuweni:tuweni-config'
   implementation 'org.apache.tuweni:tuweni-ssz'
-  // implementation files('../../lib/tuweni-ssz-0.9.0-SNAPSHOT.jar')
   implementation 'com.google.guava:guava'
   implementation 'org.apache.logging.log4j:log4j-api'
-  runtime 'org.apache.logging.log4j:log4j-core'
 
-  testImplementation 'org.mockito:mockito-core'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
+
   testImplementation project(path: ':util', configuration: 'testSupportArtifacts')
   testImplementation project(path: ':ethereum:statetransition', configuration: 'testSupportArtifacts')
   testImplementation project(path: ':ethereum:datastructures', configuration: 'testSupportArtifacts')
-}
 
+  testImplementation 'org.mockito:mockito-core'
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Changing occurrences of `compile`, `testCompile` and `runtime` for their replacement counterparts `api`, `implementation` and `testImplementation` 

