### PR TITLE
Validate that the attestation bitlist size matches the committee size

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/artemis/core/BlockProcessorUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/artemis/core/BlockProcessorUtil.java
@@ -427,7 +427,7 @@ public final class BlockProcessorUtil {
         List<Integer> committee = get_beacon_committee(state, data.getSlot(), data.getIndex());
         checkArgument(
             attestation.getAggregation_bits().getCurrentSize() == committee.size(),
-            "process_attestations: Attestation aggregation bit, custody bit, and committee doesn't have the same length");
+            "process_attestations: Attestation aggregation bits and committee don't have the same length");
 
         PendingAttestation pendingAttestation =
             new PendingAttestation(

--- a/ethereum/core/src/main/java/tech/pegasys/artemis/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/artemis/core/ForkChoiceUtil.java
@@ -302,10 +302,9 @@ public class ForkChoiceUtil {
               IndexedAttestation indexed_attestation;
               try {
                 indexed_attestation = get_indexed_attestation(target_state, attestation);
-              } catch (IndexOutOfBoundsException e) {
+              } catch (IllegalArgumentException e) {
                 return AttestationProcessingResult.invalid(
-                    "on_attestation: Attestation is not valid, IndexOutOfBoundsException: "
-                        + e.getMessage());
+                    "on_attestation: Attestation is not valid: " + e.getMessage());
               }
               if (!is_valid_indexed_attestation(target_state, indexed_attestation)) {
                 return AttestationProcessingResult.invalid(

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/AttestationUtil.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.artemis.datastructures.util;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_signing_root;
 import static tech.pegasys.artemis.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
@@ -114,7 +115,11 @@ public class AttestationUtil {
   public static List<Integer> get_attesting_indices(
       BeaconState state, AttestationData data, Bitlist bits) {
     List<Integer> committee = get_beacon_committee(state, data.getSlot(), data.getIndex());
-
+    checkArgument(
+        bits.getCurrentSize() == committee.size(),
+        "Aggregation bitlist size (%s) does not match committee size (%s)",
+        bits.getCurrentSize(),
+        committee.size());
     Set<Integer> attesting_indices = new HashSet<>();
     for (int i = 0; i < committee.size(); i++) {
       int index = committee.get(i);

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/topics/validation/AttestationValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/topics/validation/AttestationValidator.java
@@ -17,6 +17,7 @@ import static com.google.common.primitives.UnsignedLong.ONE;
 import static com.google.common.primitives.UnsignedLong.ZERO;
 import static tech.pegasys.artemis.datastructures.util.AttestationUtil.get_indexed_attestation;
 import static tech.pegasys.artemis.datastructures.util.AttestationUtil.is_valid_indexed_attestation;
+import static tech.pegasys.artemis.datastructures.util.CommitteeUtil.get_beacon_committee;
 import static tech.pegasys.artemis.networking.eth2.gossip.topics.validation.ValidationResult.INVALID;
 import static tech.pegasys.artemis.networking.eth2.gossip.topics.validation.ValidationResult.SAVED_FOR_FUTURE;
 import static tech.pegasys.artemis.networking.eth2.gossip.topics.validation.ValidationResult.VALID;
@@ -25,6 +26,7 @@ import static tech.pegasys.artemis.util.config.Constants.SECONDS_PER_SLOT;
 import static tech.pegasys.artemis.util.config.Constants.VALID_ATTESTATION_SET_SIZE;
 
 import com.google.common.primitives.UnsignedLong;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -121,6 +123,13 @@ public class AttestationValidator {
     }
 
     final BeaconState state = maybeState.get();
+
+    final List<Integer> committee =
+        get_beacon_committee(
+            state, attestation.getData().getSlot(), attestation.getData().getIndex());
+    if (committee.size() != attestation.getAggregation_bits().getCurrentSize()) {
+      return INVALID;
+    }
 
     // The signature of attestation is valid.
     final IndexedAttestation indexedAttestation = get_indexed_attestation(state, attestation);

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/validation/AttestationValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/validation/AttestationValidatorTest.java
@@ -35,6 +35,7 @@ import tech.pegasys.artemis.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.artemis.datastructures.operations.Attestation;
 import tech.pegasys.artemis.datastructures.util.BeaconStateUtil;
 import tech.pegasys.artemis.datastructures.util.CommitteeUtil;
+import tech.pegasys.artemis.ssz.SSZTypes.Bitlist;
 import tech.pegasys.artemis.statetransition.BeaconChainUtil;
 import tech.pegasys.artemis.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.artemis.storage.client.RecentChainData;
@@ -90,6 +91,20 @@ class AttestationValidatorTest {
     final Attestation attestation =
         attestationGenerator.validAttestation(recentChainData.getBestBlockAndState().orElseThrow());
     assertThat(validate(attestation)).isEqualTo(VALID);
+  }
+
+  @Test
+  public void shouldRejectAttestationWithIncorrectAggregateBitsSize() {
+    final Attestation attestation =
+        attestationGenerator.validAttestation(recentChainData.getBestBlockAndState().orElseThrow());
+    final Bitlist validAggregationBits = attestation.getAggregation_bits();
+    final Bitlist invalidAggregationBits =
+        new Bitlist(validAggregationBits.getCurrentSize() + 1, validAggregationBits.getMaxSize());
+    invalidAggregationBits.setAllBits(validAggregationBits);
+    final Attestation invalidAttestation =
+        new Attestation(
+            invalidAggregationBits, attestation.getData(), attestation.getAggregate_signature());
+    assertThat(validate(invalidAttestation)).isEqualTo(INVALID);
   }
 
   @Test


### PR DESCRIPTION
## PR Description
When creating an indexed attestation we need to ensure that the aggregation bits are the same size as the committee.  There are four places this can occur:

 * When a `BeaconState` contains invalid `PendingAttestation` waiting processing at the end of the epoch. This will never occur "naturally" but could occur if an invalid start state is provided.
 * When an attestation is received via gossip. We need to create the indexed attestation as part of validating it.
 * As part of running fork choice rule on received attestations. Partial validation was in place here - if the bitlist was too short the attestation was rejected, but if it was too large it was processed.
 * When an attestation is received as part of a block.  Validation is already in place here.

An explicit precondition check has been added in `get_attesting_indices` so that it's now impossible to create an indexed attestation if the bitlist size is incorrect.  All of the above cases now will reject the attestation.  

The gossip attestation validator also performs an explicit check so it can return a standard INVALID result instead of throwing an `IllegalStateException`.  Fork choice now catches `InvalidArgumentException` when creating the indexed attestation instead of `IndexOutOfBoundsException` (which is what was thrown if the bitlist was too short). The other cases already expect and handle the precondition check exception.

## Fixed Issue(s)
fixes #1685 
covers at least part of #1686 