### PR TITLE
Fix nightly compatibility tests

### DIFF
--- a/compatibility-tests/multiclient/src/compatibility-test/java/tech/pegasys/artemis/compatibility/multiclient/StatusMessageCompatibilityTest.java
+++ b/compatibility-tests/multiclient/src/compatibility-test/java/tech/pegasys/artemis/compatibility/multiclient/StatusMessageCompatibilityTest.java
@@ -40,12 +40,14 @@ class StatusMessageCompatibilityTest {
 
   @BeforeEach
   public void setUp() throws Exception {
+    Constants.setConstants("mainnet");
     artemis = networkFactory.builder().startNetwork();
   }
 
   @AfterEach
   public void tearDown() {
     networkFactory.stopAll();
+    Constants.setConstants("minimal");
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Nightly compatibility tests are failing because main net and minimal now have different fork versions in the 0.10 spec and Prysm is defaulting to main net config but Teku was using minimal.