### PR TITLE
Store pending subnet subscriptions to be activated once the network starts

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
@@ -15,7 +15,9 @@ package tech.pegasys.teku.networking.eth2;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import tech.pegasys.teku.core.StateTransition;
@@ -47,6 +49,7 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
   private final AtomicReference<State> state = new AtomicReference<>(State.IDLE);
   private final GossipEncoding gossipEncoding;
   private final AttestationSubnetService attestationSubnetService;
+  private final Set<Integer> pendingSubnetSubscriptions = new HashSet<>();
 
   private BlockGossipManager blockGossipManager;
   private AttestationGossipManager attestationGossipManager;
@@ -82,7 +85,7 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
     return super.start().thenAccept(r -> startup());
   }
 
-  private void startup() {
+  private synchronized void startup() {
     state.set(State.RUNNING);
     BlockValidator blockValidator = new BlockValidator(recentChainData, new StateTransition());
     AttestationValidator attestationValidator = new AttestationValidator(recentChainData);
@@ -103,10 +106,13 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
     discoveryNetworkAttestationSubnetsSubscription =
         attestationSubnetService.subscribeToUpdates(
             discoveryNetwork::setLongTermAttestationSubnetSubscriptions);
+
+    pendingSubnetSubscriptions.forEach(this::subscribeToAttestationSubnetId);
+    pendingSubnetSubscriptions.clear();
   }
 
   @Override
-  public void stop() {
+  public synchronized void stop() {
     if (!state.compareAndSet(State.RUNNING, State.STOPPED)) {
       return;
     }
@@ -149,21 +155,23 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
   }
 
   @Override
-  public void subscribeToAttestationSubnetId(final int subnetId) {
-    if (aggregateGossipManager == null) {
-      throw new IllegalStateException(
-          "Attestation committee can not be subscribed due to gossip manager not being initialized");
+  public synchronized void subscribeToAttestationSubnetId(final int subnetId) {
+    if (attestationGossipManager == null) {
+      System.out.println("Adding pending subscription to " + subnetId);
+      pendingSubnetSubscriptions.add(subnetId);
+    } else {
+      System.out.println("Subscribing to " + subnetId);
+      attestationGossipManager.subscribeToSubnetId(subnetId);
     }
-    attestationGossipManager.subscribeToSubnetId(subnetId);
   }
 
   @Override
-  public void unsubscribeFromAttestationSubnetId(final int subnetId) {
-    if (aggregateGossipManager == null) {
-      throw new IllegalStateException(
-          "Attestation committee can not be unsubscribed due to gossip manager not being initialized");
+  public synchronized void unsubscribeFromAttestationSubnetId(final int subnetId) {
+    if (attestationGossipManager == null) {
+      pendingSubnetSubscriptions.remove(subnetId);
+    } else {
+      attestationGossipManager.unsubscribeFromSubnetId(subnetId);
     }
-    attestationGossipManager.unsubscribeFromSubnetId(subnetId);
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
@@ -157,10 +157,8 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
   @Override
   public synchronized void subscribeToAttestationSubnetId(final int subnetId) {
     if (attestationGossipManager == null) {
-      System.out.println("Adding pending subscription to " + subnetId);
       pendingSubnetSubscriptions.add(subnetId);
     } else {
-      System.out.println("Subscribing to " + subnetId);
       attestationGossipManager.subscribeToSubnetId(subnetId);
     }
   }


### PR DESCRIPTION
## PR Description
Fix a race condition during genesis event by storing attestation subnet subscriptions to be activated once the network starts.  Otherwise the validator client may request subscriptions before the network has started and throw `IllegalStateException`.

## Fixed Issue(s)
fixes #1897