### PR TITLE
Ignore seen aggregates

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/attestation/ValidateableAttestation.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/attestation/ValidateableAttestation.java
@@ -34,11 +34,11 @@ public class ValidateableAttestation {
 
   private volatile Optional<IndexedAttestation> maybeIndexedAttestation = Optional.empty();
 
-  public static ValidateableAttestation fromSingle(Attestation attestation) {
+  public static ValidateableAttestation fromAttestation(Attestation attestation) {
     return new ValidateableAttestation(attestation, Optional.empty());
   }
 
-  public static ValidateableAttestation fromAggregate(SignedAggregateAndProof attestation) {
+  public static ValidateableAttestation fromSignedAggregate(SignedAggregateAndProof attestation) {
     return new ValidateableAttestation(
         attestation.getMessage().getAggregate(), Optional.of(attestation));
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
@@ -58,7 +58,7 @@ class AggregateAttestationBuilder {
 
   public ValidateableAttestation buildAggregate() {
     checkState(currentAggregateBits != null, "Must aggregate at least one attestation");
-    return ValidateableAttestation.fromSingle(
+    return ValidateableAttestation.fromAttestation(
         new Attestation(
             currentAggregateBits,
             attestationData,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/BlockImporter.java
@@ -69,8 +69,9 @@ public class BlockImporter {
 
       final Optional<BlockProcessingRecord> record = result.getBlockProcessingRecord();
       eventBus.post(new ImportedBlockEvent(block));
-      attestationsFromVerifiedBlockSubscriberSubscribers.forEach(
-          s -> s.accept(block.getMessage().getBody().getAttestations()));
+      attestationsFromVerifiedBlockSubscriberSubscribers.deliver(
+              VerifiedBlockAttestationsListener::accept,
+              block.getMessage().getBody().getAttestations());
       record.ifPresent(eventBus::post);
 
       return result;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/BlockImporter.java
@@ -27,12 +27,16 @@ import tech.pegasys.teku.statetransition.events.block.ProposedBlockEvent;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.util.async.SafeFuture;
+import tech.pegasys.teku.util.events.Subscribers;
 
 public class BlockImporter {
   private static final Logger LOG = LogManager.getLogger();
   private final RecentChainData recentChainData;
   private final ForkChoice forkChoice;
   private final EventBus eventBus;
+
+  private Subscribers<VerifiedBlockAttestationsListener>
+      attestationsFromVerifiedBlockSubscriberSubscribers = Subscribers.create(true);
 
   public BlockImporter(
       final RecentChainData recentChainData, final ForkChoice forkChoice, final EventBus eventBus) {
@@ -65,6 +69,8 @@ public class BlockImporter {
 
       final Optional<BlockProcessingRecord> record = result.getBlockProcessingRecord();
       eventBus.post(new ImportedBlockEvent(block));
+      attestationsFromVerifiedBlockSubscriberSubscribers.forEach(
+          s -> s.accept(block.getMessage().getBody().getAttestations()));
       record.ifPresent(eventBus::post);
 
       return result;
@@ -93,5 +99,10 @@ public class BlockImporter {
               + blockProposedEvent,
           result.getFailureCause().orElse(null));
     }
+  }
+
+  public void subscribeToVerifiedBlockAttestations(
+      VerifiedBlockAttestationsListener verifiedBlockAttestationsListener) {
+    attestationsFromVerifiedBlockSubscriberSubscribers.subscribe(verifiedBlockAttestationsListener);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/BlockImporter.java
@@ -70,8 +70,8 @@ public class BlockImporter {
       final Optional<BlockProcessingRecord> record = result.getBlockProcessingRecord();
       eventBus.post(new ImportedBlockEvent(block));
       attestationsFromVerifiedBlockSubscriberSubscribers.deliver(
-              VerifiedBlockAttestationsListener::onAttestationsFromBlock,
-              block.getMessage().getBody().getAttestations());
+          VerifiedBlockAttestationsListener::onAttestationsFromBlock,
+          block.getMessage().getBody().getAttestations());
       record.ifPresent(eventBus::post);
 
       return result;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/BlockImporter.java
@@ -70,7 +70,7 @@ public class BlockImporter {
       final Optional<BlockProcessingRecord> record = result.getBlockProcessingRecord();
       eventBus.post(new ImportedBlockEvent(block));
       attestationsFromVerifiedBlockSubscriberSubscribers.deliver(
-              VerifiedBlockAttestationsListener::accept,
+              VerifiedBlockAttestationsListener::onAttestationsFromBlock,
               block.getMessage().getBody().getAttestations());
       record.ifPresent(eventBus::post);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/VerifiedBlockAttestationsListener.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/VerifiedBlockAttestationsListener.java
@@ -17,5 +17,5 @@ import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 
 public interface VerifiedBlockAttestationsListener {
-  void accept(SSZList<Attestation> attestations);
+  void onAttestationsFromBlock(SSZList<Attestation> attestations);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/VerifiedBlockAttestationsListener.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/VerifiedBlockAttestationsListener.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.blockimport;
+
+import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.ssz.SSZTypes.SSZList;
+
+public interface VerifiedBlockAttestationsListener {
+  void accept(SSZList<Attestation> attestations);
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilderTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilderTest.java
@@ -90,7 +90,7 @@ class AggregateAttestationBuilderTest {
 
     assertThat(builder.buildAggregate())
         .isEqualTo(
-            ValidateableAttestation.fromSingle(
+            ValidateableAttestation.fromAttestation(
                 new Attestation(expectedAggregationBits, attestationData, expectedSignature)));
   }
 
@@ -102,7 +102,7 @@ class AggregateAttestationBuilderTest {
   private ValidateableAttestation createAttestation(final int... validators) {
     final Bitlist aggregationBits = new Bitlist(BITLIST_SIZE, MAX_VALIDATORS_PER_COMMITTEE);
     IntStream.of(validators).forEach(aggregationBits::setBit);
-    return ValidateableAttestation.fromSingle(
+    return ValidateableAttestation.fromAttestation(
         new Attestation(aggregationBits, attestationData, dataStructureUtil.randomSignature()));
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -186,7 +186,7 @@ class AggregatingAttestationPoolTest {
     IntStream.of(validators).forEach(bitlist::setBit);
     final Attestation attestation =
         new Attestation(bitlist, data, dataStructureUtil.randomSignature());
-    aggregatingPool.add(ValidateableAttestation.fromSingle(attestation));
+    aggregatingPool.add(ValidateableAttestation.fromAttestation(attestation));
     return attestation;
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerTest.java
@@ -78,7 +78,7 @@ class AttestationManagerTest {
   @Test
   public void shouldProcessAttestationsThatAreReadyImmediately() {
     final ValidateableAttestation attestation =
-        ValidateableAttestation.fromSingle(dataStructureUtil.randomAttestation());
+        ValidateableAttestation.fromAttestation(dataStructureUtil.randomAttestation());
     when(attestationProcessor.processAttestation(any())).thenReturn(SUCCESSFUL);
     attestationManager.onAttestation(attestation);
 
@@ -91,7 +91,8 @@ class AttestationManagerTest {
   @Test
   public void shouldProcessAggregatesThatAreReadyImmediately() {
     final ValidateableAttestation aggregate =
-        ValidateableAttestation.fromAggregate(dataStructureUtil.randomSignedAggregateAndProof());
+        ValidateableAttestation.fromSignedAggregate(
+            dataStructureUtil.randomSignedAggregateAndProof());
     when(attestationProcessor.processAttestation(any())).thenReturn(SUCCESSFUL);
     attestationManager.onAttestation(aggregate);
 
@@ -104,7 +105,7 @@ class AttestationManagerTest {
   @Test
   public void shouldAddAttestationsThatHaveNotYetReachedTargetSlotToFutureItemsAndPool() {
     ValidateableAttestation attestation =
-        ValidateableAttestation.fromSingle(attestationFromSlot(100));
+        ValidateableAttestation.fromAttestation(attestationFromSlot(100));
     IndexedAttestation randomIndexedAttestation = dataStructureUtil.randomIndexedAttestation();
     when(attestationProcessor.processAttestation(any())).thenReturn(SAVED_FOR_FUTURE);
     attestationManager.onAttestation(attestation);
@@ -133,7 +134,7 @@ class AttestationManagerTest {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
     final Bytes32 requiredBlockRoot = block.getMessage().hash_tree_root();
     final ValidateableAttestation attestation =
-        ValidateableAttestation.fromSingle(attestationFromSlot(1, requiredBlockRoot));
+        ValidateableAttestation.fromAttestation(attestationFromSlot(1, requiredBlockRoot));
     when(attestationProcessor.processAttestation(any()))
         .thenReturn(UNKNOWN_BLOCK)
         .thenReturn(SUCCESSFUL);
@@ -164,7 +165,7 @@ class AttestationManagerTest {
   @Test
   public void shouldNotPublishProcessedAttestationEventWhenAttestationIsInvalid() {
     final ValidateableAttestation attestation =
-        ValidateableAttestation.fromSingle(dataStructureUtil.randomAttestation());
+        ValidateableAttestation.fromAttestation(dataStructureUtil.randomAttestation());
     when(attestationProcessor.processAttestation(any()))
         .thenReturn(AttestationProcessingResult.invalid("Didn't like it"));
     attestationManager.onAttestation(attestation);
@@ -178,7 +179,8 @@ class AttestationManagerTest {
   @Test
   public void shouldNotPublishProcessedAggregationEventWhenAttestationIsInvalid() {
     final ValidateableAttestation aggregateAndProof =
-        ValidateableAttestation.fromAggregate(dataStructureUtil.randomSignedAggregateAndProof());
+        ValidateableAttestation.fromSignedAggregate(
+            dataStructureUtil.randomSignedAggregateAndProof());
     when(attestationProcessor.processAttestation(any()))
         .thenReturn(AttestationProcessingResult.invalid("Don't wanna"));
     attestationManager.onAttestation(aggregateAndProof);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
@@ -85,7 +85,7 @@ class MatchingDataAttestationGroupTest {
 
     final Attestation expected =
         aggregateAttestations(attestation1.getAttestation(), attestation2.getAttestation());
-    assertThat(group).containsExactlyInAnyOrder(ValidateableAttestation.fromSingle(expected));
+    assertThat(group).containsExactlyInAnyOrder(ValidateableAttestation.fromAttestation(expected));
   }
 
   @Test
@@ -96,7 +96,7 @@ class MatchingDataAttestationGroupTest {
 
     assertThat(group)
         .containsExactly(
-            ValidateableAttestation.fromSingle(
+            ValidateableAttestation.fromAttestation(
                 aggregateAttestations(
                     bigAttestation.getAttestation(), littleAttestation.getAttestation())),
             mediumAttestation);
@@ -127,7 +127,7 @@ class MatchingDataAttestationGroupTest {
   private ValidateableAttestation createAttestation(final int... validators) {
     final Bitlist aggregationBits = new Bitlist(10, MAX_VALIDATORS_PER_COMMITTEE);
     IntStream.of(validators).forEach(aggregationBits::setBit);
-    return ValidateableAttestation.fromSingle(
+    return ValidateableAttestation.fromAttestation(
         new Attestation(aggregationBits, attestationData, dataStructureUtil.randomSignature()));
   }
 }

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GossipMessageHandlerIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GossipMessageHandlerIntegrationTest.java
@@ -190,7 +190,7 @@ public class GossipMessageHandlerIntegrationTest {
         node1.storageClient().getBestBlockAndState().orElseThrow();
     Attestation validAttestation = attestationGenerator.validAttestation(bestBlockAndState);
     processedAttestationSubscribers.forEach(
-        s -> s.accept(ValidateableAttestation.fromSingle(validAttestation)));
+        s -> s.accept(ValidateableAttestation.fromAttestation(validAttestation)));
 
     ensureConditionRemainsMet(() -> assertThat(node2attestations).isEmpty());
   }
@@ -237,7 +237,7 @@ public class GossipMessageHandlerIntegrationTest {
     final BeaconBlockAndState bestBlockAndState =
         node1.storageClient().getBestBlockAndState().orElseThrow();
     ValidateableAttestation validAttestation =
-        ValidateableAttestation.fromSingle(
+        ValidateableAttestation.fromAttestation(
             attestationGenerator.validAttestation(bestBlockAndState));
 
     node1
@@ -300,7 +300,7 @@ public class GossipMessageHandlerIntegrationTest {
     final BeaconBlockAndState bestBlockAndState =
         node1.storageClient().getBestBlockAndState().orElseThrow();
     ValidateableAttestation validAttestation =
-        ValidateableAttestation.fromSingle(
+        ValidateableAttestation.fromAttestation(
             attestationGenerator.validAttestation(bestBlockAndState));
 
     node1

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import tech.pegasys.teku.core.StateTransition;
+import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.MetadataMessage;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.networking.eth2.gossip.AggregateGossipManager;
@@ -31,6 +32,7 @@ import tech.pegasys.teku.networking.eth2.gossip.VoluntaryExitGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipedAttestationConsumer;
 import tech.pegasys.teku.networking.eth2.gossip.topics.ProcessedAttestationSubscriptionProvider;
+import tech.pegasys.teku.networking.eth2.gossip.topics.VerifiedBlockAttestationsSubscriptionProvider;
 import tech.pegasys.teku.networking.eth2.gossip.topics.validation.AttestationValidator;
 import tech.pegasys.teku.networking.eth2.gossip.topics.validation.BlockValidator;
 import tech.pegasys.teku.networking.eth2.gossip.topics.validation.SignedAggregateAndProofValidator;
@@ -56,6 +58,8 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
   private final AttestationSubnetService attestationSubnetService;
   private final GossipedAttestationConsumer gossipedAttestationConsumer;
   private final ProcessedAttestationSubscriptionProvider processedAttestationSubscriptionProvider;
+  private final VerifiedBlockAttestationsSubscriptionProvider
+      verifiedBlockAttestationsSubscriptionProvider;
   private final Set<Integer> pendingSubnetSubscriptions = new HashSet<>();
 
   private BlockGossipManager blockGossipManager;
@@ -72,7 +76,9 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
       final GossipEncoding gossipEncoding,
       final AttestationSubnetService attestationSubnetService,
       final GossipedAttestationConsumer gossipedAttestationConsumer,
-      final ProcessedAttestationSubscriptionProvider processedAttestationSubscriptionProvider) {
+      final ProcessedAttestationSubscriptionProvider processedAttestationSubscriptionProvider,
+      final VerifiedBlockAttestationsSubscriptionProvider
+          verifiedBlockAttestationsSubscriptionProvider) {
     super(discoveryNetwork);
     this.discoveryNetwork = discoveryNetwork;
     this.peerManager = peerManager;
@@ -82,6 +88,8 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
     this.attestationSubnetService = attestationSubnetService;
     this.gossipedAttestationConsumer = gossipedAttestationConsumer;
     this.processedAttestationSubscriptionProvider = processedAttestationSubscriptionProvider;
+    this.verifiedBlockAttestationsSubscriptionProvider =
+        verifiedBlockAttestationsSubscriptionProvider;
   }
 
   @Override
@@ -141,6 +149,13 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
 
     processedAttestationSubscriptionProvider.subscribe(attestationGossipManager::onNewAttestation);
     processedAttestationSubscriptionProvider.subscribe(aggregateGossipManager::onNewAggregate);
+
+    verifiedBlockAttestationsSubscriptionProvider.subscribe(
+        (attestations) ->
+            attestations.forEach(
+                attestation ->
+                    aggregateValidator.addSeenAggregate(
+                        ValidateableAttestation.fromAttestation(attestation))));
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipedAttestationConsumer;
 import tech.pegasys.teku.networking.eth2.gossip.topics.ProcessedAttestationSubscriptionProvider;
+import tech.pegasys.teku.networking.eth2.gossip.topics.VerifiedBlockAttestationsSubscriptionProvider;
 import tech.pegasys.teku.networking.eth2.peers.Eth2PeerManager;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.networking.p2p.DiscoveryNetwork;
@@ -51,6 +52,8 @@ public class Eth2NetworkBuilder {
   private RecentChainData recentChainData;
   private GossipedAttestationConsumer gossipedAttestationConsumer;
   private ProcessedAttestationSubscriptionProvider processedAttestationSubscriptionProvider;
+  private VerifiedBlockAttestationsSubscriptionProvider
+      verifiedBlockAttestationsSubscriptionProvider;
   private StorageQueryChannel historicalChainData;
   private MetricsSystem metricsSystem;
   private List<RpcMethod> rpcMethods = new ArrayList<>();
@@ -102,7 +105,8 @@ public class Eth2NetworkBuilder {
         gossipEncoding,
         attestationSubnetService,
         gossipedAttestationConsumer,
-        processedAttestationSubscriptionProvider);
+        processedAttestationSubscriptionProvider,
+        verifiedBlockAttestationsSubscriptionProvider);
   }
 
   protected DiscoveryNetwork<?> buildNetwork() {
@@ -161,6 +165,15 @@ public class Eth2NetworkBuilder {
       final ProcessedAttestationSubscriptionProvider processedAttestationSubscriptionProvider) {
     checkNotNull(processedAttestationSubscriptionProvider);
     this.processedAttestationSubscriptionProvider = processedAttestationSubscriptionProvider;
+    return this;
+  }
+
+  public Eth2NetworkBuilder verifiedBlockAttestationsProvider(
+      final VerifiedBlockAttestationsSubscriptionProvider
+          verifiedBlockAttestationsSubscriptionProvider) {
+    checkNotNull(verifiedBlockAttestationsSubscriptionProvider);
+    this.verifiedBlockAttestationsSubscriptionProvider =
+        verifiedBlockAttestationsSubscriptionProvider;
     return this;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManager.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
 public class AggregateGossipManager {
   private final GossipEncoding gossipEncoding;
   private final TopicChannel channel;
+  private final SignedAggregateAndProofValidator validator;
 
   private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
@@ -36,6 +37,7 @@ public class AggregateGossipManager {
       final ForkInfo forkInfo,
       final SignedAggregateAndProofValidator validator,
       final GossipedAttestationConsumer gossipedAttestationConsumer) {
+    this.validator = validator;
     this.gossipEncoding = gossipEncoding;
     final AggregateAttestationTopicHandler aggregateAttestationTopicHandler =
         new AggregateAttestationTopicHandler(
@@ -49,6 +51,7 @@ public class AggregateGossipManager {
     if (!validateableAttestation.isAggregate() || !validateableAttestation.markGossiped()) {
       return;
     }
+    validator.addSeenAggregate(validateableAttestation);
     final Bytes data = gossipEncoding.encode(validateableAttestation.getSignedAggregateAndProof());
     channel.gossip(data);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/AggregateAttestationTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/AggregateAttestationTopicHandler.java
@@ -50,7 +50,7 @@ public class AggregateAttestationTopicHandler implements Eth2TopicHandler<Signed
   public ValidationResult handleMessage(final Bytes bytes) {
     try {
       ValidateableAttestation attestation =
-          ValidateableAttestation.fromAggregate(deserialize(bytes));
+          ValidateableAttestation.fromSignedAggregate(deserialize(bytes));
       final InternalValidationResult internalValidationResult = validateData(attestation);
       switch (internalValidationResult) {
         case REJECT:

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandler.java
@@ -51,7 +51,8 @@ public class SingleAttestationTopicHandler implements Eth2TopicHandler<Attestati
   @Override
   public ValidationResult handleMessage(final Bytes bytes) {
     try {
-      ValidateableAttestation attestation = ValidateableAttestation.fromSingle(deserialize(bytes));
+      ValidateableAttestation attestation =
+          ValidateableAttestation.fromAttestation(deserialize(bytes));
       final InternalValidationResult internalValidationResult = validateData(attestation);
       switch (internalValidationResult) {
         case REJECT:

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/VerifiedBlockAttestationsSubscriptionProvider.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/VerifiedBlockAttestationsSubscriptionProvider.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.gossip.topics;
+
+import tech.pegasys.teku.statetransition.blockimport.VerifiedBlockAttestationsListener;
+
+public interface VerifiedBlockAttestationsSubscriptionProvider {
+  void subscribe(VerifiedBlockAttestationsListener verifiedBlockAttestationsListener);
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/SignedAggregateAndProofValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/SignedAggregateAndProofValidator.java
@@ -85,7 +85,7 @@ public class SignedAggregateAndProofValidator {
     }
 
     if (receivedValidAggregations.contains(attestation.hash_tree_root())) {
-      LOG.trace("Ignoring duplicate aggregate");
+      LOG.trace("Ignoring duplicate aggregate based on hash tree root");
       return IGNORE;
     }
 
@@ -139,7 +139,7 @@ public class SignedAggregateAndProofValidator {
     }
 
     if (!receivedValidAggregations.add(attestation.hash_tree_root())) {
-      LOG.trace("Ignoring duplicate aggregate");
+      LOG.trace("Ignoring duplicate aggregate based on hash tree root");
       return IGNORE;
     }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManagerTest.java
@@ -63,7 +63,7 @@ public class AggregateGossipManagerTest {
   public void onNewAggregate() {
     final SignedAggregateAndProof aggregate = dataStructureUtil.randomSignedAggregateAndProof();
     final Bytes serialized = gossipEncoding.encode(aggregate);
-    gossipManager.onNewAggregate(ValidateableAttestation.fromAggregate(aggregate));
+    gossipManager.onNewAggregate(ValidateableAttestation.fromSignedAggregate(aggregate));
 
     verify(topicChannel).gossip(serialized);
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
@@ -78,7 +78,7 @@ public class AttestationGossipManagerTest {
     final Attestation attestation = dataStructureUtil.randomAttestation();
     setCommitteeIndex(attestation, committeeIndex);
     final Bytes serialized = gossipEncoding.encode(attestation);
-    attestationGossipManager.onNewAttestation(ValidateableAttestation.fromSingle(attestation));
+    attestationGossipManager.onNewAttestation(ValidateableAttestation.fromAttestation(attestation));
 
     verify(topicChannel).gossip(serialized);
 
@@ -86,7 +86,8 @@ public class AttestationGossipManagerTest {
     final Attestation attestation2 = dataStructureUtil.randomAttestation();
     setCommitteeIndex(attestation2, committeeIndex + ATTESTATION_SUBNET_COUNT);
     final Bytes serialized2 = gossipEncoding.encode(attestation2);
-    attestationGossipManager.onNewAttestation(ValidateableAttestation.fromSingle(attestation2));
+    attestationGossipManager.onNewAttestation(
+        ValidateableAttestation.fromAttestation(attestation2));
 
     verify(topicChannel).gossip(serialized2);
   }
@@ -100,7 +101,7 @@ public class AttestationGossipManagerTest {
     // Post new attestation
     final Attestation attestation = dataStructureUtil.randomAttestation();
     setCommitteeIndex(attestation, committeeIndex + 1);
-    attestationGossipManager.onNewAttestation(ValidateableAttestation.fromSingle(attestation));
+    attestationGossipManager.onNewAttestation(ValidateableAttestation.fromAttestation(attestation));
 
     verifyNoInteractions(topicChannel);
   }
@@ -119,7 +120,7 @@ public class AttestationGossipManagerTest {
     final Attestation attestation = dataStructureUtil.randomAttestation();
     setCommitteeIndex(attestation, dismissedIndex);
     final Bytes serialized = gossipEncoding.encode(attestation);
-    attestationGossipManager.onNewAttestation(ValidateableAttestation.fromSingle(attestation));
+    attestationGossipManager.onNewAttestation(ValidateableAttestation.fromAttestation(attestation));
 
     verify(topicChannel, never()).gossip(serialized);
 
@@ -127,7 +128,8 @@ public class AttestationGossipManagerTest {
     final Attestation attestation2 = dataStructureUtil.randomAttestation();
     setCommitteeIndex(attestation2, committeeIndex);
     final Bytes serialized2 = gossipEncoding.encode(attestation2);
-    attestationGossipManager.onNewAttestation(ValidateableAttestation.fromSingle(attestation2));
+    attestationGossipManager.onNewAttestation(
+        ValidateableAttestation.fromAttestation(attestation2));
 
     verify(topicChannel).gossip(serialized2);
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AggregateTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AggregateTopicHandlerTest.java
@@ -43,7 +43,8 @@ public class AggregateTopicHandlerTest {
   @Test
   public void handleMessage_validAggregate() {
     final ValidateableAttestation aggregate =
-        ValidateableAttestation.fromAggregate(dataStructureUtil.randomSignedAggregateAndProof());
+        ValidateableAttestation.fromSignedAggregate(
+            dataStructureUtil.randomSignedAggregateAndProof());
     when(validator.validate(aggregate)).thenReturn(InternalValidationResult.ACCEPT);
 
     final ValidationResult result =
@@ -55,7 +56,8 @@ public class AggregateTopicHandlerTest {
   @Test
   public void handleMessage_savedForFuture() {
     final ValidateableAttestation aggregate =
-        ValidateableAttestation.fromAggregate(dataStructureUtil.randomSignedAggregateAndProof());
+        ValidateableAttestation.fromSignedAggregate(
+            dataStructureUtil.randomSignedAggregateAndProof());
     when(validator.validate(aggregate)).thenReturn(InternalValidationResult.SAVE_FOR_FUTURE);
 
     final ValidationResult result =
@@ -67,7 +69,8 @@ public class AggregateTopicHandlerTest {
   @Test
   public void handleMessage_ignoredAggregate() {
     final ValidateableAttestation aggregate =
-        ValidateableAttestation.fromAggregate(dataStructureUtil.randomSignedAggregateAndProof());
+        ValidateableAttestation.fromSignedAggregate(
+            dataStructureUtil.randomSignedAggregateAndProof());
     when(validator.validate(aggregate)).thenReturn(InternalValidationResult.IGNORE);
 
     final ValidationResult result =
@@ -79,7 +82,8 @@ public class AggregateTopicHandlerTest {
   @Test
   public void handleMessage_invalidAggregate() {
     final ValidateableAttestation aggregate =
-        ValidateableAttestation.fromAggregate(dataStructureUtil.randomSignedAggregateAndProof());
+        ValidateableAttestation.fromSignedAggregate(
+            dataStructureUtil.randomSignedAggregateAndProof());
     when(validator.validate(aggregate)).thenReturn(InternalValidationResult.REJECT);
 
     final ValidationResult result =

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
@@ -72,7 +72,8 @@ public class SingleAttestationTopicHandlerTest {
     final AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
     final BeaconBlockAndState blockAndState = recentChainData.getBestBlockAndState().orElseThrow();
     final ValidateableAttestation attestation =
-        ValidateableAttestation.fromSingle(attestationGenerator.validAttestation(blockAndState));
+        ValidateableAttestation.fromAttestation(
+            attestationGenerator.validAttestation(blockAndState));
     when(attestationValidator.validate(attestation, SUBNET_ID)).thenReturn(ACCEPT);
     final Bytes serialized = gossipEncoding.encode(attestation.getAttestation());
 
@@ -86,7 +87,8 @@ public class SingleAttestationTopicHandlerTest {
     final AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
     final BeaconBlockAndState blockAndState = recentChainData.getBestBlockAndState().orElseThrow();
     final ValidateableAttestation attestation =
-        ValidateableAttestation.fromSingle(attestationGenerator.validAttestation(blockAndState));
+        ValidateableAttestation.fromAttestation(
+            attestationGenerator.validAttestation(blockAndState));
     when(attestationValidator.validate(attestation, SUBNET_ID)).thenReturn(IGNORE);
     final Bytes serialized = gossipEncoding.encode(attestation.getAttestation());
 
@@ -100,7 +102,8 @@ public class SingleAttestationTopicHandlerTest {
     final AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
     final BeaconBlockAndState blockAndState = recentChainData.getBestBlockAndState().orElseThrow();
     final ValidateableAttestation attestation =
-        ValidateableAttestation.fromSingle(attestationGenerator.validAttestation(blockAndState));
+        ValidateableAttestation.fromAttestation(
+            attestationGenerator.validAttestation(blockAndState));
     when(attestationValidator.validate(attestation, SUBNET_ID)).thenReturn(SAVE_FOR_FUTURE);
     final Bytes serialized = gossipEncoding.encode(attestation.getAttestation());
 
@@ -114,7 +117,8 @@ public class SingleAttestationTopicHandlerTest {
     final AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
     final BeaconBlockAndState blockAndState = recentChainData.getBestBlockAndState().orElseThrow();
     final ValidateableAttestation attestation =
-        ValidateableAttestation.fromSingle(attestationGenerator.validAttestation(blockAndState));
+        ValidateableAttestation.fromAttestation(
+            attestationGenerator.validAttestation(blockAndState));
     when(attestationValidator.validate(attestation, SUBNET_ID)).thenReturn(REJECT);
     final Bytes serialized = gossipEncoding.encode(attestation.getAttestation());
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/AttestationValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/AttestationValidatorTest.java
@@ -276,16 +276,18 @@ class AttestationValidatorTest {
     final int expectedSubnetId = CommitteeUtil.getSubnetId(attestation);
     assertThat(
             validator.validate(
-                ValidateableAttestation.fromSingle(attestation), expectedSubnetId + 1))
+                ValidateableAttestation.fromAttestation(attestation), expectedSubnetId + 1))
         .isEqualTo(REJECT);
     assertThat(
-            validator.validate(ValidateableAttestation.fromSingle(attestation), expectedSubnetId))
+            validator.validate(
+                ValidateableAttestation.fromAttestation(attestation), expectedSubnetId))
         .isEqualTo(ACCEPT);
   }
 
   private InternalValidationResult validate(final Attestation attestation) {
     return validator.validate(
-        ValidateableAttestation.fromSingle(attestation), CommitteeUtil.getSubnetId(attestation));
+        ValidateableAttestation.fromAttestation(attestation),
+        CommitteeUtil.getSubnetId(attestation));
   }
 
   private boolean hasSameValidators(final Attestation attestation1, final Attestation attestation) {

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.datastructures.attestation.ProcessedAttestationListener
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipedAttestationConsumer;
 import tech.pegasys.teku.networking.eth2.gossip.topics.ProcessedAttestationSubscriptionProvider;
+import tech.pegasys.teku.networking.eth2.gossip.topics.VerifiedBlockAttestationsSubscriptionProvider;
 import tech.pegasys.teku.networking.eth2.peers.Eth2PeerManager;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.networking.p2p.DiscoveryNetwork;
@@ -53,6 +54,7 @@ import tech.pegasys.teku.networking.p2p.network.PeerHandler;
 import tech.pegasys.teku.networking.p2p.network.WireLogsConfig;
 import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
+import tech.pegasys.teku.statetransition.blockimport.VerifiedBlockAttestationsListener;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StubStorageQueryChannel;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
@@ -89,6 +91,8 @@ public class Eth2NetworkFactory {
     protected RecentChainData recentChainData;
     protected GossipedAttestationConsumer gossipedAttestationConsumer;
     protected ProcessedAttestationSubscriptionProvider processedAttestationSubscriptionProvider;
+    protected VerifiedBlockAttestationsSubscriptionProvider
+        verifiedBlockAttestationsSubscriptionProvider;
     protected Function<RpcMethod, Stream<RpcMethod>> rpcMethodsModifier = Stream::of;
     protected List<PeerHandler> peerHandlers = new ArrayList<>();
     protected RpcEncoding rpcEncoding = RpcEncoding.SSZ_SNAPPY;
@@ -177,7 +181,8 @@ public class Eth2NetworkFactory {
             gossipEncoding,
             attestationSubnetService,
             gossipedAttestationConsumer,
-            processedAttestationSubscriptionProvider);
+            processedAttestationSubscriptionProvider,
+            verifiedBlockAttestationsSubscriptionProvider);
       }
     }
 
@@ -227,6 +232,10 @@ public class Eth2NetworkFactory {
         Subscribers<ProcessedAttestationListener> subscribers = Subscribers.create(false);
         processedAttestationSubscriptionProvider = subscribers::subscribe;
       }
+      if (verifiedBlockAttestationsSubscriptionProvider == null) {
+        Subscribers<VerifiedBlockAttestationsListener> subscribers = Subscribers.create(false);
+        verifiedBlockAttestationsSubscriptionProvider = subscribers::subscribe;
+      }
     }
 
     public Eth2P2PNetworkBuilder rpcEncoding(final RpcEncoding rpcEncoding) {
@@ -269,6 +278,15 @@ public class Eth2NetworkFactory {
         final ProcessedAttestationSubscriptionProvider processedAttestationSubscriptionProvider) {
       checkNotNull(processedAttestationSubscriptionProvider);
       this.processedAttestationSubscriptionProvider = processedAttestationSubscriptionProvider;
+      return this;
+    }
+
+    public Eth2P2PNetworkBuilder verifiedBlockAttestationsSubscriptionProvider(
+        final VerifiedBlockAttestationsSubscriptionProvider
+            verifiedBlockAttestationsSubscriptionProvider) {
+      checkNotNull(verifiedBlockAttestationsSubscriptionProvider);
+      this.verifiedBlockAttestationsSubscriptionProvider =
+          verifiedBlockAttestationsSubscriptionProvider;
       return this;
     }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -361,6 +361,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
                               reason -> LOG.debug("Rejected gossiped attestation: " + reason)))
               .processedAttestationSubscriptionProvider(
                   attestationManager::subscribeToProcessedAttestations)
+              .verifiedBlockAttestationsProvider(
+                  blockImporter::subscribeToVerifiedBlockAttestations)
               .historicalChainData(eventChannels.getPublisher(StorageQueryChannel.class))
               .metricsSystem(metricsSystem)
               .timeProvider(timeProvider)

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -224,7 +224,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public void sendSignedAttestation(final Attestation attestation) {
     attestationManager
-        .onAttestation(ValidateableAttestation.fromSingle(attestation))
+        .onAttestation(ValidateableAttestation.fromAttestation(attestation))
         .ifInvalid(
             reason ->
                 VALIDATOR_LOGGER.producedInvalidAttestation(
@@ -234,7 +234,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public void sendAggregateAndProof(final SignedAggregateAndProof aggregateAndProof) {
     attestationManager
-        .onAttestation(ValidateableAttestation.fromAggregate(aggregateAndProof))
+        .onAttestation(ValidateableAttestation.fromSignedAggregate(aggregateAndProof))
         .ifInvalid(
             reason ->
                 VALIDATOR_LOGGER.producedInvalidAggregate(

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -306,7 +306,7 @@ class ValidatorApiHandlerTest {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     final Optional<Attestation> aggregate = Optional.of(dataStructureUtil.randomAttestation());
     when(attestationPool.createAggregateFor(attestationData))
-        .thenReturn(aggregate.map(ValidateableAttestation::fromSingle));
+        .thenReturn(aggregate.map(ValidateableAttestation::fromAttestation));
 
     assertThat(validatorApiHandler.createAggregate(attestationData))
         .isCompletedWithValue(aggregate);
@@ -344,7 +344,7 @@ class ValidatorApiHandlerTest {
     when(attestationManager.onAttestation(any())).thenReturn(SUCCESSFUL);
     validatorApiHandler.sendSignedAttestation(attestation);
 
-    verify(attestationManager).onAttestation(ValidateableAttestation.fromSingle(attestation));
+    verify(attestationManager).onAttestation(ValidateableAttestation.fromAttestation(attestation));
   }
 
   @Test
@@ -363,7 +363,7 @@ class ValidatorApiHandlerTest {
     validatorApiHandler.sendAggregateAndProof(aggregateAndProof);
 
     verify(attestationManager)
-        .onAttestation(ValidateableAttestation.fromAggregate(aggregateAndProof));
+        .onAttestation(ValidateableAttestation.fromSignedAggregate(aggregateAndProof));
   }
 
   private Optional<List<ValidatorDuties>> assertCompletedSuccessfully(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Implement the missing validation: ignoring seen (produced in the validator, seen in verified blocks, or already gossiped)  aggregates by checking hash tree roots.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes https://github.com/PegaSysEng/teku/issues/2080

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.