### PR TITLE
Fix docker upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -667,6 +667,6 @@ task dockerUpload(type: Exec) {
   additionalTags.each { tag ->
     cmd.add("docker tag '${image}' '${imageName}:${tag.trim()}' && docker push '${imageName}:${tag.trim()}'")
   }
-  executable "echo"
+  executable "sh"
   args '-c', cmd.join(' && ')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -653,8 +653,8 @@ task dockerUpload(type: Exec) {
   def imageRepos = 'pegasyseng'
   def imageName = "${imageRepos}/teku"
   def image = "${imageName}:develop"
-  def cmd = "docker push ${imageName}:${rootProject.version}"
-  def additionalTags = []
+  def cmd = []
+  def additionalTags = ["${rootProject.version}"]
   if (project.hasProperty('branch') && project.property('branch') == 'master') {
     additionalTags.add('develop')
   }
@@ -665,8 +665,8 @@ task dockerUpload(type: Exec) {
   }
 
   additionalTags.each { tag ->
-    cmd += " && docker tag '${image}' '${imageName}:${tag.trim()}' && docker push '${imageName}:${tag.trim()}'"
+    cmd.add("docker tag '${image}' '${imageName}:${tag.trim()}' && docker push '${imageName}:${tag.trim()}'")
   }
-  executable "sh"
-  args "-c", cmd
+  executable "echo"
+  args '-c', cmd.join(' && ')
 }


### PR DESCRIPTION
## PR Description
Our docker build tags the image as `develop` but our upload was expecting to be able to push `rootProject.version` without first adding that tag to the develop image. As a result, the image wasn't found and the upload failed.