### PR TITLE
[BC-18] Bump libp2p version to support the latest Noise spec updates.

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -28,7 +28,7 @@ dependencyManagement {
     dependency 'io.protostuff:protostuff-core:1.6.2'
     dependency 'io.protostuff:protostuff-runtime:1.6.2'
 
-    dependency 'io.libp2p:jvm-libp2p-minimal:0.3.3-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p-minimal:0.3.4-RELEASE'
     dependency 'org.jetbrains.kotlin:kotlin-stdlib:1.3.61'
 
     dependency 'io.pkts:pkts-core:3.0.3'

--- a/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/artemis/networking/p2p/libp2p/LibP2PNetwork.java
@@ -111,6 +111,12 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
     // Setup peers
     peerManager = new PeerManager(metricsSystem, reputationManager, peerHandlers, rpcHandlers);
 
+    // temporary flag
+    // set true for Lighthouse compatibility
+    // set false for Prysm compatibility
+    // TODO remove when all clients adjust the same Noise spec
+    NoiseXXSecureChannel.setRustInteroperability(false);
+
     host =
         BuilderJKt.hostJ(
             Defaults.None,


### PR DESCRIPTION
## PR Description
- Bump libp2p version to support the latest Noise spec updates (Go Libp2p Noise compatible)
- Add temporary flag to interop with Lighthouse until they update Noise

When approved I'm going to publish the Libp2p release `0.3.4` and merge. 
Is not buildable now as of the Libp2p release lack