### PR TITLE
Prevent loss of exception by logging

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/artemis/beaconrestapi/BeaconRestApi.java
@@ -91,7 +91,7 @@ public class BeaconRestApi {
               ctx.contentType("text/html");
             });
       } catch (IOException ex) {
-        LOG.error("Could not read custom " + FILE_NOT_FOUND_HTML, ex.getMessage());
+        LOG.error("Could not read custom " + FILE_NOT_FOUND_HTML, ex);
       }
     }
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
When logging the exception, the message is lost as there are no `{}` in the primary string.

The exception either needs to logged as such, or if converted to a string then changing the message to include the argument substitution.

