### PR TITLE
Exclude 'resources' folders from spotless scope

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,7 @@ allprojects {
         //Excluding tech.pegasys.teku.datastructures due to preferred formatting overwritten by plugin in getConstantsAsString.
         exclude '**/src/main/java/tech/pegasys/teku/Constants.java'
         exclude '**/proto'
+        exclude '**/resources'
       }
 
       importOrder 'tech.pegasys', 'net.consensys', 'java', ''


### PR DESCRIPTION
## PR Description

Spotless has nothing to check/fix in `resources` subfolders. Let's exclude them. 

This significantly speeds up `spotlessApply` task (especially with reference tests pulled): from 4 min to 30 sec on my local machine.