### PR TITLE
Add validator API to subscribe to attestation topics

### DIFF
--- a/networking/eth2/build.gradle
+++ b/networking/eth2/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
+  api project(':networking:p2p')
   implementation project(':bls')
   implementation project(':data')
   implementation project(':data:metrics')
   implementation project(':ethereum:core')
   implementation project(':ethereum:datastructures')
   implementation project(':ethereum:statetransition')
-  implementation project(':networking:p2p')
   implementation project(':logging')
   implementation project(':ssz')
   implementation project(':storage')

--- a/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/ErrorConditionsIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/ErrorConditionsIntegrationTest.java
@@ -48,7 +48,7 @@ public class ErrorConditionsIntegrationTest {
     final Eth2Peer peer = network1.getPeer(network2.getNodeId()).orElseThrow();
 
     final Eth2RpcMethod<StatusMessage, StatusMessage> status =
-        network1.getBeaconChainMethods().status();
+        ((ActiveEth2Network) network1).getBeaconChainMethods().status();
     final SafeFuture<StatusMessage> response =
         peer.sendRequest(status, new InvalidStatusMessage())
             .thenCompose(ResponseStream::expectSingleResponse);

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/ActiveEth2Network.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/ActiveEth2Network.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.eth2;
+
+import com.google.common.eventbus.EventBus;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import tech.pegasys.artemis.networking.eth2.gossip.AggregateGossipManager;
+import tech.pegasys.artemis.networking.eth2.gossip.AttestationGossipManager;
+import tech.pegasys.artemis.networking.eth2.gossip.BlockGossipManager;
+import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.artemis.networking.eth2.peers.Eth2PeerManager;
+import tech.pegasys.artemis.networking.eth2.rpc.beaconchain.BeaconChainMethods;
+import tech.pegasys.artemis.networking.p2p.network.DelegatingP2PNetwork;
+import tech.pegasys.artemis.networking.p2p.network.NetworkConfig;
+import tech.pegasys.artemis.networking.p2p.network.P2PNetwork;
+import tech.pegasys.artemis.networking.p2p.peer.NodeId;
+import tech.pegasys.artemis.networking.p2p.peer.PeerConnectedSubscriber;
+import tech.pegasys.artemis.storage.client.RecentChainData;
+import tech.pegasys.artemis.util.async.SafeFuture;
+
+public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements Eth2Network {
+  private final P2PNetwork<?> network;
+  private final Eth2PeerManager peerManager;
+  private final EventBus eventBus;
+  private final RecentChainData recentChainData;
+  private final AtomicReference<State> state = new AtomicReference<>(State.IDLE);
+
+  private BlockGossipManager blockGossipManager;
+  private AttestationGossipManager attestationGossipManager;
+  private AggregateGossipManager aggregateGossipManager;
+
+  public ActiveEth2Network(
+      final P2PNetwork<?> network,
+      final Eth2PeerManager peerManager,
+      final EventBus eventBus,
+      final RecentChainData recentChainData) {
+    super(network);
+    this.network = network;
+    this.peerManager = peerManager;
+    this.eventBus = eventBus;
+    this.recentChainData = recentChainData;
+  }
+
+  @Override
+  public SafeFuture<?> start() {
+    return super.start().thenAccept(r -> startup());
+  }
+
+  private void startup() {
+    state.set(State.RUNNING);
+    blockGossipManager = new BlockGossipManager(network, eventBus, recentChainData);
+    attestationGossipManager = new AttestationGossipManager(network, eventBus, recentChainData);
+    aggregateGossipManager = new AggregateGossipManager(network, eventBus, recentChainData);
+  }
+
+  @Override
+  public void stop() {
+    if (!state.compareAndSet(State.RUNNING, State.STOPPED)) {
+      return;
+    }
+    blockGossipManager.shutdown();
+    attestationGossipManager.shutdown();
+    aggregateGossipManager.shutdown();
+    super.stop();
+  }
+
+  @Override
+  public NetworkConfig getConfig() {
+    return network.getConfig();
+  }
+
+  @Override
+  public Optional<Eth2Peer> getPeer(final NodeId id) {
+    return peerManager.getPeer(id);
+  }
+
+  @Override
+  public Stream<Eth2Peer> streamPeers() {
+    return peerManager.streamPeers();
+  }
+
+  @Override
+  public int getPeerCount() {
+    // TODO - look into keep separate collections for pending peers / validated peers so
+    // we don't have to iterate over the peer list to get this count.
+    return Math.toIntExact(streamPeers().count());
+  }
+
+  @Override
+  public long subscribeConnect(final PeerConnectedSubscriber<Eth2Peer> subscriber) {
+    return peerManager.subscribeConnect(subscriber);
+  }
+
+  @Override
+  public void unsubscribeConnect(final long subscriptionId) {
+    peerManager.unsubscribeConnect(subscriptionId);
+  }
+
+  public BeaconChainMethods getBeaconChainMethods() {
+    return peerManager.getBeaconChainMethods();
+  }
+
+  @Override
+  public void subscribeToAttestationCommitteeTopic(final int committeeIndex) {
+    attestationGossipManager.subscribeToCommitteeTopic(committeeIndex);
+  }
+
+  @Override
+  public void unsubscribeFromAttestationCommitteeTopic(final int committeeIndex) {
+    attestationGossipManager.unsubscribeFromCommitteeTopic(committeeIndex);
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/Eth2NetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/Eth2NetworkBuilder.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2PeerManager;
 import tech.pegasys.artemis.networking.p2p.DiscoveryNetwork;
 import tech.pegasys.artemis.networking.p2p.connection.ReputationManager;
@@ -52,7 +51,7 @@ public class Eth2NetworkBuilder {
     return new Eth2NetworkBuilder();
   }
 
-  public P2PNetwork<Eth2Peer> build() {
+  public Eth2Network build() {
     validate();
 
     // Setup eth2 handlers
@@ -65,7 +64,7 @@ public class Eth2NetworkBuilder {
     // Build core network and inject eth2 handlers
     final P2PNetwork<?> network = buildNetwork();
 
-    return new Eth2Network(network, eth2PeerManager, eventBus, recentChainData);
+    return new ActiveEth2Network(network, eth2PeerManager, eventBus, recentChainData);
   }
 
   protected P2PNetwork<?> buildNetwork() {

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationGossipManager.java
@@ -72,21 +72,29 @@ public class AttestationGossipManager {
   public void onCommitteeAssignment(CommitteeAssignmentEvent assignmentEvent) {
     List<Integer> committeeIndices = assignmentEvent.getCommitteeIndices();
     for (int committeeIndex : committeeIndices) {
-      attestationChannels.computeIfAbsent(committeeIndex, this::createChannelForCommitteeIndex);
+      subscribeToCommitteeTopic(committeeIndex);
     }
+  }
+
+  public void subscribeToCommitteeTopic(final int committeeIndex) {
+    attestationChannels.computeIfAbsent(committeeIndex, this::createChannelForCommitteeIndex);
   }
 
   @Subscribe
   public void onCommitteeDismissal(CommitteeDismissalEvent dismissalEvent) {
     List<Integer> committeeIndices = dismissalEvent.getCommitteeIndices();
     for (int committeeIndex : committeeIndices) {
-      attestationChannels.computeIfPresent(
-          committeeIndex,
-          (index, channel) -> {
-            channel.close();
-            return null;
-          });
+      unsubscribeFromCommitteeTopic(committeeIndex);
     }
+  }
+
+  public void unsubscribeFromCommitteeTopic(final int committeeIndex) {
+    attestationChannels.computeIfPresent(
+        committeeIndex,
+        (index, channel) -> {
+          channel.close();
+          return null;
+        });
   }
 
   private TopicChannel createChannelForCommitteeIndex(final int committeeIndex) {

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationTopicSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationTopicSubscriptions.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.eth2.gossip;
+
+import static com.google.common.primitives.UnsignedLong.ZERO;
+import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.max;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import tech.pegasys.artemis.networking.eth2.Eth2Network;
+import tech.pegasys.artemis.util.time.channels.SlotEventsChannel;
+
+public class AttestationTopicSubscriptions implements SlotEventsChannel {
+  private final Map<Integer, UnsignedLong> unsubscriptionSlotByCommittee = new HashMap<>();
+  private final Eth2Network eth2Network;
+
+  public AttestationTopicSubscriptions(final Eth2Network eth2Network) {
+    this.eth2Network = eth2Network;
+  }
+
+  public synchronized void subscribeToCommittee(
+      final int committeeIndex, final UnsignedLong aggregationSlot) {
+    eth2Network.subscribeToAttestationCommitteeTopic(committeeIndex);
+    final UnsignedLong currentUnsubscribeSlot =
+        unsubscriptionSlotByCommittee.getOrDefault(committeeIndex, ZERO);
+    unsubscriptionSlotByCommittee.put(committeeIndex, max(currentUnsubscribeSlot, aggregationSlot));
+  }
+
+  @Override
+  public synchronized void onSlot(final UnsignedLong slot) {
+    final Iterator<Entry<Integer, UnsignedLong>> iterator =
+        unsubscriptionSlotByCommittee.entrySet().iterator();
+    while (iterator.hasNext()) {
+      final Entry<Integer, UnsignedLong> entry = iterator.next();
+      if (entry.getValue().compareTo(slot) < 0) {
+        iterator.remove();
+        eth2Network.unsubscribeFromAttestationCommitteeTopic(entry.getKey());
+      }
+    }
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/mock/MockEth2Network.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/mock/MockEth2Network.java
@@ -11,14 +11,17 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.artemis.networking.eth2;
+package tech.pegasys.artemis.networking.eth2.mock;
 
+import tech.pegasys.artemis.networking.eth2.Eth2Network;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.artemis.networking.p2p.network.P2PNetwork;
+import tech.pegasys.artemis.networking.p2p.mock.MockP2PNetwork;
 
-public interface Eth2Network extends P2PNetwork<Eth2Peer> {
+public class MockEth2Network extends MockP2PNetwork<Eth2Peer> implements Eth2Network {
 
-  void subscribeToAttestationCommitteeTopic(int committeeIndex);
+  @Override
+  public void subscribeToAttestationCommitteeTopic(final int committeeIndex) {}
 
-  void unsubscribeFromAttestationCommitteeTopic(int committeeIndex);
+  @Override
+  public void unsubscribeFromAttestationCommitteeTopic(final int committeeIndex) {}
 }

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/mock/NoOpEth2Network.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/mock/NoOpEth2Network.java
@@ -17,7 +17,7 @@ import tech.pegasys.artemis.networking.eth2.Eth2Network;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.artemis.networking.p2p.mock.MockP2PNetwork;
 
-public class MockEth2Network extends MockP2PNetwork<Eth2Peer> implements Eth2Network {
+public class NoOpEth2Network extends MockP2PNetwork<Eth2Peer> implements Eth2Network {
 
   @Override
   public void subscribeToAttestationCommitteeTopic(final int committeeIndex) {}

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationTopicSubscriptionsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationTopicSubscriptionsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.eth2.gossip;
+
+import static com.google.common.primitives.UnsignedLong.ONE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.networking.eth2.Eth2Network;
+
+class AttestationTopicSubscriptionsTest {
+
+  private final Eth2Network eth2Network = mock(Eth2Network.class);
+
+  private final AttestationTopicSubscriptions subscriptions =
+      new AttestationTopicSubscriptions(eth2Network);
+
+  @Test
+  public void shouldSubscribeToCommittee() {
+    final int committeeIndex = 10;
+    subscriptions.subscribeToCommittee(committeeIndex, ONE);
+
+    verify(eth2Network).subscribeToAttestationCommitteeTopic(committeeIndex);
+  }
+
+  @Test
+  public void shouldUnsubscribeFromCommitteeWhenPastSlot() {
+    final int committeeIndex = 12;
+    final UnsignedLong aggregationSlot = UnsignedLong.valueOf(10);
+    subscriptions.subscribeToCommittee(committeeIndex, aggregationSlot);
+
+    subscriptions.onSlot(aggregationSlot.plus(ONE));
+
+    verify(eth2Network).unsubscribeFromAttestationCommitteeTopic(committeeIndex);
+  }
+
+  @Test
+  public void shouldNotUnsubscribeAtStartOfTargetSlot() {
+    final int committeeIndex = 16;
+    final UnsignedLong aggregationSlot = UnsignedLong.valueOf(10);
+    subscriptions.subscribeToCommittee(committeeIndex, aggregationSlot);
+
+    subscriptions.onSlot(aggregationSlot);
+
+    verify(eth2Network, never()).unsubscribeFromAttestationCommitteeTopic(committeeIndex);
+  }
+
+  @Test
+  public void shouldExtendSubscriptionPeriod() {
+    final int committeeIndex = 3;
+    final UnsignedLong firstSlot = UnsignedLong.valueOf(10);
+    final UnsignedLong secondSlot = UnsignedLong.valueOf(15);
+
+    subscriptions.subscribeToCommittee(committeeIndex, firstSlot);
+    subscriptions.subscribeToCommittee(committeeIndex, secondSlot);
+
+    subscriptions.onSlot(firstSlot.plus(ONE));
+    verify(eth2Network, never()).unsubscribeFromAttestationCommitteeTopic(committeeIndex);
+
+    subscriptions.onSlot(secondSlot.plus(ONE));
+    verify(eth2Network).unsubscribeFromAttestationCommitteeTopic(committeeIndex);
+  }
+
+  @Test
+  public void shouldPreserveLaterSubscriptionPeriodWhenEarlierSlotAdded() {
+    final int committeeIndex = 3;
+    final UnsignedLong firstSlot = UnsignedLong.valueOf(10);
+    final UnsignedLong secondSlot = UnsignedLong.valueOf(15);
+
+    subscriptions.subscribeToCommittee(committeeIndex, secondSlot);
+    subscriptions.subscribeToCommittee(committeeIndex, firstSlot);
+
+    subscriptions.onSlot(firstSlot.plus(ONE));
+    verify(eth2Network, never()).unsubscribeFromAttestationCommitteeTopic(committeeIndex);
+
+    subscriptions.onSlot(secondSlot.plus(ONE));
+    verify(eth2Network).unsubscribeFromAttestationCommitteeTopic(committeeIndex);
+  }
+}

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/artemis/networking/eth2/Eth2NetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/artemis/networking/eth2/Eth2NetworkFactory.java
@@ -127,7 +127,7 @@ public class Eth2NetworkFactory {
                 reputationManager,
                 config);
 
-        return new Eth2Network(network, eth2PeerManager, eventBus, recentChainData);
+        return new ActiveEth2Network(network, eth2PeerManager, eventBus, recentChainData);
       }
     }
 

--- a/networking/p2p/build.gradle
+++ b/networking/p2p/build.gradle
@@ -8,7 +8,6 @@ dependencies {
   implementation project(':services:serviceutils')
   implementation project(':storage')
   implementation project(':util')
-  implementation project(':validator:coordinator')
 
   implementation 'de.undercouch:bson4jackson'
   implementation 'io.libp2p:jvm-libp2p-minimal'

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/mock/MockP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/mock/MockP2PNetwork.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.artemis.networking.p2p.mock;
 
-import com.google.common.eventbus.EventBus;
 import java.util.Optional;
 import java.util.stream.Stream;
 import tech.pegasys.artemis.networking.p2p.discovery.DiscoveryPeer;
@@ -30,10 +29,6 @@ import tech.pegasys.artemis.util.async.SafeFuture;
 public class MockP2PNetwork<P extends Peer> implements P2PNetwork<P> {
   private final int port = 6000;
   private final NodeId nodeId = new MockNodeId();
-
-  public MockP2PNetwork(EventBus eventBus) {
-    eventBus.register(this);
-  }
 
   @Override
   public SafeFuture<Peer> connect(PeerAddress peer) {

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -41,12 +41,11 @@ import tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.artemis.events.EventChannels;
 import tech.pegasys.artemis.metrics.ArtemisMetricCategory;
 import tech.pegasys.artemis.metrics.SettableGauge;
+import tech.pegasys.artemis.networking.eth2.Eth2Network;
 import tech.pegasys.artemis.networking.eth2.Eth2NetworkBuilder;
-import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.artemis.networking.eth2.mock.MockEth2Network;
 import tech.pegasys.artemis.networking.p2p.connection.TargetPeerRange;
-import tech.pegasys.artemis.networking.p2p.mock.MockP2PNetwork;
 import tech.pegasys.artemis.networking.p2p.network.NetworkConfig;
-import tech.pegasys.artemis.networking.p2p.network.P2PNetwork;
 import tech.pegasys.artemis.pow.api.Eth1EventsChannel;
 import tech.pegasys.artemis.service.serviceutils.Service;
 import tech.pegasys.artemis.statetransition.AttestationAggregator;
@@ -101,7 +100,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   private final SlotEventsChannel slotEventsChannelPublisher;
 
   private volatile RecentChainData recentChainData;
-  private volatile P2PNetwork<Eth2Peer> p2pNetwork;
+  private volatile Eth2Network p2pNetwork;
   private volatile SettableGauge currentSlotGauge;
   private volatile SettableGauge currentEpochGauge;
   private volatile StateProcessor stateProcessor;
@@ -299,7 +298,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   public void initP2PNetwork() {
     LOG.debug("BeaconChainController.initP2PNetwork()");
     if (!config.isP2pEnabled()) {
-      this.p2pNetwork = new MockP2PNetwork<>(eventBus);
+      this.p2pNetwork = new MockEth2Network();
     } else {
       final Optional<Bytes> bytes = getP2pPrivateKeyBytes();
       PrivKey pk =

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -44,7 +44,7 @@ import tech.pegasys.artemis.metrics.SettableGauge;
 import tech.pegasys.artemis.networking.eth2.Eth2Network;
 import tech.pegasys.artemis.networking.eth2.Eth2NetworkBuilder;
 import tech.pegasys.artemis.networking.eth2.gossip.AttestationTopicSubscriptions;
-import tech.pegasys.artemis.networking.eth2.mock.MockEth2Network;
+import tech.pegasys.artemis.networking.eth2.mock.NoOpEth2Network;
 import tech.pegasys.artemis.networking.p2p.connection.TargetPeerRange;
 import tech.pegasys.artemis.networking.p2p.network.NetworkConfig;
 import tech.pegasys.artemis.pow.api.Eth1EventsChannel;
@@ -304,7 +304,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   public void initP2PNetwork() {
     LOG.debug("BeaconChainController.initP2PNetwork()");
     if (!config.isP2pEnabled()) {
-      this.p2pNetwork = new MockEth2Network();
+      this.p2pNetwork = new NoOpEth2Network();
     } else {
       final Optional<Bytes> bytes = getP2pPrivateKeyBytes();
       PrivKey pk =

--- a/validator/api/src/main/java/tech/pegasys/artemis/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/artemis/validator/api/ValidatorApiChannel.java
@@ -41,6 +41,8 @@ public interface ValidatorApiChannel {
 
   SafeFuture<Optional<Attestation>> createAggregate(AttestationData attestationData);
 
+  void subscribeToBeaconCommittee(int committeeIndex, UnsignedLong aggregationSlot);
+
   void sendSignedAttestation(Attestation attestation);
 
   void sendAggregateAndProof(AggregateAndProof aggregateAndProof);

--- a/validator/coordinator/build.gradle
+++ b/validator/coordinator/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   implementation project(':ethereum:statetransition')
   implementation project(':ethereum:core')
   implementation project(':ethereum:datastructures')
+  implementation project(':networking:eth2')
   implementation project(':util')
   implementation project(':logging')
   implementation project(':pow')

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/ValidatorApiHandler.java
@@ -47,6 +47,7 @@ import tech.pegasys.artemis.datastructures.state.Fork;
 import tech.pegasys.artemis.datastructures.util.AttestationUtil;
 import tech.pegasys.artemis.datastructures.util.CommitteeUtil;
 import tech.pegasys.artemis.datastructures.util.ValidatorsUtil;
+import tech.pegasys.artemis.networking.eth2.gossip.AttestationTopicSubscriptions;
 import tech.pegasys.artemis.ssz.SSZTypes.Bitlist;
 import tech.pegasys.artemis.statetransition.AttestationAggregator;
 import tech.pegasys.artemis.statetransition.attestation.AggregatingAttestationPool;
@@ -65,6 +66,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   private final BlockFactory blockFactory;
   private final AggregatingAttestationPool attestationPool;
   private final AttestationAggregator attestationAggregator;
+  private final AttestationTopicSubscriptions attestationTopicSubscriptions;
   private final EventBus eventBus;
 
   public ValidatorApiHandler(
@@ -72,11 +74,13 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final BlockFactory blockFactory,
       final AggregatingAttestationPool attestationPool,
       final AttestationAggregator attestationAggregator,
+      final AttestationTopicSubscriptions attestationTopicSubscriptions,
       final EventBus eventBus) {
     this.combinedChainDataClient = combinedChainDataClient;
     this.blockFactory = blockFactory;
     this.attestationPool = attestationPool;
     this.attestationAggregator = attestationAggregator;
+    this.attestationTopicSubscriptions = attestationTopicSubscriptions;
     this.eventBus = eventBus;
   }
 
@@ -166,6 +170,12 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<Attestation>> createAggregate(final AttestationData attestationData) {
     return SafeFuture.completedFuture(attestationPool.createAggregateFor(attestationData));
+  }
+
+  @Override
+  public void subscribeToBeaconCommittee(
+      final int committeeIndex, final UnsignedLong aggregationSlot) {
+    attestationTopicSubscriptions.subscribeToCommittee(committeeIndex, aggregationSlot);
   }
 
   @Override

--- a/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/ValidatorApiHandlerTest.java
@@ -40,6 +40,7 @@ import tech.pegasys.artemis.datastructures.state.Validator;
 import tech.pegasys.artemis.datastructures.util.AttestationUtil;
 import tech.pegasys.artemis.datastructures.util.BeaconStateUtil;
 import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
+import tech.pegasys.artemis.networking.eth2.gossip.AttestationTopicSubscriptions;
 import tech.pegasys.artemis.ssz.SSZTypes.Bitlist;
 import tech.pegasys.artemis.ssz.SSZTypes.SSZMutableList;
 import tech.pegasys.artemis.statetransition.AttestationAggregator;
@@ -60,11 +61,18 @@ class ValidatorApiHandlerTest {
   private final BlockFactory blockFactory = mock(BlockFactory.class);
   private final AggregatingAttestationPool attestationPool = mock(AggregatingAttestationPool.class);
   private final AttestationAggregator attestationAggregator = mock(AttestationAggregator.class);
+  private final AttestationTopicSubscriptions attestationTopicSubscriptions =
+      mock(AttestationTopicSubscriptions.class);
   private final EventBus eventBus = mock(EventBus.class);
 
   private final ValidatorApiHandler validatorApiHandler =
       new ValidatorApiHandler(
-          chainDataClient, blockFactory, attestationPool, attestationAggregator, eventBus);
+          chainDataClient,
+          blockFactory,
+          attestationPool,
+          attestationAggregator,
+          attestationTopicSubscriptions,
+          eventBus);
 
   @Test
   public void getDuties_shouldReturnEmptyWhenStateIsUnavailable() {
@@ -245,6 +253,15 @@ class ValidatorApiHandlerTest {
     when(chainDataClient.getHeadStateFromStore()).thenReturn(Optional.of(state));
 
     assertThat(validatorApiHandler.getFork()).isCompletedWithValue(Optional.of(state.getFork()));
+  }
+
+  @Test
+  public void subscribeToBeaconCommittee_shouldSubscribeViaAttestationTopicSubscriptions() {
+    final int committeeIndex = 10;
+    final UnsignedLong aggregationSlot = UnsignedLong.valueOf(13);
+    validatorApiHandler.subscribeToBeaconCommittee(committeeIndex, aggregationSlot);
+
+    verify(attestationTopicSubscriptions).subscribeToCommittee(committeeIndex, aggregationSlot);
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Adds `ValidatorApiChannel.subscribeToBeaconCommittee` method so that validator clients can subscribe to a beacon committee topic for attestations until the scheduled aggregation slot is completed.

Since the network is internal to the beacon chain this also moves us towards using method calls for interaction rather than posting events to the event bus for subscribing and unsubscribing to topics.  The old version is still in place to support the old validator but its days are numbered.