### PR TITLE
Use ArtemisMetricCategory as the source for valid metric categories.

### DIFF
--- a/artemis/build.gradle
+++ b/artemis/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-toml'
   implementation 'org.apache.tuweni:tuweni-units'
   implementation 'org.hyperledger.besu:plugin-api'
+  implementation 'org.hyperledger.besu.internal:metrics-core'
   implementation 'tech.pegasys.signers.internal:bls-keystore'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/converter/MetricCategoryConverter.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/converter/MetricCategoryConverter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.cli.converter;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
+import picocli.CommandLine;
+
+public class MetricCategoryConverter implements CommandLine.ITypeConverter<MetricCategory> {
+
+  private final Map<String, MetricCategory> metricCategories = new HashMap<>();
+
+  @Override
+  public MetricCategory convert(final String value) {
+    final MetricCategory category = metricCategories.get(value);
+    if (category == null) {
+      throw new IllegalArgumentException("Unknown category: " + value);
+    }
+    return category;
+  }
+
+  public <T extends Enum<T> & MetricCategory> void addCategories(final Class<T> categoryEnum) {
+    EnumSet.allOf(categoryEnum)
+        .forEach(category -> metricCategories.put(category.name(), category));
+  }
+
+  public void addRegistryCategory(final MetricCategory metricCategory) {
+    metricCategories.put(metricCategory.getName().toUpperCase(), metricCategory);
+  }
+
+  @VisibleForTesting
+  Map<String, MetricCategory> getMetricCategories() {
+    return metricCategories;
+  }
+}

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/MetricsOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/MetricsOptions.java
@@ -13,8 +13,12 @@
 
 package tech.pegasys.artemis.cli.options;
 
-import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import picocli.CommandLine;
+import tech.pegasys.artemis.metrics.ArtemisMetricCategory;
+
+import static tech.pegasys.artemis.metrics.ArtemisMetricCategory.BEACON;
 
 public class MetricsOptions {
 
@@ -26,7 +30,7 @@ public class MetricsOptions {
   public static final boolean DEFAULT_METRICS_ENABLED = false;
   public static final int DEFAULT_METRICS_PORT = 8008;
   public static final String DEFAULT_METRICS_INTERFACE = "127.0.0.1";
-  public static final ArrayList<String> DEFAULT_METRICS_CATEGORIES = new ArrayList<>();
+  public static final List<ArtemisMetricCategory> DEFAULT_METRICS_CATEGORIES = List.of(BEACON);
 
   @CommandLine.Option(
       names = {METRICS_ENABLED_OPTION_NAME},
@@ -55,7 +59,7 @@ public class MetricsOptions {
       description = "Metric categories to enable",
       split = ",",
       arity = "0..*")
-  private ArrayList<String> metricsCategories = DEFAULT_METRICS_CATEGORIES;
+  private List<ArtemisMetricCategory> metricsCategories = DEFAULT_METRICS_CATEGORIES;
 
   public boolean isMetricsEnabled() {
     return metricsEnabled;
@@ -69,7 +73,7 @@ public class MetricsOptions {
     return metricsInterface;
   }
 
-  public ArrayList<String> getMetricsCategories() {
-    return metricsCategories;
+  public List<String> getMetricsCategories() {
+    return metricsCategories.stream().map(Enum::toString).collect(Collectors.toList());
   }
 }

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/MetricsOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/MetricsOptions.java
@@ -13,12 +13,15 @@
 
 package tech.pegasys.artemis.cli.options;
 
+import com.google.common.collect.ImmutableSet;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import org.hyperledger.besu.metrics.StandardMetricCategory;
+import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 import picocli.CommandLine;
 import tech.pegasys.artemis.metrics.ArtemisMetricCategory;
-
-import static tech.pegasys.artemis.metrics.ArtemisMetricCategory.BEACON;
 
 public class MetricsOptions {
 
@@ -30,7 +33,11 @@ public class MetricsOptions {
   public static final boolean DEFAULT_METRICS_ENABLED = false;
   public static final int DEFAULT_METRICS_PORT = 8008;
   public static final String DEFAULT_METRICS_INTERFACE = "127.0.0.1";
-  public static final List<ArtemisMetricCategory> DEFAULT_METRICS_CATEGORIES = List.of(BEACON);
+  public static final ImmutableSet<MetricCategory> DEFAULT_METRICS_CATEGORIES =
+      ImmutableSet.<MetricCategory>builder()
+          .addAll(EnumSet.allOf(StandardMetricCategory.class))
+          .addAll(EnumSet.allOf(ArtemisMetricCategory.class))
+          .build();
 
   @CommandLine.Option(
       names = {METRICS_ENABLED_OPTION_NAME},
@@ -59,7 +66,7 @@ public class MetricsOptions {
       description = "Metric categories to enable",
       split = ",",
       arity = "0..*")
-  private List<ArtemisMetricCategory> metricsCategories = DEFAULT_METRICS_CATEGORIES;
+  private Set<MetricCategory> metricsCategories = DEFAULT_METRICS_CATEGORIES;
 
   public boolean isMetricsEnabled() {
     return metricsEnabled;
@@ -74,6 +81,6 @@ public class MetricsOptions {
   }
 
   public List<String> getMetricsCategories() {
-    return metricsCategories.stream().map(Enum::toString).collect(Collectors.toList());
+    return metricsCategories.stream().map(value -> value.toString()).collect(Collectors.toList());
   }
 }

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
@@ -157,7 +157,9 @@ public class BeaconNodeCommandTest {
   @Test
   public void overrideDefaultMetricsCategory() throws IOException {
     final Path configFile = createConfigFile();
-    final String[] args = {CONFIG_FILE_OPTION_NAME, configFile.toString(),"--metrics-categories", "BEACON"};
+    final String[] args = {
+      CONFIG_FILE_OPTION_NAME, configFile.toString(), "--metrics-categories", "BEACON"
+    };
 
     beaconNodeCommand.parse(args);
     assertArtemisConfiguration(
@@ -192,7 +194,7 @@ public class BeaconNodeCommandTest {
       "--metrics-enabled", "false",
       "--metrics-port", "8008",
       "--metrics-interface", "127.0.0.1",
-      "--metrics-categories", "BEACON,LIBP2P,NETWORK,EVENTBUS",
+      "--metrics-categories", "BEACON,LIBP2P,NETWORK,EVENTBUS,JVM,PROCESS",
       "--data-path", dataPath.toString(),
       "--data-storage-mode", "prune",
       "--rest-api-port", "5051",
@@ -206,7 +208,10 @@ public class BeaconNodeCommandTest {
     return expectedConfigurationBuilder()
         .setEth1DepositContractAddress(DEFAULT_ETH1_DEPOSIT_CONTRACT_ADDRESS)
         .setEth1Endpoint(DEFAULT_ETH1_ENDPOINT)
-        .setMetricsCategories(DEFAULT_METRICS_CATEGORIES.stream().map(Enum::toString).collect(Collectors.toList()))
+        .setMetricsCategories(
+            DEFAULT_METRICS_CATEGORIES.stream()
+                .map(value -> value.toString())
+                .collect(Collectors.toList()))
         .setP2pAdvertisedPort(DEFAULT_P2P_ADVERTISED_PORT)
         .setP2pDiscoveryEnabled(DEFAULT_P2P_DISCOVERY_ENABLED)
         .setP2pInterface(DEFAULT_P2P_INTERFACE)
@@ -251,7 +256,8 @@ public class BeaconNodeCommandTest {
         .setMetricsEnabled(false)
         .setMetricsPort(8008)
         .setMetricsInterface("127.0.0.1")
-        .setMetricsCategories(Arrays.asList("BEACON", "LIBP2P", "NETWORK", "EVENTBUS"))
+        .setMetricsCategories(
+            Arrays.asList("BEACON", "LIBP2P", "NETWORK", "EVENTBUS", "JVM", "PROCESS"))
         .setLogColorEnabled(true)
         .setLogDestination(DEFAULT_LOG_DESTINATION)
         .setLogFile(DEFAULT_LOG_FILE)

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
@@ -41,8 +41,10 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
@@ -152,6 +154,16 @@ public class BeaconNodeCommandTest {
     assertArtemisConfiguration(expectedCompleteConfigInFileBuilder().build());
   }
 
+  @Test
+  public void overrideDefaultMetricsCategory() throws IOException {
+    final Path configFile = createConfigFile();
+    final String[] args = {CONFIG_FILE_OPTION_NAME, configFile.toString(),"--metrics-categories", "BEACON"};
+
+    beaconNodeCommand.parse(args);
+    assertArtemisConfiguration(
+        expectedCompleteConfigInFileBuilder().setMetricsCategories(List.of("BEACON")).build());
+  }
+
   private Path createConfigFile() throws IOException {
     final URL configFile = this.getClass().getResource("/complete_config.yaml");
     final String updatedConfig =
@@ -180,7 +192,7 @@ public class BeaconNodeCommandTest {
       "--metrics-enabled", "false",
       "--metrics-port", "8008",
       "--metrics-interface", "127.0.0.1",
-      "--metrics-categories", "BEACON,JVM,PROCESS",
+      "--metrics-categories", "BEACON,LIBP2P,NETWORK,EVENTBUS",
       "--data-path", dataPath.toString(),
       "--data-storage-mode", "prune",
       "--rest-api-port", "5051",
@@ -194,7 +206,7 @@ public class BeaconNodeCommandTest {
     return expectedConfigurationBuilder()
         .setEth1DepositContractAddress(DEFAULT_ETH1_DEPOSIT_CONTRACT_ADDRESS)
         .setEth1Endpoint(DEFAULT_ETH1_ENDPOINT)
-        .setMetricsCategories(DEFAULT_METRICS_CATEGORIES)
+        .setMetricsCategories(DEFAULT_METRICS_CATEGORIES.stream().map(Enum::toString).collect(Collectors.toList()))
         .setP2pAdvertisedPort(DEFAULT_P2P_ADVERTISED_PORT)
         .setP2pDiscoveryEnabled(DEFAULT_P2P_DISCOVERY_ENABLED)
         .setP2pInterface(DEFAULT_P2P_INTERFACE)
@@ -239,7 +251,7 @@ public class BeaconNodeCommandTest {
         .setMetricsEnabled(false)
         .setMetricsPort(8008)
         .setMetricsInterface("127.0.0.1")
-        .setMetricsCategories(Arrays.asList("BEACON", "JVM", "PROCESS"))
+        .setMetricsCategories(Arrays.asList("BEACON", "LIBP2P", "NETWORK", "EVENTBUS"))
         .setLogColorEnabled(true)
         .setLogDestination(DEFAULT_LOG_DESTINATION)
         .setLogFile(DEFAULT_LOG_FILE)

--- a/artemis/src/test/resources/complete_config.yaml
+++ b/artemis/src/test/resources/complete_config.yaml
@@ -40,7 +40,7 @@ log-file-name-pattern: "teku_%d{yyyy-MM-dd}.log"
 metrics-enabled: False
 metrics-port: 8008
 metrics-interface: "127.0.0.1"
-metrics-categories: ["BEACON","JVM","PROCESS"]
+metrics-categories: ["BEACON","LIBP2P", "NETWORK", "EVENTBUS"]
 
 # database
 data-path: "."

--- a/artemis/src/test/resources/complete_config.yaml
+++ b/artemis/src/test/resources/complete_config.yaml
@@ -40,7 +40,7 @@ log-file-name-pattern: "teku_%d{yyyy-MM-dd}.log"
 metrics-enabled: False
 metrics-port: 8008
 metrics-interface: "127.0.0.1"
-metrics-categories: ["BEACON","LIBP2P", "NETWORK", "EVENTBUS"]
+metrics-categories: ["BEACON", "LIBP2P", "NETWORK", "EVENTBUS", "JVM", "PROCESS"]
 
 # database
 data-path: "."

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -43,7 +43,7 @@ eth1-endpoint: "http://localhost:8545"
 metrics-enabled: False
 metrics-port: 8008
 metrics-interface: "127.0.0.1"
-metrics-categories: ["BEACON","JVM","PROCESS"]
+metrics-categories: ["BEACON", "LIBP2P", "NETWORK", "EVENTBUS"]
 
 # database
 #data-path: "."

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -43,7 +43,7 @@ eth1-endpoint: "http://localhost:8545"
 metrics-enabled: False
 metrics-port: 8008
 metrics-interface: "127.0.0.1"
-metrics-categories: ["BEACON", "LIBP2P", "NETWORK", "EVENTBUS"]
+metrics-categories: ["BEACON", "LIBP2P", "NETWORK", "EVENTBUS", "JVM", "PROCESS"]
 
 # database
 #data-path: "."


### PR DESCRIPTION
 - due to dependencies continue to export strings to the lower levels.

 - Update the default categories in the config.yaml to contain no invalid values.

 - set the default prometheus categories to at least include the beacon category.

 Addresses #1619

Signed-off-by: Paul Harris <paul.harris@consensys.net>
