### PR TITLE
Publish artefacts from integration branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,6 +391,7 @@ workflows:
               only:
                 - master
                 - /^release-.*/
+                - /^.*-integration$/
           requires:
             - unitTests
             - integrationTests
@@ -404,6 +405,7 @@ workflows:
               only:
                 - master
                 - /^release-.*/
+                - /^.*-integration$/
           requires:
             - unitTests
             - integrationTests


### PR DESCRIPTION
## PR Description
Enable publishing artefacts from `-integration` branches so that binary builds are available for our v0.12.1 branch.

The docker `latest` tag is still the master branch - you'd have to specifically request `pegasyseng/teku:0.12.0-SNAPSHOT` to get this branch.  Bintray provides access to both v0.11 and v0.12 builds with no default.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

We might want to note that the 0.11.x builds are compatible with witti and the 0.12.x builds are compatible with v12 of the spec (Onyx and the next multi client testnet).  This branch is probably not going to be very long lived though - once the next multi client testnet launches we'll merge this to master and recommend all users should use v0.12 builds with the new testnet.
