### PR TITLE
Apply v0.11.2 updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,7 +211,7 @@ allprojects {
   }
 }
 
-def refTestVersion = 'v0.11.1'
+def refTestVersion = 'v0.11.2'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
 def refTestDownloadDir = "${buildDir}/refTests/${refTestVersion}"
 def refTestExpandDir = "${project.rootDir}/eth-reference-tests/src/referenceTest/resources/eth2.0-spec-tests/"

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/AttestationUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/AttestationUtil.java
@@ -149,11 +149,6 @@ public class AttestationUtil {
       BLSSignatureVerifier signatureVerifier) {
     SSZList<UnsignedLong> attesting_indices = indexed_attestation.getAttesting_indices();
 
-    if (!(attesting_indices.size() <= MAX_VALIDATORS_PER_COMMITTEE)) {
-      LOG.debug("AttestationUtil.is_valid_indexed_attestation: Verify max number of indices");
-      return false;
-    }
-
     List<UnsignedLong> bit_0_indices_sorted =
         attesting_indices.stream().sorted().distinct().collect(Collectors.toList());
     if (!attesting_indices.equals(bit_0_indices_sorted)) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/AttestationValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/AttestationValidator.java
@@ -45,7 +45,7 @@ public class AttestationValidator {
   private static final UnsignedLong MAXIMUM_GOSSIP_CLOCK_DISPARITY =
       UnsignedLong.valueOf(Constants.MAXIMUM_GOSSIP_CLOCK_DISPARITY);
 
-  private final Set<ValidatorAndSlot> receivedValidAttestations =
+  private final Set<ValidatorAndTargetEpoch> receivedValidAttestations =
       ConcurrentLimitedSet.create(
           VALID_ATTESTATION_SET_SIZE, LimitStrategy.DROP_LEAST_RECENTLY_ACCESSED);
   private final RecentChainData recentChainData;
@@ -71,7 +71,7 @@ public class AttestationValidator {
   private ValidationResult addAndCheckFirstValidAttestation(final Attestation attestation) {
     // The attestation is the first valid attestation received for the participating validator for
     // the slot, attestation.data.slot.
-    if (!receivedValidAttestations.add(getValidatorAndSlot(attestation))) {
+    if (!receivedValidAttestations.add(getValidatorAndTargetEpoch(attestation))) {
       return INVALID;
     }
     return VALID;
@@ -92,7 +92,7 @@ public class AttestationValidator {
 
     // The attestation is the first valid attestation received for the participating validator for
     // the slot, attestation.data.slot.
-    if (receivedValidAttestations.contains(getValidatorAndSlot(attestation))) {
+    if (receivedValidAttestations.contains(getValidatorAndTargetEpoch(attestation))) {
       return INVALID;
     }
     return VALID;
@@ -138,9 +138,9 @@ public class AttestationValidator {
     return VALID;
   }
 
-  private ValidatorAndSlot getValidatorAndSlot(final Attestation attestation) {
-    return new ValidatorAndSlot(
-        attestation.getData().getSlot(),
+  private ValidatorAndTargetEpoch getValidatorAndTargetEpoch(final Attestation attestation) {
+    return new ValidatorAndTargetEpoch(
+        attestation.getData().getTarget().getEpoch(),
         attestation.getData().getIndex(),
         attestation.getAggregation_bits().streamAllSetBits().findFirst().orElseThrow());
   }
@@ -185,16 +185,18 @@ public class AttestationValidator {
     return secondsToMillis(lastAllowedTime).plus(MAXIMUM_GOSSIP_CLOCK_DISPARITY);
   }
 
-  private static class ValidatorAndSlot {
-    private final UnsignedLong slot;
+  private static class ValidatorAndTargetEpoch {
+    private final UnsignedLong targetEpoch;
     // Validator is identified via committee index and position to avoid resolving the actual
     // validator ID before checking for duplicates
     private final UnsignedLong committeeIndex;
     private final int committeePosition;
 
-    private ValidatorAndSlot(
-        final UnsignedLong slot, final UnsignedLong committeeIndex, final int committeePosition) {
-      this.slot = slot;
+    private ValidatorAndTargetEpoch(
+        final UnsignedLong targetEpoch,
+        final UnsignedLong committeeIndex,
+        final int committeePosition) {
+      this.targetEpoch = targetEpoch;
       this.committeeIndex = committeeIndex;
       this.committeePosition = committeePosition;
     }
@@ -207,15 +209,15 @@ public class AttestationValidator {
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
-      final ValidatorAndSlot that = (ValidatorAndSlot) o;
+      final ValidatorAndTargetEpoch that = (ValidatorAndTargetEpoch) o;
       return committeePosition == that.committeePosition
-          && Objects.equals(slot, that.slot)
+          && Objects.equals(targetEpoch, that.targetEpoch)
           && Objects.equals(committeeIndex, that.committeeIndex);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(slot, committeeIndex, committeePosition);
+      return Objects.hash(targetEpoch, committeeIndex, committeePosition);
     }
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/Store.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.storage;
 
+import static tech.pegasys.teku.util.config.Constants.SECONDS_PER_SLOT;
+
 import com.google.common.collect.Sets;
 import com.google.common.primitives.UnsignedLong;
 import java.util.Collections;
@@ -95,7 +97,9 @@ public class Store implements ReadOnlyStore {
     checkpoint_states.put(anchorCheckpoint, anchorState);
 
     return new Store(
-        anchorState.getGenesis_time(),
+        anchorState
+            .getGenesis_time()
+            .plus(UnsignedLong.valueOf(SECONDS_PER_SLOT).times(anchorState.getSlot())),
         anchorState.getGenesis_time(),
         anchorCheckpoint,
         anchorCheckpoint,


### PR DESCRIPTION
## PR Description
Applies the updates from v0.11.2 of the spec.  These are all backwards compatible.
https://github.com/ethereum/eth2.0-specs/compare/v0.11.1...v0.11.2 has the full diff

The one part not done is ensuring we set the default eth2 field value in the ENR prior to genesis (to support bootnodes). https://pegasys1.atlassian.net/browse/BC-423 has been logged to ensure we can generate an ENR prior to genesis and that it includes that default value.