### PR TITLE
disable doc commit until we find a way to make it work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,12 +405,12 @@ workflows:
       - extractAPISpec:
           requires:
             - publish
-      - publishAPIDoc:
-          requires:
-            - extractAPISpec
-          filters:
-            branches:
-              only: master
+      # - publishAPIDoc:
+      #     requires:
+      #       - extractAPISpec
+      #     filters:
+      #       branches:
+      #         only: master
 #  nightly:
 #    triggers:
 #      - schedule:


### PR DESCRIPTION

Disable doc publishing until we figure out how to push on master from CI. 


relates to #1507