### PR TITLE
[BC-428] Disconnect a peer which doesn't respond to N PINGs in a row

### DIFF
--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerAccess.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerAccess.java
@@ -1,0 +1,7 @@
+package tech.pegasys.teku.networking.eth2.peers;
+
+public class Eth2PeerManagerAccess {
+  public static void invokeSendPeriodicPing(Eth2PeerManager peerManager, Eth2Peer peer) {
+    peerManager.sendPeriodicPing(peer);
+  }
+}

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerAccess.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerAccess.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.networking.eth2.peers;
 
 public class Eth2PeerManagerAccess {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -170,6 +171,7 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
     attestationSubnetService.updateSubscriptions(subnetIndices);
   }
 
+  @VisibleForTesting
   Eth2PeerManager getPeerManager() {
     return peerManager;
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
@@ -169,4 +169,8 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
   public void setLongTermAttestationSubnetSubscriptions(final Iterable<Integer> subnetIndices) {
     attestationSubnetService.updateSubscriptions(subnetIndices);
   }
+
+  Eth2PeerManager getPeerManager() {
+    return peerManager;
+  }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
@@ -171,19 +171,19 @@ public class Eth2NetworkBuilder {
     return this;
   }
 
-  public Eth2NetworkBuilder asyncRunner(AsyncRunner asyncRunner) {
+  public Eth2NetworkBuilder asyncRunner(final AsyncRunner asyncRunner) {
     checkNotNull(asyncRunner);
     this.asyncRunner = asyncRunner;
     return this;
   }
 
-  public Eth2NetworkBuilder eth2RpcPingInterval(Duration eth2RpcPingInterval) {
+  public Eth2NetworkBuilder eth2RpcPingInterval(final Duration eth2RpcPingInterval) {
     checkNotNull(eth2RpcPingInterval);
     this.eth2RpcPingInterval = eth2RpcPingInterval;
     return this;
   }
 
-  public Eth2NetworkBuilder eth2RpcOutstandingPingThreshold(int eth2RpcOutstandingPingThreshold) {
+  public Eth2NetworkBuilder eth2RpcOutstandingPingThreshold(final int eth2RpcOutstandingPingThreshold) {
     checkArgument(eth2RpcOutstandingPingThreshold > 0);
     this.eth2RpcOutstandingPingThreshold = eth2RpcOutstandingPingThreshold;
     return this;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
@@ -183,7 +183,8 @@ public class Eth2NetworkBuilder {
     return this;
   }
 
-  public Eth2NetworkBuilder eth2RpcOutstandingPingThreshold(final int eth2RpcOutstandingPingThreshold) {
+  public Eth2NetworkBuilder eth2RpcOutstandingPingThreshold(
+      final int eth2RpcOutstandingPingThreshold) {
     checkArgument(eth2RpcOutstandingPingThreshold > 0);
     this.eth2RpcOutstandingPingThreshold = eth2RpcOutstandingPingThreshold;
     return this;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -39,6 +40,7 @@ import tech.pegasys.teku.util.time.TimeProvider;
 
 public class Eth2NetworkBuilder {
   public static final Duration DEFAULT_ETH2_RPC_PING_INTERVAL = Duration.ofSeconds(10);
+  public static final int DEFAULT_ETH2_RPC_OUTSTANDING_PING_THRESHOLD = 2;
 
   private NetworkConfig config;
   private Eth2Config eth2Config;
@@ -51,6 +53,7 @@ public class Eth2NetworkBuilder {
   private TimeProvider timeProvider;
   private AsyncRunner asyncRunner;
   private Duration eth2RpcPingInterval = DEFAULT_ETH2_RPC_PING_INTERVAL;
+  private int eth2RpcOutstandingPingThreshold = DEFAULT_ETH2_RPC_OUTSTANDING_PING_THRESHOLD;
 
   private Eth2NetworkBuilder() {}
 
@@ -73,7 +76,8 @@ public class Eth2NetworkBuilder {
             metricsSystem,
             attestationSubnetService,
             rpcEncoding,
-            eth2RpcPingInterval);
+            eth2RpcPingInterval,
+            eth2RpcOutstandingPingThreshold);
     final Collection<RpcMethod> eth2RpcMethods = eth2PeerManager.getBeaconChainMethods().all();
     rpcMethods.addAll(eth2RpcMethods);
     peerHandlers.add(eth2PeerManager);
@@ -176,6 +180,12 @@ public class Eth2NetworkBuilder {
   public Eth2NetworkBuilder eth2RpcPingInterval(Duration eth2RpcPingInterval) {
     checkNotNull(eth2RpcPingInterval);
     this.eth2RpcPingInterval = eth2RpcPingInterval;
+    return this;
+  }
+
+  public Eth2NetworkBuilder eth2RpcOutstandingPingThreshold(int eth2RpcOutstandingPingThreshold) {
+    checkArgument(eth2RpcOutstandingPingThreshold > 0);
+    this.eth2RpcOutstandingPingThreshold = eth2RpcOutstandingPingThreshold;
     return this;
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -20,8 +20,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
@@ -47,8 +45,6 @@ import tech.pegasys.teku.ssz.SSZTypes.Bitvector;
 import tech.pegasys.teku.util.async.SafeFuture;
 
 public class Eth2Peer extends DelegatingPeer implements Peer {
-  private static final Logger LOG = LogManager.getLogger();
-
   private final BeaconChainMethods rpcMethods;
   private final StatusMessageFactory statusMessageFactory;
   private final MetadataMessagesFactory metadataMessagesFactory;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2.peers;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.UnsignedLong;
 import java.time.Duration;
 import java.util.Optional;
@@ -160,6 +161,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
     peer.subscribeDisconnect(() -> pingTask.cancel(false));
   }
 
+  @VisibleForTesting
   void sendPeriodicPing(Eth2Peer peer) {
     if (peer.getOutstandingPings() >= eth2RpcOutstandingPingThreshold) {
       LOG.debug("Disconnecting the peer {} due to PING timeout.", peer.getId());

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerTest.java
@@ -176,8 +176,7 @@ public class Eth2PeerManagerTest {
             peer,
             peerManager.getBeaconChainMethods(),
             statusMessageFactory,
-            new MetadataMessagesFactory(),
-            Eth2NetworkBuilder.DEFAULT_ETH2_RPC_OUTSTANDING_PING_THRESHOLD);
+            new MetadataMessagesFactory());
     when(peer.idMatches(eth2Peer)).thenReturn(true);
     return eth2Peer;
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerTest.java
@@ -59,7 +59,8 @@ public class Eth2PeerManagerTest {
           peerValidatorFactory,
           new AttestationSubnetService(),
           rpcEncoding,
-          Eth2NetworkBuilder.DEFAULT_ETH2_RPC_PING_INTERVAL);
+          Eth2NetworkBuilder.DEFAULT_ETH2_RPC_PING_INTERVAL,
+          Eth2NetworkBuilder.DEFAULT_ETH2_RPC_OUTSTANDING_PING_THRESHOLD);
 
   @BeforeEach
   public void setup() {
@@ -175,7 +176,8 @@ public class Eth2PeerManagerTest {
             peer,
             peerManager.getBeaconChainMethods(),
             statusMessageFactory,
-            new MetadataMessagesFactory());
+            new MetadataMessagesFactory(),
+            Eth2NetworkBuilder.DEFAULT_ETH2_RPC_OUTSTANDING_PING_THRESHOLD);
     when(peer.idMatches(eth2Peer)).thenReturn(true);
     return eth2Peer;
   }

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
@@ -24,13 +25,14 @@ import io.libp2p.core.crypto.KeyKt;
 import java.net.BindException;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -81,11 +83,12 @@ public class Eth2NetworkFactory {
     protected AsyncRunner asyncRunner;
     protected EventBus eventBus;
     protected RecentChainData recentChainData;
-    protected List<RpcMethod> rpcMethods = new ArrayList<>();
+    protected Function<RpcMethod, Stream<RpcMethod>> rpcMethodsModifier = Stream::of;
     protected List<PeerHandler> peerHandlers = new ArrayList<>();
     protected RpcEncoding rpcEncoding = RpcEncoding.SSZ_SNAPPY;
     protected GossipEncoding gossipEncoding = GossipEncoding.SSZ_SNAPPY;
     protected Duration eth2RpcPingInterval;
+    protected Integer eth2RpcOutstandingPingThreshold;
 
     public Eth2Network startNetwork() throws Exception {
       setDefaults();
@@ -134,10 +137,15 @@ public class Eth2NetworkFactory {
                 METRICS_SYSTEM,
                 attestationSubnetService,
                 rpcEncoding,
-                eth2RpcPingInterval);
-        final Collection<RpcMethod> eth2Protocols = eth2PeerManager.getBeaconChainMethods().all();
-        // Configure eth2 handlers
-        this.rpcMethods(eth2Protocols).peerHandler(eth2PeerManager);
+                eth2RpcPingInterval,
+                eth2RpcOutstandingPingThreshold);
+
+        List<RpcMethod> rpcMethods =
+            eth2PeerManager.getBeaconChainMethods().all().stream()
+                .flatMap(rpcMethodsModifier)
+                .collect(toList());
+
+        this.peerHandler(eth2PeerManager);
 
         final ReputationManager reputationManager =
             new ReputationManager(
@@ -145,7 +153,11 @@ public class Eth2NetworkFactory {
         final DiscoveryNetwork<?> network =
             DiscoveryNetwork.create(
                 new LibP2PNetwork(
-                    config, reputationManager, METRICS_SYSTEM, rpcMethods, peerHandlers),
+                    config,
+                    reputationManager,
+                    METRICS_SYSTEM,
+                    new ArrayList<>(rpcMethods),
+                    peerHandlers),
                 reputationManager,
                 config);
 
@@ -190,6 +202,10 @@ public class Eth2NetworkFactory {
       if (eth2RpcPingInterval == null) {
         eth2RpcPingInterval = Eth2NetworkBuilder.DEFAULT_ETH2_RPC_PING_INTERVAL;
       }
+      if (eth2RpcOutstandingPingThreshold == null) {
+        eth2RpcOutstandingPingThreshold =
+            Eth2NetworkBuilder.DEFAULT_ETH2_RPC_OUTSTANDING_PING_THRESHOLD;
+      }
       if (recentChainData == null) {
         recentChainData = MemoryOnlyRecentChainData.create(eventBus);
         BeaconChainUtil.create(0, recentChainData).initializeStorage();
@@ -225,9 +241,10 @@ public class Eth2NetworkFactory {
       return this;
     }
 
-    public Eth2P2PNetworkBuilder rpcMethods(final Collection<RpcMethod> methods) {
-      checkNotNull(methods);
-      this.rpcMethods.addAll(methods);
+    public Eth2P2PNetworkBuilder rpcMethodsModifier(
+        Function<RpcMethod, Stream<RpcMethod>> rpcMethodsModifier) {
+      checkNotNull(rpcMethodsModifier);
+      this.rpcMethodsModifier = rpcMethodsModifier;
       return this;
     }
 
@@ -246,6 +263,13 @@ public class Eth2NetworkFactory {
     public Eth2P2PNetworkBuilder eth2RpcPingInterval(Duration eth2RpcPingInterval) {
       checkNotNull(eth2RpcPingInterval);
       this.eth2RpcPingInterval = eth2RpcPingInterval;
+      return this;
+    }
+
+    public Eth2P2PNetworkBuilder eth2RpcOutstandingPingThreshold(
+        int eth2RpcOutstandingPingThreshold) {
+      checkArgument(eth2RpcOutstandingPingThreshold > 0);
+      this.eth2RpcOutstandingPingThreshold = eth2RpcOutstandingPingThreshold;
       return this;
     }
   }


### PR DESCRIPTION
## PR Description

A peer which doesn't respond to several PING request in a row should be disconnected. This should help with stall TCP connections and thus with stucked peers 

## Fixed Issue(s)
Probably fixes #1740 
