### PR TITLE
Catch IndexOutOfBoundsException in ForkChoiceUtil.on_attestation

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -335,7 +335,7 @@ public class ForkChoiceUtil {
     IndexedAttestation indexed_attestation;
     try {
       indexed_attestation = get_indexed_attestation(target_state, attestation);
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException|IndexOutOfBoundsException e) {
       LOG.warn("on_attestation: Attestation is not valid: ", e);
       return Optional.empty();
     }

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -335,7 +335,7 @@ public class ForkChoiceUtil {
     IndexedAttestation indexed_attestation;
     try {
       indexed_attestation = get_indexed_attestation(target_state, attestation);
-    } catch (IllegalArgumentException|IndexOutOfBoundsException e) {
+    } catch (IllegalArgumentException | IndexOutOfBoundsException e) {
       LOG.warn("on_attestation: Attestation is not valid: ", e);
       return Optional.empty();
     }


### PR DESCRIPTION
Which may be thrown, when attestation data contains invalid index. See also #1571 which is the same problem.

```
java.lang.IndexOutOfBoundsException: toIndex = 44

	at java.base/java.util.AbstractList.subListRangeCheck(AbstractList.java:507)
	at java.base/java.util.ArrayList.subList(ArrayList.java:1137)
	at tech.pegasys.teku.datastructures.util.CommitteeUtil.compute_committee_shuffle(CommitteeUtil.java:213)
	at tech.pegasys.teku.datastructures.util.CommitteeUtil.compute_committee(CommitteeUtil.java:231)
	at tech.pegasys.teku.datastructures.util.CommitteeUtil.lambda$get_beacon_committee$2(CommitteeUtil.java:260)
	at tech.pegasys.teku.util.cache.LRUCache.get(LRUCache.java:73)
	at tech.pegasys.teku.datastructures.util.CommitteeUtil.get_beacon_committee(CommitteeUtil.java:246)
	at tech.pegasys.teku.datastructures.util.AttestationUtil.get_attesting_indices(AttestationUtil.java:117)
	at tech.pegasys.teku.datastructures.util.AttestationUtil.get_indexed_attestation(AttestationUtil.java:90)
	at tech.pegasys.teku.core.ForkChoiceUtil.indexAndValidateAttestation(ForkChoiceUtil.java:337)
	at tech.pegasys.teku.core.ForkChoiceUtil.lambda$on_attestation$1(ForkChoiceUtil.java:303)
	at tech.pegasys.teku.core.results.AttestationProcessingResult.ifSuccessful(AttestationProcessingResult.java:25)
	at tech.pegasys.teku.core.ForkChoiceUtil.on_attestation(ForkChoiceUtil.java:300)
```