### PR TITLE
Learn syncActive without making findBestSyncPeer call

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/artemis/test/acceptance/StartupAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/artemis/test/acceptance/StartupAcceptanceTest.java
@@ -27,7 +27,7 @@ public class StartupAcceptanceTest extends AcceptanceTestBase {
     final ArtemisNode node = createArtemisNode();
     node.start();
     node.waitForGenesis();
-    node.waitForNewBlock();
+    node.waitForNewBlock(200);
   }
 
   @Test
@@ -44,7 +44,7 @@ public class StartupAcceptanceTest extends AcceptanceTestBase {
     node2.copyDatabaseVersionFileToContainer(tempDatabaseVersionFile);
     node2.start();
     node2.waitForGenesisTime(genesisTime);
-    node2.waitForNewBlock();
+    node2.waitForNewBlock(200);
   }
 
   @Test

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/artemis/test/acceptance/StartupAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/artemis/test/acceptance/StartupAcceptanceTest.java
@@ -27,7 +27,7 @@ public class StartupAcceptanceTest extends AcceptanceTestBase {
     final ArtemisNode node = createArtemisNode();
     node.start();
     node.waitForGenesis();
-    node.waitForNewBlock(200);
+    node.waitForNewBlock(50);
   }
 
   @Test
@@ -44,7 +44,7 @@ public class StartupAcceptanceTest extends AcceptanceTestBase {
     node2.copyDatabaseVersionFileToContainer(tempDatabaseVersionFile);
     node2.start();
     node2.waitForGenesisTime(genesisTime);
-    node2.waitForNewBlock(200);
+    node2.waitForNewBlock(50);
   }
 
   @Test

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
@@ -145,8 +145,9 @@ public class ArtemisNode extends Node {
 
   public void waitForNewBlock(int timeoutSeconds) {
     final Bytes32 startingBlockRoot = waitForBeaconHead().block_root;
-    waitFor(() -> assertThat(fetchBeaconHead().get().block_root).isNotEqualTo(startingBlockRoot),
-            timeoutSeconds);
+    waitFor(
+        () -> assertThat(fetchBeaconHead().get().block_root).isNotEqualTo(startingBlockRoot),
+        timeoutSeconds);
   }
 
   public void waitForNewFinalization() {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
@@ -143,6 +143,12 @@ public class ArtemisNode extends Node {
     waitFor(() -> assertThat(fetchBeaconHead().get().block_root).isNotEqualTo(startingBlockRoot));
   }
 
+  public void waitForNewBlock(int timeoutSeconds) {
+    final Bytes32 startingBlockRoot = waitForBeaconHead().block_root;
+    waitFor(() -> assertThat(fetchBeaconHead().get().block_root).isNotEqualTo(startingBlockRoot),
+            timeoutSeconds);
+  }
+
   public void waitForNewFinalization() {
     UnsignedLong startingFinalizedEpoch = waitForChainHead().finalized_epoch;
     LOG.debug("Wait for finalized block");

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -362,7 +362,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   @Override
   public void onTick(Date date) {
-    if (chainStorageClient.isPreGenesis() || syncService.getSyncStatus().isSyncing()) {
+    if (chainStorageClient.isPreGenesis() || syncService.isSyncActive()) {
       return;
     }
     final UnsignedLong currentTime = UnsignedLong.valueOf(date.getTime() / 1000);

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -362,7 +362,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   @Override
   public void onTick(Date date) {
-    if (chainStorageClient.isPreGenesis() || syncService.isSyncActive()) {
+    if (chainStorageClient.isPreGenesis()) {
       return;
     }
     final UnsignedLong currentTime = UnsignedLong.valueOf(date.getTime() / 1000);
@@ -373,7 +373,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
         chainStorageClient
             .getGenesisTime()
             .plus(nodeSlot.times(UnsignedLong.valueOf(SECONDS_PER_SLOT)));
-    if (chainStorageClient.getStore().getTime().compareTo(nextSlotStartTime) >= 0) {
+    if (chainStorageClient.getStore().getTime().compareTo(nextSlotStartTime) >= 0 || !syncService.isSyncActive()) {
       processSlot();
     }
   }

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -373,7 +373,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
         chainStorageClient
             .getGenesisTime()
             .plus(nodeSlot.times(UnsignedLong.valueOf(SECONDS_PER_SLOT)));
-    if (chainStorageClient.getStore().getTime().compareTo(nextSlotStartTime) >= 0 || !syncService.isSyncActive()) {
+    if (chainStorageClient.getStore().getTime().compareTo(nextSlotStartTime) >= 0
+        || !syncService.isSyncActive()) {
       processSlot();
     }
   }

--- a/sync/build.gradle
+++ b/sync/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     integrationTestImplementation testFixtures(project(':util'))
 
     integrationTestImplementation 'org.mockito:mockito-core'
-//    integrationTestImplementation 'org.hyperledger.besu:plugin-api'
 
     testFixturesImplementation project(':services:serviceutils')
     testFixturesImplementation project(':util')

--- a/sync/src/main/java/tech/pegasys/artemis/sync/SyncService.java
+++ b/sync/src/main/java/tech/pegasys/artemis/sync/SyncService.java
@@ -53,4 +53,8 @@ public class SyncService extends Service {
   public SyncingStatus getSyncStatus() {
     return syncManager.getSyncStatus();
   }
+
+  public boolean isSyncActive() {
+    return syncManager.isSyncActive();
+  }
 }

--- a/util/src/testFixtures/java/tech/pegasys/artemis/util/Waiter.java
+++ b/util/src/testFixtures/java/tech/pegasys/artemis/util/Waiter.java
@@ -28,7 +28,7 @@ import org.awaitility.pollinterval.IterativePollInterval;
  */
 public class Waiter {
 
-  private static final int DEFAULT_TIMEOUT_SECONDS = 60;
+  private static final int DEFAULT_TIMEOUT_SECONDS = 90;
   private static final Duration INITIAL_POLL_INTERVAL = Duration.ofMillis(200);
   private static final Duration MAX_POLL_INTERVAL = Duration.ofSeconds(5);
 

--- a/util/src/testFixtures/java/tech/pegasys/artemis/util/Waiter.java
+++ b/util/src/testFixtures/java/tech/pegasys/artemis/util/Waiter.java
@@ -28,7 +28,7 @@ import org.awaitility.pollinterval.IterativePollInterval;
  */
 public class Waiter {
 
-  private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+  private static final int DEFAULT_TIMEOUT_SECONDS = 60;
   private static final Duration INITIAL_POLL_INTERVAL = Duration.ofMillis(200);
   private static final Duration MAX_POLL_INTERVAL = Duration.ofSeconds(5);
 

--- a/util/src/testFixtures/java/tech/pegasys/artemis/util/Waiter.java
+++ b/util/src/testFixtures/java/tech/pegasys/artemis/util/Waiter.java
@@ -28,7 +28,7 @@ import org.awaitility.pollinterval.IterativePollInterval;
  */
 public class Waiter {
 
-  private static final int DEFAULT_TIMEOUT_SECONDS = 180;
+  private static final int DEFAULT_TIMEOUT_SECONDS = 30;
   private static final Duration INITIAL_POLL_INTERVAL = Duration.ofMillis(200);
   private static final Duration MAX_POLL_INTERVAL = Duration.ofSeconds(5);
 

--- a/util/src/testFixtures/java/tech/pegasys/artemis/util/Waiter.java
+++ b/util/src/testFixtures/java/tech/pegasys/artemis/util/Waiter.java
@@ -28,7 +28,7 @@ import org.awaitility.pollinterval.IterativePollInterval;
  */
 public class Waiter {
 
-  private static final int DEFAULT_TIMEOUT_SECONDS = 90;
+  private static final int DEFAULT_TIMEOUT_SECONDS = 180;
   private static final Duration INITIAL_POLL_INTERVAL = Duration.ofMillis(200);
   private static final Duration MAX_POLL_INTERVAL = Duration.ofSeconds(5);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Only check the syncActive boolean onTick events, do not create a SyncStatus. Also, change the default timeout seconds because acceptance tests are failing due to our slow startup.