### PR TITLE
Add options to connect to a chain with ETH1 disabled

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
@@ -347,7 +347,7 @@ public class ArtemisNode extends Node {
 
     public Config withGenesisState(String pathToGenesisState) {
       checkNotNull(pathToGenesisState);
-      configMap.put("genesis-state", pathToGenesisState);
+      configMap.put("initial-state", pathToGenesisState);
       return this;
     }
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/artemis/test/acceptance/dsl/ArtemisNode.java
@@ -347,7 +347,7 @@ public class ArtemisNode extends Node {
 
     public Config withGenesisState(String pathToGenesisState) {
       checkNotNull(pathToGenesisState);
-      configMap.put("Xinterop-start-state", pathToGenesisState);
+      configMap.put("genesis-state", pathToGenesisState);
       return this;
     }
 

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
@@ -269,7 +269,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setInteropGenesisTime(interopOptions.getInteropGenesisTime())
         .setInteropOwnedValidatorStartIndex(interopOptions.getInteropOwnerValidatorStartIndex())
         .setInteropOwnedValidatorCount(interopOptions.getInteropOwnerValidatorCount())
-        .setInteropStartState(interopOptions.getInteropStartState())
+        .setGenesisState(networkOptions.getGenesisState())
         .setInteropNumberOfValidators(interopOptions.getInteropNumberOfValidators())
         .setInteropEnabled(interopOptions.isInteropEnabled())
         .setValidatorKeyFile(validatorOptions.getValidatorKeyFile())

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
@@ -13,12 +13,14 @@
 
 package tech.pegasys.artemis.cli;
 
+import com.google.common.base.Throwables;
 import java.io.File;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.Level;
 import org.hyperledger.besu.metrics.StandardMetricCategory;
@@ -51,6 +53,7 @@ import tech.pegasys.artemis.storage.server.DatabaseStorageException;
 import tech.pegasys.artemis.util.cli.LogTypeConverter;
 import tech.pegasys.artemis.util.cli.VersionProvider;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
+import tech.pegasys.artemis.util.config.InvalidConfigurationException;
 import tech.pegasys.artemis.util.config.NetworkDefinition;
 import tech.pegasys.teku.logging.LoggingConfigurator;
 
@@ -231,15 +234,30 @@ public class BeaconNodeCommand implements Callable<Integer> {
       final ArtemisConfiguration artemisConfiguration = artemisConfiguration();
       startAction.accept(artemisConfiguration);
       return 0;
-    } catch (DatabaseStorageException ex) {
-      System.err.println(ex.getMessage());
-      System.exit(1);
+    } catch (InvalidConfigurationException | DatabaseStorageException ex) {
+      reportUserError(ex);
+    } catch (CompletionException e) {
+      if (Throwables.getRootCause(e) instanceof InvalidConfigurationException) {
+        reportUserError(Throwables.getRootCause(e));
+      } else {
+        reportUnexpectedError(e);
+      }
+
     } catch (Throwable t) {
-      System.err.println("Teku failed to start.");
-      t.printStackTrace();
-      System.exit(1);
+      reportUnexpectedError(t);
     }
     return 1;
+  }
+
+  private void reportUnexpectedError(final Throwable t) {
+    System.err.println("Teku failed to start.");
+    t.printStackTrace();
+    System.exit(1);
+  }
+
+  private void reportUserError(final Throwable ex) {
+    System.err.println(ex.getMessage());
+    System.exit(1);
   }
 
   private void setLogLevels() {
@@ -279,6 +297,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
             validatorOptions.getValidatorExternalSignerPublicKeys())
         .setValidatorExternalSignerUrl(validatorOptions.getValidatorExternalSignerUrl())
         .setValidatorExternalSignerTimeout(validatorOptions.getValidatorExternalSignerTimeout())
+        .setEth1Enabled(depositOptions.isEth1Enabled())
         .setEth1DepositContractAddress(depositOptions.getEth1DepositContractAddress())
         .setEth1Endpoint(depositOptions.getEth1Endpoint())
         .setLogColorEnabled(loggingOptions.isLogColorEnabled())

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
@@ -287,7 +287,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setInteropGenesisTime(interopOptions.getInteropGenesisTime())
         .setInteropOwnedValidatorStartIndex(interopOptions.getInteropOwnerValidatorStartIndex())
         .setInteropOwnedValidatorCount(interopOptions.getInteropOwnerValidatorCount())
-        .setGenesisState(networkOptions.getGenesisState())
+        .setInitialState(networkOptions.getInitialState())
         .setInteropNumberOfValidators(interopOptions.getInteropNumberOfValidators())
         .setInteropEnabled(interopOptions.isInteropEnabled())
         .setValidatorKeyFile(validatorOptions.getValidatorKeyFile())

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/DepositOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/DepositOptions.java
@@ -34,7 +34,7 @@ public class DepositOptions {
   @Option(
       names = {"--eth1-enabled"},
       paramLabel = "<BOOLEAN>",
-      description = "Whether to load deposits from the ETH1 chain",
+      description = "Whether to connect to the ETH1 chain",
       fallbackValue = "true",
       arity = "0..1")
   private boolean eth1Enabled = true;

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/DepositOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/DepositOptions.java
@@ -13,23 +13,31 @@
 
 package tech.pegasys.artemis.cli.options;
 
-import picocli.CommandLine;
+import picocli.CommandLine.Option;
 
 public class DepositOptions {
 
-  @CommandLine.Option(
+  @Option(
       names = {"--eth1-deposit-contract-address"},
       paramLabel = "<ADDRESS>",
       description = "Contract address for the deposit contract",
       arity = "1")
   private String eth1DepositContractAddress = null; // Depends on network configuration
 
-  @CommandLine.Option(
+  @Option(
       names = {"--eth1-endpoint"},
       paramLabel = "<NETWORK>",
       description = "URL for Eth 1.0 node",
       arity = "1")
   private String eth1Endpoint = null;
+
+  @Option(
+      names = {"--eth1-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Whether to load deposits from the ETH1 chain",
+      fallbackValue = "true",
+      arity = "0..1")
+  private boolean eth1Enabled = true;
 
   public String getEth1DepositContractAddress() {
     return eth1DepositContractAddress;
@@ -37,5 +45,9 @@ public class DepositOptions {
 
   public String getEth1Endpoint() {
     return eth1Endpoint;
+  }
+
+  public boolean isEth1Enabled() {
+    return eth1Enabled;
   }
 }

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/DepositOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/DepositOptions.java
@@ -17,28 +17,19 @@ import picocli.CommandLine;
 
 public class DepositOptions {
 
-  public static final String ETH1_DEPOSIT_CONTRACT_ADDRESS_OPTION_NAME =
-      "--eth1-deposit-contract-address";
-  public static final String ETH1_ENDPOINT_OPTION_NAME = "--eth1-endpoint";
-
-  public static final String DEFAULT_ETH1_DEPOSIT_CONTRACT_ADDRESS =
-      null; // depends on network option
-  public static final String DEFAULT_ETH1_ENDPOINT =
-      null; // required but could change as technically not needed if no validators are running
-
   @CommandLine.Option(
-      names = {ETH1_DEPOSIT_CONTRACT_ADDRESS_OPTION_NAME},
+      names = {"--eth1-deposit-contract-address"},
       paramLabel = "<ADDRESS>",
       description = "Contract address for the deposit contract",
       arity = "1")
-  private String eth1DepositContractAddress = DEFAULT_ETH1_DEPOSIT_CONTRACT_ADDRESS;
+  private String eth1DepositContractAddress = null; // Depends on network configuration
 
   @CommandLine.Option(
-      names = {ETH1_ENDPOINT_OPTION_NAME},
+      names = {"--eth1-endpoint"},
       paramLabel = "<NETWORK>",
       description = "URL for Eth 1.0 node",
       arity = "1")
-  private String eth1Endpoint = DEFAULT_ETH1_ENDPOINT;
+  private String eth1Endpoint = null;
 
   public String getEth1DepositContractAddress() {
     return eth1DepositContractAddress;

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/InteropOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/InteropOptions.java
@@ -21,7 +21,6 @@ public class InteropOptions {
       "--Xinterop-owned-validator-start-index";
   public static final String INTEROP_OWNED_VALIDATOR_COUNT_OPTION_NAME =
       "--Xinterop-owned-validator-count";
-  public static final String INTEROP_START_STATE_OPTION_NAME = "--Xinterop-start-state";
   public static final String INTEROP_NUMBER_OF_VALIDATORS_OPTION_NAME =
       "--Xinterop-number-of-validators";
   public static final String INTEROP_ENABLED_OPTION_NAME = "--Xinterop-enabled";
@@ -29,7 +28,6 @@ public class InteropOptions {
   public static final Integer DEFAULT_X_INTEROP_GENESIS_TIME = null;
   public static final int DEFAULT_X_INTEROP_OWNED_VALIDATOR_START_INDEX = 0;
   public static final int DEFAULT_X_INTEROP_OWNED_VALIDATOR_COUNT = 0;
-  public static final String DEFAULT_X_INTEROP_START_STATE = "";
   public static final int DEFAULT_X_INTEROP_NUMBER_OF_VALIDATORS = 64;
   public static final boolean DEFAULT_X_INTEROP_ENABLED = false;
 
@@ -59,14 +57,6 @@ public class InteropOptions {
 
   @CommandLine.Option(
       hidden = true,
-      names = {INTEROP_START_STATE_OPTION_NAME},
-      paramLabel = "<STRING>",
-      description = "Initial BeaconState to load",
-      arity = "1")
-  private String interopStartState = DEFAULT_X_INTEROP_START_STATE;
-
-  @CommandLine.Option(
-      hidden = true,
       names = {INTEROP_NUMBER_OF_VALIDATORS_OPTION_NAME},
       paramLabel = "<INTEGER>",
       description = "Represents the total number of validators in the network")
@@ -91,10 +81,6 @@ public class InteropOptions {
 
   public int getInteropOwnerValidatorCount() {
     return interopOwnerValidatorCount;
-  }
-
-  public String getInteropStartState() {
-    return interopStartState;
   }
 
   public int getInteropNumberOfValidators() {

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/NetworkOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/NetworkOptions.java
@@ -24,7 +24,18 @@ public class NetworkOptions {
       arity = "1")
   private String network = "minimal";
 
+  @Option(
+      names = {"--genesis-state"},
+      paramLabel = "<STRING>",
+      description = "Initial BeaconState to load",
+      arity = "1")
+  private String genesisState = null;
+
   public String getNetwork() {
     return network;
+  }
+
+  public String getGenesisState() {
+    return genesisState;
   }
 }

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/NetworkOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/NetworkOptions.java
@@ -25,17 +25,17 @@ public class NetworkOptions {
   private String network = "minimal";
 
   @Option(
-      names = {"--genesis-state"},
+      names = {"--initial-state"},
       paramLabel = "<STRING>",
       description = "Initial BeaconState to load",
       arity = "1")
-  private String genesisState = null;
+  private String initialState = null;
 
   public String getNetwork() {
     return network;
   }
 
-  public String getGenesisState() {
-    return genesisState;
+  public String getInitialState() {
+    return initialState;
   }
 }

--- a/artemis/src/main/java/tech/pegasys/artemis/services/ServiceController.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/services/ServiceController.java
@@ -33,7 +33,7 @@ public class ServiceController extends Service {
     services.add(new BeaconChainService(config));
     services.add(new ChainStorageService(config));
     services.add(ValidatorClientService.create(config));
-    if (!config.getConfig().isInteropEnabled()) {
+    if (!config.getConfig().isInteropEnabled() && config.getConfig().isEth1Enabled()) {
       services.add(new PowchainService(config));
     }
   }

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
@@ -16,8 +16,6 @@ package tech.pegasys.artemis.cli;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.artemis.cli.BeaconNodeCommand.CONFIG_FILE_OPTION_NAME;
-import static tech.pegasys.artemis.cli.options.DepositOptions.DEFAULT_ETH1_DEPOSIT_CONTRACT_ADDRESS;
-import static tech.pegasys.artemis.cli.options.DepositOptions.DEFAULT_ETH1_ENDPOINT;
 import static tech.pegasys.artemis.cli.options.InteropOptions.DEFAULT_X_INTEROP_ENABLED;
 import static tech.pegasys.artemis.cli.options.InteropOptions.DEFAULT_X_INTEROP_GENESIS_TIME;
 import static tech.pegasys.artemis.cli.options.InteropOptions.DEFAULT_X_INTEROP_OWNED_VALIDATOR_COUNT;
@@ -200,7 +198,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
       "--Xinterop-genesis-time", "1",
       "--Xinterop-owned-validator-start-index", "0",
       "--Xinterop-owned-validator-count", "64",
-      "--Xinterop-start-state", "",
+      "--genesis-state", "",
       "--Xinterop-number-of-validators", "64",
       "--Xinterop-enabled", "true",
       "--eth1-deposit-contract-address", "0x77f7bED277449F51505a4C54550B074030d989bC",
@@ -220,8 +218,8 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
 
   private ArtemisConfigurationBuilder expectedDefaultConfigurationBuilder() {
     return expectedConfigurationBuilder()
-        .setEth1DepositContractAddress(DEFAULT_ETH1_DEPOSIT_CONTRACT_ADDRESS)
-        .setEth1Endpoint(DEFAULT_ETH1_ENDPOINT)
+        .setEth1DepositContractAddress(null)
+        .setEth1Endpoint(null)
         .setMetricsCategories(
             DEFAULT_METRICS_CATEGORIES.stream().map(Object::toString).collect(Collectors.toList()))
         .setP2pAdvertisedPort(DEFAULT_P2P_ADVERTISED_PORT)
@@ -259,7 +257,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setP2pPeerUpperBound(30)
         .setP2pStaticPeers(Collections.emptyList())
         .setInteropGenesisTime(1)
-        .setInteropStartState("")
+        .setGenesisState("")
         .setInteropOwnedValidatorStartIndex(0)
         .setInteropOwnedValidatorCount(64)
         .setInteropNumberOfValidators(64)

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
@@ -257,7 +257,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setP2pPeerUpperBound(30)
         .setP2pStaticPeers(Collections.emptyList())
         .setInteropGenesisTime(1)
-        .setGenesisState("")
+        .setInitialState("")
         .setInteropOwnedValidatorStartIndex(0)
         .setInteropOwnedValidatorCount(64)
         .setInteropNumberOfValidators(64)

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
@@ -198,7 +198,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
       "--Xinterop-genesis-time", "1",
       "--Xinterop-owned-validator-start-index", "0",
       "--Xinterop-owned-validator-count", "64",
-      "--genesis-state", "",
+      "--initial-state", "",
       "--Xinterop-number-of-validators", "64",
       "--Xinterop-enabled", "true",
       "--eth1-deposit-contract-address", "0x77f7bED277449F51505a4C54550B074030d989bC",
@@ -264,6 +264,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setInteropEnabled(true)
         .setEth1DepositContractAddress("0x77f7bED277449F51505a4C54550B074030d989bC")
         .setEth1Endpoint("http://localhost:8545")
+        .setEth1Enabled(true)
         .setMetricsEnabled(false)
         .setMetricsPort(8008)
         .setMetricsInterface("127.0.0.1")

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/options/DepositOptionsTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/options/DepositOptionsTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.artemis.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/options/DepositOptionsTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/options/DepositOptionsTest.java
@@ -1,0 +1,27 @@
+package tech.pegasys.artemis.cli.options;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.artemis.cli.AbstractBeaconNodeCommandTest;
+import tech.pegasys.artemis.util.config.ArtemisConfiguration;
+
+public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
+
+  @Test
+  public void shouldReadDepositOptionsFromConfigurationFile() {
+    final ArtemisConfiguration config =
+        getArtemisConfigurationFromFile("depositOptions_config.yaml");
+
+    assertThat(config.isEth1Enabled()).isFalse();
+    assertThat(config.getEth1DepositContractAddress())
+        .isEqualTo("0xfe3b557e8fb62b89f4916b721be55ceb828dbd73");
+    assertThat(config.getEth1Endpoint()).isEqualTo("http://example.com:1234/path/");
+  }
+
+  @Test
+  public void eth1Enabled_shouldNotRequireAValue() {
+    final ArtemisConfiguration config = getArtemisConfigurationFromArguments("--eth1-enabled");
+    assertThat(config.isEth1Enabled()).isTrue();
+  }
+}

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/options/NetworkOptionsTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/options/NetworkOptionsTest.java
@@ -68,4 +68,12 @@ public class NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
     final ArtemisConfiguration artemisConfiguration = getResultingArtemisConfiguration();
     assertThat(artemisConfiguration.getConstants()).isEqualTo(url);
   }
+
+  @Test
+  public void useInitialState() {
+    String initialState = "some-file-or-url";
+    final ArtemisConfiguration config =
+        getArtemisConfigurationFromArguments("--initial-state", initialState);
+    assertThat(config.getInitialState()).isEqualTo(initialState);
+  }
 }

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/options/NetworkOptionsTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/options/NetworkOptionsTest.java
@@ -42,6 +42,8 @@ public class NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(config.getP2pDiscoveryBootnodes())
         .isEqualTo(networkDefinition.getDiscoveryBootnodes());
     assertThat(config.getConstants()).isEqualTo(networkDefinition.getConstants());
+    assertThat(config.getInitialState())
+        .isEqualTo(networkDefinition.getInitialState().orElse(null));
     assertThat(config.getStartupTargetPeerCount())
         .isEqualTo(networkDefinition.getStartupTargetPeerCount());
     assertThat(config.getStartupTimeoutSeconds())

--- a/artemis/src/test/resources/complete_config.yaml
+++ b/artemis/src/test/resources/complete_config.yaml
@@ -15,7 +15,7 @@ p2p-private-key-file: "path/to/file"
 Xinterop-genesis-time: 1
 Xinterop-owned-validator-start-index: 0
 Xinterop-owned-validator-count: 64
-Xinterop-start-state: ""
+genesis-state: ""
 Xinterop-number-of-validators: 64
 Xinterop-enabled: True
 

--- a/artemis/src/test/resources/complete_config.yaml
+++ b/artemis/src/test/resources/complete_config.yaml
@@ -15,7 +15,7 @@ p2p-private-key-file: "path/to/file"
 Xinterop-genesis-time: 1
 Xinterop-owned-validator-start-index: 0
 Xinterop-owned-validator-count: 64
-genesis-state: ""
+initial-state: ""
 Xinterop-number-of-validators: 64
 Xinterop-enabled: True
 

--- a/artemis/src/test/resources/depositOptions_config.yaml
+++ b/artemis/src/test/resources/depositOptions_config.yaml
@@ -1,0 +1,4 @@
+# metrics
+eth1-enabled: False
+eth1-deposit-contract-address: "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73"
+eth1-endpoint: "http://example.com:1234/path/"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,6 @@
 # network
 network: "minimal"
+#genesis-state: ""
 
 # p2p
 # p2p-enabled options:
@@ -18,7 +19,6 @@ p2p-private-key-file: "path/to/file"
 Xinterop-genesis-time: 0
 Xinterop-owned-validator-start-index: 0
 Xinterop-owned-validator-count: 64
-Xinterop-start-state: ""
 Xinterop-number-of-validators: 64
 Xinterop-enabled: True
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,6 @@
 # network
 network: "minimal"
-#genesis-state: ""
+#initial-state: ""
 
 # p2p
 # p2p-enabled options:

--- a/scripts/run_artemis.sh
+++ b/scripts/run_artemis.sh
@@ -50,7 +50,7 @@ sh configurator.sh "$CONFIG_DIR/runConfig.0.yaml" active $INTEROP_MODE
 sh configurator.sh "$CONFIG_DIR/runConfig.0.yaml" Xinterop-genesis-time $GENESIS_TIME
 sh configurator.sh "$CONFIG_DIR/runConfig.0.yaml" Xinterop-owned-validator-start-index $OWNED_VALIDATOR_START_INDEX
 sh configurator.sh "$CONFIG_DIR/runConfig.0.yaml" Xinterop-owned-validator-count $OWNED_VALIDATOR_COUNT
-sh configurator.sh "$CONFIG_DIR/runConfig.0.yaml" genesis-state "\"$GENESIS_FILE"\"
+sh configurator.sh "$CONFIG_DIR/runConfig.0.yaml" initial-state "\"$GENESIS_FILE"\"
 
 
 if [ "$PEERS" != "" ]

--- a/scripts/run_artemis.sh
+++ b/scripts/run_artemis.sh
@@ -50,7 +50,7 @@ sh configurator.sh "$CONFIG_DIR/runConfig.0.yaml" active $INTEROP_MODE
 sh configurator.sh "$CONFIG_DIR/runConfig.0.yaml" Xinterop-genesis-time $GENESIS_TIME
 sh configurator.sh "$CONFIG_DIR/runConfig.0.yaml" Xinterop-owned-validator-start-index $OWNED_VALIDATOR_START_INDEX
 sh configurator.sh "$CONFIG_DIR/runConfig.0.yaml" Xinterop-owned-validator-count $OWNED_VALIDATOR_COUNT
-sh configurator.sh "$CONFIG_DIR/runConfig.0.yaml" Xinterop-start-state "\"$GENESIS_FILE"\"
+sh configurator.sh "$CONFIG_DIR/runConfig.0.yaml" genesis-state "\"$GENESIS_FILE"\"
 
 
 if [ "$PEERS" != "" ]

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -181,7 +181,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
                   STATUS_LOG.loadingGenesisFromEth1Chain();
                 } else {
                   throw new InvalidConfigurationException(
-                      "ETH1 is disabled but genesis state is unknown. Enable ETH1 or specify an initial state.");
+                      "ETH1 is disabled but initial state is unknown. Enable ETH1 or specify an initial state.");
                 }
               }
               recentChainData.subscribeStoreInitialized(this::onStoreInitialized);

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -133,7 +133,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     this.config = config;
     this.metricsSystem = metricsSystem;
     this.slotEventsChannelPublisher = eventChannels.getPublisher(SlotEventsChannel.class);
-    this.setupInitialState = config.isInteropEnabled() || config.getGenesisState() != null;
+    this.setupInitialState = config.isInteropEnabled() || config.getInitialState() != null;
   }
 
   @Override
@@ -181,7 +181,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
                   STATUS_LOG.loadingGenesisFromEth1Chain();
                 } else {
                   throw new InvalidConfigurationException(
-                      "ETH1 is disabled but genesis state is unknown. Enable ETH1 or specify a genesis state.");
+                      "ETH1 is disabled but genesis state is unknown. Enable ETH1 or specify an initial state.");
                 }
               }
               recentChainData.subscribeStoreInitialized(this::onStoreInitialized);
@@ -416,7 +416,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     StartupUtil.setupInitialState(
         recentChainData,
         config.getInteropGenesisTime(),
-        config.getGenesisState(),
+        config.getInitialState(),
         config.getInteropNumberOfValidators());
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -83,6 +83,7 @@ import tech.pegasys.artemis.sync.util.NoopSyncService;
 import tech.pegasys.artemis.util.async.DelayedExecutorAsyncRunner;
 import tech.pegasys.artemis.util.async.SafeFuture;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
+import tech.pegasys.artemis.util.config.InvalidConfigurationException;
 import tech.pegasys.artemis.util.time.TimeProvider;
 import tech.pegasys.artemis.util.time.channels.SlotEventsChannel;
 import tech.pegasys.artemis.util.time.channels.TimeTickChannel;
@@ -176,8 +177,11 @@ public class BeaconChainController extends Service implements TimeTickChannel {
               if (recentChainData.isPreGenesis()) {
                 if (setupInitialState) {
                   setupInitialState();
-                } else {
+                } else if (config.isEth1Enabled()) {
                   STATUS_LOG.loadingGenesisFromEth1Chain();
+                } else {
+                  throw new InvalidConfigurationException(
+                      "ETH1 is disabled but genesis state is unknown. Enable ETH1 or specify a genesis state.");
                 }
               }
               recentChainData.subscribeStoreInitialized(this::onStoreInitialized);

--- a/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/artemis/services/beaconchain/BeaconChainController.java
@@ -132,7 +132,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     this.config = config;
     this.metricsSystem = metricsSystem;
     this.slotEventsChannelPublisher = eventChannels.getPublisher(SlotEventsChannel.class);
-    this.setupInitialState = config.isInteropEnabled() || config.getInteropStartState() != null;
+    this.setupInitialState = config.isInteropEnabled() || config.getGenesisState() != null;
   }
 
   @Override
@@ -412,7 +412,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     StartupUtil.setupInitialState(
         recentChainData,
         config.getInteropGenesisTime(),
-        config.getInteropStartState(),
+        config.getGenesisState(),
         config.getInteropNumberOfValidators());
   }
 

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
@@ -28,6 +28,7 @@ import tech.pegasys.artemis.bls.BLSPublicKey;
 public class ArtemisConfiguration {
   // Network
   private final String constants;
+  private final String genesisState;
   private final Integer startupTargetPeerCount;
   private final Integer startupTimeoutSeconds;
 
@@ -48,7 +49,6 @@ public class ArtemisConfiguration {
   private final Integer interopGenesisTime;
   private final int interopOwnedValidatorStartIndex;
   private final int interopOwnedValidatorCount;
-  private final String interopStartState;
   private final int interopNumberOfValidators;
   private final boolean interopEnabled;
 
@@ -113,7 +113,7 @@ public class ArtemisConfiguration {
       final Integer interopGenesisTime,
       final int interopOwnedValidatorStartIndex,
       final int interopOwnedValidatorCount,
-      final String interopStartState,
+      final String genesisState,
       final int interopNumberOfValidators,
       final boolean interopEnabled,
       final String validatorsKeyFile,
@@ -157,7 +157,7 @@ public class ArtemisConfiguration {
     this.interopGenesisTime = interopGenesisTime;
     this.interopOwnedValidatorStartIndex = interopOwnedValidatorStartIndex;
     this.interopOwnedValidatorCount = interopOwnedValidatorCount;
-    this.interopStartState = interopStartState;
+    this.genesisState = genesisState;
     this.interopNumberOfValidators = interopNumberOfValidators;
     this.interopEnabled = interopEnabled;
     this.validatorsKeyFile = validatorsKeyFile;
@@ -258,8 +258,8 @@ public class ArtemisConfiguration {
     return interopOwnedValidatorCount;
   }
 
-  public String getInteropStartState() {
-    return interopStartState == null || interopStartState.isEmpty() ? null : interopStartState;
+  public String getGenesisState() {
+    return genesisState == null || genesisState.isEmpty() ? null : genesisState;
   }
 
   public int getInteropNumberOfValidators() {

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
@@ -28,7 +28,7 @@ import tech.pegasys.artemis.bls.BLSPublicKey;
 public class ArtemisConfiguration {
   // Network
   private final String constants;
-  private final String genesisState;
+  private final String initialState;
   private final Integer startupTargetPeerCount;
   private final Integer startupTimeoutSeconds;
 
@@ -114,7 +114,7 @@ public class ArtemisConfiguration {
       final Integer interopGenesisTime,
       final int interopOwnedValidatorStartIndex,
       final int interopOwnedValidatorCount,
-      final String genesisState,
+      final String initialState,
       final int interopNumberOfValidators,
       final boolean interopEnabled,
       final String validatorsKeyFile,
@@ -159,7 +159,7 @@ public class ArtemisConfiguration {
     this.interopGenesisTime = interopGenesisTime;
     this.interopOwnedValidatorStartIndex = interopOwnedValidatorStartIndex;
     this.interopOwnedValidatorCount = interopOwnedValidatorCount;
-    this.genesisState = genesisState;
+    this.initialState = initialState;
     this.interopNumberOfValidators = interopNumberOfValidators;
     this.interopEnabled = interopEnabled;
     this.validatorsKeyFile = validatorsKeyFile;
@@ -261,8 +261,8 @@ public class ArtemisConfiguration {
     return interopOwnedValidatorCount;
   }
 
-  public String getGenesisState() {
-    return genesisState == null || genesisState.isEmpty() ? null : genesisState;
+  public String getInitialState() {
+    return initialState == null || initialState.isEmpty() ? null : initialState;
   }
 
   public int getInteropNumberOfValidators() {

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
@@ -61,6 +61,7 @@ public class ArtemisConfiguration {
   private final String validatorExternalSignerUrl;
   private final int validatorExternalSignerTimeout;
 
+  private final boolean eth1Enabled;
   // Deposit
   private final String eth1DepositContractAddress;
   private final String eth1Endpoint;
@@ -122,6 +123,7 @@ public class ArtemisConfiguration {
       final List<String> validatorExternalSignerPublicKeys,
       final String validatorExternalSignerUrl,
       final int validatorExternalSignerTimeout,
+      final boolean eth1Enabled,
       final String eth1DepositContractAddress,
       final String eth1Endpoint,
       final boolean logColorEnabled,
@@ -166,6 +168,7 @@ public class ArtemisConfiguration {
     this.validatorExternalSignerPublicKeys = validatorExternalSignerPublicKeys;
     this.validatorExternalSignerUrl = validatorExternalSignerUrl;
     this.validatorExternalSignerTimeout = validatorExternalSignerTimeout;
+    this.eth1Enabled = eth1Enabled;
     this.eth1DepositContractAddress = eth1DepositContractAddress;
     this.eth1Endpoint = eth1Endpoint;
     this.logColorEnabled = logColorEnabled;
@@ -307,6 +310,10 @@ public class ArtemisConfiguration {
     return validatorExternalSignerTimeout;
   }
 
+  public boolean isEth1Enabled() {
+    return eth1Enabled;
+  }
+
   public String getEth1DepositContractAddress() {
     return eth1DepositContractAddress;
   }
@@ -400,7 +407,7 @@ public class ArtemisConfiguration {
   public void validateConfig() throws IllegalArgumentException {
     final int interopNumberOfValidators = getInteropNumberOfValidators();
     if (interopNumberOfValidators < Constants.SLOTS_PER_EPOCH) {
-      throw new IllegalArgumentException(
+      throw new InvalidConfigurationException(
           String.format(
               "Invalid configuration. Interop number of validators [%d] must be greater than or equal to [%d]",
               interopNumberOfValidators, Constants.SLOTS_PER_EPOCH));
@@ -417,7 +424,7 @@ public class ArtemisConfiguration {
           String.format(
               "Invalid configuration. The size of validator.validatorsKeystoreFiles [%d] and validator.validatorsKeystorePasswordFiles [%d] must match",
               validatorKeystoreFiles.size(), validatorKeystorePasswordFiles.size());
-      throw new IllegalArgumentException(errorMessage);
+      throw new InvalidConfigurationException(errorMessage);
     }
   }
 }

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
@@ -311,6 +311,7 @@ public class ArtemisConfigurationBuilder {
   public ArtemisConfiguration build() {
     if (network != null) {
       constants = getOrDefault(constants, network::getConstants);
+      initialState = getOrOptionalDefault(initialState, network::getInitialState);
       startupTargetPeerCount =
           getOrDefault(startupTargetPeerCount, network::getStartupTargetPeerCount);
       startupTimeoutSeconds =

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
@@ -35,7 +35,7 @@ public class ArtemisConfigurationBuilder {
   private Integer interopGenesisTime;
   private int interopOwnedValidatorStartIndex;
   private int interopOwnedValidatorCount;
-  private String interopStartState;
+  private String genesisState;
   private int interopNumberOfValidators;
   private boolean interopEnabled;
   private String validatorsKeyFile;
@@ -153,8 +153,8 @@ public class ArtemisConfigurationBuilder {
     return this;
   }
 
-  public ArtemisConfigurationBuilder setInteropStartState(final String interopStartState) {
-    this.interopStartState = interopStartState;
+  public ArtemisConfigurationBuilder setGenesisState(final String genesisState) {
+    this.genesisState = genesisState;
     return this;
   }
 
@@ -332,7 +332,7 @@ public class ArtemisConfigurationBuilder {
         interopGenesisTime,
         interopOwnedValidatorStartIndex,
         interopOwnedValidatorCount,
-        interopStartState,
+        genesisState,
         interopNumberOfValidators,
         interopEnabled,
         validatorsKeyFile,

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
@@ -63,6 +63,7 @@ public class ArtemisConfigurationBuilder {
   private boolean restApiEnabled;
   private String restApiInterface;
   private NetworkDefinition network;
+  private boolean eth1Enabled;
 
   public ArtemisConfigurationBuilder setConstants(final String constants) {
     this.constants = constants;
@@ -204,6 +205,11 @@ public class ArtemisConfigurationBuilder {
     return this;
   }
 
+  public ArtemisConfigurationBuilder setEth1Enabled(final boolean eth1Enabled) {
+    this.eth1Enabled = eth1Enabled;
+    return this;
+  }
+
   public ArtemisConfigurationBuilder setEth1DepositContractAddress(
       final String eth1DepositContractAddress) {
     this.eth1DepositContractAddress = eth1DepositContractAddress;
@@ -341,6 +347,7 @@ public class ArtemisConfigurationBuilder {
         validatorExternalSignerPublicKeys,
         validatorExternalSignerUrl,
         validatorExternalSignerTimeout,
+        eth1Enabled,
         eth1DepositContractAddress,
         eth1Endpoint,
         logColorEnabled,

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
@@ -35,7 +35,7 @@ public class ArtemisConfigurationBuilder {
   private Integer interopGenesisTime;
   private int interopOwnedValidatorStartIndex;
   private int interopOwnedValidatorCount;
-  private String genesisState;
+  private String initialState;
   private int interopNumberOfValidators;
   private boolean interopEnabled;
   private String validatorsKeyFile;
@@ -154,8 +154,8 @@ public class ArtemisConfigurationBuilder {
     return this;
   }
 
-  public ArtemisConfigurationBuilder setGenesisState(final String genesisState) {
-    this.genesisState = genesisState;
+  public ArtemisConfigurationBuilder setInitialState(final String initialState) {
+    this.initialState = initialState;
     return this;
   }
 
@@ -338,7 +338,7 @@ public class ArtemisConfigurationBuilder {
         interopGenesisTime,
         interopOwnedValidatorStartIndex,
         interopOwnedValidatorCount,
-        genesisState,
+        initialState,
         interopNumberOfValidators,
         interopEnabled,
         validatorsKeyFile,

--- a/util/src/main/java/tech/pegasys/artemis/util/config/InvalidConfigurationException.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/InvalidConfigurationException.java
@@ -1,0 +1,7 @@
+package tech.pegasys.artemis.util.config;
+
+public class InvalidConfigurationException extends RuntimeException {
+  public InvalidConfigurationException(final String message) {
+    super(message);
+  }
+}

--- a/util/src/main/java/tech/pegasys/artemis/util/config/InvalidConfigurationException.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/InvalidConfigurationException.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.artemis.util.config;
 
 public class InvalidConfigurationException extends RuntimeException {

--- a/util/src/main/java/tech/pegasys/artemis/util/config/NetworkDefinition.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/NetworkDefinition.java
@@ -31,6 +31,8 @@ public class NetworkDefinition {
               "topaz",
               builder()
                   .constants("mainnet")
+                  .initialState(
+                      "https://github.com/eth2-clients/eth2-testnets/raw/master/prysm/Topaz(v0.11.1)/genesis.ssz")
                   .discoveryBootnodes(
                       "enr:-Ku4QAGwOT9StqmwI5LHaIymIO4ooFKfNkEjWa0f1P8OsElgBh2Ijb-GrD_-b9W4kcPFcwmHQEy5RncqXNqdpVo1heoBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAAAAAAAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQJxCnE6v_x2ekgY_uoE1rtwzvGy40mq9eD66XfHPBWgIIN1ZHCCD6A")
                   .eth1DepositContractAddress("0x5cA1e00004366Ac85f492887AAab12d0e6418876")
@@ -38,6 +40,7 @@ public class NetworkDefinition {
           .build();
 
   private final String constants;
+  private final Optional<String> initialState;
   private final int startupTargetPeerCount;
   private final int startupTimeoutSeconds;
   private final List<String> discoveryBootnodes;
@@ -46,12 +49,14 @@ public class NetworkDefinition {
 
   private NetworkDefinition(
       final String constants,
+      final Optional<String> initialState,
       final int startupTargetPeerCount,
       final int startupTimeoutSeconds,
       final List<String> discoveryBootnodes,
       final Optional<String> eth1DepositContractAddress,
       final Optional<String> eth1Endpoint) {
     this.constants = constants;
+    this.initialState = initialState;
     this.startupTargetPeerCount = startupTargetPeerCount;
     this.startupTimeoutSeconds = startupTimeoutSeconds;
     this.discoveryBootnodes = discoveryBootnodes;
@@ -69,6 +74,10 @@ public class NetworkDefinition {
 
   public String getConstants() {
     return constants;
+  }
+
+  public Optional<String> getInitialState() {
+    return initialState;
   }
 
   public Integer getStartupTargetPeerCount() {
@@ -93,6 +102,7 @@ public class NetworkDefinition {
 
   private static class Builder {
     private String constants;
+    private Optional<String> initialState = Optional.empty();
     private int startupTargetPeerCount = Constants.DEFAULT_STARTUP_TARGET_PEER_COUNT;
     private int startupTimeoutSeconds = Constants.DEFAULT_STARTUP_TIMEOUT_SECONDS;
     private List<String> discoveryBootnodes = new ArrayList<>();
@@ -101,6 +111,11 @@ public class NetworkDefinition {
 
     public Builder constants(final String constants) {
       this.constants = constants;
+      return this;
+    }
+
+    public Builder initialState(final String initialState) {
+      this.initialState = Optional.of(initialState);
       return this;
     }
 
@@ -133,6 +148,7 @@ public class NetworkDefinition {
       checkNotNull(constants, "Missing constants");
       return new NetworkDefinition(
           constants,
+          initialState,
           startupTargetPeerCount,
           startupTimeoutSeconds,
           discoveryBootnodes,


### PR DESCRIPTION
## PR Description
Make the `--Xinterop-start-state` a "real" option `--initial-state` to allow starting the chain from an initial state from a file or URL.
Add `--eth1-enabled` option (defaults to true) to allow disabling loading of data from the ETH1 chain.

This enables a variety of scenarios:
 * Syncing a beacon node to an existing network without running validators (`--eth1-enabled=false --initial-state=<genesis.ssz>` (eth1 data is only required to find genesis and create new blocks so unneeded in this case)
 * Allowing a beacon node to start syncing blocks before it has caught up with ETH1 deposits (`--initial-state=<genesis.ssz>`.  Avoids the delay in determining genesis from the ETH1 chain before existing blocks can start to be downloaded an imported.

If ETH1 is disabled and no initial state is provided, Teku can still start from an existing database which would provide the initial state to work from.  If there is also no initial state in the database, it terminates with an error:
`ETH1 is disabled but initial state is unknown. Enable ETH1 or specify an initial state.`