### PR TITLE
Fix the default logging option so custom log configs are supported again

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/LoggingOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/LoggingOptions.java
@@ -28,7 +28,7 @@ public class LoggingOptions {
 
   public static final boolean DEFAULT_LOG_COLOR_ENABLED = true;
   public static final boolean DEFAULT_LOG_INCLUDE_EVENTS_ENABLED = true;
-  public static final String DEFAULT_LOG_DESTINATION = "both";
+  public static final String DEFAULT_LOG_DESTINATION = "default_of_both";
   private static final String SEP = System.getProperty("file.separator");
   public static final String DEFAULT_LOG_FILE =
       StringUtils.joinWith(SEP, VersionProvider.defaultStoragePath(), "logs", "teku.log");

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
@@ -53,6 +53,7 @@ import org.mockito.ArgumentCaptor;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
 import tech.pegasys.artemis.util.config.ArtemisConfigurationBuilder;
 import tech.pegasys.artemis.util.config.NetworkDefinition;
+import tech.pegasys.teku.logging.LoggingDestination;
 
 public class BeaconNodeCommandTest {
 
@@ -196,6 +197,17 @@ public class BeaconNodeCommandTest {
     assertThat(config.getP2pDiscoveryBootnodes()).isEmpty();
   }
 
+  @Test
+  public void shouldUseDefaultOfBothAsLogDestinationDefault() {
+    // This is important!
+    // If it defaults to "both" or some other value custom log4j configs get overwritten
+    beaconNodeCommand.parse(new String[0]);
+
+    final ArtemisConfiguration config = getResultingArtemisConfiguration();
+    assertThat(LoggingDestination.get(config.getLogDestination()))
+        .isEqualTo(LoggingDestination.DEFAULT_BOTH);
+  }
+
   private Path createConfigFile() throws IOException {
     final URL configFile = this.getClass().getResource("/complete_config.yaml");
     final String updatedConfig =
@@ -256,6 +268,7 @@ public class BeaconNodeCommandTest {
   private ArtemisConfigurationBuilder expectedCompleteConfigInFileBuilder() {
     return expectedConfigurationBuilder()
         .setLogFile("teku.log")
+        .setLogDestination("both")
         .setLogFileNamePattern("teku_%d{yyyy-MM-dd}.log");
   }
 

--- a/logging/src/main/java/tech/pegasys/teku/logging/LoggingDestination.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/LoggingDestination.java
@@ -21,13 +21,13 @@ public enum LoggingDestination {
 
   private final String key;
 
-  private LoggingDestination(final String key) {
+  LoggingDestination(final String key) {
     this.key = key;
   }
 
   public static LoggingDestination get(final String destination) {
     for (final LoggingDestination candidate : LoggingDestination.values()) {
-      if (candidate.key.equals(destination)) {
+      if (candidate.key.equalsIgnoreCase(destination)) {
         return candidate;
       }
     }


### PR DESCRIPTION
## PR Description
Make the default value for log destination be the default value marker so that it doesn't override custom logging configuration.