### PR TITLE
Actually use the default bootnodes from NetworkDefinition

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/P2POptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/P2POptions.java
@@ -36,7 +36,7 @@ public class P2POptions {
   public static final int DEFAULT_P2P_PORT = 30303;
   public static final boolean DEFAULT_P2P_DISCOVERY_ENABLED = true;
   public static final List<String> DEFAULT_P2P_DISCOVERY_BOOTNODES =
-      new ArrayList<>(); // depends on network option
+      null; // depends on network option
   public static final String DEFAULT_P2P_ADVERTISED_IP = "127.0.0.1";
   public static final int DEFAULT_P2P_ADVERTISED_PORT = DEFAULT_P2P_PORT;
   public static final String DEFAULT_P2P_PRIVATE_KEY_FILE = null;

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
@@ -47,6 +47,8 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
 import tech.pegasys.artemis.util.config.ArtemisConfigurationBuilder;
@@ -166,6 +168,34 @@ public class BeaconNodeCommandTest {
         expectedCompleteConfigInFileBuilder().setMetricsCategories(List.of("BEACON")).build());
   }
 
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(strings = {"mainnet", "minimal", "topaz"})
+  public void useDefaultsFromNetworkDefinition(final String networkName) {
+    final NetworkDefinition networkDefinition = NetworkDefinition.fromCliArg(networkName);
+
+    beaconNodeCommand.parse(new String[] {"--network", networkName});
+    final ArtemisConfiguration config = getResultingArtemisConfiguration();
+    assertThat(config.getP2pDiscoveryBootnodes())
+        .isEqualTo(networkDefinition.getDiscoveryBootnodes());
+    assertThat(config.getConstants()).isEqualTo(networkDefinition.getConstants());
+    assertThat(config.getStartupTargetPeerCount())
+        .isEqualTo(networkDefinition.getStartupTargetPeerCount());
+    assertThat(config.getStartupTimeoutSeconds())
+        .isEqualTo(networkDefinition.getStartupTimeoutSeconds());
+    assertThat(config.getEth1DepositContractAddress())
+        .isEqualTo(networkDefinition.getEth1DepositContractAddress().orElse(null));
+    assertThat(config.getEth1Endpoint())
+        .isEqualTo(networkDefinition.getEth1Endpoint().orElse(null));
+  }
+
+  @Test
+  public void overrideDefaultBootnodesWithEmptyList() {
+    beaconNodeCommand.parse(new String[] {"--network", "topaz", "--p2p-discovery-bootnodes"});
+
+    final ArtemisConfiguration config = getResultingArtemisConfiguration();
+    assertThat(config.getP2pDiscoveryBootnodes()).isEmpty();
+  }
+
   private Path createConfigFile() throws IOException {
     final URL configFile = this.getClass().getResource("/complete_config.yaml");
     final String updatedConfig =
@@ -209,9 +239,7 @@ public class BeaconNodeCommandTest {
         .setEth1DepositContractAddress(DEFAULT_ETH1_DEPOSIT_CONTRACT_ADDRESS)
         .setEth1Endpoint(DEFAULT_ETH1_ENDPOINT)
         .setMetricsCategories(
-            DEFAULT_METRICS_CATEGORIES.stream()
-                .map(value -> value.toString())
-                .collect(Collectors.toList()))
+            DEFAULT_METRICS_CATEGORIES.stream().map(Object::toString).collect(Collectors.toList()))
         .setP2pAdvertisedPort(DEFAULT_P2P_ADVERTISED_PORT)
         .setP2pDiscoveryEnabled(DEFAULT_P2P_DISCOVERY_ENABLED)
         .setP2pInterface(DEFAULT_P2P_INTERFACE)
@@ -275,12 +303,16 @@ public class BeaconNodeCommandTest {
   }
 
   private void assertArtemisConfiguration(final ArtemisConfiguration expected) {
+    final ArtemisConfiguration actual = getResultingArtemisConfiguration();
+    assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+  }
+
+  private ArtemisConfiguration getResultingArtemisConfiguration() {
     final ArgumentCaptor<ArtemisConfiguration> configCaptor =
         ArgumentCaptor.forClass(ArtemisConfiguration.class);
     verify(startAction).accept(configCaptor.capture());
 
-    final ArtemisConfiguration actual = configCaptor.getValue();
-    assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    return configCaptor.getValue();
   }
 
   private Path createTempFile(final byte[] contents) throws IOException {

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
@@ -311,8 +311,7 @@ public class ArtemisConfigurationBuilder {
           getOrDefault(startupTimeoutSeconds, network::getStartupTimeoutSeconds);
       eth1DepositContractAddress =
           getOrOptionalDefault(eth1DepositContractAddress, network::getEth1DepositContractAddress);
-      p2pDiscoveryBootnodes =
-          getOrOptionalDefault(p2pDiscoveryBootnodes, network::getDiscoveryBootnodes);
+      p2pDiscoveryBootnodes = getOrDefault(p2pDiscoveryBootnodes, network::getDiscoveryBootnodes);
       eth1Endpoint = getOrOptionalDefault(eth1Endpoint, network::getEth1Endpoint);
     }
     return new ArtemisConfiguration(

--- a/util/src/main/java/tech/pegasys/artemis/util/config/NetworkDefinition.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/NetworkDefinition.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Arrays.asList;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -40,7 +41,7 @@ public class NetworkDefinition {
   private final String constants;
   private final int startupTargetPeerCount;
   private final int startupTimeoutSeconds;
-  private final Optional<List<String>> discoveryBootnodes;
+  private final List<String> discoveryBootnodes;
   private final Optional<String> eth1DepositContractAddress;
   private final Optional<String> eth1Endpoint;
 
@@ -48,7 +49,7 @@ public class NetworkDefinition {
       final String constants,
       final int startupTargetPeerCount,
       final int startupTimeoutSeconds,
-      final Optional<List<String>> discoveryBootnodes,
+      final List<String> discoveryBootnodes,
       final Optional<String> eth1DepositContractAddress,
       final Optional<String> eth1Endpoint) {
     this.constants = constants;
@@ -79,7 +80,7 @@ public class NetworkDefinition {
     return startupTimeoutSeconds;
   }
 
-  public Optional<List<String>> getDiscoveryBootnodes() {
+  public List<String> getDiscoveryBootnodes() {
     return discoveryBootnodes;
   }
 
@@ -95,7 +96,7 @@ public class NetworkDefinition {
     private String constants;
     private int startupTargetPeerCount = Constants.DEFAULT_STARTUP_TARGET_PEER_COUNT;
     private int startupTimeoutSeconds = Constants.DEFAULT_STARTUP_TIMEOUT_SECONDS;
-    private Optional<List<String>> discoveryBootnodes = Optional.empty();
+    private List<String> discoveryBootnodes = new ArrayList<>();
     private Optional<String> eth1DepositContractAddress = Optional.empty();
     private Optional<String> eth1Endpoint = Optional.empty();
 
@@ -115,7 +116,7 @@ public class NetworkDefinition {
     }
 
     public Builder discoveryBootnodes(final String... discoveryBootnodes) {
-      this.discoveryBootnodes = Optional.of(asList(discoveryBootnodes));
+      this.discoveryBootnodes = asList(discoveryBootnodes);
       return this;
     }
 


### PR DESCRIPTION
## PR Description
Since the default value for `--p2p-discovery-bootnodes` was an empty list, it was always considered specified so we never used the bootnodes defined by the network.  Make the new default `null` and always have the network provide boot nodes (which may be the empty list).  We still wind up with the empty list instead of null but can differentiate between boot nodes not being specified and the user explicitly specifying no boot nodes.