### PR TITLE
Reduce log level for deposit processing message

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/GenesisGenerator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/GenesisGenerator.java
@@ -79,7 +79,7 @@ public class GenesisGenerator {
     // Process deposits
     deposits.forEach(
         deposit -> {
-          LOG.debug("About to process deposit: " + depositDataList.size());
+          LOG.trace("About to process deposit: {}", depositDataList::size);
           depositDataList.add(deposit.getData());
 
           // Skip verifying the merkle proof as these deposits come directly from an Eth1 event.


### PR DESCRIPTION
## PR Description
Reduce the "About to process deposit" message during genesis generation to trace level instead of debug.  It's very noisy.