### PR TITLE
Bitlist SSZ data validation prior to deserialization

### DIFF
--- a/ssz/src/main/java/tech/pegasys/artemis/ssz/SSZTypes/Bitlist.java
+++ b/ssz/src/main/java/tech/pegasys/artemis/ssz/SSZTypes/Bitlist.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.artemis.ssz.SSZTypes;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkElementIndex;
 
 import java.util.ArrayList;
@@ -111,6 +112,7 @@ public class Bitlist {
 
   public static Bitlist fromBytes(Bytes bytes, long maxSize) {
     int numBytes = bytes.size();
+    checkArgument(numBytes > 0, "Bitlist must contain at least one byte");
     int leadingBitIndex = 0;
     while ((bytes.get(numBytes - 1) >>> (7 - leadingBitIndex)) % 2 == 0) {
       leadingBitIndex++;

--- a/ssz/src/main/java/tech/pegasys/artemis/ssz/SSZTypes/Bitlist.java
+++ b/ssz/src/main/java/tech/pegasys/artemis/ssz/SSZTypes/Bitlist.java
@@ -113,6 +113,7 @@ public class Bitlist {
   public static Bitlist fromBytes(Bytes bytes, long maxSize) {
     int numBytes = bytes.size();
     checkArgument(numBytes > 0, "Bitlist must contain at least one byte");
+    checkArgument(bytes.get(numBytes - 1) != 0, "Bitlist data must contain end marker bit");
     int leadingBitIndex = 0;
     while ((bytes.get(numBytes - 1) >>> (7 - leadingBitIndex)) % 2 == 0) {
       leadingBitIndex++;

--- a/ssz/src/main/java/tech/pegasys/artemis/ssz/SSZTypes/Bitvector.java
+++ b/ssz/src/main/java/tech/pegasys/artemis/ssz/SSZTypes/Bitvector.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.artemis.ssz.SSZTypes;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkElementIndex;
 
 import com.google.common.base.Objects;
@@ -68,12 +69,17 @@ public class Bitvector {
 
   @SuppressWarnings("NarrowingCompoundAssignment")
   public Bytes serialize() {
-    byte[] array = new byte[(size + 7) / 8];
+    byte[] array = new byte[sszSerializationLength(size)];
     IntStream.range(0, size).forEach(i -> array[i / 8] |= ((data.get(i) ? 1 : 0) << (i % 8)));
     return Bytes.wrap(array);
   }
 
   public static Bitvector fromBytes(Bytes bytes, int size) {
+    checkArgument(
+        bytes.size() == sszSerializationLength(size),
+        "Incorrect data size (%s) for Bitvector of size %s",
+        bytes.size(),
+        size);
     BitSet bitset = new BitSet(size);
 
     for (int i = size - 1; i >= 0; i--) {
@@ -83,6 +89,10 @@ public class Bitvector {
     }
 
     return new Bitvector(bitset, size);
+  }
+
+  private static int sszSerializationLength(final int size) {
+    return (size + 7) / 8;
   }
 
   public Bitvector rightShift(int i) {

--- a/ssz/src/test/java/tech/pegasys/artemis/ssz/ssztypes/BitlistTest.java
+++ b/ssz/src/test/java/tech/pegasys/artemis/ssz/ssztypes/BitlistTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.artemis.ssz.ssztypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.ssz.SSZTypes.Bitlist;
 
 class BitlistTest {
-  private static int bitlistMaxSize = 4000;
+  private static final int BITLIST_MAX_SIZE = 4000;
 
   @Test
   void initTest() {
@@ -120,13 +121,13 @@ class BitlistTest {
     Bitlist bitlist = createBitlist();
 
     Bytes bitlistSerialized = bitlist.serialize();
-    Bitlist newBitlist = Bitlist.fromBytes(bitlistSerialized, bitlistMaxSize);
+    Bitlist newBitlist = Bitlist.fromBytes(bitlistSerialized, BITLIST_MAX_SIZE);
     Assertions.assertEquals(bitlist, newBitlist);
   }
 
   @Test
   void serializationTest2() {
-    Bitlist bitlist = new Bitlist(9, bitlistMaxSize);
+    Bitlist bitlist = new Bitlist(9, BITLIST_MAX_SIZE);
     bitlist.setBit(0);
     bitlist.setBit(3);
     bitlist.setBit(4);
@@ -141,7 +142,7 @@ class BitlistTest {
 
   @Test
   void deserializationTest2() {
-    Bitlist bitlist = new Bitlist(9, bitlistMaxSize);
+    Bitlist bitlist = new Bitlist(9, BITLIST_MAX_SIZE);
     bitlist.setBit(0);
     bitlist.setBit(3);
     bitlist.setBit(4);
@@ -150,12 +151,19 @@ class BitlistTest {
     bitlist.setBit(7);
     bitlist.setBit(8);
 
-    Bitlist newBitlist = Bitlist.fromBytes(Bytes.fromHexString("0xf903"), bitlistMaxSize);
+    Bitlist newBitlist = Bitlist.fromBytes(Bytes.fromHexString("0xf903"), BITLIST_MAX_SIZE);
     Assertions.assertEquals(bitlist, newBitlist);
   }
 
+  @Test
+  void deserializationShouldRejectZeroLengthBytes() {
+    assertThatThrownBy(() -> Bitlist.fromBytes(Bytes.EMPTY, BITLIST_MAX_SIZE))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("at least one byte");
+  }
+
   private static Bitlist create(int... bits) {
-    Bitlist bitlist = new Bitlist(18, bitlistMaxSize);
+    Bitlist bitlist = new Bitlist(18, BITLIST_MAX_SIZE);
     IntStream.of(bits).forEach(bitlist::setBit);
     return bitlist;
   }

--- a/ssz/src/test/java/tech/pegasys/artemis/ssz/ssztypes/BitlistTest.java
+++ b/ssz/src/test/java/tech/pegasys/artemis/ssz/ssztypes/BitlistTest.java
@@ -162,6 +162,13 @@ class BitlistTest {
         .hasMessageContaining("at least one byte");
   }
 
+  @Test
+  void deserializationShouldRejectDataWhenEndMarkerBitNotSet() {
+    assertThatThrownBy(() -> Bitlist.fromBytes(Bytes.of(0), BITLIST_MAX_SIZE))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("marker bit");
+  }
+
   private static Bitlist create(int... bits) {
     Bitlist bitlist = new Bitlist(18, BITLIST_MAX_SIZE);
     IntStream.of(bits).forEach(bitlist::setBit);

--- a/ssz/src/test/java/tech/pegasys/artemis/ssz/ssztypes/BitvectorTest.java
+++ b/ssz/src/test/java/tech/pegasys/artemis/ssz/ssztypes/BitvectorTest.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.artemis.ssz.ssztypes;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Assertions;
@@ -70,6 +72,12 @@ class BitvectorTest {
     Bytes bitvectorSerialized = bitvector.serialize();
     Bitvector newBitvector = Bitvector.fromBytes(bitvectorSerialized, testBitvectorLength);
     Assertions.assertEquals(bitvector, newBitvector);
+  }
+
+  @Test
+  public void deserializationEmptyBytesTest() {
+    final Bitvector result = Bitvector.fromBytes(Bytes.EMPTY, 0);
+    assertThat(result.getSize()).isZero();
   }
 
   @Test

--- a/ssz/src/test/java/tech/pegasys/artemis/ssz/ssztypes/BitvectorTest.java
+++ b/ssz/src/test/java/tech/pegasys/artemis/ssz/ssztypes/BitvectorTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.artemis.ssz.ssztypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -78,6 +79,20 @@ class BitvectorTest {
   public void deserializationEmptyBytesTest() {
     final Bitvector result = Bitvector.fromBytes(Bytes.EMPTY, 0);
     assertThat(result.getSize()).isZero();
+  }
+
+  @Test
+  public void deserializationNotEnoughBytes() {
+    assertThatThrownBy(() -> Bitvector.fromBytes(Bytes.of(1, 2, 3), 50))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Incorrect data size");
+  }
+
+  @Test
+  public void deserializationTooManyBytes() {
+    assertThatThrownBy(() -> Bitvector.fromBytes(Bytes.of(1, 2, 3), 1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Incorrect data size");
   }
 
   @Test


### PR DESCRIPTION
## PR Description
The length of a Bitlist is encoded at the start of the data, so attempting to deserialise an empty byte array is invalid.  Previously this resulted in a `IndexOutOfBoundsException` but it's better to catch it with an explicit precondition check.

Also add an explicit check that the last byte is not 0 (it must contain a marker bit indicating the end of the bitlist).  This fixes the infinite loop from #1674 

## Fixed Issue(s)
fixes #1678 
fixes #1674