### PR TITLE
Extract the API spec in parallel with publish and publishDocker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,7 +404,11 @@ workflows:
             - docker
       - extractAPISpec:
           requires:
-            - publish
+            - unitTests
+            - integrationTests
+            - acceptanceTests
+            - referenceTests
+            - docker
       # - publishAPIDoc:
       #     requires:
       #       - extractAPISpec


### PR DESCRIPTION
## PR Description
Moves extractAPISpec to run in parallel with other publish tasks to improve build times.  All of the tests have already completed and it's just pushing artefacts out so no need to wait for publish to finish.