### PR TITLE
[BC-439] Resolve issues with large RPC response chunks

### DIFF
--- a/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/util/DataStructureUtil.java
+++ b/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/util/DataStructureUtil.java
@@ -223,7 +223,11 @@ public final class DataStructureUtil {
   }
 
   public SignedBeaconBlock randomSignedBeaconBlock(long slotNum, Bytes32 parentRoot) {
-    final BeaconBlock beaconBlock = randomBeaconBlock(slotNum, parentRoot);
+    return randomSignedBeaconBlock(slotNum, parentRoot, false);
+  }
+
+  public SignedBeaconBlock randomSignedBeaconBlock(long slotNum, Bytes32 parentRoot, boolean full) {
+    final BeaconBlock beaconBlock = randomBeaconBlock(slotNum, parentRoot, full);
     return new SignedBeaconBlock(beaconBlock, randomSignature());
   }
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -27,7 +27,7 @@ dependencyManagement {
     dependency 'io.protostuff:protostuff-core:1.6.2'
     dependency 'io.protostuff:protostuff-runtime:1.6.2'
 
-    dependency 'io.libp2p:jvm-libp2p-minimal:0.4.0-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p-minimal:0.4.1-RELEASE'
     dependency 'org.jetbrains.kotlin:kotlin-stdlib:1.3.61'
 
     dependency 'io.pkts:pkts-core:3.0.3'

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRootIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRootIntegrationTest.java
@@ -158,6 +158,18 @@ public abstract class BeaconBlocksByRootIntegrationTest {
   }
 
   @Test
+  public void shouldReturnMultipleLargeBlocksWhenAllRequestsMatch() throws Exception {
+    final List<SignedBeaconBlock> blocks = asList(addBlock(true), addBlock(true), addBlock(true));
+    final List<Bytes32> blockRoots =
+        blocks.stream()
+            .map(SignedBeaconBlock::getMessage)
+            .map(BeaconBlock::hash_tree_root)
+            .collect(toList());
+    final List<SignedBeaconBlock> response = requestBlocks(blockRoots);
+    assertThat(response).containsExactlyElementsOf(blocks);
+  }
+
+  @Test
   public void shouldReturnMatchingBlocksWhenSomeRequestsDoNotMatch() throws Exception {
     final List<SignedBeaconBlock> blocks = asList(addBlock(), addBlock(), addBlock());
 
@@ -174,7 +186,12 @@ public abstract class BeaconBlocksByRootIntegrationTest {
   }
 
   private SignedBeaconBlock addBlock() {
-    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
+    return addBlock(false);
+  }
+
+  private SignedBeaconBlock addBlock(boolean full) {
+    final SignedBeaconBlock block =
+        dataStructureUtil.randomSignedBeaconBlock(1, dataStructureUtil.randomBytes32(), full);
     final Bytes32 blockRoot = block.getMessage().hash_tree_root();
     final Transaction transaction = storageClient1.startStoreTransaction();
     transaction.putBlock(blockRoot, block);


### PR DESCRIPTION
## PR Description

- add the test with large response chunks (blocks of size > 90K)
- bump Libp2p version to `0.4.1` where issues with large packets are addressed 

Pending Libp2p PR: https://github.com/libp2p/jvm-libp2p/pull/110
