### PR TITLE
Fix to okhhtp3 dependency for teku sub-project build

### DIFF
--- a/teku/build.gradle
+++ b/teku/build.gradle
@@ -23,6 +23,7 @@ dependencies {
   api 'com.google.guava:guava'
 
   implementation 'com.google.code.gson:gson'
+  implementation 'com.squareup.okhttp3:okhttp'
   implementation 'info.picocli:picocli'
   implementation 'io.libp2p:jvm-libp2p-minimal'
   implementation 'io.vertx:vertx-core'
@@ -41,7 +42,6 @@ dependencies {
 
   testImplementation testFixtures(project(':util'))
 
-  testImplementation 'com.squareup.okhttp3:okhttp'
   testImplementation 'org.awaitility:awaitility'
 
   test {


### PR DESCRIPTION
## PR Description

The OKHttp3 dependency in _teku/build.gradle_ was enabled only for testing, which made my IntelliJ confused. Not sure how it works for anyone else as OKHttp3 is used in production. Anyway, this fixes things up.