### PR TITLE
Implement missing SSZ reference tests

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/AttestationDataSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/AttestationDataSszStaticReferenceTest.java
@@ -25,22 +25,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.operations.ProposerSlashing;
+import tech.pegasys.artemis.datastructures.operations.AttestationData;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class proposerSlashing extends TestSuite {
+public class AttestationDataSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
-      name =
-          "{index}. ssz_static/ProposerSlashing deserializedProposerSlashing={0}, root={1}, signingRoot={2}")
+      name = "{index}. ssz_static/AttestationData deserializedAttestationData={0}, root={1}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticBeaconBlock(ProposerSlashing deserializedProposerSlashing, Bytes32 root)
+  void processSSZStaticAttestationData(AttestationData deserializedAttestationData, Bytes32 root)
       throws Exception {
-    assertEquals(deserializedProposerSlashing.hash_tree_root(), root);
+    assertEquals(deserializedAttestationData.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -56,7 +55,7 @@ public class proposerSlashing extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "ProposerSlashing");
-    return sszStaticSetup(path, configPath, ProposerSlashing.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "AttestationData");
+    return sszStaticSetup(path, configPath, AttestationData.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/AttestationSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/AttestationSszStaticReferenceTest.java
@@ -25,22 +25,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.operations.IndexedAttestation;
+import tech.pegasys.artemis.datastructures.operations.Attestation;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class indexedAttestation extends TestSuite {
+public class AttestationSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
       name =
-          "{index}. ssz_static/IndexedAttestation deserializedIndexedAttestation={0}, root={1}, signingRoot={2}")
+          "{index}. ssz_static/Attestation deserializedAttestation={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticIndexedAttestation(
-      IndexedAttestation deserializedIndexedAttestation, Bytes32 root) throws Exception {
-    assertEquals(deserializedIndexedAttestation.hash_tree_root(), root);
+  void processSSZStaticAttestation(Attestation deserializedAttestation, Bytes32 root)
+      throws Exception {
+    assertEquals(deserializedAttestation.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -56,7 +56,7 @@ public class indexedAttestation extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "IndexedAttestation");
-    return sszStaticSetup(path, configPath, IndexedAttestation.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "Attestation");
+    return sszStaticSetup(path, configPath, Attestation.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/AttesterSlashingSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/AttesterSlashingSszStaticReferenceTest.java
@@ -25,21 +25,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.operations.AttestationData;
+import tech.pegasys.artemis.datastructures.operations.AttesterSlashing;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class attestationData extends TestSuite {
+public class AttesterSlashingSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
-      name = "{index}. ssz_static/AttestationData deserializedAttestationData={0}, root={1}")
+      name = "{index}. ssz_static/AttesterSlashing deserializedAttesterSlashing={0}, root={1}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticAttestationData(AttestationData deserializedAttestationData, Bytes32 root)
+  void processSSZStaticAttesterSlashing(AttesterSlashing deserializedAttesterSlashing, Bytes32 root)
       throws Exception {
-    assertEquals(deserializedAttestationData.hash_tree_root(), root);
+    assertEquals(deserializedAttesterSlashing.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -55,7 +55,7 @@ public class attestationData extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "AttestationData");
-    return sszStaticSetup(path, configPath, AttestationData.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "AttesterSlashing");
+    return sszStaticSetup(path, configPath, AttesterSlashing.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/BeaconBlockBodySszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/BeaconBlockBodySszStaticReferenceTest.java
@@ -25,22 +25,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.blocks.BeaconBlockHeader;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlockBody;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class beaconBlockHeader extends TestSuite {
+public class BeaconBlockBodySszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
       name =
-          "{index}. ssz_static/BeaconBlockHeader deserializedBeaconBlockHeader={0}, root={1}, signingRoot={2}")
+          "{index}. ssz_static/BeaconBlockBody deserializedBeaconBlockBody={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticBeaconBlock(BeaconBlockHeader deserializedBeaconBlockHeader, Bytes32 root)
+  void processSSZStaticBeaconBlock(BeaconBlockBody deserializedBeaconBlockBody, Bytes32 root)
       throws Exception {
-    assertEquals(deserializedBeaconBlockHeader.hash_tree_root(), root);
+    assertEquals(deserializedBeaconBlockBody.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -56,7 +56,7 @@ public class beaconBlockHeader extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "BeaconBlockHeader");
-    return sszStaticSetup(path, configPath, BeaconBlockHeader.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "BeaconBlockBody");
+    return sszStaticSetup(path, configPath, BeaconBlockBody.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/BeaconBlockHeaderSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/BeaconBlockHeaderSszStaticReferenceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.reference.phase0.ssz_static;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.errorprone.annotations.MustBeClosed;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.junit.BouncyCastleExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlockHeader;
+import tech.pegasys.artemis.ethtests.TestSuite;
+
+@ExtendWith(BouncyCastleExtension.class)
+public class BeaconBlockHeaderSszStaticReferenceTest extends TestSuite {
+
+  @ParameterizedTest(
+      name =
+          "{index}. ssz_static/BeaconBlockHeader deserializedBeaconBlockHeader={0}, root={1}, signingRoot={2}")
+  @MethodSource({
+    "processMinimal",
+    "processMainnet",
+  })
+  void processSSZStaticBeaconBlock(BeaconBlockHeader deserializedBeaconBlockHeader, Bytes32 root)
+      throws Exception {
+    assertEquals(deserializedBeaconBlockHeader.hash_tree_root(), root);
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> processMinimal() throws Exception {
+    return process("minimal");
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> processMainnet() throws Exception {
+    return process("mainnet");
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> process(String config) throws Exception {
+    Path configPath = Paths.get(config);
+    Path path = Paths.get(config, "phase0", "ssz_static", "BeaconBlockHeader");
+    return sszStaticSetup(path, configPath, BeaconBlockHeader.class);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/BeaconBlockSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/BeaconBlockSszStaticReferenceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.reference.phase0.ssz_static;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.errorprone.annotations.MustBeClosed;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.junit.BouncyCastleExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
+import tech.pegasys.artemis.ethtests.TestSuite;
+
+@ExtendWith(BouncyCastleExtension.class)
+public class BeaconBlockSszStaticReferenceTest extends TestSuite {
+
+  @ParameterizedTest(
+      name =
+          "{index}. ssz_static/BeaconBlock deserializedBeaconBlock={0}, root={1}, signingRoot={2}")
+  @MethodSource({
+    "processMinimal",
+    "processMainnet",
+  })
+  void processSSZStaticBeaconBlock(BeaconBlock deserializedBeaconBlock, Bytes32 root)
+      throws Exception {
+    assertEquals(deserializedBeaconBlock.hash_tree_root(), root);
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> processMinimal() throws Exception {
+    return process("minimal");
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> processMainnet() throws Exception {
+    return process("mainnet");
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> process(String config) throws Exception {
+    Path configPath = Paths.get(config);
+    Path path = Paths.get(config, "phase0", "ssz_static", "BeaconBlock");
+    return sszStaticSetup(path, configPath, BeaconBlock.class);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/BeaconStateSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/BeaconStateSszStaticReferenceTest.java
@@ -25,21 +25,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.operations.AttesterSlashing;
+import tech.pegasys.artemis.datastructures.state.BeaconState;
+import tech.pegasys.artemis.datastructures.state.BeaconStateImpl;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class attesterSlashing extends TestSuite {
+public class BeaconStateSszStaticReferenceTest extends TestSuite {
 
-  @ParameterizedTest(
-      name = "{index}. ssz_static/AttesterSlashing deserializedAttesterSlashing={0}, root={1}")
+  @ParameterizedTest(name = "{index}. ssz_static/BeaconState root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticAttesterSlashing(AttesterSlashing deserializedAttesterSlashing, Bytes32 root)
+  void processSSZStaticBeaconBlock(BeaconState deserializedBeaconState, Bytes32 root)
       throws Exception {
-    assertEquals(deserializedAttesterSlashing.hash_tree_root(), root);
+    assertEquals(deserializedBeaconState.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -55,7 +55,7 @@ public class attesterSlashing extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "AttesterSlashing");
-    return sszStaticSetup(path, configPath, AttesterSlashing.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "BeaconState");
+    return sszStaticSetup(path, configPath, BeaconStateImpl.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/CheckpointSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/CheckpointSszStaticReferenceTest.java
@@ -25,22 +25,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.blocks.BeaconBlockBody;
+import tech.pegasys.artemis.datastructures.state.Checkpoint;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class beaconBlockBody extends TestSuite {
+public class CheckpointSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
-      name =
-          "{index}. ssz_static/BeaconBlockBody deserializedBeaconBlockBody={0}, root={1}, signingRoot={2}")
+      name = "{index}. ssz_static/Checkpoint deserializedCheckpoint={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticBeaconBlock(BeaconBlockBody deserializedBeaconBlockBody, Bytes32 root)
+  void processSSZStaticBeaconBlock(Checkpoint deserializedCheckpoint, Bytes32 root)
       throws Exception {
-    assertEquals(deserializedBeaconBlockBody.hash_tree_root(), root);
+    assertEquals(deserializedCheckpoint.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -56,7 +55,7 @@ public class beaconBlockBody extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "BeaconBlockBody");
-    return sszStaticSetup(path, configPath, BeaconBlockBody.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "Checkpoint");
+    return sszStaticSetup(path, configPath, Checkpoint.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/DepositDataSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/DepositDataSszStaticReferenceTest.java
@@ -25,22 +25,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.operations.Attestation;
+import tech.pegasys.artemis.datastructures.operations.DepositData;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class attestation extends TestSuite {
+public class DepositDataSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
       name =
-          "{index}. ssz_static/Attestation deserializedAttestation={0}, root={1}, signingRoot={2}")
+          "{index}. ssz_static/DepositData deserializedDepositData={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticAttestation(Attestation deserializedAttestation, Bytes32 root)
+  void processSSZStaticDepositData(DepositData deserializedDepositData, Bytes32 root)
       throws Exception {
-    assertEquals(deserializedAttestation.hash_tree_root(), root);
+    assertEquals(deserializedDepositData.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -56,7 +56,7 @@ public class attestation extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "Attestation");
-    return sszStaticSetup(path, configPath, Attestation.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "DepositData");
+    return sszStaticSetup(path, configPath, DepositData.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/DepositMessageSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/DepositMessageSszStaticReferenceTest.java
@@ -25,21 +25,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.state.Checkpoint;
+import tech.pegasys.artemis.datastructures.operations.DepositMessage;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class checkpoint extends TestSuite {
+public class DepositMessageSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
-      name = "{index}. ssz_static/Checkpoint deserializedCheckpoint={0}, root={1}, signingRoot={2}")
+      name =
+          "{index}. ssz_static/DepositMessage deserializedDepositMessage={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticBeaconBlock(Checkpoint deserializedCheckpoint, Bytes32 root)
+  void processSSZStaticDepositData(DepositMessage deserializedDepositData, Bytes32 root)
       throws Exception {
-    assertEquals(deserializedCheckpoint.hash_tree_root(), root);
+    assertEquals(deserializedDepositData.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -55,7 +56,7 @@ public class checkpoint extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "Checkpoint");
-    return sszStaticSetup(path, configPath, Checkpoint.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "DepositMessage");
+    return sszStaticSetup(path, configPath, DepositMessage.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/DepositSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/DepositSszStaticReferenceTest.java
@@ -25,20 +25,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.state.Fork;
+import tech.pegasys.artemis.datastructures.operations.Deposit;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class fork extends TestSuite {
+public class DepositSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
-      name = "{index}. ssz_static/Fork deserializedFork={0}, root={1}, signingRoot={2}")
+      name = "{index}. ssz_static/Deposit deserializedDeposit={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticBeaconBlock(Fork deserializedFork, Bytes32 root) throws Exception {
-    assertEquals(deserializedFork.hash_tree_root(), root);
+  void processSSZStaticBeaconBlock(Deposit deserializedDeposit, Bytes32 root) throws Exception {
+    assertEquals(deserializedDeposit.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -54,7 +54,7 @@ public class fork extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "Fork");
-    return sszStaticSetup(path, configPath, Fork.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "Deposit");
+    return sszStaticSetup(path, configPath, Deposit.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/Eth1DataSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/Eth1DataSszStaticReferenceTest.java
@@ -29,7 +29,7 @@ import tech.pegasys.artemis.datastructures.blocks.Eth1Data;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class eth1Data extends TestSuite {
+public class Eth1DataSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
       name = "{index}. ssz_static/Eth1Data deserializedEth1Data={0}, root={1}, signingRoot={2}")

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/ForkDataSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/ForkDataSszStaticReferenceTest.java
@@ -25,22 +25,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.state.PendingAttestation;
+import tech.pegasys.artemis.datastructures.state.ForkData;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class pendingAttestation extends TestSuite {
+public class ForkDataSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
-      name =
-          "{index}. ssz_static/PendingAttestation deserializedPendingAttestation={0}, root={1}, signingRoot={2}")
+      name = "{index}. ssz_static/ForkData deserializedForkData={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticBeaconBlock(PendingAttestation deserializedPendingAttestation, Bytes32 root)
-      throws Exception {
-    assertEquals(deserializedPendingAttestation.hash_tree_root(), root);
+  void processSSZStaticBeaconBlock(ForkData deserializedForkData, Bytes32 root) throws Exception {
+    assertEquals(deserializedForkData.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -56,7 +54,7 @@ public class pendingAttestation extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "PendingAttestation");
-    return sszStaticSetup(path, configPath, PendingAttestation.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "ForkData");
+    return sszStaticSetup(path, configPath, ForkData.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/ForkSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/ForkSszStaticReferenceTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.reference.phase0.ssz_static;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.errorprone.annotations.MustBeClosed;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.junit.BouncyCastleExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.artemis.datastructures.state.Fork;
+import tech.pegasys.artemis.ethtests.TestSuite;
+
+@ExtendWith(BouncyCastleExtension.class)
+public class ForkSszStaticReferenceTest extends TestSuite {
+
+  @ParameterizedTest(
+      name = "{index}. ssz_static/Fork deserializedFork={0}, root={1}, signingRoot={2}")
+  @MethodSource({
+    "processMinimal",
+    "processMainnet",
+  })
+  void processSSZStaticBeaconBlock(Fork deserializedFork, Bytes32 root) throws Exception {
+    assertEquals(deserializedFork.hash_tree_root(), root);
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> processMinimal() throws Exception {
+    return process("minimal");
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> processMainnet() throws Exception {
+    return process("mainnet");
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> process(String config) throws Exception {
+    Path configPath = Paths.get(config);
+    Path path = Paths.get(config, "phase0", "ssz_static", "Fork");
+    return sszStaticSetup(path, configPath, Fork.class);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/HistoricalBatchSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/HistoricalBatchSszStaticReferenceTest.java
@@ -25,22 +25,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.operations.VoluntaryExit;
+import tech.pegasys.artemis.datastructures.state.HistoricalBatch;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class voluntaryExit extends TestSuite {
+public class HistoricalBatchSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
       name =
-          "{index}. ssz_static/VoluntaryExit deserializedVoluntaryExit={0}, root={1}, signingRoot={2}")
+          "{index}. ssz_static/HistoricalBatch deserializedHistoricalBatch={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticVoluntaryExit(VoluntaryExit deserializedVoluntaryExit, Bytes32 root)
+  void processSSZStaticBeaconBlock(HistoricalBatch deserializedHistoricalBatch, Bytes32 root)
       throws Exception {
-    assertEquals(deserializedVoluntaryExit.hash_tree_root(), root);
+    assertEquals(deserializedHistoricalBatch.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -56,7 +56,7 @@ public class voluntaryExit extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "VoluntaryExit");
-    return sszStaticSetup(path, configPath, VoluntaryExit.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "HistoricalBatch");
+    return sszStaticSetup(path, configPath, HistoricalBatch.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/IndexedAttestationSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/IndexedAttestationSszStaticReferenceTest.java
@@ -25,21 +25,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.state.BeaconState;
-import tech.pegasys.artemis.datastructures.state.BeaconStateImpl;
+import tech.pegasys.artemis.datastructures.operations.IndexedAttestation;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class beaconState extends TestSuite {
+public class IndexedAttestationSszStaticReferenceTest extends TestSuite {
 
-  @ParameterizedTest(name = "{index}. ssz_static/BeaconState root={1}, signingRoot={2}")
+  @ParameterizedTest(
+      name =
+          "{index}. ssz_static/IndexedAttestation deserializedIndexedAttestation={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticBeaconBlock(BeaconState deserializedBeaconState, Bytes32 root)
-      throws Exception {
-    assertEquals(deserializedBeaconState.hash_tree_root(), root);
+  void processSSZStaticIndexedAttestation(
+      IndexedAttestation deserializedIndexedAttestation, Bytes32 root) throws Exception {
+    assertEquals(deserializedIndexedAttestation.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -55,7 +56,7 @@ public class beaconState extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "BeaconState");
-    return sszStaticSetup(path, configPath, BeaconStateImpl.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "IndexedAttestation");
+    return sszStaticSetup(path, configPath, IndexedAttestation.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/PendingAttestationSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/PendingAttestationSszStaticReferenceTest.java
@@ -25,22 +25,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.operations.DepositData;
+import tech.pegasys.artemis.datastructures.state.PendingAttestation;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class depositData extends TestSuite {
+public class PendingAttestationSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
       name =
-          "{index}. ssz_static/DepositData deserializedDepositData={0}, root={1}, signingRoot={2}")
+          "{index}. ssz_static/PendingAttestation deserializedPendingAttestation={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticDepositData(DepositData deserializedDepositData, Bytes32 root)
+  void processSSZStaticBeaconBlock(PendingAttestation deserializedPendingAttestation, Bytes32 root)
       throws Exception {
-    assertEquals(deserializedDepositData.hash_tree_root(), root);
+    assertEquals(deserializedPendingAttestation.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -56,7 +56,7 @@ public class depositData extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "DepositData");
-    return sszStaticSetup(path, configPath, DepositData.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "PendingAttestation");
+    return sszStaticSetup(path, configPath, PendingAttestation.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/ProposerSlashingSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/ProposerSlashingSszStaticReferenceTest.java
@@ -25,22 +25,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
+import tech.pegasys.artemis.datastructures.operations.ProposerSlashing;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class beaconBlock extends TestSuite {
+public class ProposerSlashingSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
       name =
-          "{index}. ssz_static/BeaconBlock deserializedBeaconBlock={0}, root={1}, signingRoot={2}")
+          "{index}. ssz_static/ProposerSlashing deserializedProposerSlashing={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticBeaconBlock(BeaconBlock deserializedBeaconBlock, Bytes32 root)
+  void processSSZStaticBeaconBlock(ProposerSlashing deserializedProposerSlashing, Bytes32 root)
       throws Exception {
-    assertEquals(deserializedBeaconBlock.hash_tree_root(), root);
+    assertEquals(deserializedProposerSlashing.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -56,7 +56,7 @@ public class beaconBlock extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "BeaconBlock");
-    return sszStaticSetup(path, configPath, BeaconBlock.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "ProposerSlashing");
+    return sszStaticSetup(path, configPath, ProposerSlashing.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/SignedBeaconBlockHeaderSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/SignedBeaconBlockHeaderSszStaticReferenceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.reference.phase0.ssz_static;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.errorprone.annotations.MustBeClosed;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.junit.BouncyCastleExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlockHeader;
+import tech.pegasys.artemis.ethtests.TestSuite;
+
+@ExtendWith(BouncyCastleExtension.class)
+public class SignedBeaconBlockHeaderSszStaticReferenceTest extends TestSuite {
+
+  @ParameterizedTest(
+      name =
+          "{index}. ssz_static/SignedBeaconBlockHeader deserialized={0}, root={1}, signingRoot={2}")
+  @MethodSource({
+    "processMinimal",
+    "processMainnet",
+  })
+  void processSSZStaticBeaconBlock(SignedBeaconBlockHeader deserialized, Bytes32 root)
+      throws Exception {
+    assertEquals(deserialized.hash_tree_root(), root);
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> processMinimal() throws Exception {
+    return process("minimal");
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> processMainnet() throws Exception {
+    return process("mainnet");
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> process(String config) throws Exception {
+    Path configPath = Paths.get(config);
+    Path path = Paths.get(config, "phase0", "ssz_static", "SignedBeaconBlockHeader");
+    return sszStaticSetup(path, configPath, SignedBeaconBlockHeader.class);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/SignedBeaconBlockSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/SignedBeaconBlockSszStaticReferenceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.reference.phase0.ssz_static;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.errorprone.annotations.MustBeClosed;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.junit.BouncyCastleExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.artemis.ethtests.TestSuite;
+
+@ExtendWith(BouncyCastleExtension.class)
+public class SignedBeaconBlockSszStaticReferenceTest extends TestSuite {
+
+  @ParameterizedTest(
+      name =
+          "{index}. ssz_static/SignedBeaconBlock deserialized={0}, root={1}, signingRoot={2}")
+  @MethodSource({
+    "processMinimal",
+    "processMainnet",
+  })
+  void processSSZStaticBeaconBlock(SignedBeaconBlock deserialized, Bytes32 root)
+      throws Exception {
+    assertEquals(deserialized.hash_tree_root(), root);
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> processMinimal() throws Exception {
+    return process("minimal");
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> processMainnet() throws Exception {
+    return process("mainnet");
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> process(String config) throws Exception {
+    Path configPath = Paths.get(config);
+    Path path = Paths.get(config, "phase0", "ssz_static", "SignedBeaconBlock");
+    return sszStaticSetup(path, configPath, SignedBeaconBlock.class);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/SignedBeaconBlockSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/SignedBeaconBlockSszStaticReferenceTest.java
@@ -32,14 +32,12 @@ import tech.pegasys.artemis.ethtests.TestSuite;
 public class SignedBeaconBlockSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
-      name =
-          "{index}. ssz_static/SignedBeaconBlock deserialized={0}, root={1}, signingRoot={2}")
+      name = "{index}. ssz_static/SignedBeaconBlock deserialized={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticBeaconBlock(SignedBeaconBlock deserialized, Bytes32 root)
-      throws Exception {
+  void processSSZStaticBeaconBlock(SignedBeaconBlock deserialized, Bytes32 root) throws Exception {
     assertEquals(deserialized.hash_tree_root(), root);
   }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/SignedVoluntaryExitSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/SignedVoluntaryExitSszStaticReferenceTest.java
@@ -25,20 +25,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.state.Validator;
+import tech.pegasys.artemis.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class validator extends TestSuite {
+public class SignedVoluntaryExitSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
-      name = "{index}. ssz_static/Validator deserializedValidator={0}, root={1}, signingRoot={2}")
+      name =
+          "{index}. ssz_static/SignedVoluntaryExit deserialized={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticBeaconBlock(Validator deserializedValidator, Bytes32 root) throws Exception {
-    assertEquals(deserializedValidator.hash_tree_root(), root);
+  void processSSZStaticBeaconBlock(SignedVoluntaryExit deserialized, Bytes32 root)
+      throws Exception {
+    assertEquals(deserialized.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -54,7 +56,7 @@ public class validator extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "Validator");
-    return sszStaticSetup(path, configPath, Validator.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "SignedVoluntaryExit");
+    return sszStaticSetup(path, configPath, SignedVoluntaryExit.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/SignedVoluntaryExitSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/SignedVoluntaryExitSszStaticReferenceTest.java
@@ -32,8 +32,7 @@ import tech.pegasys.artemis.ethtests.TestSuite;
 public class SignedVoluntaryExitSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
-      name =
-          "{index}. ssz_static/SignedVoluntaryExit deserialized={0}, root={1}, signingRoot={2}")
+      name = "{index}. ssz_static/SignedVoluntaryExit deserialized={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/ValidatorSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/ValidatorSszStaticReferenceTest.java
@@ -25,22 +25,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.state.HistoricalBatch;
+import tech.pegasys.artemis.datastructures.state.Validator;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class historicalBatch extends TestSuite {
+public class ValidatorSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
-      name =
-          "{index}. ssz_static/HistoricalBatch deserializedHistoricalBatch={0}, root={1}, signingRoot={2}")
+      name = "{index}. ssz_static/Validator deserializedValidator={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticBeaconBlock(HistoricalBatch deserializedHistoricalBatch, Bytes32 root)
-      throws Exception {
-    assertEquals(deserializedHistoricalBatch.hash_tree_root(), root);
+  void processSSZStaticBeaconBlock(Validator deserializedValidator, Bytes32 root) throws Exception {
+    assertEquals(deserializedValidator.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -56,7 +54,7 @@ public class historicalBatch extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "HistoricalBatch");
-    return sszStaticSetup(path, configPath, HistoricalBatch.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "Validator");
+    return sszStaticSetup(path, configPath, Validator.class);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/VoluntaryExitSszStaticReferenceTest.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/artemis/reference/phase0/ssz_static/VoluntaryExitSszStaticReferenceTest.java
@@ -25,20 +25,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.artemis.datastructures.operations.Deposit;
+import tech.pegasys.artemis.datastructures.operations.VoluntaryExit;
 import tech.pegasys.artemis.ethtests.TestSuite;
 
 @ExtendWith(BouncyCastleExtension.class)
-public class deposit extends TestSuite {
+public class VoluntaryExitSszStaticReferenceTest extends TestSuite {
 
   @ParameterizedTest(
-      name = "{index}. ssz_static/Deposit deserializedDeposit={0}, root={1}, signingRoot={2}")
+      name =
+          "{index}. ssz_static/VoluntaryExit deserializedVoluntaryExit={0}, root={1}, signingRoot={2}")
   @MethodSource({
     "processMinimal",
     "processMainnet",
   })
-  void processSSZStaticBeaconBlock(Deposit deserializedDeposit, Bytes32 root) throws Exception {
-    assertEquals(deserializedDeposit.hash_tree_root(), root);
+  void processSSZStaticVoluntaryExit(VoluntaryExit deserializedVoluntaryExit, Bytes32 root)
+      throws Exception {
+    assertEquals(deserializedVoluntaryExit.hash_tree_root(), root);
   }
 
   @MustBeClosed
@@ -54,7 +56,7 @@ public class deposit extends TestSuite {
   @MustBeClosed
   static Stream<Arguments> process(String config) throws Exception {
     Path configPath = Paths.get(config);
-    Path path = Paths.get(config, "phase0", "ssz_static", "Deposit");
-    return sszStaticSetup(path, configPath, Deposit.class);
+    Path path = Paths.get(config, "phase0", "ssz_static", "VoluntaryExit");
+    return sszStaticSetup(path, configPath, VoluntaryExit.class);
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/blocks/SignedBeaconBlock.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/blocks/SignedBeaconBlock.java
@@ -24,8 +24,11 @@ import tech.pegasys.artemis.bls.BLSSignature;
 import tech.pegasys.artemis.datastructures.util.SimpleOffsetSerializer;
 import tech.pegasys.artemis.ssz.SSZTypes.SSZContainer;
 import tech.pegasys.artemis.ssz.sos.SimpleOffsetSerializable;
+import tech.pegasys.artemis.util.hashtree.HashTreeUtil;
+import tech.pegasys.artemis.util.hashtree.HashTreeUtil.SSZTypes;
+import tech.pegasys.artemis.util.hashtree.Merkleizable;
 
-public class SignedBeaconBlock implements SimpleOffsetSerializable, SSZContainer {
+public class SignedBeaconBlock implements SimpleOffsetSerializable, SSZContainer, Merkleizable {
 
   private final BeaconBlock message;
   private final BLSSignature signature;
@@ -101,5 +104,13 @@ public class SignedBeaconBlock implements SimpleOffsetSerializable, SSZContainer
         .add("message", message)
         .add("signature", signature)
         .toString();
+  }
+
+  @Override
+  public Bytes32 hash_tree_root() {
+    return HashTreeUtil.merkleize(
+        List.of(
+            message.hash_tree_root(),
+            HashTreeUtil.hash_tree_root(SSZTypes.VECTOR_OF_BASIC, signature.toBytes())));
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/ForkData.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/ForkData.java
@@ -16,12 +16,19 @@ package tech.pegasys.artemis.datastructures.state;
 import com.google.common.base.MoreObjects;
 import java.util.List;
 import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.ssz.SSZ;
 import tech.pegasys.artemis.ssz.SSZTypes.Bytes4;
+import tech.pegasys.artemis.ssz.SSZTypes.SSZContainer;
+import tech.pegasys.artemis.ssz.sos.SimpleOffsetSerializable;
 import tech.pegasys.artemis.util.hashtree.HashTreeUtil;
 import tech.pegasys.artemis.util.hashtree.HashTreeUtil.SSZTypes;
+import tech.pegasys.artemis.util.hashtree.Merkleizable;
 
-public class ForkData {
+public class ForkData implements SimpleOffsetSerializable, SSZContainer, Merkleizable {
+
+  public static final int SSZ_FIELD_COUNT = 2;
   private final Bytes4 currentVersion;
   private final Bytes32 genesisValidatorsRoot;
 
@@ -38,6 +45,7 @@ public class ForkData {
     return genesisValidatorsRoot;
   }
 
+  @Override
   public Bytes32 hash_tree_root() {
     return HashTreeUtil.merkleize(
         List.of(
@@ -69,5 +77,17 @@ public class ForkData {
         .add("currentVersion", currentVersion)
         .add("genesisValidatorsRoot", genesisValidatorsRoot)
         .toString();
+  }
+
+  @Override
+  public int getSSZFieldCount() {
+    return SSZ_FIELD_COUNT;
+  }
+
+  @Override
+  public List<Bytes> get_fixed_parts() {
+    return List.of(
+        SSZ.encode(writer -> writer.writeFixedBytes(currentVersion.getWrappedBytes())),
+        SSZ.encode(writer -> writer.writeFixedBytes(genesisValidatorsRoot)));
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/SimpleOffsetSerializer.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/SimpleOffsetSerializer.java
@@ -54,6 +54,7 @@ import tech.pegasys.artemis.datastructures.operations.VoluntaryExit;
 import tech.pegasys.artemis.datastructures.state.BeaconStateImpl;
 import tech.pegasys.artemis.datastructures.state.Checkpoint;
 import tech.pegasys.artemis.datastructures.state.Fork;
+import tech.pegasys.artemis.datastructures.state.ForkData;
 import tech.pegasys.artemis.datastructures.state.HistoricalBatch;
 import tech.pegasys.artemis.datastructures.state.PendingAttestation;
 import tech.pegasys.artemis.datastructures.state.Validator;
@@ -102,6 +103,7 @@ public class SimpleOffsetSerializer {
         BeaconStateImpl.class, new ReflectionInformation(BeaconStateImpl.class));
     classReflectionInfo.put(Checkpoint.class, new ReflectionInformation(Checkpoint.class));
     classReflectionInfo.put(Fork.class, new ReflectionInformation(Fork.class));
+    classReflectionInfo.put(ForkData.class, new ReflectionInformation(ForkData.class));
     classReflectionInfo.put(
         HistoricalBatch.class, new ReflectionInformation(HistoricalBatch.class));
     classReflectionInfo.put(


### PR DESCRIPTION
## PR Description
A number of classes were missing ssz_static reference tests.

`AggregateAndProof` and `SignedAggregateAndProof` tests are added in #1636 to manage conflicts with the other changes in that PR.