### PR TITLE
Add a debug subcommand as a place for useful utilities

### DIFF
--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -42,7 +42,9 @@ public class StorageService extends Service {
     return SafeFuture.fromRunnable(
         () -> {
           final VersionedDatabaseFactory dbFactory =
-              new VersionedDatabaseFactory(serviceConfig.getConfig());
+              new VersionedDatabaseFactory(
+                  serviceConfig.getConfig().getDataPath(),
+                  serviceConfig.getConfig().getDataStorageMode());
           database = dbFactory.createDatabase();
 
           chainStorage = ChainStorage.create(serviceConfig.getEventBus(), database);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -24,7 +24,6 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.storage.server.rocksdb.RocksDbConfiguration;
 import tech.pegasys.teku.storage.server.rocksdb.RocksDbDatabase;
 import tech.pegasys.teku.util.config.StateStorageMode;
-import tech.pegasys.teku.util.config.TekuConfiguration;
 
 public class VersionedDatabaseFactory implements DatabaseFactory {
   private static final Logger LOG = LogManager.getLogger();
@@ -37,11 +36,11 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
   private final File dbVersionFile;
   private final StateStorageMode stateStorageMode;
 
-  public VersionedDatabaseFactory(final TekuConfiguration config) {
-    this.dataDirectory = Paths.get(config.getDataPath()).toFile();
+  public VersionedDatabaseFactory(final String dataPath, final StateStorageMode dataStorageMode) {
+    this.dataDirectory = Paths.get(dataPath).toFile();
     this.dbDirectory = this.dataDirectory.toPath().resolve(DB_PATH).toFile();
     this.dbVersionFile = this.dataDirectory.toPath().resolve(DB_VERSION_PATH).toFile();
-    this.stateStorageMode = config.getDataStorageMode();
+    this.stateStorageMode = dataStorageMode;
   }
 
   @Override

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
@@ -22,24 +22,20 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import tech.pegasys.teku.util.config.TekuConfiguration;
+import tech.pegasys.teku.util.config.StateStorageMode;
 
 public class VersionedDatabaseFactoryTest {
 
+  private static final StateStorageMode DATA_STORAGE_MODE = PRUNE;
   @TempDir Path dataDir;
-  TekuConfiguration config;
 
-  @BeforeEach
-  public void setup() {
-    config = createConfig(dataDir);
-  }
 
   @Test
   public void createDatabase_fromEmptyDataDir() throws Exception {
-    final DatabaseFactory dbFactory = new VersionedDatabaseFactory(config);
+    final DatabaseFactory dbFactory =
+        new VersionedDatabaseFactory(dataDir.toString(), DATA_STORAGE_MODE);
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
 
@@ -52,7 +48,8 @@ public class VersionedDatabaseFactoryTest {
     createDbDirectory(dataDir);
     createVersionFile(dataDir, DatabaseVersion.V3);
 
-    final DatabaseFactory dbFactory = new VersionedDatabaseFactory(config);
+    final DatabaseFactory dbFactory =
+        new VersionedDatabaseFactory(dataDir.toString(), DATA_STORAGE_MODE);
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
     }
@@ -63,7 +60,8 @@ public class VersionedDatabaseFactoryTest {
     createDbDirectory(dataDir);
     createVersionFile(dataDir, "bla");
 
-    final DatabaseFactory dbFactory = new VersionedDatabaseFactory(config);
+    final DatabaseFactory dbFactory =
+        new VersionedDatabaseFactory(dataDir.toString(), DATA_STORAGE_MODE);
     assertThatThrownBy(dbFactory::createDatabase)
         .isInstanceOf(DatabaseStorageException.class)
         .hasMessageContaining("Unrecognized database version: bla");
@@ -73,7 +71,8 @@ public class VersionedDatabaseFactoryTest {
   public void createDatabase_dbExistsButNoVersionIsSaved() throws Exception {
     createDbDirectory(dataDir);
 
-    final DatabaseFactory dbFactory = new VersionedDatabaseFactory(config);
+    final DatabaseFactory dbFactory =
+        new VersionedDatabaseFactory(dataDir.toString(), DATA_STORAGE_MODE);
     assertThatThrownBy(dbFactory::createDatabase)
         .isInstanceOf(DatabaseStorageException.class)
         .hasMessageContaining("No database version file was found");
@@ -102,13 +101,5 @@ public class VersionedDatabaseFactoryTest {
     final String versionValue =
         Files.readString(dataDirectory.resolve(VersionedDatabaseFactory.DB_VERSION_PATH));
     assertThat(versionValue).isEqualTo(defaultVersion.getValue());
-  }
-
-  private TekuConfiguration createConfig(final Path dataPath) {
-
-    return TekuConfiguration.builder()
-        .setDataPath(dataPath.toAbsolutePath().toString())
-        .setDataStorageMode(PRUNE)
-        .build();
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
@@ -31,7 +31,6 @@ public class VersionedDatabaseFactoryTest {
   private static final StateStorageMode DATA_STORAGE_MODE = PRUNE;
   @TempDir Path dataDir;
 
-
   @Test
   public void createDatabase_fromEmptyDataDir() throws Exception {
     final DatabaseFactory dbFactory =

--- a/teku/build.gradle
+++ b/teku/build.gradle
@@ -16,6 +16,7 @@ dependencies {
   implementation project(':services:serviceutils')
   implementation project(':services:timer')
   implementation project(':storage')
+  implementation project(':storage:api')
   implementation project(':util')
   implementation project(':validator:coordinator')
   implementation project(':validator:client')

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.cli.subcommand.DepositCommand;
 import tech.pegasys.teku.cli.subcommand.GenesisCommand;
 import tech.pegasys.teku.cli.subcommand.PeerCommand;
 import tech.pegasys.teku.cli.subcommand.TransitionCommand;
+import tech.pegasys.teku.cli.subcommand.debug.DebugCommand;
 import tech.pegasys.teku.cli.util.CascadingDefaultProvider;
 import tech.pegasys.teku.cli.util.EnvironmentVariableDefaultProvider;
 import tech.pegasys.teku.cli.util.YamlConfigFileDefaultProvider;
@@ -66,7 +67,8 @@ import tech.pegasys.teku.util.config.TekuConfiguration;
       TransitionCommand.class,
       PeerCommand.class,
       DepositCommand.class,
-      GenesisCommand.class
+      GenesisCommand.class,
+      DebugCommand.class
     },
     showDefaultValues = true,
     abbreviateSynopsis = true,

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugCommand.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.subcommand.debug;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import tech.pegasys.teku.util.cli.PicoCliVersionProvider;
+
+@Command(
+    name = "debug",
+    description = "Utilities for debugging issues",
+    subcommands = {DebugDbCommand.class},
+    showDefaultValues = true,
+    abbreviateSynopsis = true,
+    mixinStandardHelpOptions = true,
+    versionProvider = PicoCliVersionProvider.class,
+    synopsisHeading = "%n",
+    descriptionHeading = "%nDescription:%n%n",
+    optionListHeading = "%nOptions:%n",
+    footerHeading = "%n",
+    footer = "Teku is licensed under the Apache License 2.0")
+public class DebugCommand implements Runnable {
+  @Override
+  public void run() {
+    CommandLine.usage(this, System.out);
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.subcommand.debug;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import tech.pegasys.teku.cli.options.DataOptions;
+import tech.pegasys.teku.storage.server.Database;
+import tech.pegasys.teku.storage.server.DepositStorage;
+import tech.pegasys.teku.storage.server.VersionedDatabaseFactory;
+import tech.pegasys.teku.util.cli.PicoCliVersionProvider;
+
+@Command(
+    name = "db",
+    description = "Debugging tools for inspecting the contents of the database",
+    showDefaultValues = true,
+    abbreviateSynopsis = true,
+    mixinStandardHelpOptions = true,
+    versionProvider = PicoCliVersionProvider.class,
+    synopsisHeading = "%n",
+    descriptionHeading = "%nDescription:%n%n",
+    optionListHeading = "%nOptions:%n",
+    footerHeading = "%n",
+    footer = "Teku is licensed under the Apache License 2.0")
+public class DebugDbCommand implements Runnable {
+  @Override
+  public void run() {
+    CommandLine.usage(this, System.out);
+  }
+
+  @Command(
+      name = "get-deposits",
+      description = "List the ETH1 deposit information stored in the database",
+      mixinStandardHelpOptions = true,
+      showDefaultValues = true,
+      abbreviateSynopsis = true,
+      versionProvider = PicoCliVersionProvider.class,
+      synopsisHeading = "%n",
+      descriptionHeading = "%nDescription:%n%n",
+      optionListHeading = "%nOptions:%n",
+      footerHeading = "%n",
+      footer = "Teku is licensed under the Apache License 2.0")
+  public int blocks(@Mixin final DataOptions dataOptions) throws Exception {
+    try (final YamlEth1EventsChannel eth1EventsChannel = new YamlEth1EventsChannel(System.out);
+        final Database database = createDatabase(dataOptions)) {
+      final DepositStorage depositStorage =
+          DepositStorage.create(eth1EventsChannel, database, true);
+      depositStorage.replayDepositEvents().join();
+    }
+    return 0;
+  }
+
+  private Database createDatabase(final DataOptions dataOptions) {
+    final VersionedDatabaseFactory databaseFactory =
+        new VersionedDatabaseFactory(dataOptions.getDataPath(), dataOptions.getDataStorageMode());
+    return databaseFactory.createDatabase();
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/YamlEth1EventsChannel.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/YamlEth1EventsChannel.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.subcommand.debug;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SequenceWriter;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.primitives.UnsignedLong;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.pow.api.Eth1EventsChannel;
+import tech.pegasys.teku.pow.event.Deposit;
+import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
+import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
+
+class YamlEth1EventsChannel implements Eth1EventsChannel, AutoCloseable {
+
+  private UnsignedLong nextExpectedDeposit = UnsignedLong.ZERO;
+  private UnsignedLong lastBlockNumber;
+  private UnsignedLong lastBlockTimestamp;
+  private final SequenceWriter writer;
+
+  public YamlEth1EventsChannel(final PrintStream out) throws IOException {
+    final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    writer = mapper.writerWithDefaultPrettyPrinter().writeValuesAsArray(out);
+  }
+
+  @Override
+  public void onDepositsFromBlock(final DepositsFromBlockEvent event) {
+    final List<String> errors = new ArrayList<>();
+    if (lastBlockNumber != null && event.getBlockNumber().compareTo(lastBlockNumber) <= 0) {
+      errors.add(
+          "Blocks received out of order. Got number "
+              + event.getBlockNumber()
+              + " after "
+              + lastBlockNumber);
+    }
+    if (lastBlockTimestamp != null
+        && event.getBlockTimestamp().compareTo(lastBlockTimestamp) <= 0) {
+      errors.add(
+          "Blocks received out of order. Got timestamp "
+              + event.getBlockTimestamp()
+              + " after "
+              + lastBlockTimestamp);
+    }
+    final List<DepositInfo> deposits =
+        event.getDeposits().stream().map(this::handleDeposit).collect(Collectors.toList());
+
+    lastBlockNumber = event.getBlockNumber();
+    lastBlockTimestamp = event.getBlockTimestamp();
+    try {
+      writer.write(
+          new BlockInfo(
+              event.getBlockNumber(),
+              event.getBlockTimestamp(),
+              event.getBlockHash(),
+              deposits,
+              errors));
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private DepositInfo handleDeposit(final Deposit deposit) {
+    final List<String> errors = new ArrayList<>();
+    if (!nextExpectedDeposit.equals(deposit.getMerkle_tree_index())) {
+      errors.add(
+          "Incorrect deposit index. Expected "
+              + nextExpectedDeposit
+              + " but got "
+              + deposit.getMerkle_tree_index());
+    }
+    nextExpectedDeposit = deposit.getMerkle_tree_index().plus(UnsignedLong.ONE);
+    return new DepositInfo(
+        deposit.getMerkle_tree_index(), deposit.getPubkey(), deposit.getAmount(), errors);
+  }
+
+  @Override
+  public void onMinGenesisTimeBlock(final MinGenesisTimeBlockEvent event) {
+    try {
+      writer.write(new MinGenesisTimeInfo(event));
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    writer.close();
+  }
+
+  private static class BlockInfo {
+    public final UnsignedLong block;
+    public final UnsignedLong timestamp;
+    public final String hash;
+    public final List<DepositInfo> deposits;
+
+    @JsonInclude(Include.NON_EMPTY)
+    public final List<String> errors;
+
+    public BlockInfo(
+        final UnsignedLong blockNumber,
+        final UnsignedLong blockTimestamp,
+        final Bytes32 blockHash,
+        final List<DepositInfo> deposits,
+        final List<String> errors) {
+      this.block = blockNumber;
+      this.timestamp = blockTimestamp;
+      this.hash = blockHash.toHexString();
+      this.errors = errors;
+      this.deposits = deposits;
+    }
+  }
+
+  private static class MinGenesisTimeInfo {
+    public final UnsignedLong number;
+    public final UnsignedLong timestamp;
+    public final String hash;
+    public final boolean minGenesisBlock = true;
+
+    public MinGenesisTimeInfo(final MinGenesisTimeBlockEvent event) {
+      this.number = event.getBlockNumber();
+      this.timestamp = event.getTimestamp();
+      this.hash = event.getBlockHash().toHexString();
+    }
+  }
+
+  private static class DepositInfo {
+    public final UnsignedLong index;
+    public final String publicKey;
+    public final UnsignedLong amount;
+
+    @JsonInclude(Include.NON_EMPTY)
+    public final List<String> errors;
+
+    private DepositInfo(
+        final UnsignedLong index,
+        final BLSPublicKey publicKey,
+        final UnsignedLong amount,
+        final List<String> errors) {
+      this.index = index;
+      this.publicKey = publicKey.toBytesCompressed().toHexString();
+      this.amount = amount;
+      this.errors = errors;
+    }
+  }
+}


### PR DESCRIPTION
## PR Description
Added a `debug` subcommand as a place for utilities that users wouldn't normally use but that can output useful information to aid debugging.

Initial command `teku debug db get-deposits` loads the ETH1 data from the database and prints it as YAML.  Checks are performed that blocks are in order and there are no deposits missing with an error noted if they are.

## Documentation

Not intended for normal use.

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.