### PR TITLE
Catch errors from Supplier and pass to returned future

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.networking.eth2.peers.PeerLookup;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.rpc.RpcRequestHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStream;
+import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 import tech.pegasys.teku.util.async.AsyncRunner;
 
 public class Eth2IncomingRequestHandler<TRequest extends RpcRequest, TResponse>
@@ -79,6 +80,9 @@ public class Eth2IncomingRequestHandler<TRequest extends RpcRequest, TResponse>
     try {
       requestHandled.set(true);
       localMessageHandler.onIncomingMessage(peer, request, callback);
+    } catch (final StreamClosedException e) {
+      LOG.trace("Stream closed before response sent for request " + method.getMultistreamId(), e);
+      callback.completeWithUnexpectedError(e);
     } catch (final Throwable t) {
       LOG.error("Unhandled error while processing request " + method.getMultistreamId(), t);
       callback.completeWithUnexpectedError(t);

--- a/util/src/main/java/tech/pegasys/teku/util/async/DelayedExecutorAsyncRunner.java
+++ b/util/src/main/java/tech/pegasys/teku/util/async/DelayedExecutorAsyncRunner.java
@@ -56,21 +56,13 @@ public class DelayedExecutorAsyncRunner implements AsyncRunner {
   <U> SafeFuture<U> runAsync(final Supplier<SafeFuture<U>> action, final Executor executor) {
     final SafeFuture<U> result = new SafeFuture<>();
     try {
-      executor.execute(() -> runTask(action, result));
+      executor.execute(() -> SafeFuture.ofComposed(action::get).propagateTo(result));
     } catch (final RejectedExecutionException ex) {
       LOG.debug("shutting down ", ex);
     } catch (final Throwable t) {
       result.completeExceptionally(t);
     }
     return result;
-  }
-
-  private <U> void runTask(final Supplier<SafeFuture<U>> action, final SafeFuture<U> result) {
-    try {
-      action.get().propagateTo(result);
-    } catch (final Throwable t) {
-      result.completeExceptionally(t);
-    }
   }
 
   private Executor getAsyncExecutor() {


### PR DESCRIPTION
## PR Description
When the supplier passed to `AsyncRunner` methods throws an exception (instead of returning a failed SafeFuture), catch and propagate the exception to the future returned by `AsyncRunner`.

Much more targeted change than #2150 which doesn't give us the metrics but hopefully still fixes the memory leak.

## Fixed Issue(s)
Catching exceptions may be the fix for #2149 as many StreamClosedExceptions are encountered but weren't being reported back to the request callback so the request wasn't cleaned up.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.