### PR TITLE
Load duties sooner after node finishes syncing

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
@@ -113,14 +113,14 @@ public class BeaconNodeCommand implements Callable<Integer> {
   private File configFile;
 
   @Option(
-      names = {"-Xstartup-target-peer-count"},
+      names = {"--Xstartup-target-peer-count"},
       paramLabel = "<NUMBER>",
       description = "Number of peers to wait for before considering the node in sync.",
       hidden = true)
   private Integer startupTargetPeerCount;
 
   @Option(
-      names = {"-Xstartup-timeout-seconds"},
+      names = {"--Xstartup-timeout-seconds"},
       paramLabel = "<NUMBER>",
       description =
           "Timeout in seconds to allow the node to be in sync even if startup target peer count has not yet been reached.",

--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/DutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/DutyLoader.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.validator.client;
+
+import com.google.common.primitives.UnsignedLong;
+import tech.pegasys.artemis.util.async.SafeFuture;
+import tech.pegasys.artemis.validator.client.duties.ScheduledDuties;
+
+public interface DutyLoader {
+  SafeFuture<ScheduledDuties> loadDutiesForEpoch(final UnsignedLong epoch);
+}

--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/DutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/DutyScheduler.java
@@ -80,8 +80,7 @@ public class DutyScheduler implements ValidatorTimingChannel {
   }
 
   private void removePriorEpochs(final UnsignedLong epochNumber) {
-    final SortedMap<UnsignedLong, DutyQueue> toRemove =
-        dutiesByEpoch.headMap(epochNumber);
+    final SortedMap<UnsignedLong, DutyQueue> toRemove = dutiesByEpoch.headMap(epochNumber);
     toRemove.values().forEach(DutyQueue::cancel);
     toRemove.clear();
   }

--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/NodeDataUnavailableException.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/NodeDataUnavailableException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.validator.client;
+
+public class NodeDataUnavailableException extends RuntimeException {
+
+  public NodeDataUnavailableException(final String message) {
+    super(message);
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/artemis/validator/client/RetryingDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/artemis/validator/client/RetryingDutyLoader.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.validator.client;
+
+import com.google.common.base.Throwables;
+import com.google.common.primitives.UnsignedLong;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.artemis.util.async.AsyncRunner;
+import tech.pegasys.artemis.util.async.SafeFuture;
+import tech.pegasys.artemis.validator.api.NodeSyncingException;
+import tech.pegasys.artemis.validator.client.duties.ScheduledDuties;
+
+public class RetryingDutyLoader implements DutyLoader {
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final DutyLoader delegate;
+  private final AsyncRunner asyncRunner;
+
+  public RetryingDutyLoader(final AsyncRunner asyncRunner, final DutyLoader delegate) {
+    this.delegate = delegate;
+    this.asyncRunner = asyncRunner;
+  }
+
+  @Override
+  public SafeFuture<ScheduledDuties> loadDutiesForEpoch(final UnsignedLong epoch) {
+    final SafeFuture<ScheduledDuties> duties = new SafeFuture<>();
+    requestDuties(epoch, duties).propagateTo(duties);
+    return duties;
+  }
+
+  private SafeFuture<ScheduledDuties> requestDuties(
+      final UnsignedLong epoch, final SafeFuture<ScheduledDuties> cancellable) {
+    return delegate
+        .loadDutiesForEpoch(epoch)
+        .exceptionallyCompose(
+            error -> {
+              if (cancellable.isCancelled()) {
+                LOG.debug("Request for duties for epoch {} cancelled.", epoch);
+                return SafeFuture.failedFuture(error);
+              }
+              final Throwable rootCause = Throwables.getRootCause(error);
+              if (rootCause instanceof NodeSyncingException) {
+                LOG.debug(
+                    "Unable to schedule duties for epoch {} because node was syncing. Retrying.",
+                    epoch);
+              } else if (rootCause instanceof NodeDataUnavailableException) {
+                LOG.debug(
+                    "Unable to schedule duties for epoch {} because required state was not yet available. Retrying.",
+                    epoch);
+              } else {
+                LOG.error(
+                    "Failed to request validator duties for epoch "
+                        + epoch
+                        + ". Retrying after delay.",
+                    error);
+              }
+              return asyncRunner.runAfterDelay(
+                  () -> requestDuties(epoch, cancellable), 5, TimeUnit.SECONDS);
+            });
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/artemis/validator/client/DutyQueueTest.java
+++ b/validator/client/src/test/java/tech/pegasys/artemis/validator/client/DutyQueueTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.artemis.validator.client;
 
 import static com.google.common.primitives.UnsignedLong.ONE;
 import static com.google.common.primitives.UnsignedLong.ZERO;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -30,6 +31,12 @@ class DutyQueueTest {
   private final ScheduledDuties scheduledDuties = mock(ScheduledDuties.class);
 
   private final DutyQueue duties = new DutyQueue(scheduledDutiesFuture);
+
+  @Test
+  public void cancel_shouldCancelFuture() {
+    duties.cancel();
+    assertThat(scheduledDutiesFuture).isCancelled();
+  }
 
   @Test
   public void onBlockProductionDue_shouldActImmediatelyIfDutiesLoaded() {

--- a/validator/client/src/test/java/tech/pegasys/artemis/validator/client/DutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/artemis/validator/client/DutySchedulerTest.java
@@ -74,12 +74,13 @@ class DutySchedulerTest {
 
   private final DutyScheduler dutyScheduler =
       new DutyScheduler(
-          new EpochDutiesScheduler(
+          new RetryingDutyLoader(
               asyncRunner,
-              validatorApiChannel,
-              forkProvider,
-              () -> new ScheduledDuties(dutyFactory),
-              Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2)));
+              new ValidatorApiDutyLoader(
+                  validatorApiChannel,
+                  forkProvider,
+                  () -> new ScheduledDuties(dutyFactory),
+                  Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2))));
 
   @BeforeEach
   public void setUp() {
@@ -197,12 +198,13 @@ class DutySchedulerTest {
     final ScheduledDuties scheduledDuties = mock(ScheduledDuties.class);
     final ValidatorTimingChannel dutyScheduler =
         new DutyScheduler(
-            new EpochDutiesScheduler(
+            new RetryingDutyLoader(
                 asyncRunner,
-                validatorApiChannel,
-                forkProvider,
-                () -> scheduledDuties,
-                Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2)));
+                new ValidatorApiDutyLoader(
+                    validatorApiChannel,
+                    forkProvider,
+                    () -> scheduledDuties,
+                    Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2))));
     final SafeFuture<Optional<List<ValidatorDuties>>> epoch0Duties = new SafeFuture<>();
 
     when(validatorApiChannel.getDuties(eq(ZERO), any())).thenReturn(epoch0Duties);

--- a/validator/client/src/test/java/tech/pegasys/artemis/validator/client/RetryingDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/artemis/validator/client/RetryingDutyLoaderTest.java
@@ -26,7 +26,7 @@ import tech.pegasys.artemis.util.async.StubAsyncRunner;
 import tech.pegasys.artemis.validator.api.NodeSyncingException;
 import tech.pegasys.artemis.validator.client.duties.ScheduledDuties;
 
-class RetryingDutySchedulerTest {
+class RetryingDutyLoaderTest {
 
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final DutyLoader delegate = mock(DutyLoader.class);

--- a/validator/client/src/test/java/tech/pegasys/artemis/validator/client/RetryingDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/artemis/validator/client/RetryingDutySchedulerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.validator.client;
+
+import static com.google.common.primitives.UnsignedLong.ONE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.util.async.SafeFuture;
+import tech.pegasys.artemis.util.async.StubAsyncRunner;
+import tech.pegasys.artemis.validator.api.NodeSyncingException;
+import tech.pegasys.artemis.validator.client.duties.ScheduledDuties;
+
+class RetryingDutySchedulerTest {
+
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+  private final DutyLoader delegate = mock(DutyLoader.class);
+  private final ScheduledDuties scheduledDuties = mock(ScheduledDuties.class);
+
+  private final RetryingDutyLoader dutyLoader = new RetryingDutyLoader(asyncRunner, delegate);
+
+  @Test
+  public void shouldReturnDutiesWhenLoadedSuccessfully() {
+    when(delegate.loadDutiesForEpoch(ONE)).thenReturn(SafeFuture.completedFuture(scheduledDuties));
+
+    assertThat(dutyLoader.loadDutiesForEpoch(ONE)).isCompletedWithValue(scheduledDuties);
+  }
+
+  @Test
+  public void shouldRetryWhenRequestForDutiesFailsBecauseNodeIsSyncing() {
+    when(delegate.loadDutiesForEpoch(ONE))
+        .thenReturn(NodeSyncingException.failedFuture())
+        .thenReturn(SafeFuture.completedFuture(scheduledDuties));
+
+    final SafeFuture<ScheduledDuties> result = dutyLoader.loadDutiesForEpoch(ONE);
+    assertThat(result).isNotDone();
+    assertThat(asyncRunner.hasDelayedActions()).isTrue();
+
+    asyncRunner.executeQueuedActions();
+    assertThat(result).isCompletedWithValue(scheduledDuties);
+  }
+
+  @Test
+  public void shouldRetryWhenRequestForDutiesFailsBecauseNodeDataIsUnavailable() {
+    when(delegate.loadDutiesForEpoch(ONE))
+        .thenReturn(SafeFuture.failedFuture(new NodeDataUnavailableException("Sorry")))
+        .thenReturn(SafeFuture.completedFuture(scheduledDuties));
+
+    final SafeFuture<ScheduledDuties> result = dutyLoader.loadDutiesForEpoch(ONE);
+    assertThat(result).isNotDone();
+    assertThat(asyncRunner.hasDelayedActions()).isTrue();
+
+    asyncRunner.executeQueuedActions();
+    assertThat(result).isCompletedWithValue(scheduledDuties);
+  }
+
+  @Test
+  public void shouldRetryWhenUnexpectedErrorOccurs() {
+    when(delegate.loadDutiesForEpoch(ONE))
+        .thenReturn(SafeFuture.failedFuture(new RuntimeException("No way")))
+        .thenReturn(SafeFuture.completedFuture(scheduledDuties));
+
+    final SafeFuture<ScheduledDuties> result = dutyLoader.loadDutiesForEpoch(ONE);
+    assertThat(result).isNotDone();
+    assertThat(asyncRunner.hasDelayedActions()).isTrue();
+
+    asyncRunner.executeQueuedActions();
+    assertThat(result).isCompletedWithValue(scheduledDuties);
+  }
+
+  @Test
+  public void shouldStopRetryingWhenFutureIsCancelled() {
+    final RuntimeException error = new RuntimeException("No way");
+    final SafeFuture<ScheduledDuties> delegateResponse = new SafeFuture<>();
+    when(delegate.loadDutiesForEpoch(ONE)).thenReturn(delegateResponse);
+
+    final SafeFuture<ScheduledDuties> result = dutyLoader.loadDutiesForEpoch(ONE);
+    verify(delegate).loadDutiesForEpoch(ONE);
+    assertThat(result).isNotDone();
+
+    result.cancel(false);
+
+    // When the request then fails, we don't retry it.
+    delegateResponse.completeExceptionally(error);
+    assertThat(asyncRunner.hasDelayedActions()).isFalse();
+    verifyNoMoreInteractions(delegate);
+  }
+}


### PR DESCRIPTION
## PR Description
Previously, if loading validator duties failed because the node was syncing, it was not retried, so up to two epochs had to pass before validators would begin performing their duties. 
Additionally, when errors that could be retried occurred repeatedly the validator client would never give up requesting duties for that epoch. Now once the epoch has passed, retries are aborted.

Also fixes the `--X` CLI args for startup conditions to have a double `-` prefix instead of single.