### PR TITLE
CLI enabled flags should not require true to be specified

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/BeaconRestApiOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/BeaconRestApiOptions.java
@@ -38,14 +38,16 @@ public class BeaconRestApiOptions {
       names = {REST_API_DOCS_ENABLED_OPTION_NAME},
       paramLabel = "<BOOLEAN>",
       description = "Enable swagger-docs and swagger-ui endpoints",
-      arity = "1")
+      fallbackValue = "true",
+      arity = "0..1")
   private boolean restApiDocsEnabled = DEFAULT_REST_API_DOCS_ENABLED;
 
   @CommandLine.Option(
       names = {REST_API_ENABLED_OPTION_NAME},
       paramLabel = "<BOOLEAN>",
       description = "Enables Beacon Rest API",
-      arity = "1")
+      fallbackValue = "true",
+      arity = "0..1")
   private boolean restApiEnabled = DEFAULT_REST_API_ENABLED;
 
   @CommandLine.Option(

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/InteropOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/InteropOptions.java
@@ -76,8 +76,9 @@ public class InteropOptions {
       hidden = true,
       names = {INTEROP_ENABLED_OPTION_NAME},
       paramLabel = "<BOOLEAN>",
+      fallbackValue = "true",
       description = "Enables developer options for testing",
-      arity = "1")
+      arity = "0..1")
   private boolean interopEnabled = DEFAULT_X_INTEROP_ENABLED;
 
   public Integer getInteropGenesisTime() {

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/LoggingOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/LoggingOptions.java
@@ -40,7 +40,8 @@ public class LoggingOptions {
       names = {LOG_COLOR_ENABLED_OPTION_NAME},
       paramLabel = "<BOOLEAN>",
       description = "Whether Status and Event log messages include a console color display code",
-      arity = "1")
+      fallbackValue = "true",
+      arity = "0..1")
   private boolean logColorEnabled = DEFAULT_LOG_COLOR_ENABLED;
 
   @CommandLine.Option(

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/MetricsOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/MetricsOptions.java
@@ -43,7 +43,8 @@ public class MetricsOptions {
       names = {METRICS_ENABLED_OPTION_NAME},
       paramLabel = "<BOOLEAN>",
       description = "Enables metrics collection via Prometheus",
-      arity = "1")
+      fallbackValue = "true",
+      arity = "0..1")
   private boolean metricsEnabled = DEFAULT_METRICS_ENABLED;
 
   @CommandLine.Option(

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/P2POptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/P2POptions.java
@@ -48,7 +48,8 @@ public class P2POptions {
       names = {P2P_ENABLED_OPTION_NAME},
       paramLabel = "<BOOLEAN>",
       description = "Enables peer to peer",
-      arity = "1")
+      fallbackValue = "true",
+      arity = "0..1")
   private boolean p2pEnabled = DEFAULT_P2P_ENABLED;
 
   @CommandLine.Option(
@@ -69,7 +70,8 @@ public class P2POptions {
       names = {P2P_DISCOVERY_ENABLED_OPTION_NAME},
       paramLabel = "<BOOLEAN>",
       description = "Enables discv5 discovery",
-      arity = "1")
+      fallbackValue = "true",
+      arity = "0..1")
   private boolean p2pDiscoveryEnabled = DEFAULT_P2P_DISCOVERY_ENABLED;
 
   @CommandLine.Option(

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
@@ -18,20 +18,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static tech.pegasys.artemis.cli.BeaconNodeCommand.CONFIG_FILE_OPTION_NAME;
+import static tech.pegasys.artemis.cli.options.BeaconRestApiOptions.REST_API_DOCS_ENABLED_OPTION_NAME;
+import static tech.pegasys.artemis.cli.options.BeaconRestApiOptions.REST_API_ENABLED_OPTION_NAME;
 import static tech.pegasys.artemis.cli.options.DepositOptions.DEFAULT_ETH1_DEPOSIT_CONTRACT_ADDRESS;
 import static tech.pegasys.artemis.cli.options.DepositOptions.DEFAULT_ETH1_ENDPOINT;
 import static tech.pegasys.artemis.cli.options.InteropOptions.DEFAULT_X_INTEROP_ENABLED;
 import static tech.pegasys.artemis.cli.options.InteropOptions.DEFAULT_X_INTEROP_GENESIS_TIME;
 import static tech.pegasys.artemis.cli.options.InteropOptions.DEFAULT_X_INTEROP_OWNED_VALIDATOR_COUNT;
+import static tech.pegasys.artemis.cli.options.InteropOptions.INTEROP_ENABLED_OPTION_NAME;
 import static tech.pegasys.artemis.cli.options.LoggingOptions.DEFAULT_LOG_DESTINATION;
 import static tech.pegasys.artemis.cli.options.LoggingOptions.DEFAULT_LOG_FILE;
 import static tech.pegasys.artemis.cli.options.LoggingOptions.DEFAULT_LOG_FILE_NAME_PATTERN;
 import static tech.pegasys.artemis.cli.options.MetricsOptions.DEFAULT_METRICS_CATEGORIES;
+import static tech.pegasys.artemis.cli.options.MetricsOptions.METRICS_ENABLED_OPTION_NAME;
 import static tech.pegasys.artemis.cli.options.P2POptions.DEFAULT_P2P_ADVERTISED_PORT;
 import static tech.pegasys.artemis.cli.options.P2POptions.DEFAULT_P2P_DISCOVERY_ENABLED;
 import static tech.pegasys.artemis.cli.options.P2POptions.DEFAULT_P2P_INTERFACE;
 import static tech.pegasys.artemis.cli.options.P2POptions.DEFAULT_P2P_PORT;
 import static tech.pegasys.artemis.cli.options.P2POptions.DEFAULT_P2P_PRIVATE_KEY_FILE;
+import static tech.pegasys.artemis.cli.options.P2POptions.P2P_DISCOVERY_ENABLED_OPTION_NAME;
+import static tech.pegasys.artemis.cli.options.P2POptions.P2P_ENABLED_OPTION_NAME;
 
 import com.google.common.io.Resources;
 import java.io.IOException;
@@ -166,6 +172,48 @@ public class BeaconNodeCommandTest {
     beaconNodeCommand.parse(args);
     assertArtemisConfiguration(
         expectedCompleteConfigInFileBuilder().setMetricsCategories(List.of("BEACON")).build());
+  }
+
+  @Test
+  public void p2pEnabled_ShouldNotRequireAValue() throws IOException {
+    final ArtemisConfiguration artemisConfiguration =
+        getArtemisConfigurationFromArguments(List.of(P2P_ENABLED_OPTION_NAME));
+    assertThat(artemisConfiguration.isP2pEnabled()).isTrue();
+  }
+
+  @Test
+  public void p2pDiscoveryEnabled_ShouldNotRequireAValue() throws IOException {
+    final ArtemisConfiguration artemisConfiguration =
+        getArtemisConfigurationFromArguments(List.of(P2P_DISCOVERY_ENABLED_OPTION_NAME));
+    assertThat(artemisConfiguration.isP2pEnabled()).isTrue();
+  }
+
+  @Test
+  public void metricsEnabled_ShouldNotRequireAValue() throws IOException {
+    final ArtemisConfiguration artemisConfiguration =
+        getArtemisConfigurationFromArguments(List.of(METRICS_ENABLED_OPTION_NAME));
+    assertThat(artemisConfiguration.isMetricsEnabled()).isTrue();
+  }
+
+  @Test
+  public void interopEnabled_ShouldNotRequireAValue() throws IOException {
+    final ArtemisConfiguration artemisConfiguration =
+        getArtemisConfigurationFromArguments(List.of(INTEROP_ENABLED_OPTION_NAME));
+    assertThat(artemisConfiguration.isInteropEnabled()).isTrue();
+  }
+
+  @Test
+  public void restApiDocsEnabled_ShouldNotRequireAValue() throws IOException {
+    final ArtemisConfiguration artemisConfiguration =
+        getArtemisConfigurationFromArguments(List.of(REST_API_DOCS_ENABLED_OPTION_NAME));
+    assertThat(artemisConfiguration.isRestApiDocsEnabled()).isTrue();
+  }
+
+  @Test
+  public void restApiEnabled_ShouldNotRequireAValue() throws IOException {
+    final ArtemisConfiguration artemisConfiguration =
+        getArtemisConfigurationFromArguments(List.of(REST_API_ENABLED_OPTION_NAME));
+    assertThat(artemisConfiguration.isRestApiEnabled()).isTrue();
   }
 
   @ParameterizedTest(name = "{0}")
@@ -313,6 +361,12 @@ public class BeaconNodeCommandTest {
     verify(startAction).accept(configCaptor.capture());
 
     return configCaptor.getValue();
+  }
+
+  private ArtemisConfiguration getArtemisConfigurationFromArguments(List<String> arguments)
+      throws IOException {
+    beaconNodeCommand.parse(arguments.toArray(String[]::new));
+    return getResultingArtemisConfiguration();
   }
 
   private Path createTempFile(final byte[] contents) throws IOException {

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
@@ -177,42 +177,42 @@ public class BeaconNodeCommandTest {
   @Test
   public void p2pEnabled_ShouldNotRequireAValue() throws IOException {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(List.of(P2P_ENABLED_OPTION_NAME));
+        getArtemisConfigurationFromArguments(P2P_ENABLED_OPTION_NAME);
     assertThat(artemisConfiguration.isP2pEnabled()).isTrue();
   }
 
   @Test
   public void p2pDiscoveryEnabled_ShouldNotRequireAValue() throws IOException {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(List.of(P2P_DISCOVERY_ENABLED_OPTION_NAME));
+        getArtemisConfigurationFromArguments(P2P_DISCOVERY_ENABLED_OPTION_NAME);
     assertThat(artemisConfiguration.isP2pEnabled()).isTrue();
   }
 
   @Test
   public void metricsEnabled_ShouldNotRequireAValue() throws IOException {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(List.of(METRICS_ENABLED_OPTION_NAME));
+        getArtemisConfigurationFromArguments(METRICS_ENABLED_OPTION_NAME);
     assertThat(artemisConfiguration.isMetricsEnabled()).isTrue();
   }
 
   @Test
   public void interopEnabled_ShouldNotRequireAValue() throws IOException {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(List.of(INTEROP_ENABLED_OPTION_NAME));
+        getArtemisConfigurationFromArguments(INTEROP_ENABLED_OPTION_NAME);
     assertThat(artemisConfiguration.isInteropEnabled()).isTrue();
   }
 
   @Test
   public void restApiDocsEnabled_ShouldNotRequireAValue() throws IOException {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(List.of(REST_API_DOCS_ENABLED_OPTION_NAME));
+        getArtemisConfigurationFromArguments(REST_API_DOCS_ENABLED_OPTION_NAME);
     assertThat(artemisConfiguration.isRestApiDocsEnabled()).isTrue();
   }
 
   @Test
   public void restApiEnabled_ShouldNotRequireAValue() throws IOException {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(List.of(REST_API_ENABLED_OPTION_NAME));
+        getArtemisConfigurationFromArguments(REST_API_ENABLED_OPTION_NAME);
     assertThat(artemisConfiguration.isRestApiEnabled()).isTrue();
   }
 
@@ -363,9 +363,9 @@ public class BeaconNodeCommandTest {
     return configCaptor.getValue();
   }
 
-  private ArtemisConfiguration getArtemisConfigurationFromArguments(List<String> arguments)
+  private ArtemisConfiguration getArtemisConfigurationFromArguments(String... arguments)
       throws IOException {
-    beaconNodeCommand.parse(arguments.toArray(String[]::new));
+    beaconNodeCommand.parse(arguments);
     return getResultingArtemisConfiguration();
   }
 

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
@@ -363,8 +363,7 @@ public class BeaconNodeCommandTest {
     return configCaptor.getValue();
   }
 
-  private ArtemisConfiguration getArtemisConfigurationFromArguments(String... arguments)
-      throws IOException {
+  private ArtemisConfiguration getArtemisConfigurationFromArguments(String... arguments) {
     beaconNodeCommand.parse(arguments);
     return getResultingArtemisConfiguration();
   }


### PR DESCRIPTION
 - Added fallback value for boolean enabled flags

 - changed their arity to 0..1 and added test cases showing when a value wasn't specified.

 Addresses #1616

Signed-off-by: Paul Harris <paul.harris@consensys.net>
