### PR TITLE
Change whitelist to allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ we recommend most users use the latest `master` branch of Teku.
 
  - Anyone using `/node/version` should switch to use
    the new endpoint, as `/node/version` will be removed in a future release.
+ - `--metrics-host-whitelist` CLI option will be renamed `--metrics-host-allowlist` (currently both are supported)
+ - `--rest-api-host-whitelist` CLI option will be renamed `--rest-api-host-allowlist` (currently both are supported)
 
 ## 0.11.4
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -45,7 +45,7 @@ metrics-enabled: False
 metrics-port: 8008
 metrics-interface: "127.0.0.1"
 metrics-categories: ["BEACON", "LIBP2P", "NETWORK", "EVENTBUS", "JVM", "PROCESS"]
-#metrics-host-whitelist: ["localhost", "127.0.0.1"]
+#metrics-host-allowlist: ["localhost", "127.0.0.1"]
 
 # database
 #data-path: "."
@@ -56,4 +56,4 @@ rest-api-port: 5051
 rest-api-docs-enabled: True
 rest-api-enabled: True
 rest-api-interface: "127.0.0.1"
-#rest-api-host-whitelist: ["localhost", "127.0.0.1"]
+#rest-api-host-allowlist: ["localhost", "127.0.0.1"]

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractBeaconRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractBeaconRestAPIIntegrationTest.java
@@ -50,7 +50,7 @@ public abstract class AbstractBeaconRestAPIIntegrationTest {
       TekuConfiguration.builder()
           .setRestApiPort(0)
           .setRestApiDocsEnabled(false)
-          .setRestApiHostWhitelist(List.of("127.0.0.1", "localhost"))
+          .setRestApiHostAllowlist(List.of("127.0.0.1", "localhost"))
           .build();
 
   protected final DataStructureUtil dataStructureUtil = new DataStructureUtil();

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -62,7 +62,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
       TekuConfiguration.builder()
           .setRestApiPort(0)
           .setRestApiDocsEnabled(false)
-          .setRestApiHostWhitelist(List.of("127.0.0.1", "localhost"))
+          .setRestApiHostAllowlist(List.of("127.0.0.1", "localhost"))
           .build();
 
   protected static final UnsignedLong SIX = UnsignedLong.valueOf(6);

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/beacon/RestApiHostAllowlistIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/beacon/RestApiHostAllowlistIntegrationTest.java
@@ -21,7 +21,7 @@ import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetVersion;
 import tech.pegasys.teku.util.config.TekuConfiguration;
 
-public class RestApiHostWhitelistIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
+public class RestApiHostAllowlistIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
 
   @Test
   public void shouldReturnForbiddenIfHostNotAuthorized() throws Exception {
@@ -29,7 +29,7 @@ public class RestApiHostWhitelistIntegrationTest extends AbstractDataBackedRestA
         TekuConfiguration.builder()
             .setRestApiPort(0)
             .setRestApiDocsEnabled(false)
-            .setRestApiHostWhitelist(List.of("not.authorized.host"))
+            .setRestApiHostAllowlist(List.of("not.authorized.host"))
             .build();
     startPreGenesisRestAPIWithConfig(config);
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -76,7 +76,7 @@ public class BeaconRestApi {
   private void initialize(final DataProvider dataProvider, final TekuConfiguration configuration) {
     app.server().setServerPort(configuration.getRestApiPort());
 
-    addHostWhitelistHandler(configuration);
+    addHostAllowlistHandler(configuration);
 
     addExceptionHandlers();
     addAdminHandlers();
@@ -88,7 +88,7 @@ public class BeaconRestApi {
     addCustomErrorPages(configuration);
   }
 
-  private void addHostWhitelistHandler(final TekuConfiguration configuration) {
+  private void addHostAllowlistHandler(final TekuConfiguration configuration) {
     app.before(
         (ctx) -> {
           String header = ctx.host();

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.beaconrestapi;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
-import static tech.pegasys.teku.beaconrestapi.HostWhitelistUtils.isHostAuthorized;
+import static tech.pegasys.teku.beaconrestapi.HostAllowlistUtils.isHostAuthorized;
 
 import com.google.common.io.Resources;
 import io.javalin.Javalin;
@@ -92,7 +92,7 @@ public class BeaconRestApi {
     app.before(
         (ctx) -> {
           String header = ctx.host();
-          if (!isHostAuthorized(configuration.getRestApiHostWhitelist(), header)) {
+          if (!isHostAuthorized(configuration.getRestApiHostAllowlist(), header)) {
             LOG.debug("Host not authorized " + header);
             throw new ForbiddenResponse("Host not authorized");
           }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/HostAllowlistUtils.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/HostAllowlistUtils.java
@@ -20,12 +20,12 @@ import com.google.common.collect.Iterables;
 import java.util.List;
 import java.util.Optional;
 
-public class HostWhitelistUtils {
+public class HostAllowlistUtils {
 
-  static boolean isHostAuthorized(final List<String> whitelist, String hostHeader) {
+  static boolean isHostAuthorized(final List<String> allowlist, String hostHeader) {
     Optional<String> optionalHost = getAndValidateHostHeader(hostHeader);
-    if (whitelist.contains("*")
-        || (optionalHost.isPresent() && hostIsInWhitelist(whitelist, optionalHost.get()))) {
+    if (allowlist.contains("*")
+        || (optionalHost.isPresent() && hostIsInAllowlist(allowlist, optionalHost.get()))) {
       return true;
     } else {
       return false;
@@ -44,8 +44,8 @@ public class HostWhitelistUtils {
     return Optional.ofNullable(Iterables.get(splitHostHeader, 0));
   }
 
-  static boolean hostIsInWhitelist(final List<String> whitelist, final String hostHeader) {
-    return whitelist.stream()
-        .anyMatch(whitelistEntry -> whitelistEntry.toLowerCase().equals(hostHeader.toLowerCase()));
+  static boolean hostIsInAllowlist(final List<String> allowlist, final String hostHeader) {
+    return allowlist.stream()
+        .anyMatch(allowlistEntry -> allowlistEntry.toLowerCase().equals(hostHeader.toLowerCase()));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/HostAllowlistUtilsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/HostAllowlistUtilsTest.java
@@ -33,14 +33,14 @@ class HostAllowlistUtilsTest {
   }
 
   @Test
-  public void hostIsInWhitelist_shouldBeTrueIfInList() {
+  public void hostIsInAllowlist_shouldBeTrueIfInList() {
     assertThat(hostIsInAllowlist(List.of("A", "B"), "A")).isTrue();
     assertThat(hostIsInAllowlist(List.of("A", "B"), "B")).isTrue();
     assertThat(hostIsInAllowlist(List.of("A", "MIXed.CASE"), "miXED.caSE")).isTrue();
   }
 
   @Test
-  public void hostIsInWhitelist_shouldBeFalseIfNotInList() {
+  public void hostIsInAllowlist_shouldBeFalseIfNotInList() {
     assertThat(hostIsInAllowlist(List.of("A", "B"), "C")).isFalse();
     assertThat(hostIsInAllowlist(List.of("A", "B"), "AA")).isFalse();
     assertThat(hostIsInAllowlist(List.of("A.B.C", "B"), "A")).isFalse();

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/HostAllowlistUtilsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/HostAllowlistUtilsTest.java
@@ -14,14 +14,14 @@
 package tech.pegasys.teku.beaconrestapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.teku.beaconrestapi.HostWhitelistUtils.getAndValidateHostHeader;
-import static tech.pegasys.teku.beaconrestapi.HostWhitelistUtils.hostIsInWhitelist;
-import static tech.pegasys.teku.beaconrestapi.HostWhitelistUtils.isHostAuthorized;
+import static tech.pegasys.teku.beaconrestapi.HostAllowlistUtils.getAndValidateHostHeader;
+import static tech.pegasys.teku.beaconrestapi.HostAllowlistUtils.hostIsInAllowlist;
+import static tech.pegasys.teku.beaconrestapi.HostAllowlistUtils.isHostAuthorized;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class HostWhitelistUtilsTest {
+class HostAllowlistUtilsTest {
   private static final String BAD_HOST = "too.many:colons:5051";
 
   @Test
@@ -34,16 +34,16 @@ class HostWhitelistUtilsTest {
 
   @Test
   public void hostIsInWhitelist_shouldBeTrueIfInList() {
-    assertThat(hostIsInWhitelist(List.of("A", "B"), "A")).isTrue();
-    assertThat(hostIsInWhitelist(List.of("A", "B"), "B")).isTrue();
-    assertThat(hostIsInWhitelist(List.of("A", "MIXed.CASE"), "miXED.caSE")).isTrue();
+    assertThat(hostIsInAllowlist(List.of("A", "B"), "A")).isTrue();
+    assertThat(hostIsInAllowlist(List.of("A", "B"), "B")).isTrue();
+    assertThat(hostIsInAllowlist(List.of("A", "MIXed.CASE"), "miXED.caSE")).isTrue();
   }
 
   @Test
   public void hostIsInWhitelist_shouldBeFalseIfNotInList() {
-    assertThat(hostIsInWhitelist(List.of("A", "B"), "C")).isFalse();
-    assertThat(hostIsInWhitelist(List.of("A", "B"), "AA")).isFalse();
-    assertThat(hostIsInWhitelist(List.of("A.B.C", "B"), "A")).isFalse();
+    assertThat(hostIsInAllowlist(List.of("A", "B"), "C")).isFalse();
+    assertThat(hostIsInAllowlist(List.of("A", "B"), "AA")).isFalse();
+    assertThat(hostIsInAllowlist(List.of("A.B.C", "B"), "A")).isFalse();
   }
 
   @Test

--- a/data/metrics/src/main/java/tech/pegasys/teku/metrics/MetricsEndpoint.java
+++ b/data/metrics/src/main/java/tech/pegasys/teku/metrics/MetricsEndpoint.java
@@ -72,7 +72,7 @@ public class MetricsEndpoint {
         .port(tekuConfig.getMetricsPort())
         .host(tekuConfig.getMetricsInterface())
         .metricCategories(getEnabledMetricCategories(tekuConfig))
-        .hostsWhitelist(tekuConfig.getMetricsHostWhitelist())
+        .hostsWhitelist(tekuConfig.getMetricsHostAllowlist())
         .build();
   }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -333,14 +333,14 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setMetricsPort(metricsOptions.getMetricsPort())
         .setMetricsInterface(metricsOptions.getMetricsInterface())
         .setMetricsCategories(metricsOptions.getMetricsCategories())
-        .setMetricsHostWhitelist(metricsOptions.getMetricsHostWhitelist())
+        .setMetricsHostAllowlist(metricsOptions.getMetricsHostAllowlist())
         .setDataPath(dataOptions.getDataPath())
         .setDataStorageMode(dataOptions.getDataStorageMode())
         .setRestApiPort(beaconRestApiOptions.getRestApiPort())
         .setRestApiDocsEnabled(beaconRestApiOptions.isRestApiDocsEnabled())
         .setRestApiEnabled(beaconRestApiOptions.isRestApiEnabled())
         .setRestApiInterface(beaconRestApiOptions.getRestApiInterface())
-        .setRestApiHostWhitelist(beaconRestApiOptions.getRestApiHostWhitelist())
+        .setRestApiHostAllowlist(beaconRestApiOptions.getRestApiHostAllowlist())
         .build();
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
@@ -55,7 +55,7 @@ public class BeaconRestApiOptions {
       description = "Comma separated list of hostnames to allow, or * to allow any host",
       split = ",",
       arity = "0..*")
-  private final List<String> restApiHostWhitelist = Arrays.asList("127.0.0.1", "localhost");
+  private final List<String> restApiHostAllowlist = Arrays.asList("127.0.0.1", "localhost");
 
   public int getRestApiPort() {
     return restApiPort;
@@ -73,7 +73,7 @@ public class BeaconRestApiOptions {
     return restApiInterface;
   }
 
-  public List<String> getRestApiHostWhitelist() {
-    return restApiHostWhitelist;
+  public List<String> getRestApiHostAllowlist() {
+    return restApiHostAllowlist;
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
@@ -50,10 +50,9 @@ public class BeaconRestApiOptions {
   private String restApiInterface = "127.0.0.1";
 
   @Option(
-      names = {"--rest-api-host-whitelist"},
+      names = {"--rest-api-host-allowlist", "--rest-api-host-whitelist"},
       paramLabel = "<hostname>",
-      description =
-          "Comma separated list of hostnames to whitelist for access, or * to accept any host",
+      description = "Comma separated list of hostnames to allow, or * to allow any host",
       split = ",",
       arity = "0..*")
   private final List<String> restApiHostWhitelist = Arrays.asList("127.0.0.1", "localhost");

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -63,10 +63,9 @@ public class MetricsOptions {
   private Set<MetricCategory> metricsCategories = DEFAULT_METRICS_CATEGORIES;
 
   @Option(
-      names = {"--metrics-host-whitelist"},
+      names = {"--metrics-host-allowlist", "--metrics-host-whitelist"},
       paramLabel = "<hostname>",
-      description =
-          "Comma separated list of hostnames to whitelist for access, or * to accept any host",
+      description = "Comma separated list of hostnames to allow, or * to allow any host",
       split = ",",
       arity = "0..*")
   private final List<String> metricsHostWhitelist = Arrays.asList("127.0.0.1", "localhost");

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -68,7 +68,7 @@ public class MetricsOptions {
       description = "Comma separated list of hostnames to allow, or * to allow any host",
       split = ",",
       arity = "0..*")
-  private final List<String> metricsHostWhitelist = Arrays.asList("127.0.0.1", "localhost");
+  private final List<String> metricsHostAllowlist = Arrays.asList("127.0.0.1", "localhost");
 
   public boolean isMetricsEnabled() {
     return metricsEnabled;
@@ -86,7 +86,7 @@ public class MetricsOptions {
     return metricsCategories.stream().map(Object::toString).collect(Collectors.toList());
   }
 
-  public List<String> getMetricsHostWhitelist() {
-    return metricsHostWhitelist;
+  public List<String> getMetricsHostAllowlist() {
+    return metricsHostAllowlist;
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -292,7 +292,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setMetricsInterface("127.0.0.1")
         .setMetricsCategories(
             Arrays.asList("BEACON", "LIBP2P", "NETWORK", "EVENTBUS", "JVM", "PROCESS"))
-        .setMetricsHostWhitelist(List.of("127.0.0.1", "localhost"))
+        .setMetricsHostAllowlist(List.of("127.0.0.1", "localhost"))
         .setLogColorEnabled(true)
         .setLogDestination(DEFAULT_BOTH)
         .setLogFile(DEFAULT_LOG_FILE)
@@ -307,7 +307,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setRestApiDocsEnabled(false)
         .setRestApiEnabled(false)
         .setRestApiInterface("127.0.0.1")
-        .setRestApiHostWhitelist(List.of("127.0.0.1", "localhost"));
+        .setRestApiHostAllowlist(List.of("127.0.0.1", "localhost"));
   }
 
   private void assertTekuConfiguration(final TekuConfiguration expected) {

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconRestApiOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconRestApiOptionsTest.java
@@ -46,28 +46,28 @@ public class BeaconRestApiOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void restApiHostWhitelist_shouldNotRequireAValue() {
+  public void restApiHostAllowlist_shouldNotRequireAValue() {
     final TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--rest-api-host-allowlist");
     assertThat(tekuConfiguration.getRestApiHostAllowlist()).isEmpty();
   }
 
   @Test
-  public void restApiHostWhitelist_shouldSupportWhitelistingMultipleHosts() {
+  public void restApiHostAllowlist_shouldSupportAllowingMultipleHosts() {
     final TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--rest-api-host-allowlist", "my.host,their.host");
     assertThat(tekuConfiguration.getRestApiHostAllowlist()).containsOnly("my.host", "their.host");
   }
 
   @Test
-  public void restApiHostWhitelist_shouldSupportWhitelistingAllHosts() {
+  public void restApiHostAllowlist_shouldSupportAllowingAllHosts() {
     final TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--rest-api-host-allowlist", "*");
     assertThat(tekuConfiguration.getRestApiHostAllowlist()).containsOnly("*");
   }
 
   @Test
-  public void restApiHostWhitelist_shouldDefaultToLocalhost() {
+  public void restApiHostAllowlist_shouldDefaultToLocalhost() {
     assertThat(getTekuConfigurationFromArguments().getRestApiHostAllowlist())
         .containsOnly("localhost", "127.0.0.1");
   }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconRestApiOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconRestApiOptionsTest.java
@@ -48,21 +48,21 @@ public class BeaconRestApiOptionsTest extends AbstractBeaconNodeCommandTest {
   @Test
   public void restApiHostWhitelist_shouldNotRequireAValue() {
     final TekuConfiguration tekuConfiguration =
-        getTekuConfigurationFromArguments("--rest-api-host-whitelist");
+        getTekuConfigurationFromArguments("--rest-api-host-allowlist");
     assertThat(tekuConfiguration.getRestApiHostWhitelist()).isEmpty();
   }
 
   @Test
   public void restApiHostWhitelist_shouldSupportWhitelistingMultipleHosts() {
     final TekuConfiguration tekuConfiguration =
-        getTekuConfigurationFromArguments("--rest-api-host-whitelist", "my.host,their.host");
+        getTekuConfigurationFromArguments("--rest-api-host-allowlist", "my.host,their.host");
     assertThat(tekuConfiguration.getRestApiHostWhitelist()).containsOnly("my.host", "their.host");
   }
 
   @Test
   public void restApiHostWhitelist_shouldSupportWhitelistingAllHosts() {
     final TekuConfiguration tekuConfiguration =
-        getTekuConfigurationFromArguments("--rest-api-host-whitelist", "*");
+        getTekuConfigurationFromArguments("--rest-api-host-allowlist", "*");
     assertThat(tekuConfiguration.getRestApiHostWhitelist()).containsOnly("*");
   }
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconRestApiOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconRestApiOptionsTest.java
@@ -49,26 +49,26 @@ public class BeaconRestApiOptionsTest extends AbstractBeaconNodeCommandTest {
   public void restApiHostWhitelist_shouldNotRequireAValue() {
     final TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--rest-api-host-allowlist");
-    assertThat(tekuConfiguration.getRestApiHostWhitelist()).isEmpty();
+    assertThat(tekuConfiguration.getRestApiHostAllowlist()).isEmpty();
   }
 
   @Test
   public void restApiHostWhitelist_shouldSupportWhitelistingMultipleHosts() {
     final TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--rest-api-host-allowlist", "my.host,their.host");
-    assertThat(tekuConfiguration.getRestApiHostWhitelist()).containsOnly("my.host", "their.host");
+    assertThat(tekuConfiguration.getRestApiHostAllowlist()).containsOnly("my.host", "their.host");
   }
 
   @Test
   public void restApiHostWhitelist_shouldSupportWhitelistingAllHosts() {
     final TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--rest-api-host-allowlist", "*");
-    assertThat(tekuConfiguration.getRestApiHostWhitelist()).containsOnly("*");
+    assertThat(tekuConfiguration.getRestApiHostAllowlist()).containsOnly("*");
   }
 
   @Test
   public void restApiHostWhitelist_shouldDefaultToLocalhost() {
-    assertThat(getTekuConfigurationFromArguments().getRestApiHostWhitelist())
+    assertThat(getTekuConfigurationFromArguments().getRestApiHostAllowlist())
         .containsOnly("localhost", "127.0.0.1");
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/MetricsOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/MetricsOptionsTest.java
@@ -60,21 +60,21 @@ public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
   @Test
   public void metricsHostWhitelist_shouldNotRequireAValue() {
     final TekuConfiguration tekuConfiguration =
-        getTekuConfigurationFromArguments("--metrics-host-whitelist");
+        getTekuConfigurationFromArguments("--metrics-host-allowlist");
     assertThat(tekuConfiguration.getMetricsHostWhitelist()).isEmpty();
   }
 
   @Test
   public void metricsHostWhitelist_shouldSupportWhitelistingMultipleHosts() {
     final TekuConfiguration tekuConfiguration =
-        getTekuConfigurationFromArguments("--metrics-host-whitelist", "my.host,their.host");
+        getTekuConfigurationFromArguments("--metrics-host-allowlist", "my.host,their.host");
     assertThat(tekuConfiguration.getMetricsHostWhitelist()).containsOnly("my.host", "their.host");
   }
 
   @Test
   public void metricsHostWhitelist_shouldSupportWhitelistingAllHosts() {
     final TekuConfiguration tekuConfiguration =
-        getTekuConfigurationFromArguments("--metrics-host-whitelist", "*");
+        getTekuConfigurationFromArguments("--metrics-host-allowlist", "*");
     assertThat(tekuConfiguration.getMetricsHostWhitelist()).containsOnly("*");
   }
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/MetricsOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/MetricsOptionsTest.java
@@ -58,29 +58,29 @@ public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void metricsHostWhitelist_shouldNotRequireAValue() {
+  public void metricsHostAllowlist_shouldNotRequireAValue() {
     final TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--metrics-host-allowlist");
-    assertThat(tekuConfiguration.getMetricsHostWhitelist()).isEmpty();
+    assertThat(tekuConfiguration.getMetricsHostAllowlist()).isEmpty();
   }
 
   @Test
-  public void metricsHostWhitelist_shouldSupportWhitelistingMultipleHosts() {
+  public void metricsHostAllowlist_shouldSupportAllowingMultipleHosts() {
     final TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--metrics-host-allowlist", "my.host,their.host");
-    assertThat(tekuConfiguration.getMetricsHostWhitelist()).containsOnly("my.host", "their.host");
+    assertThat(tekuConfiguration.getMetricsHostAllowlist()).containsOnly("my.host", "their.host");
   }
 
   @Test
-  public void metricsHostWhitelist_shouldSupportWhitelistingAllHosts() {
+  public void metricsHostAllowlist_shouldSupportWhitelistingAllHosts() {
     final TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--metrics-host-allowlist", "*");
-    assertThat(tekuConfiguration.getMetricsHostWhitelist()).containsOnly("*");
+    assertThat(tekuConfiguration.getMetricsHostAllowlist()).containsOnly("*");
   }
 
   @Test
-  public void metricsHostWhitelist_shouldDefaultToLocalhost() {
-    assertThat(getTekuConfigurationFromArguments().getMetricsHostWhitelist())
+  public void metricsHostAllowlist_shouldDefaultToLocalhost() {
+    assertThat(getTekuConfigurationFromArguments().getMetricsHostAllowlist())
         .containsOnly("localhost", "127.0.0.1");
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/MetricsOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/MetricsOptionsTest.java
@@ -72,7 +72,7 @@ public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void metricsHostAllowlist_shouldSupportWhitelistingAllHosts() {
+  public void metricsHostAllowlist_shouldSupportAllowingAllHosts() {
     final TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--metrics-host-allowlist", "*");
     assertThat(tekuConfiguration.getMetricsHostAllowlist()).containsOnly("*");

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
@@ -93,7 +93,7 @@ public class TekuConfiguration {
   private final int metricsPort;
   private final String metricsInterface;
   private final List<String> metricsCategories;
-  private final List<String> metricsHostWhitelist;
+  private final List<String> metricsHostAllowlist;
 
   // Database
   private final String dataPath;
@@ -104,7 +104,7 @@ public class TekuConfiguration {
   private final boolean restApiDocsEnabled;
   private final boolean restApiEnabled;
   private final String restApiInterface;
-  private final List<String> restApiHostWhitelist;
+  private final List<String> restApiHostAllowlist;
 
   public static TekuConfigurationBuilder builder() {
     return new TekuConfigurationBuilder();
@@ -156,14 +156,14 @@ public class TekuConfiguration {
       final int metricsPort,
       final String metricsInterface,
       final List<String> metricsCategories,
-      final List<String> metricsHostWhitelist,
+      final List<String> metricsHostAllowlist,
       final String dataPath,
       final StateStorageMode dataStorageMode,
       final int restApiPort,
       final boolean restApiDocsEnabled,
       final boolean restApiEnabled,
       final String restApiInterface,
-      final List<String> restApiHostWhitelist,
+      final List<String> restApiHostAllowlist,
       final Bytes32 graffiti) {
     this.constants = constants;
     this.startupTargetPeerCount = startupTargetPeerCount;
@@ -210,14 +210,14 @@ public class TekuConfiguration {
     this.metricsPort = metricsPort;
     this.metricsInterface = metricsInterface;
     this.metricsCategories = metricsCategories;
-    this.metricsHostWhitelist = metricsHostWhitelist;
+    this.metricsHostAllowlist = metricsHostAllowlist;
     this.dataPath = dataPath;
     this.dataStorageMode = dataStorageMode;
     this.restApiPort = restApiPort;
     this.restApiDocsEnabled = restApiDocsEnabled;
     this.restApiEnabled = restApiEnabled;
     this.restApiInterface = restApiInterface;
-    this.restApiHostWhitelist = restApiHostWhitelist;
+    this.restApiHostAllowlist = restApiHostAllowlist;
     this.graffiti = graffiti;
   }
 
@@ -422,8 +422,8 @@ public class TekuConfiguration {
     return metricsCategories;
   }
 
-  public List<String> getMetricsHostWhitelist() {
-    return metricsHostWhitelist;
+  public List<String> getMetricsHostAllowlist() {
+    return metricsHostAllowlist;
   }
 
   public String getDataPath() {
@@ -450,8 +450,8 @@ public class TekuConfiguration {
     return restApiInterface;
   }
 
-  public List<String> getRestApiHostWhitelist() {
-    return restApiHostWhitelist;
+  public List<String> getRestApiHostAllowlist() {
+    return restApiHostAllowlist;
   }
 
   public Bytes32 getGraffiti() {

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
@@ -66,14 +66,14 @@ public class TekuConfigurationBuilder {
   private int metricsPort;
   private String metricsInterface;
   private List<String> metricsCategories;
-  private List<String> metricsHostWhitelist;
+  private List<String> metricsHostAllowlist;
   private String dataPath;
   private StateStorageMode dataStorageMode;
   private int restApiPort;
   private boolean restApiDocsEnabled;
   private boolean restApiEnabled;
   private String restApiInterface;
-  private List<String> restApiHostWhitelist;
+  private List<String> restApiHostAllowlist;
   private NetworkDefinition network;
   private Bytes32 graffiti;
 
@@ -316,8 +316,8 @@ public class TekuConfigurationBuilder {
     return this;
   }
 
-  public TekuConfigurationBuilder setMetricsHostWhitelist(final List<String> metricsHostWhitelist) {
-    this.metricsHostWhitelist = metricsHostWhitelist;
+  public TekuConfigurationBuilder setMetricsHostAllowlist(final List<String> metricsHostAllowlist) {
+    this.metricsHostAllowlist = metricsHostAllowlist;
     return this;
   }
 
@@ -351,8 +351,8 @@ public class TekuConfigurationBuilder {
     return this;
   }
 
-  public TekuConfigurationBuilder setRestApiHostWhitelist(final List<String> restApiHostWhitelist) {
-    this.restApiHostWhitelist = restApiHostWhitelist;
+  public TekuConfigurationBuilder setRestApiHostAllowlist(final List<String> restApiHostAllowlist) {
+    this.restApiHostAllowlist = restApiHostAllowlist;
     return this;
   }
 
@@ -434,14 +434,14 @@ public class TekuConfigurationBuilder {
         metricsPort,
         metricsInterface,
         metricsCategories,
-        metricsHostWhitelist,
+        metricsHostAllowlist,
         dataPath,
         dataStorageMode,
         restApiPort,
         restApiDocsEnabled,
         restApiEnabled,
         restApiInterface,
-        restApiHostWhitelist,
+        restApiHostAllowlist,
         graffiti);
   }
 


### PR DESCRIPTION
Support both versions of CLI options for now. Renamed variables throughout the code.
See #2113 

 - `--metrics-host-whitelist` CLI option will be renamed `--metrics-host-allowlist` (currently both are supported)
 - `--rest-api-host-whitelist` CLI option will be renamed `--rest-api-host-allowlist` (currently both are supported)

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.