### PR TITLE
Fix fork choice race condition

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/artemis/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/artemis/core/ForkChoiceUtil.java
@@ -151,8 +151,7 @@ public class ForkChoiceUtil {
   public static BlockImportResult on_block(
       final MutableStore store,
       final SignedBeaconBlock signed_block,
-      final StateTransition st,
-      final ForkChoiceStrategy forkChoiceStrategy) {
+      final StateTransition st) {
     final BeaconBlock block = signed_block.getMessage();
     final BeaconState preState = store.getBlockState(block.getParent_root());
 
@@ -228,8 +227,6 @@ public class ForkChoiceUtil {
         }
       }
     }
-
-    forkChoiceStrategy.onBlock(store, block);
 
     final BlockProcessingRecord record = new BlockProcessingRecord(preState, signed_block, state);
     return BlockImportResult.successful(record);

--- a/ethereum/core/src/main/java/tech/pegasys/artemis/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/artemis/core/ForkChoiceUtil.java
@@ -149,9 +149,7 @@ public class ForkChoiceUtil {
    */
   @CheckReturnValue
   public static BlockImportResult on_block(
-      final MutableStore store,
-      final SignedBeaconBlock signed_block,
-      final StateTransition st) {
+      final MutableStore store, final SignedBeaconBlock signed_block, final StateTransition st) {
     final BeaconBlock block = signed_block.getMessage();
     final BeaconState preState = store.getBlockState(block.getParent_root());
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/blockimport/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/blockimport/BlockImporter.java
@@ -52,11 +52,12 @@ public class BlockImporter {
             block.getMessage().hash_tree_root());
         return BlockImportResult.knownBlock(block);
       }
-
       BlockImportResult result = forkChoice.onBlock(block);
-      final Optional<BlockProcessingRecord> record = result.getBlockProcessingRecord();
-      eventBus.post(new ImportedBlockEvent(block));
-      record.ifPresent(eventBus::post);
+      if (result.isSuccessful()) {
+        final Optional<BlockProcessingRecord> record = result.getBlockProcessingRecord();
+        eventBus.post(new ImportedBlockEvent(block));
+        record.ifPresent(eventBus::post);
+      }
       return result;
     } catch (Exception e) {
       LOG.error("Internal error while importing block: " + block.getMessage(), e);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/blockimport/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/blockimport/BlockImporter.java
@@ -25,7 +25,6 @@ import tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.artemis.statetransition.events.block.ImportedBlockEvent;
 import tech.pegasys.artemis.statetransition.events.block.ProposedBlockEvent;
 import tech.pegasys.artemis.statetransition.forkchoice.ForkChoice;
-import tech.pegasys.artemis.storage.Store;
 import tech.pegasys.artemis.storage.client.RecentChainData;
 import tech.pegasys.artemis.util.async.SafeFuture;
 
@@ -59,7 +58,6 @@ public class BlockImporter {
       eventBus.post(new ImportedBlockEvent(block));
       record.ifPresent(eventBus::post);
       return result;
-
     } catch (Exception e) {
       LOG.error("Internal error while importing block: " + block.getMessage(), e);
       return BlockImportResult.internalError(e);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/blockimport/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/blockimport/BlockImporter.java
@@ -53,23 +53,13 @@ public class BlockImporter {
             block.getMessage().hash_tree_root());
         return BlockImportResult.knownBlock(block);
       }
-      Store.Transaction transaction = recentChainData.startStoreTransaction();
-      final BlockImportResult result = forkChoice.onBlock(transaction, block);
-      if (!result.isSuccessful()) {
-        LOG.trace(
-            "Failed to import block for reason {}: {}",
-            result.getFailureReason(),
-            block.getMessage());
-        return result;
-      }
-      LOG.trace("Successfully imported block {}", block.getMessage().hash_tree_root());
 
+      BlockImportResult result = forkChoice.onBlock(block);
       final Optional<BlockProcessingRecord> record = result.getBlockProcessingRecord();
-      transaction.commit().join();
       eventBus.post(new ImportedBlockEvent(block));
       record.ifPresent(eventBus::post);
-
       return result;
+
     } catch (Exception e) {
       LOG.error("Internal error while importing block: " + block.getMessage(), e);
       return BlockImportResult.internalError(e);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/forkchoice/ForkChoice.java
@@ -66,14 +66,8 @@ public class ForkChoice implements FinalizedCheckpointChannel {
     final BlockImportResult result = on_block(transaction, block, stateTransition);
 
     if (!result.isSuccessful()) {
-      LOG.trace(
-          "Failed to import block for reason {}: {}",
-          result.getFailureReason(),
-          block.getMessage());
       return result;
     }
-
-    LOG.trace("Successfully imported block {}", block.getMessage().hash_tree_root());
 
     transaction.commit().join();
     protoArrayForkChoiceStrategy.onBlock(recentChainData.getStore(), block.getMessage());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/forkchoice/ForkChoice.java
@@ -22,19 +22,15 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.artemis.core.StateTransition;
 import tech.pegasys.artemis.core.results.AttestationProcessingResult;
 import tech.pegasys.artemis.core.results.BlockImportResult;
-import tech.pegasys.artemis.data.BlockProcessingRecord;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.artemis.datastructures.forkchoice.MutableStore;
 import tech.pegasys.artemis.datastructures.operations.Attestation;
 import tech.pegasys.artemis.datastructures.state.Checkpoint;
 import tech.pegasys.artemis.protoarray.ProtoArrayForkChoiceStrategy;
-import tech.pegasys.artemis.statetransition.blockimport.BlockImporter;
 import tech.pegasys.artemis.storage.Store;
 import tech.pegasys.artemis.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.artemis.storage.client.RecentChainData;
-
-import java.util.Optional;
 
 public class ForkChoice implements FinalizedCheckpointChannel {
 
@@ -71,16 +67,13 @@ public class ForkChoice implements FinalizedCheckpointChannel {
 
     if (!result.isSuccessful()) {
       LOG.trace(
-              "Failed to import block for reason {}: {}",
-              result.getFailureReason(),
-              block.getMessage());
+          "Failed to import block for reason {}: {}",
+          result.getFailureReason(),
+          block.getMessage());
       return result;
     }
 
-    LOG.trace(
-            "Successfully imported block {}",
-            block.getMessage().hash_tree_root()
-    );
+    LOG.trace("Successfully imported block {}", block.getMessage().hash_tree_root());
 
     transaction.commit().join();
     protoArrayForkChoiceStrategy.onBlock(recentChainData.getStore(), block.getMessage());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/forkchoice/ForkChoice.java
@@ -51,7 +51,7 @@ public class ForkChoice implements FinalizedCheckpointChannel {
   public Bytes32 processHead() {
     Store.Transaction transaction = recentChainData.startStoreTransaction();
     Bytes32 headBlockRoot = protoArrayForkChoiceStrategy.findHead(transaction);
-    transaction.commit(() -> {}, "Failed to persist validator vote changes.");
+    transaction.commit().join();
     BeaconBlock headBlock = recentChainData.getStore().getBlock(headBlockRoot);
     recentChainData.updateBestBlock(headBlockRoot, headBlock.getSlot());
     return headBlockRoot;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/forkchoice/ForkChoice.java
@@ -16,8 +16,6 @@ package tech.pegasys.artemis.statetransition.forkchoice;
 import static tech.pegasys.artemis.core.ForkChoiceUtil.on_attestation;
 import static tech.pegasys.artemis.core.ForkChoiceUtil.on_block;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.artemis.core.StateTransition;
 import tech.pegasys.artemis.core.results.AttestationProcessingResult;
@@ -33,8 +31,6 @@ import tech.pegasys.artemis.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.artemis.storage.client.RecentChainData;
 
 public class ForkChoice implements FinalizedCheckpointChannel {
-
-  private static final Logger LOG = LogManager.getLogger();
 
   private final RecentChainData recentChainData;
   private final StateTransition stateTransition;

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/artemis/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/artemis/statetransition/BeaconChainUtil.java
@@ -35,7 +35,6 @@ import tech.pegasys.artemis.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.artemis.datastructures.operations.Attestation;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.util.MockStartValidatorKeyPairFactory;
-import tech.pegasys.artemis.protoarray.StubForkChoiceStrategy;
 import tech.pegasys.artemis.ssz.SSZTypes.SSZList;
 import tech.pegasys.artemis.statetransition.util.StartupUtil;
 import tech.pegasys.artemis.storage.Store.Transaction;
@@ -138,7 +137,7 @@ public class BeaconChainUtil {
     setSlot(slot);
     final Transaction transaction = recentChainData.startStoreTransaction();
     final BlockImportResult importResult =
-        ForkChoiceUtil.on_block(transaction, block, stateTransition, new StubForkChoiceStrategy());
+        ForkChoiceUtil.on_block(transaction, block, stateTransition);
     if (!importResult.isSuccessful()) {
       throw new IllegalStateException(
           "Produced an invalid block ( reason "


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Fixes the fork choice race condition described here: [Jira BC-403](https://pegasys1.atlassian.net/browse/BC-403).

#### Analysis of the bug:
- On block occurs, `onBlock` (store) transaction starts
- During `onBlock`, `protoArrayForkChoice` gets updated with block information
- Before `onBlock` transaction finishes committing, and thus saving the block to store, `processHead` starts.
- Since we did not wait for the `onBlock` transaction to finish, in `processHead` when we get the block and call .`getSlot()`, we get a `NPE`. 

#### Fix:
After offline discussion with @mbaxter, we decided that the best way going forward is to make sure `Store` and `ForkChoiceStrategy` are in sync with respect to the elements they reference. So, this PR moves on block transaction creation and commit to the `ForkChoice.onBlock()` method so that `ForkChoiceStategy.onBlock()` only gets called after the `Store` transaction commit is successfully done.