### PR TITLE
Add test case for infinite pubkey and signature

### DIFF
--- a/bls/src/test/java/tech/pegasys/teku/bls/BLSTest.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/BLSTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 
 class BLSTest {
@@ -77,26 +78,38 @@ class BLSTest {
     assertTrue(BLS.fastAggregateVerify(publicKeys, message, aggregatedSignature));
   }
 
+  static final BLSPublicKey infinityG1 =
+      BLSPublicKey.fromBytesCompressed(
+          Bytes.fromHexString(
+              "0x"
+                  + "c0000000000000000000000000000000"
+                  + "00000000000000000000000000000000"
+                  + "00000000000000000000000000000000"));
+  static final BLSSignature infinityG2 =
+      BLSSignature.fromBytes(
+          Bytes.fromHexString(
+              "0x"
+                  + "c000000000000000000000000000000000000000000000000000000000000000"
+                  + "0000000000000000000000000000000000000000000000000000000000000000"
+                  + "0000000000000000000000000000000000000000000000000000000000000000"));
+  static final BLSSecretKey zeroSK = BLSSecretKey.fromBytes(Bytes32.ZERO);
+
   @Test
   void succeedsWhenPubkeyAndSignatureBothTheIdentityIsOK() {
-    // Public key is the point at infinity (the identity)
-    BLSPublicKey pubkey =
-        BLSPublicKey.fromBytesCompressed(
-            Bytes.fromHexString(
-                "0x"
-                    + "c0000000000000000000000000000000"
-                    + "00000000000000000000000000000000"
-                    + "00000000000000000000000000000000"));
-    // Signature key is the point at infinity (the identity)
-    BLSSignature signature =
-        BLSSignature.fromBytes(
-            Bytes.fromHexString(
-                "0x"
-                    + "c000000000000000000000000000000000000000000000000000000000000000"
-                    + "0000000000000000000000000000000000000000000000000000000000000000"
-                    + "0000000000000000000000000000000000000000000000000000000000000000"));
     // Any message should verify
     Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
-    assertTrue(BLS.verify(pubkey, message, signature));
+    assertTrue(BLS.verify(infinityG1, message, infinityG2));
+  }
+
+  @Test
+  void succeedsWhenZeroSecretKeyGivesInfinitePublicKey() {
+    assertEquals(infinityG1, new BLSPublicKey(zeroSK));
+  }
+
+  @Test
+  void succeedsWhenInfinitePublicKeyGivesInfiniteSignature() {
+    // Any message should result in the signature at infinity
+    Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
+    assertEquals(infinityG2, BLS.sign(zeroSK, message));
   }
 }

--- a/bls/src/test/java/tech/pegasys/teku/bls/BLSTest.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/BLSTest.java
@@ -76,4 +76,27 @@ class BLSTest {
 
     assertTrue(BLS.fastAggregateVerify(publicKeys, message, aggregatedSignature));
   }
+
+  @Test
+  void succeedsWhenPubkeyAndSignatureBothTheIdentityIsOK() {
+    // Public key is the point at infinity (the identity)
+    BLSPublicKey pubkey =
+        BLSPublicKey.fromBytesCompressed(
+            Bytes.fromHexString(
+                "0x"
+                    + "c0000000000000000000000000000000"
+                    + "00000000000000000000000000000000"
+                    + "00000000000000000000000000000000"));
+    // Signature key is the point at infinity (the identity)
+    BLSSignature signature =
+        BLSSignature.fromBytes(
+            Bytes.fromHexString(
+                "0x"
+                    + "c000000000000000000000000000000000000000000000000000000000000000"
+                    + "0000000000000000000000000000000000000000000000000000000000000000"
+                    + "0000000000000000000000000000000000000000000000000000000000000000"));
+    // Any message should verify
+    Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
+    assertTrue(BLS.verify(pubkey, message, signature));
+  }
 }


### PR DESCRIPTION
This adds a test to confirm behaviour in the case that a message has both public key and signature being the identity - the points at infinity in their respective subgroups.

It's prompted by [this deposit](https://goerli.etherscan.io/tx/0xa2784acaf5fdcf8cb1e9fe4d416d84a23aa5ff37677846f2a4bf1ce7f9bb1dd4) on Witti which has infinite public key and signature.

I can't find anything in the [IETF draft](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02) that covers this case, and the math checks out, so I'm assuming this makes sense. There doesn't seem to have been a fork on Witti, and the validator has been inducted, so it looks like Teku, LH and Prysm all agree about this.