### PR TITLE
Use grGit Gradle plugin to retrieve the head commit hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
   id 'net.researchgate.release' version '2.8.1'
   id 'me.champeau.gradle.jmh' version '0.5.0' apply false
   id 'de.undercouch.download' version '4.0.1'
+  id 'org.ajoberstar.grgit' version '4.0.2'
 }
 
 apply plugin: 'application'
@@ -580,25 +581,8 @@ def calculateVersion() {
 }
 
 def getCheckedOutGitCommitHash() {
-  def gitFolder = "$projectDir/.git/"
-  if (!file(gitFolder).isDirectory()) {
-    // We are in a submodule.  The file's contents are `gitdir: <gitFolder>\n`.
-    // Read the file, cut off the front, and trim the whitespace.
-    gitFolder = file(gitFolder).text.substring(8).trim() + "/"
-  }
   def takeFromHash = 8
-  /*
-   * '.git/HEAD' contains either
-   *      in case of detached head: the currently checked out commit hash
-   *      otherwise: a reference to a file containing the current commit hash
-   */
-  def head = new File(gitFolder + "HEAD").text.split(":") // .git/HEAD
-  def isCommit = head.length == 1 // e5a7c79edabbf7dd39888442df081b1c9d8e88fd
-
-  if (isCommit) return head[0].trim().take(takeFromHash) // e5a7c79edabb
-
-  def refHead = new File(gitFolder + head[1].trim()) // .git/refs/heads/master
-  refHead.text.trim().take takeFromHash
+  grgit.head().id.take(takeFromHash)
 }
 
 task jacocoRootReport(type: JacocoReport) {


### PR DESCRIPTION
## PR Description

When there are many local branches files from `.git\refs\heads` are packed into `.git/packed-refs` file and the getCheckedOutGitCommitHash() function fails to find the head ref. 
Not sure if this ref packing process is performed by git automatically or initiated by IDEA, but I hit that issue locally several times 

Suggest to use this plugin https://github.com/ajoberstar/grgit

Checked that the following cases work with plugin: 
- head is a ref which is in `.git\refs\heads`
- head is a ref packed to `.git/packed-refs`
- head is a non-tagged commit 

## Fixed Issue(s)
BC-387