### PR TITLE
Refactor attestation manager and processing

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -27,7 +27,6 @@ import com.google.common.primitives.UnsignedLong;
 import java.time.Instant;
 import java.util.Optional;
 import javax.annotation.CheckReturnValue;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -298,15 +297,17 @@ public class ForkChoiceUtil {
     Checkpoint target = attestation.getData().getTarget();
 
     return validateOnAttestation(store, attestation)
-            .ifSuccessful(() -> storeTargetCheckpointState(store, stateTransition, target))
-            .ifSuccessful(() -> validateAndApplyIndexedAttestation(store, attestation, target, forkChoiceStrategy));
-    }
+        .ifSuccessful(() -> storeTargetCheckpointState(store, stateTransition, target))
+        .ifSuccessful(
+            () ->
+                validateAndApplyIndexedAttestation(store, attestation, target, forkChoiceStrategy));
+  }
 
   private static AttestationProcessingResult validateAndApplyIndexedAttestation(
-          MutableStore store,
-          Attestation attestation,
-          Checkpoint target,
-          ForkChoiceStrategy forkChoiceStrategy) {
+      MutableStore store,
+      Attestation attestation,
+      Checkpoint target,
+      ForkChoiceStrategy forkChoiceStrategy) {
     BeaconState target_state = store.getCheckpointState(target);
 
     // Get state at the `target` to validate attestation and calculate the committees
@@ -390,7 +391,8 @@ public class ForkChoiceUtil {
             .getSlot()
             .compareTo(attestation.getData().getSlot())
         > 0) {
-      LOG.warn("on_attestation: Attestations must not be for blocks in the future. If not, the attestation should not be considered");
+      LOG.warn(
+          "on_attestation: Attestations must not be for blocks in the future. If not, the attestation should not be considered");
       return AttestationProcessingResult.INVALID;
     }
 

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.core;
 
+import static tech.pegasys.teku.core.results.AttestationProcessingResult.SUCCESSFUL;
 import static tech.pegasys.teku.datastructures.util.AttestationUtil.get_indexed_attestation;
 import static tech.pegasys.teku.datastructures.util.AttestationUtil.is_valid_indexed_attestation;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
@@ -26,6 +27,9 @@ import com.google.common.primitives.UnsignedLong;
 import java.time.Instant;
 import java.util.Optional;
 import javax.annotation.CheckReturnValue;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.core.exceptions.EpochProcessingException;
 import tech.pegasys.teku.core.exceptions.SlotProcessingException;
@@ -43,6 +47,9 @@ import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
 
 public class ForkChoiceUtil {
+
+  private static final Logger LOG = LogManager.getLogger();
+
   public static UnsignedLong get_slots_since_genesis(ReadOnlyStore store, boolean useUnixTime) {
     UnsignedLong time =
         useUnixTime ? UnsignedLong.valueOf(Instant.now().getEpochSecond()) : store.getTime();
@@ -291,28 +298,33 @@ public class ForkChoiceUtil {
     Checkpoint target = attestation.getData().getTarget();
 
     return validateOnAttestation(store, attestation)
-        .ifSuccessful(() -> storeTargetCheckpointState(store, stateTransition, target))
-        .ifSuccessful(
-            () -> {
-              BeaconState target_state = store.getCheckpointState(target);
+            .ifSuccessful(() -> storeTargetCheckpointState(store, stateTransition, target))
+            .ifSuccessful(() -> validateAndApplyIndexedAttestation(store, attestation, target, forkChoiceStrategy));
+    }
 
-              // Get state at the `target` to validate attestation and calculate the committees
-              IndexedAttestation indexed_attestation;
-              try {
-                indexed_attestation = get_indexed_attestation(target_state, attestation);
-              } catch (IllegalArgumentException e) {
-                return AttestationProcessingResult.invalid(
-                    "on_attestation: Attestation is not valid: " + e.getMessage());
-              }
-              if (!is_valid_indexed_attestation(target_state, indexed_attestation)) {
-                return AttestationProcessingResult.invalid(
-                    "on_attestation: Attestation is not valid");
-              }
+  private static AttestationProcessingResult validateAndApplyIndexedAttestation(
+          MutableStore store,
+          Attestation attestation,
+          Checkpoint target,
+          ForkChoiceStrategy forkChoiceStrategy) {
+    BeaconState target_state = store.getCheckpointState(target);
 
-              forkChoiceStrategy.onAttestation(store, indexed_attestation);
+    // Get state at the `target` to validate attestation and calculate the committees
+    IndexedAttestation indexed_attestation;
+    try {
+      indexed_attestation = get_indexed_attestation(target_state, attestation);
+    } catch (IllegalArgumentException e) {
+      LOG.warn("on_attestation: Attestation is not valid: ", e);
+      return AttestationProcessingResult.INVALID;
+    }
+    if (!is_valid_indexed_attestation(target_state, indexed_attestation)) {
+      LOG.warn("on_attestation: Attestation is not valid");
+      return AttestationProcessingResult.INVALID;
+    }
 
-              return AttestationProcessingResult.SUCCESSFUL;
-            });
+    forkChoiceStrategy.onAttestation(store, indexed_attestation);
+
+    return SUCCESSFUL;
   }
 
   private static AttestationProcessingResult storeTargetCheckpointState(
@@ -321,12 +333,11 @@ public class ForkChoiceUtil {
     BeaconState targetRootState = store.getBlockState(target.getRoot());
     try {
       storeCheckpointState(store, stateTransition, target, targetRootState);
-    } catch (SlotProcessingException e) {
-      return AttestationProcessingResult.failedStateTransition(e);
-    } catch (EpochProcessingException e) {
-      return AttestationProcessingResult.failedStateTransition(e);
+    } catch (SlotProcessingException | EpochProcessingException e) {
+      LOG.warn("on_attestation: Attestation failed state transition. ", e);
+      return AttestationProcessingResult.INVALID;
     }
-    return AttestationProcessingResult.SUCCESSFUL;
+    return SUCCESSFUL;
   }
 
   private static AttestationProcessingResult validateOnAttestation(
@@ -341,37 +352,37 @@ public class ForkChoiceUtil {
             : UnsignedLong.valueOf(GENESIS_EPOCH);
 
     if (!target.getEpoch().equals(previous_epoch) && !target.getEpoch().equals(current_epoch)) {
-      return AttestationProcessingResult.invalid(
-          "on_attestation: Attestations must be from the current or previous epoch");
+      LOG.warn("on_attestation: Attestations must be from the current or previous epoch");
+      return AttestationProcessingResult.INVALID;
     }
 
     if (!target.getEpoch().equals(compute_epoch_at_slot(attestation.getData().getSlot()))) {
-      return AttestationProcessingResult.invalid(
-          "on_attestation: Attestation slot must be within specified epoch");
+      LOG.warn("on_attestation: Attestation slot must be within specified epoch");
+      return AttestationProcessingResult.INVALID;
     }
 
     // Attestations can only affect the fork choice of subsequent slots.
     // Delay consideration in the fork choice until their slot is in the past.
     if (get_current_slot(store).compareTo(attestation.getData().getSlot()) <= 0) {
-      return AttestationProcessingResult.FAILED_NOT_FROM_PAST;
+      return AttestationProcessingResult.SAVED_FOR_FUTURE;
     }
 
     if (!store.getBlockRoots().contains(target.getRoot())) {
       // Attestations target must be for a known block. If a target block is unknown, delay
       // consideration until the block is found
-      return AttestationProcessingResult.FAILED_UNKNOWN_BLOCK;
+      return AttestationProcessingResult.UNKNOWN_BLOCK;
     }
 
     // Attestations cannot be from future epochs. If they are, delay consideration until the epoch
     // arrives
     if (get_current_slot(store).compareTo(target.getEpochStartSlot()) < 0) {
-      return AttestationProcessingResult.FAILED_FUTURE_EPOCH;
+      return AttestationProcessingResult.SAVED_FOR_FUTURE;
     }
 
     if (!store.getBlockRoots().contains(attestation.getData().getBeacon_block_root())) {
       // Attestations must be for a known block. If block is unknown, delay consideration until the
       // block is found
-      return AttestationProcessingResult.FAILED_UNKNOWN_BLOCK;
+      return AttestationProcessingResult.UNKNOWN_BLOCK;
     }
 
     if (store
@@ -379,11 +390,11 @@ public class ForkChoiceUtil {
             .getSlot()
             .compareTo(attestation.getData().getSlot())
         > 0) {
-      return AttestationProcessingResult.invalid(
-          "on_attestation: Attestations must not be for blocks in the future. If not, the attestation should not be considered");
+      LOG.warn("on_attestation: Attestations must not be for blocks in the future. If not, the attestation should not be considered");
+      return AttestationProcessingResult.INVALID;
     }
 
-    return AttestationProcessingResult.SUCCESSFUL;
+    return SUCCESSFUL;
   }
 
   private static void storeCheckpointState(

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/results/AttestationProcessingResult.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/results/AttestationProcessingResult.java
@@ -25,4 +25,3 @@ public enum AttestationProcessingResult {
     return this == SUCCESSFUL ? nextStep.get() : this;
   }
 }
-

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/results/AttestationProcessingResult.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/results/AttestationProcessingResult.java
@@ -14,94 +14,15 @@
 package tech.pegasys.teku.core.results;
 
 import java.util.function.Supplier;
-import tech.pegasys.teku.core.exceptions.EpochProcessingException;
-import tech.pegasys.teku.core.exceptions.SlotProcessingException;
 
-public interface AttestationProcessingResult {
-  AttestationProcessingResult SUCCESSFUL = new Successful();
-  AttestationProcessingResult FAILED_UNKNOWN_BLOCK = new Failure(FailureReason.UNKNOWN_BLOCK);
-  AttestationProcessingResult FAILED_NOT_FROM_PAST =
-      new Failure(FailureReason.ATTESTATION_IS_NOT_FROM_PREVIOUS_SLOT);
-  AttestationProcessingResult FAILED_FUTURE_EPOCH = new Failure(FailureReason.FOR_FUTURE_EPOCH);
+public enum AttestationProcessingResult {
+  SUCCESSFUL,
+  UNKNOWN_BLOCK,
+  SAVED_FOR_FUTURE,
+  INVALID;
 
-  static AttestationProcessingResult invalid(final String message) {
-    return new Failure(FailureReason.ATTESTATION_IS_INVALID, message);
-  }
-
-  static AttestationProcessingResult failedStateTransition(final SlotProcessingException cause) {
-    return new Failure(FailureReason.FAILED_STATE_TRANSITION, cause.getMessage());
-  }
-
-  static AttestationProcessingResult failedStateTransition(final EpochProcessingException cause) {
-    return new Failure(FailureReason.FAILED_STATE_TRANSITION, cause.getMessage());
-  }
-
-  boolean isSuccessful();
-
-  default AttestationProcessingResult ifSuccessful(Supplier<AttestationProcessingResult> nextStep) {
-    return isSuccessful() ? nextStep.get() : this;
-  }
-
-  /** @return If failed, returns a non-null failure reason, otherwise returns null. */
-  FailureReason getFailureReason();
-
-  /** @return If failed, returns a non-null failure message, otherwise returns null. */
-  String getFailureMessage();
-
-  enum FailureReason {
-    UNKNOWN_BLOCK,
-    ATTESTATION_IS_NOT_FROM_PREVIOUS_SLOT,
-    FOR_FUTURE_EPOCH,
-    FAILED_STATE_TRANSITION,
-    ATTESTATION_IS_INVALID
-  }
-
-  class Successful implements AttestationProcessingResult {
-
-    private Successful() {}
-
-    @Override
-    public boolean isSuccessful() {
-      return true;
-    }
-
-    @Override
-    public FailureReason getFailureReason() {
-      return null;
-    }
-
-    @Override
-    public String getFailureMessage() {
-      return null;
-    }
-  }
-
-  class Failure implements AttestationProcessingResult {
-    private final FailureReason failureReason;
-    private final String failureMessage;
-
-    private Failure(final FailureReason failureReason) {
-      this(failureReason, failureReason.name());
-    }
-
-    private Failure(final FailureReason failureReason, final String failureMessage) {
-      this.failureReason = failureReason;
-      this.failureMessage = failureMessage;
-    }
-
-    @Override
-    public boolean isSuccessful() {
-      return false;
-    }
-
-    @Override
-    public FailureReason getFailureReason() {
-      return failureReason;
-    }
-
-    @Override
-    public String getFailureMessage() {
-      return failureMessage;
-    }
+  public AttestationProcessingResult ifSuccessful(Supplier<AttestationProcessingResult> nextStep) {
+    return this == SUCCESSFUL ? nextStep.get() : this;
   }
 }
+

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/results/AttestationProcessingResult.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/results/AttestationProcessingResult.java
@@ -22,6 +22,10 @@ public enum AttestationProcessingResult {
   INVALID;
 
   public AttestationProcessingResult ifSuccessful(Supplier<AttestationProcessingResult> nextStep) {
-    return this == SUCCESSFUL ? nextStep.get() : this;
+    return isSuccessful() ? nextStep.get() : this;
+  }
+
+  public boolean isSuccessful() {
+    return this == SUCCESSFUL;
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/ForkChoiceAttestationProcessor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/ForkChoiceAttestationProcessor.java
@@ -33,7 +33,7 @@ public class ForkChoiceAttestationProcessor {
   public AttestationProcessingResult processAttestation(final Attestation attestation) {
     final Store.Transaction transaction = recentChainData.startStoreTransaction();
     final AttestationProcessingResult result = forkChoice.onAttestation(transaction, attestation);
-    if (result.isSuccessful()) {
+    if (result == AttestationProcessingResult.SUCCESSFUL) {
       transaction.commit(() -> {}, "Failed to persist attestation result");
     }
     return result;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/ForkChoiceAttestationProcessor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/ForkChoiceAttestationProcessor.java
@@ -33,7 +33,7 @@ public class ForkChoiceAttestationProcessor {
   public AttestationProcessingResult processAttestation(final Attestation attestation) {
     final Store.Transaction transaction = recentChainData.startStoreTransaction();
     final AttestationProcessingResult result = forkChoice.onAttestation(transaction, attestation);
-    if (result == AttestationProcessingResult.SUCCESSFUL) {
+    if (result.isSuccessful()) {
       transaction.commit(() -> {}, "Failed to persist attestation result");
     }
     return result;

--- a/sync/src/test/java/tech/pegasys/teku/sync/AttestationManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/AttestationManagerTest.java
@@ -20,8 +20,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.core.results.AttestationProcessingResult.SAVED_FOR_FUTURE;
-import static tech.pegasys.teku.core.results.AttestationProcessingResult.UNKNOWN_BLOCK;
 import static tech.pegasys.teku.core.results.AttestationProcessingResult.SUCCESSFUL;
+import static tech.pegasys.teku.core.results.AttestationProcessingResult.UNKNOWN_BLOCK;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.primitives.UnsignedLong;
@@ -170,7 +170,7 @@ class AttestationManagerTest {
   public void shouldNotPublishProcessedAttestationEventWhenAttestationIsInvalid() {
     final Attestation attestation = dataStructureUtil.randomAttestation();
     when(attestationProcessor.processAttestation(attestation))
-        .thenReturn(AttestationProcessingResult.invalid("Seems fishy"));
+        .thenReturn(AttestationProcessingResult.INVALID);
 
     eventBus.post(attestation);
 
@@ -185,7 +185,7 @@ class AttestationManagerTest {
     final AggregateAndProof aggregateAndProof = dataStructureUtil.randomAggregateAndProof();
     final Attestation attestation = aggregateAndProof.getAggregate();
     when(attestationProcessor.processAttestation(attestation))
-        .thenReturn(AttestationProcessingResult.invalid("Seems fishy"));
+        .thenReturn(AttestationProcessingResult.INVALID);
 
     eventBus.post(attestation);
 

--- a/sync/src/test/java/tech/pegasys/teku/sync/AttestationManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/AttestationManagerTest.java
@@ -19,8 +19,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.core.results.AttestationProcessingResult.FAILED_NOT_FROM_PAST;
-import static tech.pegasys.teku.core.results.AttestationProcessingResult.FAILED_UNKNOWN_BLOCK;
+import static tech.pegasys.teku.core.results.AttestationProcessingResult.SAVED_FOR_FUTURE;
+import static tech.pegasys.teku.core.results.AttestationProcessingResult.UNKNOWN_BLOCK;
 import static tech.pegasys.teku.core.results.AttestationProcessingResult.SUCCESSFUL;
 
 import com.google.common.eventbus.EventBus;
@@ -108,7 +108,7 @@ class AttestationManagerTest {
   public void shouldDeferProcessingForAttestationsThatHaveNotYetReachedTargetSlot() {
     final Attestation attestation = attestationFromSlot(100);
     when(attestationProcessor.processAttestation(attestation))
-        .thenReturn(FAILED_NOT_FROM_PAST)
+        .thenReturn(SAVED_FOR_FUTURE)
         .thenReturn(SUCCESSFUL);
 
     eventBus.post(attestation);
@@ -137,7 +137,7 @@ class AttestationManagerTest {
     final Bytes32 requiredBlockRoot = block.getMessage().hash_tree_root();
     final Attestation attestation = attestationFromSlot(1, requiredBlockRoot);
     when(attestationProcessor.processAttestation(attestation))
-        .thenReturn(FAILED_UNKNOWN_BLOCK)
+        .thenReturn(UNKNOWN_BLOCK)
         .thenReturn(SUCCESSFUL);
 
     eventBus.post(attestation);
@@ -203,7 +203,7 @@ class AttestationManagerTest {
             new AggregateAndProof(UnsignedLong.ZERO, attestation, BLSSignature.empty()),
             BLSSignature.empty());
     when(attestationProcessor.processAttestation(attestation))
-        .thenReturn(FAILED_NOT_FROM_PAST)
+        .thenReturn(SAVED_FOR_FUTURE)
         .thenReturn(SUCCESSFUL);
 
     eventBus.post(aggregateAndProof);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Remove FailureReason enum class, and make AttestationProcessingResult an enum instead so that the code is easier to follow during the processing and once the processing is done. 
