### PR TITLE
Perform aggregation duties in validator client service

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/CommitteeUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/CommitteeUtil.java
@@ -38,6 +38,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.Hash;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.state.BeaconStateCache;
+import tech.pegasys.artemis.util.bls.BLSSignature;
 
 public class CommitteeUtil {
 
@@ -267,5 +268,9 @@ public class CommitteeUtil {
     return TARGET_AGGREGATORS_PER_COMMITTEE == 0
         ? 1
         : Math.max(1, committeeSize / TARGET_AGGREGATORS_PER_COMMITTEE);
+  }
+
+  public static boolean isAggregator(final BLSSignature slot_signature, final int modulo) {
+    return (bytes_to_int(Hash.sha2_256(slot_signature.toBytes()).slice(0, 8)) % modulo) == 0;
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/events/attestation/BroadcastAggregatesEvent.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/events/attestation/BroadcastAggregatesEvent.java
@@ -13,7 +13,17 @@
 
 package tech.pegasys.artemis.statetransition.events.attestation;
 
+import com.google.common.primitives.UnsignedLong;
+
 public class BroadcastAggregatesEvent {
 
-  public BroadcastAggregatesEvent() {}
+  private final UnsignedLong slot;
+
+  public BroadcastAggregatesEvent(final UnsignedLong slot) {
+    this.slot = slot;
+  }
+
+  public UnsignedLong getSlot() {
+    return slot;
+  }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -475,7 +475,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
           recentChainData.getFinalizedRoot());
       this.eventBus.post(new BroadcastAttestationEvent(headBlockRoot, nodeSlot));
       Thread.sleep(SECONDS_PER_SLOT * 1000 / 3);
-      this.eventBus.post(new BroadcastAggregatesEvent());
+      this.eventBus.post(new BroadcastAggregatesEvent(nodeSlot));
       nodeSlot = nodeSlot.plus(UnsignedLong.ONE);
     } catch (InterruptedException e) {
       LOG.fatal("onTick: {}", e.toString(), e);

--- a/validator/anticorruption/src/main/java/tech/pegasys/artemis/validator/anticorruption/BeaconChainEventAdapter.java
+++ b/validator/anticorruption/src/main/java/tech/pegasys/artemis/validator/anticorruption/BeaconChainEventAdapter.java
@@ -15,6 +15,7 @@ package tech.pegasys.artemis.validator.anticorruption;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.common.primitives.UnsignedLong;
+import tech.pegasys.artemis.statetransition.events.attestation.BroadcastAggregatesEvent;
 import tech.pegasys.artemis.statetransition.events.attestation.BroadcastAttestationEvent;
 import tech.pegasys.artemis.util.time.channels.SlotEventsChannel;
 import tech.pegasys.artemis.validator.api.ValidatorTimingChannel;
@@ -34,6 +35,11 @@ class BeaconChainEventAdapter implements SlotEventsChannel {
   @Subscribe
   public void onBroadcastAttestationEvent(final BroadcastAttestationEvent event) {
     validatorTimingChannel.onAttestationCreationDue(event.getNodeSlot());
+  }
+
+  @Subscribe
+  public void onAggregationEvent(BroadcastAggregatesEvent event) {
+    validatorTimingChannel.onAttestationAggregationDue(event.getSlot());
   }
 
   @Override

--- a/validator/api/src/main/java/tech/pegasys/artemis/validator/api/ValidatorTimingChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/artemis/validator/api/ValidatorTimingChannel.java
@@ -21,4 +21,6 @@ public interface ValidatorTimingChannel {
   void onBlockProductionDue(UnsignedLong slot);
 
   void onAttestationCreationDue(UnsignedLong slot);
+
+  void onAttestationAggregationDue(UnsignedLong slot);
 }

--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/DutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/DutyScheduler.java
@@ -173,7 +173,7 @@ public class DutyScheduler implements ValidatorTimingChannel {
     forkProvider
         .getFork()
         .thenCompose(fork -> validator.getSigner().signAggregationSlot(slot, fork))
-        .thenAccept(
+        .finish(
             slotSignature -> {
               if (CommitteeUtil.isAggregator(slotSignature, aggregatorModulo)) {
                 aggregationDuties
@@ -184,7 +184,8 @@ public class DutyScheduler implements ValidatorTimingChannel {
                         attestationCommitteeIndex,
                         unsignedAttestationFuture);
               }
-            });
+            },
+            error -> LOG.error("Failed to schedule aggregation duties", error));
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/DutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/DutyScheduler.java
@@ -13,16 +13,20 @@
 
 package tech.pegasys.artemis.validator.client;
 
+import static com.google.common.primitives.UnsignedLong.ONE;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import tech.pegasys.artemis.datastructures.operations.Attestation;
+import tech.pegasys.artemis.datastructures.util.CommitteeUtil;
 import tech.pegasys.artemis.util.async.AsyncRunner;
 import tech.pegasys.artemis.util.async.SafeFuture;
 import tech.pegasys.artemis.util.bls.BLSPublicKey;
@@ -30,6 +34,7 @@ import tech.pegasys.artemis.util.config.Constants;
 import tech.pegasys.artemis.validator.api.ValidatorApiChannel;
 import tech.pegasys.artemis.validator.api.ValidatorDuties;
 import tech.pegasys.artemis.validator.api.ValidatorTimingChannel;
+import tech.pegasys.artemis.validator.client.duties.AggregationDuty;
 import tech.pegasys.artemis.validator.client.duties.AttestationProductionDuty;
 import tech.pegasys.artemis.validator.client.duties.BlockProductionDuty;
 import tech.pegasys.artemis.validator.client.duties.Duty;
@@ -42,18 +47,23 @@ public class DutyScheduler implements ValidatorTimingChannel {
       new ConcurrentHashMap<>();
   private final ConcurrentMap<UnsignedLong, AttestationProductionDuty> attestationProposalDuties =
       new ConcurrentHashMap<>();
+  private final ConcurrentMap<UnsignedLong, AggregationDuty> aggregationDuties =
+      new ConcurrentHashMap<>();
   private final AsyncRunner asyncRunner;
   private final ValidatorApiChannel validatorApiChannel;
+  private final ForkProvider forkProvider;
   private final ValidatorDutyFactory dutyFactory;
   private final Map<BLSPublicKey, Validator> validators;
 
   public DutyScheduler(
       final AsyncRunner asyncRunner,
       final ValidatorApiChannel validatorApiChannel,
+      final ForkProvider forkProvider,
       final ValidatorDutyFactory dutyFactory,
       final Map<BLSPublicKey, Validator> validators) {
     this.asyncRunner = asyncRunner;
     this.validatorApiChannel = validatorApiChannel;
+    this.forkProvider = forkProvider;
     this.dutyFactory = dutyFactory;
     this.validators = validators;
   }
@@ -64,11 +74,11 @@ public class DutyScheduler implements ValidatorTimingChannel {
     latestScheduledEpoch.getAndUpdate(
         lastRequestedEpoch -> {
           final UnsignedLong startEpoch =
-              lastRequestedEpoch == null ? epochNumber : lastRequestedEpoch.plus(UnsignedLong.ONE);
-          final UnsignedLong endEpoch = epochNumber.plus(UnsignedLong.ONE);
+              lastRequestedEpoch == null ? epochNumber : lastRequestedEpoch.plus(ONE);
+          final UnsignedLong endEpoch = epochNumber.plus(ONE);
           for (UnsignedLong currentEpoch = startEpoch;
               currentEpoch.compareTo(endEpoch) <= 0;
-              currentEpoch = currentEpoch.plus(UnsignedLong.ONE)) {
+              currentEpoch = currentEpoch.plus(ONE)) {
             scheduleDutiesForEpoch(currentEpoch).reportExceptions();
           }
           return startEpoch.compareTo(endEpoch) > 0 ? lastRequestedEpoch : endEpoch;
@@ -109,11 +119,13 @@ public class DutyScheduler implements ValidatorTimingChannel {
               duties
                   .getBlockProposalSlots()
                   .forEach(slot -> scheduleBlockProduction(validator, slot));
-              scheduleAttestationProduction(
+              scheduleAttestationDuties(
                   duties.getAttestationCommitteeIndex(),
                   duties.getAttestationCommitteePosition(),
+                  duties.getValidatorIndex(),
                   validator,
-                  duties.getAttestationSlot());
+                  duties.getAttestationSlot(),
+                  duties.getAggregatorModulo());
             });
   }
 
@@ -121,14 +133,58 @@ public class DutyScheduler implements ValidatorTimingChannel {
     blockProposalDuties.put(slot, dutyFactory.createBlockProductionDuty(validator, slot));
   }
 
-  private void scheduleAttestationProduction(
+  private void scheduleAttestationDuties(
+      final int attestationCommitteeIndex,
+      final int attestationCommitteePosition,
+      final int validatorIndex,
+      final Validator validator,
+      final UnsignedLong slot,
+      final int aggregatorModulo) {
+    final SafeFuture<Optional<Attestation>> unsignedAttestationFuture =
+        scheduleAttestationProduction(
+            attestationCommitteeIndex, attestationCommitteePosition, validator, slot);
+
+    scheduleAggregationDuties(
+        attestationCommitteeIndex,
+        validatorIndex,
+        validator,
+        slot,
+        aggregatorModulo,
+        unsignedAttestationFuture);
+  }
+
+  private SafeFuture<Optional<Attestation>> scheduleAttestationProduction(
       final int attestationCommitteeIndex,
       final int attestationCommitteePosition,
       final Validator validator,
       final UnsignedLong slot) {
-    attestationProposalDuties
+    return attestationProposalDuties
         .computeIfAbsent(slot, dutyFactory::createAttestationProductionDuty)
         .addValidator(validator, attestationCommitteeIndex, attestationCommitteePosition);
+  }
+
+  public void scheduleAggregationDuties(
+      final int attestationCommitteeIndex,
+      final int validatorIndex,
+      final Validator validator,
+      final UnsignedLong slot,
+      final int aggregatorModulo,
+      final SafeFuture<Optional<Attestation>> unsignedAttestationFuture) {
+    forkProvider
+        .getFork()
+        .thenCompose(fork -> validator.getSigner().signAggregationSlot(slot, fork))
+        .thenAccept(
+            slotSignature -> {
+              if (CommitteeUtil.isAggregator(slotSignature, aggregatorModulo)) {
+                aggregationDuties
+                    .computeIfAbsent(slot, dutyFactory::createAggregationDuty)
+                    .addValidator(
+                        validatorIndex,
+                        slotSignature,
+                        attestationCommitteeIndex,
+                        unsignedAttestationFuture);
+              }
+            });
   }
 
   @Override
@@ -139,6 +195,11 @@ public class DutyScheduler implements ValidatorTimingChannel {
   @Override
   public void onAttestationCreationDue(final UnsignedLong slot) {
     performDutyForSlot(attestationProposalDuties, slot);
+  }
+
+  @Override
+  public void onAttestationAggregationDue(final UnsignedLong slot) {
+    performDutyForSlot(aggregationDuties, slot);
   }
 
   public void performDutyForSlot(

--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/DutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/DutyScheduler.java
@@ -144,7 +144,7 @@ public class DutyScheduler implements ValidatorTimingChannel {
         scheduleAttestationProduction(
             attestationCommitteeIndex, attestationCommitteePosition, validator, slot);
 
-    scheduleAggregationDuties(
+    scheduleAggregation(
         attestationCommitteeIndex,
         validatorIndex,
         validator,
@@ -163,7 +163,7 @@ public class DutyScheduler implements ValidatorTimingChannel {
         .addValidator(validator, attestationCommitteeIndex, attestationCommitteePosition);
   }
 
-  public void scheduleAggregationDuties(
+  public void scheduleAggregation(
       final int attestationCommitteeIndex,
       final int validatorIndex,
       final Validator validator,

--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/ValidatorClientService.java
@@ -48,7 +48,8 @@ public class ValidatorClientService extends Service {
     final ValidatorDutyFactory validatorDutyFactory =
         new ValidatorDutyFactory(forkProvider, validatorApiChannel);
     final DutyScheduler validatorClient =
-        new DutyScheduler(asyncRunner, validatorApiChannel, validatorDutyFactory, validators);
+        new DutyScheduler(
+            asyncRunner, validatorApiChannel, forkProvider, validatorDutyFactory, validators);
 
     ValidatorAnticorruptionLayer.initAnticorruptionLayer(config);
 

--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/duties/AggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/duties/AggregationDuty.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.validator.client.duties;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Consumer;
+import tech.pegasys.artemis.datastructures.operations.AggregateAndProof;
+import tech.pegasys.artemis.datastructures.operations.Attestation;
+import tech.pegasys.artemis.datastructures.operations.AttestationData;
+import tech.pegasys.artemis.util.async.SafeFuture;
+import tech.pegasys.artemis.util.bls.BLSSignature;
+import tech.pegasys.artemis.validator.api.ValidatorApiChannel;
+
+public class AggregationDuty implements Duty {
+  private final ConcurrentMap<Integer, CommitteeAggregators> aggregatorsByCommitteeIndex =
+      new ConcurrentHashMap<>();
+  private final UnsignedLong slot;
+  private final ValidatorApiChannel validatorApiChannel;
+
+  public AggregationDuty(final UnsignedLong slot, final ValidatorApiChannel validatorApiChannel) {
+    this.slot = slot;
+    this.validatorApiChannel = validatorApiChannel;
+  }
+
+  public void addValidator(
+      final int validatorIndex,
+      final BLSSignature proof,
+      final int attestationCommitteeIndex,
+      final SafeFuture<Optional<Attestation>> unsignedAttestationFuture) {
+    aggregatorsByCommitteeIndex
+        .computeIfAbsent(
+            attestationCommitteeIndex, __ -> new CommitteeAggregators(unsignedAttestationFuture))
+        .addValidator(validatorIndex, proof);
+  }
+
+  @Override
+  public SafeFuture<?> performDuty() {
+    return SafeFuture.allOf(
+        aggregatorsByCommitteeIndex.values().stream()
+            .map(this::aggregateCommittee)
+            .toArray(SafeFuture[]::new));
+  }
+
+  public SafeFuture<Void> aggregateCommittee(final CommitteeAggregators aggregators) {
+    return aggregators
+        .unsignedAttestationFuture
+        .thenCompose(
+            maybeAttestation -> {
+              final AttestationData attestationData =
+                  maybeAttestation
+                      .orElseThrow(
+                          () ->
+                              new IllegalStateException(
+                                  "Unable to perform aggregation for committee because no attestation was produced"))
+                      .getData();
+              return validatorApiChannel.createAggregate(attestationData);
+            })
+        .thenAccept(maybeAggregate -> sendAggregates(aggregators, maybeAggregate));
+  }
+
+  private void sendAggregates(
+      final CommitteeAggregators aggregators, final Optional<Attestation> maybeAggregate) {
+    final Attestation aggregate =
+        maybeAggregate.orElseThrow(
+            () -> new IllegalStateException("No aggregation could be created"));
+    aggregators.forEach(
+        aggregator ->
+            validatorApiChannel.sendAggregateAndProof(
+                new AggregateAndProof(aggregator.validatorIndex, aggregator.proof, aggregate)));
+  }
+
+  @Override
+  public String describe() {
+    return "Attestation aggregation for slot " + slot;
+  }
+
+  private static class CommitteeAggregators {
+    private final List<Aggregator> validators = new ArrayList<>();
+    private final SafeFuture<Optional<Attestation>> unsignedAttestationFuture;
+
+    private CommitteeAggregators(
+        final SafeFuture<Optional<Attestation>> unsignedAttestationFuture) {
+      this.unsignedAttestationFuture = unsignedAttestationFuture;
+    }
+
+    public synchronized void addValidator(final int validatorIndex, final BLSSignature proof) {
+      validators.add(new Aggregator(UnsignedLong.valueOf(validatorIndex), proof));
+    }
+
+    public synchronized void forEach(final Consumer<Aggregator> consumer) {
+      validators.forEach(consumer);
+    }
+  }
+
+  private static class Aggregator {
+    private final UnsignedLong validatorIndex;
+    private final BLSSignature proof;
+
+    private Aggregator(final UnsignedLong validatorIndex, final BLSSignature proof) {
+      this.validatorIndex = validatorIndex;
+      this.proof = proof;
+    }
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/duties/AggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/duties/AggregationDuty.java
@@ -14,12 +14,10 @@
 package tech.pegasys.artemis.validator.client.duties;
 
 import com.google.common.primitives.UnsignedLong;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.Consumer;
 import tech.pegasys.artemis.datastructures.operations.AggregateAndProof;
 import tech.pegasys.artemis.datastructures.operations.Attestation;
 import tech.pegasys.artemis.datastructures.operations.AttestationData;
@@ -28,7 +26,7 @@ import tech.pegasys.artemis.util.bls.BLSSignature;
 import tech.pegasys.artemis.validator.api.ValidatorApiChannel;
 
 public class AggregationDuty implements Duty {
-  private final ConcurrentMap<Integer, CommitteeAggregators> aggregatorsByCommitteeIndex =
+  private final ConcurrentMap<Integer, CommitteeAggregator> aggregatorsByCommitteeIndex =
       new ConcurrentHashMap<>();
   private final UnsignedLong slot;
   private final ValidatorApiChannel validatorApiChannel;
@@ -43,10 +41,11 @@ public class AggregationDuty implements Duty {
       final BLSSignature proof,
       final int attestationCommitteeIndex,
       final SafeFuture<Optional<Attestation>> unsignedAttestationFuture) {
-    aggregatorsByCommitteeIndex
-        .computeIfAbsent(
-            attestationCommitteeIndex, __ -> new CommitteeAggregators(unsignedAttestationFuture))
-        .addValidator(validatorIndex, proof);
+    aggregatorsByCommitteeIndex.computeIfAbsent(
+        attestationCommitteeIndex,
+        __ ->
+            new CommitteeAggregator(
+                UnsignedLong.valueOf(validatorIndex), proof, unsignedAttestationFuture));
   }
 
   @Override
@@ -57,32 +56,33 @@ public class AggregationDuty implements Duty {
             .toArray(SafeFuture[]::new));
   }
 
-  public SafeFuture<Void> aggregateCommittee(final CommitteeAggregators aggregators) {
+  public SafeFuture<Void> aggregateCommittee(final CommitteeAggregator aggregators) {
     return aggregators
         .unsignedAttestationFuture
-        .thenCompose(
-            maybeAttestation -> {
-              final AttestationData attestationData =
-                  maybeAttestation
-                      .orElseThrow(
-                          () ->
-                              new IllegalStateException(
-                                  "Unable to perform aggregation for committee because no attestation was produced"))
-                      .getData();
-              return validatorApiChannel.createAggregate(attestationData);
-            })
-        .thenAccept(maybeAggregate -> sendAggregates(aggregators, maybeAggregate));
+        .thenCompose(this::createAggregate)
+        .thenAccept(maybeAggregate -> sendAggregate(aggregators, maybeAggregate));
   }
 
-  private void sendAggregates(
-      final CommitteeAggregators aggregators, final Optional<Attestation> maybeAggregate) {
+  public CompletionStage<Optional<Attestation>> createAggregate(
+      final Optional<Attestation> maybeAttestation) {
+    final AttestationData attestationData =
+        maybeAttestation
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Unable to perform aggregation for committee because no attestation was produced"))
+            .getData();
+    return validatorApiChannel.createAggregate(attestationData);
+  }
+
+  private void sendAggregate(
+      final CommitteeAggregator aggregator, final Optional<Attestation> maybeAggregate) {
     final Attestation aggregate =
         maybeAggregate.orElseThrow(
             () -> new IllegalStateException("No aggregation could be created"));
-    aggregators.forEach(
-        aggregator ->
-            validatorApiChannel.sendAggregateAndProof(
-                new AggregateAndProof(aggregator.validatorIndex, aggregator.proof, aggregate)));
+
+    validatorApiChannel.sendAggregateAndProof(
+        new AggregateAndProof(aggregator.validatorIndex, aggregator.proof, aggregate));
   }
 
   @Override
@@ -90,31 +90,18 @@ public class AggregationDuty implements Duty {
     return "Attestation aggregation for slot " + slot;
   }
 
-  private static class CommitteeAggregators {
-    private final List<Aggregator> validators = new ArrayList<>();
-    private final SafeFuture<Optional<Attestation>> unsignedAttestationFuture;
-
-    private CommitteeAggregators(
-        final SafeFuture<Optional<Attestation>> unsignedAttestationFuture) {
-      this.unsignedAttestationFuture = unsignedAttestationFuture;
-    }
-
-    public synchronized void addValidator(final int validatorIndex, final BLSSignature proof) {
-      validators.add(new Aggregator(UnsignedLong.valueOf(validatorIndex), proof));
-    }
-
-    public synchronized void forEach(final Consumer<Aggregator> consumer) {
-      validators.forEach(consumer);
-    }
-  }
-
-  private static class Aggregator {
+  private static class CommitteeAggregator {
     private final UnsignedLong validatorIndex;
     private final BLSSignature proof;
+    private final SafeFuture<Optional<Attestation>> unsignedAttestationFuture;
 
-    private Aggregator(final UnsignedLong validatorIndex, final BLSSignature proof) {
+    private CommitteeAggregator(
+        final UnsignedLong validatorIndex,
+        final BLSSignature proof,
+        final SafeFuture<Optional<Attestation>> unsignedAttestationFuture) {
       this.validatorIndex = validatorIndex;
       this.proof = proof;
+      this.unsignedAttestationFuture = unsignedAttestationFuture;
     }
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/duties/AttestationProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/duties/AttestationProductionDuty.java
@@ -34,8 +34,6 @@ import tech.pegasys.artemis.validator.client.ForkProvider;
 import tech.pegasys.artemis.validator.client.Validator;
 import tech.pegasys.artemis.validator.client.signer.Signer;
 
-// We want to synchronize on the specific list to ensure we don't modify it while iterating
-// but are ok with other threads simultaneously operating on other lists.
 public class AttestationProductionDuty implements Duty {
   private static final Logger LOG = LogManager.getLogger();
   private final Map<Integer, Committee> validatorsByCommitteeIndex = new HashMap<>();

--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/duties/AttestationProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/duties/AttestationProductionDuty.java
@@ -58,7 +58,7 @@ public class AttestationProductionDuty implements Duty {
    * @param committeePosition the validator's position within the committee
    * @return a future which will be completed with the unsigned attestation for the committee.
    */
-  public synchronized SafeFuture<Optional<Attestation>> addValidator(
+  public SafeFuture<Optional<Attestation>> addValidator(
       final Validator validator, final int attestationCommitteeIndex, final int committeePosition) {
     final Committee committee =
         validatorsByCommitteeIndex.computeIfAbsent(
@@ -68,7 +68,7 @@ public class AttestationProductionDuty implements Duty {
   }
 
   @Override
-  public synchronized SafeFuture<?> performDuty() {
+  public SafeFuture<?> performDuty() {
     LOG.trace("Creating attestations at slot {}", slot);
     if (validatorsByCommitteeIndex.isEmpty()) {
       return SafeFuture.COMPLETE;

--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/duties/AttestationProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/duties/AttestationProductionDuty.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.artemis.datastructures.operations.Attestation;
@@ -32,10 +34,11 @@ import tech.pegasys.artemis.validator.client.ForkProvider;
 import tech.pegasys.artemis.validator.client.Validator;
 import tech.pegasys.artemis.validator.client.signer.Signer;
 
+// We want to synchronize on the specific list to ensure we don't modify it while iterating
+// but are ok with other threads simultaneously operating on other lists.
 public class AttestationProductionDuty implements Duty {
   private static final Logger LOG = LogManager.getLogger();
-  private final Map<Integer, List<ValidatorWithCommitteePosition>> validatorsByCommitteeIndex =
-      new HashMap<>();
+  private final Map<Integer, Committee> validatorsByCommitteeIndex = new HashMap<>();
   private final UnsignedLong slot;
   private final ForkProvider forkProvider;
   private final ValidatorApiChannel validatorApiChannel;
@@ -49,11 +52,21 @@ public class AttestationProductionDuty implements Duty {
     this.validatorApiChannel = validatorApiChannel;
   }
 
-  public synchronized void addValidator(
+  /**
+   * Adds a validator that should produce an attestation in this slot.
+   *
+   * @param validator the validator to produce an attestation
+   * @param attestationCommitteeIndex the committee index for the validator
+   * @param committeePosition the validator's position within the committee
+   * @return a future which will be completed with the unsigned attestation for the committee.
+   */
+  public synchronized SafeFuture<Optional<Attestation>> addValidator(
       final Validator validator, final int attestationCommitteeIndex, final int committeePosition) {
-    validatorsByCommitteeIndex
-        .computeIfAbsent(attestationCommitteeIndex, key -> new ArrayList<>())
-        .add(new ValidatorWithCommitteePosition(validator, committeePosition));
+    final Committee committee =
+        validatorsByCommitteeIndex.computeIfAbsent(
+            attestationCommitteeIndex, key -> new Committee());
+    committee.addValidator(validator, committeePosition);
+    return committee.attestationFuture;
   }
 
   @Override
@@ -78,35 +91,30 @@ public class AttestationProductionDuty implements Duty {
   }
 
   private SafeFuture<Void> produceAttestationsForCommittee(
-      final Fork fork,
-      final int committeeIndex,
-      final List<ValidatorWithCommitteePosition> validators) {
-    return validatorApiChannel
-        .createUnsignedAttestation(slot, committeeIndex)
-        .thenCompose(
-            maybeUnsignedAttestation ->
-                maybeUnsignedAttestation
-                    .map(attestation -> signAttestationsForCommittee(fork, validators, attestation))
-                    .orElseGet(
-                        () -> {
-                          return failedFuture(
-                              new IllegalStateException(
-                                  "Unable to produce attestation for slot "
-                                      + slot
-                                      + " with committee "
-                                      + committeeIndex
-                                      + " because chain data was unavailable"));
-                        }));
+      final Fork fork, final int committeeIndex, final Committee committee) {
+    final SafeFuture<Optional<Attestation>> unsignedAttestationFuture =
+        validatorApiChannel.createUnsignedAttestation(slot, committeeIndex);
+    unsignedAttestationFuture.propagateTo(committee.attestationFuture);
+    return unsignedAttestationFuture.thenCompose(
+        maybeUnsignedAttestation ->
+            maybeUnsignedAttestation
+                .map(attestation -> signAttestationsForCommittee(fork, committee, attestation))
+                .orElseGet(
+                    () -> {
+                      return failedFuture(
+                          new IllegalStateException(
+                              "Unable to produce attestation for slot "
+                                  + slot
+                                  + " with committee "
+                                  + committeeIndex
+                                  + " because chain data was unavailable"));
+                    }));
   }
 
   private SafeFuture<Void> signAttestationsForCommittee(
-      final Fork fork,
-      final List<ValidatorWithCommitteePosition> validators,
-      final Attestation attestation) {
-    return SafeFuture.allOf(
-        validators.stream()
-            .map(validator -> signAttestationForValidator(fork, attestation, validator))
-            .toArray(SafeFuture[]::new));
+      final Fork fork, final Committee validators, final Attestation attestation) {
+    return validators.forEach(
+        validator -> signAttestationForValidator(fork, attestation, validator));
   }
 
   private SafeFuture<Void> signAttestationForValidator(
@@ -127,6 +135,20 @@ public class AttestationProductionDuty implements Duty {
     final Bitlist aggregationBits = new Bitlist(attestation.getAggregation_bits());
     aggregationBits.setBit(validator.getCommitteePosition());
     return new Attestation(aggregationBits, attestation.getData(), signature);
+  }
+
+  private static class Committee {
+    private final List<ValidatorWithCommitteePosition> validators = new ArrayList<>();
+    private final SafeFuture<Optional<Attestation>> attestationFuture = new SafeFuture<>();
+
+    public synchronized void addValidator(final Validator validator, final int committeePosition) {
+      validators.add(new ValidatorWithCommitteePosition(validator, committeePosition));
+    }
+
+    public synchronized SafeFuture<Void> forEach(
+        final Function<ValidatorWithCommitteePosition, SafeFuture<Void>> action) {
+      return SafeFuture.allOf(validators.stream().map(action).toArray(SafeFuture[]::new));
+    }
   }
 
   private static class ValidatorWithCommitteePosition {

--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/duties/ValidatorDutyFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/duties/ValidatorDutyFactory.java
@@ -36,4 +36,8 @@ public class ValidatorDutyFactory {
   public AttestationProductionDuty createAttestationProductionDuty(final UnsignedLong slot) {
     return new AttestationProductionDuty(slot, forkProvider, validatorApiChannel);
   }
+
+  public AggregationDuty createAggregationDuty(final UnsignedLong slot) {
+    return new AggregationDuty(slot, validatorApiChannel);
+  }
 }

--- a/validator/client/src/test/java/tech/pegasys/artemis/validator/client/duties/AggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/artemis/validator/client/duties/AggregationDutyTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.validator.client.duties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.artemis.util.async.SafeFuture.completedFuture;
+import static tech.pegasys.artemis.util.async.SafeFuture.failedFuture;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.datastructures.operations.AggregateAndProof;
+import tech.pegasys.artemis.datastructures.operations.Attestation;
+import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
+import tech.pegasys.artemis.util.async.SafeFuture;
+import tech.pegasys.artemis.util.bls.BLSSignature;
+import tech.pegasys.artemis.validator.api.ValidatorApiChannel;
+
+class AggregationDutyTest {
+
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
+
+  private final AggregationDuty duty = new AggregationDuty(UnsignedLong.ONE, validatorApiChannel);
+
+  @Test
+  public void shouldBeCompleteWhenNoValidatorsAdded() {
+    assertThat(duty.performDuty()).isCompleted();
+  }
+
+  @Test
+  public void shouldProduceAggregateAndProof() {
+    final int validatorIndex = 1;
+    final int attestationCommitteeIndex = 2;
+    final BLSSignature proof = dataStructureUtil.randomSignature();
+    final Attestation unsignedAttestation = dataStructureUtil.randomAttestation();
+    final Attestation aggregate = dataStructureUtil.randomAttestation();
+    duty.addValidator(
+        validatorIndex,
+        proof,
+        attestationCommitteeIndex,
+        completedFuture(Optional.of(unsignedAttestation)));
+
+    when(validatorApiChannel.createAggregate(unsignedAttestation.getData()))
+        .thenReturn(completedFuture(Optional.of(aggregate)));
+
+    assertThat(duty.performDuty()).isCompleted();
+
+    verify(validatorApiChannel)
+        .sendAggregateAndProof(
+            new AggregateAndProof(UnsignedLong.valueOf(validatorIndex), proof, aggregate));
+  }
+
+  @Test
+  public void shouldProduceAggregateAndProofForMultipleCommittees() {
+    final int validator1Index = 1;
+    final int validator1CommitteeIndex = 2;
+    final BLSSignature validator1Proof = dataStructureUtil.randomSignature();
+
+    final int validator2Index = 6;
+    final int validator2CommitteeIndex = 0;
+    final BLSSignature validator2Proof = dataStructureUtil.randomSignature();
+
+    final Attestation committee1UnsignedAttestation = dataStructureUtil.randomAttestation();
+    final Attestation committee2UnsignedAttestation = dataStructureUtil.randomAttestation();
+    final Attestation committee1Aggregate = dataStructureUtil.randomAttestation();
+    final Attestation committee2Aggregate = dataStructureUtil.randomAttestation();
+    duty.addValidator(
+        validator1Index,
+        validator1Proof,
+        validator1CommitteeIndex,
+        completedFuture(Optional.of(committee1UnsignedAttestation)));
+    duty.addValidator(
+        validator2Index,
+        validator2Proof,
+        validator2CommitteeIndex,
+        completedFuture(Optional.of(committee2UnsignedAttestation)));
+
+    when(validatorApiChannel.createAggregate(committee1UnsignedAttestation.getData()))
+        .thenReturn(completedFuture(Optional.of(committee1Aggregate)));
+    when(validatorApiChannel.createAggregate(committee2UnsignedAttestation.getData()))
+        .thenReturn(completedFuture(Optional.of(committee2Aggregate)));
+
+    assertThat(duty.performDuty()).isCompleted();
+
+    verify(validatorApiChannel)
+        .sendAggregateAndProof(
+            new AggregateAndProof(
+                UnsignedLong.valueOf(validator1Index), validator1Proof, committee1Aggregate));
+
+    verify(validatorApiChannel)
+        .sendAggregateAndProof(
+            new AggregateAndProof(
+                UnsignedLong.valueOf(validator2Index), validator2Proof, committee2Aggregate));
+  }
+
+  @Test
+  public void shouldFailWhenUnsignedAttestationNotCreated() {
+    duty.addValidator(1, dataStructureUtil.randomSignature(), 2, completedFuture(Optional.empty()));
+
+    assertThat(duty.performDuty()).isCompletedExceptionally();
+    verifyNoMoreInteractions(validatorApiChannel);
+  }
+
+  @Test
+  public void shouldFailWhenUnsignedAttestationCompletesExceptionally() {
+    final RuntimeException exception = new RuntimeException("Doh!");
+    duty.addValidator(1, dataStructureUtil.randomSignature(), 2, failedFuture(exception));
+
+    final SafeFuture<?> result = duty.performDuty();
+    assertThat(result).isCompletedExceptionally();
+    assertThatThrownBy(result::join).hasRootCause(exception);
+  }
+
+  @Test
+  public void shouldFailWhenAggregateNotCreated() {
+    final Attestation unsignedAttestation = dataStructureUtil.randomAttestation();
+    duty.addValidator(
+        1,
+        dataStructureUtil.randomSignature(),
+        2,
+        completedFuture(Optional.of(unsignedAttestation)));
+    when(validatorApiChannel.createAggregate(unsignedAttestation.getData()))
+        .thenReturn(completedFuture(Optional.empty()));
+
+    assertThat(duty.performDuty()).isCompletedExceptionally();
+    verify(validatorApiChannel, never()).sendAggregateAndProof(any());
+  }
+
+  @Test
+  public void shouldFailWhenAggregateFails() {
+    final Exception exception = new RuntimeException("Whoops");
+    final Attestation unsignedAttestation = dataStructureUtil.randomAttestation();
+    duty.addValidator(
+        1,
+        dataStructureUtil.randomSignature(),
+        2,
+        completedFuture(Optional.of(unsignedAttestation)));
+    when(validatorApiChannel.createAggregate(unsignedAttestation.getData()))
+        .thenReturn(failedFuture(exception));
+
+    final SafeFuture<?> result = duty.performDuty();
+    assertThat(result).isCompletedExceptionally();
+    assertThatThrownBy(result::join).hasRootCause(exception);
+    verify(validatorApiChannel, never()).sendAggregateAndProof(any());
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/artemis/validator/client/duties/AttestationProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/artemis/validator/client/duties/AttestationProductionDutyTest.java
@@ -200,10 +200,16 @@ class AttestationProductionDutyTest {
     final Attestation expectedAttestation3 =
         expectSignAttestation(validator3, validator3CommitteePosition, unsignedAttestation);
 
-    duty.addValidator(validator1, committeeIndex, validator1CommitteePosition);
-    duty.addValidator(validator2, committeeIndex, validator2CommitteePosition);
-    duty.addValidator(validator3, committeeIndex, validator3CommitteePosition);
+    final SafeFuture<Optional<Attestation>> attestationResult1 =
+        duty.addValidator(validator1, committeeIndex, validator1CommitteePosition);
+    final SafeFuture<Optional<Attestation>> attestationResult2 =
+        duty.addValidator(validator2, committeeIndex, validator2CommitteePosition);
+    final SafeFuture<Optional<Attestation>> attestationResult3 =
+        duty.addValidator(validator3, committeeIndex, validator3CommitteePosition);
     assertThat(duty.performDuty()).isCompleted();
+    assertThat(attestationResult1).isCompletedWithValue(Optional.of(unsignedAttestation));
+    assertThat(attestationResult2).isCompletedWithValue(Optional.of(unsignedAttestation));
+    assertThat(attestationResult3).isCompletedWithValue(Optional.of(unsignedAttestation));
 
     verify(validatorApiChannel).sendSignedAttestation(expectedAttestation1);
     verify(validatorApiChannel).sendSignedAttestation(expectedAttestation2);

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/CommitteeAssignmentManager.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/CommitteeAssignmentManager.java
@@ -14,9 +14,9 @@
 package tech.pegasys.artemis.validator.coordinator;
 
 import static java.lang.Math.toIntExact;
-import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.bytes_to_int;
 import static tech.pegasys.artemis.datastructures.util.CommitteeUtil.getAggregatorModulo;
 import static tech.pegasys.artemis.datastructures.util.CommitteeUtil.get_beacon_committee;
+import static tech.pegasys.artemis.datastructures.util.CommitteeUtil.isAggregator;
 import static tech.pegasys.artemis.util.config.Constants.COMMITTEE_INDEX_SUBSCRIPTION_LENGTH;
 
 import com.google.common.eventbus.EventBus;
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.tuweni.crypto.Hash;
 import tech.pegasys.artemis.core.CommitteeAssignmentUtil;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.state.Committee;
@@ -154,6 +153,6 @@ public class CommitteeAssignmentManager {
       BLSSignature slot_signature) {
     List<Integer> committee = get_beacon_committee(state, slot, committeeIndex);
     int modulo = getAggregatorModulo(committee.size());
-    return (bytes_to_int(Hash.sha2_256(slot_signature.toBytes()).slice(0, 8)) % modulo) == 0;
+    return isAggregator(slot_signature, modulo);
   }
 }


### PR DESCRIPTION
## PR Description
Add aggregation duties to the validator client service so that it follows the naive attestation aggregation algorithm.

The validator client deliberately only publishes one aggregate for each committee, even when multiple validators are assigned to aggregate the same committee. This is because they'd both use exactly the same aggregate anyway and there's no reward for producing the aggregate so no point putting the extra traffic on the gossip network.

This doesn't include subscribing to the committee subnet - that will be done in a future piece of work.