### PR TITLE
Use the fork info at the current time rather than where sync is up to

### DIFF
--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
@@ -224,7 +224,7 @@ public class BlockImporterTest {
             invalidAncestryUnsignedBlock,
             signer
                 .signBlock(
-                    invalidAncestryUnsignedBlock, otherStorage.getCurrentForkInfo().orElseThrow())
+                    invalidAncestryUnsignedBlock, otherStorage.getHeadForkInfo().orElseThrow())
                 .join());
 
     final BlockImportResult result = blockImporter.importBlock(invalidAncestryBlock);

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
@@ -177,7 +177,7 @@ public class PeerStatusIntegrationTest {
     final BeaconState state = storageClient.getBestState().orElseThrow();
     assertStatus(
         status,
-        storageClient.getCurrentForkInfo().orElseThrow().getForkDigest(),
+        storageClient.getHeadForkInfo().orElseThrow().getForkDigest(),
         state.getFinalized_checkpoint().getRoot(),
         state.getFinalized_checkpoint().getEpoch(),
         storageClient.getBestBlockRoot().orElseThrow(),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
@@ -85,7 +85,7 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
     // Set the current fork info prior to discovery starting up.
     final ForkInfo currentForkInfo =
         recentChainData
-            .getCurrentForkInfo()
+            .getHeadForkInfo()
             .orElseThrow(
                 () ->
                     new IllegalStateException("Can not start Eth2Network before genesis is known"));
@@ -99,7 +99,7 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
     AttestationValidator attestationValidator = new AttestationValidator(recentChainData);
     SignedAggregateAndProofValidator aggregateValidator =
         new SignedAggregateAndProofValidator(attestationValidator, recentChainData);
-    final ForkInfo forkInfo = recentChainData.getCurrentForkInfo().orElseThrow();
+    final ForkInfo forkInfo = recentChainData.getHeadForkInfo().orElseThrow();
 
     AttestationSubnetSubscriptions attestationSubnetSubscriptions =
         new AttestationSubnetSubscriptions(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttestationSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttestationSubnetSubscriptions.java
@@ -63,7 +63,7 @@ public class AttestationSubnetSubscriptions implements AutoCloseable {
   }
 
   private TopicChannel createChannelForSubnetId(final int subnetId) {
-    final ForkInfo forkInfo = recentChainData.getCurrentForkInfo().orElseThrow();
+    final ForkInfo forkInfo = recentChainData.getHeadForkInfo().orElseThrow();
     final SingleAttestationTopicHandler topicHandler =
         new SingleAttestationTopicHandler(
             gossipEncoding, forkInfo, subnetId, attestationValidator, gossipedAttestationConsumer);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
@@ -104,7 +104,7 @@ public class PeerChainValidator {
     }
 
     // Check fork compatibility
-    Bytes4 expectedForkDigest = storageClient.getCurrentForkInfo().orElseThrow().getForkDigest();
+    Bytes4 expectedForkDigest = storageClient.getHeadForkInfo().orElseThrow().getForkDigest();
     if (!Objects.equals(expectedForkDigest, status.getForkDigest())) {
       LOG.trace(
           "Peer's fork ({}) differs from our fork ({}): {}",

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
@@ -34,9 +34,10 @@ public class StatusMessageFactory {
       // We don't have chainhead information, so we can't generate an accurate status message
       return Optional.empty();
     }
-    final ForkInfo forkInfo = recentChainData.getCurrentForkInfo().orElseThrow();
+
     final BeaconBlockAndState bestBlockAndState =
         recentChainData.getBestBlockAndState().orElseThrow();
+    final ForkInfo forkInfo = recentChainData.getForkInfoAtCurrentTime().orElseThrow();
     final Checkpoint finalizedCheckpoint = bestBlockAndState.getState().getFinalized_checkpoint();
     final BeaconBlock chainHead = bestBlockAndState.getBlock();
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationSubnetSubscriptionsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationSubnetSubscriptionsTest.java
@@ -44,7 +44,7 @@ public class AttestationSubnetSubscriptionsTest {
   @BeforeEach
   void setUp() {
     final RecentChainData recentChainData = mock(RecentChainData.class);
-    when(recentChainData.getCurrentForkInfo())
+    when(recentChainData.getHeadForkInfo())
         .thenReturn(Optional.of(dataStructureUtil.randomForkInfo()));
     subnetSubscriptions =
         new AttestationSubnetSubscriptions(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
@@ -270,11 +270,11 @@ public class PeerChainValidatorTest {
   }
 
   private void forksMatch() {
-    when(recentChainData.getCurrentForkInfo()).thenReturn(Optional.of(remoteForkInfo));
+    when(recentChainData.getHeadForkInfo()).thenReturn(Optional.of(remoteForkInfo));
   }
 
   private void forksDontMatch() {
-    when(recentChainData.getCurrentForkInfo()).thenReturn(Optional.of(otherForkInfo));
+    when(recentChainData.getHeadForkInfo()).thenReturn(Optional.of(otherForkInfo));
   }
 
   private void finalizedCheckpointsMatch() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -196,7 +196,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     return Optional.of(ForkChoiceUtil.get_current_slot(store));
   }
 
-  public Optional<ForkInfo> getCurrentForkInfo() {
+  public Optional<ForkInfo> getHeadForkInfo() {
     return getBestState().map(BeaconState::getForkInfo);
   }
 
@@ -209,10 +209,13 @@ public abstract class RecentChainData implements StoreUpdateHandler {
    * Returns the fork info that applies based on the node's current slot, regardless of where the
    * sync progress is up to.
    *
+   * <p>NOTE: Works on the basis that there is only one future forked scheduled as that's all we can
+   * currently support.
+   *
    * @return fork info based on the current time, not head block
    */
   public Optional<ForkInfo> getForkInfoAtCurrentTime() {
-    return getCurrentForkInfo()
+    return getHeadForkInfo()
         .map(
             headForkInfo ->
                 getNextFork()


### PR DESCRIPTION
## PR Description
The status message should use the fork version that would be in effect at the current time, not the time of the best head block.

While this means the status still makes two separate calls to chain data, we're guaranteed to get consistent data.  Even if the next fork activates between getting the best state and next fork, the state and nextFork will now match and we'll get the same result.

All a bit redundant as there is no next fork yet anyway, but good to be clear about where things should come from.

## Fixed Issue(s)
fixes #1945 