### PR TITLE
Prune attestations from the aggregating pool

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -17,7 +17,6 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.TreeMap;
@@ -60,8 +59,7 @@ class MatchingDataAttestationGroup implements Iterable<Attestation> {
    */
   public void add(final Attestation attestation) {
     attestationsByValidatorCount
-        .computeIfAbsent(
-            attestation.getAggregation_bits().countSetBits(), count -> new LinkedHashSet<>())
+        .computeIfAbsent(attestation.getAggregation_bits().countSetBits(), count -> new HashSet<>())
         .add(attestation);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -141,7 +141,8 @@ class AggregatingAttestationPoolTest {
     aggregatingPool.onSlot(
         pruneAttestationData
             .getSlot()
-            .plus(UnsignedLong.valueOf(SLOTS_PER_EPOCH * ATTESTATION_RETENTION_EPOCHS)));
+            .plus(UnsignedLong.valueOf(SLOTS_PER_EPOCH * ATTESTATION_RETENTION_EPOCHS))
+            .plus(ONE));
 
     assertThat(
             aggregatingPool.getAttestationsForBlock(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -131,7 +131,7 @@ class AggregatingAttestationPoolTest {
 
   @Test
   public void onSlot_shouldPruneAttestationsMoreThanTwoEpochsBehindCurrentSlot() {
-    final AttestationData pruneAttestationData = randomAttestationDataToIncludeInBlock();
+    final AttestationData pruneAttestationData = randomAttestationDataToIncludeInBlock(SLOT);
     final AttestationData preserveAttestationData =
         randomAttestationDataToIncludeInBlock(SLOT.plus(ONE));
     addAttestationFromValidators(pruneAttestationData, 1);
@@ -141,8 +141,7 @@ class AggregatingAttestationPoolTest {
     aggregatingPool.onSlot(
         pruneAttestationData
             .getSlot()
-            .plus(UnsignedLong.valueOf(SLOTS_PER_EPOCH * ATTESTATION_RETENTION_EPOCHS))
-            .plus(ONE));
+            .plus(UnsignedLong.valueOf(SLOTS_PER_EPOCH * ATTESTATION_RETENTION_EPOCHS)));
 
     assertThat(
             aggregatingPool.getAttestationsForBlock(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -378,6 +378,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   public void initAttestationPool() {
     LOG.debug("BeaconChainController.initAttestationPool()");
     attestationPool = new AggregatingAttestationPool();
+    eventChannels.subscribe(SlotEventsChannel.class, attestationPool);
   }
 
   public void initRestAPI() {
@@ -512,6 +513,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     this.forkChoice.processHead();
     EVENT_LOG.syncEvent(
         nodeSlot.getValue(), recentChainData.getBestSlot(), p2pNetwork.getPeerCount());
+    slotEventsChannelPublisher.onSlot(nodeSlot.getValue());
     nodeSlot.inc();
   }
 }

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -142,6 +142,7 @@ public class Constants {
   public static final int PROTOARRAY_FORKCHOICE_PRUNE_THRESHOLD = 256;
   public static final int DEFAULT_STARTUP_TARGET_PEER_COUNT = 5;
   public static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 30;
+  public static final int ATTESTATION_RETENTION_EPOCHS = 2;
 
   // Teku Validator Client Specific
   public static final long FORK_RETRY_DELAY_SECONDS = 10; // in sec


### PR DESCRIPTION
## PR Description
Prune old attestations from the `AggregatingAttestationPool` to resolve a memory leak.

Fire slot events even while syncing so pruning actions are applied (applies to a number of pending pools and other systems).  The only major work that happens on onSlot is the validator client loading duties, but during sync the request for duties is immediately rejected.