### PR TITLE
1800 - /beacon/block now returns block root

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/beacon/GetBlockWithDataIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/beacon/GetBlockWithDataIntegrationTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import okhttp3.Response;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.response.GetBlockResponse;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.beacon.GetBlock;
@@ -36,10 +37,9 @@ public class GetBlockWithDataIntegrationTest extends AbstractDataBackedRestAPIIn
     final List<SignedBeaconBlock> blocks = withBlockDataAtSlot(SIX, SEVEN, EIGHT);
     final Response response = getByEpoch(ONE);
     final String responseBody = response.body().string();
-    final SignedBeaconBlock result =
-        jsonProvider.jsonToObject(responseBody, SignedBeaconBlock.class);
+    final GetBlockResponse result = jsonProvider.jsonToObject(responseBody, GetBlockResponse.class);
 
-    assertThat(result).usingRecursiveComparison().isEqualTo(blocks.get(2));
+    assertThat(result.signedBeaconBlock).usingRecursiveComparison().isEqualTo(blocks.get(2));
     assertThat(response.code()).isEqualTo(SC_OK);
   }
 
@@ -48,10 +48,9 @@ public class GetBlockWithDataIntegrationTest extends AbstractDataBackedRestAPIIn
     final List<SignedBeaconBlock> blocks = withBlockDataAtSlot(EIGHT, NINE);
     final Response response = getBySlot(EIGHT);
     final String responseBody = response.body().string();
-    final SignedBeaconBlock result =
-        jsonProvider.jsonToObject(responseBody, SignedBeaconBlock.class);
+    final GetBlockResponse result = jsonProvider.jsonToObject(responseBody, GetBlockResponse.class);
 
-    assertThat(result).usingRecursiveComparison().isEqualTo(blocks.get(0));
+    assertThat(result.signedBeaconBlock).usingRecursiveComparison().isEqualTo(blocks.get(0));
     assertThat(response.code()).isEqualTo(SC_OK);
   }
 
@@ -60,10 +59,9 @@ public class GetBlockWithDataIntegrationTest extends AbstractDataBackedRestAPIIn
     final List<SignedBeaconBlock> blocks = withBlockDataAtSlot(SIX, SEVEN, NINE, TEN);
     final Response response = getByEpoch(ONE);
     final String responseBody = response.body().string();
-    final SignedBeaconBlock result =
-        jsonProvider.jsonToObject(responseBody, SignedBeaconBlock.class);
+    final GetBlockResponse result = jsonProvider.jsonToObject(responseBody, GetBlockResponse.class);
 
-    assertThat(result).usingRecursiveComparison().isEqualTo(blocks.get(1));
+    assertThat(result.signedBeaconBlock).usingRecursiveComparison().isEqualTo(blocks.get(1));
     assertThat(response.code()).isEqualTo(SC_OK);
   }
 
@@ -72,10 +70,10 @@ public class GetBlockWithDataIntegrationTest extends AbstractDataBackedRestAPIIn
     final List<SignedBeaconBlock> blocks = withBlockDataAtSlot(SIX, SEVEN, TEN);
     final Response response = getBySlot(NINE);
     final String responseBody = response.body().string();
-    final SignedBeaconBlock result =
-        jsonProvider.jsonToObject(responseBody, SignedBeaconBlock.class);
+    final GetBlockResponse result =
+        jsonProvider.jsonToObject(responseBody, GetBlockResponse.class);
 
-    assertThat(result).usingRecursiveComparison().isEqualTo(blocks.get(1));
+    assertThat(result.signedBeaconBlock).usingRecursiveComparison().isEqualTo(blocks.get(1));
     assertThat(response.code()).isEqualTo(SC_OK);
   }
 

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/beacon/GetBlockWithDataIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/beacon/GetBlockWithDataIntegrationTest.java
@@ -70,8 +70,7 @@ public class GetBlockWithDataIntegrationTest extends AbstractDataBackedRestAPIIn
     final List<SignedBeaconBlock> blocks = withBlockDataAtSlot(SIX, SEVEN, TEN);
     final Response response = getBySlot(NINE);
     final String responseBody = response.body().string();
-    final GetBlockResponse result =
-        jsonProvider.jsonToObject(responseBody, GetBlockResponse.class);
+    final GetBlockResponse result = jsonProvider.jsonToObject(responseBody, GetBlockResponse.class);
 
     assertThat(result.signedBeaconBlock).usingRecursiveComparison().isEqualTo(blocks.get(1));
     assertThat(response.code()).isEqualTo(SC_OK);

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetBlock.java
@@ -47,6 +47,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
+import tech.pegasys.teku.beaconrestapi.schema.GetBlockResponse;
 import tech.pegasys.teku.provider.JsonProvider;
 
 public class GetBlock implements Handler {
@@ -79,9 +80,7 @@ public class GetBlock implements Handler {
       description =
           "Returns the beacon chain block that matches the specified epoch, slot, or block root.",
       responses = {
-        @OpenApiResponse(
-            status = RES_OK,
-            content = @OpenApiContent(from = SignedBeaconBlock.class)),
+        @OpenApiResponse(status = RES_OK, content = @OpenApiContent(from = GetBlockResponse.class)),
         @OpenApiResponse(status = RES_BAD_REQUEST, description = "Invalid parameter supplied"),
         @OpenApiResponse(status = RES_NOT_FOUND, description = "Specified block not found")
       })
@@ -131,7 +130,7 @@ public class GetBlock implements Handler {
     if (blockOptional.isPresent()) {
       SignedBeaconBlock signedBeaconBlock = blockOptional.get();
       ctx.header(Header.CACHE_CONTROL, getMaxAgeForSignedBlock(provider, signedBeaconBlock));
-      return jsonProvider.objectToJSON(signedBeaconBlock);
+      return jsonProvider.objectToJSON(new GetBlockResponse(signedBeaconBlock));
     } else {
       ctx.status(SC_NOT_FOUND);
       return null;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetBlock.java
@@ -45,9 +45,8 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.ChainDataProvider;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock;
+import tech.pegasys.teku.api.response.GetBlockResponse;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
-import tech.pegasys.teku.beaconrestapi.schema.GetBlockResponse;
 import tech.pegasys.teku.provider.JsonProvider;
 
 public class GetBlock implements Handler {
@@ -125,12 +124,13 @@ public class GetBlock implements Handler {
     }
   }
 
-  private String handleResponseContext(Context ctx, Optional<SignedBeaconBlock> blockOptional)
+  private String handleResponseContext(Context ctx, Optional<GetBlockResponse> blockOptional)
       throws JsonProcessingException {
     if (blockOptional.isPresent()) {
-      SignedBeaconBlock signedBeaconBlock = blockOptional.get();
-      ctx.header(Header.CACHE_CONTROL, getMaxAgeForSignedBlock(provider, signedBeaconBlock));
-      return jsonProvider.objectToJSON(new GetBlockResponse(signedBeaconBlock));
+      GetBlockResponse response = blockOptional.get();
+      ctx.header(
+          Header.CACHE_CONTROL, getMaxAgeForSignedBlock(provider, response.signedBeaconBlock));
+      return jsonProvider.objectToJSON(response);
     } else {
       ctx.status(SC_NOT_FOUND);
       return null;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/schema/GetBlockResponse.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/schema/GetBlockResponse.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.schema;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import tech.pegasys.teku.api.schema.SignedBeaconBlock;
+
+public class GetBlockResponse {
+
+  @JsonProperty("beacon_block")
+  public final SignedBeaconBlock signedBeaconBlock;
+
+  public final String root;
+
+  public GetBlockResponse(final SignedBeaconBlock signedBeaconBlock) {
+    this.signedBeaconBlock = signedBeaconBlock;
+    this.root =
+        signedBeaconBlock
+            .asInternalSignedBeaconBlock()
+            .getMessage()
+            .hash_tree_root()
+            .toHexString()
+            .toLowerCase();
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetBlockTest.java
@@ -41,9 +41,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.api.ChainDataProvider;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock;
+import tech.pegasys.teku.api.response.GetBlockResponse;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
-import tech.pegasys.teku.beaconrestapi.schema.GetBlockResponse;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.util.async.SafeFuture;
@@ -102,28 +101,23 @@ public class GetBlockTest {
   @Test
   public void shouldReturnBlockWhenQueryByRoot() throws Exception {
     final Map<String, List<String>> params = Map.of(ROOT, List.of(blockRoot.toHexString()));
-    SafeFuture<Optional<SignedBeaconBlock>> providerData =
-        completedFuture(Optional.of(new SignedBeaconBlock(signedBeaconBlock)));
+    SafeFuture<Optional<GetBlockResponse>> providerData =
+        completedFuture(Optional.of(new GetBlockResponse(signedBeaconBlock)));
     when(context.queryParamMap()).thenReturn(params);
     when(provider.getBlockByBlockRoot(blockRoot)).thenReturn(providerData);
-
-    GetBlockResponse expectedResponse =
-        new GetBlockResponse(new SignedBeaconBlock(signedBeaconBlock));
-    assertThat(expectedResponse.root)
-        .isEqualTo(signedBeaconBlock.getMessage().hash_tree_root().toHexString().toLowerCase());
 
     handler.handle(context);
     verify(context).result(args.capture());
     verify(context).header(Header.CACHE_CONTROL, CACHE_NONE);
     SafeFuture<String> future = args.getValue();
     String data = future.get();
-    assertThat(data).isEqualTo(jsonProvider.objectToJSON(expectedResponse));
+    assertThat(data).isEqualTo(jsonProvider.objectToJSON(providerData.get().get()));
   }
 
   @Test
   public void shouldReturnEmptyWhenQueryByRootNotFound() throws Exception {
     final Map<String, List<String>> params = Map.of(ROOT, List.of(blockRoot.toHexString()));
-    SafeFuture<Optional<SignedBeaconBlock>> providerData = completedFuture(Optional.empty());
+    SafeFuture<Optional<GetBlockResponse>> providerData = completedFuture(Optional.empty());
     when(context.queryParamMap()).thenReturn(params);
     when(provider.getBlockByBlockRoot(blockRoot)).thenReturn(providerData);
 
@@ -134,28 +128,23 @@ public class GetBlockTest {
   @Test
   public void shouldReturnBlockWhenQueryBySlot() throws Exception {
     final Map<String, List<String>> params = Map.of(SLOT, List.of(ONE.toString()));
-    SafeFuture<Optional<SignedBeaconBlock>> providerData =
-        completedFuture(Optional.of(new SignedBeaconBlock(signedBeaconBlock)));
+    SafeFuture<Optional<GetBlockResponse>> providerData =
+        completedFuture(Optional.of(new GetBlockResponse(signedBeaconBlock)));
     when(context.queryParamMap()).thenReturn(params);
     when(provider.getBlockBySlot(ONE)).thenReturn(providerData);
-
-    GetBlockResponse expectedResponse =
-        new GetBlockResponse(new SignedBeaconBlock(signedBeaconBlock));
-    assertThat(expectedResponse.root)
-        .isEqualTo(signedBeaconBlock.getMessage().hash_tree_root().toHexString().toLowerCase());
 
     handler.handle(context);
     verify(context).result(args.capture());
     verify(context).header(Header.CACHE_CONTROL, CACHE_NONE);
     SafeFuture<String> future = args.getValue();
     String data = future.get();
-    assertThat(data).isEqualTo(jsonProvider.objectToJSON(expectedResponse));
+    assertThat(data).isEqualTo(jsonProvider.objectToJSON(providerData.get().get()));
   }
 
   @Test
   public void shouldReturnEmptyWhenQueryBySlotNotFound() throws Exception {
     final Map<String, List<String>> params = Map.of(SLOT, List.of(ONE.toString()));
-    SafeFuture<Optional<SignedBeaconBlock>> providerData = completedFuture(Optional.empty());
+    SafeFuture<Optional<GetBlockResponse>> providerData = completedFuture(Optional.empty());
     when(context.queryParamMap()).thenReturn(params);
     when(provider.getBlockBySlot(ONE)).thenReturn(providerData);
 
@@ -166,27 +155,23 @@ public class GetBlockTest {
   @Test
   public void shouldReturnBlockWhenQueryByEpoch() throws Exception {
     final Map<String, List<String>> params = Map.of(EPOCH, List.of(ONE.toString()));
-    SafeFuture<Optional<SignedBeaconBlock>> providerData =
-        completedFuture(Optional.of(new SignedBeaconBlock(signedBeaconBlock)));
+    SafeFuture<Optional<GetBlockResponse>> providerData =
+        completedFuture(Optional.of(new GetBlockResponse(signedBeaconBlock)));
     when(context.queryParamMap()).thenReturn(params);
     when(provider.getBlockBySlot(UnsignedLong.valueOf(8))).thenReturn(providerData);
 
-    GetBlockResponse expectedResponse =
-        new GetBlockResponse(new SignedBeaconBlock(signedBeaconBlock));
-    assertThat(expectedResponse.root)
-        .isEqualTo(signedBeaconBlock.getMessage().hash_tree_root().toHexString().toLowerCase());
     handler.handle(context);
     verify(context).result(args.capture());
     verify(context).header(Header.CACHE_CONTROL, CACHE_NONE);
     SafeFuture<String> future = args.getValue();
     String data = future.get();
-    assertThat(data).isEqualTo(jsonProvider.objectToJSON(expectedResponse));
+    assertThat(data).isEqualTo(jsonProvider.objectToJSON(providerData.get().get()));
   }
 
   @Test
   public void shouldReturnEmptyWhenQueryByEpochNotFound() throws Exception {
     final Map<String, List<String>> params = Map.of(EPOCH, List.of(ONE.toString()));
-    SafeFuture<Optional<SignedBeaconBlock>> providerData = completedFuture(Optional.empty());
+    SafeFuture<Optional<GetBlockResponse>> providerData = completedFuture(Optional.empty());
     when(context.queryParamMap()).thenReturn(params);
     when(provider.getBlockBySlot(UnsignedLong.valueOf(8))).thenReturn(providerData);
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetBlockTest.java
@@ -43,6 +43,7 @@ import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
+import tech.pegasys.teku.beaconrestapi.schema.GetBlockResponse;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.util.async.SafeFuture;
@@ -106,12 +107,17 @@ public class GetBlockTest {
     when(context.queryParamMap()).thenReturn(params);
     when(provider.getBlockByBlockRoot(blockRoot)).thenReturn(providerData);
 
+    GetBlockResponse expectedResponse =
+        new GetBlockResponse(new SignedBeaconBlock(signedBeaconBlock));
+    assertThat(expectedResponse.root)
+        .isEqualTo(signedBeaconBlock.getMessage().hash_tree_root().toHexString().toLowerCase());
+
     handler.handle(context);
     verify(context).result(args.capture());
     verify(context).header(Header.CACHE_CONTROL, CACHE_NONE);
     SafeFuture<String> future = args.getValue();
     String data = future.get();
-    assertThat(data).isEqualTo(jsonProvider.objectToJSON(new SignedBeaconBlock(signedBeaconBlock)));
+    assertThat(data).isEqualTo(jsonProvider.objectToJSON(expectedResponse));
   }
 
   @Test
@@ -133,12 +139,17 @@ public class GetBlockTest {
     when(context.queryParamMap()).thenReturn(params);
     when(provider.getBlockBySlot(ONE)).thenReturn(providerData);
 
+    GetBlockResponse expectedResponse =
+        new GetBlockResponse(new SignedBeaconBlock(signedBeaconBlock));
+    assertThat(expectedResponse.root)
+        .isEqualTo(signedBeaconBlock.getMessage().hash_tree_root().toHexString().toLowerCase());
+
     handler.handle(context);
     verify(context).result(args.capture());
     verify(context).header(Header.CACHE_CONTROL, CACHE_NONE);
     SafeFuture<String> future = args.getValue();
     String data = future.get();
-    assertThat(data).isEqualTo(jsonProvider.objectToJSON(new SignedBeaconBlock(signedBeaconBlock)));
+    assertThat(data).isEqualTo(jsonProvider.objectToJSON(expectedResponse));
   }
 
   @Test
@@ -160,12 +171,16 @@ public class GetBlockTest {
     when(context.queryParamMap()).thenReturn(params);
     when(provider.getBlockBySlot(UnsignedLong.valueOf(8))).thenReturn(providerData);
 
+    GetBlockResponse expectedResponse =
+        new GetBlockResponse(new SignedBeaconBlock(signedBeaconBlock));
+    assertThat(expectedResponse.root)
+        .isEqualTo(signedBeaconBlock.getMessage().hash_tree_root().toHexString().toLowerCase());
     handler.handle(context);
     verify(context).result(args.capture());
     verify(context).header(Header.CACHE_CONTROL, CACHE_NONE);
     SafeFuture<String> future = args.getValue();
     String data = future.get();
-    assertThat(data).isEqualTo(jsonProvider.objectToJSON(new SignedBeaconBlock(signedBeaconBlock)));
+    assertThat(data).isEqualTo(jsonProvider.objectToJSON(expectedResponse));
   }
 
   @Test

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.response.GetBlockResponse;
 import tech.pegasys.teku.api.schema.BeaconChainHead;
 import tech.pegasys.teku.api.schema.BeaconHead;
 import tech.pegasys.teku.api.schema.BeaconState;
@@ -102,13 +103,13 @@ public class ChainDataProvider {
                             .collect(Collectors.toList())));
   }
 
-  public SafeFuture<Optional<SignedBeaconBlock>> getBlockBySlot(final UnsignedLong slot) {
+  public SafeFuture<Optional<GetBlockResponse>> getBlockBySlot(final UnsignedLong slot) {
     if (!isStoreAvailable()) {
       return SafeFuture.failedFuture(new ChainDataUnavailableException());
     }
     return combinedChainDataClient
         .getBlockBySlot(slot)
-        .thenApply(block -> block.map(SignedBeaconBlock::new));
+        .thenApply(block -> block.map(GetBlockResponse::new));
   }
 
   public boolean isStoreAvailable() {
@@ -119,13 +120,13 @@ public class ChainDataProvider {
     return combinedChainDataClient.getBestBlockRoot();
   }
 
-  public SafeFuture<Optional<SignedBeaconBlock>> getBlockByBlockRoot(final Bytes32 blockParam) {
+  public SafeFuture<Optional<GetBlockResponse>> getBlockByBlockRoot(final Bytes32 blockParam) {
     if (!isStoreAvailable()) {
       return SafeFuture.failedFuture(new ChainDataUnavailableException());
     }
     return combinedChainDataClient
         .getBlockByBlockRoot(blockParam)
-        .thenApply(block -> block.map(SignedBeaconBlock::new));
+        .thenApply(block -> block.map(GetBlockResponse::new));
   }
 
   public SafeFuture<Optional<BeaconState>> getStateByBlockRoot(final Bytes32 blockRoot) {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/response/GetBlockResponse.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/response/GetBlockResponse.java
@@ -11,8 +11,9 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beaconrestapi.schema;
+package tech.pegasys.teku.api.response;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 
@@ -23,14 +24,17 @@ public class GetBlockResponse {
 
   public final String root;
 
-  public GetBlockResponse(final SignedBeaconBlock signedBeaconBlock) {
+  public GetBlockResponse(
+      final tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock signedBeaconBlock) {
+    this.signedBeaconBlock = new SignedBeaconBlock(signedBeaconBlock);
+    this.root = signedBeaconBlock.getMessage().hash_tree_root().toHexString().toLowerCase();
+  }
+
+  @JsonCreator
+  public GetBlockResponse(
+      @JsonProperty("root") final String root,
+      @JsonProperty("beacon_block") final SignedBeaconBlock signedBeaconBlock) {
+    this.root = root;
     this.signedBeaconBlock = signedBeaconBlock;
-    this.root =
-        signedBeaconBlock
-            .asInternalSignedBeaconBlock()
-            .getMessage()
-            .hash_tree_root()
-            .toHexString()
-            .toLowerCase();
   }
 }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ExecutionException;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.response.GetBlockResponse;
 import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.api.schema.BeaconHead;
 import tech.pegasys.teku.api.schema.BeaconState;
@@ -183,7 +184,7 @@ public class ChainDataProviderTest {
   public void getBlockBySlot_shouldThrowWhenStoreNotFound() {
     final ChainDataProvider provider = new ChainDataProvider(null, mockCombinedChainDataClient);
 
-    final SafeFuture<Optional<SignedBeaconBlock>> future = provider.getBlockBySlot(ZERO);
+    final SafeFuture<Optional<GetBlockResponse>> future = provider.getBlockBySlot(ZERO);
     assertThatThrownBy(future::get).hasCauseInstanceOf(ChainDataUnavailableException.class);
   }
 
@@ -196,7 +197,7 @@ public class ChainDataProviderTest {
     when(mockCombinedChainDataClient.isStoreAvailable()).thenReturn(true);
     when(mockCombinedChainDataClient.getBlockBySlot(ZERO))
         .thenReturn(completedFuture(Optional.empty()));
-    final SafeFuture<Optional<SignedBeaconBlock>> future = provider.getBlockBySlot(ZERO);
+    final SafeFuture<Optional<GetBlockResponse>> future = provider.getBlockBySlot(ZERO);
     assertTrue(future.get().isEmpty());
   }
 
@@ -210,10 +211,10 @@ public class ChainDataProviderTest {
 
     when(mockCombinedChainDataClient.isStoreAvailable()).thenReturn(true);
     when(mockCombinedChainDataClient.getBlockBySlot(ZERO)).thenReturn(data);
-    final SafeFuture<Optional<SignedBeaconBlock>> future = provider.getBlockBySlot(ZERO);
+    final SafeFuture<Optional<GetBlockResponse>> future = provider.getBlockBySlot(ZERO);
     verify(mockCombinedChainDataClient).getBlockBySlot(ZERO);
 
-    final SignedBeaconBlock result = future.get().get();
+    final SignedBeaconBlock result = future.get().get().signedBeaconBlock;
     assertThat(result)
         .usingRecursiveComparison()
         .isEqualTo(new SignedBeaconBlock(signedBeaconBlock));
@@ -222,7 +223,7 @@ public class ChainDataProviderTest {
   @Test
   public void getBlockByBlockRoot_shouldThrowWhenStoreNotFound() {
     final ChainDataProvider provider = new ChainDataProvider(null, mockCombinedChainDataClient);
-    final SafeFuture<Optional<SignedBeaconBlock>> future = provider.getBlockByBlockRoot(blockRoot);
+    final SafeFuture<Optional<GetBlockResponse>> future = provider.getBlockByBlockRoot(blockRoot);
     assertThatThrownBy(future::get).hasCauseInstanceOf(ChainDataUnavailableException.class);
   }
 
@@ -235,7 +236,7 @@ public class ChainDataProviderTest {
     when(mockCombinedChainDataClient.isStoreAvailable()).thenReturn(true);
     when(mockCombinedChainDataClient.getBlockByBlockRoot(blockRoot))
         .thenReturn(completedFuture(Optional.empty()));
-    final SafeFuture<Optional<SignedBeaconBlock>> future = provider.getBlockByBlockRoot(blockRoot);
+    final SafeFuture<Optional<GetBlockResponse>> future = provider.getBlockByBlockRoot(blockRoot);
     assertTrue(future.get().isEmpty());
   }
 
@@ -249,10 +250,10 @@ public class ChainDataProviderTest {
 
     when(mockCombinedChainDataClient.isStoreAvailable()).thenReturn(true);
     when(mockCombinedChainDataClient.getBlockByBlockRoot(blockRoot)).thenReturn(data);
-    final SafeFuture<Optional<SignedBeaconBlock>> future = provider.getBlockByBlockRoot(blockRoot);
+    final SafeFuture<Optional<GetBlockResponse>> future = provider.getBlockByBlockRoot(blockRoot);
     verify(mockCombinedChainDataClient).getBlockByBlockRoot(blockRoot);
 
-    final SignedBeaconBlock result = future.get().get();
+    final SignedBeaconBlock result = future.get().get().signedBeaconBlock;
     assertThat(result)
         .usingRecursiveComparison()
         .isEqualTo(new SignedBeaconBlock(signedBeaconBlock));


### PR DESCRIPTION
 - wrapped the response for GetBlock and included the beacon block header in the response object.

Signed-off-by: Paul Harris <paul.harris@consensys.net>
