### PR TITLE
Reduce ClosedChannelException to debug level

### DIFF
--- a/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
@@ -30,6 +30,10 @@ public class StatusLogger {
     this.log = LogManager.getLogger(name);
   }
 
+  public void fatalError(final String description, final Throwable cause) {
+    log.fatal("Exiting due to fatal error in {}", description, cause);
+  }
+
   public void specificationFailure(final String description, final Throwable cause) {
     log.warn("Spec failed for {}: {}", description, cause, cause);
   }


### PR DESCRIPTION
## PR Description
Netty keeps logging ClosedChannelException when a channel is closed unexpected.  It does that from it's own thread so none of our code can catch it except for the uncaught exception handler so suppress it there.

Also report OutOfMemoryErrors as fatal instead of error.

## Fixed Issue(s)
fixes #2033 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.