### PR TITLE
Don't remove all duties during epoch 0

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/DutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/DutyScheduler.java
@@ -20,9 +20,12 @@ import com.google.common.primitives.UnsignedLong;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 import java.util.function.BiConsumer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.artemis.validator.api.ValidatorTimingChannel;
 
 public class DutyScheduler implements ValidatorTimingChannel {
+  private static final Logger LOG = LogManager.getLogger();
   private final EpochDutiesScheduler epochDutiesScheduler;
   private NavigableMap<UnsignedLong, DutyQueue> dutiesByEpoch = new TreeMap<>();
 
@@ -40,6 +43,7 @@ public class DutyScheduler implements ValidatorTimingChannel {
 
   @Override
   public void onChainReorg(final UnsignedLong newSlot) {
+    LOG.debug("Chain reorganisation detected. Recalculating validator duties");
     dutiesByEpoch.clear();
     final UnsignedLong epochNumber = compute_epoch_at_slot(newSlot);
     final UnsignedLong nextEpochNumber = epochNumber.plus(ONE);
@@ -75,6 +79,6 @@ public class DutyScheduler implements ValidatorTimingChannel {
   }
 
   private void removePriorEpochs(final UnsignedLong epochNumber) {
-    dutiesByEpoch.headMap(epochNumber.minus(ONE)).clear();
+    dutiesByEpoch.headMap(epochNumber).clear();
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/artemis/validator/client/DutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/artemis/validator/client/DutySchedulerTest.java
@@ -133,6 +133,21 @@ class DutySchedulerTest {
   }
 
   @Test
+  public void shouldNotRefetchDutiesWhichHaveAlreadyBeenRetrievedDuringFirstEpoch() {
+    when(validatorApiChannel.getDuties(any(), any())).thenReturn(new SafeFuture<>());
+    dutyScheduler.onSlot(ZERO);
+
+    verify(validatorApiChannel).getDuties(ZERO, VALIDATOR_KEYS);
+    verify(validatorApiChannel).getDuties(ONE, VALIDATOR_KEYS);
+
+    // Second slot in epoch 0
+    dutyScheduler.onSlot(ONE);
+
+    // Shouldn't request any more duties
+    verifyNoMoreInteractions(validatorApiChannel);
+  }
+
+  @Test
   public void shouldRetryWhenRequestingDutiesFails() {
     final SafeFuture<Optional<List<ValidatorDuties>>> request1 = new SafeFuture<>();
     final SafeFuture<Optional<List<ValidatorDuties>>> request2 = new SafeFuture<>();


### PR DESCRIPTION
## PR Description
Fix an underflow bug when removing duties for prior epochs in `DutyScheduler`.