### PR TITLE
Create attestation for correct slot and include attestation_committee_position

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/artemis/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/artemis/api/ValidatorDataProvider.java
@@ -114,13 +114,14 @@ public class ValidatorDataProvider {
       final tech.pegasys.artemis.validator.api.ValidatorDuties duty) {
     final BLSPubKey pubKey = new BLSPubKey(duty.getPublicKey().toBytesCompressed());
     if (duty.getDuties().isEmpty()) {
-      return new ValidatorDuties(pubKey, null, null, emptyList(), null);
+      return new ValidatorDuties(pubKey, null, null, null, emptyList(), null);
     }
     final Duties duties = duty.getDuties().get();
     return new ValidatorDuties(
         pubKey,
         duties.getValidatorIndex(),
         duties.getAttestationCommitteeIndex(),
+        duties.getAttestationCommitteePosition(),
         duties.getBlockProposalSlots(),
         duties.getAttestationSlot());
   }

--- a/data/provider/src/main/java/tech/pegasys/artemis/api/schema/ValidatorDuties.java
+++ b/data/provider/src/main/java/tech/pegasys/artemis/api/schema/ValidatorDuties.java
@@ -20,6 +20,7 @@ public class ValidatorDuties {
   public final BLSPubKey validator_pubkey;
   public final Integer validator_index;
   public final Integer attestation_committee_index;
+  public final Integer attestation_committee_position;
   public final List<UnsignedLong> block_proposal_slots;
   public final UnsignedLong attestation_slot;
 
@@ -27,11 +28,13 @@ public class ValidatorDuties {
       BLSPubKey validator_pubkey,
       Integer validator_index,
       Integer attestation_committee_index,
+      Integer attestation_committee_position,
       List<UnsignedLong> block_proposal_slots,
       UnsignedLong attestation_slot) {
     this.validator_pubkey = validator_pubkey;
     this.validator_index = validator_index;
     this.attestation_committee_index = attestation_committee_index;
+    this.attestation_committee_position = attestation_committee_position;
     this.block_proposal_slots = block_proposal_slots;
     this.attestation_slot = attestation_slot;
   }

--- a/data/provider/src/test/java/tech/pegasys/artemis/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/artemis/api/ValidatorDataProviderTest.java
@@ -160,7 +160,7 @@ public class ValidatorDataProviderTest {
     assertThat(validatorDuties.size()).isEqualTo(1);
     ValidatorDuties expected =
         new ValidatorDuties(
-            new BLSPubKey(publicKey.toBytesCompressed()), null, null, emptyList(), null);
+            new BLSPubKey(publicKey.toBytesCompressed()), null, null, null, emptyList(), null);
     assertThat(validatorDuties.get(0)).isEqualToComparingFieldByField(expected);
   }
 
@@ -201,6 +201,7 @@ public class ValidatorDataProviderTest {
             List.of(new BLSPubKey(publicKey.toBytesCompressed())));
     final int validatorIndex = 4;
     final int attestationCommitteeIndex = 2;
+    final int attestationCommitteePosition = 5;
     final List<UnsignedLong> blockProposalSlots =
         List.of(UnsignedLong.valueOf(66), UnsignedLong.valueOf(77));
     final UnsignedLong attestationSlot = UnsignedLong.valueOf(50);
@@ -213,6 +214,7 @@ public class ValidatorDataProviderTest {
                             publicKey,
                             validatorIndex,
                             attestationCommitteeIndex,
+                            attestationCommitteePosition,
                             blockProposalSlots,
                             attestationSlot)))));
 
@@ -227,6 +229,7 @@ public class ValidatorDataProviderTest {
             new BLSPubKey(publicKey.toBytesCompressed()),
             validatorIndex,
             attestationCommitteeIndex,
+            attestationCommitteePosition,
             blockProposalSlots,
             attestationSlot);
     assertThat(validatorDuties.get(0)).isEqualToComparingFieldByField(expected);

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
@@ -13,10 +13,10 @@
 
 package tech.pegasys.artemis.datastructures.util;
 
+import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_signing_root;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_block_root_at_slot;
-import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_current_epoch;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.get_domain;
 import static tech.pegasys.artemis.datastructures.util.CommitteeUtil.get_beacon_committee;
 import static tech.pegasys.artemis.util.config.Constants.DOMAIN_BEACON_ATTESTER;
@@ -219,17 +219,18 @@ public class AttestationUtil {
   }
 
   // Get attestation data that does not include attester specific shard or crosslink information
-  public static AttestationData getGenericAttestationData(BeaconState state, BeaconBlock block) {
-    UnsignedLong slot = state.getSlot();
+  public static AttestationData getGenericAttestationData(
+      UnsignedLong slot, BeaconState state, BeaconBlock block) {
+    UnsignedLong epoch = compute_epoch_at_slot(slot);
     // Get variables necessary that can be shared among Attestations of all validators
     Bytes32 beacon_block_root = block.hash_tree_root();
-    UnsignedLong start_slot = compute_start_slot_at_epoch(get_current_epoch(state));
+    UnsignedLong start_slot = compute_start_slot_at_epoch(epoch);
     Bytes32 epoch_boundary_block_root =
-        start_slot.compareTo(slot) == 0
+        start_slot.compareTo(slot) == 0 || state.getSlot().compareTo(start_slot) <= 0
             ? block.hash_tree_root()
             : get_block_root_at_slot(state, start_slot);
     Checkpoint source = state.getCurrent_justified_checkpoint();
-    Checkpoint target = new Checkpoint(get_current_epoch(state), epoch_boundary_block_root);
+    Checkpoint target = new Checkpoint(epoch, epoch_boundary_block_root);
 
     // Set attestation data
     return new AttestationData(slot, UnsignedLong.ZERO, beacon_block_root, source, target);

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/artemis/statetransition/AttestationGenerator.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/artemis/statetransition/AttestationGenerator.java
@@ -200,7 +200,7 @@ public class AttestationGenerator {
     Committee committee = new Committee(committeeIndex, committeeIndices);
     int indexIntoCommittee = committeeIndices.indexOf(validatorIndex);
     AttestationData genericAttestationData =
-        AttestationUtil.getGenericAttestationData(postState, block);
+        AttestationUtil.getGenericAttestationData(postState.getSlot(), postState, block);
 
     final BLSKeyPair validatorKeyPair =
         withValidSignature ? validatorKeys.get(validatorIndex) : randomKeyPair;
@@ -234,7 +234,7 @@ public class AttestationGenerator {
       Committee committee = new Committee(committeeIndex, committeeIndices);
       int indexIntoCommittee = committeeIndices.indexOf(validatorIndex);
       AttestationData genericAttestationData =
-          AttestationUtil.getGenericAttestationData(state, block);
+          AttestationUtil.getGenericAttestationData(state.getSlot(), state, block);
       final BLSKeyPair validatorKeyPair = validatorKeys.get(validatorIndex);
       attestations.add(
           createAttestation(

--- a/validator/api/src/main/java/tech/pegasys/artemis/validator/api/ValidatorDuties.java
+++ b/validator/api/src/main/java/tech/pegasys/artemis/validator/api/ValidatorDuties.java
@@ -33,13 +33,18 @@ public class ValidatorDuties {
       final BLSPublicKey publicKey,
       final int validatorIndex,
       final int attestationCommitteeIndex,
+      final int attestationCommitteePosition,
       final List<UnsignedLong> blockProposalSlots,
       final UnsignedLong attestationSlot) {
     return new ValidatorDuties(
         publicKey,
         Optional.of(
             new Duties(
-                validatorIndex, attestationCommitteeIndex, blockProposalSlots, attestationSlot)));
+                validatorIndex,
+                attestationCommitteeIndex,
+                attestationCommitteePosition,
+                blockProposalSlots,
+                attestationSlot)));
   }
 
   public static ValidatorDuties noDuties(final BLSPublicKey publicKey) {
@@ -82,16 +87,19 @@ public class ValidatorDuties {
   public static class Duties {
     private final int validatorIndex;
     private final int attestationCommitteeIndex;
+    private final int attestationCommitteePosition;
     private final List<UnsignedLong> blockProposalSlots;
     private final UnsignedLong attestationSlot;
 
     public Duties(
         final int validatorIndex,
         final int attestationCommitteeIndex,
+        final int attestationCommitteePosition,
         final List<UnsignedLong> blockProposalSlots,
         final UnsignedLong attestationSlot) {
       this.validatorIndex = validatorIndex;
       this.attestationCommitteeIndex = attestationCommitteeIndex;
+      this.attestationCommitteePosition = attestationCommitteePosition;
       this.blockProposalSlots = blockProposalSlots;
       this.attestationSlot = attestationSlot;
     }
@@ -102,6 +110,10 @@ public class ValidatorDuties {
 
     public int getAttestationCommitteeIndex() {
       return attestationCommitteeIndex;
+    }
+
+    public int getAttestationCommitteePosition() {
+      return attestationCommitteePosition;
     }
 
     public List<UnsignedLong> getBlockProposalSlots() {
@@ -123,6 +135,7 @@ public class ValidatorDuties {
       final Duties duties = (Duties) o;
       return validatorIndex == duties.validatorIndex
           && attestationCommitteeIndex == duties.attestationCommitteeIndex
+          && attestationCommitteePosition == duties.attestationCommitteePosition
           && Objects.equals(blockProposalSlots, duties.blockProposalSlots)
           && Objects.equals(attestationSlot, duties.attestationSlot);
     }
@@ -130,7 +143,11 @@ public class ValidatorDuties {
     @Override
     public int hashCode() {
       return Objects.hash(
-          validatorIndex, attestationCommitteeIndex, blockProposalSlots, attestationSlot);
+          validatorIndex,
+          attestationCommitteeIndex,
+          attestationCommitteePosition,
+          blockProposalSlots,
+          attestationSlot);
     }
 
     @Override
@@ -138,6 +155,7 @@ public class ValidatorDuties {
       return MoreObjects.toStringHelper(this)
           .add("validatorIndex", validatorIndex)
           .add("attestationCommitteeIndex", attestationCommitteeIndex)
+          .add("attestationCommitteePosition", attestationCommitteePosition)
           .add("blockProposalSlots", blockProposalSlots)
           .add("attestationSlot", attestationSlot)
           .toString();

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorApiHandler.java
@@ -145,7 +145,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                     + (committeeCount - 1));
           }
           final AttestationData attestationData =
-              AttestationUtil.getGenericAttestationData(state, block);
+              AttestationUtil.getGenericAttestationData(slot, state, block);
           final List<Integer> committee =
               CommitteeUtil.get_beacon_committee(state, slot, UnsignedLong.valueOf(committeeIndex));
 
@@ -203,6 +203,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
         key,
         validatorIndex,
         Math.toIntExact(committeeAssignment.getCommitteeIndex().longValue()),
+        committeeAssignment.getCommittee().indexOf(validatorIndex),
         proposerSlots,
         committeeAssignment.getSlot());
   }

--- a/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/ValidatorApiHandlerTest.java
@@ -99,7 +99,7 @@ class ValidatorApiHandlerTest {
     assertThat(duties.get())
         .containsExactly(
             ValidatorDuties.withDuties(
-                publicKey, validatorIndex, 0, emptyList(), UnsignedLong.valueOf(110)));
+                publicKey, validatorIndex, 0, 2, emptyList(), UnsignedLong.valueOf(110)));
   }
 
   @Test
@@ -116,12 +116,13 @@ class ValidatorApiHandlerTest {
             EPOCH, List.of(validator3Key, unknownPublicKey, validator31Key));
     final Optional<List<ValidatorDuties>> duties = assertCompletedSuccessfully(result);
     final ValidatorDuties validator3Duties =
-        ValidatorDuties.withDuties(validator3Key, 3, 0, emptyList(), UnsignedLong.valueOf(110));
+        ValidatorDuties.withDuties(validator3Key, 3, 0, 2, emptyList(), UnsignedLong.valueOf(110));
     final ValidatorDuties unknownValidatorDuties = ValidatorDuties.noDuties(unknownPublicKey);
     final ValidatorDuties validator6Duties =
         ValidatorDuties.withDuties(
             validator31Key,
             31,
+            0,
             0,
             List.of(UnsignedLong.valueOf(107), UnsignedLong.valueOf(111)),
             UnsignedLong.valueOf(104));
@@ -187,9 +188,9 @@ class ValidatorApiHandlerTest {
 
   @Test
   public void createUnsignedAttestation_shouldCreateAttestation() {
-    final UnsignedLong slot = UnsignedLong.valueOf(26);
     final Bytes32 blockRoot = dataStructureUtil.randomBytes32();
     final BeaconState state = createStateWithActiveValidators();
+    final UnsignedLong slot = state.getSlot().plus(UnsignedLong.valueOf(5));
     final BeaconBlock block = dataStructureUtil.randomBeaconBlock(state.getSlot().longValue());
 
     when(chainDataClient.getBestBlockRoot()).thenReturn(Optional.of(blockRoot));
@@ -207,7 +208,8 @@ class ValidatorApiHandlerTest {
     assertThat(attestation.getAggregation_bits())
         .isEqualTo(new Bitlist(4, Constants.MAX_VALIDATORS_PER_COMMITTEE));
     assertThat(attestation.getData())
-        .isEqualTo(AttestationUtil.getGenericAttestationData(state, block));
+        .isEqualTo(AttestationUtil.getGenericAttestationData(slot, state, block));
+    assertThat(attestation.getData().getSlot()).isEqualTo(slot);
     assertThat(attestation.getAggregate_signature().toBytes())
         .isEqualTo(BLSSignature.empty().toBytes());
   }


### PR DESCRIPTION
## PR Description
When Teku was creating an attestation for a slot after one or more empty slots, it would incorrectly use the slot of the last block in the attestation data instead of the slot the validator was scheduled to create an attestation in.

In Validator Duties, Teku's response was missing the attestation_committee_position which is required for the validator client to set the attestation bit correctly when generating attestations.