### PR TITLE
Change validator generate output to go to a single directory

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/deposit/DepositGenerateCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/deposit/DepositGenerateCommand.java
@@ -97,7 +97,7 @@ public class DepositGenerateCommand implements Runnable {
 
   public DepositGenerateCommand() {
     this.shutdownFunction =
-        System::exit; // required because web3j use non-daemon threads which halts the program
+        System::exit; // required because web3j uses non-daemon threads which halts the program
     this.envSupplier = System::getenv;
     this.consoleAdapter = new ConsoleAdapter();
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/deposit/EncryptedKeystoreWriter.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/deposit/EncryptedKeystoreWriter.java
@@ -45,12 +45,12 @@ public class EncryptedKeystoreWriter implements KeysWriter {
     this.validatorKeyPassword = validatorKeyPassword;
     this.withdrawalKeyPassword = withdrawalKeyPassword;
     this.outputPath = outputPath;
+    createKeystoreDirectory();
   }
 
   @Override
   public void writeKeys(final BLSKeyPair validatorKey, final BLSKeyPair withdrawalKey)
       throws UncheckedIOException, KeyStoreValidationException {
-    final Path keystoreDirectory = createKeystoreDirectory(validatorKey);
 
     final KeyStoreData validatorKeyStoreData =
         generateKeystoreData(validatorKey, validatorKeyPassword);
@@ -58,22 +58,20 @@ public class EncryptedKeystoreWriter implements KeysWriter {
         generateKeystoreData(withdrawalKey, withdrawalKeyPassword);
 
     final String validatorFileName =
-        "validator_" + shortPublicKey(validatorKey.getPublicKey()) + ".json";
+        shortPublicKey(validatorKey.getPublicKey()) + "_validator.json";
     final String withdrawalFileName =
-        "withdrawal_" + shortPublicKey(withdrawalKey.getPublicKey()) + ".json";
+        shortPublicKey(withdrawalKey.getPublicKey()) + "_withdrawal.json";
 
-    saveKeyStore(keystoreDirectory.resolve(validatorFileName), validatorKeyStoreData);
-    saveKeyStore(keystoreDirectory.resolve(withdrawalFileName), withdrawalKeyStoreData);
+    saveKeyStore(outputPath.resolve(validatorFileName), validatorKeyStoreData);
+    saveKeyStore(outputPath.resolve(withdrawalFileName), withdrawalKeyStoreData);
   }
 
-  private Path createKeystoreDirectory(final BLSKeyPair validatorKey) {
-    final Path keystoreDirectory =
-        outputPath.resolve("validator_" + shortPublicKey(validatorKey.getPublicKey()));
+  private void createKeystoreDirectory() {
     try {
-      return Files.createDirectories(keystoreDirectory);
+      Files.createDirectories(outputPath);
     } catch (IOException e) {
       STATUS_LOG.validatorDepositEncryptedKeystoreWriterFailure(
-          "Error: Unable to create directory [{}] : {}", keystoreDirectory, e.getMessage());
+          "Error: Unable to create directory [{}] : {}", outputPath, e.getMessage());
       throw new UncheckedIOException(e);
     }
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/deposit/EncryptedKeystoreWriter.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/deposit/EncryptedKeystoreWriter.java
@@ -60,7 +60,7 @@ public class EncryptedKeystoreWriter implements KeysWriter {
     final String validatorFileName =
         shortPublicKey(validatorKey.getPublicKey()) + "_validator.json";
     final String withdrawalFileName =
-        shortPublicKey(withdrawalKey.getPublicKey()) + "_withdrawal.json";
+        shortPublicKey(validatorKey.getPublicKey()) + "_withdrawal.json";
 
     saveKeyStore(outputPath.resolve(validatorFileName), validatorKeyStoreData);
     saveKeyStore(outputPath.resolve(withdrawalFileName), withdrawalKeyStoreData);

--- a/teku/src/test/java/tech/pegasys/teku/cli/deposit/EncryptedKeystoreWriterTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/deposit/EncryptedKeystoreWriterTest.java
@@ -44,9 +44,7 @@ class EncryptedKeystoreWriterTest {
           Bytes.fromHexString(
               "0x000000000000000000000000000000000610B84CD68FB0FAB2F04A2A05EE01CD5F7374EB8EA93E26DB9C61DD2704B5BD"));
   private static final String validator1PubKey = new BLSPublicKey(validator1SecretKey).toString();
-  private static final String withdrawal1PubKey = new BLSPublicKey(withdrawal1SecretKey).toString();
   private static final String validator2PubKey = new BLSPublicKey(validator2SecretKey).toString();
-  private static final String withdrawal2PubKey = new BLSPublicKey(withdrawal2SecretKey).toString();
 
   private static final String PASSWORD = "test123";
 
@@ -58,7 +56,7 @@ class EncryptedKeystoreWriterTest {
     assertKeyStoreCreatedAndCanBeDecrypted(
         tempDir.resolve(trimPublicKey(validator1PubKey) + "_validator.json"), validator1SecretKey);
     assertKeyStoreCreatedAndCanBeDecrypted(
-        tempDir.resolve(trimPublicKey(withdrawal1PubKey) + "_withdrawal.json"),
+        tempDir.resolve(trimPublicKey(validator1PubKey) + "_withdrawal.json"),
         withdrawal1SecretKey);
 
     keysWriter.writeKeys(new BLSKeyPair(validator2SecretKey), new BLSKeyPair(withdrawal2SecretKey));
@@ -66,7 +64,7 @@ class EncryptedKeystoreWriterTest {
     assertKeyStoreCreatedAndCanBeDecrypted(
         tempDir.resolve(trimPublicKey(validator2PubKey) + "_validator.json"), validator2SecretKey);
     assertKeyStoreCreatedAndCanBeDecrypted(
-        tempDir.resolve(trimPublicKey(withdrawal2PubKey) + "_withdrawal.json"),
+        tempDir.resolve(trimPublicKey(validator2PubKey) + "_withdrawal.json"),
         withdrawal2SecretKey);
   }
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/deposit/EncryptedKeystoreWriterTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/deposit/EncryptedKeystoreWriterTest.java
@@ -56,39 +56,17 @@ class EncryptedKeystoreWriterTest {
     keysWriter.writeKeys(new BLSKeyPair(validator1SecretKey), new BLSKeyPair(withdrawal1SecretKey));
 
     assertKeyStoreCreatedAndCanBeDecrypted(
-        tempDir.resolve(
-            "validator_"
-                + trimPublicKey(validator1PubKey)
-                + "/validator_"
-                + trimPublicKey(validator1PubKey)
-                + ".json"),
-        validator1SecretKey);
+        tempDir.resolve(trimPublicKey(validator1PubKey) + "_validator.json"), validator1SecretKey);
     assertKeyStoreCreatedAndCanBeDecrypted(
-        tempDir.resolve(
-            "validator_"
-                + trimPublicKey(validator1PubKey)
-                + "/withdrawal_"
-                + trimPublicKey(withdrawal1PubKey)
-                + ".json"),
+        tempDir.resolve(trimPublicKey(withdrawal1PubKey) + "_withdrawal.json"),
         withdrawal1SecretKey);
 
     keysWriter.writeKeys(new BLSKeyPair(validator2SecretKey), new BLSKeyPair(withdrawal2SecretKey));
 
     assertKeyStoreCreatedAndCanBeDecrypted(
-        tempDir.resolve(
-            "validator_"
-                + trimPublicKey(validator2PubKey)
-                + "/validator_"
-                + trimPublicKey(validator2PubKey)
-                + ".json"),
-        validator2SecretKey);
+        tempDir.resolve(trimPublicKey(validator2PubKey) + "_validator.json"), validator2SecretKey);
     assertKeyStoreCreatedAndCanBeDecrypted(
-        tempDir.resolve(
-            "validator_"
-                + trimPublicKey(validator2PubKey)
-                + "/withdrawal_"
-                + trimPublicKey(withdrawal2PubKey)
-                + ".json"),
+        tempDir.resolve(trimPublicKey(withdrawal2PubKey) + "_withdrawal.json"),
         withdrawal2SecretKey);
   }
 


### PR DESCRIPTION
Change validator generate to use single output directory, rather than a directory per key.

See #2088 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.