### PR TITLE
Apply snappy compression to RPC messages

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
@@ -249,6 +249,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setP2pPeerLowerBound(p2POptions.getP2pLowerBound())
         .setP2pPeerUpperBound(p2POptions.getP2pUpperBound())
         .setP2pStaticPeers(p2POptions.getP2pStaticPeers())
+        .setP2pSnappyEnabled(p2POptions.isP2pSnappyEnabled())
         .setInteropGenesisTime(interopOptions.getInteropGenesisTime())
         .setInteropOwnedValidatorStartIndex(interopOptions.getInteropOwnerValidatorStartIndex())
         .setInteropOwnedValidatorCount(interopOptions.getInteropOwnerValidatorCount())

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/P2POptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/P2POptions.java
@@ -29,6 +29,7 @@ public class P2POptions {
   public static final String P2P_PEER_LOWER_BOUND_OPTION_NAME = "--p2p-peer-lower-bound";
   public static final String P2P_PEER_UPPER_BOUND_OPTION_NAME = "--p2p-peer-upper-bound";
   public static final String P2P_STATIC_PEERS_OPTION_NAME = "--p2p-static-peers";
+  public static final String P2P_SNAPPY_ENABLED = "--p2p-snappy-enabled";
 
   public static final boolean DEFAULT_P2P_ENABLED = true;
   public static final String DEFAULT_P2P_INTERFACE = "0.0.0.0";
@@ -42,6 +43,7 @@ public class P2POptions {
   public static final int DEFAULT_P2P_PEER_LOWER_BOUND = 20;
   public static final int DEFAULT_P2P_PEER_UPPER_BOUND = 30;
   public static final ArrayList<String> DEFAULT_P2P_STATIC_PEERS = new ArrayList<>();
+  public static final boolean DEFAULT_P2P_SNAPPY_ENABLED = false;
 
   @CommandLine.Option(
       names = {P2P_ENABLED_OPTION_NAME},
@@ -122,6 +124,13 @@ public class P2POptions {
       arity = "0..*")
   private ArrayList<String> p2pStaticPeers = DEFAULT_P2P_STATIC_PEERS;
 
+  @CommandLine.Option(
+      names = {P2P_SNAPPY_ENABLED},
+      paramLabel = "<BOOLEAN>",
+      description = "Enables snappy compression for P2P traffic",
+      arity = "1")
+  private boolean p2pSnappyEnabled = DEFAULT_P2P_SNAPPY_ENABLED;
+
   public boolean isP2pEnabled() {
     return p2pEnabled;
   }
@@ -164,5 +173,9 @@ public class P2POptions {
 
   public ArrayList<String> getP2pStaticPeers() {
     return p2pStaticPeers;
+  }
+
+  public boolean isP2pSnappyEnabled() {
+    return p2pSnappyEnabled;
   }
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,6 +12,7 @@ p2p-discovery-enabled: False
 p2p-advertised-port: 9000
 #this.privKey.bytes().toHexString() who's corresponding sha2(publicKey) == 16Uiu2HAm8cQB9DcwMtaSVuHNiJEPSq9mXM6FHho7c55M6XN2P3EQ
 p2p-private-key-file: "path/to/file"
+p2p-snappy-enabled: False
 
 # interop
 # when genesis time is set to 0, teku takes genesis time as currentTime + 5 seconds.

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/Eth2NetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/Eth2NetworkBuilder.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2PeerManager;
+import tech.pegasys.artemis.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.artemis.networking.p2p.DiscoveryNetwork;
 import tech.pegasys.artemis.networking.p2p.connection.ReputationManager;
 import tech.pegasys.artemis.networking.p2p.libp2p.LibP2PNetwork;
@@ -53,10 +54,12 @@ public class Eth2NetworkBuilder {
 
   public Eth2Network build() {
     validate();
+    final RpcEncoding encoding =
+        config.isSnappyEnabled() ? RpcEncoding.SSZ_SNAPPY : RpcEncoding.SSZ;
 
     // Setup eth2 handlers
     final Eth2PeerManager eth2PeerManager =
-        Eth2PeerManager.create(recentChainData, historicalChainData, metricsSystem);
+        Eth2PeerManager.create(recentChainData, historicalChainData, metricsSystem, encoding);
     final Collection<RpcMethod> eth2RpcMethods = eth2PeerManager.getBeaconChainMethods().all();
     rpcMethods.addAll(eth2RpcMethods);
     peerHandlers.add(eth2PeerManager);

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2PeerManager.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.GoodbyeMessage;
 import tech.pegasys.artemis.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.artemis.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
+import tech.pegasys.artemis.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.artemis.networking.p2p.network.PeerHandler;
 import tech.pegasys.artemis.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
 import tech.pegasys.artemis.networking.p2p.peer.NodeId;
@@ -50,7 +51,8 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
       final CombinedChainDataClient combinedChainDataClient,
       final RecentChainData storageClient,
       final MetricsSystem metricsSystem,
-      final PeerValidatorFactory peerValidatorFactory) {
+      final PeerValidatorFactory peerValidatorFactory,
+      final RpcEncoding encoding) {
     this.statusMessageFactory = new StatusMessageFactory(storageClient);
     this.peerValidatorFactory = peerValidatorFactory;
     this.rpcMethods =
@@ -60,13 +62,15 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
             combinedChainDataClient,
             storageClient,
             metricsSystem,
-            statusMessageFactory);
+            statusMessageFactory,
+            encoding);
   }
 
   public static Eth2PeerManager create(
       final RecentChainData storageClient,
       final StorageQueryChannel historicalChainData,
-      final MetricsSystem metricsSystem) {
+      final MetricsSystem metricsSystem,
+      final RpcEncoding encoding) {
     final PeerValidatorFactory peerValidatorFactory =
         (peer, status) ->
             PeerChainValidator.create(storageClient, historicalChainData, peer, status);
@@ -74,7 +78,8 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
         new CombinedChainDataClient(storageClient, historicalChainData),
         storageClient,
         metricsSystem,
-        peerValidatorFactory);
+        peerValidatorFactory,
+        encoding);
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -71,23 +71,25 @@ public class BeaconChainMethods {
       final CombinedChainDataClient combinedChainDataClient,
       final RecentChainData recentChainData,
       final MetricsSystem metricsSystem,
-      final StatusMessageFactory statusMessageFactory) {
+      final StatusMessageFactory statusMessageFactory,
+      final RpcEncoding encoding) {
     return new BeaconChainMethods(
-        createStatus(asyncRunner, statusMessageFactory, peerLookup),
-        createGoodBye(asyncRunner, metricsSystem, peerLookup),
-        createBeaconBlocksByRoot(asyncRunner, recentChainData, peerLookup),
-        createBeaconBlocksByRange(asyncRunner, combinedChainDataClient, peerLookup));
+        createStatus(asyncRunner, statusMessageFactory, peerLookup, encoding),
+        createGoodBye(asyncRunner, metricsSystem, peerLookup, encoding),
+        createBeaconBlocksByRoot(asyncRunner, recentChainData, peerLookup, encoding),
+        createBeaconBlocksByRange(asyncRunner, combinedChainDataClient, peerLookup, encoding));
   }
 
   private static Eth2RpcMethod<StatusMessage, StatusMessage> createStatus(
       final AsyncRunner asyncRunner,
       final StatusMessageFactory statusMessageFactory,
-      final PeerLookup peerLookup) {
+      final PeerLookup peerLookup,
+      final RpcEncoding encoding) {
     final StatusMessageHandler statusHandler = new StatusMessageHandler(statusMessageFactory);
     return new Eth2RpcMethod<>(
         asyncRunner,
         STATUS,
-        RpcEncoding.SSZ,
+        encoding,
         StatusMessage.class,
         StatusMessage.class,
         true,
@@ -98,12 +100,13 @@ public class BeaconChainMethods {
   private static Eth2RpcMethod<GoodbyeMessage, GoodbyeMessage> createGoodBye(
       final AsyncRunner asyncRunner,
       final MetricsSystem metricsSystem,
-      final PeerLookup peerLookup) {
+      final PeerLookup peerLookup,
+      final RpcEncoding encoding) {
     final GoodbyeMessageHandler goodbyeHandler = new GoodbyeMessageHandler(metricsSystem);
     return new Eth2RpcMethod<>(
         asyncRunner,
         GOODBYE,
-        RpcEncoding.SSZ,
+        encoding,
         GoodbyeMessage.class,
         GoodbyeMessage.class,
         false,
@@ -115,13 +118,14 @@ public class BeaconChainMethods {
       createBeaconBlocksByRoot(
           final AsyncRunner asyncRunner,
           final RecentChainData recentChainData,
-          final PeerLookup peerLookup) {
+          final PeerLookup peerLookup,
+          final RpcEncoding encoding) {
     final BeaconBlocksByRootMessageHandler beaconBlocksByRootHandler =
         new BeaconBlocksByRootMessageHandler(recentChainData);
     return new Eth2RpcMethod<>(
         asyncRunner,
         BEACON_BLOCKS_BY_ROOT,
-        RpcEncoding.SSZ,
+        encoding,
         BeaconBlocksByRootRequestMessage.class,
         SignedBeaconBlock.class,
         true,
@@ -133,14 +137,15 @@ public class BeaconChainMethods {
       createBeaconBlocksByRange(
           final AsyncRunner asyncRunner,
           final CombinedChainDataClient combinedChainDataClient,
-          final PeerLookup peerLookup) {
+          final PeerLookup peerLookup,
+          final RpcEncoding encoding) {
 
     final BeaconBlocksByRangeMessageHandler beaconBlocksByRangeHandler =
         new BeaconBlocksByRangeMessageHandler(combinedChainDataClient);
     return new Eth2RpcMethod<>(
         asyncRunner,
         BEACON_BLOCKS_BY_RANGE,
-        RpcEncoding.SSZ,
+        encoding,
         BeaconBlocksByRangeRequestMessage.class,
         SignedBeaconBlock.class,
         true,

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/encodings/RpcPayloadEncoderProvider.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/encodings/RpcPayloadEncoderProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 ConsenSys AG.
+ * Copyright 2020 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,20 +13,7 @@
 
 package tech.pegasys.artemis.networking.eth2.rpc.core.encodings;
 
-import java.util.OptionalInt;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.artemis.networking.eth2.rpc.core.RpcException;
+public interface RpcPayloadEncoderProvider {
 
-public interface RpcEncoding {
-  RpcEncoding SSZ = LengthPrefixedEncoding.createUncompressed();
-
-  RpcEncoding SSZ_SNAPPY = LengthPrefixedEncoding.createWithSnappyCompression();
-
-  <T> Bytes encode(T message);
-
-  <T> T decode(Bytes message, Class<T> clazz) throws RpcException;
-
-  String getName();
-
-  OptionalInt getMessageLength(Bytes message) throws RpcException;
+  <T> RpcPayloadEncoder<T> getEncoder(Class<T> clazz);
 }

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/encodings/RpcPayloadEncoders.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/encodings/RpcPayloadEncoders.java
@@ -19,8 +19,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import tech.pegasys.artemis.networking.eth2.rpc.core.encodings.snappy.SnappyCompressor;
 
-public class RpcPayloadEncoders {
+public class RpcPayloadEncoders implements RpcPayloadEncoderProvider {
 
   private final Map<Class<?>, RpcPayloadEncoder<?>> encoders;
   private final Function<Class<?>, RpcPayloadEncoder<?>> defaultEncoderProvider;
@@ -36,6 +37,7 @@ public class RpcPayloadEncoders {
     return new RpcPayloadEncoders.Builder();
   }
 
+  @Override
   @SuppressWarnings("unchecked")
   public <T> RpcPayloadEncoder<T> getEncoder(final Class<T> clazz) {
     RpcPayloadEncoder<?> encoder = encoders.get(clazz);
@@ -49,7 +51,7 @@ public class RpcPayloadEncoders {
     private Builder() {}
 
     public <T> Builder withEncoder(final Class<T> clazz, final RpcPayloadEncoder<T> encoder) {
-      encoders.put(clazz, encoder);
+      encoders.put(clazz, new SnappyCompressor<>(encoder));
       return this;
     }
 
@@ -59,7 +61,7 @@ public class RpcPayloadEncoders {
       return this;
     }
 
-    public RpcPayloadEncoders build() {
+    public RpcPayloadEncoderProvider build() {
       checkNotNull(defaultEncoderProvider, "Must provide a default encoder");
       return new RpcPayloadEncoders(Collections.unmodifiableMap(encoders), defaultEncoderProvider);
     }

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/encodings/snappy/SnappyCompressor.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/encodings/snappy/SnappyCompressor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.eth2.rpc.core.encodings.snappy;
+
+import java.io.IOException;
+import org.apache.tuweni.bytes.Bytes;
+import org.xerial.snappy.Snappy;
+import tech.pegasys.artemis.networking.eth2.rpc.core.RpcException;
+import tech.pegasys.artemis.networking.eth2.rpc.core.encodings.LengthPrefixedEncoding;
+import tech.pegasys.artemis.networking.eth2.rpc.core.encodings.RpcPayloadEncoder;
+
+public class SnappyCompressor<T> implements RpcPayloadEncoder<T> {
+
+  private final RpcPayloadEncoder<T> delegate;
+
+  public SnappyCompressor(final RpcPayloadEncoder<T> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Bytes encode(final T message) {
+    final Bytes data = delegate.encode(message);
+    try {
+      return Bytes.wrap(Snappy.compress(data.toArrayUnsafe()));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public T decode(final Bytes message) throws RpcException {
+    final Bytes data;
+    try {
+      final byte[] dataArray = message.toArrayUnsafe();
+      if (Snappy.uncompressedLength(dataArray) >= LengthPrefixedEncoding.MAX_CHUNK_SIZE) {
+        throw RpcException.CHUNK_TOO_LONG_ERROR;
+      }
+      data = Bytes.wrap(Snappy.uncompress(dataArray));
+    } catch (IOException e) {
+      throw RpcException.MALFORMED_REQUEST_ERROR;
+    }
+    return delegate.decode(data);
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/encodings/snappy/SnappyRpcPayloadEncoderProvider.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/rpc/core/encodings/snappy/SnappyRpcPayloadEncoderProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.networking.eth2.rpc.core.encodings.snappy;
+
+import tech.pegasys.artemis.networking.eth2.rpc.core.encodings.RpcPayloadEncoder;
+import tech.pegasys.artemis.networking.eth2.rpc.core.encodings.RpcPayloadEncoderProvider;
+
+public class SnappyRpcPayloadEncoderProvider implements RpcPayloadEncoderProvider {
+
+  private final RpcPayloadEncoderProvider delegate;
+
+  public SnappyRpcPayloadEncoderProvider(final RpcPayloadEncoderProvider delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public <T> RpcPayloadEncoder<T> getEncoder(final Class<T> clazz) {
+    return new SnappyCompressor<>(delegate.getEncoder(clazz));
+  }
+}

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/peers/Eth2PeerManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/peers/Eth2PeerManagerTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2PeerManager.PeerValidatorFactory;
 import tech.pegasys.artemis.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
+import tech.pegasys.artemis.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.artemis.networking.p2p.mock.MockNodeId;
 import tech.pegasys.artemis.networking.p2p.peer.Peer;
 import tech.pegasys.artemis.storage.client.CombinedChainDataClient;
@@ -44,7 +45,11 @@ public class Eth2PeerManagerTest {
 
   private final Eth2PeerManager peerManager =
       new Eth2PeerManager(
-          combinedChainDataClient, storageClient, new NoOpMetricsSystem(), peerValidatorFactory);
+          combinedChainDataClient,
+          storageClient,
+          new NoOpMetricsSystem(),
+          peerValidatorFactory,
+          RpcEncoding.SSZ);
 
   @BeforeEach
   public void setup() {

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/BeaconChainMethodsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/beaconchain/methods/BeaconChainMethodsTest.java
@@ -27,6 +27,7 @@ import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.artemis.networking.eth2.peers.PeerLookup;
 import tech.pegasys.artemis.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.artemis.networking.eth2.rpc.core.RequestRpcDecoder;
+import tech.pegasys.artemis.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.artemis.ssz.SSZTypes.Bytes4;
 import tech.pegasys.artemis.storage.client.CombinedChainDataClient;
 import tech.pegasys.artemis.storage.client.RecentChainData;
@@ -60,7 +61,8 @@ public class BeaconChainMethodsTest {
           combinedChainDataClient,
           recentChainData,
           metricsSystem,
-          statusMessageFactory);
+          statusMessageFactory,
+          RpcEncoding.SSZ);
 
   @Test
   void testStatusRoundtripSerialization() throws Exception {

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
@@ -35,6 +35,7 @@ import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.artemis.networking.eth2.peers.PeerLookup;
 import tech.pegasys.artemis.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.artemis.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
+import tech.pegasys.artemis.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.artemis.networking.p2p.mock.MockNodeId;
 import tech.pegasys.artemis.networking.p2p.peer.NodeId;
 import tech.pegasys.artemis.networking.p2p.rpc.RpcStream;
@@ -58,7 +59,8 @@ public class Eth2IncomingRequestHandlerTest {
           combinedChainDataClient,
           recentChainData,
           new NoOpMetricsSystem(),
-          new StatusMessageFactory(recentChainData));
+          new StatusMessageFactory(recentChainData),
+          RpcEncoding.SSZ);
 
   private final Eth2RpcMethod<BeaconBlocksByRangeRequestMessage, SignedBeaconBlock>
       blocksByRangeMethod = beaconChainMethods.beaconBlocksByRange();

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
@@ -37,6 +37,7 @@ import tech.pegasys.artemis.networking.eth2.peers.PeerLookup;
 import tech.pegasys.artemis.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.artemis.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
 import tech.pegasys.artemis.networking.eth2.rpc.core.ResponseStream.ResponseListener;
+import tech.pegasys.artemis.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.artemis.networking.p2p.mock.MockNodeId;
 import tech.pegasys.artemis.networking.p2p.peer.NodeId;
 import tech.pegasys.artemis.networking.p2p.rpc.RpcStream;
@@ -63,7 +64,8 @@ public class Eth2OutgoingRequestHandlerTest {
           combinedChainDataClient,
           recentChainData,
           new NoOpMetricsSystem(),
-          new StatusMessageFactory(recentChainData));
+          new StatusMessageFactory(recentChainData),
+          RpcEncoding.SSZ);
 
   private final Eth2RpcMethod<BeaconBlocksByRangeRequestMessage, SignedBeaconBlock>
       blocksByRangeMethod = beaconChainMethods.beaconBlocksByRange();

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/core/RpcDecoderTestBase.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/rpc/core/RpcDecoderTestBase.java
@@ -69,7 +69,8 @@ public class RpcDecoderTestBase {
           combinedChainDataClient,
           RECENT_CHAIN_DATA,
           new NoOpMetricsSystem(),
-          new StatusMessageFactory(RECENT_CHAIN_DATA));
+          new StatusMessageFactory(RECENT_CHAIN_DATA),
+          RpcEncoding.SSZ);
 
   @SuppressWarnings("unchecked")
   protected static final Eth2RpcMethod<

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/artemis/networking/eth2/Eth2NetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/artemis/networking/eth2/Eth2NetworkFactory.java
@@ -32,6 +32,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2PeerManager;
+import tech.pegasys.artemis.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.artemis.networking.p2p.DiscoveryNetwork;
 import tech.pegasys.artemis.networking.p2p.connection.ReputationManager;
 import tech.pegasys.artemis.networking.p2p.connection.TargetPeerRange;
@@ -112,7 +113,8 @@ public class Eth2NetworkFactory {
         // Setup eth2 handlers
         final StorageQueryChannel historicalChainData = new StubStorageQueryChannel();
         final Eth2PeerManager eth2PeerManager =
-            Eth2PeerManager.create(recentChainData, historicalChainData, METRICS_SYSTEM);
+            Eth2PeerManager.create(
+                recentChainData, historicalChainData, METRICS_SYSTEM, RpcEncoding.SSZ);
         final Collection<RpcMethod> eth2Protocols = eth2PeerManager.getBeaconChainMethods().all();
         // Configure eth2 handlers
         this.rpcMethods(eth2Protocols).peerHandler(eth2PeerManager);
@@ -148,6 +150,7 @@ public class Eth2NetworkFactory {
           false,
           emptyList(),
           new TargetPeerRange(20, 30),
+          false,
           false,
           false,
           false);

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/network/NetworkConfig.java
@@ -31,6 +31,7 @@ public class NetworkConfig {
   private final boolean isDiscoveryEnabled;
   private final List<String> bootnodes;
   private final TargetPeerRange targetPeerRange;
+  private final boolean isSnappyEnabled;
   private final boolean logWireCipher;
   private final boolean logWirePlain;
   private final boolean logMuxFrames;
@@ -45,11 +46,13 @@ public class NetworkConfig {
       final boolean isDiscoveryEnabled,
       final List<String> bootnodes,
       final TargetPeerRange targetPeerRange,
+      final boolean isSnappyEnabled,
       final boolean logWireCipher,
       final boolean logWirePlain,
       final boolean logMuxFrames) {
     this.privateKey = privateKey;
     this.networkInterface = networkInterface;
+    this.isSnappyEnabled = isSnappyEnabled;
 
     if (advertisedIp.trim().isEmpty()) {
       this.advertisedIp = Optional.empty();
@@ -104,6 +107,10 @@ public class NetworkConfig {
 
   public TargetPeerRange getTargetPeerRange() {
     return targetPeerRange;
+  }
+
+  public boolean isSnappyEnabled() {
+    return isSnappyEnabled;
   }
 
   public boolean isLogWireCipher() {

--- a/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/DiscoveryNetworkTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/artemis/networking/p2p/DiscoveryNetworkTest.java
@@ -126,6 +126,7 @@ class DiscoveryNetworkTest {
                 new TargetPeerRange(20, 30),
                 false,
                 false,
+                false,
                 false));
     assertThat(network.getEnr()).isEmpty();
   }

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/artemis/network/p2p/DiscoveryNetworkFactory.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/artemis/network/p2p/DiscoveryNetworkFactory.java
@@ -86,6 +86,7 @@ public class DiscoveryNetworkFactory {
                 new TargetPeerRange(20, 30),
                 false,
                 false,
+                false,
                 false);
         final ReputationManager reputationManager =
             new ReputationManager(

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -346,6 +346,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
               config.isP2pDiscoveryEnabled(),
               config.getP2pDiscoveryBootnodes(),
               new TargetPeerRange(config.getP2pPeerLowerBound(), config.getP2pPeerUpperBound()),
+              config.isP2pSnappyEnabled(),
               true,
               true,
               true);

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
@@ -41,6 +41,7 @@ public class ArtemisConfiguration {
   private final int p2pPeerLowerBound;
   private final int p2pPeerUpperBound;
   private final List<String> p2pStaticPeers;
+  private final boolean p2pSnappyEnabled;
 
   // Interop
   private final Integer interopGenesisTime;
@@ -106,6 +107,7 @@ public class ArtemisConfiguration {
       final int p2pPeerLowerBound,
       final int p2pPeerUpperBound,
       final List<String> p2pStaticPeers,
+      final boolean p2pSnappyEnabled,
       final Integer interopGenesisTime,
       final int interopOwnedValidatorStartIndex,
       final int interopOwnedValidatorCount,
@@ -148,6 +150,7 @@ public class ArtemisConfiguration {
     this.p2pPeerLowerBound = p2pPeerLowerBound;
     this.p2pPeerUpperBound = p2pPeerUpperBound;
     this.p2pStaticPeers = p2pStaticPeers;
+    this.p2pSnappyEnabled = p2pSnappyEnabled;
     this.interopGenesisTime = interopGenesisTime;
     this.interopOwnedValidatorStartIndex = interopOwnedValidatorStartIndex;
     this.interopOwnedValidatorCount = interopOwnedValidatorCount;
@@ -226,6 +229,10 @@ public class ArtemisConfiguration {
 
   public List<String> getP2pStaticPeers() {
     return p2pStaticPeers;
+  }
+
+  public boolean isP2pSnappyEnabled() {
+    return p2pSnappyEnabled;
   }
 
   public Integer getInteropGenesisTime() {

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
@@ -28,6 +28,7 @@ public class ArtemisConfigurationBuilder {
   private int p2pPeerLowerBound;
   private int p2pPeerUpperBound;
   private List<String> p2pStaticPeers;
+  private boolean p2pSnappyEnabled;
   private Integer interopGenesisTime;
   private int interopOwnedValidatorStartIndex;
   private int interopOwnedValidatorCount;
@@ -117,6 +118,11 @@ public class ArtemisConfigurationBuilder {
 
   public ArtemisConfigurationBuilder setP2pStaticPeers(final List<String> p2pStaticPeers) {
     this.p2pStaticPeers = p2pStaticPeers;
+    return this;
+  }
+
+  public ArtemisConfigurationBuilder setP2pSnappyEnabled(final boolean p2pSnappyEnabled) {
+    this.p2pSnappyEnabled = p2pSnappyEnabled;
     return this;
   }
 
@@ -295,6 +301,7 @@ public class ArtemisConfigurationBuilder {
         p2pPeerLowerBound,
         p2pPeerUpperBound,
         p2pStaticPeers,
+        p2pSnappyEnabled,
         interopGenesisTime,
         interopOwnedValidatorStartIndex,
         interopOwnedValidatorCount,


### PR DESCRIPTION
## PR Description
Applies snappy compression to RPC messages.

TODO:
 * Add tests
 * Length prefix should be of the raw data, not the compressed version
 * Should restrict the amount of data to read to 1/6th the declared length when using snappy compression
 * Check this is using framed compression instead of block compression (suspect it's not)
 * Need to apply snappy compression to gossip messages as well.

It's likely the need to calculate the length prefix on the raw data completely breaks this approach to integrating snappy, but the command line option and associated plumbing will still be useful.