### PR TITLE
Remove redundant block roots on restart

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V3RocksDbDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V3RocksDbDao.java
@@ -217,6 +217,12 @@ public class V3RocksDbDao implements RocksDbDao {
           "Only {} hot states produced for {} hot blocks.  Some hot blocks must be incompatible with the latest finalized block.",
           hotStates.size(),
           hotBlocksByRoot.size());
+
+      Transaction transaction = db.startTransaction();
+      hotBlocksByRoot.keySet().stream()
+          .filter(signedBeaconBlock -> !hotStates.containsKey(signedBeaconBlock))
+          .forEach(blockRoot -> transaction.delete(V3Schema.HOT_BLOCKS_BY_ROOT, blockRoot));
+      transaction.commit();
     }
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
@@ -680,6 +680,12 @@ public abstract class AbstractDatabaseTest {
     }
   }
 
+  protected void assertBlocksUnavailable(final Collection<Bytes32> roots) {
+    for (Bytes32 root : roots) {
+      assertThat(database.getSignedBlock(root)).isEmpty();
+    }
+  }
+
   protected void assertLatestUpdateResultContains(
       final Set<Bytes32> blockRoots, final Set<Checkpoint> checkpoints) {
     final StorageUpdateResult latestResult = getLatestUpdateResult();

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/V3RocksDbDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/V3RocksDbDatabaseTest.java
@@ -91,7 +91,11 @@ public class V3RocksDbDatabaseTest extends AbstractRocksDbDatabaseTest {
 
     // Fork states should be unavailable
     final List<Bytes32> unavailableBlockRoots =
-        forkChain.streamBlocksAndStates(7, 9).map(b -> b.getRoot()).collect(Collectors.toList());
+        forkChain
+            .streamBlocksAndStates(7, 9)
+            .map(SignedBlockAndState::getRoot)
+            .collect(Collectors.toList());
     assertStatesUnavailable(unavailableBlockRoots);
+    assertBlocksUnavailable(unavailableBlockRoots);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Remove blocks that don't have a corresponding state from the disk at the restart, and as a side effect, do not load these blocks into memory either.