### PR TITLE
Fix build when git is not available

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -585,7 +585,7 @@ def calculateVersion() {
 
 def getCheckedOutGitCommitHash() {
   def takeFromHash = 8
-  grgit.head().id.take(takeFromHash)
+  grgit ? grgit.head().id.take(takeFromHash) : 'UNKNOWN'
 }
 
 task jacocoRootReport(type: JacocoReport) {


### PR DESCRIPTION
## PR Description
Use "UNKNOWN" if the source code is not in a git checkout and the git commit hash can't be determined.

## Fixed Issue(s)
fixes #2055 