### PR TITLE
Upgrade to discovery 0.3.4

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -111,7 +111,7 @@ dependencyManagement {
     dependency "org.testcontainers:testcontainers:1.12.3"
     dependency "org.testcontainers:junit-jupiter:1.12.3"
 
-    dependency 'tech.pegasys.discovery:discovery:0.3.3'
+    dependency 'tech.pegasys.discovery:discovery:0.3.4'
 
     dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.0'
   }


### PR DESCRIPTION
## PR Description
Upgrade to discovery 0.3.4 to fix parsing of ENRs with extra fields.