### PR TITLE
Abstract out committee indices from network

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/CommitteeUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/CommitteeUtil.java
@@ -276,11 +276,15 @@ public class CommitteeUtil {
     return (bytes_to_int(Hash.sha2_256(slot_signature.toBytes()).slice(0, 8)) % modulo) == 0;
   }
 
-  public static UnsignedLong getSubnetId(final Attestation attestation) {
+  public static int getSubnetId(final Attestation attestation) {
     return committeeIndexToSubnetId(attestation.getData().getIndex());
   }
 
-  public static UnsignedLong committeeIndexToSubnetId(final UnsignedLong committeeIndex) {
-    return committeeIndex.mod(UnsignedLong.valueOf(ATTESTATION_SUBNET_COUNT));
+  public static int committeeIndexToSubnetId(final UnsignedLong committeeIndex) {
+    return committeeIndexToSubnetId(toIntExact(committeeIndex.longValue()));
+  }
+
+  public static int committeeIndexToSubnetId(final int committeeIndex) {
+    return committeeIndex % ATTESTATION_SUBNET_COUNT;
   }
 }

--- a/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/GossipMessageHandlerIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/artemis/networking/eth2/GossipMessageHandlerIntegrationTest.java
@@ -196,10 +196,10 @@ public class GossipMessageHandlerIntegrationTest {
 
     node1
         .network()
-        .subscribeToAttestationCommitteeTopic(validAttestation.getData().getIndex().intValue());
+        .subscribeToAttestationSubnetId(validAttestation.getData().getIndex().intValue());
     node2
         .network()
-        .subscribeToAttestationCommitteeTopic(validAttestation.getData().getIndex().intValue());
+        .subscribeToAttestationSubnetId(validAttestation.getData().getIndex().intValue());
 
     waitForTopicRegistration();
 
@@ -239,10 +239,10 @@ public class GossipMessageHandlerIntegrationTest {
 
     node1
         .network()
-        .subscribeToAttestationCommitteeTopic(validAttestation.getData().getIndex().intValue());
+        .subscribeToAttestationSubnetId(validAttestation.getData().getIndex().intValue());
     node2
         .network()
-        .subscribeToAttestationCommitteeTopic(validAttestation.getData().getIndex().intValue());
+        .subscribeToAttestationSubnetId(validAttestation.getData().getIndex().intValue());
 
     waitForTopicRegistration();
 
@@ -254,10 +254,10 @@ public class GossipMessageHandlerIntegrationTest {
 
     node1
         .network()
-        .unsubscribeFromAttestationCommitteeTopic(validAttestation.getData().getIndex().intValue());
+        .unsubscribeFromAttestationSubnetId(validAttestation.getData().getIndex().intValue());
     node2
         .network()
-        .unsubscribeFromAttestationCommitteeTopic(validAttestation.getData().getIndex().intValue());
+        .unsubscribeFromAttestationSubnetId(validAttestation.getData().getIndex().intValue());
 
     waitForTopicDeregistration();
 

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/ActiveEth2Network.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/ActiveEth2Network.java
@@ -140,21 +140,21 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
   }
 
   @Override
-  public void subscribeToAttestationCommitteeTopic(final int committeeIndex) {
+  public void subscribeToAttestationSubnetId(final int subnetId) {
     if (aggregateGossipManager == null) {
       throw new IllegalStateException(
           "Attestation committee can not be subscribed due to gossip manager not being initialized");
     }
-    attestationGossipManager.subscribeToCommitteeTopic(committeeIndex);
+    attestationGossipManager.subscribeToSubnetId(subnetId);
   }
 
   @Override
-  public void unsubscribeFromAttestationCommitteeTopic(final int committeeIndex) {
+  public void unsubscribeFromAttestationSubnetId(final int subnetId) {
     if (aggregateGossipManager == null) {
       throw new IllegalStateException(
           "Attestation committee can not be unsubscribed due to gossip manager not being initialized");
     }
-    attestationGossipManager.unsubscribeFromCommitteeTopic(committeeIndex);
+    attestationGossipManager.unsubscribeFromSubnetId(subnetId);
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/Eth2Network.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/Eth2Network.java
@@ -18,9 +18,9 @@ import tech.pegasys.artemis.networking.p2p.network.P2PNetwork;
 
 public interface Eth2Network extends P2PNetwork<Eth2Peer> {
 
-  void subscribeToAttestationCommitteeTopic(final int committeeIndex);
+  void subscribeToAttestationSubnetId(final int subnetId);
 
-  void unsubscribeFromAttestationCommitteeTopic(final int committeeIndex);
+  void unsubscribeFromAttestationSubnetId(final int subnetId);
 
   void setLongTermAttestationSubnetSubscriptions(final Iterable<Integer> subnetIndices);
 }

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationGossipManager.java
@@ -13,9 +13,10 @@
 
 package tech.pegasys.artemis.networking.eth2.gossip;
 
+import static tech.pegasys.artemis.datastructures.util.CommitteeUtil.committeeIndexToSubnetId;
+
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
-import com.google.common.primitives.UnsignedLong;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -39,23 +40,23 @@ public class AttestationGossipManager {
 
   @Subscribe
   public void onNewAttestation(final Attestation attestation) {
-    final UnsignedLong committeeIndex = attestation.getData().getIndex();
+    final int subnetId = committeeIndexToSubnetId(attestation.getData().getIndex());
     subnetSubscriptions
-        .getChannel(committeeIndex)
+        .getChannel(subnetId)
         .ifPresentOrElse(
             channel -> channel.gossip(SimpleOffsetSerializer.serialize(attestation)),
             () ->
                 LOG.trace(
-                    "Ignoring attestation for committee {}, which does not correspond to any currently assigned committee.",
-                    committeeIndex));
+                    "Ignoring attestation for subnet id {}, which does not correspond to any currently assigned subnet ids.",
+                    subnetId));
   }
 
-  public void subscribeToCommitteeTopic(final int committeeIndex) {
-    subnetSubscriptions.subscribeToCommitteeTopic(UnsignedLong.valueOf(committeeIndex));
+  public void subscribeToSubnetId(final int subnetId) {
+    subnetSubscriptions.subscribeToSubnetId(subnetId);
   }
 
-  public void unsubscribeFromCommitteeTopic(final int committeeIndex) {
-    subnetSubscriptions.unsubscribeFromCommitteeTopic(UnsignedLong.valueOf(committeeIndex));
+  public void unsubscribeFromSubnetId(final int subnetId) {
+    subnetSubscriptions.unsubscribeFromSubnetId(subnetId);
   }
 
   public void shutdown() {

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationSubnetSubscriptions.java
@@ -13,16 +13,10 @@
 
 package tech.pegasys.artemis.networking.eth2.gossip;
 
-import static tech.pegasys.artemis.datastructures.util.CommitteeUtil.committeeIndexToSubnetId;
-
 import com.google.common.eventbus.EventBus;
-import com.google.common.primitives.UnsignedLong;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import tech.pegasys.artemis.networking.eth2.gossip.topics.AttestationTopicHandler;
 import tech.pegasys.artemis.networking.eth2.gossip.topics.validation.AttestationValidator;
 import tech.pegasys.artemis.networking.p2p.gossip.GossipNetwork;
@@ -35,8 +29,7 @@ public class AttestationSubnetSubscriptions implements AutoCloseable {
   private final AttestationValidator attestationValidator;
   private final EventBus eventBus;
 
-  private final Map<UnsignedLong, Set<UnsignedLong>> subnetIdToCommittees = new HashMap<>();
-  private final Map<UnsignedLong, TopicChannel> subnetIdToTopicChannel = new HashMap<>();
+  private final Map<Integer, TopicChannel> subnetIdToTopicChannel = new HashMap<>();
 
   public AttestationSubnetSubscriptions(
       final GossipNetwork gossipNetwork,
@@ -49,36 +42,22 @@ public class AttestationSubnetSubscriptions implements AutoCloseable {
     this.eventBus = eventBus;
   }
 
-  public synchronized Optional<TopicChannel> getChannel(final UnsignedLong committeeIndex) {
-    final UnsignedLong subnetId = committeeIndexToSubnetId(committeeIndex);
+  public synchronized Optional<TopicChannel> getChannel(final int subnetId) {
     return Optional.ofNullable(subnetIdToTopicChannel.get(subnetId));
   }
 
-  public synchronized void subscribeToCommitteeTopic(final UnsignedLong committeeIndex) {
-    final UnsignedLong subnetId = committeeIndexToSubnetId(committeeIndex);
-    final Set<UnsignedLong> subscribedCommittees =
-        subnetIdToCommittees.computeIfAbsent(subnetId, __ -> new HashSet<>());
-    subscribedCommittees.add(committeeIndex);
+  public synchronized void subscribeToSubnetId(final int subnetId) {
     subnetIdToTopicChannel.computeIfAbsent(subnetId, this::createChannelForSubnetId);
   }
 
-  public synchronized void unsubscribeFromCommitteeTopic(final UnsignedLong committeeIndex) {
-    final UnsignedLong subnetId = committeeIndexToSubnetId(committeeIndex);
-    final Set<UnsignedLong> committees =
-        subnetIdToCommittees.getOrDefault(subnetId, Collections.emptySet());
-    committees.remove(committeeIndex);
-    if (!committees.isEmpty()) {
-      // We still have some subscribers, don't actually unsubscribe
-      return;
-    }
-    subnetIdToCommittees.remove(subnetId);
+  public synchronized void unsubscribeFromSubnetId(final int subnetId) {
     final TopicChannel topicChannel = subnetIdToTopicChannel.remove(subnetId);
     if (topicChannel != null) {
       topicChannel.close();
     }
   }
 
-  private TopicChannel createChannelForSubnetId(final UnsignedLong subnetId) {
+  private TopicChannel createChannelForSubnetId(final int subnetId) {
     final AttestationTopicHandler topicHandler =
         new AttestationTopicHandler(
             eventBus,
@@ -92,7 +71,6 @@ public class AttestationSubnetSubscriptions implements AutoCloseable {
   public synchronized void close() {
     // Close gossip channels
     subnetIdToTopicChannel.values().forEach(TopicChannel::close);
-    subnetIdToCommittees.clear();
     subnetIdToTopicChannel.clear();
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationTopicSubscriber.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationTopicSubscriber.java
@@ -36,12 +36,12 @@ public class AttestationTopicSubscriber implements SlotEventsChannel {
   public synchronized void subscribeToCommittee(
       final int committeeIndex, final UnsignedLong aggregationSlot) {
     final int subnetId = committeeIndexToSubnetId(committeeIndex);
-    final UnsignedLong currentUnsubscribeSlot =
+    final UnsignedLong currentUnsubscriptionSlot =
         unsubscriptionSlotBySubnetId.getOrDefault(subnetId, ZERO);
-    if (currentUnsubscribeSlot.equals(ZERO)) {
+    if (currentUnsubscriptionSlot.equals(ZERO)) {
       eth2Network.subscribeToAttestationSubnetId(subnetId);
     }
-    unsubscriptionSlotBySubnetId.put(committeeIndex, max(currentUnsubscribeSlot, aggregationSlot));
+    unsubscriptionSlotBySubnetId.put(subnetId, max(currentUnsubscriptionSlot, aggregationSlot));
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/topics/AttestationTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/topics/AttestationTopicHandler.java
@@ -13,10 +13,7 @@
 
 package tech.pegasys.artemis.networking.eth2.gossip.topics;
 
-import static java.lang.StrictMath.toIntExact;
-
 import com.google.common.eventbus.EventBus;
-import com.google.common.primitives.UnsignedLong;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.ssz.SSZException;
 import tech.pegasys.artemis.datastructures.operations.Attestation;
@@ -27,13 +24,13 @@ import tech.pegasys.artemis.networking.eth2.gossip.topics.validation.ValidationR
 
 public class AttestationTopicHandler extends Eth2TopicHandler<Attestation> {
 
-  private final UnsignedLong subnetId;
+  private final int subnetId;
   private final AttestationValidator attestationValidator;
 
   public AttestationTopicHandler(
       final EventBus eventBus,
       final AttestationValidator attestationValidator,
-      final UnsignedLong subnetId,
+      final int subnetId,
       final ForkInfo forkInfo) {
     super(eventBus, forkInfo);
     this.attestationValidator = attestationValidator;
@@ -42,7 +39,7 @@ public class AttestationTopicHandler extends Eth2TopicHandler<Attestation> {
 
   @Override
   public String getTopicName() {
-    return "committee_index" + toIntExact(subnetId.longValue()) + "_beacon_attestation";
+    return "committee_index" + subnetId + "_beacon_attestation";
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/topics/validation/AttestationValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/gossip/topics/validation/AttestationValidator.java
@@ -54,8 +54,7 @@ public class AttestationValidator {
     this.recentChainData = recentChainData;
   }
 
-  public ValidationResult validate(
-      final Attestation attestation, final UnsignedLong receivedOnSubnetId) {
+  public ValidationResult validate(final Attestation attestation, final int receivedOnSubnetId) {
     ValidationResult validationResult = singleAttestationChecks(attestation, receivedOnSubnetId);
     if (validationResult != VALID) {
       return validationResult;
@@ -79,9 +78,9 @@ public class AttestationValidator {
   }
 
   private ValidationResult singleAttestationChecks(
-      final Attestation attestation, final UnsignedLong receivedOnSubnetId) {
+      final Attestation attestation, final int receivedOnSubnetId) {
     // The attestation's committee index (attestation.data.index) is for the correct subnet.
-    if (!CommitteeUtil.getSubnetId(attestation).equals(receivedOnSubnetId)) {
+    if (CommitteeUtil.getSubnetId(attestation) != receivedOnSubnetId) {
       return INVALID;
     }
 

--- a/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/mock/NoOpEth2Network.java
+++ b/networking/eth2/src/main/java/tech/pegasys/artemis/networking/eth2/mock/NoOpEth2Network.java
@@ -20,10 +20,10 @@ import tech.pegasys.artemis.networking.p2p.mock.MockP2PNetwork;
 public class NoOpEth2Network extends MockP2PNetwork<Eth2Peer> implements Eth2Network {
 
   @Override
-  public void subscribeToAttestationCommitteeTopic(final int committeeIndex) {}
+  public void subscribeToAttestationSubnetId(final int subnetId) {}
 
   @Override
-  public void unsubscribeFromAttestationCommitteeTopic(final int committeeIndex) {}
+  public void unsubscribeFromAttestationSubnetId(final int subnetId) {}
 
   @Override
   public void setLongTermAttestationSubnetSubscriptions(final Iterable<Integer> subnetIndices) {}

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationGossipManagerTest.java
@@ -46,14 +46,13 @@ public class AttestationGossipManagerTest {
   private final RecentChainData recentChainData = MemoryOnlyRecentChainData.create(eventBus);
   private final GossipNetwork gossipNetwork = mock(GossipNetwork.class);
   private final TopicChannel topicChannel = mock(TopicChannel.class);
-  private AttestationSubnetSubscriptions attestationSubnetSubscriptions;
   private AttestationGossipManager attestationGossipManager;
 
   @BeforeEach
   public void setup() {
     BeaconChainUtil.create(0, recentChainData).initializeStorage();
     doReturn(topicChannel).when(gossipNetwork).subscribe(contains("committee_index"), any());
-    attestationSubnetSubscriptions =
+    AttestationSubnetSubscriptions attestationSubnetSubscriptions =
         new AttestationSubnetSubscriptions(
             gossipNetwork, recentChainData, attestationValidator, eventBus);
     attestationGossipManager =
@@ -64,7 +63,7 @@ public class AttestationGossipManagerTest {
   public void onNewAttestation_afterMatchingAssignment() {
     // Setup committee assignment
     final int committeeIndex = 2;
-    attestationGossipManager.subscribeToCommitteeTopic(committeeIndex);
+    attestationGossipManager.subscribeToSubnetId(committeeIndex);
 
     // Post new attestation
     final Attestation attestation = dataStructureUtil.randomAttestation();
@@ -87,7 +86,7 @@ public class AttestationGossipManagerTest {
   public void onNewAttestation_noMatchingAssignment() {
     // Setup committee assignment
     final int committeeIndex = 2;
-    attestationGossipManager.subscribeToCommitteeTopic(committeeIndex);
+    attestationGossipManager.subscribeToSubnetId(committeeIndex);
 
     // Post new attestation
     final Attestation attestation = dataStructureUtil.randomAttestation();
@@ -102,10 +101,10 @@ public class AttestationGossipManagerTest {
     // Setup committee assignment
     final int committeeIndex = 2;
     final int dismissedIndex = 3;
-    attestationGossipManager.subscribeToCommitteeTopic(committeeIndex);
+    attestationGossipManager.subscribeToSubnetId(committeeIndex);
 
     // Unassign
-    attestationGossipManager.unsubscribeFromCommitteeTopic(dismissedIndex);
+    attestationGossipManager.unsubscribeFromSubnetId(dismissedIndex);
 
     // Attestation for dismissed assignment should be ignored
     final Attestation attestation = dataStructureUtil.randomAttestation();

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationSubnetSubscriptionsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationSubnetSubscriptionsTest.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.artemis.networking.eth2.gossip;
 
-import static com.google.common.primitives.UnsignedLong.valueOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -22,10 +21,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.artemis.util.config.Constants.ATTESTATION_SUBNET_COUNT;
 
 import com.google.common.eventbus.EventBus;
-import com.google.common.primitives.UnsignedLong;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,21 +52,17 @@ public class AttestationSubnetSubscriptionsTest {
 
   @Test
   void getChannelReturnsEmptyIfNotSubscribedToSubnet() {
-    UnsignedLong COMMITTEE_INDEX = UnsignedLong.ONE;
-    subnetSubscriptions.subscribeToCommitteeTopic(COMMITTEE_INDEX);
+    int COMMITTEE_INDEX = 1;
+    subnetSubscriptions.subscribeToSubnetId(COMMITTEE_INDEX);
     assertThat(subnetSubscriptions.getChannel(COMMITTEE_INDEX)).isNotEqualTo(Optional.empty());
-    assertThat(subnetSubscriptions.getChannel(COMMITTEE_INDEX.plus(UnsignedLong.ONE)))
-        .isEqualTo(Optional.empty());
+    assertThat(subnetSubscriptions.getChannel(COMMITTEE_INDEX + 1)).isEqualTo(Optional.empty());
   }
 
   @Test
-  void getChannelReturnsTheChannelFromSameSubnetEvenIfNotSubscribedToSpecificCommittee() {
-    UnsignedLong COMMITTEE_INDEX = UnsignedLong.ONE;
-    subnetSubscriptions.subscribeToCommitteeTopic(COMMITTEE_INDEX);
+  void getChannelReturnsTheChannelFromSubnet() {
+    int COMMITTEE_INDEX = 1;
+    subnetSubscriptions.subscribeToSubnetId(COMMITTEE_INDEX);
     assertThat(subnetSubscriptions.getChannel(COMMITTEE_INDEX)).isNotEqualTo(Optional.empty());
-    assertThat(
-            subnetSubscriptions.getChannel(COMMITTEE_INDEX.plus(valueOf(ATTESTATION_SUBNET_COUNT))))
-        .isNotEqualTo(Optional.empty());
   }
 
   @Test
@@ -79,11 +72,11 @@ public class AttestationSubnetSubscriptionsTest {
     when(gossipNetwork.subscribe(contains("committee_index1"), any())).thenReturn(topicChannel1);
     when(gossipNetwork.subscribe(contains("committee_index2"), any())).thenReturn(topicChannel2);
 
-    UnsignedLong COMMITTEE_INDEX_1 = UnsignedLong.ONE;
-    UnsignedLong COMMITTEE_INDEX_2 = UnsignedLong.valueOf(2);
+    int COMMITTEE_INDEX_1 = 1;
+    int COMMITTEE_INDEX_2 = 2;
 
-    subnetSubscriptions.subscribeToCommitteeTopic(COMMITTEE_INDEX_1);
-    subnetSubscriptions.subscribeToCommitteeTopic(COMMITTEE_INDEX_2);
+    subnetSubscriptions.subscribeToSubnetId(COMMITTEE_INDEX_1);
+    subnetSubscriptions.subscribeToSubnetId(COMMITTEE_INDEX_2);
 
     verifyNoInteractions(topicChannel2);
 
@@ -97,63 +90,21 @@ public class AttestationSubnetSubscriptionsTest {
   }
 
   @Test
-  void shouldSubscribeToCommitteesOnSameSubnet() {
-    TopicChannel topicChannel = mock(TopicChannel.class);
-    when(gossipNetwork.subscribe(contains("committee_index1"), any())).thenReturn(topicChannel);
-
-    UnsignedLong COMMITTEE_INDEX_1 = UnsignedLong.ONE;
-    UnsignedLong COMMITTEE_INDEX_65 = UnsignedLong.valueOf(65);
-
-    subnetSubscriptions.subscribeToCommitteeTopic(COMMITTEE_INDEX_1);
-    subnetSubscriptions.subscribeToCommitteeTopic(COMMITTEE_INDEX_65);
-
-    verify(gossipNetwork).subscribe(any(), any());
-
-    assertThat(subnetSubscriptions.getChannel(COMMITTEE_INDEX_1))
-        .isEqualTo(Optional.of(topicChannel));
-    assertThat(subnetSubscriptions.getChannel(COMMITTEE_INDEX_65))
-        .isEqualTo(Optional.of(topicChannel));
-  }
-
-  @Test
   void shouldUnsubscribeFromOnlyCommitteeOnSubnet() {
     TopicChannel topicChannel = mock(TopicChannel.class);
     when(gossipNetwork.subscribe(contains("committee_index1"), any())).thenReturn(topicChannel);
 
-    UnsignedLong COMMITTEE_INDEX_1 = UnsignedLong.ONE;
+    int COMMITTEE_INDEX_1 = 1;
 
-    subnetSubscriptions.subscribeToCommitteeTopic(COMMITTEE_INDEX_1);
+    subnetSubscriptions.subscribeToSubnetId(COMMITTEE_INDEX_1);
 
     verify(gossipNetwork).subscribe(any(), any());
 
     assertThat(subnetSubscriptions.getChannel(COMMITTEE_INDEX_1))
         .isEqualTo(Optional.of(topicChannel));
 
-    subnetSubscriptions.unsubscribeFromCommitteeTopic(COMMITTEE_INDEX_1);
+    subnetSubscriptions.unsubscribeFromSubnetId(COMMITTEE_INDEX_1);
 
     verify(topicChannel).close();
-  }
-
-  @Test
-  void shouldNotUnsubscribeFromSubnetWhenOtherCommitteesStillRequireIt() {
-    TopicChannel topicChannel = mock(TopicChannel.class);
-    when(gossipNetwork.subscribe(contains("committee_index1"), any())).thenReturn(topicChannel);
-
-    UnsignedLong COMMITTEE_INDEX_1 = UnsignedLong.ONE;
-    UnsignedLong COMMITTEE_INDEX_65 = UnsignedLong.valueOf(65);
-
-    subnetSubscriptions.subscribeToCommitteeTopic(COMMITTEE_INDEX_1);
-    subnetSubscriptions.subscribeToCommitteeTopic(COMMITTEE_INDEX_65);
-
-    verify(gossipNetwork).subscribe(any(), any());
-
-    assertThat(subnetSubscriptions.getChannel(COMMITTEE_INDEX_1))
-        .isEqualTo(Optional.of(topicChannel));
-    assertThat(subnetSubscriptions.getChannel(COMMITTEE_INDEX_65))
-        .isEqualTo(Optional.of(topicChannel));
-
-    subnetSubscriptions.unsubscribeFromCommitteeTopic(COMMITTEE_INDEX_1);
-
-    verifyNoInteractions(topicChannel);
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationTopicSubscriberTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationTopicSubscriberTest.java
@@ -34,7 +34,7 @@ class AttestationTopicSubscriberTest {
     final int committeeIndex = 10;
     subscriptions.subscribeToCommittee(committeeIndex, ONE);
 
-    verify(eth2Network).subscribeToAttestationCommitteeTopic(committeeIndex);
+    verify(eth2Network).subscribeToAttestationSubnetId(committeeIndex);
   }
 
   @Test
@@ -45,7 +45,7 @@ class AttestationTopicSubscriberTest {
 
     subscriptions.onSlot(aggregationSlot.plus(ONE));
 
-    verify(eth2Network).unsubscribeFromAttestationCommitteeTopic(committeeIndex);
+    verify(eth2Network).unsubscribeFromAttestationSubnetId(committeeIndex);
   }
 
   @Test
@@ -56,7 +56,7 @@ class AttestationTopicSubscriberTest {
 
     subscriptions.onSlot(aggregationSlot);
 
-    verify(eth2Network, never()).unsubscribeFromAttestationCommitteeTopic(committeeIndex);
+    verify(eth2Network, never()).unsubscribeFromAttestationSubnetId(committeeIndex);
   }
 
   @Test
@@ -69,10 +69,10 @@ class AttestationTopicSubscriberTest {
     subscriptions.subscribeToCommittee(committeeIndex, secondSlot);
 
     subscriptions.onSlot(firstSlot.plus(ONE));
-    verify(eth2Network, never()).unsubscribeFromAttestationCommitteeTopic(committeeIndex);
+    verify(eth2Network, never()).unsubscribeFromAttestationSubnetId(committeeIndex);
 
     subscriptions.onSlot(secondSlot.plus(ONE));
-    verify(eth2Network).unsubscribeFromAttestationCommitteeTopic(committeeIndex);
+    verify(eth2Network).unsubscribeFromAttestationSubnetId(committeeIndex);
   }
 
   @Test
@@ -85,9 +85,9 @@ class AttestationTopicSubscriberTest {
     subscriptions.subscribeToCommittee(committeeIndex, firstSlot);
 
     subscriptions.onSlot(firstSlot.plus(ONE));
-    verify(eth2Network, never()).unsubscribeFromAttestationCommitteeTopic(committeeIndex);
+    verify(eth2Network, never()).unsubscribeFromAttestationSubnetId(committeeIndex);
 
     subscriptions.onSlot(secondSlot.plus(ONE));
-    verify(eth2Network).unsubscribeFromAttestationCommitteeTopic(committeeIndex);
+    verify(eth2Network).unsubscribeFromAttestationSubnetId(committeeIndex);
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationTopicSubscriberTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/AttestationTopicSubscriberTest.java
@@ -30,64 +30,64 @@ class AttestationTopicSubscriberTest {
       new AttestationTopicSubscriber(eth2Network);
 
   @Test
-  public void shouldSubscribeToCommittee() {
-    final int committeeIndex = 10;
-    subscriptions.subscribeToCommittee(committeeIndex, ONE);
+  public void shouldSubscribeToSubnet() {
+    final int subnetId = 10;
+    subscriptions.subscribeToCommittee(subnetId, ONE);
 
-    verify(eth2Network).subscribeToAttestationSubnetId(committeeIndex);
+    verify(eth2Network).subscribeToAttestationSubnetId(subnetId);
   }
 
   @Test
-  public void shouldUnsubscribeFromCommitteeWhenPastSlot() {
-    final int committeeIndex = 12;
+  public void shouldUnsubscribeFromSubnetWhenPastSlot() {
+    final int subnetId = 12;
     final UnsignedLong aggregationSlot = UnsignedLong.valueOf(10);
-    subscriptions.subscribeToCommittee(committeeIndex, aggregationSlot);
+    subscriptions.subscribeToCommittee(subnetId, aggregationSlot);
 
     subscriptions.onSlot(aggregationSlot.plus(ONE));
 
-    verify(eth2Network).unsubscribeFromAttestationSubnetId(committeeIndex);
+    verify(eth2Network).unsubscribeFromAttestationSubnetId(subnetId);
   }
 
   @Test
   public void shouldNotUnsubscribeAtStartOfTargetSlot() {
-    final int committeeIndex = 16;
+    final int subnetId = 16;
     final UnsignedLong aggregationSlot = UnsignedLong.valueOf(10);
-    subscriptions.subscribeToCommittee(committeeIndex, aggregationSlot);
+    subscriptions.subscribeToCommittee(subnetId, aggregationSlot);
 
     subscriptions.onSlot(aggregationSlot);
 
-    verify(eth2Network, never()).unsubscribeFromAttestationSubnetId(committeeIndex);
+    verify(eth2Network, never()).unsubscribeFromAttestationSubnetId(subnetId);
   }
 
   @Test
   public void shouldExtendSubscriptionPeriod() {
-    final int committeeIndex = 3;
+    final int subnetId = 3;
     final UnsignedLong firstSlot = UnsignedLong.valueOf(10);
     final UnsignedLong secondSlot = UnsignedLong.valueOf(15);
 
-    subscriptions.subscribeToCommittee(committeeIndex, firstSlot);
-    subscriptions.subscribeToCommittee(committeeIndex, secondSlot);
+    subscriptions.subscribeToCommittee(subnetId, firstSlot);
+    subscriptions.subscribeToCommittee(subnetId, secondSlot);
 
     subscriptions.onSlot(firstSlot.plus(ONE));
-    verify(eth2Network, never()).unsubscribeFromAttestationSubnetId(committeeIndex);
+    verify(eth2Network, never()).unsubscribeFromAttestationSubnetId(subnetId);
 
     subscriptions.onSlot(secondSlot.plus(ONE));
-    verify(eth2Network).unsubscribeFromAttestationSubnetId(committeeIndex);
+    verify(eth2Network).unsubscribeFromAttestationSubnetId(subnetId);
   }
 
   @Test
   public void shouldPreserveLaterSubscriptionPeriodWhenEarlierSlotAdded() {
-    final int committeeIndex = 3;
+    final int subnetId = 3;
     final UnsignedLong firstSlot = UnsignedLong.valueOf(10);
     final UnsignedLong secondSlot = UnsignedLong.valueOf(15);
 
-    subscriptions.subscribeToCommittee(committeeIndex, secondSlot);
-    subscriptions.subscribeToCommittee(committeeIndex, firstSlot);
+    subscriptions.subscribeToCommittee(subnetId, secondSlot);
+    subscriptions.subscribeToCommittee(subnetId, firstSlot);
 
     subscriptions.onSlot(firstSlot.plus(ONE));
-    verify(eth2Network, never()).unsubscribeFromAttestationSubnetId(committeeIndex);
+    verify(eth2Network, never()).unsubscribeFromAttestationSubnetId(subnetId);
 
     subscriptions.onSlot(secondSlot.plus(ONE));
-    verify(eth2Network).unsubscribeFromAttestationSubnetId(committeeIndex);
+    verify(eth2Network).unsubscribeFromAttestationSubnetId(subnetId);
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/AttestationTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/AttestationTopicHandlerTest.java
@@ -23,7 +23,6 @@ import static tech.pegasys.artemis.networking.eth2.gossip.topics.validation.Vali
 import static tech.pegasys.artemis.networking.eth2.gossip.topics.validation.ValidationResult.VALID;
 
 import com.google.common.eventbus.EventBus;
-import com.google.common.primitives.UnsignedLong;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +41,7 @@ import tech.pegasys.artemis.storage.client.RecentChainData;
 
 public class AttestationTopicHandlerTest {
 
-  private static final UnsignedLong SUBNET_ID = UnsignedLong.valueOf(1);
+  private static final int SUBNET_ID = 1;
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(12);
   private final EventBus eventBus = mock(EventBus.class);

--- a/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/validation/AttestationValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/artemis/networking/eth2/gossip/topics/validation/AttestationValidatorTest.java
@@ -265,8 +265,8 @@ class AttestationValidatorTest {
   public void shouldRejectAttestationsSentOnTheWrongSubnet() {
     final Attestation attestation =
         attestationGenerator.validAttestation(recentChainData.getBestBlockAndState().orElseThrow());
-    final UnsignedLong expectedSubnetId = CommitteeUtil.getSubnetId(attestation);
-    assertThat(validator.validate(attestation, expectedSubnetId.plus(ONE))).isEqualTo(INVALID);
+    final int expectedSubnetId = CommitteeUtil.getSubnetId(attestation);
+    assertThat(validator.validate(attestation, expectedSubnetId + 1)).isEqualTo(INVALID);
     assertThat(validator.validate(attestation, expectedSubnetId)).isEqualTo(VALID);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
This PR abstracts out the committee indices from networking layer, only using subnet ids for subscription/unsubscription. This makes things way easier to deal with, and deduplicates a good amount of code. 

Builds on: https://github.com/PegaSysEng/teku/pull/1709
