### PR TITLE
Removes recursion from get_ancestor()

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -84,23 +84,11 @@ public class ForkChoiceUtil {
    */
   private static Optional<Bytes32> get_ancestor(
       ForkChoiceStrategy forkChoiceStrategy, Bytes32 root, UnsignedLong slot) {
-    return forkChoiceStrategy
-        .blockSlot(root)
-        .flatMap(
-            blockSlot -> {
-              if (blockSlot.compareTo(slot) > 0) {
-                return get_ancestor(
-                    forkChoiceStrategy,
-                    forkChoiceStrategy.blockParentRoot(root).orElseThrow(),
-                    slot);
-              } else if (blockSlot.equals(slot)) {
-                return Optional.of(root);
-              } else {
-                // root is older than the queried slot, thus a skip slot. Return earliest root prior
-                // to slot.
-                return Optional.of(root);
-              }
-            });
+    Bytes32 parentRoot = root;
+    while (forkChoiceStrategy.blockSlot(parentRoot).get().compareTo(slot) > 0) {
+      parentRoot = forkChoiceStrategy.blockParentRoot(parentRoot).orElseThrow();
+    }
+    return Optional.of(parentRoot);
   }
 
   /*

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -85,10 +85,12 @@ public class ForkChoiceUtil {
   private static Optional<Bytes32> get_ancestor(
       ForkChoiceStrategy forkChoiceStrategy, Bytes32 root, UnsignedLong slot) {
     Bytes32 parentRoot = root;
-    while (forkChoiceStrategy.blockSlot(parentRoot).get().compareTo(slot) > 0) {
+    Optional<UnsignedLong> blockSlot = forkChoiceStrategy.blockSlot(root);
+    while (blockSlot.isPresent() && blockSlot.get().compareTo(slot) > 0) {
       parentRoot = forkChoiceStrategy.blockParentRoot(parentRoot).orElseThrow();
+      blockSlot = forkChoiceStrategy.blockSlot(parentRoot);
     }
-    return Optional.of(parentRoot);
+    return blockSlot.isPresent() ? Optional.of(parentRoot) : Optional.empty();
   }
 
   /*


### PR DESCRIPTION
# PR Description

I and others have been experiencing stack overflows during a long period of non-finalisation due to deep recursion in the fork choice rule. This PR removes the recursion from `get_ancestor()`.

I've run this for several hours on Witti, and it seems good.

## Fixed Issue(s)
Fixes #2144

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.