### PR TITLE
[#1534] validator generate subcommand --number-of-validators

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisDepositSender.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisDepositSender.java
@@ -43,7 +43,7 @@ public class ArtemisDepositSender extends Node {
         ENCRYPTED_KEYSTORE_ENABLED,
         "--eth1-deposit-contract-address",
         eth1Node.getDepositContractAddress(),
-        "--Xnumber-of-validators",
+        "--number-of-validators",
         Integer.toString(numberOfValidators),
         "--eth1-private-key",
         eth1Node.getRichBenefactorKey(),

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/deposit/DepositGenerateCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/deposit/DepositGenerateCommand.java
@@ -31,11 +31,13 @@ import java.util.function.Function;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.ITypeConverter;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParameterException;
 import picocli.CommandLine.Spec;
+import picocli.CommandLine.TypeConversionException;
 import tech.pegasys.artemis.services.powchain.DepositTransactionSender;
 import tech.pegasys.artemis.util.async.SafeFuture;
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
@@ -65,10 +67,10 @@ public class DepositGenerateCommand implements Runnable {
   @Mixin private CommonParams params;
 
   @Option(
-      names = {"--Xnumber-of-validators"},
+      names = {"--number-of-validators"},
       paramLabel = "<NUMBER>",
       description = "The number of validators to create keys for and register",
-      hidden = true,
+      converter = NumberOfValidatorConverter.class,
       defaultValue = "1")
   private int validatorCount = 1;
 
@@ -272,6 +274,22 @@ public class DepositGenerateCommand implements Runnable {
     @Override
     public String getPasswordEnvironmentVariable() {
       return withdrawalPasswordEnv;
+    }
+  }
+
+  private static class NumberOfValidatorConverter implements ITypeConverter<Integer> {
+    @Override
+    public Integer convert(final String value) throws TypeConversionException {
+      try {
+        final int validatorCount = Integer.parseInt(value);
+        if (validatorCount <= 0) {
+          throw new TypeConversionException("Invalid value: must be a positive number");
+        }
+        return validatorCount;
+      } catch (final NumberFormatException e) {
+        throw new TypeConversionException(
+            "Invalid format: must be a numeric value but was " + value);
+      }
     }
   }
 }

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/deposit/DepositGenerateCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/deposit/DepositGenerateCommand.java
@@ -70,7 +70,7 @@ public class DepositGenerateCommand implements Runnable {
       names = {"--number-of-validators"},
       paramLabel = "<NUMBER>",
       description = "The number of validators to create keys for and register",
-      converter = NumberOfValidatorConverter.class,
+      converter = PositiveIntegerTypeConverter.class,
       defaultValue = "1")
   private int validatorCount = 1;
 
@@ -277,18 +277,18 @@ public class DepositGenerateCommand implements Runnable {
     }
   }
 
-  private static class NumberOfValidatorConverter implements ITypeConverter<Integer> {
+  private static class PositiveIntegerTypeConverter implements ITypeConverter<Integer> {
     @Override
     public Integer convert(final String value) throws TypeConversionException {
       try {
-        final int validatorCount = Integer.parseInt(value);
-        if (validatorCount <= 0) {
-          throw new TypeConversionException("Invalid value: must be a positive number");
+        final int parsedValue = Integer.parseInt(value);
+        if (parsedValue <= 0) {
+          throw new TypeConversionException("Must be a positive number");
         }
-        return validatorCount;
+        return parsedValue;
       } catch (final NumberFormatException e) {
         throw new TypeConversionException(
-            "Invalid format: must be a numeric value but was " + value);
+            "Invalid format: must be a numeric value but was '" + value + "'");
       }
     }
   }


### PR DESCRIPTION
Make dev option `--Xnumber-of-validators` as standard option `--number-of-validators` in `validator generate` subcommand. Specifying a large number of validators, such as 64, is a standard use case in testnets.

Signed-off-by: Usman Saleem <usman@usmans.info>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->
