### PR TITLE
Prune Eth1DataCache based on latest block timestamp

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -259,14 +259,13 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   private void initEth1DataCache() {
     LOG.debug("BeaconChainController.initEth1DataCache");
-    eth1DataCache = new Eth1DataCache(eventBus, timeProvider);
+    eth1DataCache = new Eth1DataCache(eventBus);
     recentChainData.subscribeBestBlockInitialized(
         () -> {
           final Bytes32 head = recentChainData.getBestBlockRoot().orElseThrow();
           final BeaconState headState = recentChainData.getStore().getBlockState(head);
           eth1DataCache.startBeaconChainMode(headState);
         });
-    eventChannels.subscribe(TimeTickChannel.class, eth1DataCache);
   }
 
   public void initValidatorApiHandler() {
@@ -481,7 +480,6 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             recentChainData.getFinalizedRoot());
       }
 
-      eth1DataCache.onSlot(nodeSlot);
       slotEventsChannelPublisher.onSlot(nodeSlot);
       Thread.sleep(SECONDS_PER_SLOT * 1000 / 3);
       Bytes32 headBlockRoot = this.forkChoice.processHead();

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/Eth1DataCache.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/Eth1DataCache.java
@@ -92,9 +92,9 @@ public class Eth1DataCache {
     // Worst case this slot is at the very end of the current voting period
     cacheDurationSeconds += (EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH * SECONDS_PER_SLOT);
 
-    // We need 2 * ETH1_FOLLOW_DISTANCE prior to that
-    cacheDurationSeconds +=
-        SECONDS_PER_ETH1_BLOCK.longValue() * ETH1_FOLLOW_DISTANCE.longValue() * 2;
+    // We need 2 * ETH1_FOLLOW_DISTANCE prior to that but the blocks we get from Eth1DataManager are
+    // already ETH1_FOLLOW_DISTANCE behind head and the current time is taken from that.
+    cacheDurationSeconds += SECONDS_PER_ETH1_BLOCK.longValue() * ETH1_FOLLOW_DISTANCE.longValue();
 
     // And we want to be able to create blocks for at least the past epoch
     cacheDurationSeconds += SLOTS_PER_EPOCH * SECONDS_PER_SLOT;

--- a/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/Eth1DataCache.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/artemis/validator/coordinator/Eth1DataCache.java
@@ -13,19 +13,15 @@
 
 package tech.pegasys.artemis.validator.coordinator;
 
-import static tech.pegasys.artemis.pow.Eth1DataManager.getCacheRangeLowerBound;
-import static tech.pegasys.artemis.pow.Eth1DataManager.hasBeenApproximately;
 import static tech.pegasys.artemis.util.config.Constants.EPOCHS_PER_ETH1_VOTING_PERIOD;
 import static tech.pegasys.artemis.util.config.Constants.ETH1_FOLLOW_DISTANCE;
 import static tech.pegasys.artemis.util.config.Constants.SECONDS_PER_ETH1_BLOCK;
+import static tech.pegasys.artemis.util.config.Constants.SECONDS_PER_SLOT;
 import static tech.pegasys.artemis.util.config.Constants.SLOTS_PER_EPOCH;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.primitives.UnsignedLong;
-import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -35,61 +31,32 @@ import tech.pegasys.artemis.datastructures.blocks.Eth1Data;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.pow.event.CacheEth1BlockEvent;
 import tech.pegasys.artemis.util.config.Constants;
-import tech.pegasys.artemis.util.time.TimeProvider;
-import tech.pegasys.artemis.util.time.channels.TimeTickChannel;
 
-public class Eth1DataCache implements TimeTickChannel {
+public class Eth1DataCache {
 
-  private final TimeProvider timeProvider;
+  private final UnsignedLong cacheDuration;
   private volatile Optional<UnsignedLong> genesisTime = Optional.empty();
 
   private final NavigableMap<UnsignedLong, Eth1Data> eth1ChainCache = new ConcurrentSkipListMap<>();
-  private volatile UnsignedLong currentVotingPeriodStartTime;
 
-  public Eth1DataCache(EventBus eventBus, TimeProvider timeProvider) {
-    this.timeProvider = timeProvider;
+  public Eth1DataCache(EventBus eventBus) {
     eventBus.register(this);
+    cacheDuration = calculateCacheDuration();
   }
 
   public void startBeaconChainMode(BeaconState headState) {
     this.genesisTime = Optional.of(headState.getGenesis_time());
-    this.currentVotingPeriodStartTime = getVotingPeriodStartTime(headState.getSlot());
-    this.onSlot(headState.getSlot());
   }
 
   @Subscribe
   public void onCacheEth1BlockEvent(CacheEth1BlockEvent cacheEth1BlockEvent) {
-    eth1ChainCache.put(
-        cacheEth1BlockEvent.getBlockTimestamp(), createEth1Data(cacheEth1BlockEvent));
-  }
-
-  @Override
-  public void onTick(Date date) {
-    if (genesisTime.isPresent()
-        || !hasBeenApproximately(SECONDS_PER_ETH1_BLOCK, timeProvider.getTimeInSeconds())) {
-      return;
-    }
-    prune();
-  }
-
-  // Called by BeaconChainController not the event bus to ensure we process slot events in sync
-  public void onSlot(UnsignedLong slot) {
-    if (genesisTime.isEmpty()) {
-      return;
-    }
-
-    UnsignedLong voting_period_start_time = getVotingPeriodStartTime(slot);
-
-    if (voting_period_start_time.equals(currentVotingPeriodStartTime)) {
-      return;
-    }
-
-    currentVotingPeriodStartTime = voting_period_start_time;
-    prune();
+    final UnsignedLong latestBlockTimestamp = cacheEth1BlockEvent.getBlockTimestamp();
+    eth1ChainCache.put(latestBlockTimestamp, createEth1Data(cacheEth1BlockEvent));
+    prune(latestBlockTimestamp);
   }
 
   public Eth1Data get_eth1_vote(BeaconState state) {
-    NavigableMap<UnsignedLong, Eth1Data> votesToConsider = getVotesToConsider();
+    NavigableMap<UnsignedLong, Eth1Data> votesToConsider = getVotesToConsider(state.getSlot());
     Map<Eth1Data, Eth1Vote> validVotes = new HashMap<>();
 
     int i = 0;
@@ -113,13 +80,34 @@ public class Eth1DataCache implements TimeTickChannel {
     return vote.orElse(defaultVote);
   }
 
-  private NavigableMap<UnsignedLong, Eth1Data> getVotesToConsider() {
-    return eth1ChainCache.subMap(getSpecRangeLowerBound(), true, getSpecRangeUpperBound(), true);
+  private NavigableMap<UnsignedLong, Eth1Data> getVotesToConsider(final UnsignedLong slot) {
+    return eth1ChainCache.subMap(
+        getSpecRangeLowerBound(slot), true, getSpecRangeUpperBound(slot), true);
   }
 
-  private void prune() {
-    while (!eth1ChainCache.isEmpty() && isBlockTooOld(eth1ChainCache.firstKey())) {
-      eth1ChainCache.remove(eth1ChainCache.firstKey());
+  private UnsignedLong calculateCacheDuration() {
+    // Worst case we're in the very last moment of the current slot
+    long cacheDurationSeconds = SECONDS_PER_SLOT;
+
+    // Worst case this slot is at the very end of the current voting period
+    cacheDurationSeconds += (EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH * SECONDS_PER_SLOT);
+
+    // We need 2 * ETH1_FOLLOW_DISTANCE prior to that
+    cacheDurationSeconds +=
+        SECONDS_PER_ETH1_BLOCK.longValue() * ETH1_FOLLOW_DISTANCE.longValue() * 2;
+
+    // And we want to be able to create blocks for at least the past epoch
+    cacheDurationSeconds += SLOTS_PER_EPOCH * SECONDS_PER_SLOT;
+    return UnsignedLong.valueOf(cacheDurationSeconds);
+  }
+
+  private void prune(final UnsignedLong latestBlockTimestamp) {
+    while (!eth1ChainCache.isEmpty()) {
+      final UnsignedLong earliestBlockTimestamp = eth1ChainCache.firstKey();
+      if (earliestBlockTimestamp.plus(cacheDuration).compareTo(latestBlockTimestamp) >= 0) {
+        break;
+      }
+      eth1ChainCache.remove(earliestBlockTimestamp);
     }
   }
 
@@ -129,18 +117,19 @@ public class Eth1DataCache implements TimeTickChannel {
     return computeTimeAtSlot(eth1VotingPeriodStartSlot);
   }
 
-  UnsignedLong getSpecRangeLowerBound() {
+  UnsignedLong getSpecRangeLowerBound(final UnsignedLong slot) {
     return secondsBeforeCurrentVotingPeriodStartTime(
-        ETH1_FOLLOW_DISTANCE.times(SECONDS_PER_ETH1_BLOCK).times(UnsignedLong.valueOf(2)));
+        slot, ETH1_FOLLOW_DISTANCE.times(SECONDS_PER_ETH1_BLOCK).times(UnsignedLong.valueOf(2)));
   }
 
-  UnsignedLong getSpecRangeUpperBound() {
+  UnsignedLong getSpecRangeUpperBound(final UnsignedLong slot) {
     return secondsBeforeCurrentVotingPeriodStartTime(
-        ETH1_FOLLOW_DISTANCE.times(SECONDS_PER_ETH1_BLOCK));
+        slot, ETH1_FOLLOW_DISTANCE.times(SECONDS_PER_ETH1_BLOCK));
   }
 
   private UnsignedLong secondsBeforeCurrentVotingPeriodStartTime(
-      final UnsignedLong valueToSubtract) {
+      final UnsignedLong slot, final UnsignedLong valueToSubtract) {
+    final UnsignedLong currentVotingPeriodStartTime = getVotingPeriodStartTime(slot);
     if (currentVotingPeriodStartTime.compareTo(valueToSubtract) > 0) {
       return currentVotingPeriodStartTime.minus(valueToSubtract);
     } else {
@@ -155,14 +144,6 @@ public class Eth1DataCache implements TimeTickChannel {
         .plus(slot.times(UnsignedLong.valueOf(Constants.SECONDS_PER_SLOT)));
   }
 
-  private boolean isBlockTooOld(UnsignedLong blockTimestamp) {
-    if (genesisTime.isPresent()) {
-      return blockTimestamp.compareTo(getSpecRangeLowerBound()) < 0;
-    } else {
-      return blockTimestamp.compareTo(getCacheRangeLowerBound(timeProvider.getTimeInSeconds())) < 0;
-    }
-  }
-
   public static Eth1Data createEth1Data(CacheEth1BlockEvent eth1BlockEvent) {
     return new Eth1Data(
         eth1BlockEvent.getDepositRoot(),
@@ -170,8 +151,11 @@ public class Eth1DataCache implements TimeTickChannel {
         eth1BlockEvent.getBlockHash());
   }
 
-  @VisibleForTesting
-  NavigableMap<UnsignedLong, Eth1Data> getMapForTesting() {
-    return Collections.unmodifiableNavigableMap(eth1ChainCache);
+  UnsignedLong getCacheDuration() {
+    return cacheDuration;
+  }
+
+  int size() {
+    return eth1ChainCache.size();
   }
 }

--- a/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/Eth1DataCacheTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/artemis/validator/coordinator/Eth1DataCacheTest.java
@@ -14,13 +14,11 @@
 package tech.pegasys.artemis.validator.coordinator;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.primitives.UnsignedLong;
-import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -30,13 +28,10 @@ import tech.pegasys.artemis.datastructures.blocks.Eth1Data;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.state.BeaconStateImpl;
 import tech.pegasys.artemis.datastructures.util.DataStructureUtil;
-import tech.pegasys.artemis.pow.Eth1DataManager;
 import tech.pegasys.artemis.pow.event.CacheEth1BlockEvent;
 import tech.pegasys.artemis.ssz.SSZTypes.SSZList;
 import tech.pegasys.artemis.ssz.SSZTypes.SSZMutableList;
-import tech.pegasys.artemis.util.Waiter;
 import tech.pegasys.artemis.util.config.Constants;
-import tech.pegasys.artemis.util.time.StubTimeProvider;
 
 public class Eth1DataCacheTest {
 
@@ -48,7 +43,6 @@ public class Eth1DataCacheTest {
   private final UnsignedLong NEXT_VOTING_PERIOD_SLOT = UnsignedLong.valueOf(102);
   private final UnsignedLong testStartTime = UnsignedLong.valueOf(1000);
 
-  private StubTimeProvider timeProvider;
   private Eth1DataCache eth1DataCache;
 
   // Voting Period Start Time
@@ -84,35 +78,32 @@ public class Eth1DataCacheTest {
         .thenReturn(testStartTime.minus(UnsignedLong.valueOf(1000)));
     when(genesisState.getSlot()).thenReturn(UnsignedLong.ZERO);
 
-    timeProvider = StubTimeProvider.withTimeInSeconds(testStartTime);
-    eth1DataCache = new Eth1DataCache(eventBus, timeProvider);
+    eth1DataCache = new Eth1DataCache(eventBus);
   }
 
   @Test
   void checkTimeValues() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eth1DataCache.onSlot(START_SLOT);
-    assertThat(eth1DataCache.getSpecRangeLowerBound())
+    assertThat(eth1DataCache.getSpecRangeLowerBound(START_SLOT))
         .isEqualByComparingTo(UnsignedLong.valueOf(354));
-    assertThat(eth1DataCache.getSpecRangeUpperBound())
+    assertThat(eth1DataCache.getSpecRangeUpperBound(START_SLOT))
         .isEqualByComparingTo(UnsignedLong.valueOf(369));
-    eth1DataCache.onSlot(NEXT_VOTING_PERIOD_SLOT);
-    assertThat(eth1DataCache.getSpecRangeLowerBound())
+    assertThat(eth1DataCache.getSpecRangeLowerBound(NEXT_VOTING_PERIOD_SLOT))
         .isEqualByComparingTo(UnsignedLong.valueOf(378));
   }
 
   @Test
   void checkTimeValuesStayAboveZero() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eth1DataCache.onSlot(UnsignedLong.ONE);
-    assertThat(eth1DataCache.getSpecRangeLowerBound()).isEqualByComparingTo(UnsignedLong.ZERO);
-    assertThat(eth1DataCache.getSpecRangeUpperBound()).isEqualByComparingTo(UnsignedLong.ZERO);
+    assertThat(eth1DataCache.getSpecRangeLowerBound(UnsignedLong.ONE))
+        .isEqualByComparingTo(UnsignedLong.ZERO);
+    assertThat(eth1DataCache.getSpecRangeUpperBound(UnsignedLong.ONE))
+        .isEqualByComparingTo(UnsignedLong.ZERO);
   }
 
   @Test
   void majorityVoteWins() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eth1DataCache.onSlot(START_SLOT);
 
     // Both Eth1Data timestamp inside the spec range
     CacheEth1BlockEvent cacheEth1BlockEvent1 =
@@ -130,13 +121,13 @@ public class Eth1DataCacheTest {
         SSZList.createMutable(List.of(eth1Data1, eth1Data2, eth1Data2), 10, Eth1Data.class);
     BeaconStateImpl beaconState = mock(BeaconStateImpl.class);
     when(beaconState.getEth1_data_votes()).thenReturn(eth1DataVotes);
+    when(beaconState.getSlot()).thenReturn(START_SLOT);
     assertThat(eth1DataCache.get_eth1_vote(beaconState)).isEqualTo(eth1Data2);
   }
 
   @Test
   void smallestDistanceWinsIfNoMajority() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eth1DataCache.onSlot(START_SLOT);
 
     // Both Eth1Data timestamp inside the spec range
     CacheEth1BlockEvent cacheEth1BlockEvent1 =
@@ -150,6 +141,7 @@ public class Eth1DataCacheTest {
     SSZMutableList<Eth1Data> eth1DataVotes =
         SSZList.createMutable(List.of(eth1Data1, eth1Data2), 10, Eth1Data.class);
     BeaconStateImpl beaconState = mock(BeaconStateImpl.class);
+    when(beaconState.getSlot()).thenReturn(START_SLOT);
     when(beaconState.getEth1_data_votes()).thenReturn(eth1DataVotes);
 
     eventBus.post(cacheEth1BlockEvent1);
@@ -161,7 +153,6 @@ public class Eth1DataCacheTest {
   @Test
   void oldVoteDoesNotCount() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eth1DataCache.onSlot(START_SLOT);
 
     // Eth1Data inside the range
     CacheEth1BlockEvent cacheEth1BlockEvent1 =
@@ -180,13 +171,13 @@ public class Eth1DataCacheTest {
         SSZList.createMutable(List.of(eth1Data1, eth1Data2, eth1Data2), 10, Eth1Data.class);
     BeaconStateImpl beaconState = mock(BeaconStateImpl.class);
     when(beaconState.getEth1_data_votes()).thenReturn(eth1DataVotes);
+    when(beaconState.getSlot()).thenReturn(START_SLOT);
     assertThat(eth1DataCache.get_eth1_vote(beaconState)).isEqualTo(eth1Data1);
   }
 
   @Test
   void tooRecentVoteDoesNotCount() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eth1DataCache.onSlot(START_SLOT);
 
     // Eth1Data inside the range
     CacheEth1BlockEvent cacheEth1BlockEvent1 =
@@ -204,6 +195,7 @@ public class Eth1DataCacheTest {
     SSZMutableList<Eth1Data> eth1DataVotes =
         SSZList.createMutable(List.of(eth1Data1, eth1Data2, eth1Data2), 10, Eth1Data.class);
     BeaconStateImpl beaconState = mock(BeaconStateImpl.class);
+    when(beaconState.getSlot()).thenReturn(START_SLOT);
     when(beaconState.getEth1_data_votes()).thenReturn(eth1DataVotes);
     assertThat(eth1DataCache.get_eth1_vote(beaconState)).isEqualTo(eth1Data1);
   }
@@ -211,7 +203,6 @@ public class Eth1DataCacheTest {
   @Test
   void noValidVotesInThisPeriod_eth1ChainLive() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eth1DataCache.onSlot(START_SLOT);
 
     // Both Eth1Data timestamp inside the spec range
     CacheEth1BlockEvent cacheEth1BlockEvent1 =
@@ -225,6 +216,7 @@ public class Eth1DataCacheTest {
     SSZMutableList<Eth1Data> eth1DataVotes = SSZList.createMutable(List.of(), 10, Eth1Data.class);
     BeaconStateImpl beaconState = mock(BeaconStateImpl.class);
     when(beaconState.getEth1_data_votes()).thenReturn(eth1DataVotes);
+    when(beaconState.getSlot()).thenReturn(START_SLOT);
 
     // The most recent Eth1Data in getVotesToConsider wins
     Eth1Data eth1Data2 = Eth1DataCache.createEth1Data(cacheEth1BlockEvent2);
@@ -234,93 +226,38 @@ public class Eth1DataCacheTest {
   @Test
   void noValidVotesInThisPeriod_eth1ChainNotLive() {
     eth1DataCache.startBeaconChainMode(genesisState);
-    eth1DataCache.onSlot(START_SLOT);
 
     Eth1Data eth1Data = dataStructureUtil.randomEth1Data();
 
     SSZMutableList<Eth1Data> eth1DataVotes =
         SSZList.createMutable(List.of(eth1Data), 10, Eth1Data.class);
     BeaconStateImpl beaconState = mock(BeaconStateImpl.class);
+    when(beaconState.getSlot()).thenReturn(START_SLOT);
     when(beaconState.getEth1_data_votes()).thenReturn(eth1DataVotes);
     when(beaconState.getEth1_data()).thenReturn(eth1Data);
     assertThat(eth1DataCache.get_eth1_vote(beaconState)).isEqualTo(eth1Data);
   }
 
   @Test
-  void pruneBeforeGenesis() {
-    CacheEth1BlockEvent cacheEth1BlockEvent1 =
-        createRandomCacheEth1BlockEvent(Eth1DataManager.getCacheMidRangeTimestamp(testStartTime));
-    CacheEth1BlockEvent cacheEth1BlockEvent2 =
+  void shouldPruneOldBlocksWhenNewerOnesReceived() {
+    final UnsignedLong cacheDuration = eth1DataCache.getCacheDuration();
+    final CacheEth1BlockEvent oldBlock = createRandomCacheEth1BlockEvent(UnsignedLong.ZERO);
+    final CacheEth1BlockEvent newBlock =
         createRandomCacheEth1BlockEvent(
-            Eth1DataManager.getCacheRangeLowerBound(testStartTime).minus(UnsignedLong.ONE));
+            oldBlock.getBlockTimestamp().plus(cacheDuration).plus(UnsignedLong.ONE));
+    final CacheEth1BlockEvent newerBlock =
+        createRandomCacheEth1BlockEvent(newBlock.getBlockTimestamp().plus(cacheDuration));
 
-    // Make sure hasBeenApproximately returns true
-    timeProvider.advanceTimeBySeconds(2);
+    eventBus.post(oldBlock);
+    assertThat(eth1DataCache.size()).isEqualTo(1);
 
-    eventBus.post(cacheEth1BlockEvent1);
-    eventBus.post(cacheEth1BlockEvent2);
-    eth1DataCache.onTick(new Date());
+    // Next block causes the first to be pruned.
+    eventBus.post(newBlock);
+    assertThat(eth1DataCache.size()).isEqualTo(1);
 
-    Eth1Data eth1Data1 = Eth1DataCache.createEth1Data(cacheEth1BlockEvent1);
-
-    Waiter.waitFor(() -> assertThat(eth1DataCache.getMapForTesting().values().size()).isEqualTo(1));
-
-    assertThat(eth1DataCache.getMapForTesting().values()).containsExactly(eth1Data1);
-  }
-
-  @Test
-  void pruneAfterGenesis() {
-    eth1DataCache.startBeaconChainMode(genesisState);
-    eth1DataCache.onSlot(START_SLOT);
-
-    // First two Eth1Data timestamps inside the spec range for this voting period
-    CacheEth1BlockEvent cacheEth1BlockEvent1 =
-        createRandomCacheEth1BlockEvent(UnsignedLong.valueOf(359));
-    CacheEth1BlockEvent cacheEth1BlockEvent2 =
-        createRandomCacheEth1BlockEvent(UnsignedLong.valueOf(360));
-
-    // This Eth1Data timestamp inside the spec range for the next voting period
-    CacheEth1BlockEvent cacheEth1BlockEvent3 =
-        createRandomCacheEth1BlockEvent(UnsignedLong.valueOf(379));
-
-    eventBus.post(cacheEth1BlockEvent1);
-    eventBus.post(cacheEth1BlockEvent2);
-    eventBus.post(cacheEth1BlockEvent3);
-
-    eth1DataCache.onSlot(NEXT_VOTING_PERIOD_SLOT);
-
-    Eth1Data eth1Data3 = Eth1DataCache.createEth1Data(cacheEth1BlockEvent3);
-
-    Waiter.waitFor(() -> assertThat(eth1DataCache.getMapForTesting().values().size()).isEqualTo(1));
-
-    assertThat(eth1DataCache.getMapForTesting().values()).containsExactly(eth1Data3);
-  }
-
-  @Test
-  void pruneAllBlockData() {
-    eth1DataCache.startBeaconChainMode(genesisState);
-    eth1DataCache.onSlot(START_SLOT);
-
-    // All Eth1Data timestamps inside the spec range for this voting period
-    CacheEth1BlockEvent cacheEth1BlockEvent1 =
-        createRandomCacheEth1BlockEvent(UnsignedLong.valueOf(359));
-    CacheEth1BlockEvent cacheEth1BlockEvent2 =
-        createRandomCacheEth1BlockEvent(UnsignedLong.valueOf(360));
-    CacheEth1BlockEvent cacheEth1BlockEvent3 =
-        createRandomCacheEth1BlockEvent(UnsignedLong.valueOf(361));
-
-    eventBus.post(cacheEth1BlockEvent1);
-    eventBus.post(cacheEth1BlockEvent2);
-    eventBus.post(cacheEth1BlockEvent3);
-
-    eth1DataCache.onSlot(NEXT_VOTING_PERIOD_SLOT);
-
-    assertThat(eth1DataCache.getMapForTesting().values()).isEmpty();
-  }
-
-  @Test
-  void onSlotBeingCalled_withoutGenesisTimeBeingSet() {
-    assertDoesNotThrow(() -> eth1DataCache.onSlot(START_SLOT));
+    // Third block is close enough to the second that they are both kept
+    eventBus.post(newerBlock);
+    assertThat(eth1DataCache.size()).isEqualTo(2);
   }
 
   private CacheEth1BlockEvent createRandomCacheEth1BlockEvent(UnsignedLong timestamp) {


### PR DESCRIPTION
## PR Description
Remove Eth1DataCache's dependency on tick and slot events by pruning the cache purely based on the timestamp of the latest block.