### PR TITLE
[BC-413] Fix queries for latest forkInfo

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/node/GetForkIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/node/GetForkIntegrationTest.java
@@ -38,7 +38,7 @@ public class GetForkIntegrationTest extends AbstractBeaconRestAPIIntegrationTest
   public void shouldReturnNoContentIfBestBlockStateIsMissing() throws Exception {
     final Store store = mock(Store.class);
     when(recentChainData.getStore()).thenReturn(store);
-    when(recentChainData.getBestBlockRootState()).thenReturn(Optional.empty());
+    when(recentChainData.getBestState()).thenReturn(Optional.empty());
 
     final Response response = get();
     assertNoContent(response);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -77,7 +77,7 @@ public class ChainDataProvider {
     }
 
     tech.pegasys.teku.datastructures.state.BeaconState bestBlockRootState =
-        recentChainData.getBestBlockRootState().orElseThrow(ChainDataUnavailableException::new);
+        recentChainData.getBestState().orElseThrow(ChainDataUnavailableException::new);
     return new Fork(bestBlockRootState.getFork());
   }
 

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -419,7 +419,7 @@ public class ChainDataProviderTest {
     ChainDataProvider provider =
         new ChainDataProvider(mockRecentChainData, mockCombinedChainDataClient);
     when(mockCombinedChainDataClient.isStoreAvailable()).thenReturn(true);
-    when(mockRecentChainData.getBestBlockRootState()).thenReturn(Optional.empty());
+    when(mockRecentChainData.getBestState()).thenReturn(Optional.empty());
     assertThatThrownBy(provider::getFork).isInstanceOf(ChainDataUnavailableException.class);
   }
 
@@ -428,7 +428,7 @@ public class ChainDataProviderTest {
     final ChainDataProvider provider =
         new ChainDataProvider(mockRecentChainData, mockCombinedChainDataClient);
     when(mockCombinedChainDataClient.isStoreAvailable()).thenReturn(true);
-    when(mockRecentChainData.getBestBlockRootState()).thenReturn(Optional.of(beaconStateInternal));
+    when(mockRecentChainData.getBestState()).thenReturn(Optional.of(beaconStateInternal));
     final Fork result = provider.getFork();
     verify(mockCombinedChainDataClient).isStoreAvailable();
     assertThat(result).isEqualToComparingFieldByField(beaconState.fork);

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -186,7 +186,7 @@ public class ChainBuilder {
         new MockStartBeaconStateGenerator()
             .createInitialBeaconState(UnsignedLong.ZERO, initialDepositData);
 
-    // Generage genesis block
+    // Generate genesis block
     BeaconBlock genesisBlock = new BeaconBlock(genesisState.hash_tree_root());
     final SignedBeaconBlock signedBlock = new SignedBeaconBlock(genesisBlock, BLSSignature.empty());
 

--- a/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/util/DataStructureUtil.java
+++ b/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/util/DataStructureUtil.java
@@ -227,6 +227,19 @@ public final class DataStructureUtil {
     return new SignedBeaconBlock(beaconBlock, randomSignature());
   }
 
+  public SignedBeaconBlock randomSignedBeaconBlock(long slotNum, BeaconState state) {
+    return randomSignedBeaconBlock(UnsignedLong.valueOf(slotNum), state);
+  }
+
+  public SignedBeaconBlock randomSignedBeaconBlock(UnsignedLong slotNum, BeaconState state) {
+    final BeaconBlockBody body = randomBeaconBlockBody();
+    final Bytes32 stateRoot = state.hash_tree_root();
+
+    final BeaconBlock block =
+        new BeaconBlock(slotNum, randomUnsignedLong(), randomBytes32(), stateRoot, body);
+    return new SignedBeaconBlock(block, randomSignature());
+  }
+
   public BeaconBlock randomBeaconBlock(long slotNum) {
     return randomBeaconBlock(UnsignedLong.valueOf(slotNum));
   }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -186,7 +186,7 @@ public class BeaconChainUtil {
         "Must have >1 validator in order to create a block from an invalid proposer.");
     final Bytes32 bestBlockRoot = recentChainData.getBestBlockRoot().orElseThrow();
     final BeaconBlock bestBlock = recentChainData.getStore().getBlock(bestBlockRoot);
-    final BeaconState preState = recentChainData.getBestBlockRootState().orElseThrow();
+    final BeaconState preState = recentChainData.getBestState().orElseThrow();
     checkArgument(bestBlock.getSlot().compareTo(slot) < 0, "Slot must be in the future.");
 
     final int correctProposerIndex = blockCreator.getProposerIndexForSlot(preState, slot);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlockValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlockValidatorTest.java
@@ -96,7 +96,7 @@ public class BlockValidatorTest {
 
     BLSSignature blockSignature =
         new Signer(beaconChainUtil.getSigner(proposerIndex.intValue()))
-            .signBlock(block, recentChainData.getBestBlockRootState().get().getForkInfo())
+            .signBlock(block, recentChainData.getBestState().get().getForkInfo())
             .join();
     final SignedBeaconBlock blockWithNoParent = new SignedBeaconBlock(block, blockSignature);
 
@@ -135,7 +135,7 @@ public class BlockValidatorTest {
 
     BLSSignature blockSignature =
         new Signer(beaconChainUtil.getSigner(invalidProposerIndex.intValue()))
-            .signBlock(block, recentChainData.getBestBlockRootState().get().getForkInfo())
+            .signBlock(block, recentChainData.getBestState().get().getForkInfo())
             .join();
     final SignedBeaconBlock invalidProposerSignedBlock =
         new SignedBeaconBlock(block, blockSignature);

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_EPOCH;
 
+import com.google.common.eventbus.EventBus;
 import com.google.common.primitives.UnsignedLong;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -29,6 +30,7 @@ import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.datastructures.blocks.NodeSlot;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
+import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 class BeaconChainMetricsTest {
@@ -47,6 +49,8 @@ class BeaconChainMetricsTest {
   private final NodeSlot nodeSlot = new NodeSlot(NODE_SLOT_VALUE);
 
   private final RecentChainData recentChainData = mock(RecentChainData.class);
+  private final RecentChainData preGenesisChainData =
+      MemoryOnlyRecentChainData.create(mock(EventBus.class));
 
   @Test
   void getLongFromRoot_shouldParseNegativeOne() {
@@ -129,12 +133,10 @@ class BeaconChainMetricsTest {
 
   @Test
   void getFinalizedRootValue_shouldReturnNotSetWhenStoreNotPresent() {
-    BeaconChainMetrics metrics = new BeaconChainMetrics(recentChainData, nodeSlot);
-    when(recentChainData.isPreGenesis()).thenReturn(true);
-    when(recentChainData.getBestBlockAndState()).thenCallRealMethod();
+    assertThat(preGenesisChainData.isPreGenesis()).isTrue(); // Sanity check
+    BeaconChainMetrics metrics = new BeaconChainMetrics(preGenesisChainData, nodeSlot);
 
     assertThat(0L).isEqualTo(metrics.getFinalizedRootValue());
-    verify(recentChainData).isPreGenesis();
   }
 
   @Test
@@ -150,12 +152,10 @@ class BeaconChainMetricsTest {
 
   @Test
   void getPreviousJustifiedEpochValue_shouldReturnNotSetWhenStoreNotPresent() {
-    BeaconChainMetrics metrics = new BeaconChainMetrics(recentChainData, nodeSlot);
-    when(recentChainData.isPreGenesis()).thenReturn(true);
-    when(recentChainData.getBestBlockAndState()).thenCallRealMethod();
+    assertThat(preGenesisChainData.isPreGenesis()).isTrue(); // Sanity check
+    BeaconChainMetrics metrics = new BeaconChainMetrics(preGenesisChainData, nodeSlot);
 
     assertThat(0L).isEqualTo(metrics.getPreviousJustifiedEpochValue());
-    verify(recentChainData).isPreGenesis();
   }
 
   @Test
@@ -172,12 +172,10 @@ class BeaconChainMetricsTest {
 
   @Test
   void getPreviousJustifiedRootValue_shouldReturnNotSetWhenStoreNotPresent() {
-    BeaconChainMetrics metrics = new BeaconChainMetrics(recentChainData, nodeSlot);
-    when(recentChainData.isPreGenesis()).thenReturn(true);
-    when(recentChainData.getBestBlockAndState()).thenCallRealMethod();
+    assertThat(preGenesisChainData.isPreGenesis()).isTrue(); // Sanity check
+    BeaconChainMetrics metrics = new BeaconChainMetrics(preGenesisChainData, nodeSlot);
 
     assertThat(0L).isEqualTo(metrics.getPreviousJustifiedRootValue());
-    verify(recentChainData).isPreGenesis();
   }
 
   @Test
@@ -193,12 +191,10 @@ class BeaconChainMetricsTest {
 
   @Test
   void getJustifiedRootValue_shouldReturnNotSetWhenStoreNotPresent() {
-    BeaconChainMetrics metrics = new BeaconChainMetrics(recentChainData, nodeSlot);
-    when(recentChainData.isPreGenesis()).thenReturn(true);
-    when(recentChainData.getBestBlockAndState()).thenCallRealMethod();
+    assertThat(preGenesisChainData.isPreGenesis()).isTrue(); // Sanity check
+    BeaconChainMetrics metrics = new BeaconChainMetrics(preGenesisChainData, nodeSlot);
 
     assertThat(0L).isEqualTo(metrics.getJustifiedRootValue());
-    verify(recentChainData).isPreGenesis();
   }
 
   @Test

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -26,6 +26,8 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.core.ForkChoiceUtil;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.datastructures.state.BeaconState;
@@ -55,11 +57,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   private final SafeFuture<Void> bestBlockInitialized = new SafeFuture<>();
 
   private volatile Store store;
-  private volatile Optional<Bytes32> bestBlockRoot =
-      Optional.empty(); // block chosen by lmd ghost to build and attest on
-  private volatile UnsignedLong bestSlot =
-      UnsignedLong.ZERO; // slot of the block chosen by lmd ghost to build and attest on
-  // Time
+  private volatile Optional<SignedBlockAndState> chainHead = Optional.empty();
   private volatile UnsignedLong genesisTime;
 
   RecentChainData(
@@ -133,17 +131,31 @@ public abstract class RecentChainData implements StoreUpdateHandler {
    * @param slot
    */
   public void updateBestBlock(Bytes32 root, UnsignedLong slot) {
-    final Optional<Bytes32> originalBestRoot = bestBlockRoot;
-    final UnsignedLong originalBestSlot = bestSlot;
-    this.bestBlockRoot = Optional.of(root);
-    this.bestSlot = slot;
-    bestBlockInitialized.complete(null);
+    synchronized (this) {
+      final SignedBeaconBlock newBestBlock = store.getSignedBlock(root);
+      final BeaconState newBestState = store.getBlockState(root);
+      if (newBestBlock == null || newBestState == null) {
+        LOG.warn(
+            "Unable to update best block (slot={}, root={}). Corresponding {} unavailable",
+            slot,
+            root,
+            newBestBlock == null ? "block" : "state");
+      }
+      final SignedBlockAndState newChainHead = new SignedBlockAndState(newBestBlock, newBestState);
 
-    if (originalBestRoot
-        .map(original -> hasReorgedFrom(original, originalBestSlot))
-        .orElse(false)) {
-      reorgEventChannel.reorgOccurred(root, bestSlot);
+      final Optional<Bytes32> originalBestRoot = chainHead.map(SignedBlockAndState::getRoot);
+      final UnsignedLong originalBestSlot =
+          chainHead.map(SignedBlockAndState::getSlot).orElse(UnsignedLong.ZERO);
+
+      this.chainHead = Optional.of(newChainHead);
+      if (originalBestRoot
+          .map(original -> hasReorgedFrom(original, originalBestSlot))
+          .orElse(false)) {
+        reorgEventChannel.reorgOccurred(root, newChainHead.getSlot());
+      }
     }
+
+    bestBlockInitialized.complete(null);
   }
 
   private boolean hasReorgedFrom(
@@ -169,7 +181,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   }
 
   public Optional<ForkInfo> getCurrentForkInfo() {
-    return getBestBlockRoot().map(store::getBlockState).map(BeaconState::getForkInfo);
+    return getBestState().map(BeaconState::getForkInfo);
   }
 
   public Optional<Fork> getNextFork() {
@@ -183,7 +195,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
    * @return
    */
   public Optional<Bytes32> getBestBlockRoot() {
-    return this.bestBlockRoot;
+    return chainHead.map(SignedBlockAndState::getRoot);
   }
 
   /**
@@ -192,16 +204,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
    * @return The best block along with its corresponding state.
    */
   public Optional<BeaconBlockAndState> getBestBlockAndState() {
-    if (isPreGenesis()) {
-      return Optional.empty();
-    }
-
-    return bestBlockRoot.map(
-        (bestRoot) -> {
-          BeaconBlock block = getStore().getBlock(bestRoot);
-          BeaconState state = getStore().getBlockState(bestRoot);
-          return new BeaconBlockAndState(block, state);
-        });
+    return chainHead.map(SignedBlockAndState::toUnsigned);
   }
 
   /**
@@ -209,8 +212,8 @@ public abstract class RecentChainData implements StoreUpdateHandler {
    *
    * @return
    */
-  public Optional<BeaconState> getBestBlockRootState() {
-    return bestBlockRoot.map(root -> this.store.getBlockState(root));
+  public Optional<BeaconState> getBestState() {
+    return chainHead.map(SignedBlockAndState::getState);
   }
 
   /**
@@ -219,7 +222,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
    * @return
    */
   public UnsignedLong getBestSlot() {
-    return this.bestSlot;
+    return chainHead.map(SignedBlockAndState::getSlot).orElse(UnsignedLong.ZERO);
   }
 
   @Subscribe
@@ -280,21 +283,18 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   }
 
   public Optional<Bytes32> getBlockRootBySlot(final UnsignedLong slot) {
-    if (store == null || bestBlockRoot.isEmpty()) {
+    if (store == null || chainHead.isEmpty()) {
       LOG.trace("No block root at slot {} because store or best block root is not set", slot);
       return Optional.empty();
     }
-    if (bestSlot.compareTo(slot) <= 0) {
+
+    final SignedBlockAndState bestBlock = chainHead.get();
+    if (bestBlock.getSlot().compareTo(slot) <= 0) {
       LOG.trace("Block root at slot {} is at or after the current best slot root", slot);
-      return bestBlockRoot;
+      return Optional.of(bestBlock.getRoot());
     }
 
-    final BeaconState bestState = store.getBlockState(bestBlockRoot.get());
-    if (bestState == null) {
-      LOG.trace("No block root at slot {} because best state is not available", slot);
-      return Optional.empty();
-    }
-
+    final BeaconState bestState = bestBlock.getState();
     if (!BeaconStateUtil.isBlockRootAvailableFromState(bestState, slot)) {
       LOG.trace("No block root at slot {} because slot is not within historical root", slot);
       return Optional.empty();

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -140,6 +140,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
             slot,
             root,
             newBestBlock == null ? "block" : "state");
+        return;
       }
       final SignedBlockAndState newChainHead = new SignedBlockAndState(newBestBlock, newBestState);
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -64,7 +64,7 @@ class RecentChainDataTest {
     assertThat(preGenesisStorageClient.getGenesisTime()).isEqualTo(INITIAL_STATE.getGenesis_time());
     assertThat(preGenesisStorageClient.getBestSlot())
         .isEqualTo(UnsignedLong.valueOf(Constants.GENESIS_SLOT));
-    assertThat(preGenesisStorageClient.getBestBlockRootState()).hasValue(INITIAL_STATE);
+    assertThat(preGenesisStorageClient.getBestState()).hasValue(INITIAL_STATE);
     assertThat(preGenesisStorageClient.getStore()).isNotNull();
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Store "best block" / chainhead info in an atomic datastructure, preventing race conditions.

This PR fixes errors related to retrieving the most recent `ForkInfo` (see error below).  It appears these errors are the result of a race condition where:  we pull the latest head root and then look up the corresponding state.  If the corresponding state is pruned before we can look it up, we'll throw an error on failure to retrieve this state:

```
2020-05-05 17:54:48.022-04:00 | ForkJoinPool.commonPool-worker-11 | ERROR | Eth2IncomingRequestHandler | Unhandled error while processing request /eth2/beacon_chain/req/status/1/ssz_snappy
java.util.NoSuchElementException: No value present
	at java.util.Optional.orElseThrow(Optional.java:382) ~[?:?]
	at tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory.createStatusMessage(StatusMessageFactory.java:40) ~[classes/:?]
	at tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageHandler.onIncomingMessage(StatusMessageHandler.java:40) ~[classes/:?]
	at tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageHandler.onIncomingMessage(StatusMessageHandler.java:24) ~[classes/:?]
	at tech.pegasys.teku.networking.eth2.rpc.core.Eth2IncomingRequestHandler.handleRequest(Eth2IncomingRequestHandler.java:80) ~[classes/:?]
	at tech.pegasys.teku.networking.eth2.rpc.core.Eth2IncomingRequestHandler.processInput(Eth2IncomingRequestHandler.java:69) ~[classes/:?]
	at tech.pegasys.teku.networking.p2p.libp2p.rpc.RpcHandler$Controller.lambda$setRequestHandler$0(RpcHandler.java:206) ~[classes/:?]
	at tech.pegasys.teku.util.async.SafeFuture.fromRunnable(SafeFuture.java:106) ~[classes/:?]
	at tech.pegasys.teku.util.async.AsyncRunner.lambda$runAsync$0(AsyncRunner.java:22) ~[classes/:?]
	at tech.pegasys.teku.util.async.DelayedExecutorAsyncRunner.lambda$runAsync$1(DelayedExecutorAsyncRunner.java:57) ~[classes/:?]
	at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426) [?:?]
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290) [?:?]
	at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020) [?:?]
	at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656) [?:?]
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594) [?:?]
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177) [?:?]
```

