### PR TITLE
Default interopGenesisTime to 0 instead of null

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/InteropOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/InteropOptions.java
@@ -23,7 +23,7 @@ public class InteropOptions {
       paramLabel = "<INTEGER>",
       description = "Time of mocked genesis",
       arity = "1")
-  private Integer interopGenesisTime = null;
+  private int interopGenesisTime = 0;
 
   @Option(
       hidden = true,

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
@@ -229,7 +229,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setP2pPort(30303)
         .setP2pPrivateKeyFile(null)
         .setInteropEnabled(false)
-        .setInteropGenesisTime(null)
+        .setInteropGenesisTime(0)
         .setInteropOwnedValidatorCount(0)
         .setLogDestination(DEFAULT_BOTH)
         .setLogFile(DEFAULT_LOG_FILE)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Default `interopGenesisTime` to 0 instead of null

## Fixed Issue(s)
Fixes an NPE when trying to connect `--network=topaz`
