### PR TITLE
Use binary search to find the min genesis block

### DIFF
--- a/pow/src/main/java/tech/pegasys/artemis/pow/MinimumGenesisTimeBlockFinder.java
+++ b/pow/src/main/java/tech/pegasys/artemis/pow/MinimumGenesisTimeBlockFinder.java
@@ -62,7 +62,7 @@ public class MinimumGenesisTimeBlockFinder {
                   return binarySearchLoop(searchContext);
                 } else if (cmp > 0) {
                   if (mid.equals(ZERO)) {
-                    // The very first block is after min genesis so just use it
+                    // The very first eth1 block is after eth2 min genesis so just use it
                     return SafeFuture.completedFuture(midBlock);
                   }
                   searchContext.high = mid.minus(ONE);

--- a/pow/src/main/java/tech/pegasys/artemis/pow/MinimumGenesisTimeBlockFinder.java
+++ b/pow/src/main/java/tech/pegasys/artemis/pow/MinimumGenesisTimeBlockFinder.java
@@ -13,6 +13,9 @@
 
 package tech.pegasys.artemis.pow;
 
+import static com.google.common.primitives.UnsignedLong.ONE;
+import static com.google.common.primitives.UnsignedLong.ZERO;
+
 import com.google.common.primitives.UnsignedLong;
 import java.math.BigInteger;
 import org.apache.logging.log4j.LogManager;
@@ -28,6 +31,8 @@ public class MinimumGenesisTimeBlockFinder {
 
   private static final Logger LOG = LogManager.getLogger();
 
+  private static final UnsignedLong TWO = UnsignedLong.valueOf(2);
+
   private final Eth1Provider eth1Provider;
 
   public MinimumGenesisTimeBlockFinder(Eth1Provider eth1Provider) {
@@ -37,75 +42,40 @@ public class MinimumGenesisTimeBlockFinder {
   /**
    * Find first block in history that has timestamp greater than MIN_GENESIS_TIME
    *
-   * @param estimationBlock estimationBlock that will be used for estimation
+   * @param headBlock block at current chain head
    * @return min genesis time block
    */
-  public SafeFuture<EthBlock.Block> findMinGenesisTimeBlockInHistory(
-      EthBlock.Block estimationBlock) {
-    UnsignedLong estimatedBlockNumber =
-        getEstimatedMinGenesisTimeBlockNumber(estimationBlock, Constants.SECONDS_PER_ETH1_BLOCK);
-    return eth1Provider
-        .getEth1BlockFuture(estimatedBlockNumber)
-        .thenCompose(
-            block -> {
-              int comparison = compareBlockTimestampToMinGenesisTime(block);
-              if (comparison > 0) {
-                // If block timestamp is greater than min genesis time
-                // explore blocks downwards
-                return exploreBlocksDownwards(block);
-              } else if (comparison < 0) {
-                // If block timestamp is less than min genesis time
-                // explore blocks upwards
-                return exploreBlocksUpwards(block);
-              } else {
-                return SafeFuture.completedFuture(block);
-              }
-            });
+  public SafeFuture<EthBlock.Block> findMinGenesisTimeBlockInHistory(EthBlock.Block headBlock) {
+    return binarySearchLoop(new SearchContext(headBlock));
   }
 
-  private SafeFuture<EthBlock.Block> exploreBlocksDownwards(EthBlock.Block previousBlock) {
-    if (previousBlock.getNumber().equals(BigInteger.ZERO)) {
-      // We reached genesis and thus should be returning genesis as the min genesis block.
-      return SafeFuture.completedFuture(previousBlock);
+  private SafeFuture<EthBlock.Block> binarySearchLoop(final SearchContext searchContext) {
+    if (searchContext.low.compareTo(searchContext.high) <= 0) {
+      final UnsignedLong mid = searchContext.low.plus(searchContext.high).dividedBy(TWO);
+      return eth1Provider
+          .getEth1BlockFuture(mid)
+          .thenCompose(
+              midBlock -> {
+                final int cmp = compareBlockTimestampToMinGenesisTime(midBlock);
+                if (cmp < 0) {
+                  searchContext.low = mid.plus(ONE);
+                  return binarySearchLoop(searchContext);
+                } else if (cmp > 0) {
+                  if (mid.equals(ZERO)) {
+                    // The very first block is after min genesis so just use it
+                    return SafeFuture.completedFuture(midBlock);
+                  }
+                  searchContext.high = mid.minus(ONE);
+                  return binarySearchLoop(searchContext);
+                } else {
+                  // This block has exactly the min genesis time
+                  return SafeFuture.completedFuture(midBlock);
+                }
+              });
+    } else {
+      // Completed search
+      return eth1Provider.getEth1BlockFuture(searchContext.low);
     }
-
-    UnsignedLong previousBlockNumber = UnsignedLong.valueOf(previousBlock.getNumber());
-    UnsignedLong newBlockNumber = previousBlockNumber.minus(UnsignedLong.ONE);
-    SafeFuture<EthBlock.Block> blockFuture = eth1Provider.getEth1BlockFuture(newBlockNumber);
-    return blockFuture.thenCompose(
-        block -> {
-          int comparison = compareBlockTimestampToMinGenesisTime(block);
-          if (comparison > 0) {
-            // If exploring downwards and block timestamp > min genesis time,
-            // then block must still be downwards.
-            return exploreBlocksDownwards(block);
-          } else if (comparison < 0) {
-            // If exploring downwards and block timestamp < min genesis time,
-            // then previous block must have been the min genesis time block.
-            return SafeFuture.completedFuture(previousBlock);
-          } else {
-            return SafeFuture.completedFuture(block);
-          }
-        });
-  }
-
-  private SafeFuture<EthBlock.Block> exploreBlocksUpwards(EthBlock.Block previousBlock) {
-    UnsignedLong previousBlockNumber = UnsignedLong.valueOf(previousBlock.getNumber());
-    UnsignedLong newBlockNumber = previousBlockNumber.plus(UnsignedLong.ONE);
-    SafeFuture<EthBlock.Block> blockFuture = eth1Provider.getEth1BlockFuture(newBlockNumber);
-    return blockFuture.thenCompose(
-        block -> {
-          int comparison = compareBlockTimestampToMinGenesisTime(block);
-          if (comparison >= 0) {
-            // If exploring upwards and block timestamp >= min genesis time,
-            // then current block must be the min genesis time block.
-            return SafeFuture.completedFuture(block);
-          } else {
-            // If exploring upwards and block timestamp < min genesis time,
-            // then previous block must have been the min genesis time block.
-            return exploreBlocksUpwards(block);
-          }
-        });
   }
 
   // eth1_timestamp - eth1_timestamp % MIN_GENESIS_DELAY + 2 * MIN_GENESIS_DELAY,
@@ -116,41 +86,19 @@ public class MinimumGenesisTimeBlockFinder {
         .plus(UnsignedLong.valueOf(2 * Constants.MIN_GENESIS_DELAY));
   }
 
-  /**
-   * Given that blockTimestamp is greater than min genesis time, find the min genesis time block
-   *
-   * @param block that is going to be used for estimation
-   * @param secondsPerEth1Block seconds per Eth1 Block
-   * @return estimated block number of min genesis time block
-   */
-  private static UnsignedLong getEstimatedMinGenesisTimeBlockNumber(
-      EthBlock.Block block, UnsignedLong secondsPerEth1Block) {
-    UnsignedLong blockNumber = UnsignedLong.valueOf(block.getNumber());
-    UnsignedLong blockTimestamp = UnsignedLong.valueOf(block.getTimestamp());
-    UnsignedLong timeDiff =
-        calculateCandidateGenesisTimestamp(blockTimestamp.bigIntegerValue())
-            .minus(Constants.MIN_GENESIS_TIME);
-    UnsignedLong blockNumberDiff = timeDiff.dividedBy(secondsPerEth1Block);
-    if (blockNumberDiff.compareTo(blockNumber) > 0) {
-      return UnsignedLong.ZERO;
-    } else {
-      return blockNumber.minus(blockNumberDiff);
-    }
-  }
-
-  public static int compareBlockTimestampToMinGenesisTime(EthBlock.Block block) {
+  static int compareBlockTimestampToMinGenesisTime(EthBlock.Block block) {
     return calculateCandidateGenesisTimestamp(block.getTimestamp())
         .compareTo(Constants.MIN_GENESIS_TIME);
   }
 
-  public static Boolean isBlockAfterMinGenesis(EthBlock.Block block) {
+  static Boolean isBlockAfterMinGenesis(EthBlock.Block block) {
     int comparison = compareBlockTimestampToMinGenesisTime(block);
     // If block timestamp is greater than min genesis time,
     // min genesis block must be in the future
     return comparison > 0;
   }
 
-  public static void notifyMinGenesisTimeBlockReached(
+  static void notifyMinGenesisTimeBlockReached(
       Eth1EventsChannel eth1EventsChannel, EthBlock.Block block) {
     MinGenesisTimeBlockEvent event =
         new MinGenesisTimeBlockEvent(
@@ -159,5 +107,14 @@ public class MinimumGenesisTimeBlockFinder {
             Bytes32.fromHexString(block.getHash()));
     eth1EventsChannel.onMinGenesisTimeBlock(event);
     LOG.debug("Notifying BeaconChainService of MinGenesisTimeBlock: {}", event);
+  }
+
+  private static class SearchContext {
+    private UnsignedLong low = UnsignedLong.ZERO;
+    private UnsignedLong high;
+
+    public SearchContext(final EthBlock.Block chainHead) {
+      this.high = UnsignedLong.valueOf(chainHead.getNumber());
+    }
   }
 }

--- a/pow/src/test/java/tech/pegasys/artemis/pow/MinimumGenesisTimeBlockFinderTest.java
+++ b/pow/src/test/java/tech/pegasys/artemis/pow/MinimumGenesisTimeBlockFinderTest.java
@@ -36,7 +36,7 @@ public class MinimumGenesisTimeBlockFinderTest {
 
   @BeforeAll
   static void setUp() {
-    // calculateCandidateGenesisTimestamp will return blockTime + 2
+    // Setup so genesis time for a block will be blockTime + 2
     Constants.MIN_GENESIS_DELAY = 1;
   }
 
@@ -51,14 +51,6 @@ public class MinimumGenesisTimeBlockFinderTest {
     final Block[] blocks = withBlockTimestamps(timestamps);
     final int minGenesisTime = 3500;
     final Block expectedMinGenesisTimeBlock = blocks[4];
-    assertMinGenesisBlock(blocks, minGenesisTime, expectedMinGenesisTimeBlock);
-  }
-
-  @Test
-  public void shouldAddGenesisDelayToBlockTimestampWhenConsideringIfItIsTheMinGenesisBlock() {
-    final Block[] blocks = withBlockTimestamps(1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000);
-    final int minGenesisTime = 3002;
-    final Block expectedMinGenesisTimeBlock = blocks[2];
     assertMinGenesisBlock(blocks, minGenesisTime, expectedMinGenesisTimeBlock);
   }
 


### PR DESCRIPTION
## PR Description
Improve the performance of calculating the genesis state from an eth1 chain when the minimum genesis time is somewhere in the middle of the chain by using binary search to find the first block that meets the time criteria.