### PR TITLE
[BC-442] Require block and state to be added to Store atomically

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -167,10 +167,6 @@ public class ForkChoiceUtil {
       return maybeFailure.get();
     }
 
-    Bytes32 blockRoot = block.hash_tree_root();
-    // Add new block to the store
-    store.putBlock(blockRoot, signed_block);
-
     // Make a copy of the state to avoid mutability issues
     BeaconState state;
 
@@ -181,8 +177,8 @@ public class ForkChoiceUtil {
       return BlockImportResult.failedStateTransition(e);
     }
 
-    // Add new state for this block to the store
-    store.putBlockState(blockRoot, state);
+    // Add new block to store
+    store.putBlockAndState(signed_block, state);
 
     // Update justified checkpoint
     final Checkpoint justifiedCheckpoint = state.getCurrent_justified_checkpoint();

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/MutableStore.java
@@ -14,8 +14,8 @@
 package tech.pegasys.teku.datastructures.forkchoice;
 
 import com.google.common.primitives.UnsignedLong;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 
@@ -23,9 +23,11 @@ public interface MutableStore extends ReadOnlyStore {
 
   void putCheckpointState(Checkpoint checkpoint, BeaconState state);
 
-  void putBlockState(Bytes32 blockRoot, BeaconState state);
+  void putBlockAndState(SignedBeaconBlock block, BeaconState state);
 
-  void putBlock(Bytes32 blockRoot, SignedBeaconBlock block);
+  default void putBlockAndState(SignedBlockAndState blockAndState) {
+    putBlockAndState(blockAndState.getBlock(), blockAndState.getState());
+  }
 
   void setTime(UnsignedLong time);
 

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRootIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRootIntegrationTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
@@ -192,9 +193,9 @@ public abstract class BeaconBlocksByRootIntegrationTest {
   private SignedBeaconBlock addBlock(boolean full) {
     final SignedBeaconBlock block =
         dataStructureUtil.randomSignedBeaconBlock(1, dataStructureUtil.randomBytes32(), full);
-    final Bytes32 blockRoot = block.getMessage().hash_tree_root();
+    final BeaconState state = dataStructureUtil.randomBeaconState();
     final Transaction transaction = storageClient1.startStoreTransaction();
-    transaction.putBlock(blockRoot, block);
+    transaction.putBlockAndState(block, state);
     assertThat(transaction.commit()).isCompleted();
     return block;
   }

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/client/AbstractCombinedChainDataClientTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/client/AbstractCombinedChainDataClientTest.java
@@ -260,8 +260,8 @@ public abstract class AbstractCombinedChainDataClientTest {
     chainUpdater.initializeGenesis();
 
     final SignedBlockAndState targetBlock = chainBuilder.generateNextBlock();
-    chainUpdater.saveState(targetBlock.getRoot(), targetBlock.getState());
-    chainUpdater.saveBlock(targetBlock.getBlock());
+    chainUpdater.saveBlock(targetBlock);
+    ;
 
     final SignedBlockAndState bestBlock = chainUpdater.addNewBestBlock();
     // Sanity check
@@ -270,38 +270,6 @@ public abstract class AbstractCombinedChainDataClientTest {
     final SafeFuture<Optional<BeaconBlockAndState>> result =
         client.getBlockAndStateInEffectAtSlot(targetBlock.getSlot());
     assertThat(result).isCompletedWithValue(Optional.of(targetBlock.toUnsigned()));
-  }
-
-  @Test
-  public void getBlockAndStateInEffectAtSlot_missingBlock() throws Exception {
-    chainUpdater.initializeGenesis();
-
-    final SignedBlockAndState targetBlock = chainBuilder.generateNextBlock();
-    chainUpdater.saveState(targetBlock.getRoot(), targetBlock.getState());
-
-    final SignedBlockAndState bestBlock = chainUpdater.addNewBestBlock();
-    // Sanity check
-    assertThat(bestBlock.getSlot()).isGreaterThan(targetBlock.getSlot());
-
-    final SafeFuture<Optional<BeaconBlockAndState>> result =
-        client.getBlockAndStateInEffectAtSlot(targetBlock.getSlot());
-    assertThat(result).isCompletedWithValue(Optional.empty());
-  }
-
-  @Test
-  public void getBlockAndStateInEffectAtSlot_missingState() throws Exception {
-    chainUpdater.initializeGenesis();
-
-    final SignedBlockAndState targetBlock = chainBuilder.generateNextBlock();
-    chainUpdater.saveBlock(targetBlock.getBlock());
-
-    final SignedBlockAndState bestBlock = chainUpdater.addNewBestBlock();
-    // Sanity check
-    assertThat(bestBlock.getSlot()).isGreaterThan(targetBlock.getSlot());
-
-    final SafeFuture<Optional<BeaconBlockAndState>> result =
-        client.getBlockAndStateInEffectAtSlot(targetBlock.getSlot());
-    assertThat(result).isCompletedWithValue(Optional.empty());
   }
 
   @Test

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/client/AbstractCombinedChainDataClientTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/client/AbstractCombinedChainDataClientTest.java
@@ -261,7 +261,6 @@ public abstract class AbstractCombinedChainDataClientTest {
 
     final SignedBlockAndState targetBlock = chainBuilder.generateNextBlock();
     chainUpdater.saveBlock(targetBlock);
-    ;
 
     final SignedBlockAndState bestBlock = chainUpdater.addNewBestBlock();
     // Sanity check

--- a/storage/src/main/java/tech/pegasys/teku/storage/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/Store.java
@@ -307,13 +307,9 @@ public class Store implements ReadOnlyStore {
     }
 
     @Override
-    public void putBlockState(Bytes32 blockRoot, BeaconState state) {
-      block_states.put(blockRoot, state);
-    }
-
-    @Override
-    public void putBlock(Bytes32 blockRoot, SignedBeaconBlock block) {
-      blocks.put(blockRoot, block);
+    public void putBlockAndState(SignedBeaconBlock block, BeaconState state) {
+      blocks.put(block.getRoot(), block);
+      block_states.put(block.getRoot(), state);
     }
 
     @Override

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/StoreTest.java
@@ -65,16 +65,15 @@ class StoreTest {
             SafeFuture.completedFuture(
                 new SuccessfulStorageUpdateResult(Collections.emptySet(), Collections.emptySet())));
     final Transaction transaction = store.startTransaction(storageUpdateChannel);
-    final Bytes32 blockRoot = dataStructureUtil.randomBytes32();
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(10);
+    final Bytes32 blockRoot = block.getRoot();
+    final BeaconState state = dataStructureUtil.randomBeaconState();
     final Checkpoint justifiedCheckpoint = new Checkpoint(UnsignedLong.valueOf(2), blockRoot);
     final Checkpoint finalizedCheckpoint = new Checkpoint(UnsignedLong.ONE, blockRoot);
     final Checkpoint bestJustifiedCheckpoint = new Checkpoint(UnsignedLong.valueOf(3), blockRoot);
-    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(10);
-    final BeaconState state = dataStructureUtil.randomBeaconState();
     final UnsignedLong genesisTime = UnsignedLong.valueOf(1);
     final UnsignedLong time = UnsignedLong.valueOf(3);
-    transaction.putBlock(blockRoot, block);
-    transaction.putBlockState(blockRoot, state);
+    transaction.putBlockAndState(block, state);
     transaction.setFinalizedCheckpoint(finalizedCheckpoint);
     transaction.setJustifiedCheckpoint(justifiedCheckpoint);
     transaction.setBestJustifiedCheckpoint(bestJustifiedCheckpoint);

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/AbstractRocksDbDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/AbstractRocksDbDatabaseTest.java
@@ -91,8 +91,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
     final SignedBlockAndState newBlock = chainBuilder.getBlockAndStateAtSlot(1);
     final Checkpoint newCheckpoint = getCheckpointForBlock(newBlock.getBlock());
     final Transaction transaction = store.startTransaction(storageUpdateChannel);
-    transaction.putBlock(newBlock.getRoot(), newBlock.getBlock());
-    transaction.putBlockState(newBlock.getRoot(), newBlock.getState());
+    transaction.putBlockAndState(newBlock);
     transaction.setFinalizedCheckpoint(newCheckpoint);
     transaction.commit().reportExceptions();
     // Close db

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -14,12 +14,9 @@
 package tech.pegasys.teku.storage.client;
 
 import com.google.common.primitives.UnsignedLong;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.core.ChainBuilder;
 import tech.pegasys.teku.core.StateTransitionException;
-import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
-import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.storage.Store.Transaction;
 
@@ -99,20 +96,7 @@ public class ChainUpdater {
 
   public void saveBlock(final SignedBlockAndState block) {
     final Transaction tx = recentChainData.startStoreTransaction();
-    tx.putBlock(block.getRoot(), block.getBlock());
-    tx.putBlockState(block.getRoot(), block.getState());
-    tx.commit().reportExceptions();
-  }
-
-  public void saveBlock(final SignedBeaconBlock block) {
-    final Transaction tx = recentChainData.startStoreTransaction();
-    tx.putBlock(block.getRoot(), block);
-    tx.commit().reportExceptions();
-  }
-
-  public void saveState(final Bytes32 blockRoot, final BeaconState state) {
-    final Transaction tx = recentChainData.startStoreTransaction();
-    tx.putBlockState(blockRoot, state);
+    tx.putBlockAndState(block.getBlock(), block.getState());
     tx.commit().reportExceptions();
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
In order to simplify `Store` transaction logic, ensure that blocks and states are always stored together: merge `MutableStore.putBlock()` and `MutableStore.putBlockState()` into `MutableStore.putBlockAndState()`.
