### PR TITLE
Add documentation checkbox to the PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,4 @@
 
 ## Documentation
 
-- [ ] No documentation changes required or `documentation` label has been added to the PR.
+- [ ] I thought about documentation and added the `documentation` label to this PR if updates are required.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,3 +6,7 @@
 ## Fixed Issue(s)
 <!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
 <!-- Example: "fixes #2" -->
+
+## Documentation
+
+- [ ] No documentation changes required or `documentation` label has been added to the PR.


### PR DESCRIPTION
## PR Description
Add a checkbox to the PR template to remind people to flag when documentation changes are required (or acknowledge they aren't).

## Documentation

- [x] No documentation changes required or `documentation` label has been added to the PR.