### PR TITLE
Improve validator logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ named CLI option `--validators-key-files` which is used to specify encrypted val
 - `--network witti` includes the final configuration for the Witti testnet. The genesis state is included so an ETH1 endpoint is no longer required when connecting to Witti
 - Teku can now use Infura as the ETH1 endpoint
 - ETH1 node is no longer required to maintain historic world state
+- Added `--log-include-validator-duties-enabled` option to enable log messages when validator clients produce blocks, attestations or aggregates (defaults to off)
+- Improved logging of errors during execution of validator duties to be more informative, less noisy and set log levels more appropriately
 - Teku will now exit when an `OutOfMemoryError` is encountered to allow tools like systemd to restart it
 - Added support for compiling from source using Java 14
 - Improved error messages for a number of configuration errors

--- a/events/src/test/java/tech/pegasys/teku/events/DirectEventDelivererTest.java
+++ b/events/src/test/java/tech/pegasys/teku/events/DirectEventDelivererTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.events;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.lang.reflect.Method;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.junit.jupiter.api.Test;
+
+class DirectEventDelivererTest {
+
+  private final ChannelExceptionHandler exceptionHandler = mock(ChannelExceptionHandler.class);
+  private final Runnable target = mock(Runnable.class);
+
+  private final DirectEventDeliverer<Runnable> deliverer =
+      new DirectEventDeliverer<>(exceptionHandler, new NoOpMetricsSystem());
+  public static final Object[] NO_ARGS = new Object[0];
+
+  @Test
+  void shouldInvokeMethod() throws Exception {
+    deliverer.deliverTo(target, Runnable.class.getMethod("run"), new Object[0]);
+
+    verify(target).run();
+  }
+
+  @Test
+  void shouldNotifyExceptionHandlerWhenMethodThrowsException() throws Exception {
+    final RuntimeException error = new RuntimeException("Nope");
+    doThrow(error).when(target).run();
+
+    final Method method = Runnable.class.getMethod("run");
+    deliverer.deliverTo(target, method, NO_ARGS);
+
+    verify(target).run();
+    verify(exceptionHandler).handleException(error, target, method, NO_ARGS);
+    verifyNoMoreInteractions(exceptionHandler);
+  }
+
+  @Test
+  void shouldNotifyExceptionHandlerWhenIllegalAccessExceptionOccurs() throws Exception {
+    final ClassWithPrivateMethod target = new ClassWithPrivateMethod();
+    final Method method = ClassWithPrivateMethod.class.getDeclaredMethod("run");
+    final DirectEventDeliverer<ClassWithPrivateMethod> deliverer =
+        new DirectEventDeliverer<>(exceptionHandler, new NoOpMetricsSystem());
+    deliverer.deliverTo(target, method, NO_ARGS);
+
+    verify(exceptionHandler)
+        .handleException(any(IllegalAccessException.class), eq(target), eq(method), eq(NO_ARGS));
+    verifyNoMoreInteractions(exceptionHandler);
+  }
+
+  public static class ClassWithPrivateMethod {
+    @SuppressWarnings("unused")
+    private void run() {}
+  }
+}

--- a/logging/src/main/java/tech/pegasys/teku/logging/EventLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/EventLogger.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.logging;
 
 import static tech.pegasys.teku.logging.ColorConsolePrinter.print;
+import static tech.pegasys.teku.logging.LogFormatter.formatHashRoot;
 import static tech.pegasys.teku.logging.LoggingConfigurator.EVENT_LOGGER_NAME;
 
 import com.google.common.primitives.UnsignedLong;
@@ -51,8 +52,8 @@ public class EventLogger {
             currentEpoch.toString(),
             justifiedCheckpoint.toString(),
             finalizedCheckpoint.toString(),
-            shortenHash(finalizedRoot.toHexString()));
-    info(epochEventLog, Color.YELLOW);
+            formatHashRoot(finalizedRoot));
+    info(epochEventLog, Color.GREEN);
   }
 
   public void syncEvent(
@@ -74,7 +75,7 @@ public class EventLogger {
       final int numPeers) {
     String blockRoot = "   ... empty";
     if (nodeSlot.equals(headSlot)) {
-      blockRoot = shortenHash(bestBlockRoot.toHexString());
+      blockRoot = formatHashRoot(bestBlockRoot);
     }
     final String slotEventLog =
         String.format(
@@ -83,34 +84,12 @@ public class EventLogger {
             blockRoot,
             nodeEpoch.toString(),
             finalizedCheckpoint.toString(),
-            shortenHash(finalizedRoot.toHexString()),
+            formatHashRoot(finalizedRoot),
             numPeers);
     info(slotEventLog, Color.WHITE);
   }
 
-  public void unprocessedAttestation(final Bytes32 beaconBlockRoot) {
-    debug("New Attestation with block root:  " + beaconBlockRoot + " detected.", Color.GREEN);
-  }
-
-  public void aggregateAndProof(final Bytes32 beaconBlockRoot) {
-    debug("New AggregateAndProof with block root:  " + beaconBlockRoot + " detected.", Color.BLUE);
-  }
-
-  public void unprocessedBlock(final Bytes32 stateRoot) {
-    debug(
-        "New BeaconBlock with state root:  " + stateRoot.toHexString() + " detected.", Color.GREEN);
-  }
-
-  private void debug(final String message, final Color color) {
-    log.debug(print(message, color));
-  }
-
   private void info(final String message, final Color color) {
     log.info(print(message, color));
-  }
-
-  private String shortenHash(final String hash) {
-    return String.format(
-        "%s..%s", hash.substring(0, 6), hash.substring(hash.length() - 4, hash.length()));
   }
 }

--- a/logging/src/main/java/tech/pegasys/teku/logging/EventLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/EventLogger.java
@@ -60,7 +60,7 @@ public class EventLogger {
       final UnsignedLong nodeSlot, final UnsignedLong headSlot, final int numPeers) {
     final String syncEventLog =
         String.format(
-            "Sync Event *** Current slot: %s, Head slot: %s, Connected peers: %d",
+            "Sync Event  *** Current slot: %s, Head slot: %s, Connected peers: %d",
             nodeSlot, headSlot.toString(), numPeers);
     info(syncEventLog, Color.WHITE);
   }
@@ -79,7 +79,7 @@ public class EventLogger {
     }
     final String slotEventLog =
         String.format(
-            "Slot Event *** Slot: %s, Block: %s, Epoch: %s, Finalized checkpoint: %s, Finalized root: %s, Peers: %d",
+            "Slot Event  *** Slot: %s, Block: %s, Epoch: %s, Finalized checkpoint: %s, Finalized root: %s, Peers: %d",
             nodeSlot.toString(),
             blockRoot,
             nodeEpoch.toString(),

--- a/logging/src/main/java/tech/pegasys/teku/logging/LogFormatter.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/LogFormatter.java
@@ -11,12 +11,13 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.validator.client.duties;
+package tech.pegasys.teku.logging;
 
-import tech.pegasys.teku.util.async.SafeFuture;
+import org.apache.tuweni.bytes.Bytes32;
 
-public interface Duty {
-  SafeFuture<DutyResult> performDuty();
-
-  String getProducedType();
+public class LogFormatter {
+  public static String formatHashRoot(final Bytes32 root) {
+    final String hash = root.toUnprefixedHexString();
+    return String.format("%s..%s", hash.substring(0, 6), hash.substring(hash.length() - 4));
+  }
 }

--- a/logging/src/main/java/tech/pegasys/teku/logging/LoggingConfiguration.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/LoggingConfiguration.java
@@ -19,6 +19,7 @@ public class LoggingConfiguration {
 
   private final boolean colorEnabled;
   private final boolean includeEventsEnabled;
+  private final boolean includeValidatorDutiesEnabled;
   private final LoggingDestination destination;
   private final String file;
   private final String fileNamePattern;
@@ -26,11 +27,13 @@ public class LoggingConfiguration {
   public LoggingConfiguration(
       final boolean colorEnabled,
       final boolean includeEventsEnabled,
+      final boolean includeValidatorDutiesEnabled,
       final LoggingDestination destination,
       final String file,
       final String fileNamePattern) {
     this.colorEnabled = colorEnabled;
     this.includeEventsEnabled = includeEventsEnabled;
+    this.includeValidatorDutiesEnabled = includeValidatorDutiesEnabled;
     this.destination = destination;
     this.file = file;
     this.fileNamePattern = fileNamePattern;
@@ -42,6 +45,10 @@ public class LoggingConfiguration {
 
   public boolean isIncludeEventsEnabled() {
     return includeEventsEnabled;
+  }
+
+  public boolean isIncludeValidatorDutiesEnabled() {
+    return includeValidatorDutiesEnabled;
   }
 
   public LoggingDestination getDestination() {

--- a/logging/src/main/java/tech/pegasys/teku/logging/ValidatorLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/ValidatorLogger.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.logging;
+
+import static tech.pegasys.teku.logging.ColorConsolePrinter.print;
+import static tech.pegasys.teku.logging.LoggingConfigurator.VALIDATOR_LOGGER_NAME;
+
+import com.google.common.base.Strings;
+import com.google.common.primitives.UnsignedLong;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.logging.ColorConsolePrinter.Color;
+
+public class ValidatorLogger {
+  public static final ValidatorLogger VALIDATOR_LOGGER = new ValidatorLogger(VALIDATOR_LOGGER_NAME);
+  public static final int LONGEST_TYPE_LENGTH = "attestation".length();
+  private static final String PREFIX = "Validator  *** ";
+
+  private final Logger log;
+
+  private ValidatorLogger(final String name) {
+    this.log = LogManager.getLogger(name);
+  }
+
+  public void dutyCompleted(
+      final String producedType,
+      final UnsignedLong slot,
+      final int successCount,
+      final Set<Bytes32> blockRoots) {
+    final String paddedType = Strings.padEnd(producedType, LONGEST_TYPE_LENGTH, ' ');
+    logDuty(paddedType, slot, successCount, blockRoots);
+  }
+
+  public void dutySkippedWhileSyncing(
+      final String producedType, final UnsignedLong slot, final int skippedCount) {
+    log.warn(
+        print(
+            String.format(
+                "%sSkipped producing %s while node is syncing  Count: %s, Slot: %s",
+                PREFIX, producedType, skippedCount, slot),
+            Color.YELLOW));
+  }
+
+  public void dutyFailed(
+      final String producedType, final UnsignedLong slot, final Throwable error) {
+    log.error(
+        print(
+            String.format("%sFailed to produce %s  Slot: %s", PREFIX, producedType, slot),
+            Color.RED),
+        error);
+  }
+
+  private void logDuty(
+      final String type, final UnsignedLong slot, final int count, final Set<Bytes32> roots) {
+    log.info(
+        print(
+            String.format(
+                "%sPublished %s  Count: %s, Slot: %s, Root: %s",
+                PREFIX, type, count, slot, formatBlockRoots(roots)),
+            Color.BLUE));
+  }
+
+  private String formatBlockRoots(final Set<Bytes32> blockRoots) {
+    return blockRoots.stream().map(LogFormatter::formatHashRoot).collect(Collectors.joining(", "));
+  }
+
+  public void aggregationSkipped(final UnsignedLong slot) {
+    log.warn(
+        print(
+            PREFIX
+                + "Skipped aggregation for slot "
+                + slot
+                + " because there was nothing to aggregate",
+            Color.YELLOW));
+  }
+}

--- a/logging/src/main/java/tech/pegasys/teku/logging/ValidatorLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/ValidatorLogger.java
@@ -28,7 +28,7 @@ import tech.pegasys.teku.logging.ColorConsolePrinter.Color;
 public class ValidatorLogger {
   public static final ValidatorLogger VALIDATOR_LOGGER = new ValidatorLogger(VALIDATOR_LOGGER_NAME);
   public static final int LONGEST_TYPE_LENGTH = "attestation".length();
-  private static final String PREFIX = "Validator  *** ";
+  private static final String PREFIX = "Validator   *** ";
 
   private final Logger log;
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -15,12 +15,10 @@ package tech.pegasys.teku.storage.client;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_block_root_at_slot;
-import static tech.pegasys.teku.logging.EventLogger.EVENT_LOG;
 import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_HISTORICAL_ROOT;
 import static tech.pegasys.teku.util.unsignedlong.UnsignedLongMath.max;
 
 import com.google.common.eventbus.EventBus;
-import com.google.common.eventbus.Subscribe;
 import com.google.common.primitives.UnsignedLong;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -32,8 +30,6 @@ import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
-import tech.pegasys.teku.datastructures.operations.Attestation;
-import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.state.Fork;
@@ -247,22 +243,6 @@ public abstract class RecentChainData implements StoreUpdateHandler {
    */
   public UnsignedLong getBestSlot() {
     return chainHead.map(SignedBlockAndState::getSlot).orElse(UnsignedLong.ZERO);
-  }
-
-  @Subscribe
-  public void onNewUnprocessedBlock(BeaconBlock block) {
-    EVENT_LOG.unprocessedBlock(block.getState_root());
-  }
-
-  @Subscribe
-  public void onNewUnprocessedAttestation(Attestation attestation) {
-    EVENT_LOG.unprocessedAttestation(attestation.getData().getBeacon_block_root());
-  }
-
-  @Subscribe
-  public void onNewAggregateAndProof(SignedAggregateAndProof attestation) {
-    EVENT_LOG.aggregateAndProof(
-        attestation.getMessage().getAggregate().getData().getBeacon_block_root());
   }
 
   public boolean containsBlock(final Bytes32 root) {

--- a/teku/src/main/java/tech/pegasys/teku/BeaconNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/BeaconNode.java
@@ -53,6 +53,7 @@ public class BeaconNode {
         new LoggingConfiguration(
             config.isLogColorEnabled(),
             config.isLogIncludeEventsEnabled(),
+            config.isLogIncludeValidatorDutiesEnabled(),
             config.getLogDestination(),
             config.getLogFile(),
             config.getLogFileNamePattern()));

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -318,6 +318,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setEth1Endpoint(depositOptions.getEth1Endpoint())
         .setLogColorEnabled(loggingOptions.isLogColorEnabled())
         .setLogIncludeEventsEnabled(loggingOptions.isLogIncludeEventsEnabled())
+        .setLogIncludeValidatorDutiesEnabled(loggingOptions.isLogIncludeValidatorDutiesEnabled())
         .setLogDestination(loggingOptions.getLogDestination())
         .setLogFile(loggingOptions.getLogFile())
         .setLogFileNamePattern(loggingOptions.getLogFileNamePattern())

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
@@ -40,11 +40,18 @@ public class LoggingOptions {
   @CommandLine.Option(
       names = {"--log-include-events-enabled"},
       paramLabel = "<BOOLEAN>",
-      description =
-          "Whether frequent update events are logged (e.g. every slot event, with validators and attestations)",
+      description = "Whether frequent update events are logged (e.g. every slot and epoch event)",
       fallbackValue = "true",
       arity = "0..1")
   private boolean logIncludeEventsEnabled = true;
+
+  @CommandLine.Option(
+      names = {"--log-include-validator-duties-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Whether events are logged when validators perform duties",
+      fallbackValue = "true",
+      arity = "0..1")
+  private boolean logIncludeValidatorDutiesEnabled = false;
 
   @CommandLine.Option(
       names = {"--log-destination"},
@@ -110,6 +117,10 @@ public class LoggingOptions {
 
   public boolean isLogIncludeEventsEnabled() {
     return logIncludeEventsEnabled;
+  }
+
+  public boolean isLogIncludeValidatorDutiesEnabled() {
+    return logIncludeValidatorDutiesEnabled;
   }
 
   public LoggingDestination getLogDestination() {

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
@@ -73,6 +73,7 @@ public class TekuConfiguration {
   // Logging
   private final boolean logColorEnabled;
   private final boolean logIncludeEventsEnabled;
+  private final boolean logIncludeValidatorDutiesEnabled;
   private final LoggingDestination logDestination;
   private final String logFile;
   private final String logFileNamePattern;
@@ -138,6 +139,7 @@ public class TekuConfiguration {
       final String eth1Endpoint,
       final boolean logColorEnabled,
       final boolean logIncludeEventsEnabled,
+      final boolean logIncludeValidatorDutiesEnabled,
       final LoggingDestination logDestination,
       final String logFile,
       final String logFileNamePattern,
@@ -189,6 +191,7 @@ public class TekuConfiguration {
     this.eth1Endpoint = eth1Endpoint;
     this.logColorEnabled = logColorEnabled;
     this.logIncludeEventsEnabled = logIncludeEventsEnabled;
+    this.logIncludeValidatorDutiesEnabled = logIncludeValidatorDutiesEnabled;
     this.logDestination = logDestination;
     this.logFile = logFile;
     this.logFileNamePattern = logFileNamePattern;
@@ -354,6 +357,10 @@ public class TekuConfiguration {
 
   public boolean isLogIncludeEventsEnabled() {
     return logIncludeEventsEnabled;
+  }
+
+  public boolean isLogIncludeValidatorDutiesEnabled() {
+    return logIncludeValidatorDutiesEnabled;
   }
 
   public LoggingDestination getLogDestination() {

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
@@ -51,6 +51,7 @@ public class TekuConfigurationBuilder {
   private String eth1Endpoint;
   private boolean logColorEnabled;
   private boolean logIncludeEventsEnabled;
+  private boolean logIncludeValidatorDutiesEnabled;
   private LoggingDestination logDestination;
   private String logFile;
   private String logFileNamePattern;
@@ -239,6 +240,12 @@ public class TekuConfigurationBuilder {
     return this;
   }
 
+  public TekuConfigurationBuilder setLogIncludeValidatorDutiesEnabled(
+      final boolean logIncludeValidatorDutiesEnabled) {
+    this.logIncludeValidatorDutiesEnabled = logIncludeValidatorDutiesEnabled;
+    return this;
+  }
+
   public TekuConfigurationBuilder setLogDestination(final LoggingDestination logDestination) {
     this.logDestination = logDestination;
     return this;
@@ -399,6 +406,7 @@ public class TekuConfigurationBuilder {
         eth1Endpoint,
         logColorEnabled,
         logIncludeEventsEnabled,
+        logIncludeValidatorDutiesEnabled,
         logDestination,
         logFile,
         logFileNamePattern,

--- a/validator/client/build.gradle
+++ b/validator/client/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   implementation project(':ethereum:core')
   implementation project(':ethereum:datastructures')
   implementation project(':events')
+  implementation project(':logging')
   implementation project(':services:serviceutils')
   implementation project(':validator:anticorruption')
   implementation project(':validator:api')

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/DutyResult.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/DutyResult.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.duties;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletionException;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.logging.ValidatorLogger;
+import tech.pegasys.teku.util.async.SafeFuture;
+import tech.pegasys.teku.validator.api.NodeSyncingException;
+
+public class DutyResult {
+  public static final DutyResult NO_OP = new DutyResult(0, 0, emptySet(), emptyList());
+  private final int successCount;
+  private final int nodeSyncingCount;
+  private final Set<Bytes32> roots;
+  private final List<Throwable> errors;
+
+  private DutyResult(
+      final int successCount,
+      final int nodeSyncingCount,
+      final Set<Bytes32> roots,
+      final List<Throwable> errors) {
+    this.successCount = successCount;
+    this.nodeSyncingCount = nodeSyncingCount;
+    this.roots = roots;
+    this.errors = errors;
+  }
+
+  public static DutyResult success(final Bytes32 result) {
+    return new DutyResult(1, 0, singleton(result), emptyList());
+  }
+
+  public static DutyResult forError(final Throwable error) {
+    // Not using getRootCause here because we only want to unwrap CompletionException
+    Throwable cause = error;
+    while (cause instanceof CompletionException && cause.getCause() != null) {
+      cause = cause.getCause();
+    }
+    if (cause instanceof NodeSyncingException) {
+      return new DutyResult(0, 1, emptySet(), emptyList());
+    } else {
+      return new DutyResult(0, 0, emptySet(), List.of(cause));
+    }
+  }
+
+  public static SafeFuture<DutyResult> combine(final List<SafeFuture<DutyResult>> futures) {
+    return SafeFuture.allOf(futures.toArray(SafeFuture[]::new))
+        .handle(
+            (ok, error) ->
+                futures.stream()
+                    .map(future -> future.exceptionally(DutyResult::forError).getNow(null))
+                    .reduce(DutyResult::combine)
+                    .orElse(NO_OP));
+  }
+
+  public DutyResult combine(final DutyResult other) {
+    final int combinedSuccessCount = this.successCount + other.successCount;
+    final int combinedSyncingCount = this.nodeSyncingCount + other.nodeSyncingCount;
+
+    final Set<Bytes32> combinedRoots = new HashSet<>(this.roots);
+    combinedRoots.addAll(other.roots);
+
+    final List<Throwable> combinedErrors = new ArrayList<>(this.errors);
+    combinedErrors.addAll(other.errors);
+
+    return new DutyResult(
+        combinedSuccessCount, combinedSyncingCount, combinedRoots, combinedErrors);
+  }
+
+  public void report(
+      final String producedType, final UnsignedLong slot, final ValidatorLogger logger) {
+    if (successCount > 0) {
+      logger.dutyCompleted(producedType, slot, successCount, roots);
+    }
+    if (nodeSyncingCount > 0) {
+      logger.dutySkippedWhileSyncing(producedType, slot, nodeSyncingCount);
+    }
+    errors.forEach(error -> logger.dutyFailed(producedType, slot, error));
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ValidatorDutyFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ValidatorDutyFactory.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.validator.client.duties;
 
+import static tech.pegasys.teku.logging.ValidatorLogger.VALIDATOR_LOGGER;
+
 import com.google.common.primitives.UnsignedLong;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.ForkProvider;
@@ -38,6 +40,6 @@ public class ValidatorDutyFactory {
   }
 
   public AggregationDuty createAggregationDuty(final UnsignedLong slot) {
-    return new AggregationDuty(slot, validatorApiChannel, forkProvider);
+    return new AggregationDuty(slot, validatorApiChannel, forkProvider, VALIDATOR_LOGGER);
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/DutyResultTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/DutyResultTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.duties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.List;
+import java.util.Set;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.logging.ValidatorLogger;
+import tech.pegasys.teku.util.async.SafeFuture;
+import tech.pegasys.teku.validator.api.NodeSyncingException;
+
+class DutyResultTest {
+
+  private static final UnsignedLong SLOT = UnsignedLong.valueOf(323);
+  private static final String TYPE = "type";
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final ValidatorLogger validatorLogger = mock(ValidatorLogger.class);
+
+  @Test
+  void shouldReportSuccess() {
+    final Bytes32 root = dataStructureUtil.randomBytes32();
+    DutyResult.success(root).report(TYPE, SLOT, validatorLogger);
+
+    verify(validatorLogger).dutyCompleted(TYPE, SLOT, 1, Set.of(root));
+    verifyNoMoreInteractions(validatorLogger);
+  }
+
+  @Test
+  void shouldReportError() {
+    final RuntimeException error = new RuntimeException("Oh no");
+    DutyResult.forError(error).report(TYPE, SLOT, validatorLogger);
+
+    verify(validatorLogger).dutyFailed(TYPE, SLOT, error);
+    verifyNoMoreInteractions(validatorLogger);
+  }
+
+  @Test
+  void shouldReportNodeSyncing() {
+    DutyResult.forError(new NodeSyncingException()).report(TYPE, SLOT, validatorLogger);
+
+    verify(validatorLogger).dutySkippedWhileSyncing(TYPE, SLOT, 1);
+    verifyNoMoreInteractions(validatorLogger);
+  }
+
+  @Test
+  void shouldCombineSuccessResults() {
+    final Bytes32 root1 = dataStructureUtil.randomBytes32();
+    final Bytes32 root2 = dataStructureUtil.randomBytes32();
+
+    final DutyResult combined =
+        DutyResult.success(root1)
+            .combine(DutyResult.success(root2))
+            .combine(DutyResult.success(root1));
+    combined.report(TYPE, SLOT, validatorLogger);
+
+    verify(validatorLogger).dutyCompleted(TYPE, SLOT, 3, Set.of(root1, root2));
+    verifyNoMoreInteractions(validatorLogger);
+  }
+
+  @Test
+  void shouldCombineErrorResults() {
+    final RuntimeException exception1 = new RuntimeException("Oops");
+    final RuntimeException exception2 = new RuntimeException("Nope");
+
+    final DutyResult combined =
+        DutyResult.forError(exception1)
+            .combine(DutyResult.forError(exception2))
+            .combine(DutyResult.forError(exception1));
+    combined.report(TYPE, SLOT, validatorLogger);
+
+    verify(validatorLogger, times(2)).dutyFailed(TYPE, SLOT, exception1);
+    verify(validatorLogger).dutyFailed(TYPE, SLOT, exception2);
+    verifyNoMoreInteractions(validatorLogger);
+  }
+
+  @Test
+  void shouldCombineNodeSyncingResults() {
+    final DutyResult combined =
+        DutyResult.forError(new NodeSyncingException())
+            .combine(DutyResult.forError(new NodeSyncingException()))
+            .combine(DutyResult.forError(new NodeSyncingException()));
+    combined.report(TYPE, SLOT, validatorLogger);
+
+    verify(validatorLogger).dutySkippedWhileSyncing(TYPE, SLOT, 3);
+    verifyNoMoreInteractions(validatorLogger);
+  }
+
+  @Test
+  void shouldCombineMixedResults() {
+    final Bytes32 root1 = dataStructureUtil.randomBytes32();
+    final Bytes32 root2 = dataStructureUtil.randomBytes32();
+    final RuntimeException exception1 = new RuntimeException("Nope");
+    final RuntimeException exception2 = new RuntimeException("Oops");
+
+    final DutyResult combined =
+        DutyResult.success(root1)
+            .combine(DutyResult.forError(exception1))
+            .combine(DutyResult.forError(new NodeSyncingException()))
+            .combine(DutyResult.forError(exception2))
+            .combine(DutyResult.forError(new NodeSyncingException()))
+            .combine(DutyResult.success(root2))
+            .combine(DutyResult.success(root1));
+    combined.report(TYPE, SLOT, validatorLogger);
+
+    verify(validatorLogger).dutyCompleted(TYPE, SLOT, 3, Set.of(root1, root2));
+    verify(validatorLogger).dutySkippedWhileSyncing(TYPE, SLOT, 2);
+    verify(validatorLogger).dutyFailed(TYPE, SLOT, exception1);
+    verify(validatorLogger).dutyFailed(TYPE, SLOT, exception2);
+    verifyNoMoreInteractions(validatorLogger);
+  }
+
+  @Test
+  void shouldCombineSafeFutureResults() {
+    final Bytes32 root1 = dataStructureUtil.randomBytes32();
+    final Bytes32 root2 = dataStructureUtil.randomBytes32();
+    final RuntimeException exception1 = new RuntimeException("Nope");
+    final RuntimeException exception2 = new RuntimeException("Oops");
+    final SafeFuture<DutyResult> combinedFuture =
+        DutyResult.combine(
+            List.of(
+                SafeFuture.completedFuture(DutyResult.success(root1)),
+                SafeFuture.completedFuture(DutyResult.forError(exception1)),
+                SafeFuture.failedFuture(exception2),
+                SafeFuture.completedFuture(DutyResult.forError(new NodeSyncingException())),
+                SafeFuture.failedFuture(new NodeSyncingException()),
+                SafeFuture.completedFuture(DutyResult.success(root2))));
+
+    assertThat(combinedFuture).isCompleted();
+    combinedFuture.join().report(TYPE, SLOT, validatorLogger);
+    verify(validatorLogger).dutyCompleted(TYPE, SLOT, 2, Set.of(root1, root2));
+    verify(validatorLogger).dutyFailed(TYPE, SLOT, exception1);
+    verify(validatorLogger).dutyFailed(TYPE, SLOT, exception2);
+    verify(validatorLogger).dutySkippedWhileSyncing(TYPE, SLOT, 2);
+    verifyNoMoreInteractions(validatorLogger);
+  }
+
+  @Test
+  void shouldWaitForFuturesToCompleteBeforeCombining() {
+    final Bytes32 root = dataStructureUtil.randomBytes32();
+    final SafeFuture<DutyResult> future1 = new SafeFuture<>();
+    final SafeFuture<DutyResult> future2 = new SafeFuture<>();
+    final SafeFuture<DutyResult> combinedFuture = DutyResult.combine(List.of(future1, future2));
+    assertThat(combinedFuture).isNotDone();
+
+    future1.complete(DutyResult.success(root));
+    assertThat(combinedFuture).isNotDone();
+
+    future2.complete(DutyResult.success(root));
+    assertThat(combinedFuture).isCompleted();
+
+    combinedFuture.join().report(TYPE, SLOT, validatorLogger);
+    verify(validatorLogger).dutyCompleted(TYPE, SLOT, 2, Set.of(root));
+    verifyNoMoreInteractions(validatorLogger);
+  }
+}


### PR DESCRIPTION
## PR Description
Introduce validator event logging to log when validators perform duties. This can be enabled with the `--log-include-validator-duties-enabled` option and is off by default (it would be very noisy when running a lot of validators).

Improve the logging output when validators fail to perform duties.

## Fixed Issue(s)
fixes #2019 
