### PR TITLE
Capture built distributions as CircleCI artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,11 @@ jobs:
           root: ~/project
           paths:
             - ./
+      - store_artifacts:
+          name: Distribution artifacts
+          path:  build/distributions
+          destination: distributions
+          when: always
 
   spotless:
     executor: small_executor


### PR DESCRIPTION
## PR Description
Capture the built distribution as CircleCI artefacts so builds from PRs can be more easily deployed.