### PR TITLE
Log unhandled exceptions as error not fatal

### DIFF
--- a/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
@@ -35,7 +35,7 @@ public class StatusLogger {
   }
 
   public void unexpectedFailure(final String description, final Throwable cause) {
-    log.fatal("PLEASE FIX OR REPORT | Unexpected exception thrown for {}", description, cause);
+    log.error("PLEASE FIX OR REPORT | Unexpected exception thrown for {}", description, cause);
   }
 
   public void listeningForLibP2P(final String address) {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -510,7 +510,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
       this.eventBus.post(new BroadcastAggregatesEvent(nodeSlot.getValue()));
       nodeSlot.inc();
     } catch (InterruptedException e) {
-      LOG.fatal("onTick: {}", e.toString(), e);
+      LOG.error("onTick: {}", e.toString(), e);
     }
   }
 


### PR DESCRIPTION
## PR Description
Fatal errors are for when the client crashes, not just for when an unexpected error occurs.