### PR TITLE
Throw useful exception when the required deposits are not available

### DIFF
--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
@@ -101,6 +101,15 @@ public class DepositProvider implements Eth1EventsChannel, FinalizedCheckpointCh
     UnsignedLong eth1DepositCount = state.getEth1_data().getDeposit_count();
 
     UnsignedLong fromDepositIndex = state.getEth1_deposit_index();
+
+    // We need to have all the deposits that can be included in the state available to ensure
+    // the generated proofs are valid
+    final UnsignedLong lastAvailableDepositIndex =
+        depositNavigableMap.isEmpty() ? fromDepositIndex : depositNavigableMap.lastKey();
+    if (lastAvailableDepositIndex.compareTo(eth1DepositCount) < 0) {
+      throw new MissingDepositsException(lastAvailableDepositIndex, eth1DepositCount);
+    }
+
     UnsignedLong latestDepositIndexWithMaxBlock =
         fromDepositIndex.plus(UnsignedLong.valueOf(MAX_DEPOSITS));
 

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/MissingDepositsException.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/MissingDepositsException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import com.google.common.primitives.UnsignedLong;
+
+public class MissingDepositsException extends IllegalStateException {
+
+  public MissingDepositsException(
+      final UnsignedLong maxAvailableDeposit, final UnsignedLong requiredDepositIndex) {
+    super(
+        "Unable to create block because ETH1 deposits are not available. Missing deposits "
+            + maxAvailableDeposit.plus(UnsignedLong.ONE)
+            + " to "
+            + requiredDepositIndex);
+  }
+}


### PR DESCRIPTION
## PR Description
When the deposits that can be included in a beacon state have not yet been retrieved from the ETH1 chain, throw a meaningful exception which explains the problem clearly.  Previously the generated block just failed state transition leading to a confusing error.

## Fixed Issue(s)
fixes #2014 