### PR TITLE
Fix divide by zero when TARGET_AGGREGATORS_PER_COMMITTEE is zero

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/CommitteeUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/CommitteeUtil.java
@@ -264,6 +264,8 @@ public class CommitteeUtil {
   }
 
   public static int getAggregatorModulo(final int committeeSize) {
-    return Math.max(1, committeeSize / TARGET_AGGREGATORS_PER_COMMITTEE);
+    return TARGET_AGGREGATORS_PER_COMMITTEE == 0
+        ? 1
+        : Math.max(1, committeeSize / TARGET_AGGREGATORS_PER_COMMITTEE);
   }
 }


### PR DESCRIPTION
## PR Description
Lighthouse testnet5 sets `TARGET_AGGREGATORS_PER_COMMITTEE` to zero.  If Teku is running validators when it computes the committees it throws a divide by 0 exception:

```
java.util.concurrent.CompletionException: java.lang.ArithmeticException: / by zero
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:314) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:319) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:932) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:907) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073) ~[?:?]
	at tech.pegasys.artemis.storage.client.RecentChainData.updateBestBlock(RecentChainData.java:134) ~[classes/:?]
	at tech.pegasys.artemis.statetransition.StateProcessor.processHead(StateProcessor.java:47) ~[classes/:?]
	at tech.pegasys.artemis.services.beaconchain.BeaconChainController.processSlot(BeaconChainController.java:464) ~[classes/:?]
	at tech.pegasys.artemis.services.beaconchain.BeaconChainController.onTick(BeaconChainController.java:436) ~[classes/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at tech.pegasys.artemis.events.DirectEventDeliverer.executeMethod(DirectEventDeliverer.java:67) ~[classes/:?]
	at tech.pegasys.artemis.events.DirectEventDeliverer.deliverTo(DirectEventDeliverer.java:54) ~[classes/:?]
	at tech.pegasys.artemis.events.AsyncEventDeliverer.lambda$deliverTo$0(AsyncEventDeliverer.java:60) ~[classes/:?]
	at tech.pegasys.artemis.events.AsyncEventDeliverer$QueueReader.deliverNextEvent(AsyncEventDeliverer.java:111) [classes/:?]
	at tech.pegasys.artemis.events.AsyncEventDeliverer$QueueReader.run(AsyncEventDeliverer.java:103) [classes/:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
Caused by: java.lang.ArithmeticException: / by zero
	at tech.pegasys.artemis.datastructures.util.CommitteeUtil.getAggregatorModulo(CommitteeUtil.java:267) ~[classes/:?]
	at tech.pegasys.artemis.validator.coordinator.CommitteeAssignmentManager.is_aggregator(CommitteeAssignmentManager.java:156) ~[classes/:?]
	at tech.pegasys.artemis.validator.coordinator.CommitteeAssignmentManager.lambda$getNewCommitteeAssignments$2(CommitteeAssignmentManager.java:123) ~[classes/:?]
	at java.util.Optional.ifPresent(Optional.java:183) ~[?:?]
	at tech.pegasys.artemis.validator.coordinator.CommitteeAssignmentManager.lambda$getNewCommitteeAssignments$3(CommitteeAssignmentManager.java:117) ~[classes/:?]
	at java.util.HashMap.forEach(HashMap.java:1336) ~[?:?]
	at tech.pegasys.artemis.validator.coordinator.CommitteeAssignmentManager.getNewCommitteeAssignments(CommitteeAssignmentManager.java:107) ~[classes/:?]
	at tech.pegasys.artemis.validator.coordinator.CommitteeAssignmentManager.updateCommitteeAssignments(CommitteeAssignmentManager.java:58) ~[classes/:?]
	at tech.pegasys.artemis.validator.coordinator.ValidatorCoordinator.onBestBlockInitialized(ValidatorCoordinator.java:143) ~[classes/:?]
	at tech.pegasys.artemis.util.async.SafeFuture.lambda$always$10(SafeFuture.java:200) ~[classes/:?]
	at tech.pegasys.artemis.util.async.SafeFuture.lambda$finish$12(SafeFuture.java:209) ~[classes/:?]
	at java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:930) ~[?:?]
	... 19 more
```