### PR TITLE
Don't calculate duties for empty list of validators

### DIFF
--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -104,6 +104,9 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     if (isSyncActive()) {
       return NodeSyncingException.failedFuture();
     }
+    if (publicKeys.isEmpty()) {
+      return SafeFuture.completedFuture(Optional.of(emptyList()));
+    }
     final UnsignedLong slot =
         compute_start_slot_at_epoch(
             epoch.compareTo(UnsignedLong.ZERO) > 0 ? epoch.minus(UnsignedLong.ONE) : epoch);

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -108,6 +108,17 @@ class ValidatorApiHandlerTest {
   }
 
   @Test
+  public void getDuties_shouldReturnEmptyWhenNoPublicKeysSpecified() {
+    when(chainDataClient.getStateAtSlot(PREVIOUS_EPOCH_START_SLOT))
+        .thenReturn(completedFuture(Optional.of(createStateWithActiveValidators())));
+
+    final SafeFuture<Optional<List<ValidatorDuties>>> result =
+        validatorApiHandler.getDuties(EPOCH, emptyList());
+    final Optional<List<ValidatorDuties>> duties = assertCompletedSuccessfully(result);
+    assertThat(duties.get()).isEmpty();
+  }
+
+  @Test
   public void getDuties_shouldReturnDutiesForUnknownValidator() {
     when(chainDataClient.getStateAtSlot(PREVIOUS_EPOCH_START_SLOT))
         .thenReturn(completedFuture(Optional.of(createStateWithActiveValidators())));


### PR DESCRIPTION
## PR Description
When validator duties are requested for an empty list of public keys, immediately return an empty list of duties.