### PR TITLE
Should consider peer suitable if head block more than one epoch ahead

### DIFF
--- a/sync/src/main/java/tech/pegasys/teku/sync/SyncManager.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/SyncManager.java
@@ -232,10 +232,10 @@ public class SyncManager extends Service {
         ourFinalizedEpoch.toString(10));
     return !peersWithSyncErrors.contains(peer.getId())
         && (peer.getStatus().getFinalizedEpoch().compareTo(ourFinalizedEpoch) > 0
-            || isMoreThanAnEpochAhead(peer));
+            || isHeadMoreThanAnEpochAhead(peer));
   }
 
-  private boolean isMoreThanAnEpochAhead(final Eth2Peer peer) {
+  private boolean isHeadMoreThanAnEpochAhead(final Eth2Peer peer) {
     final UnsignedLong ourHeadSlot = storageClient.getBestSlot();
     final UnsignedLong theirHeadSlot = peer.getStatus().getHeadSlot();
     return theirHeadSlot.compareTo(ourHeadSlot.plus(UnsignedLong.valueOf(SLOTS_PER_EPOCH))) > 0;


### PR DESCRIPTION
## PR Description
Rather than considering sync complete if we have the same finalised epoch as all our peers, consider peers valid sync targets if their head block is more than one epoch ahead of ours.

This avoid sync stalling if there are more than 10 non-finalised epochs (as the BlockPropagationManager won't be able to catch up that far).