### PR TITLE
Reduce memory footprint for hot-state BeaconState instances 

### DIFF
--- a/ssz/src/main/java/tech/pegasys/teku/ssz/backing/cache/ArrayIntCache.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/backing/cache/ArrayIntCache.java
@@ -20,14 +20,14 @@ import java.util.function.IntFunction;
 /**
  * Thread-safe int indexed cache
  *
- * CAUTION: though the class is thread-safe it contains no synchronisation for performance reasons
- * When accessed concurrently the cache may result in extra cache misses and extra backing array
- * copying but this should be safe. In optimistic scenarios such overhead could be neglected
+ * <p>CAUTION: though the class is thread-safe it contains no synchronisation for performance
+ * reasons When accessed concurrently the cache may result in extra cache misses and extra backing
+ * array copying but this should be safe. In optimistic scenarios such overhead could be neglected
  *
- * Modify this class carefully to not violate thread safety!
+ * <p>Modify this class carefully to not violate thread safety!
  */
 public final class ArrayIntCache<V> implements IntCache<V> {
-  private final static int DEFAULT_INITIAL_CACHE_SIZE = 16;
+  private static final int DEFAULT_INITIAL_CACHE_SIZE = 16;
   private volatile V[] values;
   private final int initSize;
 

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/backing/cache/ArrayIntCache.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/backing/cache/ArrayIntCache.java
@@ -51,23 +51,23 @@ public final class ArrayIntCache<V> implements IntCache<V> {
   }
 
   private V[] extend(int index) {
-    V[] valuesLoc = this.values;
-    int newSize = valuesLoc.length;
+    V[] valuesLocal = this.values;
+    int newSize = valuesLocal.length;
     if (index >= newSize) {
       while (index >= newSize) {
         newSize <<= 1;
       }
-      V[] newValues = Arrays.copyOf(valuesLoc, newSize);
+      V[] newValues = Arrays.copyOf(valuesLocal, newSize);
       this.values = newValues;
       return newValues;
     }
-    return valuesLoc;
+    return valuesLocal;
   }
 
   @Override
   public V getInt(int key, IntFunction<V> fallback) {
-    V[] valuesLoc = this.values;
-    V val = key >= valuesLoc.length ? null : valuesLoc[key];
+    V[] valuesLocal = this.values;
+    V val = key >= valuesLocal.length ? null : valuesLocal[key];
     if (val == null) {
       val = fallback.apply(key);
       extend(key)[key] = val;
@@ -77,14 +77,14 @@ public final class ArrayIntCache<V> implements IntCache<V> {
 
   @Override
   public Optional<V> getCached(Integer key) {
-    V[] valuesLoc = this.values;
-    return key >= valuesLoc.length ? Optional.empty() : Optional.ofNullable(valuesLoc[key]);
+    V[] valuesLocal = this.values;
+    return key >= valuesLocal.length ? Optional.empty() : Optional.ofNullable(valuesLocal[key]);
   }
 
   @Override
   public IntCache<V> copy() {
-    V[] valuesLoc = this.values;
-    return new ArrayIntCache<>(Arrays.copyOf(valuesLoc, valuesLoc.length), initSize);
+    V[] valuesLocal = this.values;
+    return new ArrayIntCache<>(Arrays.copyOf(valuesLocal, valuesLocal.length), initSize);
   }
 
   @Override
@@ -101,9 +101,9 @@ public final class ArrayIntCache<V> implements IntCache<V> {
 
   @Override
   public void invalidateInt(int key) {
-    V[] valuesLoc = this.values;
-    if (key < valuesLoc.length) {
-      valuesLoc[key] = null;
+    V[] valuesLocal = this.values;
+    if (key < valuesLocal.length) {
+      valuesLocal[key] = null;
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Though `BeaconState` is backed up with a remerkable tree, accessing it and reconstructing corresponding `views` (aka vectors, containers, etc.) is a bit expensive from the performance standpoint. That's why these `views` are cached and returned unless their backing subtree is modified. 

However this comes at a cost of the memory footprint. When there are a lot of hot-state `BeaconState` instances resides in memory every instance is keeping the full set of views. This is suboptimal since the `BeaconState`s older than the `head` are most likely wouldn't be accessed or accessed very limited (just a small subset of structures). 

With this PR on any beacon state modification (`BeaconState-1` => `MutableBeaconState` => `BeaconState-2`) when the view caches are `transfer()`ed from `BeaconState-1` to `BeaconState-2` the original caches in the `BeaconState-1` would be cleared. 

This would reduce the memory footprint (in Mb below) of the `BeaconState` instances if they are all kept in memory: 
| Number of states | Before | After |
|------------------|--------|-------|
| 1                | 69     | 69    |
| 32               | 163    | 153   |
| 65               | 187    | 161   |
| 130              | 229    | 172   |
| 390              | 414    | 226   |

** these are consecutive slot states. For sparse states (e.g. on each epoch) the numbers would differ

Some more details here: https://docs.google.com/spreadsheets/d/1IA8Yq6CgCWfOBy8dTpY-uFVUDYBWCRTSl_-7LoXTA9M/edit?usp=sharing

This doesn't affect performance (at least from the point of `TransitionBenchmark`) 

