### PR TITLE
Inline CLI option names and defaults

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/BeaconRestApiOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/BeaconRestApiOptions.java
@@ -13,49 +13,39 @@
 
 package tech.pegasys.artemis.cli.options;
 
-import picocli.CommandLine;
+import picocli.CommandLine.Option;
 
 public class BeaconRestApiOptions {
 
-  public static final String REST_API_PORT_OPTION_NAME = "--rest-api-port";
-  public static final String REST_API_DOCS_ENABLED_OPTION_NAME = "--rest-api-docs-enabled";
-  public static final String REST_API_ENABLED_OPTION_NAME = "--rest-api-enabled";
-  public static final String REST_API_INTERFACE_OPTION_NAME = "--rest-api-interface";
-
-  public static final int DEFAULT_REST_API_PORT = 5051;
-  public static final boolean DEFAULT_REST_API_DOCS_ENABLED = false;
-  public static final boolean DEFAULT_REST_API_ENABLED = false;
-  public static final String DEFAULT_REST_API_INTERFACE = "127.0.0.1";
-
-  @CommandLine.Option(
-      names = {REST_API_PORT_OPTION_NAME},
+  @Option(
+      names = {"--rest-api-port"},
       paramLabel = "<INTEGER>",
       description = "Port number of Beacon Rest API",
       arity = "1")
-  private int restApiPort = DEFAULT_REST_API_PORT;
+  private int restApiPort = 5051;
 
-  @CommandLine.Option(
-      names = {REST_API_DOCS_ENABLED_OPTION_NAME},
+  @Option(
+      names = {"--rest-api-docs-enabled"},
       paramLabel = "<BOOLEAN>",
       description = "Enable swagger-docs and swagger-ui endpoints",
       fallbackValue = "true",
       arity = "0..1")
-  private boolean restApiDocsEnabled = DEFAULT_REST_API_DOCS_ENABLED;
+  private boolean restApiDocsEnabled = false;
 
-  @CommandLine.Option(
-      names = {REST_API_ENABLED_OPTION_NAME},
+  @Option(
+      names = {"--rest-api-enabled"},
       paramLabel = "<BOOLEAN>",
       description = "Enables Beacon Rest API",
       fallbackValue = "true",
       arity = "0..1")
-  private boolean restApiEnabled = DEFAULT_REST_API_ENABLED;
+  private boolean restApiEnabled = false;
 
-  @CommandLine.Option(
-      names = {REST_API_INTERFACE_OPTION_NAME},
+  @Option(
+      names = {"--rest-api-interface"},
       paramLabel = "<NETWORK>",
       description = "Interface of Beacon Rest API",
       arity = "1")
-  private String restApiInterface = DEFAULT_REST_API_INTERFACE;
+  private String restApiInterface = "127.0.0.1";
 
   public int getRestApiPort() {
     return restApiPort;

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/DataOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/DataOptions.java
@@ -13,32 +13,26 @@
 
 package tech.pegasys.artemis.cli.options;
 
-import picocli.CommandLine;
+import picocli.CommandLine.Option;
 import tech.pegasys.artemis.util.cli.VersionProvider;
 import tech.pegasys.artemis.util.config.StateStorageMode;
 
 public class DataOptions {
-  public static final String DATA_PATH_OPTION_NAME = "--data-path";
-  public static final String DATA_STORAGE_MODE_OPTION_NAME = "--data-storage-mode";
 
-  public static final String DEFAULT_DATA_PATH =
-      VersionProvider.defaultStoragePath() + System.getProperty("file.separator") + "data";
-  public static final StateStorageMode DEFAULT_DATA_STORAGE_MODE = StateStorageMode.PRUNE;
-
-  @CommandLine.Option(
-      names = {DATA_PATH_OPTION_NAME},
+  @Option(
+      names = {"--data-path"},
       paramLabel = "<FILENAME>",
       description = "Path to output data files",
       arity = "1")
-  private String dataPath = DEFAULT_DATA_PATH;
+  private String dataPath = defaultDataPath();
 
-  @CommandLine.Option(
-      names = {DATA_STORAGE_MODE_OPTION_NAME},
+  @Option(
+      names = {"--data-storage-mode"},
       paramLabel = "<STORAGE_MODE>",
       description =
           "Sets the strategy for handling historical chain data.  (Valid values: ${COMPLETION-CANDIDATES})",
       arity = "1")
-  private StateStorageMode dataStorageMode = DEFAULT_DATA_STORAGE_MODE;
+  private StateStorageMode dataStorageMode = StateStorageMode.PRUNE;
 
   public String getDataPath() {
     return dataPath;
@@ -46,5 +40,9 @@ public class DataOptions {
 
   public StateStorageMode getDataStorageMode() {
     return dataStorageMode;
+  }
+
+  private static String defaultDataPath() {
+    return VersionProvider.defaultStoragePath() + System.getProperty("file.separator") + "data";
   }
 }

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/InteropOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/InteropOptions.java
@@ -13,63 +13,49 @@
 
 package tech.pegasys.artemis.cli.options;
 
-import picocli.CommandLine;
+import picocli.CommandLine.Option;
 
 public class InteropOptions {
-  public static final String INTEROP_GENESIS_TIME_OPTION_NAME = "--Xinterop-genesis-time";
-  public static final String INTEROP_OWNED_VALIDATOR_START_INDEX_OPTION_NAME =
-      "--Xinterop-owned-validator-start-index";
-  public static final String INTEROP_OWNED_VALIDATOR_COUNT_OPTION_NAME =
-      "--Xinterop-owned-validator-count";
-  public static final String INTEROP_NUMBER_OF_VALIDATORS_OPTION_NAME =
-      "--Xinterop-number-of-validators";
-  public static final String INTEROP_ENABLED_OPTION_NAME = "--Xinterop-enabled";
 
-  public static final Integer DEFAULT_X_INTEROP_GENESIS_TIME = null;
-  public static final int DEFAULT_X_INTEROP_OWNED_VALIDATOR_START_INDEX = 0;
-  public static final int DEFAULT_X_INTEROP_OWNED_VALIDATOR_COUNT = 0;
-  public static final int DEFAULT_X_INTEROP_NUMBER_OF_VALIDATORS = 64;
-  public static final boolean DEFAULT_X_INTEROP_ENABLED = false;
-
-  @CommandLine.Option(
+  @Option(
       hidden = true,
-      names = {INTEROP_GENESIS_TIME_OPTION_NAME},
+      names = {"--Xinterop-genesis-time"},
       paramLabel = "<INTEGER>",
       description = "Time of mocked genesis",
       arity = "1")
-  private Integer interopGenesisTime = DEFAULT_X_INTEROP_GENESIS_TIME;
+  private Integer interopGenesisTime = null;
 
-  @CommandLine.Option(
+  @Option(
       hidden = true,
-      names = {INTEROP_OWNED_VALIDATOR_START_INDEX_OPTION_NAME},
+      names = {"--Xinterop-owned-validator-start-index"},
       paramLabel = "<INTEGER>",
       description = "Index of first validator owned by this node",
       arity = "1")
-  private int interopOwnerValidatorStartIndex = DEFAULT_X_INTEROP_OWNED_VALIDATOR_START_INDEX;
+  private int interopOwnerValidatorStartIndex = 0;
 
-  @CommandLine.Option(
+  @Option(
       hidden = true,
-      names = {INTEROP_OWNED_VALIDATOR_COUNT_OPTION_NAME},
+      names = {"--Xinterop-owned-validator-count"},
       paramLabel = "<INTEGER>",
       description = "Number of validators owned by this node",
       arity = "1")
-  private int interopOwnerValidatorCount = DEFAULT_X_INTEROP_OWNED_VALIDATOR_COUNT;
+  private int interopOwnerValidatorCount = 0;
 
-  @CommandLine.Option(
+  @Option(
       hidden = true,
-      names = {INTEROP_NUMBER_OF_VALIDATORS_OPTION_NAME},
+      names = {"--Xinterop-number-of-validators"},
       paramLabel = "<INTEGER>",
       description = "Represents the total number of validators in the network")
-  private int interopNumberOfValidators = DEFAULT_X_INTEROP_NUMBER_OF_VALIDATORS;
+  private int interopNumberOfValidators = 64;
 
-  @CommandLine.Option(
+  @Option(
       hidden = true,
-      names = {INTEROP_ENABLED_OPTION_NAME},
+      names = {"--Xinterop-enabled"},
       paramLabel = "<BOOLEAN>",
       fallbackValue = "true",
       description = "Enables developer options for testing",
       arity = "0..1")
-  private boolean interopEnabled = DEFAULT_X_INTEROP_ENABLED;
+  private boolean interopEnabled = false;
 
   public Integer getInteropGenesisTime() {
     return interopGenesisTime;

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/LoggingOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/LoggingOptions.java
@@ -22,16 +22,6 @@ import tech.pegasys.artemis.util.config.LoggingDestination;
 
 public class LoggingOptions {
 
-  public static final String LOG_COLOR_ENABLED_OPTION_NAME = "--log-color-enabled";
-  public static final String LOG_INCLUDE_EVENTS_ENABLED_OPTION_NAME =
-      "--log-include-events-enabled";
-  public static final String LOG_DESTINATION_OPTION_NAME = "--log-destination";
-  public static final String LOG_FILE_OPTION_NAME = "--log-file";
-  public static final String LOG_FILE_NAME_PATTERN_OPTION_NAME = "--log-file-name-pattern";
-
-  public static final boolean DEFAULT_LOG_COLOR_ENABLED = true;
-  public static final boolean DEFAULT_LOG_INCLUDE_EVENTS_ENABLED = true;
-  public static final LoggingDestination DEFAULT_LOG_DESTINATION = DEFAULT_BOTH;
   private static final String SEP = System.getProperty("file.separator");
   public static final String DEFAULT_LOG_FILE =
       StringUtils.joinWith(SEP, VersionProvider.defaultStoragePath(), "logs", "teku.log");
@@ -40,38 +30,38 @@ public class LoggingOptions {
           SEP, VersionProvider.defaultStoragePath(), "logs", "teku_%d{yyyy-MM-dd}.log");
 
   @CommandLine.Option(
-      names = {LOG_COLOR_ENABLED_OPTION_NAME},
+      names = {"--log-color-enabled"},
       paramLabel = "<BOOLEAN>",
       description = "Whether Status and Event log messages include a console color display code",
       fallbackValue = "true",
       arity = "0..1")
-  private boolean logColorEnabled = DEFAULT_LOG_COLOR_ENABLED;
+  private boolean logColorEnabled = true;
 
   @CommandLine.Option(
-      names = {LOG_INCLUDE_EVENTS_ENABLED_OPTION_NAME},
+      names = {"--log-include-events-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
           "Whether frequent update events are logged (e.g. every slot event, with validators and attestations)",
       arity = "1")
-  private boolean logIncludeEventsEnabled = DEFAULT_LOG_INCLUDE_EVENTS_ENABLED;
+  private boolean logIncludeEventsEnabled = true;
 
   @CommandLine.Option(
-      names = {LOG_DESTINATION_OPTION_NAME},
+      names = {"--log-destination"},
       paramLabel = "<LOG_DESTINATION>",
       description =
           "Whether a logger is added for the console, the log file, or both (Valid values: ${COMPLETION-CANDIDATES})",
       arity = "1")
-  private LoggingDestination logDestination = DEFAULT_LOG_DESTINATION;
+  private LoggingDestination logDestination = DEFAULT_BOTH;
 
   @CommandLine.Option(
-      names = {LOG_FILE_OPTION_NAME},
+      names = {"--log-file"},
       paramLabel = "<FILENAME>",
       description = "Path containing the location (relative or absolute) and the log filename.",
       arity = "1")
   private String logFile = DEFAULT_LOG_FILE;
 
   @CommandLine.Option(
-      names = {LOG_FILE_NAME_PATTERN_OPTION_NAME},
+      names = {"--log-file-name-pattern"},
       paramLabel = "<REGEX>",
       description = "Pattern for the filename to apply to rolled over log files.",
       arity = "1")

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/MetricsOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/MetricsOptions.java
@@ -20,49 +20,41 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.hyperledger.besu.metrics.StandardMetricCategory;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
-import picocli.CommandLine;
+import picocli.CommandLine.Option;
 import tech.pegasys.artemis.metrics.ArtemisMetricCategory;
 
 public class MetricsOptions {
 
-  public static final String METRICS_ENABLED_OPTION_NAME = "--metrics-enabled";
-  public static final String METRICS_PORT_OPTION_NAME = "--metrics-port";
-  public static final String METRICS_INTERFACE_OPTION_NAME = "--metrics-interface";
-  public static final String METRICS_CATEGORIES_OPTION_NAME = "--metrics-categories";
-
-  public static final boolean DEFAULT_METRICS_ENABLED = false;
-  public static final int DEFAULT_METRICS_PORT = 8008;
-  public static final String DEFAULT_METRICS_INTERFACE = "127.0.0.1";
   public static final ImmutableSet<MetricCategory> DEFAULT_METRICS_CATEGORIES =
       ImmutableSet.<MetricCategory>builder()
           .addAll(EnumSet.allOf(StandardMetricCategory.class))
           .addAll(EnumSet.allOf(ArtemisMetricCategory.class))
           .build();
 
-  @CommandLine.Option(
-      names = {METRICS_ENABLED_OPTION_NAME},
+  @Option(
+      names = {"--metrics-enabled"},
       paramLabel = "<BOOLEAN>",
       description = "Enables metrics collection via Prometheus",
       fallbackValue = "true",
       arity = "0..1")
-  private boolean metricsEnabled = DEFAULT_METRICS_ENABLED;
+  private boolean metricsEnabled = false;
 
-  @CommandLine.Option(
-      names = {METRICS_PORT_OPTION_NAME},
+  @Option(
+      names = {"--metrics-port"},
       paramLabel = "<INTEGER>",
       description = "Metrics port to expose metrics for Prometheus",
       arity = "1")
-  private int metricsPort = DEFAULT_METRICS_PORT;
+  private int metricsPort = 8008;
 
-  @CommandLine.Option(
-      names = {METRICS_INTERFACE_OPTION_NAME},
+  @Option(
+      names = {"--metrics-interface"},
       paramLabel = "<NETWORK>",
       description = "Metrics network interface to expose metrics for Prometheus",
       arity = "1")
-  private String metricsInterface = DEFAULT_METRICS_INTERFACE;
+  private String metricsInterface = "127.0.0.1";
 
-  @CommandLine.Option(
-      names = {METRICS_CATEGORIES_OPTION_NAME},
+  @Option(
+      names = {"--metrics-categories"},
       paramLabel = "<METRICS_CATEGORY>",
       description = "Metric categories to enable",
       split = ",",
@@ -82,6 +74,6 @@ public class MetricsOptions {
   }
 
   public List<String> getMetricsCategories() {
-    return metricsCategories.stream().map(value -> value.toString()).collect(Collectors.toList());
+    return metricsCategories.stream().map(Object::toString).collect(Collectors.toList());
   }
 }

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/OutputOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/OutputOptions.java
@@ -13,22 +13,17 @@
 
 package tech.pegasys.artemis.cli.options;
 
-import picocli.CommandLine;
+import picocli.CommandLine.Option;
 
 public class OutputOptions {
 
-  public static final String TRANSITION_RECORD_DIRECTORY_OPTION_NAME =
-      "--Xtransition-record-directory";
-
-  public static final String DEFAULT_X_TRANSITION_RECORD_DIRECTORY = null;
-
-  @CommandLine.Option(
+  @Option(
       hidden = true,
-      names = {TRANSITION_RECORD_DIRECTORY_OPTION_NAME},
+      names = {"--Xtransition-record-directory"},
       paramLabel = "<FILENAME>",
       description = "Directory to record transition pre and post states",
       arity = "1")
-  private String transitionRecordDirectory = DEFAULT_X_TRANSITION_RECORD_DIRECTORY;
+  private String transitionRecordDirectory = null;
 
   public String getTransitionRecordDirectory() {
     return transitionRecordDirectory;

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/P2POptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/P2POptions.java
@@ -13,8 +13,7 @@
 
 package tech.pegasys.artemis.cli.options;
 
-import static java.util.Collections.emptyList;
-
+import java.util.ArrayList;
 import java.util.List;
 import picocli.CommandLine.Option;
 
@@ -99,7 +98,7 @@ public class P2POptions {
       description = "Static peers",
       split = ",",
       arity = "0..*")
-  private List<String> p2pStaticPeers = emptyList();
+  private List<String> p2pStaticPeers = new ArrayList<>();
 
   public boolean isP2pEnabled() {
     return p2pEnabled;

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/P2POptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/P2POptions.java
@@ -13,117 +13,93 @@
 
 package tech.pegasys.artemis.cli.options;
 
-import java.util.ArrayList;
+import static java.util.Collections.emptyList;
+
 import java.util.List;
-import picocli.CommandLine;
+import picocli.CommandLine.Option;
 
 public class P2POptions {
 
-  public static final String P2P_ENABLED_OPTION_NAME = "--p2p-enabled";
-  public static final String P2P_INTERFACE_OPTION_NAME = "--p2p-interface";
-  public static final String P2P_PORT_OPTION_NAME = "--p2p-port";
-  public static final String P2P_DISCOVERY_ENABLED_OPTION_NAME = "--p2p-discovery-enabled";
-  public static final String P2P_DISCOVERY_BOOTNODES_OPTION_NAME = "--p2p-discovery-bootnodes";
-  public static final String P2P_ADVERTISED_IP_OPTION_NAME = "--p2p-advertised-ip";
-  public static final String P2P_ADVERTISED_PORT_OPTION_NAME = "--p2p-advertised-port";
-  public static final String P2P_PRIVATE_KEY_FILE_OPTION_NAME = "--p2p-private-key-file";
-  public static final String P2P_PEER_LOWER_BOUND_OPTION_NAME = "--p2p-peer-lower-bound";
-  public static final String P2P_PEER_UPPER_BOUND_OPTION_NAME = "--p2p-peer-upper-bound";
-  public static final String P2P_STATIC_PEERS_OPTION_NAME = "--p2p-static-peers";
-
-  public static final boolean DEFAULT_P2P_ENABLED = true;
-  public static final String DEFAULT_P2P_INTERFACE = "0.0.0.0";
-  public static final int DEFAULT_P2P_PORT = 30303;
-  public static final boolean DEFAULT_P2P_DISCOVERY_ENABLED = true;
-  public static final List<String> DEFAULT_P2P_DISCOVERY_BOOTNODES =
-      null; // depends on network option
-  public static final String DEFAULT_P2P_ADVERTISED_IP = "127.0.0.1";
-  public static final int DEFAULT_P2P_ADVERTISED_PORT = DEFAULT_P2P_PORT;
-  public static final String DEFAULT_P2P_PRIVATE_KEY_FILE = null;
-  public static final int DEFAULT_P2P_PEER_LOWER_BOUND = 20;
-  public static final int DEFAULT_P2P_PEER_UPPER_BOUND = 30;
-  public static final List<String> DEFAULT_P2P_STATIC_PEERS = new ArrayList<>();
-
-  @CommandLine.Option(
-      names = {P2P_ENABLED_OPTION_NAME},
+  @Option(
+      names = {"--p2p-enabled"},
       paramLabel = "<BOOLEAN>",
       description = "Enables peer to peer",
       fallbackValue = "true",
       arity = "0..1")
-  private boolean p2pEnabled = DEFAULT_P2P_ENABLED;
+  private boolean p2pEnabled = true;
 
-  @CommandLine.Option(
-      names = {P2P_INTERFACE_OPTION_NAME},
+  @Option(
+      names = {"--p2p-interface"},
       paramLabel = "<NETWORK>",
       description = "Peer to peer network interface",
       arity = "1")
-  private String p2pInterface = DEFAULT_P2P_INTERFACE;
+  private String p2pInterface = "0.0.0.0";
 
-  @CommandLine.Option(
-      names = {P2P_PORT_OPTION_NAME},
+  @Option(
+      names = {"--p2p-port"},
       paramLabel = "<INTEGER>",
       description = "Peer to peer port",
       arity = "1")
-  private int p2pPort = DEFAULT_P2P_PORT;
+  private int p2pPort = 30303;
 
-  @CommandLine.Option(
-      names = {P2P_DISCOVERY_ENABLED_OPTION_NAME},
+  @Option(
+      names = {"--p2p-discovery-enabled"},
       paramLabel = "<BOOLEAN>",
       description = "Enables discv5 discovery",
       fallbackValue = "true",
       arity = "0..1")
-  private boolean p2pDiscoveryEnabled = DEFAULT_P2P_DISCOVERY_ENABLED;
+  private boolean p2pDiscoveryEnabled = true;
 
-  @CommandLine.Option(
-      names = {P2P_DISCOVERY_BOOTNODES_OPTION_NAME},
+  @Option(
+      names = {"--p2p-discovery-bootnodes"},
       paramLabel = "<enode://id@host:port>",
       description = "ENR of the bootnode",
       split = ",",
       arity = "0..*")
-  private List<String> p2pDiscoveryBootnodes = DEFAULT_P2P_DISCOVERY_BOOTNODES;
+  private List<String> p2pDiscoveryBootnodes = null;
 
-  @CommandLine.Option(
-      names = {P2P_ADVERTISED_IP_OPTION_NAME},
+  @Option(
+      names = {"--p2p-advertised-ip"},
       paramLabel = "<NETWORK>",
       description = "Peer to peer advertised ip",
       arity = "1")
-  private String p2pAdvertisedIp = DEFAULT_P2P_ADVERTISED_IP;
+  private String p2pAdvertisedIp = "127.0.0.1";
 
-  @CommandLine.Option(
-      names = {P2P_ADVERTISED_PORT_OPTION_NAME},
+  @Option(
+      names = {"--p2p-advertised-port"},
       paramLabel = "<INTEGER>",
       description = "Peer to peer advertised port",
       arity = "1")
-  private int p2pAdvertisedPort = DEFAULT_P2P_ADVERTISED_PORT;
+  private int p2pAdvertisedPort = p2pPort;
 
-  @CommandLine.Option(
-      names = {P2P_PRIVATE_KEY_FILE_OPTION_NAME},
+  @Option(
+      names = {"--p2p-private-key-file"},
       paramLabel = "<FILENAME>",
       description = "This node's private key file",
       arity = "1")
-  private String p2pPrivateKeyFile = DEFAULT_P2P_PRIVATE_KEY_FILE;
+  private String p2pPrivateKeyFile = null;
 
-  @CommandLine.Option(
-      names = {P2P_PEER_LOWER_BOUND_OPTION_NAME},
+  @Option(
+      names = {"--p2p-peer-lower-bound"},
       paramLabel = "<INTEGER>",
       description = "Lower bound on the target number of peers",
       arity = "1")
-  private int p2pLowerBound = DEFAULT_P2P_PEER_LOWER_BOUND;
+  private int p2pLowerBound = 20;
 
-  @CommandLine.Option(
-      names = {P2P_PEER_UPPER_BOUND_OPTION_NAME},
+  @Option(
+      names = {"--p2p-peer-upper-bound"},
       paramLabel = "<INTEGER>",
       description = "Upper bound on the target number of peers",
       arity = "1")
-  private int p2pUpperBound = DEFAULT_P2P_PEER_UPPER_BOUND;
+  private int p2pUpperBound = 30;
 
-  @CommandLine.Option(
-      names = {P2P_STATIC_PEERS_OPTION_NAME},
+  @Option(
+      names = {"--p2p-static-peers"},
       paramLabel = "<PEER_ADDRESSES>",
       description = "Static peers",
       split = ",",
       arity = "0..*")
-  private List<String> p2pStaticPeers = DEFAULT_P2P_STATIC_PEERS;
+  private List<String> p2pStaticPeers = emptyList();
 
   public boolean isP2pEnabled() {
     return p2pEnabled;

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/ValidatorOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/ValidatorOptions.java
@@ -13,91 +13,71 @@
 
 package tech.pegasys.artemis.cli.options;
 
-import java.util.ArrayList;
-import picocli.CommandLine;
+import static java.util.Collections.emptyList;
+
+import java.util.List;
+import picocli.CommandLine.Option;
 
 public class ValidatorOptions {
 
-  public static final String VALIDATORS_KEY_FILE_OPTION_NAME = "--validators-key-file";
-  public static final String VALIDATORS_KEYSTORE_FILES_OPTION_NAME = "--validators-key-files";
-  public static final String VALIDATORS_KEYSTORE_PASSWORD_FILES_OPTION_NAME =
-      "--validators-key-password-files";
-  public static final String VALIDATORS_EXTERNAL_SIGNER_PUBLIC_KEYS_OPTION_NAME =
-      "--validators-external-signer-public-keys";
-  public static final String VALIDATORS_EXTERNAL_SIGNER_URL_OPTION_NAME =
-      "--validators-external-signer-url";
-  public static final String VALIDATORS_EXTERNAL_SIGNER_TIMEOUT_OPTION_NAME =
-      "--validators-external-signer-timeout";
-
-  public static final String DEFAULT_VALIDATORS_KEY_FILE = null;
-  public static final ArrayList<String> DEFAULT_VALIDATORS_KEYSTORE_FILES = new ArrayList<>();
-  public static final ArrayList<String> DEFAULT_VALIDATORS_KEYSTORE_PASSWORD_FILES =
-      new ArrayList<>();
-  public static final ArrayList<String> DEFAULT_VALIDATORS_EXTERNAL_SIGNER_PUBLIC_KEYS =
-      new ArrayList<>();
-  public static final String DEFAULT_VALIDATORS_EXTERNAL_SIGNER_URL = null;
-  public static final int DEFAULT_VALIDATORS_EXTERNAL_SIGNER_TIMEOUT = 1000;
-
-  @CommandLine.Option(
-      names = {VALIDATORS_KEY_FILE_OPTION_NAME},
+  @Option(
+      names = {"--validators-key-file"},
       paramLabel = "<FILENAME>",
       description = "The file to load validator keys from",
       arity = "1")
-  private String validatorKeyFile = DEFAULT_VALIDATORS_KEY_FILE;
+  private String validatorKeyFile = null;
 
-  @CommandLine.Option(
-      names = {VALIDATORS_KEYSTORE_FILES_OPTION_NAME},
+  @Option(
+      names = {"--validators-key-files"},
       paramLabel = "<FILENAMES>",
       description = "The list of encrypted keystore files to load the validator keys from",
       split = ",",
       arity = "0..*")
-  private ArrayList<String> validatorKeystoreFiles = DEFAULT_VALIDATORS_KEYSTORE_FILES;
+  private List<String> validatorKeystoreFiles = emptyList();
 
-  @CommandLine.Option(
-      names = {VALIDATORS_KEYSTORE_PASSWORD_FILES_OPTION_NAME},
+  @Option(
+      names = {"--validators-key-password-files"},
       paramLabel = "<FILENAMES>",
       description = "The list of password files to decrypt the validator keystore files",
       split = ",",
       arity = "0..*")
-  private ArrayList<String> validatorKeystorePasswordFiles =
-      DEFAULT_VALIDATORS_KEYSTORE_PASSWORD_FILES;
+  private List<String> validatorKeystorePasswordFiles = emptyList();
 
-  @CommandLine.Option(
-      names = {VALIDATORS_EXTERNAL_SIGNER_PUBLIC_KEYS_OPTION_NAME},
+  @Option(
+      names = {"--validators-external-signer-public-keys"},
       paramLabel = "<STRINGS>",
       description = "The list of external signer public keys",
       split = ",",
       arity = "0..*")
-  private ArrayList<String> validatorExternalSignerPublicKeys =
-      DEFAULT_VALIDATORS_EXTERNAL_SIGNER_PUBLIC_KEYS;
+  private List<String> validatorExternalSignerPublicKeys = emptyList();
 
-  @CommandLine.Option(
-      names = {VALIDATORS_EXTERNAL_SIGNER_URL_OPTION_NAME},
+  @Option(
+      names = {"--validators-external-signer-url"},
       paramLabel = "<NETWORK>",
       description = "URL for the external signing service",
       arity = "1")
-  private String validatorExternalSignerUrl = DEFAULT_VALIDATORS_EXTERNAL_SIGNER_URL;
+  private String validatorExternalSignerUrl = null;
 
-  @CommandLine.Option(
-      names = {VALIDATORS_EXTERNAL_SIGNER_TIMEOUT_OPTION_NAME},
+  @Option(
+      names = {"--validators-external-signer-timeout"},
       paramLabel = "<INTEGER>",
       description = "Timeout for the external signing service",
       arity = "1")
-  private int validatorExternalSignerTimeout = DEFAULT_VALIDATORS_EXTERNAL_SIGNER_TIMEOUT;
+  private int validatorExternalSignerTimeout = 1000;
 
   public String getValidatorKeyFile() {
     return validatorKeyFile;
   }
 
-  public ArrayList<String> getValidatorKeystoreFiles() {
+  public List<String> getValidatorKeystoreFiles() {
     return validatorKeystoreFiles;
   }
 
-  public ArrayList<String> getValidatorKeystorePasswordFiles() {
+  public List<String> getValidatorKeystorePasswordFiles() {
     return validatorKeystorePasswordFiles;
   }
 
-  public ArrayList<String> getValidatorExternalSignerPublicKeys() {
+  public List<String> getValidatorExternalSignerPublicKeys() {
     return validatorExternalSignerPublicKeys;
   }
 

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/ValidatorOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/ValidatorOptions.java
@@ -13,8 +13,7 @@
 
 package tech.pegasys.artemis.cli.options;
 
-import static java.util.Collections.emptyList;
-
+import java.util.ArrayList;
 import java.util.List;
 import picocli.CommandLine.Option;
 
@@ -33,7 +32,7 @@ public class ValidatorOptions {
       description = "The list of encrypted keystore files to load the validator keys from",
       split = ",",
       arity = "0..*")
-  private List<String> validatorKeystoreFiles = emptyList();
+  private List<String> validatorKeystoreFiles = new ArrayList<>();
 
   @Option(
       names = {"--validators-key-password-files"},
@@ -41,7 +40,7 @@ public class ValidatorOptions {
       description = "The list of password files to decrypt the validator keystore files",
       split = ",",
       arity = "0..*")
-  private List<String> validatorKeystorePasswordFiles = emptyList();
+  private List<String> validatorKeystorePasswordFiles = new ArrayList<>();
 
   @Option(
       names = {"--validators-external-signer-public-keys"},
@@ -49,7 +48,7 @@ public class ValidatorOptions {
       description = "The list of external signer public keys",
       split = ",",
       arity = "0..*")
-  private List<String> validatorExternalSignerPublicKeys = emptyList();
+  private List<String> validatorExternalSignerPublicKeys = new ArrayList<>();
 
   @Option(
       names = {"--validators-external-signer-url"},

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/AbstractBeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/AbstractBeaconNodeCommandTest.java
@@ -41,11 +41,16 @@ public abstract class AbstractBeaconNodeCommandTest {
   @TempDir Path dataPath;
 
   public ArtemisConfiguration getResultingArtemisConfiguration() {
+    try {
     final ArgumentCaptor<ArtemisConfiguration> configCaptor =
         ArgumentCaptor.forClass(ArtemisConfiguration.class);
     verify(startAction).accept(configCaptor.capture());
 
     return configCaptor.getValue();
+    } catch (Throwable t) {
+      System.out.println(stringWriter);
+      throw t;
+    }
   }
 
   public ArtemisConfiguration getArtemisConfigurationFromArguments(String... arguments) {

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/AbstractBeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/AbstractBeaconNodeCommandTest.java
@@ -42,11 +42,11 @@ public abstract class AbstractBeaconNodeCommandTest {
 
   public ArtemisConfiguration getResultingArtemisConfiguration() {
     try {
-    final ArgumentCaptor<ArtemisConfiguration> configCaptor =
-        ArgumentCaptor.forClass(ArtemisConfiguration.class);
-    verify(startAction).accept(configCaptor.capture());
+      final ArgumentCaptor<ArtemisConfiguration> configCaptor =
+          ArgumentCaptor.forClass(ArtemisConfiguration.class);
+      verify(startAction).accept(configCaptor.capture());
 
-    return configCaptor.getValue();
+      return configCaptor.getValue();
     } catch (Throwable t) {
       System.out.println(stringWriter);
       throw t;

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/AbstractBeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/AbstractBeaconNodeCommandTest.java
@@ -23,11 +23,14 @@ import java.io.StringWriter;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.function.Consumer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
 
 public abstract class AbstractBeaconNodeCommandTest {
+  private static final Logger LOG = LogManager.getLogger();
   final StringWriter stringWriter = new StringWriter();
   protected final PrintWriter outputWriter = new PrintWriter(stringWriter, true);
   protected final PrintWriter errorWriter = new PrintWriter(stringWriter, true);
@@ -48,7 +51,9 @@ public abstract class AbstractBeaconNodeCommandTest {
 
       return configCaptor.getValue();
     } catch (Throwable t) {
-      System.out.println(stringWriter);
+      // Ensure we get the errors reported by Teku printed when a test provides invalid input
+      // Otherwise it's a nightmare trying to guess why the test is failing
+      LOG.error("Failed to parse artemis configuration: " + stringWriter);
       throw t;
     }
   }

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
@@ -16,19 +16,10 @@ package tech.pegasys.artemis.cli;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.artemis.cli.BeaconNodeCommand.CONFIG_FILE_OPTION_NAME;
-import static tech.pegasys.artemis.cli.options.InteropOptions.DEFAULT_X_INTEROP_ENABLED;
-import static tech.pegasys.artemis.cli.options.InteropOptions.DEFAULT_X_INTEROP_GENESIS_TIME;
-import static tech.pegasys.artemis.cli.options.InteropOptions.DEFAULT_X_INTEROP_OWNED_VALIDATOR_COUNT;
-import static tech.pegasys.artemis.cli.options.InteropOptions.INTEROP_ENABLED_OPTION_NAME;
-import static tech.pegasys.artemis.cli.options.LoggingOptions.DEFAULT_LOG_DESTINATION;
 import static tech.pegasys.artemis.cli.options.LoggingOptions.DEFAULT_LOG_FILE;
 import static tech.pegasys.artemis.cli.options.LoggingOptions.DEFAULT_LOG_FILE_NAME_PATTERN;
 import static tech.pegasys.artemis.cli.options.MetricsOptions.DEFAULT_METRICS_CATEGORIES;
-import static tech.pegasys.artemis.cli.options.P2POptions.DEFAULT_P2P_ADVERTISED_PORT;
-import static tech.pegasys.artemis.cli.options.P2POptions.DEFAULT_P2P_DISCOVERY_ENABLED;
-import static tech.pegasys.artemis.cli.options.P2POptions.DEFAULT_P2P_INTERFACE;
-import static tech.pegasys.artemis.cli.options.P2POptions.DEFAULT_P2P_PORT;
-import static tech.pegasys.artemis.cli.options.P2POptions.DEFAULT_P2P_PRIVATE_KEY_FILE;
+import static tech.pegasys.artemis.util.config.LoggingDestination.DEFAULT_BOTH;
 import static tech.pegasys.artemis.util.config.StateStorageMode.PRUNE;
 
 import com.google.common.io.Resources;
@@ -174,7 +165,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   @Test
   public void interopEnabled_shouldNotRequireAValue() {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(INTEROP_ENABLED_OPTION_NAME);
+        getArtemisConfigurationFromArguments("--Xinterop-enabled");
     assertThat(artemisConfiguration.isInteropEnabled()).isTrue();
   }
 
@@ -222,15 +213,15 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setEth1Endpoint(null)
         .setMetricsCategories(
             DEFAULT_METRICS_CATEGORIES.stream().map(Object::toString).collect(Collectors.toList()))
-        .setP2pAdvertisedPort(DEFAULT_P2P_ADVERTISED_PORT)
-        .setP2pDiscoveryEnabled(DEFAULT_P2P_DISCOVERY_ENABLED)
-        .setP2pInterface(DEFAULT_P2P_INTERFACE)
-        .setP2pPort(DEFAULT_P2P_PORT)
-        .setP2pPrivateKeyFile(DEFAULT_P2P_PRIVATE_KEY_FILE)
-        .setInteropEnabled(DEFAULT_X_INTEROP_ENABLED)
-        .setInteropGenesisTime(DEFAULT_X_INTEROP_GENESIS_TIME)
-        .setInteropOwnedValidatorCount(DEFAULT_X_INTEROP_OWNED_VALIDATOR_COUNT)
-        .setLogDestination(DEFAULT_LOG_DESTINATION)
+        .setP2pAdvertisedPort(30303)
+        .setP2pDiscoveryEnabled(true)
+        .setP2pInterface("0.0.0.0")
+        .setP2pPort(30303)
+        .setP2pPrivateKeyFile(null)
+        .setInteropEnabled(false)
+        .setInteropGenesisTime(null)
+        .setInteropOwnedValidatorCount(0)
+        .setLogDestination(DEFAULT_BOTH)
         .setLogFile(DEFAULT_LOG_FILE)
         .setLogFileNamePattern(DEFAULT_LOG_FILE_NAME_PATTERN);
   }
@@ -271,7 +262,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setMetricsCategories(
             Arrays.asList("BEACON", "LIBP2P", "NETWORK", "EVENTBUS", "JVM", "PROCESS"))
         .setLogColorEnabled(true)
-        .setLogDestination(DEFAULT_LOG_DESTINATION)
+        .setLogDestination(DEFAULT_BOTH)
         .setLogFile(DEFAULT_LOG_FILE)
         .setLogFileNamePattern(DEFAULT_LOG_FILE_NAME_PATTERN)
         .setLogIncludeEventsEnabled(true)

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/options/BeaconRestApiOptionsTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/options/BeaconRestApiOptionsTest.java
@@ -14,8 +14,6 @@
 package tech.pegasys.artemis.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.artemis.cli.options.BeaconRestApiOptions.REST_API_DOCS_ENABLED_OPTION_NAME;
-import static tech.pegasys.artemis.cli.options.BeaconRestApiOptions.REST_API_ENABLED_OPTION_NAME;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.cli.AbstractBeaconNodeCommandTest;
@@ -36,14 +34,14 @@ public class BeaconRestApiOptionsTest extends AbstractBeaconNodeCommandTest {
   @Test
   public void restApiDocsEnabled_shouldNotRequireAValue() {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(REST_API_DOCS_ENABLED_OPTION_NAME);
+        getArtemisConfigurationFromArguments("--rest-api-docs-enabled");
     assertThat(artemisConfiguration.isRestApiDocsEnabled()).isTrue();
   }
 
   @Test
   public void restApiEnabled_shouldNotRequireAValue() {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(REST_API_ENABLED_OPTION_NAME);
+        getArtemisConfigurationFromArguments("--rest-api-enabled");
     assertThat(artemisConfiguration.isRestApiEnabled()).isTrue();
   }
 }

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/options/DataOptionsTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/options/DataOptionsTest.java
@@ -14,8 +14,6 @@
 package tech.pegasys.artemis.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.artemis.cli.options.DataOptions.DATA_PATH_OPTION_NAME;
-import static tech.pegasys.artemis.cli.options.DataOptions.DATA_STORAGE_MODE_OPTION_NAME;
 import static tech.pegasys.artemis.util.config.StateStorageMode.ARCHIVE;
 import static tech.pegasys.artemis.util.config.StateStorageMode.PRUNE;
 
@@ -37,21 +35,21 @@ public class DataOptionsTest extends AbstractBeaconNodeCommandTest {
   @Test
   public void dataStorageMode_shouldAcceptPrune() {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(DATA_STORAGE_MODE_OPTION_NAME, "prune");
+        getArtemisConfigurationFromArguments("--data-storage-mode", "prune");
     assertThat(artemisConfiguration.getDataStorageMode()).isEqualTo(PRUNE);
   }
 
   @Test
   public void dataStorageMode_shouldAcceptArchive() {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(DATA_STORAGE_MODE_OPTION_NAME, "archive");
+        getArtemisConfigurationFromArguments("--data-storage-mode", "archive");
     assertThat(artemisConfiguration.getDataStorageMode()).isEqualTo(ARCHIVE);
   }
 
   @Test
   public void dataPath_shouldAcceptNonDefaultValues() {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(DATA_PATH_OPTION_NAME, TEST_PATH);
+        getArtemisConfigurationFromArguments("--data-path", TEST_PATH);
     assertThat(artemisConfiguration.getDataPath()).isEqualTo(TEST_PATH);
   }
 }

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/options/LoggingOptionsTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/options/LoggingOptionsTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.artemis.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.artemis.cli.options.LoggingOptions.LOG_DESTINATION_OPTION_NAME;
 import static tech.pegasys.artemis.util.config.LoggingDestination.DEFAULT_BOTH;
 
 import org.junit.jupiter.api.Test;
@@ -49,21 +48,21 @@ public class LoggingOptionsTest extends AbstractBeaconNodeCommandTest {
   @Test
   public void logDestination_shouldAcceptFileAsDestination() {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(LOG_DESTINATION_OPTION_NAME, "file");
+        getArtemisConfigurationFromArguments("--log-destination", "file");
     assertThat(artemisConfiguration.getLogDestination()).isEqualTo(LoggingDestination.FILE);
   }
 
   @Test
   public void logDestination_shouldAcceptConsoleAsDestination() {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(LOG_DESTINATION_OPTION_NAME, "console");
+        getArtemisConfigurationFromArguments("--log-destination", "console");
     assertThat(artemisConfiguration.getLogDestination()).isEqualTo(LoggingDestination.CONSOLE);
   }
 
   @Test
   public void logDestination_shouldAcceptBothAsDestination() {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(LOG_DESTINATION_OPTION_NAME, "both");
+        getArtemisConfigurationFromArguments("--log-destination", "both");
     assertThat(artemisConfiguration.getLogDestination()).isEqualTo(LoggingDestination.BOTH);
   }
 }

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/options/MetricsOptionsTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/options/MetricsOptionsTest.java
@@ -14,8 +14,6 @@
 package tech.pegasys.artemis.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.artemis.cli.options.MetricsOptions.METRICS_CATEGORIES_OPTION_NAME;
-import static tech.pegasys.artemis.cli.options.MetricsOptions.METRICS_ENABLED_OPTION_NAME;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -40,7 +38,7 @@ public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
   @ValueSource(strings = {"BEACON", "LIBP2P", "NETWORK", "EVENTBUS", "JVM", "PROCESS"})
   public void metricsCategories_shouldAcceptValues(String category) {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(METRICS_CATEGORIES_OPTION_NAME, category);
+        getArtemisConfigurationFromArguments("--metrics-categories", category);
     assertThat(artemisConfiguration.getMetricsCategories()).isEqualTo(List.of(category));
   }
 
@@ -48,7 +46,7 @@ public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
   public void metricsCategories_shouldAcceptMultipleValues() {
     final ArtemisConfiguration artemisConfiguration =
         getArtemisConfigurationFromArguments(
-            METRICS_CATEGORIES_OPTION_NAME, "LIBP2P,NETWORK,EVENTBUS,PROCESS");
+            "--metrics-categories", "LIBP2P,NETWORK,EVENTBUS,PROCESS");
     assertThat(artemisConfiguration.getMetricsCategories())
         .isEqualTo(List.of("LIBP2P", "NETWORK", "EVENTBUS", "PROCESS"));
   }
@@ -56,7 +54,7 @@ public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
   @Test
   public void metricsEnabled_shouldNotRequireAValue() {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(METRICS_ENABLED_OPTION_NAME);
+        getArtemisConfigurationFromArguments("--metrics-enabled");
     assertThat(artemisConfiguration.isMetricsEnabled()).isTrue();
   }
 }

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/options/P2POptionsTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/options/P2POptionsTest.java
@@ -14,8 +14,6 @@
 package tech.pegasys.artemis.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.artemis.cli.options.P2POptions.P2P_DISCOVERY_ENABLED_OPTION_NAME;
-import static tech.pegasys.artemis.cli.options.P2POptions.P2P_ENABLED_OPTION_NAME;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -42,14 +40,14 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
   @Test
   public void p2pEnabled_shouldNotRequireAValue() {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(P2P_ENABLED_OPTION_NAME);
+        getArtemisConfigurationFromArguments("--p2p-enabled");
     assertThat(artemisConfiguration.isP2pEnabled()).isTrue();
   }
 
   @Test
   public void p2pDiscoveryEnabled_shouldNotRequireAValue() {
     final ArtemisConfiguration artemisConfiguration =
-        getArtemisConfigurationFromArguments(P2P_DISCOVERY_ENABLED_OPTION_NAME);
+        getArtemisConfigurationFromArguments("--p2p-discovery-enabled");
     assertThat(artemisConfiguration.isP2pEnabled()).isTrue();
   }
 }


### PR DESCRIPTION
## PR Description
Inlines the CLI option names and default values rather than using separate `public static final` variables for them all.

* Fixes intermittently failing unit test because some default values were mutable lists that were being modified (causing the recent unit test failures on master)
* Easier to read as the option information is now all centralised at the field declaration
* Tests are now separated from the production code so they can effectively test the default values and option names rather than automatically expecting whatever the production code does