### PR TITLE
Fix thread safety issue in onAttestation

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/Store.java
@@ -262,7 +262,7 @@ public class Store implements ReadOnlyStore {
     private Map<Bytes32, SignedBeaconBlock> blocks = new HashMap<>();
     private Map<Bytes32, BeaconState> block_states = new HashMap<>();
     private Map<Checkpoint, BeaconState> checkpoint_states = new HashMap<>();
-    private Map<UnsignedLong, VoteTracker> votes = new HashMap<>();
+    private Map<UnsignedLong, VoteTracker> votes = new ConcurrentHashMap<>();
     private final StoreUpdateHandler updateHandler;
 
     Transaction(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Uses `ConcurrentHashMap` instead of `HashMap` for the `votes` object in `Transaction` so that it can be used concurrently without thread-safety issues.

## Fixed Issue(s)
Fixes https://github.com/PegaSysEng/teku/issues/1743
