### PR TITLE
Use advertised ip and port in the initial ENR

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/teku/api/NetworkDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NetworkDataProvider.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.api;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
@@ -82,6 +81,6 @@ public class NetworkDataProvider {
   }
 
   public List<String> getListeningAddresses() {
-    return List.of(LibP2PNetwork.getAdvertisedAddrString(p2pNetwork.getConfig()));
+    return List.of(p2pNetwork.getNodeAddress());
   }
 }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/NetworkDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/NetworkDataProviderTest.java
@@ -18,18 +18,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.networking.p2p.network.NetworkConfig;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 
 public class NetworkDataProviderTest {
+
   @SuppressWarnings("unchecked")
-  private P2PNetwork<Peer> p2pNetwork = mock(P2PNetwork.class);
+  private final P2PNetwork<Peer> p2pNetwork = mock(P2PNetwork.class);
 
   @Test
   void getPeerCount_shouldReturnTotalPeers() {
@@ -52,50 +50,12 @@ public class NetworkDataProviderTest {
   }
 
   @Test
-  void getListeningAddresses_shouldReturnAdvertisedIp() {
+  void getListeningAddresses_shouldReturnAddressFromNetwork() {
     final NetworkDataProvider network = new NetworkDataProvider(p2pNetwork);
-    final String ipAddress = "1.1.1.1";
-    final int port = 7;
-    final NetworkConfig networkConfig = mock(NetworkConfig.class);
-    final List<String> expected = List.of(String.format("/ip4/%s/tcp/%d", ipAddress, port));
+    final String nodeAddress = "/some/libp2p/addr";
 
-    when(p2pNetwork.getConfig()).thenReturn(networkConfig);
-    when(networkConfig.getAdvertisedIp()).thenReturn(ipAddress);
-    when(networkConfig.getAdvertisedPort()).thenReturn(port);
+    when(p2pNetwork.getNodeAddress()).thenReturn(nodeAddress);
 
-    assertThat(network.getListeningAddresses()).isEqualTo(expected);
-  }
-
-  @Test
-  void getListeningAddresses_shouldReturnHostAddressIfNoAdvertisedIp() throws UnknownHostException {
-    final NetworkDataProvider network = new NetworkDataProvider(p2pNetwork);
-    final String hostAddress = InetAddress.getLocalHost().getHostAddress();
-    final String interfaceAddress = "1.1.1.1";
-    final int port = 7;
-    final NetworkConfig networkConfig = mock(NetworkConfig.class);
-    final List<String> expected = List.of(String.format("/ip4/%s/tcp/%d", hostAddress, port));
-
-    when(p2pNetwork.getConfig()).thenReturn(networkConfig);
-    when(networkConfig.getAdvertisedIp()).thenReturn(interfaceAddress);
-    when(networkConfig.getNetworkInterface()).thenReturn(interfaceAddress);
-    when(networkConfig.getAdvertisedPort()).thenReturn(port);
-
-    assertThat(network.getListeningAddresses()).isEqualTo(expected);
-  }
-
-  @Test
-  void getListeningAddresses_shouldReturnInterfaceAddressIfNoSpecifiedIp() {
-    final NetworkDataProvider network = new NetworkDataProvider(p2pNetwork);
-    final String interfaceAddress = "0.0.0.0";
-    final int port = 7;
-    final NetworkConfig networkConfig = mock(NetworkConfig.class);
-    final List<String> expected = List.of(String.format("/ip4/%s/tcp/%d", interfaceAddress, port));
-
-    when(p2pNetwork.getConfig()).thenReturn(networkConfig);
-    when(networkConfig.getAdvertisedIp()).thenReturn(interfaceAddress);
-    when(networkConfig.getNetworkInterface()).thenReturn(interfaceAddress);
-    when(networkConfig.getAdvertisedPort()).thenReturn(port);
-
-    assertThat(network.getListeningAddresses()).isEqualTo(expected);
+    assertThat(network.getListeningAddresses()).isEqualTo(List.of(nodeAddress));
   }
 }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/NetworkDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/NetworkDataProviderTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.networking.p2p.network.NetworkConfig;
@@ -61,7 +60,7 @@ public class NetworkDataProviderTest {
     final List<String> expected = List.of(String.format("/ip4/%s/tcp/%d", ipAddress, port));
 
     when(p2pNetwork.getConfig()).thenReturn(networkConfig);
-    when(networkConfig.getAdvertisedIp()).thenReturn(Optional.of(ipAddress));
+    when(networkConfig.getAdvertisedIp()).thenReturn(ipAddress);
     when(networkConfig.getAdvertisedPort()).thenReturn(port);
 
     assertThat(network.getListeningAddresses()).isEqualTo(expected);
@@ -77,7 +76,7 @@ public class NetworkDataProviderTest {
     final List<String> expected = List.of(String.format("/ip4/%s/tcp/%d", hostAddress, port));
 
     when(p2pNetwork.getConfig()).thenReturn(networkConfig);
-    when(networkConfig.getAdvertisedIp()).thenReturn(Optional.empty());
+    when(networkConfig.getAdvertisedIp()).thenReturn(interfaceAddress);
     when(networkConfig.getNetworkInterface()).thenReturn(interfaceAddress);
     when(networkConfig.getAdvertisedPort()).thenReturn(port);
 
@@ -93,7 +92,7 @@ public class NetworkDataProviderTest {
     final List<String> expected = List.of(String.format("/ip4/%s/tcp/%d", interfaceAddress, port));
 
     when(p2pNetwork.getConfig()).thenReturn(networkConfig);
-    when(networkConfig.getAdvertisedIp()).thenReturn(Optional.empty());
+    when(networkConfig.getAdvertisedIp()).thenReturn(interfaceAddress);
     when(networkConfig.getNetworkInterface()).thenReturn(interfaceAddress);
     when(networkConfig.getAdvertisedPort()).thenReturn(port);
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -109,7 +109,7 @@ dependencyManagement {
     dependency "org.testcontainers:testcontainers:1.12.3"
     dependency "org.testcontainers:junit-jupiter:1.12.3"
 
-    dependency 'tech.pegasys.discovery:discovery:0.3.5-SNAPSHOT'
+    dependency 'tech.pegasys.discovery:discovery:0.3.5'
 
     dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.0'
   }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -109,7 +109,7 @@ dependencyManagement {
     dependency "org.testcontainers:testcontainers:1.12.3"
     dependency "org.testcontainers:junit-jupiter:1.12.3"
 
-    dependency 'tech.pegasys.discovery:discovery:0.3.4'
+    dependency 'tech.pegasys.discovery:discovery:0.3.5-SNAPSHOT'
 
     dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.0'
   }

--- a/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
@@ -43,6 +43,10 @@ public class StatusLogger {
     log.info("Listening for connections on: {}", address);
   }
 
+  public void listeningForDiscv5(final String enr) {
+    log.info("Local ENR: {}", enr);
+  }
+
   public void blockCreationFailure(final Exception cause) {
     log.error("Error during block creation", cause);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
@@ -32,7 +32,6 @@ import tech.pegasys.teku.networking.eth2.peers.Eth2PeerManager;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.teku.networking.p2p.DiscoveryNetwork;
 import tech.pegasys.teku.networking.p2p.network.DelegatingP2PNetwork;
-import tech.pegasys.teku.networking.p2p.network.NetworkConfig;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -107,11 +106,6 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
     attestationGossipManager.shutdown();
     aggregateGossipManager.shutdown();
     super.stop();
-  }
-
-  @Override
-  public NetworkConfig getConfig() {
-    return discoveryNetwork.getConfig();
   }
 
   @Override

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
@@ -25,6 +25,8 @@ import java.net.BindException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -145,9 +147,9 @@ public class Eth2NetworkFactory {
       return new NetworkConfig(
           KeyKt.generateKeyPair(KEY_TYPE.SECP256K1).component1(),
           "127.0.0.1",
-          "127.0.0.1",
+          Optional.empty(),
           port,
-          port,
+          OptionalInt.empty(),
           peerAddresses,
           false,
           emptyList(),

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/DiscoveryNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/DiscoveryNetwork.java
@@ -121,11 +121,6 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
             });
   }
 
-  @Override
-  public NetworkConfig getConfig() {
-    return p2pNetwork.getConfig();
-  }
-
   public void addStaticPeer(final String peerAddress) {
     connectionManager.addStaticPeer(p2pNetwork.createPeerAddress(peerAddress));
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/DiscoveryNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/DiscoveryNetwork.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.datastructures.networking.libp2p.rpc.EnrForkId;
 import tech.pegasys.teku.datastructures.state.Fork;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.datastructures.util.SimpleOffsetSerializer;
+import tech.pegasys.teku.logging.StatusLogger;
 import tech.pegasys.teku.networking.p2p.connection.ConnectionManager;
 import tech.pegasys.teku.networking.p2p.connection.ReputationManager;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryService;
@@ -88,6 +89,8 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
               Bytes.wrap(p2pConfig.getPrivateKey().raw()),
               p2pConfig.getNetworkInterface(),
               p2pConfig.getListenPort(),
+              p2pConfig.getAdvertisedIp(),
+              p2pConfig.getAdvertisedPort(),
               p2pConfig.getBootnodes());
     } else {
       discoveryService = new NoOpDiscoveryService();
@@ -98,7 +101,8 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
   @Override
   public SafeFuture<?> start() {
     return SafeFuture.allOfFailFast(p2pNetwork.start(), discoveryService.start())
-        .thenCompose(__ -> connectionManager.start());
+        .thenCompose(__ -> connectionManager.start())
+        .thenRun(() -> getEnr().ifPresent(StatusLogger.STATUS_LOG::listeningForDiscv5));
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
@@ -37,15 +37,23 @@ public class DiscV5Service extends Service implements DiscoveryService {
   }
 
   public static DiscoveryService create(
-      final Bytes privateKey, final String address, final int port, final List<String> bootnodes) {
+      final Bytes privateKey,
+      final String listenAddress,
+      final int listenPort,
+      final String advertisedAddress,
+      final int advertisedPort,
+      final List<String> bootnodes) {
     final DiscoverySystem discoveryManager =
         new DiscoverySystemBuilder()
+            .listen(listenAddress, listenPort)
             .privateKey(privateKey)
             .bootnodes(bootnodes.toArray(new String[0]))
             .localNodeRecord(
-                new NodeRecordBuilder().privateKey(privateKey).address(address, port).build())
+                new NodeRecordBuilder()
+                    .privateKey(privateKey)
+                    .address(advertisedAddress, advertisedPort)
+                    .build())
             .build();
-
     return new DiscV5Service(discoveryManager);
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -206,10 +206,8 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
   private static Multiaddr getAdvertisedAddr(NetworkConfig config) {
     try {
       String ip;
-      if (config.getAdvertisedIp().isPresent()) {
-        ip = config.getAdvertisedIp().get();
-      } else if (NetworkUtility.isUnspecifiedAddress(config.getNetworkInterface())) {
-        ip = config.getNetworkInterface();
+      if (!NetworkUtility.isUnspecifiedAddress(config.getAdvertisedIp())) {
+        ip = config.getAdvertisedIp();
       } else {
         ip = InetAddress.getLocalHost().getHostAddress();
       }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -90,7 +90,7 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
   private final AtomicReference<State> state = new AtomicReference<>(State.IDLE);
   private final Map<RpcMethod, RpcHandler> rpcHandlers = new ConcurrentHashMap<>();
   private final AsyncRunner asyncRunner = DelayedExecutorAsyncRunner.create();
-  private int listenPort;
+  private final int listenPort;
 
   public LibP2PNetwork(
       final NetworkConfig config,
@@ -219,10 +219,6 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
     }
   }
 
-  public static String getAdvertisedAddrString(final NetworkConfig config) {
-    return getAdvertisedAddr(config).toString();
-  }
-
   @Override
   public String getNodeAddress() {
     return advertisedAddr + "/p2p/" + nodeId.toBase58();
@@ -282,7 +278,7 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
   @Override
   public int getListenPort() {
     return listenPort;
-  };
+  }
 
   @Override
   public void stop() {
@@ -291,11 +287,6 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
     }
     LOG.debug("JvmLibP2PNetwork.stop()");
     reportExceptions(host.stop());
-  }
-
-  @Override
-  public NetworkConfig getConfig() {
-    return this.config;
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/mock/MockP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/mock/MockP2PNetwork.java
@@ -18,7 +18,6 @@ import java.util.stream.Stream;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
 import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
 import tech.pegasys.teku.networking.p2p.gossip.TopicHandler;
-import tech.pegasys.teku.networking.p2p.network.NetworkConfig;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.networking.p2p.network.PeerAddress;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
@@ -98,11 +97,6 @@ public class MockP2PNetwork<P extends Peer> implements P2PNetwork<P> {
   /** Stops the P2P network layer. */
   @Override
   public void stop() {}
-
-  @Override
-  public NetworkConfig getConfig() {
-    throw new UnsupportedOperationException();
-  }
 
   @Override
   public SafeFuture<?> start() {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/NetworkConfig.java
@@ -18,6 +18,7 @@ import static com.google.common.net.InetAddresses.isInetAddress;
 import io.libp2p.core.crypto.PrivKey;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import tech.pegasys.teku.networking.p2p.connection.TargetPeerRange;
 
 public class NetworkConfig {
@@ -26,7 +27,7 @@ public class NetworkConfig {
   private final String networkInterface;
   private final Optional<String> advertisedIp;
   private final int listenPort;
-  private final int advertisedPort;
+  private final OptionalInt advertisedPort;
   private final List<String> staticPeers;
   private final boolean isDiscoveryEnabled;
   private final List<String> bootnodes;
@@ -37,9 +38,9 @@ public class NetworkConfig {
   public NetworkConfig(
       final PrivKey privateKey,
       final String networkInterface,
-      final String advertisedIp,
+      final Optional<String> advertisedIp,
       final int listenPort,
-      final int advertisedPort,
+      final OptionalInt advertisedPort,
       final List<String> staticPeers,
       final boolean isDiscoveryEnabled,
       final List<String> bootnodes,
@@ -61,9 +62,9 @@ public class NetworkConfig {
   public NetworkConfig(
       final PrivKey privateKey,
       final String networkInterface,
-      final String advertisedIp,
+      final Optional<String> advertisedIp,
       final int listenPort,
-      final int advertisedPort,
+      final OptionalInt advertisedPort,
       final List<String> staticPeers,
       final boolean isDiscoveryEnabled,
       final List<String> bootnodes,
@@ -74,12 +75,9 @@ public class NetworkConfig {
     this.privateKey = privateKey;
     this.networkInterface = networkInterface;
 
-    if (advertisedIp.trim().isEmpty()) {
-      this.advertisedIp = Optional.empty();
-    } else if (!isInetAddress(advertisedIp)) {
+    this.advertisedIp = advertisedIp.filter(ip -> !ip.isBlank());
+    if (this.advertisedIp.map(ip -> !isInetAddress(ip)).orElse(false)) {
       throw new IllegalArgumentException("Advertised ip is set incorrectly.");
-    } else {
-      this.advertisedIp = Optional.of(advertisedIp);
     }
 
     this.listenPort = listenPort;
@@ -100,8 +98,8 @@ public class NetworkConfig {
     return networkInterface;
   }
 
-  public Optional<String> getAdvertisedIp() {
-    return advertisedIp;
+  public String getAdvertisedIp() {
+    return advertisedIp.orElse(networkInterface);
   }
 
   public int getListenPort() {
@@ -109,7 +107,7 @@ public class NetworkConfig {
   }
 
   public int getAdvertisedPort() {
-    return advertisedPort;
+    return advertisedPort.orElse(listenPort);
   }
 
   public List<String> getStaticPeers() {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/P2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/P2PNetwork.java
@@ -97,11 +97,4 @@ public interface P2PNetwork<T extends Peer> extends GossipNetwork {
 
   /** Stops the P2P network layer. */
   void stop();
-
-  /**
-   * Get the network configuration for this network.
-   *
-   * @return A NetworkConfig object with the configuration of this network.
-   */
-  NetworkConfig getConfig();
 }

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkTest.java
@@ -23,6 +23,7 @@ import static tech.pegasys.teku.util.config.Constants.FAR_FUTURE_EPOCH;
 
 import java.util.Collections;
 import java.util.Optional;
+import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.EnrForkId;
 import tech.pegasys.teku.datastructures.state.Fork;
@@ -125,9 +126,9 @@ class DiscoveryNetworkTest {
             new NetworkConfig(
                 null,
                 "127.0.0.1",
-                "127.0.0.1",
+                Optional.empty(),
                 0,
-                0,
+                OptionalInt.empty(),
                 Collections.emptyList(),
                 false,
                 Collections.emptyList(),

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
@@ -19,6 +19,8 @@ import java.net.BindException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -77,9 +79,9 @@ public class DiscoveryNetworkFactory {
             new NetworkConfig(
                 KeyKt.generateKeyPair(KEY_TYPE.SECP256K1).component1(),
                 "127.0.0.1",
-                "127.0.0.1",
+                Optional.empty(),
                 port,
-                port,
+                OptionalInt.empty(),
                 staticPeers,
                 true,
                 bootnodes,

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.cli.options;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
 import picocli.CommandLine.Option;
 
 public class P2POptions {
@@ -62,14 +64,14 @@ public class P2POptions {
       paramLabel = "<NETWORK>",
       description = "Peer to peer advertised ip",
       arity = "1")
-  private String p2pAdvertisedIp = "127.0.0.1";
+  private String p2pAdvertisedIp;
 
   @Option(
       names = {"--p2p-advertised-port"},
       paramLabel = "<INTEGER>",
       description = "Peer to peer advertised port",
       arity = "1")
-  private int p2pAdvertisedPort = p2pPort;
+  private Integer p2pAdvertisedPort;
 
   @Option(
       names = {"--p2p-private-key-file"},
@@ -127,12 +129,12 @@ public class P2POptions {
     return p2pDiscoveryBootnodes;
   }
 
-  public String getP2pAdvertisedIp() {
-    return p2pAdvertisedIp;
+  public Optional<String> getP2pAdvertisedIp() {
+    return Optional.ofNullable(p2pAdvertisedIp);
   }
 
-  public int getP2pAdvertisedPort() {
-    return p2pAdvertisedPort;
+  public OptionalInt getP2pAdvertisedPort() {
+    return p2pAdvertisedPort == null ? OptionalInt.empty() : OptionalInt.of(p2pAdvertisedPort);
   }
 
   public String getP2pPrivateKeyFile() {

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -29,6 +29,8 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -224,7 +226,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setEth1Endpoint(null)
         .setMetricsCategories(
             DEFAULT_METRICS_CATEGORIES.stream().map(Object::toString).collect(Collectors.toList()))
-        .setP2pAdvertisedPort(30303)
+        .setP2pAdvertisedPort(OptionalInt.empty())
         .setP2pDiscoveryEnabled(true)
         .setP2pInterface("0.0.0.0")
         .setP2pPort(30303)
@@ -253,8 +255,8 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setP2pPort(1234)
         .setP2pDiscoveryEnabled(false)
         .setP2pDiscoveryBootnodes(Collections.emptyList())
-        .setP2pAdvertisedPort(9000)
-        .setP2pAdvertisedIp("127.0.0.1")
+        .setP2pAdvertisedPort(OptionalInt.of(9000))
+        .setP2pAdvertisedIp(Optional.empty())
         .setP2pPrivateKeyFile("path/to/file")
         .setP2pPeerLowerBound(20)
         .setP2pPeerUpperBound(30)

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.cli.options;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.teku.util.config.TekuConfiguration;
@@ -26,7 +27,7 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
   public void shouldReadFromConfigurationFile() {
     final TekuConfiguration config = getTekuConfigurationFromFile("P2POptions_config.yaml");
 
-    assertThat(config.getP2pAdvertisedIp()).isEqualTo("127.200.0.1");
+    assertThat(config.getP2pAdvertisedIp()).isEqualTo(Optional.of("127.200.0.1"));
     assertThat(config.getP2pInterface()).isEqualTo("127.100.0.1");
     assertThat(config.isP2pEnabled()).isTrue();
     assertThat(config.isP2pDiscoveryEnabled()).isTrue();
@@ -104,5 +105,30 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
 
     final TekuConfiguration tekuConfiguration = getResultingTekuConfiguration();
     assertThat(tekuConfiguration.isP2pSnappyEnabled()).isTrue();
+  }
+
+  @Test
+  public void advertisedIp_shouldDefaultToEmpty() {
+    assertThat(getTekuConfigurationFromArguments().getP2pAdvertisedIp()).isEmpty();
+  }
+
+  @Test
+  public void advertisedIp_shouldAcceptValue() {
+    final String ip = "10.0.1.200";
+    assertThat(getTekuConfigurationFromArguments("--p2p-advertised-ip", ip).getP2pAdvertisedIp())
+        .contains(ip);
+  }
+
+  @Test
+  public void advertisedPort_shouldDefaultToEmpty() {
+    assertThat(getTekuConfigurationFromArguments().getP2pAdvertisedPort()).isEmpty();
+  }
+
+  @Test
+  public void advertisedPort_shouldAcceptValue() {
+    assertThat(
+            getTekuConfigurationFromArguments("--p2p-advertised-port", "8056")
+                .getP2pAdvertisedPort())
+        .hasValue(8056);
   }
 }

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
@@ -19,6 +19,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
@@ -38,8 +40,8 @@ public class TekuConfiguration {
   private final int p2pPort;
   private final boolean p2pDiscoveryEnabled;
   private final List<String> p2pDiscoveryBootnodes;
-  private final String p2pAdvertisedIp;
-  private final int p2pAdvertisedPort;
+  private final Optional<String> p2pAdvertisedIp;
+  private final OptionalInt p2pAdvertisedPort;
   private final String p2pPrivateKeyFile;
   private final int p2pPeerLowerBound;
   private final int p2pPeerUpperBound;
@@ -110,8 +112,8 @@ public class TekuConfiguration {
       final int p2pPort,
       final boolean p2pDiscoveryEnabled,
       final List<String> p2pDiscoveryBootnodes,
-      final String p2pAdvertisedIp,
-      final int p2pAdvertisedPort,
+      final Optional<String> p2pAdvertisedIp,
+      final OptionalInt p2pAdvertisedPort,
       final String p2pPrivateKeyFile,
       final int p2pPeerLowerBound,
       final int p2pPeerUpperBound,
@@ -236,11 +238,11 @@ public class TekuConfiguration {
     return p2pDiscoveryBootnodes;
   }
 
-  public String getP2pAdvertisedIp() {
+  public Optional<String> getP2pAdvertisedIp() {
     return p2pAdvertisedIp;
   }
 
-  public int getP2pAdvertisedPort() {
+  public OptionalInt getP2pAdvertisedPort() {
     return p2pAdvertisedPort;
   }
 

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
@@ -15,10 +15,11 @@ package tech.pegasys.teku.util.config;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.Supplier;
 
 public class TekuConfigurationBuilder {
-  private static boolean DEFAULT_P2P_SNAPPY_ENABLED = false;
+  private static final boolean DEFAULT_P2P_SNAPPY_ENABLED = false;
   private String constants;
   private Integer startupTargetPeerCount;
   private Integer startupTimeoutSeconds;
@@ -27,8 +28,8 @@ public class TekuConfigurationBuilder {
   private int p2pPort;
   private boolean p2pDiscoveryEnabled;
   private List<String> p2pDiscoveryBootnodes;
-  private String p2pAdvertisedIp;
-  private int p2pAdvertisedPort;
+  private Optional<String> p2pAdvertisedIp = Optional.empty();
+  private OptionalInt p2pAdvertisedPort = OptionalInt.empty();
   private String p2pPrivateKeyFile;
   private int p2pPeerLowerBound;
   private int p2pPeerUpperBound;
@@ -112,12 +113,12 @@ public class TekuConfigurationBuilder {
     return this;
   }
 
-  public TekuConfigurationBuilder setP2pAdvertisedIp(final String p2pAdvertisedIp) {
+  public TekuConfigurationBuilder setP2pAdvertisedIp(final Optional<String> p2pAdvertisedIp) {
     this.p2pAdvertisedIp = p2pAdvertisedIp;
     return this;
   }
 
-  public TekuConfigurationBuilder setP2pAdvertisedPort(final int p2pAdvertisedPort) {
+  public TekuConfigurationBuilder setP2pAdvertisedPort(final OptionalInt p2pAdvertisedPort) {
     this.p2pAdvertisedPort = p2pAdvertisedPort;
     return this;
   }


### PR DESCRIPTION
## PR Description
When setting the local ENR, use the advertised IP and port not the listen address and port.

Depends on https://github.com/PegaSysEng/discovery/pull/44

Config has been updated to make it clear that advertised ip and port are optional and they're resolved in `NetworkConfig` to avoid duplicating that logic in the multiple places they're now used.

fixes #1726