### PR TITLE
Add Onyx network definition and fix version number

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -
 # Enable configure on demand.
 org.gradle.configureondemand=true
 
-version=0.11.4-SNAPSHOT
+version=0.12.0-SNAPSHOT

--- a/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
@@ -79,12 +79,12 @@ public class NetworkDefinition {
               builder()
                   .constants("mainnet")
                   .snappyCompressionEnabled(true)
-                  .discoveryBootnodes("enr:-Ku4QMKVC_MowDsmEa20d5uGjrChI0h8_KsKXDmgVQbIbngZV0idV6_RL7fEtZGo-kTNZ5o7_EJI_vCPJ6scrhwX0Z4Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQJxCnE6v_x2ekgY_uoE1rtwzvGy40mq9eD66XfHPBWgIIN1ZHCCD6A")
+                  .discoveryBootnodes(
+                      "enr:-Ku4QMKVC_MowDsmEa20d5uGjrChI0h8_KsKXDmgVQbIbngZV0idV6_RL7fEtZGo-kTNZ5o7_EJI_vCPJ6scrhwX0Z4Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQJxCnE6v_x2ekgY_uoE1rtwzvGy40mq9eD66XfHPBWgIIN1ZHCCD6A")
                   .eth1DepositContractAddress("0x0f0f0fc0530007361933eab5db97d09acdd6c1c8")
                   .eth1Endpoint("https://goerli.prylabs.net")
                   .startupTimeoutSeconds(120)
-                  .build()
-          )
+                  .build())
           .build();
 
   private final String constants;

--- a/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
@@ -74,6 +74,17 @@ public class NetworkDefinition {
                       "enr:-Ku4QKsKa3HbJjz8cZn4mEh-stIF6kACLh2rmCGscEsLUe4XUSt-xZEAx7SK6R3zqAc2WAVBpLkh5fu-r-PHr_8d4B8Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhDMPd52Jc2VjcDI1NmsxoQMLvOjDnLAqnQsTKqUqNr1qcleEBgkin3KOW9BeIxAJ54N1ZHCCW8w")
                   .eth1DepositContractAddress("0x42cc0FcEB02015F145105Cf6f19F90e9BEa76558")
                   .build())
+          .put(
+              "onyx",
+              builder()
+                  .constants("mainnet")
+                  .snappyCompressionEnabled(true)
+                  .discoveryBootnodes("enr:-Ku4QMKVC_MowDsmEa20d5uGjrChI0h8_KsKXDmgVQbIbngZV0idV6_RL7fEtZGo-kTNZ5o7_EJI_vCPJ6scrhwX0Z4Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQJxCnE6v_x2ekgY_uoE1rtwzvGy40mq9eD66XfHPBWgIIN1ZHCCD6A")
+                  .eth1DepositContractAddress("0x0f0f0fc0530007361933eab5db97d09acdd6c1c8")
+                  .eth1Endpoint("https://goerli.prylabs.net")
+                  .startupTimeoutSeconds(120)
+                  .build()
+          )
           .build();
 
   private final String constants;


### PR DESCRIPTION
## PR Description
Add a network definition for the new Onyx testnet.
Update version number to 0.12.0-SNAPSHOT so it stops conflicting with master.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

This is an extra option for `--network` only supported on the 0.12.1-integration branch.  At some point that will merge over to master. Since Onyx uses the v0.12.1 spec, you can't use it with the master branch which is still 0.11.3 spec (for compatibility with witti).