### PR TITLE
Remove the SafeFuture.finish variants which don't handle errors

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -82,7 +82,7 @@ public class Eth2Peer extends DelegatingPeer implements Peer {
     if (curValue.isEmpty() || seqNumber.compareTo(curValue.get()) > 0) {
       requestMetadata()
           .finish(
-              this::updateMetadata, error -> LOG.debug("Failed to retrieve mpeer metadata", error));
+              this::updateMetadata, error -> LOG.debug("Failed to retrieve peer metadata", error));
     }
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -187,7 +187,8 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
                         connectSubscribers.forEach(c -> c.onConnected(eth2Peer));
                         setUpPeriodicTasksForPeer(eth2Peer);
                       }
-                    }));
+                    },
+                    error -> LOG.debug("Error while validating peer", error)));
   }
 
   @VisibleForTesting

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
@@ -52,7 +52,12 @@ public class LibP2PPeer implements Peer {
     final PeerId peerId = connection.secureSession().getRemoteId();
     final NodeId nodeId = new LibP2PNodeId(peerId);
     peerAddress = new MultiaddrPeerAddress(nodeId, connection.remoteAddress());
-    SafeFuture.of(connection.closeFuture()).finish(this::handleConnectionClosed);
+    SafeFuture.of(connection.closeFuture())
+        .finish(
+            this::handleConnectionClosed,
+            error ->
+                LOG.trace(
+                    "Peer {} connection close future completed exceptionally", peerId, error));
   }
 
   @Override
@@ -92,7 +97,7 @@ public class LibP2PPeer implements Peer {
 
   @Override
   public void subscribeDisconnect(final PeerDisconnectedSubscriber subscriber) {
-    SafeFuture.of(connection.closeFuture()).finish(subscriber::onDisconnected);
+    SafeFuture.of(connection.closeFuture()).always(subscriber::onDisconnected);
   }
 
   @Override

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1BlockFetcher.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1BlockFetcher.java
@@ -139,7 +139,8 @@ public class Eth1BlockFetcher {
               } else {
                 LOG.debug("Completed back-fill of Eth1 blocks");
               }
-            });
+            },
+            error -> LOG.error("Unexpected error while back-filling ETH1 blocks", error));
   }
 
   private boolean isAboveLowerBound(UnsignedLong timestamp) {

--- a/sync/src/main/java/tech/pegasys/teku/sync/SyncManager.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/SyncManager.java
@@ -126,7 +126,8 @@ public class SyncManager extends Service {
                   syncSubscribers.deliver(SyncSubscriber::onSyncingChange, syncActive);
                 }
               }
-            });
+            },
+            error -> LOG.error("Unexpected error during sync", error));
   }
 
   @VisibleForTesting

--- a/util/src/main/java/tech/pegasys/teku/util/async/SafeFuture.java
+++ b/util/src/main/java/tech/pegasys/teku/util/async/SafeFuture.java
@@ -173,14 +173,6 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     reportExceptions(this);
   }
 
-  public void finish(final Runnable onSuccess) {
-    finish(complete -> onSuccess.run());
-  }
-
-  public void finish(final Consumer<T> onSuccess) {
-    reportExceptions(thenAccept(onSuccess));
-  }
-
   public void finish(final Runnable onSuccess, final Consumer<Throwable> onError) {
     finish(result -> onSuccess.run(), onError);
   }

--- a/util/src/test/java/tech/pegasys/teku/util/async/SafeFutureTest.java
+++ b/util/src/test/java/tech/pegasys/teku/util/async/SafeFutureTest.java
@@ -177,50 +177,6 @@ public class SafeFutureTest {
   }
 
   @Test
-  public void finish_executeRunnableOnSuccess() {
-    final AtomicBoolean called = new AtomicBoolean(false);
-    final SafeFuture<String> future = new SafeFuture<>();
-    future.finish(() -> called.set(true));
-
-    assertThat(called).isFalse();
-    future.complete("Yay");
-    assertThat(called).isTrue();
-  }
-
-  @Test
-  public void finish_doNotExecuteRunnableOnException() {
-    final AtomicBoolean called = new AtomicBoolean(false);
-    final SafeFuture<String> future = new SafeFuture<>();
-    future.finish(() -> called.set(true));
-
-    assertThat(called).isFalse();
-    future.completeExceptionally(new RuntimeException("Nope"));
-    assertThat(called).isFalse();
-  }
-
-  @Test
-  public void finish_executeConsumerOnSuccess() {
-    final AtomicReference<String> called = new AtomicReference<>();
-    final SafeFuture<String> future = new SafeFuture<>();
-    future.finish(called::set);
-
-    assertThat(called).hasValue(null);
-    future.complete("Yay");
-    assertThat(called).hasValue("Yay");
-  }
-
-  @Test
-  public void finish_doNotExecuteConsumerOnException() {
-    final AtomicReference<String> called = new AtomicReference<>();
-    final SafeFuture<String> future = new SafeFuture<>();
-    future.finish(called::set);
-
-    assertThat(called).hasValue(null);
-    future.completeExceptionally(new RuntimeException("Oh no"));
-    assertThat(called).hasValue(null);
-  }
-
-  @Test
   public void finish_runnableAndErrorHandler_executeRunnableOnSuccess() {
     final AtomicBoolean called = new AtomicBoolean(false);
     final AtomicReference<Throwable> errorCallback = new AtomicReference<>();
@@ -327,17 +283,6 @@ public class SafeFutureTest {
           throw new RuntimeException("Oh no!");
         });
     safeFuture.completeExceptionally(new Exception("Original exception"));
-
-    assertThat(caughtExceptions).hasSize(1);
-  }
-
-  @Test
-  public void finish_shouldReportExceptionsWhenNoErrorHandlerProvided() {
-    final List<Throwable> caughtExceptions = collectUncaughtExceptions();
-
-    final SafeFuture<Object> safeFuture = new SafeFuture<>();
-    safeFuture.finish(() -> {});
-    safeFuture.completeExceptionally(new RuntimeException("Not handled"));
 
     assertThat(caughtExceptions).hasSize(1);
   }


### PR DESCRIPTION
## PR Description
Remove the `SafeFuture.finish` variants which leave errors to the uncaught exception handler.  We should be explicit about where errors get logged and at what level.

In some cases this results in an error handler that can never be called but that's worth it to avoid cases where an exception handler is forgotten leading to very noisy errors in the logs.