### PR TITLE
[BC-332] Fix sync failing to start after genesis

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/ForkChoiceUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/ForkChoiceUtil.java
@@ -64,7 +64,7 @@ public class ForkChoiceUtil {
   }
 
   public static UnsignedLong get_current_slot(ReadOnlyStore store) {
-    return get_current_slot(store, true);
+    return get_current_slot(store, false);
   }
 
   public static UnsignedLong compute_slots_since_epoch_start(UnsignedLong slot) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/ForkChoiceUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/ForkChoiceUtil.java
@@ -64,7 +64,7 @@ public class ForkChoiceUtil {
   }
 
   public static UnsignedLong get_current_slot(ReadOnlyStore store) {
-    return get_current_slot(store, false);
+    return get_current_slot(store, true);
   }
 
   public static UnsignedLong compute_slots_since_epoch_start(UnsignedLong slot) {

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -423,15 +423,16 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     final UnsignedLong currentTime = UnsignedLong.valueOf(date.getTime() / 1000);
     final boolean nextSlotDue = isNextSlotDue(currentTime);
 
+    final Store.Transaction transaction = recentChainData.startStoreTransaction();
+    on_tick(transaction, currentTime);
+    transaction.commit().join();
+
     if (syncService.isSyncActive()) {
       if (nextSlotDue) {
         processSlotWhileSyncing();
       }
       return;
     }
-    final Store.Transaction transaction = recentChainData.startStoreTransaction();
-    on_tick(transaction, currentTime);
-    transaction.commit().join();
     if (nextSlotDue) {
       processSlot();
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Fixes sync failing to start after genesis.

Previously, the `store.time` would not get updated during initial sync, and thus when we requested the first block during sync, and tried to import it, we would think that the block is from the future, due to our `ForkChoiceUtil.get_slots_since_genesis` method returning a faulty slot number.