### PR TITLE
Fix the BlockFactory to build the new block on the state of the prior slot

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/blocksMainnetInvalid.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/blocksMainnetInvalid.java
@@ -38,7 +38,8 @@ public class blocksMainnetInvalid extends TestSuite {
   @MethodSource({
     "sanityInvalidStateRootSetup",
     "sanityExpectedDepositInBlockSetup",
-    "sanityPrevSlotBlockTransitionSetup"
+    "sanityPrevSlotBlockTransitionSetup",
+    "sanitySameSlotBlockTransitionSetup"
   })
   void sanityProcessBlockInvalid(BeaconState pre, String testName, List<SignedBeaconBlock> blocks) {
     StateTransition stateTransition = new StateTransition();
@@ -66,6 +67,13 @@ public class blocksMainnetInvalid extends TestSuite {
   static Stream<Arguments> sanityPrevSlotBlockTransitionSetup() throws Exception {
     Path configPath = Paths.get("mainnet", "phase0");
     Path path = Paths.get("/mainnet/phase0/sanity/blocks/pyspec_tests/prev_slot_block_transition");
+    return sanityMultiBlockSetupInvalid(path, configPath);
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> sanitySameSlotBlockTransitionSetup() throws Exception {
+    Path configPath = Paths.get("mainnet", "phase0");
+    Path path = Paths.get("/mainnet/phase0/sanity/blocks/pyspec_tests/same_slot_block_transition");
     return sanityMultiBlockSetupInvalid(path, configPath);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/blocksMainnetValid2.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/blocksMainnetValid2.java
@@ -39,7 +39,6 @@ public class blocksMainnetValid2 extends TestSuite {
     "sanityEmptyEpochTransitionSetup",
     "sanityHistoricalBatchSetup",
     "sanityProposerSlashingSetup",
-    "sanitySameSlotBlockTransitionSetup",
     "sanitySkippedSlotsSetup",
     "sanityVoluntaryExitSetup",
   })
@@ -74,13 +73,6 @@ public class blocksMainnetValid2 extends TestSuite {
   static Stream<Arguments> sanityProposerSlashingSetup() throws Exception {
     Path configPath = Paths.get("mainnet", "phase0");
     Path path = Paths.get("/mainnet/phase0/sanity/blocks/pyspec_tests/proposer_slashing");
-    return sanityMultiBlockSetup(path, configPath);
-  }
-
-  @MustBeClosed
-  static Stream<Arguments> sanitySameSlotBlockTransitionSetup() throws Exception {
-    Path configPath = Paths.get("mainnet", "phase0");
-    Path path = Paths.get("/mainnet/phase0/sanity/blocks/pyspec_tests/same_slot_block_transition");
     return sanityMultiBlockSetup(path, configPath);
   }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/blocksMinimal.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/blocksMinimal.java
@@ -47,7 +47,6 @@ public class blocksMinimal extends TestSuite {
     "sanityEmptyEpochTransitionSetup",
     "sanityHistoricalBatchSetup",
     "sanityProposerSlashingSetup",
-    "sanitySameSlotBlockTransitionSetup",
     "sanitySkippedSlotsSetup",
     "sanityVoluntaryExitSetup",
   })
@@ -129,13 +128,6 @@ public class blocksMinimal extends TestSuite {
   }
 
   @MustBeClosed
-  static Stream<Arguments> sanitySameSlotBlockTransitionSetup() throws Exception {
-    Path configPath = Paths.get("minimal", "phase0");
-    Path path = Paths.get("/minimal/phase0/sanity/blocks/pyspec_tests/same_slot_block_transition");
-    return sanityMultiBlockSetup(path, configPath);
-  }
-
-  @MustBeClosed
   static Stream<Arguments> sanitySkippedSlotsSetup() throws Exception {
     Path configPath = Paths.get("minimal", "phase0");
     Path path = Paths.get("/minimal/phase0/sanity/blocks/pyspec_tests/skipped_slots");
@@ -153,7 +145,8 @@ public class blocksMinimal extends TestSuite {
   @MethodSource({
     "sanityInvalidStateRootSetup",
     "sanityExpectedDepositInBlockSetup",
-    "sanityPrevSlotBlockTransitionSetup"
+    "sanityPrevSlotBlockTransitionSetup",
+    "sanitySameSlotBlockTransitionSetup"
   })
   void sanityProcessBlockInvalid(BeaconState pre, String testName, List<SignedBeaconBlock> blocks) {
     StateTransition stateTransition = new StateTransition();
@@ -182,6 +175,13 @@ public class blocksMinimal extends TestSuite {
   static Stream<Arguments> sanityPrevSlotBlockTransitionSetup() throws Exception {
     Path configPath = Paths.get("minimal", "phase0");
     Path path = Paths.get("/minimal/phase0/sanity/blocks/pyspec_tests/prev_slot_block_transition");
+    return sanityMultiBlockSetupInvalid(path, configPath);
+  }
+
+  @MustBeClosed
+  static Stream<Arguments> sanitySameSlotBlockTransitionSetup() throws Exception {
+    Path configPath = Paths.get("minimal", "phase0");
+    Path path = Paths.get("/minimal/phase0/sanity/blocks/pyspec_tests/same_slot_block_transition");
     return sanityMultiBlockSetupInvalid(path, configPath);
   }
 }

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/BlockProcessorUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/BlockProcessorUtil.java
@@ -104,6 +104,9 @@ public final class BlockProcessorUtil {
       checkArgument(
           block.getParent_root().equals(state.getLatest_block_header().hash_tree_root()),
           "process_block_header: Verify that the parent matches");
+      checkArgument(
+          state.getLatest_block_header().getSlot().compareTo(block.getSlot()) < 0,
+          "Block must be after parent");
 
       // Cache the current block as the new latest block
       state.setLatest_block_header(

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -235,6 +235,9 @@ public class ForkChoiceUtil {
     if (preState == null) {
       return Optional.of(BlockImportResult.FAILED_UNKNOWN_PARENT);
     }
+    if (preState.getSlot().compareTo(block.getSlot()) >= 0) {
+      return Optional.of(BlockImportResult.FAILED_INVALID_ANCESTRY);
+    }
     if (blockIsFromFuture(block, store)) {
       return Optional.of(BlockImportResult.FAILED_BLOCK_IS_FROM_FUTURE);
     }


### PR DESCRIPTION
## PR Description
`BlockFactory` was incorrectly running `process_slots` up to the slot of the new block, rather than to the slot prior to the block (processing the block is what moves the state forward that last slot).

Avoid these kinds of errors in the future by pulling validation that the block's slot is correct into the precondition checks.