### PR TITLE
Create Eth1DepositContractAddress as a class, and add a converter for CLI.

### DIFF
--- a/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
@@ -53,6 +53,7 @@ import tech.pegasys.artemis.storage.server.DatabaseStorageException;
 import tech.pegasys.artemis.util.cli.LogTypeConverter;
 import tech.pegasys.artemis.util.cli.VersionProvider;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
+import tech.pegasys.artemis.util.config.Eth1DepositContractAddress;
 import tech.pegasys.artemis.util.config.InvalidConfigurationException;
 import tech.pegasys.artemis.util.config.NetworkDefinition;
 import tech.pegasys.teku.logging.LoggingConfigurator;
@@ -155,13 +156,19 @@ public class BeaconNodeCommand implements Callable<Integer> {
     metricCategoryConverter.addCategories(StandardMetricCategory.class);
   }
 
+  private CommandLine registerConverters(final CommandLine commandLine) {
+    return commandLine
+        .registerConverter(MetricCategory.class, metricCategoryConverter)
+        .registerConverter(
+            Eth1DepositContractAddress.class, Eth1DepositContractAddress::fromHexString);
+  }
+
   private CommandLine getConfigFileCommandLine(final ConfigFileCommand configFileCommand) {
-    return new CommandLine(configFileCommand)
-        .registerConverter(MetricCategory.class, metricCategoryConverter);
+    return registerConverters(new CommandLine(configFileCommand));
   }
 
   private CommandLine getCommandLine() {
-    return new CommandLine(this).registerConverter(MetricCategory.class, metricCategoryConverter);
+    return registerConverters(new CommandLine(this));
   }
 
   public int parse(final String[] args) {

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/BeaconNodeCommand.java
@@ -53,7 +53,7 @@ import tech.pegasys.artemis.storage.server.DatabaseStorageException;
 import tech.pegasys.artemis.util.cli.LogTypeConverter;
 import tech.pegasys.artemis.util.cli.VersionProvider;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
-import tech.pegasys.artemis.util.config.Eth1DepositContractAddress;
+import tech.pegasys.artemis.util.config.Eth1Address;
 import tech.pegasys.artemis.util.config.InvalidConfigurationException;
 import tech.pegasys.artemis.util.config.NetworkDefinition;
 import tech.pegasys.teku.logging.LoggingConfigurator;
@@ -159,8 +159,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
   private CommandLine registerConverters(final CommandLine commandLine) {
     return commandLine
         .registerConverter(MetricCategory.class, metricCategoryConverter)
-        .registerConverter(
-            Eth1DepositContractAddress.class, Eth1DepositContractAddress::fromHexString);
+        .registerConverter(Eth1Address.class, Eth1Address::fromHexString);
   }
 
   private CommandLine getConfigFileCommandLine(final ConfigFileCommand configFileCommand) {

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/DepositOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/DepositOptions.java
@@ -14,7 +14,7 @@
 package tech.pegasys.artemis.cli.options;
 
 import picocli.CommandLine.Option;
-import tech.pegasys.artemis.util.config.Eth1DepositContractAddress;
+import tech.pegasys.artemis.util.config.Eth1Address;
 
 public class DepositOptions {
 
@@ -23,8 +23,7 @@ public class DepositOptions {
       paramLabel = "<ADDRESS>",
       description = "Contract address for the deposit contract",
       arity = "1")
-  private Eth1DepositContractAddress eth1DepositContractAddress =
-      null; // Depends on network configuration
+  private Eth1Address eth1DepositContractAddress = null; // Depends on network configuration
 
   @Option(
       names = {"--eth1-endpoint"},
@@ -41,7 +40,7 @@ public class DepositOptions {
       arity = "0..1")
   private boolean eth1Enabled = true;
 
-  public Eth1DepositContractAddress getEth1DepositContractAddress() {
+  public Eth1Address getEth1DepositContractAddress() {
     return eth1DepositContractAddress;
   }
 

--- a/artemis/src/main/java/tech/pegasys/artemis/cli/options/DepositOptions.java
+++ b/artemis/src/main/java/tech/pegasys/artemis/cli/options/DepositOptions.java
@@ -14,6 +14,7 @@
 package tech.pegasys.artemis.cli.options;
 
 import picocli.CommandLine.Option;
+import tech.pegasys.artemis.util.config.Eth1DepositContractAddress;
 
 public class DepositOptions {
 
@@ -22,7 +23,8 @@ public class DepositOptions {
       paramLabel = "<ADDRESS>",
       description = "Contract address for the deposit contract",
       arity = "1")
-  private String eth1DepositContractAddress = null; // Depends on network configuration
+  private Eth1DepositContractAddress eth1DepositContractAddress =
+      null; // Depends on network configuration
 
   @Option(
       names = {"--eth1-endpoint"},
@@ -39,7 +41,7 @@ public class DepositOptions {
       arity = "0..1")
   private boolean eth1Enabled = true;
 
-  public String getEth1DepositContractAddress() {
+  public Eth1DepositContractAddress getEth1DepositContractAddress() {
     return eth1DepositContractAddress;
   }
 

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
 import tech.pegasys.artemis.util.config.ArtemisConfigurationBuilder;
+import tech.pegasys.artemis.util.config.Eth1DepositContractAddress;
 import tech.pegasys.artemis.util.config.LoggingDestination;
 import tech.pegasys.artemis.util.config.NetworkDefinition;
 
@@ -244,6 +245,8 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   private ArtemisConfigurationBuilder expectedConfigurationBuilder() {
+    Eth1DepositContractAddress address =
+        Eth1DepositContractAddress.fromHexString("0x77f7bED277449F51505a4C54550B074030d989bC");
     return ArtemisConfiguration.builder()
         .setNetwork(NetworkDefinition.fromCliArg("minimal"))
         .setP2pEnabled(false)
@@ -263,7 +266,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setInteropOwnedValidatorCount(64)
         .setInteropNumberOfValidators(64)
         .setInteropEnabled(true)
-        .setEth1DepositContractAddress("0x77f7bED277449F51505a4C54550B074030d989bC")
+        .setEth1DepositContractAddress(address)
         .setEth1Endpoint("http://localhost:8545")
         .setEth1Enabled(true)
         .setMetricsEnabled(false)

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/BeaconNodeCommandTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
 import tech.pegasys.artemis.util.config.ArtemisConfigurationBuilder;
-import tech.pegasys.artemis.util.config.Eth1DepositContractAddress;
+import tech.pegasys.artemis.util.config.Eth1Address;
 import tech.pegasys.artemis.util.config.LoggingDestination;
 import tech.pegasys.artemis.util.config.NetworkDefinition;
 
@@ -245,8 +245,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   private ArtemisConfigurationBuilder expectedConfigurationBuilder() {
-    Eth1DepositContractAddress address =
-        Eth1DepositContractAddress.fromHexString("0x77f7bED277449F51505a4C54550B074030d989bC");
+    Eth1Address address = Eth1Address.fromHexString("0x77f7bED277449F51505a4C54550B074030d989bC");
     return ArtemisConfiguration.builder()
         .setNetwork(NetworkDefinition.fromCliArg("minimal"))
         .setP2pEnabled(false)

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/options/DepositOptionsTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/options/DepositOptionsTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
+import tech.pegasys.artemis.util.config.Eth1DepositContractAddress;
 
 public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
 
@@ -25,10 +26,11 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
   public void shouldReadDepositOptionsFromConfigurationFile() {
     final ArtemisConfiguration config =
         getArtemisConfigurationFromFile("depositOptions_config.yaml");
+    Eth1DepositContractAddress address =
+        Eth1DepositContractAddress.fromHexString("0xfe3b557e8fb62b89f4916b721be55ceb828dbd73");
 
     assertThat(config.isEth1Enabled()).isFalse();
-    assertThat(config.getEth1DepositContractAddress())
-        .isEqualTo("0xfe3b557e8fb62b89f4916b721be55ceb828dbd73");
+    assertThat(config.getEth1DepositContractAddress()).isEqualTo(address);
     assertThat(config.getEth1Endpoint()).isEqualTo("http://example.com:1234/path/");
   }
 

--- a/artemis/src/test/java/tech/pegasys/artemis/cli/options/DepositOptionsTest.java
+++ b/artemis/src/test/java/tech/pegasys/artemis/cli/options/DepositOptionsTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.artemis.util.config.ArtemisConfiguration;
-import tech.pegasys.artemis.util.config.Eth1DepositContractAddress;
+import tech.pegasys.artemis.util.config.Eth1Address;
 
 public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
 
@@ -26,8 +26,7 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
   public void shouldReadDepositOptionsFromConfigurationFile() {
     final ArtemisConfiguration config =
         getArtemisConfigurationFromFile("depositOptions_config.yaml");
-    Eth1DepositContractAddress address =
-        Eth1DepositContractAddress.fromHexString("0xfe3b557e8fb62b89f4916b721be55ceb828dbd73");
+    Eth1Address address = Eth1Address.fromHexString("0xfe3b557e8fb62b89f4916b721be55ceb828dbd73");
 
     assertThat(config.isEth1Enabled()).isFalse();
     assertThat(config.getEth1DepositContractAddress()).isEqualTo(address);

--- a/services/powchain/src/main/java/tech/pegasys/artemis/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/artemis/services/powchain/PowchainService.java
@@ -51,7 +51,7 @@ public class PowchainService extends Service {
 
     DepositContractAccessor depositContractAccessor =
         DepositContractAccessor.create(
-            eth1Provider, web3j, config.getConfig().getEth1DepositContractAddress());
+            eth1Provider, web3j, config.getConfig().getEth1DepositContractAddress().toHexString());
 
     DepositObjectsFactory depositsObjectFactory =
         new DepositObjectsFactory(

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
@@ -63,7 +63,7 @@ public class ArtemisConfiguration {
 
   private final boolean eth1Enabled;
   // Deposit
-  private final Eth1DepositContractAddress eth1DepositContractAddress;
+  private final Eth1Address eth1DepositContractAddress;
   private final String eth1Endpoint;
 
   // Logging
@@ -128,7 +128,7 @@ public class ArtemisConfiguration {
       final String validatorExternalSignerUrl,
       final int validatorExternalSignerTimeout,
       final boolean eth1Enabled,
-      final Eth1DepositContractAddress eth1DepositContractAddress,
+      final Eth1Address eth1DepositContractAddress,
       final String eth1Endpoint,
       final boolean logColorEnabled,
       final boolean logIncludeEventsEnabled,
@@ -326,7 +326,7 @@ public class ArtemisConfiguration {
     return eth1Enabled;
   }
 
-  public Eth1DepositContractAddress getEth1DepositContractAddress() {
+  public Eth1Address getEth1DepositContractAddress() {
     return eth1DepositContractAddress;
   }
 

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfiguration.java
@@ -63,7 +63,7 @@ public class ArtemisConfiguration {
 
   private final boolean eth1Enabled;
   // Deposit
-  private final String eth1DepositContractAddress;
+  private final Eth1DepositContractAddress eth1DepositContractAddress;
   private final String eth1Endpoint;
 
   // Logging
@@ -128,7 +128,7 @@ public class ArtemisConfiguration {
       final String validatorExternalSignerUrl,
       final int validatorExternalSignerTimeout,
       final boolean eth1Enabled,
-      final String eth1DepositContractAddress,
+      final Eth1DepositContractAddress eth1DepositContractAddress,
       final String eth1Endpoint,
       final boolean logColorEnabled,
       final boolean logIncludeEventsEnabled,
@@ -326,7 +326,7 @@ public class ArtemisConfiguration {
     return eth1Enabled;
   }
 
-  public String getEth1DepositContractAddress() {
+  public Eth1DepositContractAddress getEth1DepositContractAddress() {
     return eth1DepositContractAddress;
   }
 

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
@@ -44,7 +44,7 @@ public class ArtemisConfigurationBuilder {
   private List<String> validatorExternalSignerPublicKeys;
   private String validatorExternalSignerUrl;
   private int validatorExternalSignerTimeout;
-  private String eth1DepositContractAddress;
+  private Eth1DepositContractAddress eth1DepositContractAddress;
   private String eth1Endpoint;
   private boolean logColorEnabled;
   private boolean logIncludeEventsEnabled;
@@ -215,7 +215,7 @@ public class ArtemisConfigurationBuilder {
   }
 
   public ArtemisConfigurationBuilder setEth1DepositContractAddress(
-      final String eth1DepositContractAddress) {
+      final Eth1DepositContractAddress eth1DepositContractAddress) {
     this.eth1DepositContractAddress = eth1DepositContractAddress;
     return this;
   }

--- a/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/ArtemisConfigurationBuilder.java
@@ -44,7 +44,7 @@ public class ArtemisConfigurationBuilder {
   private List<String> validatorExternalSignerPublicKeys;
   private String validatorExternalSignerUrl;
   private int validatorExternalSignerTimeout;
-  private Eth1DepositContractAddress eth1DepositContractAddress;
+  private Eth1Address eth1DepositContractAddress;
   private String eth1Endpoint;
   private boolean logColorEnabled;
   private boolean logIncludeEventsEnabled;
@@ -215,7 +215,7 @@ public class ArtemisConfigurationBuilder {
   }
 
   public ArtemisConfigurationBuilder setEth1DepositContractAddress(
-      final Eth1DepositContractAddress eth1DepositContractAddress) {
+      final Eth1Address eth1DepositContractAddress) {
     this.eth1DepositContractAddress = eth1DepositContractAddress;
     return this;
   }

--- a/util/src/main/java/tech/pegasys/artemis/util/config/Eth1Address.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/Eth1Address.java
@@ -18,13 +18,13 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
 
-public class Eth1DepositContractAddress {
+public class Eth1Address {
   /** The number of bytes in this value - i.e. 20 */
   private static final int SIZE = 20;
 
   private final Bytes bytes;
 
-  public Eth1DepositContractAddress(Bytes bytes) {
+  public Eth1Address(Bytes bytes) {
     checkArgument(
         bytes.size() == SIZE,
         "Bytes%s should be %s bytes, but was %s bytes.",
@@ -42,7 +42,7 @@ public class Eth1DepositContractAddress {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final Eth1DepositContractAddress address = (Eth1DepositContractAddress) o;
+    final Eth1Address address = (Eth1Address) o;
     return bytes.equals(address.bytes);
   }
 
@@ -56,9 +56,9 @@ public class Eth1DepositContractAddress {
     return bytes.toString();
   }
 
-  public static Eth1DepositContractAddress fromHexString(String value) {
+  public static Eth1Address fromHexString(String value) {
     Bytes bytes = Bytes.fromHexString(value);
-    return new Eth1DepositContractAddress(bytes);
+    return new Eth1Address(bytes);
   }
 
   public String toHexString() {
@@ -67,9 +67,5 @@ public class Eth1DepositContractAddress {
 
   public Bytes toBytes() {
     return bytes;
-  }
-
-  public static Eth1DepositContractAddress empty() {
-    return new Eth1DepositContractAddress(Bytes.wrap(new byte[SIZE]));
   }
 }

--- a/util/src/main/java/tech/pegasys/artemis/util/config/Eth1DepositContractAddress.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/Eth1DepositContractAddress.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.util.config;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes;
+
+public class Eth1DepositContractAddress {
+  /** The number of bytes in this value - i.e. 20 */
+  private static final int SIZE = 20;
+
+  private final Bytes bytes;
+
+  public Eth1DepositContractAddress(Bytes bytes) {
+    checkArgument(
+        bytes.size() == SIZE,
+        "Bytes%s should be %s bytes, but was %s bytes.",
+        SIZE,
+        SIZE,
+        bytes.size());
+    this.bytes = bytes;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final Eth1DepositContractAddress address = (Eth1DepositContractAddress) o;
+    return bytes.equals(address.bytes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(bytes);
+  }
+
+  @Override
+  public String toString() {
+    return bytes.toString();
+  }
+
+  public static Eth1DepositContractAddress fromHexString(String value) {
+    Bytes bytes = Bytes.fromHexString(value);
+    return new Eth1DepositContractAddress(bytes);
+  }
+
+  public String toHexString() {
+    return bytes.toHexString();
+  }
+
+  public Bytes toBytes() {
+    return bytes;
+  }
+
+  public static Eth1DepositContractAddress empty() {
+    return new Eth1DepositContractAddress(Bytes.wrap(new byte[SIZE]));
+  }
+}

--- a/util/src/main/java/tech/pegasys/artemis/util/config/NetworkDefinition.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/NetworkDefinition.java
@@ -35,7 +35,9 @@ public class NetworkDefinition {
                       "https://github.com/eth2-clients/eth2-testnets/raw/master/prysm/Topaz(v0.11.1)/genesis.ssz")
                   .discoveryBootnodes(
                       "enr:-Ku4QAGwOT9StqmwI5LHaIymIO4ooFKfNkEjWa0f1P8OsElgBh2Ijb-GrD_-b9W4kcPFcwmHQEy5RncqXNqdpVo1heoBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAAAAAAAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQJxCnE6v_x2ekgY_uoE1rtwzvGy40mq9eD66XfHPBWgIIN1ZHCCD6A")
-                  .eth1DepositContractAddress("0x5cA1e00004366Ac85f492887AAab12d0e6418876")
+                  .eth1DepositContractAddress(
+                      Eth1DepositContractAddress.fromHexString(
+                          "0x5cA1e00004366Ac85f492887AAab12d0e6418876"))
                   .build())
           .build();
 
@@ -44,7 +46,7 @@ public class NetworkDefinition {
   private final int startupTargetPeerCount;
   private final int startupTimeoutSeconds;
   private final List<String> discoveryBootnodes;
-  private final Optional<String> eth1DepositContractAddress;
+  private final Optional<Eth1DepositContractAddress> eth1DepositContractAddress;
   private final Optional<String> eth1Endpoint;
 
   private NetworkDefinition(
@@ -53,7 +55,7 @@ public class NetworkDefinition {
       final int startupTargetPeerCount,
       final int startupTimeoutSeconds,
       final List<String> discoveryBootnodes,
-      final Optional<String> eth1DepositContractAddress,
+      final Optional<Eth1DepositContractAddress> eth1DepositContractAddress,
       final Optional<String> eth1Endpoint) {
     this.constants = constants;
     this.initialState = initialState;
@@ -92,7 +94,7 @@ public class NetworkDefinition {
     return discoveryBootnodes;
   }
 
-  public Optional<String> getEth1DepositContractAddress() {
+  public Optional<Eth1DepositContractAddress> getEth1DepositContractAddress() {
     return eth1DepositContractAddress;
   }
 
@@ -106,7 +108,7 @@ public class NetworkDefinition {
     private int startupTargetPeerCount = Constants.DEFAULT_STARTUP_TARGET_PEER_COUNT;
     private int startupTimeoutSeconds = Constants.DEFAULT_STARTUP_TIMEOUT_SECONDS;
     private List<String> discoveryBootnodes = new ArrayList<>();
-    private Optional<String> eth1DepositContractAddress = Optional.empty();
+    private Optional<Eth1DepositContractAddress> eth1DepositContractAddress = Optional.empty();
     private Optional<String> eth1Endpoint = Optional.empty();
 
     public Builder constants(final String constants) {
@@ -134,7 +136,8 @@ public class NetworkDefinition {
       return this;
     }
 
-    public Builder eth1DepositContractAddress(final String eth1DepositContractAddress) {
+    public Builder eth1DepositContractAddress(
+        final Eth1DepositContractAddress eth1DepositContractAddress) {
       this.eth1DepositContractAddress = Optional.of(eth1DepositContractAddress);
       return this;
     }

--- a/util/src/main/java/tech/pegasys/artemis/util/config/NetworkDefinition.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/config/NetworkDefinition.java
@@ -36,8 +36,7 @@ public class NetworkDefinition {
                   .discoveryBootnodes(
                       "enr:-Ku4QAGwOT9StqmwI5LHaIymIO4ooFKfNkEjWa0f1P8OsElgBh2Ijb-GrD_-b9W4kcPFcwmHQEy5RncqXNqdpVo1heoBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAAAAAAAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQJxCnE6v_x2ekgY_uoE1rtwzvGy40mq9eD66XfHPBWgIIN1ZHCCD6A")
                   .eth1DepositContractAddress(
-                      Eth1DepositContractAddress.fromHexString(
-                          "0x5cA1e00004366Ac85f492887AAab12d0e6418876"))
+                      Eth1Address.fromHexString("0x5cA1e00004366Ac85f492887AAab12d0e6418876"))
                   .build())
           .build();
 
@@ -46,7 +45,7 @@ public class NetworkDefinition {
   private final int startupTargetPeerCount;
   private final int startupTimeoutSeconds;
   private final List<String> discoveryBootnodes;
-  private final Optional<Eth1DepositContractAddress> eth1DepositContractAddress;
+  private final Optional<Eth1Address> eth1DepositContractAddress;
   private final Optional<String> eth1Endpoint;
 
   private NetworkDefinition(
@@ -55,7 +54,7 @@ public class NetworkDefinition {
       final int startupTargetPeerCount,
       final int startupTimeoutSeconds,
       final List<String> discoveryBootnodes,
-      final Optional<Eth1DepositContractAddress> eth1DepositContractAddress,
+      final Optional<Eth1Address> eth1DepositContractAddress,
       final Optional<String> eth1Endpoint) {
     this.constants = constants;
     this.initialState = initialState;
@@ -94,7 +93,7 @@ public class NetworkDefinition {
     return discoveryBootnodes;
   }
 
-  public Optional<Eth1DepositContractAddress> getEth1DepositContractAddress() {
+  public Optional<Eth1Address> getEth1DepositContractAddress() {
     return eth1DepositContractAddress;
   }
 
@@ -108,7 +107,7 @@ public class NetworkDefinition {
     private int startupTargetPeerCount = Constants.DEFAULT_STARTUP_TARGET_PEER_COUNT;
     private int startupTimeoutSeconds = Constants.DEFAULT_STARTUP_TIMEOUT_SECONDS;
     private List<String> discoveryBootnodes = new ArrayList<>();
-    private Optional<Eth1DepositContractAddress> eth1DepositContractAddress = Optional.empty();
+    private Optional<Eth1Address> eth1DepositContractAddress = Optional.empty();
     private Optional<String> eth1Endpoint = Optional.empty();
 
     public Builder constants(final String constants) {
@@ -136,9 +135,8 @@ public class NetworkDefinition {
       return this;
     }
 
-    public Builder eth1DepositContractAddress(
-        final Eth1DepositContractAddress eth1DepositContractAddress) {
-      this.eth1DepositContractAddress = Optional.of(eth1DepositContractAddress);
+    public Builder eth1DepositContractAddress(final Eth1Address eth1Address) {
+      this.eth1DepositContractAddress = Optional.of(eth1Address);
       return this;
     }
 


### PR DESCRIPTION

 - invalid type conversion will cause an error when parsing command line.

 Addresses #1653

Signed-off-by: Paul Harris <paul.harris@consensys.net>
