### PR TITLE
Fix asynchronous RPC issue: handler sometimes may not be ready to handle response

### DIFF
--- a/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/ErrorConditionsIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/ErrorConditionsIntegrationTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.artemis.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.artemis.networking.eth2.rpc.core.Eth2RpcMethod;
-import tech.pegasys.artemis.networking.eth2.rpc.core.ResponseStream;
 import tech.pegasys.artemis.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.artemis.util.Waiter;
 import tech.pegasys.artemis.util.async.SafeFuture;
@@ -50,8 +49,7 @@ public class ErrorConditionsIntegrationTest {
     final Eth2RpcMethod<StatusMessage, StatusMessage> status =
         ((ActiveEth2Network) network1).getBeaconChainMethods().status();
     final SafeFuture<StatusMessage> response =
-        peer.sendRequest(status, new InvalidStatusMessage())
-            .thenCompose(ResponseStream::expectSingleResponse);
+        peer.requestSingleItem(status, new InvalidStatusMessage());
 
     Assertions.assertThatThrownBy(() -> Waiter.waitFor(response))
         .isInstanceOf(ExecutionException.class)

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2Peer.java
@@ -27,7 +27,6 @@ import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.BeaconBlocksByR
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.GoodbyeMessage;
 import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.RpcRequest;
-import tech.pegasys.artemis.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.artemis.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.artemis.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
 import tech.pegasys.artemis.networking.eth2.rpc.core.Eth2OutgoingRequestHandler;
@@ -90,15 +89,9 @@ public class Eth2Peer extends DelegatingPeer implements Peer {
   }
 
   public SafeFuture<PeerStatus> sendStatus() {
-    final Eth2RpcMethod<StatusMessage, StatusMessage> statusMethod = rpcMethods.status();
-    return sendRequest(statusMethod, statusMessageFactory.createStatusMessage())
-        .thenCompose(ResponseStream::expectSingleResponse)
-        .thenApply(
-            remoteStatus -> {
-              final PeerStatus status = PeerStatus.fromStatusMessage(remoteStatus);
-              updateStatus(status);
-              return getStatus();
-            });
+    return requestSingleItem(rpcMethods.status(), statusMessageFactory.createStatusMessage())
+        .thenApply(PeerStatus::fromStatusMessage)
+        .thenPeek(this::updateStatus);
   }
 
   SafeFuture<Void> sendGoodbye(final UnsignedLong reason) {
@@ -140,27 +133,33 @@ public class Eth2Peer extends DelegatingPeer implements Peer {
 
   private <I extends RpcRequest, O> SafeFuture<Void> sendMessage(
       final Eth2RpcMethod<I, O> method, final I request) {
-    return sendRequest(method, request).thenCompose(ResponseStream::expectNoResponse);
+    final Eth2OutgoingRequestHandler<I, O> handler =
+        method.createOutgoingRequestHandler(request.getMaximumRequestChunks());
+    SafeFuture<Void> respFuture = handler.getResponseStream().expectNoResponse();
+    return sendRequest(method, request, handler).thenCompose(__ -> respFuture);
   }
 
   private <I extends RpcRequest, O> SafeFuture<O> requestSingleItem(
       final Eth2RpcMethod<I, O> method, final I request) {
-    return sendRequest(method, request).thenCompose(ResponseStream::expectSingleResponse);
+    final Eth2OutgoingRequestHandler<I, O> handler =
+        method.createOutgoingRequestHandler(request.getMaximumRequestChunks());
+    SafeFuture<O> respFuture = handler.getResponseStream().expectSingleResponse();
+    return sendRequest(method, request, handler).thenCompose(__ -> respFuture);
   }
 
   private <I extends RpcRequest, O> SafeFuture<Void> requestStream(
       final Eth2RpcMethod<I, O> method,
       final I request,
       final ResponseStream.ResponseListener<O> listener) {
-    return sendRequest(method, request)
-        .thenCompose(responseStream -> responseStream.expectMultipleResponses(listener));
+    final Eth2OutgoingRequestHandler<I, O> handler =
+        method.createOutgoingRequestHandler(request.getMaximumRequestChunks());
+    SafeFuture<Void> respFuture = handler.getResponseStream().expectMultipleResponses(listener);
+    return sendRequest(method, request, handler).thenCompose(__ -> respFuture);
   }
 
   public <I extends RpcRequest, O> SafeFuture<ResponseStream<O>> sendRequest(
-      final Eth2RpcMethod<I, O> method, final I request) {
+      final Eth2RpcMethod<I, O> method, final I request, Eth2OutgoingRequestHandler<I, O> handler) {
     Bytes payload = method.encodeRequest(request);
-    final Eth2OutgoingRequestHandler<I, O> handler =
-        method.createOutgoingRequestHandler(request.getMaximumRequestChunks());
     return this.sendRequest(method, payload, handler)
         .thenAccept(handler::handleInitialPayloadSent)
         .thenApply(

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2Peer.java
@@ -139,7 +139,7 @@ public class Eth2Peer extends DelegatingPeer implements Peer {
     return sendRequest(method, request, handler).thenCompose(__ -> respFuture);
   }
 
-  private <I extends RpcRequest, O> SafeFuture<O> requestSingleItem(
+  public <I extends RpcRequest, O> SafeFuture<O> requestSingleItem(
       final Eth2RpcMethod<I, O> method, final I request) {
     final Eth2OutgoingRequestHandler<I, O> handler =
         method.createOutgoingRequestHandler(request.getMaximumRequestChunks());
@@ -157,7 +157,7 @@ public class Eth2Peer extends DelegatingPeer implements Peer {
     return sendRequest(method, request, handler).thenCompose(__ -> respFuture);
   }
 
-  public <I extends RpcRequest, O> SafeFuture<ResponseStream<O>> sendRequest(
+  private <I extends RpcRequest, O> SafeFuture<ResponseStream<O>> sendRequest(
       final Eth2RpcMethod<I, O> method, final I request, Eth2OutgoingRequestHandler<I, O> handler) {
     Bytes payload = method.encodeRequest(request);
     return this.sendRequest(method, payload, handler)

--- a/util/src/main/java/tech/pegasys/artemis/util/async/SafeFuture.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/async/SafeFuture.java
@@ -282,6 +282,15 @@ public class SafeFuture<T> extends CompletableFuture<T> {
         });
   }
 
+  /** Shortcut to process the value when complete and return the same future */
+  public SafeFuture<T> thenPeek(Consumer<T> fn) {
+    return thenApply(
+        v -> {
+          fn.accept(v);
+          return v;
+        });
+  }
+
   @Override
   public SafeFuture<Void> thenRun(final Runnable action) {
     return (SafeFuture<Void>) super.thenRun(action);


### PR DESCRIPTION
## PR Description

In `Eth2Peer` when calling a remote RPC method we first sending request to the wire: 
https://github.com/PegaSysEng/teku/blob/340af2c6a82c77cdb5be2b5d9461703cb89c26b3/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2Peer.java#L164

and only then setting up the listener which should handle responses: 
https://github.com/PegaSysEng/teku/blob/340af2c6a82c77cdb5be2b5d9461703cb89c26b3/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/peers/Eth2Peer.java#L156

This causes async issue when the response message is delivered back prior to `ResponseStream.expect*Responses` is processed and the `ResponseStreamImpl#responseListener` is not yet set up. 

RPC ResponseStream should be ready to process responses prior to sending request to the wire

## Fixed Issue(s)
fixes #1658
