### PR TITLE
Disable nightly compatibility tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,16 +317,16 @@ workflows:
             - acceptanceTests
             - referenceTests
             - docker
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - assemble
-      - compatibilityTests:
-          requires:
-            - assemble
+#  nightly:
+#    triggers:
+#      - schedule:
+#          cron: "0 0 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - master
+#    jobs:
+#      - assemble
+#      - compatibilityTests:
+#          requires:
+#            - assemble


### PR DESCRIPTION
## PR Description
Disable the nightly compatibility tests until we've completed the v0.11.1 networking related changes.