### PR TITLE
Only report when attestations are invalid, not when they are delayed

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/AttestationProcessingResult.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/AttestationProcessingResult.java
@@ -49,6 +49,12 @@ public class AttestationProcessingResult {
     }
   }
 
+  public void ifInvalid(final Consumer<String> handler) {
+    if (status == Status.INVALID) {
+      handler.accept(getInvalidReason());
+    }
+  }
+
   public boolean isSuccessful() {
     return status == Status.SUCCESSFUL;
   }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -357,7 +357,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
                   attestation ->
                       attestationManager
                           .onAttestation(attestation)
-                          .ifUnsuccessful(
+                          .ifInvalid(
                               reason -> LOG.debug("Rejected gossiped attestation: " + reason)))
               .processedAttestationSubscriptionProvider(
                   attestationManager::subscribeToProcessedAttestations)

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -225,7 +225,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   public void sendSignedAttestation(final Attestation attestation) {
     attestationManager
         .onAttestation(ValidateableAttestation.fromSingle(attestation))
-        .ifUnsuccessful(
+        .ifInvalid(
             reason ->
                 VALIDATOR_LOGGER.producedInvalidAttestation(
                     attestation.getData().getSlot(), reason));
@@ -235,7 +235,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   public void sendAggregateAndProof(final SignedAggregateAndProof aggregateAndProof) {
     attestationManager
         .onAttestation(ValidateableAttestation.fromAggregate(aggregateAndProof))
-        .ifUnsuccessful(
+        .ifInvalid(
             reason ->
                 VALIDATOR_LOGGER.producedInvalidAggregate(
                     aggregateAndProof.getMessage().getAggregate().getData().getSlot(), reason));


### PR DESCRIPTION
## PR Description
Attestations can't be processed until the slot after they're produced so we should expect them to be delayed a lot and not log as an error.  We should log when they are invalid though (and the key checks are performed prior to delaying so logs wind up being quite useful).

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.