### PR TITLE
[BC-415] Rework status message handling

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -104,6 +104,15 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     return this.store == null;
   }
 
+  /**
+   * Returns true if the best block / chainhead has not yet been set.
+   *
+   * @return true if the best block is unknown, false otherwise.
+   */
+  public boolean isPreForkChoice() {
+    return chainHead.isEmpty();
+  }
+
   boolean setStore(Store store) {
     if (!storeInitialized.compareAndSet(false, true)) {
       return false;
@@ -206,6 +215,15 @@ public abstract class RecentChainData implements StoreUpdateHandler {
    */
   public Optional<BeaconBlockAndState> getBestBlockAndState() {
     return chainHead.map(SignedBlockAndState::toUnsigned);
+  }
+
+  /**
+   * If available, return the best block.
+   *
+   * @return The best block.
+   */
+  public Optional<SignedBeaconBlock> getBestBlock() {
+    return chainHead.map(SignedBlockAndState::getBlock);
   }
 
   /**


### PR DESCRIPTION
## PR Description
Make sure we return a consistent, valid status message.  

Previously, we were pulling the headRoot and headSlot in separate requests, which could lead to inconsistent head information.  Additionally, if the best block / chainhead was unavailable we would return zero for the headRoot / headSlot.  

This PR makes sure we're returning consistent head information, and reworks our approach to missing chainhead information.  We will now respond with an error if peers try to request status information before we're ready.  Because the network only spins up after this data is available, we shouldn't actually encounter these errors in practice. 

