### PR TITLE
Fix Store/ProtoArray synchronicity issue

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/forkchoice/ForkChoice.java
@@ -48,7 +48,7 @@ public class ForkChoice implements FinalizedCheckpointChannel {
     processHead();
   }
 
-  public Bytes32 processHead() {
+  public synchronized Bytes32 processHead() {
     Store.Transaction transaction = recentChainData.startStoreTransaction();
     Bytes32 headBlockRoot = protoArrayForkChoiceStrategy.findHead(transaction);
     transaction.commit(() -> {}, "Failed to persist validator vote changes.");
@@ -57,7 +57,7 @@ public class ForkChoice implements FinalizedCheckpointChannel {
     return headBlockRoot;
   }
 
-  public BlockImportResult onBlock(final SignedBeaconBlock block) {
+  public synchronized BlockImportResult onBlock(final SignedBeaconBlock block) {
     Store.Transaction transaction = recentChainData.startStoreTransaction();
     final BlockImportResult result = on_block(transaction, block, stateTransition);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/artemis/blob/master/CONTRIBUTING.md -->

## PR Description
Due to `processHead()` and `onBlock()` methods of `ForkChoice` previously being concurrent, the `Store` object would get updated with the latest block in`onBlock()` and `processHead()` would run before `protoArrayForkChoiceStrategy.onBlock()` finished execution. As a result, during the `processHead()` run, `Store` would have access to the latest block, whereas `ProtoArrayForkChoiceStrategy` would not, leading to synchronicity issues.

## Fixed Issue(s)
Fixes #1712 
