### PR TITLE
Improve genesis performance and logging

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -155,11 +155,11 @@ public class BeaconStateUtil {
         if (!proof_is_valid) {
           if (deposit instanceof DepositWithIndex) {
             LOG.debug(
-                "Skipping invalid deposit with index {} of pubkey {}",
+                "Skipping invalid deposit with index {} and pubkey {}",
                 ((DepositWithIndex) deposit).getIndex(),
                 pubkey);
           } else {
-            LOG.debug("Skipping invalid deposit with of pubkey {}", pubkey);
+            LOG.debug("Skipping invalid deposit with pubkey {}", pubkey);
           }
           if (pubKeyToIndexMap != null) {
             // The validator won't be created so the calculated index won't be correct

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/BeaconStateUtil.java
@@ -154,12 +154,12 @@ public class BeaconStateUtil {
                 || BLS.verify(pubkey, signing_root, deposit.getData().getSignature());
         if (!proof_is_valid) {
           if (deposit instanceof DepositWithIndex) {
-            LOG.warn(
+            LOG.debug(
                 "Skipping invalid deposit with index {} of pubkey {}",
                 ((DepositWithIndex) deposit).getIndex(),
                 pubkey);
           } else {
-            LOG.warn("Skipping invalid deposit with of pubkey {}", pubkey);
+            LOG.debug("Skipping invalid deposit with of pubkey {}", pubkey);
           }
           if (pubKeyToIndexMap != null) {
             // The validator won't be created so the calculated index won't be correct
@@ -192,17 +192,17 @@ public class BeaconStateUtil {
     }
   }
 
-  public static boolean is_valid_genesis_state(BeaconState state) {
-    return isItMinGenesisTimeYet(state) && isThereEnoughNumberOfValidators(state);
+  public static boolean is_valid_genesis_state(UnsignedLong genesisTime, int activeValidatorCount) {
+    return isItMinGenesisTimeYet(genesisTime)
+        && isThereEnoughNumberOfValidators(activeValidatorCount);
   }
 
-  public static boolean isThereEnoughNumberOfValidators(BeaconState state) {
-    return get_active_validator_indices(state, UnsignedLong.valueOf(GENESIS_EPOCH)).size()
-        >= MIN_GENESIS_ACTIVE_VALIDATOR_COUNT;
+  public static boolean isThereEnoughNumberOfValidators(int activeValidatorCount) {
+    return activeValidatorCount >= MIN_GENESIS_ACTIVE_VALIDATOR_COUNT;
   }
 
-  public static boolean isItMinGenesisTimeYet(BeaconState state) {
-    return state.getGenesis_time().compareTo(MIN_GENESIS_TIME) >= 0;
+  public static boolean isItMinGenesisTimeYet(final UnsignedLong genesisTime) {
+    return genesisTime.compareTo(MIN_GENESIS_TIME) >= 0;
   }
 
   /**

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/GenesisGenerator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/GenesisGenerator.java
@@ -25,8 +25,6 @@ import com.google.common.primitives.UnsignedLong;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.function.Predicate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -54,6 +52,8 @@ public class GenesisGenerator {
   private final long depositListLength = ((long) 1) << DEPOSIT_CONTRACT_TREE_DEPTH;
   private final SSZMutableList<DepositData> depositDataList =
       SSZList.createMutable(DepositData.class, depositListLength);
+
+  private int activeValidatorCount = 0;
 
   public GenesisGenerator() {
     Bytes32 latestBlockRoot = new BeaconBlockBody().hash_tree_root();
@@ -97,6 +97,10 @@ public class GenesisGenerator {
       return;
     }
     Validator validator = state.getValidators().get(index);
+    if (validator.getActivation_epoch().equals(UnsignedLong.valueOf(GENESIS_EPOCH))) {
+      // Validator is already activated (and thus already has the max effective balance)
+      return;
+    }
     UnsignedLong balance = state.getBalances().get(index);
     UnsignedLong effective_balance =
         BeaconStateUtil.min(
@@ -109,6 +113,7 @@ public class GenesisGenerator {
     if (validator.getEffective_balance().equals(UnsignedLong.valueOf(MAX_EFFECTIVE_BALANCE))) {
       activation_eligibility_epoch = UnsignedLong.valueOf(GENESIS_EPOCH);
       activation_epoch = UnsignedLong.valueOf(GENESIS_EPOCH);
+      activeValidatorCount++;
     }
 
     Validator modifiedValidator =
@@ -125,18 +130,17 @@ public class GenesisGenerator {
     state.getValidators().set(index, modifiedValidator);
   }
 
-  public BeaconState getGenesisState() {
-    return getGenesisStateIfValid(state -> true).orElseThrow();
+  public int getActiveValidatorCount() {
+    return activeValidatorCount;
   }
 
-  public Optional<BeaconState> getGenesisStateIfValid(Predicate<BeaconState> validityCriteria) {
-    if (!validityCriteria.test(state)) {
-      return Optional.empty();
-    }
+  public UnsignedLong getGenesisTime() {
+    return state.getGenesis_time();
+  }
 
+  public BeaconState getGenesisState() {
     finalizeState();
-
-    return Optional.of(state.commitChanges());
+    return state.commitChanges();
   }
 
   private void finalizeState() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/genesis/GenesisHandler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/genesis/GenesisHandler.java
@@ -56,6 +56,9 @@ public class GenesisHandler implements Eth1EventsChannel {
 
   @Override
   public void onMinGenesisTimeBlock(MinGenesisTimeBlockEvent event) {
+    if (!recentChainData.isPreGenesis()) {
+      return;
+    }
     STATUS_LOG.minGenesisTimeReached();
     processNewData(event.getBlockHash(), event.getTimestamp(), List.of());
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/StartupUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/StartupUtil.java
@@ -13,12 +13,13 @@
 
 package tech.pegasys.artemis.statetransition.util;
 
+import static tech.pegasys.teku.logging.StatusLogger.STATUS_LOG;
+
 import com.google.common.primitives.UnsignedLong;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -75,19 +76,13 @@ public final class StartupUtil {
     BeaconState initialState;
     if (startState != null) {
       try {
-        LOG.log(Level.INFO, "Loading initial state from " + startState);
+        STATUS_LOG.loadingGenesisFile(startState);
         initialState = StartupUtil.loadBeaconStateFromFile(startState);
       } catch (final IOException e) {
         throw new IllegalStateException("Failed to load initial state", e);
       }
     } else {
-      LOG.log(
-          Level.INFO,
-          "Starting with mocked start interoperability mode with genesis time "
-              + genesisTime
-              + " and "
-              + validatorKeyPairs.size()
-              + " validators");
+      STATUS_LOG.generatingMockStartGenesis(genesisTime, validatorKeyPairs.size());
       initialState =
           StartupUtil.createMockedStartInitialBeaconState(
               genesisTime, validatorKeyPairs, signDeposits);

--- a/logging/src/main/java/tech/pegasys/teku/logging/LoggingConfigurator.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/LoggingConfigurator.java
@@ -39,7 +39,7 @@ public class LoggingConfigurator {
   private static final String LOG4J_CONFIG_FILE_KEY = "LOG4J_CONFIGURATION_FILE";
   private static final String LOG4J_LEGACY_CONFIG_FILE_KEY = "log4j.configurationFile";
   private static final String CONSOLE_APPENDER_NAME = "teku-console-appender";
-  private static final String CONSOLE_FORMAT = "%d{HH:mm:ss.SSS} [%-5level] - %msg%n";
+  private static final String CONSOLE_FORMAT = "%d{HH:mm:ss.SSS} %-5level - %msg%n";
   private static final String FILE_APPENDER_NAME = "teku-log-appender";
   private static final String FILE_MESSAGE_FORMAT =
       "%d{yyyy-MM-dd HH:mm:ss.SSSZZZ} | %t | %-5level | %c{1} | %msg%n";
@@ -122,11 +122,15 @@ public class LoggingConfigurator {
       case DEFAULT_BOTH:
         // fall through
       case BOTH:
-        onlyEventsLoggerToConsole(configuration);
+        consoleAppender = consoleAppender(configuration);
+        final LoggerConfig eventsLogger = setUpEventsLogger(consoleAppender);
+        final LoggerConfig statusLogger = setUpStatusLogger(consoleAppender);
+        configuration.addLogger(eventsLogger.getName(), eventsLogger);
+        configuration.addLogger(statusLogger.getName(), statusLogger);
 
         fileAppender = fileAppender(configuration);
 
-        setUpStatusLogger(fileAppender);
+        setUpStatusLogger(consoleAppender);
         addAppenderToRootLogger(configuration, fileAppender);
         break;
     }
@@ -195,14 +199,6 @@ public class LoggingConfigurator {
     configuration.getRootLogger().addAppender(appender, null, null);
   }
 
-  private static void onlyEventsLoggerToConsole(final AbstractConfiguration configuration) {
-
-    final Appender consoleAppender = consoleAppender(configuration);
-    final LoggerConfig eventsLogger = setUpEventsLogger(consoleAppender);
-    configuration.addAppender(consoleAppender);
-    configuration.addLogger(eventsLogger.getName(), eventsLogger);
-  }
-
   private static LoggerConfig setUpEventsLogger(final Appender appender) {
     final Level eventsLogLevel = INCLUDE_EVENTS ? ROOT_LOG_LEVEL : Level.OFF;
     final LoggerConfig logger = new LoggerConfig(EVENT_LOGGER_NAME, eventsLogLevel, true);
@@ -210,9 +206,10 @@ public class LoggingConfigurator {
     return logger;
   }
 
-  private static void setUpStatusLogger(final Appender appender) {
+  private static LoggerConfig setUpStatusLogger(final Appender appender) {
     final LoggerConfig logger = new LoggerConfig(STATUS_LOGGER_NAME, ROOT_LOG_LEVEL, true);
     logger.addAppender(appender, ROOT_LOG_LEVEL, null);
+    return logger;
   }
 
   private static Appender consoleAppender(final AbstractConfiguration configuration) {

--- a/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.logging;
 import static tech.pegasys.teku.logging.LoggingConfigurator.STATUS_LOGGER_NAME;
 
 import java.nio.file.Path;
+import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -60,10 +61,25 @@ public class StatusLogger {
   }
 
   public void beginInitializingChainData() {
-    log.info("Begin initializing chain data from storage");
+    log.info("Initializing storage");
   }
 
   public void finishInitializingChainData() {
-    log.info("Finish initializing chain data from storage");
+    log.info("Storage initialization complete");
+  }
+
+  public void generatingMockStartGenesis(final long genesisTime, final int size) {
+    log.info(
+        "Starting with mocked start interoperability mode with genesis time {} and {} validators",
+        () -> DateFormatUtils.format(genesisTime * 1000, "yyyy-MM-dd hh:mm:ss"),
+        () -> size);
+  }
+
+  public void loadingGenesisFile(final String genesisFile) {
+    log.info("Loading genesis from file {}", genesisFile);
+  }
+
+  public void loadingGenesisFromEth1Chain() {
+    log.info("No genesis state available. Loading deposits from ETH1 chain");
   }
 }

--- a/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
@@ -82,4 +82,16 @@ public class StatusLogger {
   public void loadingGenesisFromEth1Chain() {
     log.info("No genesis state available. Loading deposits from ETH1 chain");
   }
+
+  public void genesisValidatorsActivated(int activeValidatorCount, int requiredValidatorCount) {
+    log.info(
+        "Activated {} of {} validators required for genesis ({}%)",
+        activeValidatorCount,
+        requiredValidatorCount,
+        activeValidatorCount * 100 / requiredValidatorCount);
+  }
+
+  public void minGenesisTimeReached() {
+    log.info("Minimum genesis time reached");
+  }
 }

--- a/pow/src/main/java/tech/pegasys/artemis/pow/DepositFetcher.java
+++ b/pow/src/main/java/tech/pegasys/artemis/pow/DepositFetcher.java
@@ -108,8 +108,8 @@ public class DepositFetcher {
 
     // First process completed requests using iteration.
     // Avoid StackOverflowException when there is a long string of requests already completed.
-    while (!blockRequests.isEmpty() && blockRequests.get(blockRequests.size() - 1).isDone()) {
-      final EthBlock.Block block = blockRequests.remove(blockRequests.size() - 1).join();
+    while (!blockRequests.isEmpty() && blockRequests.get(0).isDone()) {
+      final EthBlock.Block block = blockRequests.remove(0).join();
       postEventsForBlock(block, depositEventsByBlock);
     }
 
@@ -120,7 +120,7 @@ public class DepositFetcher {
 
     // Reached a block request that isn't complete so wait for it and recurse back into this method.
     return blockRequests
-        .get(blockRequests.size() - 1)
+        .get(0)
         .thenCompose(block -> postDepositEvents(blockRequests, depositEventsByBlock));
   }
 
@@ -174,11 +174,9 @@ public class DepositFetcher {
   }
 
   private static class BlockNumberAndHash implements Comparable<BlockNumberAndHash> {
-    // in descending order for efficiency
     private static final Comparator<BlockNumberAndHash> COMPARATOR =
         Comparator.comparing(BlockNumberAndHash::getNumber)
-            .thenComparing(BlockNumberAndHash::getHash)
-            .reversed();
+            .thenComparing(BlockNumberAndHash::getHash);
 
     private final BigInteger number;
     private final String hash;

--- a/storage/src/main/java/tech/pegasys/artemis/storage/client/StorageBackedRecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/artemis/storage/client/StorageBackedRecentChainData.java
@@ -61,11 +61,8 @@ public class StorageBackedRecentChainData extends RecentChainData {
     return requestInitialStore()
         .thenApply(
             maybeStore -> {
-              maybeStore.ifPresent(
-                  (store) -> {
-                    this.setStore(store);
-                    STATUS_LOG.finishInitializingChainData();
-                  });
+              maybeStore.ifPresent(this::setStore);
+              STATUS_LOG.finishInitializingChainData();
               return this;
             });
   }


### PR DESCRIPTION
## PR Description
Improve the user experience around startup.

1. Send status logs to the console which logging mode is set to "both". They're important messages that shouldn't be hidden off in the log file.
2. Provide status logs indicating which mode of genesis is being used (load from existing store on disk, load from genesis file, mock genesis or eth1 chain).
3. Count the number of activated validators in `GenesisGenerator` instead of having to generate the state and iterate through all validators counting them.
4. Send requests for ETH1 block data in increasing order of block number so that the data we get back first can be immediately sent off for processing. Previously we sent requests in reverse order and so wound up waiting for them all to complete before processing any deposits
5. Add status logs to report when min genesis time is reached and for each full percentage of required validators added so the user can see progress towards genesis.
6. Reduce log level for invalid deposits to debug instead of warn. They're really very common and probably not yours so you don't care.