### PR TITLE
Modify allOf to capture all errors thrown by the futures

### DIFF
--- a/util/src/test/java/tech/pegasys/artemis/util/async/SafeFutureTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/async/SafeFutureTest.java
@@ -486,6 +486,30 @@ public class SafeFutureTest {
   }
 
   @Test
+  public void allOf_shouldAddAllSuppressedExceptions() {
+    final Throwable error1 = new RuntimeException("Nope");
+    final Throwable error2 = new RuntimeException("Oh dear");
+    final SafeFuture<Void> future1 = new SafeFuture<>();
+    final SafeFuture<Void> future2 = new SafeFuture<>();
+    final SafeFuture<Void> future3 = new SafeFuture<>();
+
+    final SafeFuture<Void> result = SafeFuture.allOf(future1, future2, future3);
+    assertThat(result).isNotDone();
+
+    future2.completeExceptionally(error2);
+    assertThat(result).isNotDone();
+
+    future3.complete(null);
+    assertThat(result).isNotDone();
+
+    future1.completeExceptionally(error1);
+
+    assertThat(result).isCompletedExceptionally();
+    assertThatThrownBy(result::join).hasSuppressedException(error2);
+    assertThatThrownBy(result::join).hasRootCause(error1);
+  }
+
+  @Test
   public void allOfFailFast_failImmediatelyWhenAnyFutureFails() {
     final SafeFuture<Void> future1 = new SafeFuture<>();
     final SafeFuture<Void> future2 = new SafeFuture<>();

--- a/util/src/test/java/tech/pegasys/artemis/util/async/SafeFutureTest.java
+++ b/util/src/test/java/tech/pegasys/artemis/util/async/SafeFutureTest.java
@@ -510,6 +510,21 @@ public class SafeFutureTest {
   }
 
   @Test
+  public void allof_shouldCompleteWhenAllFuturesComplete() {
+    final SafeFuture<Void> future1 = new SafeFuture<>();
+    final SafeFuture<Void> future2 = new SafeFuture<>();
+
+    final SafeFuture<Void> result = SafeFuture.allOf(future1, future2);
+    assertThat(result).isNotDone();
+
+    future1.complete(null);
+    assertThat(result).isNotDone();
+
+    future2.complete(null);
+    assertThat(result).isCompletedWithValue(null);
+  }
+
+  @Test
   public void allOfFailFast_failImmediatelyWhenAnyFutureFails() {
     final SafeFuture<Void> future1 = new SafeFuture<>();
     final SafeFuture<Void> future2 = new SafeFuture<>();


### PR DESCRIPTION
## PR Description
Normally when some futures fail, `allOf` will return a failed future with a `CompletionException` that has a root cause of one of those errors.  The other errors are silently ignored.

This modified `SafeFuture` so that when `allOf` encounters errors, any errors that would have been silently ignored are added as suppressed exceptions to the `CompletionException`.