### PR TITLE
[BC-418] Search for block roots by slot across available states

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/blocks/SignedBlockAndState.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/blocks/SignedBlockAndState.java
@@ -52,4 +52,21 @@ public class SignedBlockAndState {
   public BeaconState getState() {
     return state;
   }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof SignedBlockAndState)) {
+      return false;
+    }
+    final SignedBlockAndState that = (SignedBlockAndState) o;
+    return Objects.equals(block, that.block) && Objects.equals(state, that.state);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(block, state);
+  }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
@@ -14,10 +14,12 @@
 package tech.pegasys.teku.datastructures.forkchoice;
 
 import com.google.common.primitives.UnsignedLong;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 
@@ -44,6 +46,8 @@ public interface ReadOnlyStore {
   BeaconBlock getBlock(Bytes32 blockRoot);
 
   SignedBeaconBlock getSignedBlock(Bytes32 blockRoot);
+
+  Optional<SignedBlockAndState> getBlockAndState(Bytes32 blockRoot);
 
   boolean containsBlock(Bytes32 blockRoot);
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -570,6 +570,14 @@ class RecentChainDataTest {
   }
 
   @Test
+  public void getBlockRootBySlot_forSlotAfterBestBlock() throws Exception {
+    final SignedBlockAndState bestBlock = advanceBestBlock(storageClient);
+
+    final UnsignedLong targetSlot = bestBlock.getSlot().plus(UnsignedLong.ONE);
+    assertThat(storageClient.getBlockRootBySlot(targetSlot)).contains(bestBlock.getRoot());
+  }
+
+  @Test
   public void getBlockRootBySlot_queryEntireChain() throws Exception {
     final UnsignedLong historicalRoots = UnsignedLong.valueOf(Constants.SLOTS_PER_HISTORICAL_ROOT);
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/TrackingReorgEventChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/TrackingReorgEventChannel.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.api;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes32;
+
+public class TrackingReorgEventChannel implements ReorgEventChannel {
+  private final List<ReorgEvent> reorgEvents = new ArrayList<>();
+
+  @Override
+  public void reorgOccurred(final Bytes32 bestBlockRoot, final UnsignedLong bestSlot) {
+    reorgEvents.add(new ReorgEvent(bestBlockRoot, bestSlot));
+  }
+
+  public List<ReorgEvent> getReorgEvents() {
+    return reorgEvents;
+  }
+
+  public static class ReorgEvent {
+    private final Bytes32 bestBlockRoot;
+    private final UnsignedLong bestSlot;
+
+    public ReorgEvent(final Bytes32 bestBlockRoot, final UnsignedLong bestSlot) {
+      this.bestBlockRoot = bestBlockRoot;
+      this.bestSlot = bestSlot;
+    }
+
+    public Bytes32 getBestBlockRoot() {
+      return bestBlockRoot;
+    }
+
+    public UnsignedLong getBestSlot() {
+      return bestSlot;
+    }
+  }
+}

--- a/util/src/main/java/tech/pegasys/teku/util/unsignedlong/UnsignedLongMath.java
+++ b/util/src/main/java/tech/pegasys/teku/util/unsignedlong/UnsignedLongMath.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.util.unsignedlong;
+
+import com.google.common.primitives.UnsignedLong;
+
+public class UnsignedLongMath {
+
+  public static UnsignedLong max(final UnsignedLong a, final UnsignedLong b) {
+    return a.compareTo(b) >= 0 ? a : b;
+  }
+}

--- a/util/src/test/java/tech/pegasys/teku/util/unsignedlong/UnsignedLongMathTest.java
+++ b/util/src/test/java/tech/pegasys/teku/util/unsignedlong/UnsignedLongMathTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.util.unsignedlong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Test;
+
+public class UnsignedLongMathTest {
+
+  @Test
+  public void max_firstValueIsLarger() {
+    final UnsignedLong a = UnsignedLong.valueOf(2);
+    final UnsignedLong b = UnsignedLong.valueOf(1);
+
+    final UnsignedLong result = UnsignedLongMath.max(a, b);
+    assertThat(result).isEqualTo(a);
+  }
+
+  @Test
+  public void max_secondValueIsLarger() {
+    final UnsignedLong a = UnsignedLong.valueOf(1);
+    final UnsignedLong b = UnsignedLong.valueOf(2);
+
+    final UnsignedLong result = UnsignedLongMath.max(a, b);
+    assertThat(result).isEqualTo(b);
+  }
+
+  @Test
+  public void max_valuesAreEqual() {
+    final UnsignedLong a = UnsignedLong.valueOf(10);
+    final UnsignedLong b = UnsignedLong.valueOf(10);
+
+    final UnsignedLong result = UnsignedLongMath.max(a, b);
+    assertThat(result).isEqualTo(a);
+    assertThat(result).isEqualTo(b);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Update `RecentChainData.getBlockRootBySlot` to search across all available states instead of only the best block state.

Also:
* Update `RecentChainDataTest` to use new `InMemoryStorageSystem`
* Add `UnsignedLongMath` utility
* Add `Store.getBlockAndState`