### PR TITLE
Finalized checkpoint in status messages should come from the best state

### DIFF
--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
@@ -29,12 +29,12 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
-import tech.pegasys.teku.storage.Store;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -174,12 +174,12 @@ public class PeerStatusIntegrationTest {
 
   private void assertStatusMatchesStorage(
       final RecentChainData storageClient, final PeerStatus status) {
-    final Store network2Store = storageClient.getStore();
+    final BeaconState state = storageClient.getBestState().orElseThrow();
     assertStatus(
         status,
         storageClient.getCurrentForkInfo().orElseThrow().getForkDigest(),
-        network2Store.getFinalizedCheckpoint().getRoot(),
-        network2Store.getFinalizedCheckpoint().getEpoch(),
+        state.getFinalized_checkpoint().getRoot(),
+        state.getFinalized_checkpoint().getEpoch(),
         storageClient.getBestBlockRoot().orElseThrow(),
         storageClient.getBestSlot());
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
@@ -113,11 +113,16 @@ public class PeerChainValidator {
           peer);
       return SafeFuture.completedFuture(false);
     }
+    final UnsignedLong remoteFinalizedEpoch = status.getFinalizedEpoch();
+    // Only require fork digest to match if only genesis is finalized
+    if (remoteFinalizedEpoch.equals(UnsignedLong.ZERO)) {
+      return SafeFuture.completedFuture(true);
+    }
 
     // Check finalized checkpoint compatibility
-    final Checkpoint finalizedCheckpoint = storageClient.getStore().getFinalizedCheckpoint();
+    final Checkpoint finalizedCheckpoint =
+        storageClient.getBestState().orElseThrow().getFinalized_checkpoint();
     final UnsignedLong finalizedEpoch = finalizedCheckpoint.getEpoch();
-    final UnsignedLong remoteFinalizedEpoch = status.getFinalizedEpoch();
     final UnsignedLong currentEpoch = getCurrentEpoch();
 
     // Make sure remote finalized epoch is reasonable

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
@@ -14,7 +14,8 @@
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import java.util.Optional;
-import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
@@ -34,15 +35,17 @@ public class StatusMessageFactory {
       return Optional.empty();
     }
     final ForkInfo forkInfo = recentChainData.getCurrentForkInfo().orElseThrow();
-    final Checkpoint finalizedCheckpoint = recentChainData.getStore().getFinalizedCheckpoint();
-    final SignedBeaconBlock chainHead = recentChainData.getBestBlock().orElseThrow();
+    final BeaconBlockAndState bestBlockAndState =
+        recentChainData.getBestBlockAndState().orElseThrow();
+    final Checkpoint finalizedCheckpoint = bestBlockAndState.getState().getFinalized_checkpoint();
+    final BeaconBlock chainHead = bestBlockAndState.getBlock();
 
     return Optional.of(
         new StatusMessage(
             forkInfo.getForkDigest(),
             finalizedCheckpoint.getRoot(),
             finalizedCheckpoint.getEpoch(),
-            chainHead.getRoot(),
+            chainHead.hash_tree_root(),
             chainHead.getSlot()));
   }
 }


### PR DESCRIPTION
## PR Description
The finalised checkpoint in a status message should come from the best state, not the fork choice store.  They differ for the genesis state which is causing a split between prysm or teku and lighthouse nodes.

Don't compare checkpoints at genesis - accept the peer if fork digest matches so that we connect to both Prysm and lighthouse.

## Related Issue(s)
Prysm had a similar issue: https://github.com/prysmaticlabs/prysm/issues/6001