### PR TITLE
Fix scheduling of duties when each slot in an epoch has been processed

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/DutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/DutyScheduler.java
@@ -71,7 +71,7 @@ public class DutyScheduler implements ValidatorTimingChannel {
               currentEpoch = currentEpoch.plus(UnsignedLong.ONE)) {
             scheduleDutiesForEpoch(currentEpoch).reportExceptions();
           }
-          return startEpoch.compareTo(endEpoch) > 0 ? startEpoch : endEpoch;
+          return startEpoch.compareTo(endEpoch) > 0 ? lastRequestedEpoch : endEpoch;
         });
   }
 

--- a/validator/client/src/test/java/tech/pegasys/artemis/validator/client/DutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/artemis/validator/client/DutySchedulerTest.java
@@ -80,6 +80,21 @@ class DutySchedulerTest {
   }
 
   @Test
+  public void shouldFetchDutiresForSecondEpochWhenFirstEpochReached() {
+    validatorClient.onSlot(UnsignedLong.ZERO);
+
+    verify(validatorApiChannel).getDuties(UnsignedLong.ZERO, VALIDATOR_KEYS);
+    verify(validatorApiChannel).getDuties(UnsignedLong.ONE, VALIDATOR_KEYS);
+
+    // Process each slot up to the start of epoch 1
+    final UnsignedLong epoch1Start = compute_start_slot_at_epoch(UnsignedLong.ONE);
+    for (int slot = 0; slot <= epoch1Start.intValue(); slot++) {
+      validatorClient.onSlot(UnsignedLong.valueOf(slot));
+    }
+    verify(validatorApiChannel).getDuties(UnsignedLong.valueOf(2), VALIDATOR_KEYS);
+  }
+
+  @Test
   public void shouldNotRefetchDutiesWhichHaveAlreadyBeenRetrieved() {
     when(validatorApiChannel.getDuties(any(), any())).thenReturn(new SafeFuture<>());
     validatorClient.onSlot(compute_start_slot_at_epoch(UnsignedLong.ONE));


### PR DESCRIPTION
## PR Description
The logic in `DutyScheduler` for avoiding requesting duties for the same epoch multiple times had a bug which caused it to not request the next epoch if it had processed multiple slots in the previous epoch.

Add a test to cover this case and fix the bug.