### PR TITLE
Stop printing giant Javalin banner at startup

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -123,6 +123,8 @@ public class BeaconRestApi {
               config.registerPlugin(
                   new OpenApiPlugin(getOpenApiOptions(jsonProvider, configuration)));
               config.defaultContentType = "application/json";
+              config.logIfServerNotStarted = false;
+              config.showJavalinBanner = false;
             });
     initialize(dataProvider, configuration);
   }


### PR DESCRIPTION
## PR Description
Disable the Javalin startup banner and warning that the server wasn't started (we know we'll start it when we're good and ready).