### PR TITLE
[Issue 1976] Limit hot states kept in memory

### DIFF
--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_star
 import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_EPOCH;
 
 import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -195,17 +196,23 @@ public class ChainBuilder {
     return blockAndState;
   }
 
-  public void generateBlocksUpToSlot(final long slot) throws StateTransitionException {
-    generateBlocksUpToSlot(UnsignedLong.valueOf(slot));
+  public List<SignedBlockAndState> generateBlocksUpToSlot(final long slot)
+      throws StateTransitionException {
+    return generateBlocksUpToSlot(UnsignedLong.valueOf(slot));
   }
 
-  public void generateBlocksUpToSlot(final UnsignedLong slot) throws StateTransitionException {
+  public List<SignedBlockAndState> generateBlocksUpToSlot(final UnsignedLong slot)
+      throws StateTransitionException {
     assertBlockCanBeGenerated();
+    final List<SignedBlockAndState> generated = new ArrayList<>();
 
     SignedBlockAndState latestBlock = getLatestBlockAndState();
     while (latestBlock.getState().getSlot().compareTo(slot) < 0) {
       latestBlock = generateNextBlock();
+      generated.add(latestBlock);
     }
+
+    return generated;
   }
 
   public SignedBlockAndState generateNextBlock() throws StateTransitionException {

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/blocks/SignedBlockAndState.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/blocks/SignedBlockAndState.java
@@ -41,6 +41,10 @@ public class SignedBlockAndState {
     return block.getRoot();
   }
 
+  public Bytes32 getParentRoot() {
+    return block.getParent_root();
+  }
+
   public UnsignedLong getSlot() {
     return getBlock().getSlot();
   }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
@@ -55,8 +55,6 @@ public interface ReadOnlyStore {
 
   BeaconState getBlockState(Bytes32 blockRoot);
 
-  boolean containsBlockState(Bytes32 blockRoot);
-
   BeaconState getCheckpointState(Checkpoint checkpoint);
 
   boolean containsCheckpointState(Checkpoint checkpoint);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/StateTransitionTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/StateTransitionTest.java
@@ -13,17 +13,138 @@
 
 package tech.pegasys.teku.statetransition;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Streams;
+import com.google.common.primitives.UnsignedLong;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.junit.BouncyCastleExtension;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import tech.pegasys.teku.bls.BLSKeyGenerator;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.core.ChainBuilder;
+import tech.pegasys.teku.core.StateTransition;
+import tech.pegasys.teku.core.StateTransitionException;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.datastructures.state.BeaconState;
 
 @Disabled
 @ExtendWith(BouncyCastleExtension.class)
 class StateTransitionTest {
+  protected static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(3);
+  private final ChainBuilder chainBuilder = ChainBuilder.create(VALIDATOR_KEYS);
 
   @Test
-  void testUpdateRecentBlockHashes() throws Exception {
-    // todo
+  public void produceStatesForBlocks_validChainFromGenesis() throws StateTransitionException {
+    // Build a small chain
+    final SignedBlockAndState genesis = chainBuilder.generateGenesis();
+    chainBuilder.generateBlocksUpToSlot(10);
+    final List<SignedBlockAndState> newBlocksAndStates =
+        chainBuilder
+            .streamBlocksAndStates(
+                genesis.getSlot().plus(UnsignedLong.ONE), chainBuilder.getLatestSlot())
+            .collect(Collectors.toList());
+
+    final List<SignedBeaconBlock> newBlocks =
+        newBlocksAndStates.stream().map(SignedBlockAndState::getBlock).collect(Collectors.toList());
+    final Map<Bytes32, BeaconState> expectedResult =
+        newBlocksAndStates.stream()
+            .collect(Collectors.toMap(SignedBlockAndState::getRoot, SignedBlockAndState::getState));
+    expectedResult.put(genesis.getRoot(), genesis.getState());
+
+    final Map<Bytes32, BeaconState> result =
+        StateTransition.produceStatesForBlocks(genesis.getRoot(), genesis.getState(), newBlocks);
+    assertThat(result.size()).isEqualTo(expectedResult.size());
+    assertThat(result).isEqualToComparingFieldByField(expectedResult);
+  }
+
+  @Test
+  public void produceStatesForBlocks_validPostGenesisChain() throws StateTransitionException {
+    // Build a small chain
+    chainBuilder.generateGenesis();
+    chainBuilder.generateBlocksUpToSlot(10);
+    final SignedBlockAndState baseBlock = chainBuilder.getBlockAndStateAtSlot(5);
+    final List<SignedBlockAndState> newBlocksAndStates =
+        chainBuilder
+            .streamBlocksAndStates(
+                baseBlock.getSlot().plus(UnsignedLong.ONE), chainBuilder.getLatestSlot())
+            .collect(Collectors.toList());
+
+    final List<SignedBeaconBlock> newBlocks =
+        newBlocksAndStates.stream().map(SignedBlockAndState::getBlock).collect(Collectors.toList());
+    final Map<Bytes32, BeaconState> expectedResult =
+        newBlocksAndStates.stream()
+            .collect(Collectors.toMap(SignedBlockAndState::getRoot, SignedBlockAndState::getState));
+    expectedResult.put(baseBlock.getRoot(), baseBlock.getState());
+
+    final Map<Bytes32, BeaconState> result =
+        StateTransition.produceStatesForBlocks(
+            baseBlock.getRoot(), baseBlock.getState(), newBlocks);
+    assertThat(result.size()).isEqualTo(expectedResult.size());
+    assertThat(result).isEqualToComparingFieldByField(expectedResult);
+  }
+
+  @Test
+  public void produceStatesForBlocks_withForkBlocks() throws StateTransitionException {
+    // Build a small chain
+    chainBuilder.generateGenesis();
+    chainBuilder.generateBlocksUpToSlot(5);
+    final ChainBuilder fork = chainBuilder.fork();
+
+    chainBuilder.generateBlocksUpToSlot(10);
+    // Fork chain skips a block
+    fork.generateBlockAtSlot(7);
+    fork.generateBlocksUpToSlot(10);
+
+    // Set base block so that fork blocks cannot be reconstructed
+    final SignedBlockAndState baseBlock = chainBuilder.getBlockAndStateAtSlot(6);
+
+    final List<SignedBlockAndState> newBlocksAndStates =
+        chainBuilder
+            .streamBlocksAndStates(
+                baseBlock.getSlot().plus(UnsignedLong.ONE), chainBuilder.getLatestSlot())
+            .collect(Collectors.toList());
+    final List<SignedBlockAndState> newForkBlocks =
+        fork.streamBlocksAndStates(
+                baseBlock.getSlot().plus(UnsignedLong.ONE), chainBuilder.getLatestSlot())
+            .collect(Collectors.toList());
+
+    final Set<SignedBeaconBlock> newBlocks =
+        Streams.concat(newBlocksAndStates.stream(), newForkBlocks.stream())
+            .map(SignedBlockAndState::getBlock)
+            .collect(Collectors.toSet());
+    // Sanity check that we included some fork blocks
+    assertThat(newBlocks.size()).isGreaterThan(newBlocksAndStates.size());
+    final Map<Bytes32, BeaconState> expectedResult =
+        newBlocksAndStates.stream()
+            .collect(Collectors.toMap(SignedBlockAndState::getRoot, SignedBlockAndState::getState));
+    expectedResult.put(baseBlock.getRoot(), baseBlock.getState());
+
+    final Map<Bytes32, BeaconState> result =
+        StateTransition.produceStatesForBlocks(
+            baseBlock.getRoot(), baseBlock.getState(), newBlocks);
+    assertThat(result.size()).isEqualTo(expectedResult.size());
+    assertThat(result).isEqualToComparingFieldByField(expectedResult);
+  }
+
+  @Test
+  public void produceStatesForBlocks_emptyNewBlockCollection() {
+    final SignedBlockAndState genesis = chainBuilder.generateGenesis();
+
+    final Map<Bytes32, BeaconState> expectedResult = Map.of(genesis.getRoot(), genesis.getState());
+
+    final Map<Bytes32, BeaconState> result =
+        StateTransition.produceStatesForBlocks(
+            genesis.getRoot(), genesis.getState(), Collections.emptyList());
+    assertThat(result.size()).isEqualTo(expectedResult.size());
+    assertThat(result).isEqualToComparingFieldByField(expectedResult);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
@@ -195,11 +195,9 @@ public class BlockImporterTest {
     tx.setFinalizedCheckpoint(finalized);
     tx.commit().join();
 
-    // This block does not descend from the latest finalized block, but we know about it and so
-    // we mark the import as successful without trying to re-import which would trigger a
-    // DOES_NOT_DESCEND_FROM_LATEST_FINALIZED error
+    // Import a block prior to the latest finalized block
     final BlockImportResult result = blockImporter.importBlock(blocks.get(1));
-    assertSuccessfulResult(result);
+    assertImportFailed(result, FailureReason.UNKNOWN_PARENT);
   }
 
   @Test

--- a/protoarray/src/testFixtures/java/tech/pegasys/teku/protoarray/ProtoArrayTestUtil.java
+++ b/protoarray/src/testFixtures/java/tech/pegasys/teku/protoarray/ProtoArrayTestUtil.java
@@ -36,7 +36,7 @@ public class ProtoArrayTestUtil {
       UnsignedLong finalizedCheckpointEpoch,
       UnsignedLong justifiedCheckpointEpoch) {
     Store store =
-        new Store(
+        Store.create(
             UnsignedLong.ONE,
             ZERO,
             new Checkpoint(justifiedCheckpointEpoch, Bytes32.ZERO),
@@ -61,7 +61,7 @@ public class ProtoArrayTestUtil {
   }
 
   public static Store createStoreToManipulateVotes() {
-    return new Store(
+    return Store.create(
         UnsignedLong.ONE,
         ZERO,
         new Checkpoint(ZERO, Bytes32.ZERO),

--- a/protoarray/src/testFixtures/java/tech/pegasys/teku/protoarray/ProtoArrayTestUtil.java
+++ b/protoarray/src/testFixtures/java/tech/pegasys/teku/protoarray/ProtoArrayTestUtil.java
@@ -45,7 +45,8 @@ public class ProtoArrayTestUtil {
             new HashMap<>(),
             new HashMap<>(),
             new HashMap<>(),
-            new HashMap<>());
+            new HashMap<>(),
+            Store.STATE_CACHE_SIZE);
 
     ProtoArrayForkChoiceStrategy forkChoice = ProtoArrayForkChoiceStrategy.create(store);
 
@@ -70,6 +71,7 @@ public class ProtoArrayTestUtil {
         new HashMap<>(),
         new HashMap<>(),
         new HashMap<>(),
-        new HashMap<>());
+        new HashMap<>(),
+        Store.STATE_CACHE_SIZE);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/events/FailedStorageUpdateResult.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/events/FailedStorageUpdateResult.java
@@ -13,11 +13,6 @@
 
 package tech.pegasys.teku.storage.events;
 
-import java.util.Collections;
-import java.util.Set;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.datastructures.state.Checkpoint;
-
 public class FailedStorageUpdateResult implements StorageUpdateResult {
   private final RuntimeException error;
 
@@ -33,15 +28,5 @@ public class FailedStorageUpdateResult implements StorageUpdateResult {
   @Override
   public RuntimeException getError() {
     return error;
-  }
-
-  @Override
-  public Set<Bytes32> getPrunedBlockRoots() {
-    return Collections.emptySet();
-  }
-
-  @Override
-  public Set<Checkpoint> getPrunedCheckpoints() {
-    return Collections.emptySet();
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/events/StorageUpdate.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/events/StorageUpdate.java
@@ -16,8 +16,10 @@ package tech.pegasys.teku.storage.events;
 import com.google.common.primitives.UnsignedLong;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
@@ -28,27 +30,33 @@ public class StorageUpdate {
   private final Optional<Checkpoint> justifiedCheckpoint;
   private final Optional<Checkpoint> finalizedCheckpoint;
   private final Optional<Checkpoint> bestJustifiedCheckpoint;
-  private final Map<Bytes32, SignedBeaconBlock> blocks;
-  private final Map<Bytes32, BeaconState> blockStates;
+  private final Map<Bytes32, SignedBeaconBlock> hotBlocks;
+  private final Map<Bytes32, SignedBlockAndState> finalizedChainData;
   private final Map<Checkpoint, BeaconState> checkpointStates;
   private final Map<UnsignedLong, VoteTracker> votes;
+  private final Set<Checkpoint> deletedCheckpointStates;
+  private final Set<Bytes32> deletedHotBlocks;
 
   public StorageUpdate(
       final Optional<UnsignedLong> genesisTime,
       final Optional<Checkpoint> justifiedCheckpoint,
       final Optional<Checkpoint> finalizedCheckpoint,
       final Optional<Checkpoint> bestJustifiedCheckpoint,
-      final Map<Bytes32, SignedBeaconBlock> blocks,
-      final Map<Bytes32, BeaconState> blockStates,
+      final Map<Bytes32, SignedBeaconBlock> hotBlocks,
+      final Set<Bytes32> deletedHotBlocks,
+      final Map<Bytes32, SignedBlockAndState> finalizedChainData,
       final Map<Checkpoint, BeaconState> checkpointStates,
+      final Set<Checkpoint> deletedCheckpointStates,
       final Map<UnsignedLong, VoteTracker> votes) {
     this.genesisTime = genesisTime;
     this.justifiedCheckpoint = justifiedCheckpoint;
     this.finalizedCheckpoint = finalizedCheckpoint;
     this.bestJustifiedCheckpoint = bestJustifiedCheckpoint;
-    this.blocks = blocks;
-    this.blockStates = blockStates;
+    this.hotBlocks = hotBlocks;
+    this.deletedHotBlocks = deletedHotBlocks;
+    this.finalizedChainData = finalizedChainData;
     this.checkpointStates = checkpointStates;
+    this.deletedCheckpointStates = deletedCheckpointStates;
     this.votes = votes;
   }
 
@@ -57,9 +65,11 @@ public class StorageUpdate {
         && justifiedCheckpoint.isEmpty()
         && finalizedCheckpoint.isEmpty()
         && bestJustifiedCheckpoint.isEmpty()
-        && blocks.isEmpty()
-        && blockStates.isEmpty()
+        && hotBlocks.isEmpty()
+        && deletedHotBlocks.isEmpty()
+        && finalizedChainData.isEmpty()
         && checkpointStates.isEmpty()
+        && deletedCheckpointStates.isEmpty()
         && votes.isEmpty();
   }
 
@@ -79,16 +89,24 @@ public class StorageUpdate {
     return bestJustifiedCheckpoint;
   }
 
-  public Map<Bytes32, SignedBeaconBlock> getBlocks() {
-    return blocks;
+  public Map<Bytes32, SignedBeaconBlock> getHotBlocks() {
+    return hotBlocks;
   }
 
-  public Map<Bytes32, BeaconState> getBlockStates() {
-    return blockStates;
+  public Set<Bytes32> getDeletedHotBlocks() {
+    return deletedHotBlocks;
+  }
+
+  public Map<Bytes32, SignedBlockAndState> getFinalizedBlocksAndStates() {
+    return finalizedChainData;
   }
 
   public Map<Checkpoint, BeaconState> getCheckpointStates() {
     return checkpointStates;
+  }
+
+  public Set<Checkpoint> getDeletedCheckpointStates() {
+    return deletedCheckpointStates;
   }
 
   public Map<UnsignedLong, VoteTracker> getVotes() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/events/StorageUpdateResult.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/events/StorageUpdateResult.java
@@ -13,24 +13,14 @@
 
 package tech.pegasys.teku.storage.events;
 
-import java.util.Collections;
-import java.util.Set;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.datastructures.state.Checkpoint;
-
 public interface StorageUpdateResult {
 
   static StorageUpdateResult failed(final RuntimeException error) {
     return new FailedStorageUpdateResult(error);
   }
 
-  static StorageUpdateResult successful(
-      final Set<Bytes32> prunedBlockRoots, final Set<Checkpoint> prunedCheckpoints) {
-    return new SuccessfulStorageUpdateResult(prunedBlockRoots, prunedCheckpoints);
-  }
-
-  static StorageUpdateResult successfulWithNothingPruned() {
-    return new SuccessfulStorageUpdateResult(Collections.emptySet(), Collections.emptySet());
+  static StorageUpdateResult successful() {
+    return new SuccessfulStorageUpdateResult();
   }
 
   /** @return {@code true} if the update was successfully processed */
@@ -38,15 +28,4 @@ public interface StorageUpdateResult {
 
   /** @return If the result is unsuccessful, returns the error, otherwise null. */
   RuntimeException getError();
-
-  /**
-   * @return If the update was successful returns the set of block roots that were pruned from
-   *     storage. Otherwise, returns an empty collection.
-   */
-  Set<Bytes32> getPrunedBlockRoots();
-  /**
-   * @return If the update was successful returns the set of checkpoints that were pruned from
-   *     storage. Otherwise, returns an empty collection.
-   */
-  Set<Checkpoint> getPrunedCheckpoints();
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/events/SuccessfulStorageUpdateResult.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/events/SuccessfulStorageUpdateResult.java
@@ -13,19 +13,9 @@
 
 package tech.pegasys.teku.storage.events;
 
-import java.util.Set;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.datastructures.state.Checkpoint;
-
 public class SuccessfulStorageUpdateResult implements StorageUpdateResult {
-  private final Set<Bytes32> prunedBlockRoots;
-  private final Set<Checkpoint> prunedCheckpoints;
 
-  public SuccessfulStorageUpdateResult(
-      final Set<Bytes32> prunedBlockRoots, final Set<Checkpoint> prunedCheckpoints) {
-    this.prunedBlockRoots = prunedBlockRoots;
-    this.prunedCheckpoints = prunedCheckpoints;
-  }
+  public SuccessfulStorageUpdateResult() {}
 
   @Override
   public boolean isSuccessful() {
@@ -35,15 +25,5 @@ public class SuccessfulStorageUpdateResult implements StorageUpdateResult {
   @Override
   public RuntimeException getError() {
     return null;
-  }
-
-  @Override
-  public Set<Checkpoint> getPrunedCheckpoints() {
-    return prunedCheckpoints;
-  }
-
-  @Override
-  public Set<Bytes32> getPrunedBlockRoots() {
-    return prunedBlockRoots;
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -111,11 +111,11 @@ public class ChainStorage implements StorageUpdateChannel, StorageQueryChannel {
   @Override
   public SafeFuture<Optional<BeaconState>> getLatestFinalizedStateAtSlot(final UnsignedLong slot) {
     return SafeFuture.completedFuture(
-        database.getLatestFinalizedRootAtSlot(slot).flatMap(database::getState));
+        database.getLatestFinalizedRootAtSlot(slot).flatMap(database::getFinalizedState));
   }
 
   @Override
   public SafeFuture<Optional<BeaconState>> getFinalizedStateByBlockRoot(final Bytes32 blockRoot) {
-    return SafeFuture.completedFuture(database.getState(blockRoot));
+    return SafeFuture.completedFuture(database.getFinalizedState(blockRoot));
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -51,7 +51,13 @@ public interface Database extends AutoCloseable {
 
   Optional<SignedBeaconBlock> getSignedBlock(Bytes32 root);
 
-  Optional<BeaconState> getState(Bytes32 root);
+  /**
+   * Given a block root, returns the corresponding finalized state, if this state is available.
+   *
+   * @param root A block root.
+   * @return The finalized state corresponding to the given block root.
+   */
+  Optional<BeaconState> getFinalizedState(Bytes32 root);
 
   Optional<MinGenesisTimeBlockEvent> getMinGenesisTimeBlock();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -157,8 +157,8 @@ public class RocksDbDatabase implements Database {
   }
 
   @Override
-  public Optional<BeaconState> getState(final Bytes32 root) {
-    return dao.getHotState(root).or(() -> dao.getFinalizedState(root));
+  public Optional<BeaconState> getFinalizedState(final Bytes32 root) {
+    return dao.getFinalizedState(root);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -13,20 +13,12 @@
 
 package tech.pegasys.teku.storage.server.rocksdb;
 
-import static com.google.common.primitives.UnsignedLong.ZERO;
-
-import com.google.common.collect.Streams;
 import com.google.common.primitives.UnsignedLong;
 import com.google.errorprone.annotations.MustBeClosed;
 import java.time.Instant;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
@@ -38,7 +30,6 @@ import tech.pegasys.teku.storage.Store;
 import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.events.StorageUpdateResult;
 import tech.pegasys.teku.storage.server.Database;
-import tech.pegasys.teku.storage.server.rocksdb.core.ColumnEntry;
 import tech.pegasys.teku.storage.server.rocksdb.core.RocksDbAccessor;
 import tech.pegasys.teku.storage.server.rocksdb.core.RocksDbInstanceFactory;
 import tech.pegasys.teku.storage.server.rocksdb.dataaccess.RocksDbDao;
@@ -49,7 +40,6 @@ import tech.pegasys.teku.util.config.StateStorageMode;
 
 public class RocksDbDatabase implements Database {
 
-  private static final Logger LOG = LogManager.getLogger();
   private final StateStorageMode stateStorageMode;
 
   private final RocksDbDao dao;
@@ -82,7 +72,6 @@ public class RocksDbDatabase implements Database {
       final BeaconState genesisState =
           store.getBlockState(store.getFinalizedCheckpoint().getRoot());
       updater.addCheckpointState(store.getFinalizedCheckpoint(), genesisState);
-      updater.setLatestFinalizedState(genesisState);
 
       for (Bytes32 root : store.getBlockRoots()) {
         // Since we're storing genesis, we should only have 1 root here corresponding to genesis
@@ -93,7 +82,6 @@ public class RocksDbDatabase implements Database {
         // we're guaranteed to have at least one block / state to load into RecentChainData.
         // Save to hot storage
         updater.addHotBlock(block);
-        updater.addHotState(root, state);
         // Save to cold storage
         updater.addFinalizedBlock(block);
         putFinalizedState(updater, root, state);
@@ -106,7 +94,7 @@ public class RocksDbDatabase implements Database {
   @Override
   public StorageUpdateResult update(final StorageUpdate event) {
     if (event.isEmpty()) {
-      return StorageUpdateResult.successfulWithNothingPruned();
+      return StorageUpdateResult.successful();
     }
     return doUpdate(event);
   }
@@ -124,19 +112,17 @@ public class RocksDbDatabase implements Database {
     final Checkpoint bestJustifiedCheckpoint = dao.getBestJustifiedCheckpoint().orElseThrow();
 
     final Map<Bytes32, SignedBeaconBlock> hotBlocksByRoot = dao.getHotBlocks();
-    final Map<Bytes32, BeaconState> hotStatesByRoot = dao.getHotStates();
     final Map<Checkpoint, BeaconState> checkpointStates = dao.getCheckpointStates();
     final Map<UnsignedLong, VoteTracker> votes = dao.getVotes();
 
     return Optional.of(
-        new Store(
+        Store.createByRegeneratingHotStates(
             UnsignedLong.valueOf(Instant.now().getEpochSecond()),
             genesisTime,
             justifiedCheckpoint,
             finalizedCheckpoint,
             bestJustifiedCheckpoint,
             hotBlocksByRoot,
-            hotStatesByRoot,
             checkpointStates,
             votes));
   }
@@ -191,40 +177,31 @@ public class RocksDbDatabase implements Database {
     dao.close();
   }
 
-  private Checkpoint getFinalizedCheckpoint() {
-    return dao.getFinalizedCheckpoint().orElseThrow();
-  }
-
   private StorageUpdateResult doUpdate(final StorageUpdate update) {
     try (final Updater updater = dao.updater()) {
-      final Checkpoint previousFinalizedCheckpoint = getFinalizedCheckpoint();
-      final Checkpoint newFinalizedCheckpoint =
-          update.getFinalizedCheckpoint().orElse(previousFinalizedCheckpoint);
-
       update.getGenesisTime().ifPresent(updater::setGenesisTime);
       update.getFinalizedCheckpoint().ifPresent(updater::setFinalizedCheckpoint);
       update.getJustifiedCheckpoint().ifPresent(updater::setJustifiedCheckpoint);
       update.getBestJustifiedCheckpoint().ifPresent(updater::setBestJustifiedCheckpoint);
 
       updater.addCheckpointStates(update.getCheckpointStates());
-      updater.addHotBlocks(update.getBlocks());
-      updater.addHotStates(update.getBlockStates());
+      updater.addHotBlocks(update.getHotBlocks());
       updater.addVotes(update.getVotes());
 
-      final StorageUpdateResult result;
-      if (previousFinalizedCheckpoint == null
-          || !previousFinalizedCheckpoint.equals(newFinalizedCheckpoint)) {
-        recordFinalizedBlocks(updater, update, newFinalizedCheckpoint);
-        final Set<Checkpoint> prunedCheckpoints =
-            pruneCheckpointStates(updater, update, newFinalizedCheckpoint);
-        final Set<Bytes32> prunedBlockRoots =
-            pruneHotBlocks(updater, update, newFinalizedCheckpoint);
-        result = StorageUpdateResult.successful(prunedBlockRoots, prunedCheckpoints);
-      } else {
-        result = StorageUpdateResult.successfulWithNothingPruned();
-      }
+      // Delete data
+      update.getDeletedCheckpointStates().forEach(updater::deleteCheckpointState);
+      update.getDeletedHotBlocks().forEach(updater::deleteHotBlock);
+
+      update
+          .getFinalizedBlocksAndStates()
+          .forEach(
+              (root, blockAndState) -> {
+                updater.addFinalizedBlock(blockAndState.getBlock());
+                putFinalizedState(updater, root, blockAndState.getState());
+              });
+
       updater.commit();
-      return result;
+      return StorageUpdateResult.successful();
     }
   }
 
@@ -240,88 +217,5 @@ public class RocksDbDatabase implements Database {
       default:
         throw new UnsupportedOperationException("Unhandled storage mode: " + stateStorageMode);
     }
-  }
-
-  private Set<Checkpoint> pruneCheckpointStates(
-      final Updater updater, final StorageUpdate update, final Checkpoint newFinalizedCheckpoint) {
-    final Set<Checkpoint> prunedCheckpoints = new HashSet<>();
-    try (final Stream<ColumnEntry<Checkpoint, BeaconState>> stream = dao.streamCheckpointStates()) {
-      Streams.concat(stream, update.getCheckpointStates().entrySet().stream())
-          .filter(e -> e.getKey().getEpoch().compareTo(newFinalizedCheckpoint.getEpoch()) < 0)
-          .forEach(
-              entry -> {
-                updater.deleteCheckpointState(entry.getKey());
-                prunedCheckpoints.add(entry.getKey());
-              });
-    }
-    return prunedCheckpoints;
-  }
-
-  private Set<Bytes32> pruneHotBlocks(
-      final Updater updater, final StorageUpdate update, final Checkpoint newFinalizedCheckpoint) {
-    Optional<SignedBeaconBlock> newlyFinalizedBlock =
-        getHotBlock(update, newFinalizedCheckpoint.getRoot());
-    if (newlyFinalizedBlock.isEmpty()) {
-      LOG.error(
-          "Missing finalized block {} for epoch {}",
-          newFinalizedCheckpoint.getRoot(),
-          newFinalizedCheckpoint.getEpoch());
-      return Collections.emptySet();
-    }
-    final UnsignedLong finalizedSlot = newlyFinalizedBlock.get().getSlot();
-    return updater.pruneHotBlocksAtSlotsOlderThan(finalizedSlot);
-  }
-
-  private void recordFinalizedBlocks(
-      Updater updater, final StorageUpdate update, final Checkpoint newFinalizedCheckpoint) {
-    LOG.debug(
-        "Record finalized blocks for epoch {} starting at block {}",
-        newFinalizedCheckpoint.getEpoch(),
-        newFinalizedCheckpoint.getRoot());
-
-    final UnsignedLong highestFinalizedSlot = dao.getHighestFinalizedSlot().orElse(ZERO);
-    Bytes32 newlyFinalizedBlockRoot = newFinalizedCheckpoint.getRoot();
-    Optional<SignedBeaconBlock> newlyFinalizedBlock = getHotBlock(update, newlyFinalizedBlockRoot);
-    boolean isLatestFinalizedBlock = true;
-    while (newlyFinalizedBlock.isPresent()
-        && newlyFinalizedBlock.get().getSlot().compareTo(highestFinalizedSlot) > 0) {
-      LOG.debug(
-          "Recording finalized block {} at slot {}",
-          newlyFinalizedBlockRoot,
-          newlyFinalizedBlock.get().getSlot());
-      updater.addFinalizedBlock(newlyFinalizedBlock.get());
-      final Optional<BeaconState> finalizedState = getHotState(update, newlyFinalizedBlockRoot);
-      if (finalizedState.isPresent()) {
-        putFinalizedState(updater, newlyFinalizedBlockRoot, finalizedState.get());
-        if (isLatestFinalizedBlock) {
-          updater.setLatestFinalizedState(finalizedState.get());
-          isLatestFinalizedBlock = false;
-        }
-      } else {
-        LOG.error(
-            "Missing finalized state {} for epoch {}",
-            newlyFinalizedBlockRoot,
-            newFinalizedCheckpoint.getEpoch());
-      }
-
-      // Update for next round of iteration
-      newlyFinalizedBlockRoot = newlyFinalizedBlock.get().getMessage().getParent_root();
-      newlyFinalizedBlock = getHotBlock(update, newlyFinalizedBlockRoot);
-    }
-
-    if (newlyFinalizedBlock.isEmpty()) {
-      LOG.error(
-          "Missing finalized block {} for epoch {}",
-          newlyFinalizedBlockRoot,
-          newFinalizedCheckpoint.getEpoch());
-    }
-  }
-
-  private Optional<SignedBeaconBlock> getHotBlock(final StorageUpdate update, final Bytes32 root) {
-    return Optional.ofNullable(update.getBlocks().get(root)).or(() -> dao.getHotBlock(root));
-  }
-
-  private Optional<BeaconState> getHotState(final StorageUpdate update, final Bytes32 root) {
-    return Optional.ofNullable(update.getBlockStates().get(root)).or(() -> dao.getHotState(root));
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbDao.java
@@ -17,7 +17,6 @@ import com.google.common.primitives.UnsignedLong;
 import com.google.errorprone.annotations.MustBeClosed;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
@@ -26,7 +25,6 @@ import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
-import tech.pegasys.teku.storage.server.rocksdb.core.ColumnEntry;
 
 /**
  * A RocksDB "data access object" interface to abstract interactions with underlying database.
@@ -43,8 +41,6 @@ public interface RocksDbDao extends AutoCloseable {
 
   Optional<Checkpoint> getFinalizedCheckpoint();
 
-  Optional<UnsignedLong> getHighestFinalizedSlot();
-
   Optional<Bytes32> getFinalizedRootAtSlot(final UnsignedLong slot);
 
   Optional<Bytes32> getLatestFinalizedRootAtSlot(final UnsignedLong slot);
@@ -53,17 +49,11 @@ public interface RocksDbDao extends AutoCloseable {
 
   Optional<SignedBeaconBlock> getFinalizedBlock(final Bytes32 root);
 
-  Optional<BeaconState> getHotState(final Bytes32 root);
-
   Optional<BeaconState> getFinalizedState(final Bytes32 root);
 
   Map<Bytes32, SignedBeaconBlock> getHotBlocks();
 
-  Map<Bytes32, BeaconState> getHotStates();
-
   Map<Checkpoint, BeaconState> getCheckpointStates();
-
-  Stream<ColumnEntry<Checkpoint, BeaconState>> streamCheckpointStates();
 
   Map<UnsignedLong, VoteTracker> getVotes();
 
@@ -84,8 +74,6 @@ public interface RocksDbDao extends AutoCloseable {
 
     void setFinalizedCheckpoint(final Checkpoint checkpoint);
 
-    void setLatestFinalizedState(final BeaconState state);
-
     void addCheckpointState(final Checkpoint checkpoint, final BeaconState state);
 
     void addCheckpointStates(Map<Checkpoint, BeaconState> checkpointStates);
@@ -94,26 +82,15 @@ public interface RocksDbDao extends AutoCloseable {
 
     void addFinalizedBlock(final SignedBeaconBlock block);
 
-    void addHotState(final Bytes32 blockRoot, final BeaconState state);
-
     void addFinalizedState(final Bytes32 blockRoot, final BeaconState state);
 
     void addVotes(final Map<UnsignedLong, VoteTracker> states);
 
     void addHotBlocks(final Map<Bytes32, SignedBeaconBlock> blocks);
 
-    void addHotStates(final Map<Bytes32, BeaconState> states);
-
     void deleteCheckpointState(final Checkpoint checkpoint);
 
-    /**
-     * Prune hot blocks and associated states at slots less than the given slot. Blocks at the
-     * height of {@code slot} are not pruned.
-     *
-     * @param slot The oldest slot that we want to keep in hot storage
-     * @return A list of pruned block roots
-     */
-    Set<Bytes32> pruneHotBlocksAtSlotsOlderThan(final UnsignedLong slot);
+    void deleteHotBlock(final Bytes32 blockRoot);
 
     void addMinGenesisTimeBlock(final MinGenesisTimeBlockEvent event);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V3RocksDbDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V3RocksDbDao.java
@@ -15,53 +15,27 @@ package tech.pegasys.teku.storage.server.rocksdb.dataaccess;
 
 import com.google.common.primitives.UnsignedLong;
 import com.google.errorprone.annotations.MustBeClosed;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.NavigableMap;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.core.StateTransition;
-import tech.pegasys.teku.core.StateTransitionException;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
-import tech.pegasys.teku.storage.server.DatabaseStorageException;
 import tech.pegasys.teku.storage.server.rocksdb.core.ColumnEntry;
 import tech.pegasys.teku.storage.server.rocksdb.core.RocksDbAccessor;
 import tech.pegasys.teku.storage.server.rocksdb.core.RocksDbAccessor.RocksDbTransaction;
 import tech.pegasys.teku.storage.server.rocksdb.schema.V3Schema;
 
 public class V3RocksDbDao implements RocksDbDao {
-  private static final Logger LOG = LogManager.getLogger();
-
   // Persistent data
   private final RocksDbAccessor db;
-  // In-memory data
-  private final NavigableMap<UnsignedLong, Set<Bytes32>> hotRootsBySlotCache =
-      new ConcurrentSkipListMap<>();
-  private final Map<Bytes32, BeaconState> hotStates = new ConcurrentHashMap<>();
 
   public V3RocksDbDao(final RocksDbAccessor db) {
     this.db = db;
-    initialize();
   }
 
   @Override
@@ -85,11 +59,6 @@ public class V3RocksDbDao implements RocksDbDao {
   }
 
   @Override
-  public Optional<UnsignedLong> getHighestFinalizedSlot() {
-    return db.getLastEntry(V3Schema.FINALIZED_ROOTS_BY_SLOT).map(ColumnEntry::getKey);
-  }
-
-  @Override
   public Optional<Bytes32> getFinalizedRootAtSlot(final UnsignedLong slot) {
     return db.get(V3Schema.FINALIZED_ROOTS_BY_SLOT, slot);
   }
@@ -110,11 +79,6 @@ public class V3RocksDbDao implements RocksDbDao {
   }
 
   @Override
-  public Optional<BeaconState> getHotState(final Bytes32 root) {
-    return Optional.ofNullable(hotStates.get(root));
-  }
-
-  @Override
   public Optional<BeaconState> getFinalizedState(final Bytes32 root) {
     return db.get(V3Schema.FINALIZED_STATES_BY_ROOT, root);
   }
@@ -125,19 +89,8 @@ public class V3RocksDbDao implements RocksDbDao {
   }
 
   @Override
-  public Map<Bytes32, BeaconState> getHotStates() {
-    return new HashMap<>(hotStates);
-  }
-
-  @Override
   public Map<Checkpoint, BeaconState> getCheckpointStates() {
     return db.getAll(V3Schema.CHECKPOINT_STATES);
-  }
-
-  @Override
-  @MustBeClosed
-  public Stream<ColumnEntry<Checkpoint, BeaconState>> streamCheckpointStates() {
-    return db.stream(V3Schema.CHECKPOINT_STATES);
   }
 
   @Override
@@ -156,159 +109,22 @@ public class V3RocksDbDao implements RocksDbDao {
     return db.get(V3Schema.MIN_GENESIS_TIME_BLOCK);
   }
 
-  private Optional<BeaconState> getLatestFinalizedState() {
-    return db.get(V3Schema.LATEST_FINALIZED_STATE);
-  }
-
-  public Optional<Bytes32> getLatestFinalizedRoot() {
-    return db.getLastEntry(V3Schema.FINALIZED_ROOTS_BY_SLOT).map(ColumnEntry::getValue);
-  }
-
   @Override
   public Updater updater() {
-    return new V3Updater(db, hotRootsBySlotCache, hotStates);
+    return new V3Updater(db);
   }
 
   @Override
   public void close() throws Exception {
-    hotRootsBySlotCache.clear();
     db.close();
-  }
-
-  private void initialize() {
-    final Optional<BeaconState> finalizedState = getLatestFinalizedState();
-    final Optional<Bytes32> finalizedRoot = getLatestFinalizedRoot();
-    final Map<Bytes32, SignedBeaconBlock> hotBlocksByRoot = getHotBlocks();
-
-    if (finalizedRoot.isEmpty() && finalizedState.isEmpty() && hotBlocksByRoot.isEmpty()) {
-      // Database is empty, nothing to initialize
-      LOG.trace("Database appears to be empty.  Skip initialization of hot states.");
-      return;
-    } else if (finalizedRoot.isEmpty() || finalizedState.isEmpty()) {
-      throw new DatabaseStorageException("Missing latest finalized block information");
-    }
-
-    LOG.info("Initializing hot states from hot blocks");
-    final Map<Bytes32, SignedBeaconBlock> prunedHotBlocks =
-        initializeHotStatesAndBlocks(finalizedRoot.get(), finalizedState.get(), hotBlocksByRoot);
-    LOG.info("Finished initializing hot states from hot blocks");
-
-    initializeHotSlotsByCache(prunedHotBlocks.values());
-  }
-
-  private void initializeHotSlotsByCache(Collection<SignedBeaconBlock> blocks) {
-    for (SignedBeaconBlock block : blocks) {
-      Set<Bytes32> blockRoots =
-          hotRootsBySlotCache.computeIfAbsent(
-              block.getSlot(), __ -> Collections.newSetFromMap(new ConcurrentHashMap<>()));
-      blockRoots.add(block.getRoot());
-    }
-  }
-
-  /**
-   * At the end deletes block roots for which we can't generate state for and returns the mutated
-   * hotBlocksByRoots map
-   *
-   * @param finalizedRoot
-   * @param finalizedState
-   * @param hotBlocksByRoot
-   */
-  private Map<Bytes32, SignedBeaconBlock> initializeHotStatesAndBlocks(
-      final Bytes32 finalizedRoot,
-      final BeaconState finalizedState,
-      final Map<Bytes32, SignedBeaconBlock> hotBlocksByRoot) {
-    // Initialize hot states with latest finalized state
-    hotStates.put(finalizedRoot, finalizedState);
-
-    // Index blocks by parent root
-    final Map<Bytes32, List<SignedBeaconBlock>> blocksByParent = new HashMap<>();
-    for (Entry<Bytes32, SignedBeaconBlock> hotBlockEntry : hotBlocksByRoot.entrySet()) {
-      final SignedBeaconBlock currentBlock = hotBlockEntry.getValue();
-      final List<SignedBeaconBlock> blockList =
-          blocksByParent.computeIfAbsent(currentBlock.getParent_root(), (key) -> new ArrayList<>());
-      blockList.add(currentBlock);
-    }
-
-    // Generate remaining hot states
-    final Deque<Bytes32> parentRoots = new ArrayDeque<>();
-    parentRoots.push(finalizedRoot);
-    while (!parentRoots.isEmpty()) {
-      final Bytes32 parentRoot = parentRoots.pop();
-      final BeaconState parentState = hotStates.get(parentRoot);
-      final List<SignedBeaconBlock> blocks =
-          blocksByParent.computeIfAbsent(parentRoot, (key) -> Collections.emptyList());
-      for (SignedBeaconBlock block : blocks) {
-        final Bytes32 blockRoot = block.getMessage().hash_tree_root();
-        processBlock(parentState, block)
-            .ifPresent(
-                state -> {
-                  hotStates.put(blockRoot, state);
-                  parentRoots.push(blockRoot);
-                });
-      }
-    }
-
-    if (hotStates.size() != hotBlocksByRoot.size()) {
-      LOG.trace(
-          "Only {} hot states produced for {} hot blocks.  Some hot blocks must be incompatible with the latest finalized block.",
-          hotStates.size(),
-          hotBlocksByRoot.size());
-
-      RocksDbTransaction transaction = db.startTransaction();
-      Set<Bytes32> blockRootsToDelete =
-          hotBlocksByRoot.keySet().stream()
-              .filter(blockRoot -> !hotStates.containsKey(blockRoot))
-              .collect(Collectors.toSet());
-
-      blockRootsToDelete.forEach(
-          blockRoot -> {
-            hotBlocksByRoot.remove(blockRoot);
-            transaction.delete(V3Schema.HOT_BLOCKS_BY_ROOT, blockRoot);
-          });
-
-      transaction.commit();
-    }
-
-    return hotBlocksByRoot;
-  }
-
-  private final Optional<BeaconState> processBlock(
-      final BeaconState preState, final SignedBeaconBlock block) {
-    StateTransition stateTransition = new StateTransition();
-    try {
-      final BeaconState postState = stateTransition.initiate(preState, block);
-      return Optional.of(postState);
-    } catch (StateTransitionException e) {
-      LOG.error(
-          "Unable to produce state for block at slot {} ({})",
-          block.getSlot(),
-          block.getMessage().hash_tree_root());
-      return Optional.empty();
-    }
   }
 
   private static class V3Updater implements Updater {
 
     private final RocksDbTransaction transaction;
-    private final NavigableMap<UnsignedLong, Set<Bytes32>> hotRootsBySlotCache;
-    private final Map<Bytes32, BeaconState> hotStates;
 
-    // Hot root by slot updates
-    private final NavigableMap<UnsignedLong, Set<Bytes32>> hotRootsBySlotAdditions =
-        new ConcurrentSkipListMap<>();
-    private final Set<UnsignedLong> prunedSlots = new HashSet<>();
-
-    // Hot state updates
-    private final Map<Bytes32, BeaconState> newHotStates = new HashMap<>();
-    private final Set<Bytes32> deletedStates = new HashSet<>();
-
-    V3Updater(
-        final RocksDbAccessor db,
-        final NavigableMap<UnsignedLong, Set<Bytes32>> hotRootsBySlotCache,
-        final Map<Bytes32, BeaconState> hotStates) {
+    V3Updater(final RocksDbAccessor db) {
       this.transaction = db.startTransaction();
-      this.hotRootsBySlotCache = hotRootsBySlotCache;
-      this.hotStates = hotStates;
     }
 
     @Override
@@ -324,11 +140,6 @@ public class V3RocksDbDao implements RocksDbDao {
     @Override
     public void setBestJustifiedCheckpoint(final Checkpoint checkpoint) {
       transaction.put(V3Schema.BEST_JUSTIFIED_CHECKPOINT, checkpoint);
-    }
-
-    @Override
-    public void setLatestFinalizedState(final BeaconState state) {
-      transaction.put(V3Schema.LATEST_FINALIZED_STATE, state);
     }
 
     @Override
@@ -350,9 +161,6 @@ public class V3RocksDbDao implements RocksDbDao {
     public void addHotBlock(final SignedBeaconBlock block) {
       final Bytes32 blockRoot = block.getRoot();
       transaction.put(V3Schema.HOT_BLOCKS_BY_ROOT, blockRoot, block);
-      hotRootsBySlotAdditions
-          .computeIfAbsent(block.getSlot(), key -> new HashSet<>())
-          .add(blockRoot);
     }
 
     @Override
@@ -363,11 +171,6 @@ public class V3RocksDbDao implements RocksDbDao {
     }
 
     @Override
-    public void addHotState(final Bytes32 blockRoot, final BeaconState state) {
-      newHotStates.put(blockRoot, state);
-    }
-
-    @Override
     public void addFinalizedState(final Bytes32 blockRoot, final BeaconState state) {
       transaction.put(V3Schema.FINALIZED_STATES_BY_ROOT, blockRoot, state);
     }
@@ -375,11 +178,6 @@ public class V3RocksDbDao implements RocksDbDao {
     @Override
     public void addHotBlocks(final Map<Bytes32, SignedBeaconBlock> blocks) {
       blocks.values().forEach(this::addHotBlock);
-    }
-
-    @Override
-    public void addHotStates(final Map<Bytes32, BeaconState> states) {
-      states.forEach(this::addHotState);
     }
 
     @Override
@@ -394,25 +192,8 @@ public class V3RocksDbDao implements RocksDbDao {
     }
 
     @Override
-    public Set<Bytes32> pruneHotBlocksAtSlotsOlderThan(final UnsignedLong slot) {
-      final Map<UnsignedLong, Set<Bytes32>> toRemove = new HashMap<>();
-      toRemove.putAll(hotRootsBySlotAdditions.headMap(slot));
-      toRemove.putAll(hotRootsBySlotCache.headMap(slot));
-
-      final Set<Bytes32> prunedRoots =
-          toRemove.values().stream().flatMap(Set::stream).collect(Collectors.toSet());
-      for (Set<Bytes32> hotRoots : toRemove.values()) {
-        for (Bytes32 root : hotRoots) {
-          newHotStates.remove(root);
-          deletedStates.add(root);
-          transaction.delete(V3Schema.HOT_BLOCKS_BY_ROOT, root);
-        }
-      }
-
-      hotRootsBySlotAdditions.keySet().removeAll(toRemove.keySet());
-      prunedSlots.addAll(toRemove.keySet());
-
-      return prunedRoots;
+    public void deleteHotBlock(final Bytes32 blockRoot) {
+      transaction.delete(V3Schema.HOT_BLOCKS_BY_ROOT, blockRoot);
     }
 
     @Override
@@ -429,18 +210,6 @@ public class V3RocksDbDao implements RocksDbDao {
 
     @Override
     public void commit() {
-      // Commit slot updates
-      hotRootsBySlotCache.keySet().removeAll(prunedSlots);
-      hotRootsBySlotAdditions.forEach(
-          (slot, roots) -> {
-            final Set<Bytes32> currentRoots =
-                hotRootsBySlotCache.computeIfAbsent(
-                    slot, __ -> Collections.newSetFromMap(new ConcurrentHashMap<>()));
-            currentRoots.addAll(roots);
-          });
-      // Commit hot state updates
-      deletedStates.forEach(hotStates::remove);
-      hotStates.putAll(newHotStates);
       // Commit db updates
       transaction.commit();
       close();
@@ -448,13 +217,6 @@ public class V3RocksDbDao implements RocksDbDao {
 
     @Override
     public void cancel() {
-      // Clear slot updates
-      prunedSlots.clear();
-      hotRootsBySlotAdditions.clear();
-      // Clear hot state updates
-      deletedStates.clear();
-      newHotStates.clear();
-      // Clear db updates
       transaction.rollback();
       close();
     }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
@@ -602,7 +602,6 @@ public abstract class AbstractDatabaseTest {
     assertHotBlocksAndStates(store, expectedHotBlocksAndStates);
     final SignedBlockAndState prunedForkBlock = forkChain.getBlockAndStateAtSlot(hotSlot);
     assertThat(store.containsBlock(prunedForkBlock.getRoot())).isFalse();
-    assertThat(store.containsBlockState(prunedForkBlock.getRoot())).isFalse();
 
     // Check finalized data
     final List<SignedBeaconBlock> expectedFinalizedBlocks =

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/AbstractRocksDbDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/AbstractRocksDbDatabaseTest.java
@@ -97,7 +97,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
     // Close db
     database.close();
 
-    assertThatThrownBy(() -> database.getState(genesisCheckpoint.getRoot()))
+    assertThatThrownBy(() -> database.getFinalizedState(genesisCheckpoint.getRoot()))
         .isInstanceOf(IllegalStateException.class);
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/AbstractRocksDbDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/AbstractRocksDbDatabaseTest.java
@@ -38,11 +38,11 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
     database.storeGenesis(store);
     database.close();
 
-    final Checkpoint newValue = checkpoint3;
+    final SignedBlockAndState newValue = chainBuilder.generateBlockAtSlot(1);
     // Sanity check
-    assertThat(store.getFinalizedCheckpoint()).isNotEqualTo(checkpoint3);
+    assertThat(store.getBlockState(newValue.getRoot())).isNull();
     final Transaction transaction = store.startTransaction(storageUpdateChannel);
-    transaction.setFinalizedCheckpoint(newValue);
+    transaction.putBlockAndState(newValue);
 
     final SafeFuture<Void> result = transaction.commit();
     assertThatThrownBy(result::get).hasCauseInstanceOf(IllegalStateException.class);
@@ -88,7 +88,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
     // Store genesis
     database.storeGenesis(store);
     // Add a new finalized block to supersede genesis
-    final SignedBlockAndState newBlock = chainBuilder.getBlockAndStateAtSlot(1);
+    final SignedBlockAndState newBlock = chainBuilder.generateBlockAtSlot(1);
     final Checkpoint newCheckpoint = getCheckpointForBlock(newBlock.getBlock());
     final Transaction transaction = store.startTransaction(storageUpdateChannel);
     transaction.putBlockAndState(newBlock);

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
@@ -28,7 +28,7 @@ public class StubStorageUpdateChannel implements StorageUpdateChannel {
 
   @Override
   public SafeFuture<StorageUpdateResult> onStorageUpdate(StorageUpdate event) {
-    return SafeFuture.completedFuture(StorageUpdateResult.successfulWithNothingPruned());
+    return SafeFuture.completedFuture(StorageUpdateResult.successful());
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As part of addressing #1976, limit the number of states that are kept in memory.  If a state that has been dropped from memory is later requested, regenerate the missing state.

**Note**: Builds on https://github.com/PegaSysEng/teku/pull/2006, relevant commits from 423edcc23e872a5f3a7685481f13a16da5259bdf
