### PR TITLE
Don't wait for unit tests to complete before building docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,6 @@ workflows:
       - docker:
           requires:
             - assemble
-            - unitTests
             - spotless
       - extractAPISpec:
           requires:


### PR DESCRIPTION
## PR Description
Start building the docker image once assemble and spotless pass instead of also waiting for unit tests. Publishing the docker image still waits for all tests to complete.