### PR TITLE
Support setting the network when sending deposit transactions

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
@@ -53,9 +53,10 @@ public abstract class Node {
     cleanupTemporaryDirectories();
   }
 
-  protected void waitFor(final Waiter.Condition condition, final int timeoutSeconds) {
+  protected void waitFor(
+      final Waiter.Condition condition, final int timeoutAmount, final TimeUnit timeoutUnit) {
     try {
-      Waiter.waitFor(condition, TimeUnit.SECONDS, timeoutSeconds);
+      Waiter.waitFor(condition, timeoutAmount, timeoutUnit);
     } catch (final Throwable t) {
       fail(t.getMessage() + " Logs: " + container.getLogs(), t);
     }
@@ -63,7 +64,7 @@ public abstract class Node {
 
   protected void waitFor(final Waiter.Condition condition) {
     try {
-      Waiter.waitFor(condition);
+      Waiter.waitFor(condition, 1, TimeUnit.MINUTES);
     } catch (final Throwable t) {
       fail(t.getMessage() + " Logs: " + container.getLogs(), t);
     }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -149,7 +150,7 @@ public class TekuNode extends Node {
     waitFor(
         () ->
             assertThat(fetchChainHead().get().finalized_epoch).isNotEqualTo(startingFinalizedEpoch),
-        540);
+        9, TimeUnit.MINUTES);
   }
 
   public void waitUntilInSyncWith(final TekuNode targetNode) {
@@ -162,7 +163,7 @@ public class TekuNode extends Node {
           assertThat(targetBeaconHead).isPresent();
           assertThat(beaconHead).isEqualTo(targetBeaconHead);
         },
-        300);
+        5, TimeUnit.MINUTES);
   }
 
   private BeaconHead waitForBeaconHead() {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.test.acceptance.dsl;
 import static com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature.WRITE_DOC_START_MARKER;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,7 +36,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -150,7 +150,8 @@ public class TekuNode extends Node {
     waitFor(
         () ->
             assertThat(fetchChainHead().get().finalized_epoch).isNotEqualTo(startingFinalizedEpoch),
-        9, TimeUnit.MINUTES);
+        9,
+        MINUTES);
   }
 
   public void waitUntilInSyncWith(final TekuNode targetNode) {
@@ -163,7 +164,8 @@ public class TekuNode extends Node {
           assertThat(targetBeaconHead).isPresent();
           assertThat(beaconHead).isEqualTo(targetBeaconHead);
         },
-        5, TimeUnit.MINUTES);
+        5,
+        MINUTES);
   }
 
   private BeaconHead waitForBeaconHead() {

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/DepositTransactionSender.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/DepositTransactionSender.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.datastructures.operations.DepositData;
 import tech.pegasys.teku.datastructures.util.DepositGenerator;
 import tech.pegasys.teku.pow.contract.DepositContract;
 import tech.pegasys.teku.util.async.SafeFuture;
+import tech.pegasys.teku.util.config.Eth1Address;
 
 public class DepositTransactionSender {
   // Increase the poll rate for tx receipts but keep the default 10 min timeout.
@@ -36,10 +37,12 @@ public class DepositTransactionSender {
   private final DepositContract depositContract;
 
   public DepositTransactionSender(
-      final Web3j web3j, final String depositContractAddress, final Credentials eth1Credentials) {
+      final Web3j web3j,
+      final Eth1Address depositContractAddress,
+      final Credentials eth1Credentials) {
     this.depositContract =
         DepositContract.load(
-            depositContractAddress,
+            depositContractAddress.toHexString(),
             web3j,
             new FastRawTransactionManager(
                 web3j,

--- a/teku/src/main/java/tech/pegasys/teku/cli/deposit/DepositRegisterCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/deposit/DepositRegisterCommand.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.cli.deposit;
 
-import static tech.pegasys.teku.cli.deposit.CommonParams.sendDeposit;
 import static tech.pegasys.teku.logging.SubCommandLogger.SUB_COMMAND_LOG;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -36,7 +35,6 @@ import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSecretKey;
-import tech.pegasys.teku.services.powchain.DepositTransactionSender;
 import tech.pegasys.teku.util.cli.VersionProvider;
 
 @Command(
@@ -94,16 +92,11 @@ public class DepositRegisterCommand implements Runnable {
   public void run() {
     final BLSKeyPair validatorKey = getValidatorKey();
 
-    final CommonParams _params = params; // making it effective final as it gets injected by PicoCLI
-    _params.displayConfirmation();
-    try (_params) {
-      final DepositTransactionSender sender = params.createTransactionSender();
-      sendDeposit(
-              sender,
-              validatorKey,
-              BLSPublicKey.fromBytesCompressed(Bytes.fromHexString(withdrawalKey)),
-              params.getAmount())
-          .get();
+    try (final RegisterAction registerAction = params.createRegisterAction()) {
+      final BLSPublicKey withdrawalPublicKey =
+          BLSPublicKey.fromBytesCompressed(Bytes.fromHexString(this.withdrawalKey));
+      registerAction.displayConfirmation(1);
+      registerAction.sendDeposit(validatorKey, withdrawalPublicKey).get();
     } catch (final Throwable t) {
       SUB_COMMAND_LOG.sendDepositFailure(t);
       shutdownFunction.accept(1);

--- a/teku/src/main/java/tech/pegasys/teku/cli/deposit/RegisterAction.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/deposit/RegisterAction.java
@@ -41,6 +41,7 @@ public class RegisterAction implements AutoCloseable {
   private final Eth1Address contractAddress;
   private final boolean displayConfirmation;
   private final UnsignedLong amount;
+  private final DepositTransactionSender sender;
   private OkHttpClient httpClient;
   private ScheduledExecutorService executorService;
   private Web3j web3j;
@@ -60,6 +61,7 @@ public class RegisterAction implements AutoCloseable {
     this.amount = amount;
     this.shutdownFunction = shutdownFunction;
     this.consoleAdapter = consoleAdapter;
+    this.sender = createTransactionSender();
   }
 
   private DepositTransactionSender createTransactionSender() {
@@ -109,7 +111,6 @@ public class RegisterAction implements AutoCloseable {
 
   public SafeFuture<TransactionReceipt> sendDeposit(
       final BLSKeyPair validatorKey, final BLSPublicKey withdrawalKey) {
-    final DepositTransactionSender sender = createTransactionSender();
     return sender.sendDepositTransaction(validatorKey, withdrawalKey, amount);
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/deposit/RegisterAction.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/deposit/RegisterAction.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.deposit;
+
+import com.google.common.primitives.UnsignedLong;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.IntConsumer;
+import okhttp3.ConnectionPool;
+import okhttp3.OkHttpClient;
+import org.web3j.crypto.Credentials;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.protocol.http.HttpService;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.services.powchain.DepositTransactionSender;
+import tech.pegasys.teku.util.async.SafeFuture;
+import tech.pegasys.teku.util.config.Eth1Address;
+
+public class RegisterAction implements AutoCloseable {
+
+  private final IntConsumer shutdownFunction;
+  private final ConsoleAdapter consoleAdapter;
+  private final Credentials eth1Credentials;
+  private final String eth1NodeUrl;
+  private final Eth1Address contractAddress;
+  private final boolean displayConfirmation;
+  private final UnsignedLong amount;
+  private OkHttpClient httpClient;
+  private ScheduledExecutorService executorService;
+  private Web3j web3j;
+
+  public RegisterAction(
+      final String eth1NodeUrl,
+      final Credentials eth1Credentials,
+      final Eth1Address contractAddress,
+      final boolean displayConfirmation,
+      final UnsignedLong amount,
+      final IntConsumer shutdownFunction,
+      final ConsoleAdapter consoleAdapter) {
+    this.eth1NodeUrl = eth1NodeUrl;
+    this.eth1Credentials = eth1Credentials;
+    this.contractAddress = contractAddress;
+    this.displayConfirmation = displayConfirmation;
+    this.amount = amount;
+    this.shutdownFunction = shutdownFunction;
+    this.consoleAdapter = consoleAdapter;
+  }
+
+  private DepositTransactionSender createTransactionSender() {
+    httpClient = new OkHttpClient.Builder().connectionPool(new ConnectionPool()).build();
+    executorService =
+        Executors.newScheduledThreadPool(
+            1, new ThreadFactoryBuilder().setDaemon(true).setNameFormat("web3j-%d").build());
+    web3j = Web3j.build(new HttpService(eth1NodeUrl, httpClient), 1000, executorService);
+    return new DepositTransactionSender(web3j, contractAddress, eth1Credentials);
+  }
+
+  @Override
+  public void close() {
+    if (web3j != null) {
+      web3j.shutdown();
+      httpClient.dispatcher().executorService().shutdownNow();
+      httpClient.connectionPool().evictAll();
+      executorService.shutdownNow();
+    }
+  }
+
+  public void displayConfirmation(final int totalNumberOfDeposits) {
+    if (!displayConfirmation || !consoleAdapter.isConsoleAvailable()) {
+      return;
+    }
+
+    // gwei to eth
+    final String eth =
+        new BigDecimal(amount.bigIntegerValue())
+            .divide(BigDecimal.TEN.pow(9), 9, RoundingMode.HALF_UP)
+            .toString();
+
+    final String transactionPart =
+        totalNumberOfDeposits == 1 ? "a transaction" : totalNumberOfDeposits + " transactions";
+    final String reply =
+        consoleAdapter.readLine(
+            "You are about to submit "
+                + transactionPart
+                + " of %s Eth. This is irreversible, please make sure you understand the consequences. Are you sure you want to continue? [y/n]",
+            eth);
+    if ("y".equalsIgnoreCase(reply)) {
+      return;
+    }
+    System.out.println("Transaction cancelled.");
+    shutdownFunction.accept(0);
+  }
+
+  public SafeFuture<TransactionReceipt> sendDeposit(
+      final BLSKeyPair validatorKey, final BLSPublicKey withdrawalKey) {
+    final DepositTransactionSender sender = createTransactionSender();
+    return sender.sendDepositTransaction(validatorKey, withdrawalKey, amount);
+  }
+}

--- a/teku/src/test/java/tech/pegasys/teku/cli/deposit/DepositGenerateCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/deposit/DepositGenerateCommandTest.java
@@ -37,7 +37,6 @@ import tech.pegasys.signers.bls.keystore.KeyStore;
 import tech.pegasys.signers.bls.keystore.KeyStoreLoader;
 import tech.pegasys.teku.cli.deposit.DepositGenerateCommand.ValidatorPasswordOptions;
 import tech.pegasys.teku.cli.deposit.DepositGenerateCommand.WithdrawalPasswordOptions;
-import tech.pegasys.teku.services.powchain.DepositTransactionSender;
 
 class DepositGenerateCommandTest {
   private static final int VALIDATORS_COUNT = 2;
@@ -57,15 +56,14 @@ class DepositGenerateCommandTest {
     commonParams = mock(CommonParams.class);
     commandSpec = mock(CommandSpec.class);
     final CommandLine commandLine = mock(CommandLine.class);
-    final DepositTransactionSender depositTransactionSender = mock(DepositTransactionSender.class);
+    final RegisterAction registerAction = mock(RegisterAction.class);
 
     when(commandSpec.commandLine()).thenReturn(commandLine);
     when(consoleAdapter.isConsoleAvailable()).thenReturn(true);
     when(consoleAdapter.readPassword(anyString(), any()))
         .thenReturn(EXPECTED_PASSWORD.toCharArray());
-    when(commonParams.createTransactionSender()).thenReturn(depositTransactionSender);
-    when(depositTransactionSender.sendDepositTransaction(any(), any(), any()))
-        .thenReturn(completedFuture(null));
+    when(commonParams.createRegisterAction()).thenReturn(registerAction);
+    when(registerAction.sendDeposit(any(), any())).thenReturn(completedFuture(null));
   }
 
   @Test
@@ -197,8 +195,8 @@ class DepositGenerateCommandTest {
     assertThat(subDirectories).hasSize(VALIDATORS_COUNT);
     Arrays.stream(subDirectories).forEach(file -> assertThat(file).isDirectory());
 
-    for (int i = 0; i < subDirectories.length; i++) {
-      assertKeyStoreFilesExist(subDirectories[i].toPath());
+    for (final File subDirectory : subDirectories) {
+      assertKeyStoreFilesExist(subDirectory.toPath());
     }
   }
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/deposit/DepositRegisterCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/deposit/DepositRegisterCommandTest.java
@@ -40,7 +40,6 @@ import tech.pegasys.signers.bls.keystore.model.SCryptParam;
 import tech.pegasys.teku.cli.deposit.DepositRegisterCommand.ValidatorKeyOptions;
 import tech.pegasys.teku.cli.deposit.DepositRegisterCommand.ValidatorKeyStoreOptions;
 import tech.pegasys.teku.cli.deposit.DepositRegisterCommand.ValidatorPasswordOptions;
-import tech.pegasys.teku.services.powchain.DepositTransactionSender;
 
 class DepositRegisterCommandTest {
   private static final Consumer<Integer> shutdownFunction = status -> {};
@@ -62,19 +61,18 @@ class DepositRegisterCommandTest {
       KeyStore.encrypt(BLS_PRIVATE_KEY, BLS_PUB_KEY, PASSWORD, "", KDF_PARAM, CIPHER);
   private CommonParams commonParams;
   private CommandLine.Model.CommandSpec commandSpec;
-  private DepositTransactionSender depositTransactionSender;
+  private RegisterAction registerAction;
 
   @BeforeEach
   void setUp() {
     commonParams = mock(CommonParams.class);
     commandSpec = mock(CommandLine.Model.CommandSpec.class);
     final CommandLine commandLine = mock(CommandLine.class);
-    depositTransactionSender = mock(DepositTransactionSender.class);
+    registerAction = mock(RegisterAction.class);
 
     when(commandSpec.commandLine()).thenReturn(commandLine);
-    when(commonParams.createTransactionSender()).thenReturn(depositTransactionSender);
-    when(depositTransactionSender.sendDepositTransaction(any(), any(), any()))
-        .thenReturn(completedFuture(null));
+    when(commonParams.createRegisterAction()).thenReturn(registerAction);
+    when(registerAction.sendDeposit(any(), any())).thenReturn(completedFuture(null));
   }
 
   @Test
@@ -94,7 +92,7 @@ class DepositRegisterCommandTest {
 
     assertThatCode(depositRegisterCommand::run).doesNotThrowAnyException();
 
-    verify(depositTransactionSender).sendDepositTransaction(any(), any(), any());
+    verify(registerAction).sendDeposit(any(), any());
   }
 
   @Test
@@ -111,7 +109,7 @@ class DepositRegisterCommandTest {
 
     assertThatCode(depositRegisterCommand::run).doesNotThrowAnyException();
 
-    verify(depositTransactionSender).sendDepositTransaction(any(), any(), any());
+    verify(registerAction).sendDeposit(any(), any());
   }
 
   private ValidatorKeyOptions buildValidatorKeyOptionsWithPasswordFile(

--- a/util/src/testFixtures/java/tech/pegasys/teku/util/Waiter.java
+++ b/util/src/testFixtures/java/tech/pegasys/teku/util/Waiter.java
@@ -33,7 +33,7 @@ public class Waiter {
   private static final Duration MAX_POLL_INTERVAL = Duration.ofSeconds(5);
 
   public static void waitFor(
-      final Condition assertion, final TimeUnit timeUnit, final int timeoutValue) {
+      final Condition assertion, final int timeoutValue, final TimeUnit timeUnit) {
     Awaitility.waitAtMost(timeoutValue, timeUnit)
         .ignoreExceptions()
         .pollInterval(
@@ -42,7 +42,7 @@ public class Waiter {
   }
 
   public static void waitFor(final Condition assertion) {
-    waitFor(assertion, TimeUnit.SECONDS, DEFAULT_TIMEOUT_SECONDS);
+    waitFor(assertion, DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
   }
 
   private static Duration nextPollInterval(final Duration duration) {


### PR DESCRIPTION
## PR Description
Signing deposits requires a number of values from the constants definition.  Previously the minimal configuration was always used resulting in invalid signatures so the deposit was accepted to the ETH1 chain but rejected by beacon node clients (thus losing the ETH).

Now `--network` is a required parameter when sending deposits and values for eth1-deposit-contract-address and amount are taken from that network when available.  The amount is set as the required amount to register a new validator.

fixes #1749 