### PR TITLE
Handle requests from peers which have disconnected prior to processing

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -162,8 +162,8 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
    * @return the peer corresponding to this node id.
    */
   @Override
-  public Eth2Peer getConnectedPeer(NodeId nodeId) {
-    return connectedPeerMap.get(nodeId);
+  public Optional<Eth2Peer> getConnectedPeer(NodeId nodeId) {
+    return Optional.ofNullable(connectedPeerMap.get(nodeId));
   }
 
   public Optional<Eth2Peer> getPeer(NodeId peerId) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerLookup.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerLookup.java
@@ -13,8 +13,9 @@
 
 package tech.pegasys.teku.networking.eth2.peers;
 
+import java.util.Optional;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 
 public interface PeerLookup {
-  Eth2Peer getConnectedPeer(NodeId nodeId);
+  Optional<Eth2Peer> getConnectedPeer(NodeId nodeId);
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -29,14 +29,14 @@ import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.eth2.rpc.core.LocalMessageHandler;
+import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.util.async.SafeFuture;
 
 public class BeaconBlocksByRangeMessageHandler
-    implements LocalMessageHandler<BeaconBlocksByRangeRequestMessage, SignedBeaconBlock> {
+    extends PeerRequiredLocalMessageHandler<BeaconBlocksByRangeRequestMessage, SignedBeaconBlock> {
   private static final org.apache.logging.log4j.Logger LOG = LogManager.getLogger();
 
   @VisibleForTesting

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -61,7 +61,7 @@ public class BeaconBlocksByRangeMessageHandler
         message.getCount(),
         message.getStep());
     if (message.getStep().compareTo(ONE) < 0) {
-      callback.completeWithError(INVALID_STEP);
+      callback.completeWithErrorResponse(INVALID_STEP);
       return;
     }
     sendMatchingBlocks(message, callback)
@@ -71,10 +71,10 @@ public class BeaconBlocksByRangeMessageHandler
               final Throwable rootCause = Throwables.getRootCause(error);
               if (rootCause instanceof RpcException) {
                 LOG.trace("Rejecting beacon blocks by range request", error); // Keep full context
-                callback.completeWithError((RpcException) rootCause);
+                callback.completeWithErrorResponse((RpcException) rootCause);
               } else {
                 LOG.error("Failed to process blocks by range request", error);
-                callback.completeWithError(RpcException.SERVER_ERROR);
+                callback.completeWithUnexpectedError(error);
               }
             });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
@@ -17,12 +17,12 @@ import org.apache.logging.log4j.LogManager;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.eth2.rpc.core.LocalMessageHandler;
+import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class BeaconBlocksByRootMessageHandler
-    implements LocalMessageHandler<BeaconBlocksByRootRequestMessage, SignedBeaconBlock> {
+    extends PeerRequiredLocalMessageHandler<BeaconBlocksByRootRequestMessage, SignedBeaconBlock> {
   private static final org.apache.logging.log4j.Logger LOG = LogManager.getLogger();
 
   private final RecentChainData storageClient;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/GoodbyeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/GoodbyeMessageHandler.java
@@ -14,8 +14,7 @@
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import com.google.common.primitives.UnsignedLong;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import java.util.Optional;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
@@ -27,7 +26,6 @@ import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 
 public class GoodbyeMessageHandler implements LocalMessageHandler<GoodbyeMessage, GoodbyeMessage> {
 
-  private static final Logger LOG = LogManager.getLogger();
   private final LabelledMetric<Counter> goodbyeCounter;
 
   public GoodbyeMessageHandler(final MetricsSystem metricsSystem) {
@@ -41,12 +39,11 @@ public class GoodbyeMessageHandler implements LocalMessageHandler<GoodbyeMessage
 
   @Override
   public void onIncomingMessage(
-      final Eth2Peer peer,
+      final Optional<Eth2Peer> peer,
       final GoodbyeMessage message,
       final ResponseCallback<GoodbyeMessage> callback) {
-    LOG.trace("Peer {} said goodbye.", peer.getId());
     goodbyeCounter.labels(labelForReason(message.getReason())).inc();
-    peer.disconnectImmediately();
+    peer.ifPresent(Eth2Peer::disconnectImmediately);
     callback.completeSuccessfully();
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageHandler.java
@@ -18,10 +18,11 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
-import tech.pegasys.teku.networking.eth2.rpc.core.LocalMessageHandler;
+import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 
-public class StatusMessageHandler implements LocalMessageHandler<StatusMessage, StatusMessage> {
+public class StatusMessageHandler
+    extends PeerRequiredLocalMessageHandler<StatusMessage, StatusMessage> {
   private static final Logger LOG = LogManager.getLogger();
   private final StatusMessageFactory statusMessageFactory;
 
@@ -34,7 +35,7 @@ public class StatusMessageHandler implements LocalMessageHandler<StatusMessage, 
       final Eth2Peer peer,
       final StatusMessage message,
       final ResponseCallback<StatusMessage> callback) {
-    LOG.trace("Peer {} sent status.", peer.getId());
+    LOG.trace("Peer {} sent status {}", peer.getId(), message);
     final PeerStatus status = PeerStatus.fromStatusMessage(message);
     peer.updateStatus(status);
     callback.respond(statusMessageFactory.createStatusMessage());

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
@@ -70,7 +70,7 @@ public class Eth2IncomingRequestHandler<TRequest extends RpcRequest, TResponse>
       handleRequest(peer, request, callback);
     } catch (final RpcException e) {
       requestHandled.set(true);
-      callback.completeWithError(e);
+      callback.completeWithErrorResponse(e);
     }
   }
 
@@ -81,7 +81,7 @@ public class Eth2IncomingRequestHandler<TRequest extends RpcRequest, TResponse>
       localMessageHandler.onIncomingMessage(peer, request, callback);
     } catch (final Throwable t) {
       LOG.error("Unhandled error while processing request " + method.getMultistreamId(), t);
-      callback.completeWithError(RpcException.SERVER_ERROR);
+      callback.completeWithUnexpectedError(t);
     }
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2.rpc.core;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.InputStream;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
@@ -65,7 +66,7 @@ public class Eth2IncomingRequestHandler<TRequest extends RpcRequest, TResponse>
     final ResponseCallback<TResponse> callback = new RpcResponseCallback<>(rpcStream, rpcEncoder);
     try {
       final TRequest request = requestDecoder.decodeRequest(input);
-      final Eth2Peer peer = peerLookup.getConnectedPeer(nodeId);
+      Optional<Eth2Peer> peer = peerLookup.getConnectedPeer(nodeId);
       handleRequest(peer, request, callback);
     } catch (final RpcException e) {
       requestHandled.set(true);
@@ -74,7 +75,7 @@ public class Eth2IncomingRequestHandler<TRequest extends RpcRequest, TResponse>
   }
 
   private void handleRequest(
-      Eth2Peer peer, TRequest request, ResponseCallback<TResponse> callback) {
+      Optional<Eth2Peer> peer, TRequest request, ResponseCallback<TResponse> callback) {
     try {
       requestHandled.set(true);
       localMessageHandler.onIncomingMessage(peer, request, callback);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/LocalMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/LocalMessageHandler.java
@@ -13,8 +13,9 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.core;
 
+import java.util.Optional;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 
 public interface LocalMessageHandler<I, O> {
-  void onIncomingMessage(Eth2Peer peer, I message, ResponseCallback<O> callback);
+  void onIncomingMessage(Optional<Eth2Peer> peer, I message, ResponseCallback<O> callback);
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandler.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
 
 public abstract class PeerRequiredLocalMessageHandler<I, O> implements LocalMessageHandler<I, O> {
   private static final Logger LOG = LogManager.getLogger();
@@ -29,8 +30,7 @@ public abstract class PeerRequiredLocalMessageHandler<I, O> implements LocalMess
         () -> {
           LOG.trace(
               "Ignoring message of type {} because peer has disconnected", message.getClass());
-          callback.completeWithError(
-              new RpcException(RpcResponseStatus.SERVER_ERROR_CODE, "Peer disconnected"));
+          callback.completeWithUnexpectedError(new PeerDisconnectedException());
         });
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.rpc.core;
+
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+
+public abstract class PeerRequiredLocalMessageHandler<I, O> implements LocalMessageHandler<I, O> {
+  private static final Logger LOG = LogManager.getLogger();
+
+  @Override
+  public void onIncomingMessage(
+      final Optional<Eth2Peer> maybePeer, final I message, final ResponseCallback<O> callback) {
+    maybePeer.ifPresentOrElse(
+        peer -> onIncomingMessage(peer, message, callback),
+        () -> {
+          LOG.trace("Ignoring message of type {} from disconnected peer", message.getClass());
+          callback.completeWithError(
+              new RpcException(RpcResponseStatus.SERVER_ERROR_CODE, "Peer disconnected"));
+        });
+  }
+
+  protected abstract void onIncomingMessage(
+      final Eth2Peer peer, final I message, final ResponseCallback<O> callback);
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandler.java
@@ -27,7 +27,8 @@ public abstract class PeerRequiredLocalMessageHandler<I, O> implements LocalMess
     maybePeer.ifPresentOrElse(
         peer -> onIncomingMessage(peer, message, callback),
         () -> {
-          LOG.trace("Ignoring message of type {} from disconnected peer", message.getClass());
+          LOG.trace(
+              "Ignoring message of type {} because peer has disconnected", message.getClass());
           callback.completeWithError(
               new RpcException(RpcResponseStatus.SERVER_ERROR_CODE, "Peer disconnected"));
         });

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/ResponseCallback.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/ResponseCallback.java
@@ -18,5 +18,7 @@ public interface ResponseCallback<T> {
 
   void completeSuccessfully();
 
-  void completeWithError(RpcException error);
+  void completeWithErrorResponse(RpcException error);
+
+  void completeWithUnexpectedError(Throwable error);
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerTest.java
@@ -157,7 +157,7 @@ public class Eth2PeerManagerTest {
 
   private void setInitialPeerStatus(final Eth2Peer peer) {
     final PeerStatus status = statusFactory.random();
-    peerManager.getConnectedPeer(peer.getId()).updateStatus(status);
+    peerManager.getConnectedPeer(peer.getId()).orElseThrow().updateStatus(status);
   }
 
   private Eth2Peer createEth2Peer(final Peer peer) {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -264,7 +264,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
             UnsignedLong.valueOf(startBlock), count, UnsignedLong.valueOf(skip)),
         listener);
 
-    verify(listener).completeWithError(INVALID_STEP);
+    verify(listener).completeWithErrorResponse(INVALID_STEP);
     verifyNoMoreInteractions(listener);
     verifyNoMoreInteractions(combinedChainDataClient);
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/AbstractRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/AbstractRequestHandlerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -82,7 +83,7 @@ abstract class AbstractRequestHandlerTest<T extends RpcRequestHandler> {
     lenient().when(rpcStream.close()).thenReturn(SafeFuture.COMPLETE);
     lenient().when(rpcStream.closeWriteStream()).thenReturn(SafeFuture.COMPLETE);
     lenient().when(rpcStream.writeBytes(any())).thenReturn(SafeFuture.COMPLETE);
-    lenient().when(peerLookup.getConnectedPeer(nodeId)).thenReturn(peer);
+    lenient().when(peerLookup.getConnectedPeer(nodeId)).thenReturn(Optional.of(peer));
 
     // Setup thread to process input
     startProcessingInput();


### PR DESCRIPTION
## PR Description
Cleanly handle when peers send us a request and disconnect before we begin processing the request.  Previously this resulted in a `NullPointerException` because we couldn't find the peer the request came from.  Now most requests are simply ignored but `Goodbye` requests still increment the disconnect reason metric correctly.