### PR TITLE
Restore `assert index < index_count` in compute_committee_shuffle`

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
@@ -207,9 +207,11 @@ public class CommitteeUtil {
 
   private static List<Integer> compute_committee_shuffle(
       BeaconState state, List<Integer> indices, Bytes32 seed, int fromIndex, int toIndex) {
-    int index_count = indices.size();
-    checkArgument(fromIndex < index_count, "CommitteeUtil.get_shuffled_index1");
-    checkArgument(toIndex <= index_count, "CommitteeUtil.get_shuffled_index1");
+    if (fromIndex < toIndex) {
+      int index_count = indices.size();
+      checkArgument(fromIndex < index_count, "CommitteeUtil.get_shuffled_index1");
+      checkArgument(toIndex <= index_count, "CommitteeUtil.get_shuffled_index1");
+    }
     return BeaconStateCache.getTransitionCaches(state)
         .getCommitteeShuffle()
         .get(seed, s -> shuffle_list(indices, s))

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
@@ -207,6 +207,9 @@ public class CommitteeUtil {
 
   private static List<Integer> compute_committee_shuffle(
       BeaconState state, List<Integer> indices, Bytes32 seed, int fromIndex, int toIndex) {
+    int index_count = indices.size();
+    checkArgument(fromIndex < index_count, "CommitteeUtil.get_shuffled_index1");
+    checkArgument(toIndex <= index_count, "CommitteeUtil.get_shuffled_index1");
     return BeaconStateCache.getTransitionCaches(state)
         .getCommitteeShuffle()
         .get(seed, s -> shuffle_list(indices, s))


### PR DESCRIPTION
which seems to have been lost during optimization.
It's proposed as a better fix for #2060 .
Pyspec [compute_shuffled_index](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#compute_shuffled_index) contains the check, which is triggered by bad `attestation.data.index` value.

