### PR TITLE
Set attestation data index correctly when generating unsigned attestatations

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/AttestationData.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/operations/AttestationData.java
@@ -142,10 +142,6 @@ public class AttestationData extends AbstractImmutableContainer<AttestationData>
     return ((Checkpoint) get(4));
   }
 
-  public AttestationData withIndex(final UnsignedLong index) {
-    return new AttestationData(getSlot(), index, getBeacon_block_root(), getSource(), getTarget());
-  }
-
   @Override
   public Bytes32 hash_tree_root() {
     return hashTreeRoot();

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
@@ -220,7 +220,7 @@ public class AttestationUtil {
 
   // Get attestation data that does not include attester specific shard or crosslink information
   public static AttestationData getGenericAttestationData(
-      UnsignedLong slot, BeaconState state, BeaconBlock block) {
+      UnsignedLong slot, BeaconState state, BeaconBlock block, final UnsignedLong committeeIndex) {
     UnsignedLong epoch = compute_epoch_at_slot(slot);
     // Get variables necessary that can be shared among Attestations of all validators
     Bytes32 beacon_block_root = block.hash_tree_root();
@@ -233,6 +233,6 @@ public class AttestationUtil {
     Checkpoint target = new Checkpoint(epoch, epoch_boundary_block_root);
 
     // Set attestation data
-    return new AttestationData(slot, UnsignedLong.ZERO, beacon_block_root, source, target);
+    return new AttestationData(slot, committeeIndex, beacon_block_root, source, target);
   }
 }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/artemis/statetransition/AttestationGenerator.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/artemis/statetransition/AttestationGenerator.java
@@ -200,7 +200,8 @@ public class AttestationGenerator {
     Committee committee = new Committee(committeeIndex, committeeIndices);
     int indexIntoCommittee = committeeIndices.indexOf(validatorIndex);
     AttestationData genericAttestationData =
-        AttestationUtil.getGenericAttestationData(postState.getSlot(), postState, block);
+        AttestationUtil.getGenericAttestationData(
+            postState.getSlot(), postState, block, committeeIndex);
 
     final BLSKeyPair validatorKeyPair =
         withValidSignature ? validatorKeys.get(validatorIndex) : randomKeyPair;
@@ -234,7 +235,7 @@ public class AttestationGenerator {
       Committee committee = new Committee(committeeIndex, committeeIndices);
       int indexIntoCommittee = committeeIndices.indexOf(validatorIndex);
       AttestationData genericAttestationData =
-          AttestationUtil.getGenericAttestationData(state.getSlot(), state, block);
+          AttestationUtil.getGenericAttestationData(state.getSlot(), state, block, committeeIndex);
       final BLSKeyPair validatorKeyPair = validatorKeys.get(validatorIndex);
       attestations.add(
           createAttestation(
@@ -258,11 +259,10 @@ public class AttestationGenerator {
       BLSKeyPair attesterKeyPair,
       int indexIntoCommittee,
       Committee committee,
-      AttestationData genericAttestationData) {
+      AttestationData attestationData) {
     int committeSize = committee.getCommitteeSize();
     Bitlist aggregationBitfield =
         AttestationUtil.getAggregationBits(committeSize, indexIntoCommittee);
-    AttestationData attestationData = genericAttestationData.withIndex(committee.getIndex());
 
     BLSSignature signature =
         new Signer(new LocalMessageSignerService(attesterKeyPair))

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorApiHandler.java
@@ -144,10 +144,11 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                     + " - expected between 0 and "
                     + (committeeCount - 1));
           }
+          final UnsignedLong committeeIndexUnsigned = UnsignedLong.valueOf(committeeIndex);
           final AttestationData attestationData =
-              AttestationUtil.getGenericAttestationData(slot, state, block);
+              AttestationUtil.getGenericAttestationData(slot, state, block, committeeIndexUnsigned);
           final List<Integer> committee =
-              CommitteeUtil.get_beacon_committee(state, slot, UnsignedLong.valueOf(committeeIndex));
+              CommitteeUtil.get_beacon_committee(state, slot, committeeIndexUnsigned);
 
           final Bitlist aggregationBits =
               new Bitlist(committee.size(), MAX_VALIDATORS_PER_COMMITTEE);

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinator.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorCoordinator.java
@@ -264,8 +264,7 @@ public class ValidatorCoordinator extends Service implements SlotEventsChannel {
       final AttesterInformation attester) {
     final Bitlist aggregationBitlist = new Bitlist(unsignedAttestation.getAggregation_bits());
     aggregationBitlist.setBit(attester.getIndexIntoCommittee());
-    final AttestationData attestationData =
-        unsignedAttestation.getData().withIndex(attester.getCommittee().getIndex());
+    final AttestationData attestationData = unsignedAttestation.getData();
     return signAttestation(state, attester.getPublicKey(), attestationData)
         .thenApply(signature -> new Attestation(aggregationBitlist, attestationData, signature));
   }

--- a/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/ValidatorApiHandlerTest.java
@@ -198,8 +198,9 @@ class ValidatorApiHandlerTest {
     when(chainDataClient.getBlockAndStateInEffectAtSlot(slot, blockRoot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(new BeaconBlockAndState(block, state))));
 
+    final int committeeIndex = 0;
     final SafeFuture<Optional<Attestation>> result =
-        validatorApiHandler.createUnsignedAttestation(slot, 0);
+        validatorApiHandler.createUnsignedAttestation(slot, committeeIndex);
 
     assertThat(result).isCompleted();
     final Optional<Attestation> maybeAttestation = result.join();
@@ -208,7 +209,9 @@ class ValidatorApiHandlerTest {
     assertThat(attestation.getAggregation_bits())
         .isEqualTo(new Bitlist(4, Constants.MAX_VALIDATORS_PER_COMMITTEE));
     assertThat(attestation.getData())
-        .isEqualTo(AttestationUtil.getGenericAttestationData(slot, state, block));
+        .isEqualTo(
+            AttestationUtil.getGenericAttestationData(
+                slot, state, block, UnsignedLong.valueOf(committeeIndex)));
     assertThat(attestation.getData().getSlot()).isEqualTo(slot);
     assertThat(attestation.getAggregate_signature().toBytes())
         .isEqualTo(BLSSignature.empty().toBytes());


### PR DESCRIPTION
## PR Description
The call to create an unsigned attestation includes the committee index, so we should set it in the generated `AttestationData`.  Previously this was incorrectly left to be set as part of the signing process.