### PR TITLE
Change the default p2p port to 9000

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -41,7 +41,7 @@ public class P2POptions {
       paramLabel = "<INTEGER>",
       description = "Peer to peer port",
       arity = "1")
-  private int p2pPort = 30303;
+  private int p2pPort = 9000;
 
   @Option(
       names = {"--p2p-discovery-enabled"},

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -246,7 +246,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setP2pAdvertisedPort(OptionalInt.empty())
         .setP2pDiscoveryEnabled(true)
         .setP2pInterface("0.0.0.0")
-        .setP2pPort(30303)
+        .setP2pPort(9000)
         .setP2pPrivateKeyFile(null)
         .setInteropEnabled(false)
         .setInteropGenesisTime(0)


### PR DESCRIPTION
## PR Description
Port 30303 is used by eth1 devp2p so commonly has conflicts. Change the default to port 9000 which is used by a few other clients already.

## Fixed Issue(s)
fixes #1748 