### PR TITLE
append error message to end of help

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
@@ -15,8 +15,6 @@ package tech.pegasys.artemis.cli;
 
 import java.io.File;
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -218,32 +216,12 @@ public class BeaconNodeCommand implements Callable<Integer> {
   private int handleParseException(final CommandLine.ParameterException ex, final String[] args) {
     errorWriter.println(ex.getMessage());
 
-    if (!CommandLine.UnmatchedArgumentException.printSuggestions(ex, outputWriter)) {
-      appendErrorMessageToHelp(ex.getCommandLine(), ex.getMessage());
-      ex.getCommandLine().usage(outputWriter, CommandLine.Help.Ansi.AUTO);
-    }
+    CommandLine.UnmatchedArgumentException.printSuggestions(ex, outputWriter);
+    outputWriter.println();
+    outputWriter.println("To display full help:");
+    outputWriter.println("teku --help");
 
     return ex.getCommandLine().getCommandSpec().exitCodeOnInvalidInput();
-  }
-
-  private void appendErrorMessageToHelp(CommandLine cmd, String message) {
-    final String SECTION_KEY_NEW_HEADING = "errorHeading";
-    final String SECTION_KEY_NEW_DETAILS = "errorContent";
-
-    Map<String, String> env = new LinkedHashMap<>();
-    env.put("ERROR:", message);
-    cmd.getHelpSectionMap()
-        .put(
-            SECTION_KEY_NEW_HEADING,
-            help -> help.createHeading("%n%nProblem parsing CLI options:%n"));
-    cmd.getHelpSectionMap()
-        .put(SECTION_KEY_NEW_DETAILS, help -> help.createTextTable(env).toString());
-
-    List<String> keys = new ArrayList<>(cmd.getHelpSectionKeys());
-    int index = keys.indexOf(CommandLine.Model.UsageMessageSpec.SECTION_KEY_FOOTER_HEADING);
-    keys.add(index, SECTION_KEY_NEW_HEADING);
-    keys.add(index + 1, SECTION_KEY_NEW_DETAILS);
-    cmd.setHelpSectionKeys(keys);
   }
 
   @Override

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/AbstractBeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/AbstractBeaconNodeCommandTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.artemis.cli;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static tech.pegasys.artemis.cli.BeaconNodeCommand.CONFIG_FILE_OPTION_NAME;
 
 import java.io.PrintWriter;
@@ -27,8 +28,9 @@ import org.mockito.ArgumentCaptor;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
 
 public abstract class AbstractBeaconNodeCommandTest {
-  protected final PrintWriter outputWriter = new PrintWriter(new StringWriter(), true);
-  protected final PrintWriter errorWriter = new PrintWriter(new StringWriter(), true);
+  final StringWriter stringWriter = new StringWriter();
+  protected final PrintWriter outputWriter = new PrintWriter(stringWriter, true);
+  protected final PrintWriter errorWriter = new PrintWriter(stringWriter, true);
 
   @SuppressWarnings("unchecked")
   final Consumer<ArtemisConfiguration> startAction = mock(Consumer.class);
@@ -56,5 +58,10 @@ public abstract class AbstractBeaconNodeCommandTest {
     final String[] args = {CONFIG_FILE_OPTION_NAME, configFile};
     beaconNodeCommand.parse(args);
     return getResultingArtemisConfiguration();
+  }
+
+  public String getCommandLineOutput() {
+    verifyNoInteractions(startAction);
+    return new String(stringWriter.getBuffer());
   }
 }

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
@@ -58,6 +58,41 @@ import tech.pegasys.artemis.util.config.NetworkDefinition;
 public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
 
   @Test
+  public void unknownOptionShouldDisplayShortHelpMessage() {
+    final String[] args = {"--hlp"};
+
+    beaconNodeCommand.parse(args);
+    String str = getCommandLineOutput();
+    assertThat(str).contains("Unknown option");
+    assertThat(str).contains("To display full help:");
+    assertThat(str).contains("--help");
+    assertThat(str).doesNotContain("Default");
+  }
+
+  @Test
+  public void invalidValueShouldDisplayShortHelpMessage() {
+    final String[] args = {"--metrics-enabled=bob"};
+
+    beaconNodeCommand.parse(args);
+    String str = getCommandLineOutput();
+    assertThat(str).contains("Invalid value");
+    assertThat(str).contains("To display full help:");
+    assertThat(str).contains("--help");
+    assertThat(str).doesNotContain("Default");
+  }
+
+  @Test
+  public void helpOptionShouldDisplayFullHelp() {
+    final String[] args = {"--help"};
+
+    beaconNodeCommand.parse(args);
+    String str = getCommandLineOutput();
+    assertThat(str).contains("Description:");
+    assertThat(str).contains("Default");
+    assertThat(str).doesNotContain("To display full help:");
+  }
+
+  @Test
   public void loadDefaultsWhenNoArgsArePassed() {
     // p2p-enabled default is "true" which require p2p-private-key-file to be non-null
     final String[] args = {"--data-path", dataPath.toString(), "--p2p-enabled", "false"};


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

To save scrolling back past the full help text to see what the problem was, print any error messages at the end (after the help). #1651 