### PR TITLE
Reduce log level of stream closed exceptions as they are expected

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallback.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallback.java
@@ -17,7 +17,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStream;
-import tech.pegasys.teku.networking.p2p.rpc.RpcStream.StreamClosedException;
+import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 
 class RpcResponseCallback<TResponse> implements ResponseCallback<TResponse> {
   private static final Logger LOG = LogManager.getLogger();

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/LibP2PRpcStream.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/LibP2PRpcStream.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStream;
+import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 import tech.pegasys.teku.util.async.SafeFuture;
 
 public class LibP2PRpcStream implements RpcStream {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandler.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.p2p.libp2p.rpc;
 
 import static tech.pegasys.teku.util.async.FutureUtil.ignoreFuture;
 
+import com.google.common.base.Throwables;
 import io.libp2p.core.Connection;
 import io.libp2p.core.P2PChannel;
 import io.libp2p.core.multistream.Mode;
@@ -210,7 +211,11 @@ public class RpcHandler implements ProtocolBinding<Controller> {
           .handle(
               (res, err) -> {
                 if (err != null) {
-                  LOG.error("Unhandled exception while processing rpc input", err);
+                  if (Throwables.getRootCause(err) instanceof RpcStream.StreamClosedException) {
+                    LOG.debug("Stream closed while processing rpc input", err);
+                  } else {
+                    LOG.error("Unhandled exception while processing rpc input", err);
+                  }
                 }
                 try {
                   inputStream.close();

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandler.java
@@ -211,7 +211,7 @@ public class RpcHandler implements ProtocolBinding<Controller> {
           .handle(
               (res, err) -> {
                 if (err != null) {
-                  if (Throwables.getRootCause(err) instanceof RpcStream.StreamClosedException) {
+                  if (Throwables.getRootCause(err) instanceof StreamClosedException) {
                     LOG.debug("Stream closed while processing rpc input", err);
                   } else {
                     LOG.error("Unhandled exception while processing rpc input", err);

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/rpc/RpcStream.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/rpc/RpcStream.java
@@ -34,6 +34,4 @@ public interface RpcStream {
    * @return A future completing when the write stream is closed.
    */
   SafeFuture<Void> closeWriteStream();
-
-  class StreamClosedException extends RuntimeException {}
 }


### PR DESCRIPTION
## PR Description
Reduce the log level for stream closed exceptions.  It's not unusual for peers to be disconnected while we're in the middle of processing their input.

## Fixed Issue(s)
fixes #2021 