### PR TITLE
Limit the number of attestations we include in blocks

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/attestation/AggregatingAttestationPool.java
@@ -61,6 +61,7 @@ public class AggregatingAttestationPool {
     attestationGroupByDataHash.values().stream()
         .filter(group -> canBeIncluded(group, slot))
         .flatMap(MatchingDataAttestationGroup::stream)
+        .limit(attestations.getMaxSize())
         .forEach(attestations::add);
     return attestations;
   }


### PR DESCRIPTION
## PR Description
Aggregation pool should respect the `MAX_ATTESTATIONS` limit when creating attestation lists for inclusion in a block.