### PR TITLE
SECONDS_PER_ETH1_BLOCK changed to int

### DIFF
--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1HeadTracker.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1HeadTracker.java
@@ -63,9 +63,7 @@ public class Eth1HeadTracker {
             () ->
                 asyncRunner
                     .runAfterDelay(
-                        this::pollLatestHead,
-                        Constants.SECONDS_PER_ETH1_BLOCK.longValue(),
-                        TimeUnit.SECONDS)
+                        this::pollLatestHead, Constants.SECONDS_PER_ETH1_BLOCK, TimeUnit.SECONDS)
                     .finish(
                         () -> {},
                         error ->

--- a/pow/src/main/java/tech/pegasys/teku/pow/api/Eth1DataCachePeriodCalculator.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/api/Eth1DataCachePeriodCalculator.java
@@ -32,7 +32,7 @@ public class Eth1DataCachePeriodCalculator {
 
     // We need 2 * ETH1_FOLLOW_DISTANCE prior to that but this assumes our current time is from a
     // block already ETH1_FOLLOW_DISTANCE behind head.
-    cacheDurationSeconds += SECONDS_PER_ETH1_BLOCK.longValue() * ETH1_FOLLOW_DISTANCE.longValue();
+    cacheDurationSeconds += Long.valueOf(SECONDS_PER_ETH1_BLOCK) * ETH1_FOLLOW_DISTANCE.longValue();
 
     // And we want to be able to create blocks for at least the past epoch
     cacheDurationSeconds += SLOTS_PER_EPOCH * SECONDS_PER_SLOT;
@@ -42,6 +42,6 @@ public class Eth1DataCachePeriodCalculator {
   public static UnsignedLong calculateEth1DataCacheDurationPriorToCurrentTime() {
     // Add in the difference between current time and a block ETH1_FOLLOW_DISTANCE behind.
     return calculateEth1DataCacheDurationPriorToFollowDistance()
-        .plus(SECONDS_PER_ETH1_BLOCK.times(ETH1_FOLLOW_DISTANCE));
+        .plus(ETH1_FOLLOW_DISTANCE.times(UnsignedLong.valueOf(SECONDS_PER_ETH1_BLOCK)));
   }
 }

--- a/pow/src/main/java/tech/pegasys/teku/pow/api/Eth1DataCachePeriodCalculator.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/api/Eth1DataCachePeriodCalculator.java
@@ -32,7 +32,7 @@ public class Eth1DataCachePeriodCalculator {
 
     // We need 2 * ETH1_FOLLOW_DISTANCE prior to that but this assumes our current time is from a
     // block already ETH1_FOLLOW_DISTANCE behind head.
-    cacheDurationSeconds += Long.valueOf(SECONDS_PER_ETH1_BLOCK) * ETH1_FOLLOW_DISTANCE.longValue();
+    cacheDurationSeconds += ETH1_FOLLOW_DISTANCE.longValue() * SECONDS_PER_ETH1_BLOCK;
 
     // And we want to be able to create blocks for at least the past epoch
     cacheDurationSeconds += SLOTS_PER_EPOCH * SECONDS_PER_SLOT;

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -101,7 +101,7 @@ public class Constants {
 
   // Honest Validator
   public static int TARGET_AGGREGATORS_PER_COMMITTEE = 16;
-  public static UnsignedLong SECONDS_PER_ETH1_BLOCK = UnsignedLong.valueOf(14L);
+  public static int SECONDS_PER_ETH1_BLOCK = 14;
 
   // Deposit
   public static String DEPOSIT_NORMAL = "normal";

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/Eth1VotingPeriod.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/Eth1VotingPeriod.java
@@ -35,13 +35,17 @@ public class Eth1VotingPeriod {
     return secondsBeforeCurrentVotingPeriodStartTime(
         slot,
         genesisTime,
-        ETH1_FOLLOW_DISTANCE.times(SECONDS_PER_ETH1_BLOCK).times(UnsignedLong.valueOf(2)));
+        ETH1_FOLLOW_DISTANCE
+            .times(UnsignedLong.valueOf(SECONDS_PER_ETH1_BLOCK))
+            .times(UnsignedLong.valueOf(2)));
   }
 
   public UnsignedLong getSpecRangeUpperBound(
       final UnsignedLong slot, final UnsignedLong genesisTime) {
     return secondsBeforeCurrentVotingPeriodStartTime(
-        slot, genesisTime, ETH1_FOLLOW_DISTANCE.times(SECONDS_PER_ETH1_BLOCK));
+        slot,
+        genesisTime,
+        ETH1_FOLLOW_DISTANCE.times(UnsignedLong.valueOf(SECONDS_PER_ETH1_BLOCK)));
   }
 
   private UnsignedLong secondsBeforeCurrentVotingPeriodStartTime(

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/Eth1VotingPeriodTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/Eth1VotingPeriodTest.java
@@ -46,7 +46,7 @@ class Eth1VotingPeriodTest {
 
   @BeforeAll
   static void setConstants() {
-    Constants.SECONDS_PER_ETH1_BLOCK = UnsignedLong.valueOf(3);
+    Constants.SECONDS_PER_ETH1_BLOCK = 3;
     Constants.ETH1_FOLLOW_DISTANCE = UnsignedLong.valueOf(5);
     Constants.EPOCHS_PER_ETH1_VOTING_PERIOD = 1;
     Constants.SLOTS_PER_EPOCH = 6;


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

This value does not need to be any bigger than int. 

See #2105 

- [ x] I thought about documentation and added the `documentation` label to this PR if updates are required.