### PR TITLE
Update to jvm-libp2p 0.4.0 release

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -27,7 +27,7 @@ dependencyManagement {
     dependency 'io.protostuff:protostuff-core:1.6.2'
     dependency 'io.protostuff:protostuff-runtime:1.6.2'
 
-    dependency 'io.libp2p:jvm-libp2p-minimal:0.3.4-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p-minimal:0.4.0-RELEASE'
     dependency 'org.jetbrains.kotlin:kotlin-stdlib:1.3.61'
 
     dependency 'io.pkts:pkts-core:3.0.3'


### PR DESCRIPTION
## PR Description
Update to jvm-libp2p 0.4 release.

Significantly reduces the amount of noise in the logs when peers disconnect unexpectedly or send invalid libp2p data.