### PR TITLE
Write 32 byte keys to generated keystores

### DIFF
--- a/bls/src/main/java/tech/pegasys/teku/bls/BLSSecretKey.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/BLSSecretKey.java
@@ -46,6 +46,17 @@ public final class BLSSecretKey {
     return secretKey;
   }
 
+  public Bytes toBytes() {
+    final Bytes bytes = secretKey.toBytes();
+    if (bytes.size() == 48) {
+      final int paddingLength = 48 - 32;
+      if (bytes.slice(0, paddingLength).isZero()) {
+        return bytes.slice(paddingLength, 32);
+      }
+    }
+    return bytes;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) return true;

--- a/teku/src/main/java/tech/pegasys/teku/cli/deposit/DepositGenerateCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/deposit/DepositGenerateCommand.java
@@ -128,9 +128,9 @@ public class DepositGenerateCommand implements Runnable {
 
   @Override
   public void run() {
-    final KeysWriter keysWriter = getKeysWriter();
-
     final SecureRandom srng = SecureRandomProvider.createSecureRandom();
+    final KeysWriter keysWriter = getKeysWriter(srng);
+
     try (final RegisterAction registerAction = params.createRegisterAction()) {
       registerAction.displayConfirmation(validatorCount);
       final List<SafeFuture<TransactionReceipt>> futures = new ArrayList<>();
@@ -153,7 +153,7 @@ public class DepositGenerateCommand implements Runnable {
     shutdownFunction.accept(0);
   }
 
-  private KeysWriter getKeysWriter() {
+  private KeysWriter getKeysWriter(final SecureRandom secureRandom) {
     final KeysWriter keysWriter;
     if (encryptKeys) {
       final String validatorKeystorePassword =
@@ -164,7 +164,7 @@ public class DepositGenerateCommand implements Runnable {
       final Path keystoreDir = getKeystoreOutputDir();
       keysWriter =
           new EncryptedKeystoreWriter(
-              validatorKeystorePassword, withdrawalKeystorePassword, keystoreDir);
+              secureRandom, validatorKeystorePassword, withdrawalKeystorePassword, keystoreDir);
     } else {
       keysWriter = new YamlKeysWriter(isBlank(outputPath) ? null : Path.of(outputPath));
       if (consoleAdapter.isConsoleAvailable()

--- a/teku/src/main/java/tech/pegasys/teku/cli/deposit/DepositRegisterCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/deposit/DepositRegisterCommand.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes48;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
@@ -147,7 +146,7 @@ public class DepositRegisterCommand implements Runnable {
   }
 
   private BLSKeyPair privateKeyToKeyPair(final Bytes validatorKey) {
-    return new BLSKeyPair(BLSSecretKey.fromBytes(Bytes48.leftPad(validatorKey)));
+    return new BLSKeyPair(BLSSecretKey.fromBytes(validatorKey));
   }
 
   static class ValidatorKeyOptions {

--- a/teku/src/test/java/tech/pegasys/teku/cli/deposit/DepositRegisterCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/deposit/DepositRegisterCommandTest.java
@@ -48,7 +48,7 @@ class DepositRegisterCommandTest {
   private static final Function<String, String> envSupplier =
       s -> EXPECTED_ENV_VARIABLE.equals(s) ? PASSWORD : null;
   private static final Bytes BLS_PRIVATE_KEY =
-      Bytes.fromHexString("0x19d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+      Bytes.fromHexString("0x19d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f", 32);
   private static final Bytes BLS_PUB_KEY =
       Bytes.fromHexString(
           "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07");

--- a/teku/src/test/java/tech/pegasys/teku/cli/deposit/EncryptedKeystoreWriterTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/deposit/EncryptedKeystoreWriterTest.java
@@ -25,6 +25,7 @@ import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSecretKey;
+import tech.pegasys.teku.util.crypto.SecureRandomProvider;
 
 class EncryptedKeystoreWriterTest {
   private static final BLSSecretKey validator1SecretKey =
@@ -50,7 +51,9 @@ class EncryptedKeystoreWriterTest {
 
   @Test
   void keysAreWrittenToEncryptedKeystores(@TempDir final Path tempDir) {
-    final KeysWriter keysWriter = new EncryptedKeystoreWriter(PASSWORD, PASSWORD, tempDir);
+    final KeysWriter keysWriter =
+        new EncryptedKeystoreWriter(
+            SecureRandomProvider.createSecureRandom(), PASSWORD, PASSWORD, tempDir);
     keysWriter.writeKeys(new BLSKeyPair(validator1SecretKey), new BLSKeyPair(withdrawal1SecretKey));
 
     assertKeyStoreCreatedAndCanBeDecrypted(
@@ -72,8 +75,7 @@ class EncryptedKeystoreWriterTest {
       final Path keystorePath, final BLSSecretKey blsSecretKey) {
     final KeyStoreData keyStoreData = KeyStoreLoader.loadFromFile(keystorePath);
     assertThat(KeyStore.validatePassword(PASSWORD, keyStoreData)).isTrue();
-    assertThat(KeyStore.decrypt(PASSWORD, keyStoreData))
-        .isEqualTo(blsSecretKey.getSecretKey().toBytes());
+    assertThat(KeyStore.decrypt(PASSWORD, keyStoreData)).isEqualTo(blsSecretKey.toBytes());
   }
 
   private String trimPublicKey(final String publicKey) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/KeystoresValidatorKeyProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/KeystoresValidatorKeyProvider.java
@@ -37,8 +37,6 @@ import tech.pegasys.teku.util.config.TekuConfiguration;
 
 public class KeystoresValidatorKeyProvider implements ValidatorKeyProvider {
 
-  public static final int KEY_LENGTH = 48;
-
   @Override
   public List<BLSKeyPair> loadValidatorKeys(final TekuConfiguration config) {
     final List<Pair<Path, Path>> keystorePasswordFilePairs =
@@ -47,7 +45,7 @@ public class KeystoresValidatorKeyProvider implements ValidatorKeyProvider {
 
     // return distinct loaded key pairs
     return keystorePasswordFilePairs.stream()
-        .map(pair -> padLeft(loadBLSPrivateKey(pair.getLeft(), loadPassword(pair.getRight()))))
+        .map(pair -> loadBLSPrivateKey(pair.getLeft(), loadPassword(pair.getRight())))
         .distinct()
         .map(privKey -> new BLSKeyPair(BLSSecretKey.fromBytes(privKey)))
         .collect(toList());
@@ -82,9 +80,5 @@ public class KeystoresValidatorKeyProvider implements ValidatorKeyProvider {
       throw new UncheckedIOException(errorMessage, e);
     }
     return password;
-  }
-
-  private Bytes padLeft(Bytes input) {
-    return Bytes.concatenate(Bytes.wrap(new byte[KEY_LENGTH - input.size()]), input);
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/KeystoresValidatorKeyProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/KeystoresValidatorKeyProviderTest.java
@@ -17,7 +17,6 @@ import static java.nio.file.Files.createTempFile;
 import static java.nio.file.Files.writeString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.validator.client.loader.KeystoresValidatorKeyProvider.KEY_LENGTH;
 
 import com.google.common.io.Resources;
 import java.io.IOException;
@@ -38,8 +37,7 @@ class KeystoresValidatorKeyProviderTest {
   private final KeystoresValidatorKeyProvider keystoresValidatorKeyProvider =
       new KeystoresValidatorKeyProvider();
   private static final Bytes BLS_PRIVATE_KEY =
-      Bytes.fromHexString(
-          "0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f", KEY_LENGTH);
+      Bytes.fromHexString("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f", 48);
   private static final BLSKeyPair EXPECTED_BLS_KEY_PAIR =
       new BLSKeyPair(BLSSecretKey.fromBytes(BLS_PRIVATE_KEY));
 


### PR DESCRIPTION
## PR Description
Write 32 byte keys to generated keystores instead of 48 bytes. This should make our keystores compatible with Lighthouse.  48 byte keys are still supported by Teku so backwards compatibility isn't an issue.

Generally depend on `BLSSecretKey` to handle all the mapping between 32 and 48 bytes instead of duplicating the logic.

Create a single SecureRandom instead of recreating for every random value we need.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.