### PR TITLE
Subscribe to committee topics when selected as an aggregator

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/duties/AggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/duties/AggregationDuty.java
@@ -56,9 +56,11 @@ public class AggregationDuty implements Duty {
       final SafeFuture<Optional<Attestation>> unsignedAttestationFuture) {
     aggregatorsByCommitteeIndex.computeIfAbsent(
         attestationCommitteeIndex,
-        __ ->
-            new CommitteeAggregator(
-                UnsignedLong.valueOf(validatorIndex), proof, unsignedAttestationFuture));
+        committeeIndex -> {
+          validatorApiChannel.subscribeToBeaconCommittee(committeeIndex, slot);
+          return new CommitteeAggregator(
+              UnsignedLong.valueOf(validatorIndex), proof, unsignedAttestationFuture);
+        });
   }
 
   @Override

--- a/validator/client/src/test/java/tech/pegasys/artemis/validator/client/DutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/artemis/validator/client/DutySchedulerTest.java
@@ -84,6 +84,8 @@ class DutySchedulerTest {
     when(dutyFactory.createAttestationProductionDuty(any()))
         .thenReturn(mock(AttestationProductionDuty.class));
     when(forkProvider.getFork()).thenReturn(completedFuture(fork));
+    when(validator1Signer.signAggregationSlot(any(), any())).thenReturn(new SafeFuture<>());
+    when(validator2Signer.signAggregationSlot(any(), any())).thenReturn(new SafeFuture<>());
   }
 
   @Test
@@ -267,7 +269,7 @@ class DutySchedulerTest {
             validator2Index,
             validator2Committee,
             validator2CommitteePosition,
-            0, // Guaranteed not to be an aggregator
+            100000, // Won't be an aggregator
             emptyList(),
             attestationSlot);
     when(validatorApiChannel.getDuties(eq(ONE), any()))


### PR DESCRIPTION
## PR Description
Validator client service should tell the beacon chain client to subscribe to the appropriate beacon committee when a validator is selected to perform aggregation duties.

Also fix a couple of annoying exceptions that get logged by `DutySchedulerTest` but don't affect the results.