### PR TITLE
Load all hot block roots in one pass through protoarray

### DIFF
--- a/ethereum/core/build.gradle
+++ b/ethereum/core/build.gradle
@@ -12,6 +12,7 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-bytes'
 
   testImplementation testFixtures(project(':bls'))
+  testImplementation testFixtures(project(':ethereum:datastructures'))
 
   testFixturesImplementation 'com.google.guava:guava'
   testFixturesImplementation 'org.apache.tuweni:tuweni-ssz'

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSKeyGenerator;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.datastructures.forkchoice.ReadOnlyStore;
+import tech.pegasys.teku.datastructures.forkchoice.TestStoreFactory;
+import tech.pegasys.teku.protoarray.ProtoArrayForkChoiceStrategy;
+
+class ForkChoiceUtilTest {
+
+  protected static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(16);
+  private final ChainBuilder chainBuilder = ChainBuilder.create(VALIDATOR_KEYS);
+  private final SignedBlockAndState genesis = chainBuilder.generateGenesis();
+  private final ReadOnlyStore store = new TestStoreFactory().createGenesisStore(genesis.getState());
+  private final ProtoArrayForkChoiceStrategy forkChoiceStrategy =
+      ProtoArrayForkChoiceStrategy.create(store);
+
+  @Test
+  void getAncestors_shouldGetSimpleSequenceOfAncestors() throws Exception {
+    chainBuilder.generateBlocksUpToSlot(10).forEach(this::addBlock);
+
+    final NavigableMap<UnsignedLong, Bytes32> rootsBySlot =
+        ForkChoiceUtil.getAncestors(
+            forkChoiceStrategy,
+            chainBuilder.getLatestBlockAndState().getRoot(),
+            UnsignedLong.ONE,
+            UnsignedLong.ONE,
+            UnsignedLong.valueOf(8));
+
+    assertThat(rootsBySlot).containsExactlyEntriesOf(getRootsForBlocks(1, 2, 3, 4, 5, 6, 7, 8));
+  }
+
+  @Test
+  void getAncestors_shouldGetSequenceOfRootsWhenSkipping() throws Exception {
+    chainBuilder.generateBlocksUpToSlot(10).forEach(this::addBlock);
+
+    final NavigableMap<UnsignedLong, Bytes32> rootsBySlot =
+        ForkChoiceUtil.getAncestors(
+            forkChoiceStrategy,
+            chainBuilder.getLatestBlockAndState().getRoot(),
+            UnsignedLong.ONE,
+            UnsignedLong.valueOf(2),
+            UnsignedLong.valueOf(4));
+
+    assertThat(rootsBySlot).containsExactlyEntriesOf(getRootsForBlocks(1, 3, 5, 7));
+  }
+
+  @Test
+  void getAncestors_shouldGetSequenceOfRootsWhenStartIsPriorToFinalizedCheckpoint()
+      throws Exception {
+    chainBuilder.generateBlocksUpToSlot(10).forEach(this::addBlock);
+    forkChoiceStrategy.setPruneThreshold(0);
+    forkChoiceStrategy.maybePrune(chainBuilder.getBlockAtSlot(4).getRoot());
+
+    final NavigableMap<UnsignedLong, Bytes32> rootsBySlot =
+        ForkChoiceUtil.getAncestors(
+            forkChoiceStrategy,
+            chainBuilder.getLatestBlockAndState().getRoot(),
+            UnsignedLong.ONE,
+            UnsignedLong.valueOf(2),
+            UnsignedLong.valueOf(4));
+
+    assertThat(rootsBySlot).containsExactlyEntriesOf(getRootsForBlocks(5, 7));
+  }
+
+  @Test
+  void getAncestors_shouldGetSequenceOfRootsWhenEndIsAfterChainHead() throws Exception {
+    chainBuilder.generateBlocksUpToSlot(10).forEach(this::addBlock);
+
+    final NavigableMap<UnsignedLong, Bytes32> rootsBySlot =
+        ForkChoiceUtil.getAncestors(
+            forkChoiceStrategy,
+            chainBuilder.getLatestBlockAndState().getRoot(),
+            UnsignedLong.valueOf(6),
+            UnsignedLong.valueOf(2),
+            UnsignedLong.valueOf(20));
+
+    assertThat(rootsBySlot).containsExactlyEntriesOf(getRootsForBlocks(6, 8, 10));
+  }
+
+  private Map<UnsignedLong, Bytes32> getRootsForBlocks(final int... blockNumbers) {
+    return IntStream.of(blockNumbers)
+        .mapToObj(chainBuilder::getBlockAtSlot)
+        .collect(Collectors.toMap(SignedBeaconBlock::getSlot, SignedBeaconBlock::getRoot));
+  }
+
+  private void addBlock(final SignedBlockAndState blockAndState) {
+    forkChoiceStrategy.onBlock(blockAndState.getBlock().getMessage(), blockAndState.getState());
+  }
+}

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
@@ -108,6 +108,21 @@ class ForkChoiceUtilTest {
   }
 
   @Test
+  void getAncestors_shouldNotIncludeEntryForEmptySlots() throws Exception {
+    addBlock(chainBuilder.generateBlockAtSlot(3));
+    addBlock(chainBuilder.generateBlockAtSlot(5));
+
+    final NavigableMap<UnsignedLong, Bytes32> rootsBySlot =
+        ForkChoiceUtil.getAncestors(
+            forkChoiceStrategy,
+            chainBuilder.getLatestBlockAndState().getRoot(),
+            UnsignedLong.ZERO,
+            UnsignedLong.ONE,
+            UnsignedLong.valueOf(10));
+    assertThat(rootsBySlot).containsExactlyEntriesOf(getRootsForBlocks(0, 3, 5));
+  }
+
+  @Test
   public void getCurrentSlot_shouldGetZeroAtGenesis() {
     assertThat(ForkChoiceUtil.getCurrentSlot(GENESIS_TIME, GENESIS_TIME))
         .isEqualTo(UnsignedLong.ZERO);

--- a/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreFactory.java
+++ b/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreFactory.java
@@ -40,6 +40,10 @@ public class TestStoreFactory {
     return getForkChoiceStore(StoreImpl::new, genesisStore);
   }
 
+  public ReadOnlyStore createGenesisStore(final BeaconState genesisState) {
+    return getForkChoiceStore(StoreImpl::new, genesisState);
+  }
+
   public MutableStore createMutableGenesisStore() {
     final BeaconState genesisStore = createRandomGenesisState();
     return getForkChoiceStore(MutableStoreImpl::new, genesisStore);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain;
 
+import static tech.pegasys.teku.util.config.Constants.MAX_BLOCK_BY_RANGE_REQUEST_SIZE;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -158,7 +160,8 @@ public class BeaconChainMethods {
           final RpcEncoding rpcEncoding) {
 
     final BeaconBlocksByRangeMessageHandler beaconBlocksByRangeHandler =
-        new BeaconBlocksByRangeMessageHandler(combinedChainDataClient);
+        new BeaconBlocksByRangeMessageHandler(
+            combinedChainDataClient, MAX_BLOCK_BY_RANGE_REQUEST_SIZE);
     return new Eth2RpcMethod<>(
         asyncRunner,
         BEACON_BLOCKS_BY_RANGE,

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -13,8 +13,8 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
+import static com.google.common.primitives.UnsignedLong.ONE;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -25,7 +25,9 @@ import static tech.pegasys.teku.util.async.SafeFuture.completedFuture;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.List;
+import java.util.NavigableMap;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
@@ -39,16 +41,16 @@ import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.util.async.SafeFuture;
-import tech.pegasys.teku.util.config.Constants;
 
 class BeaconBlocksByRangeMessageHandlerTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
-  private final Eth2Peer peer = mock(Eth2Peer.class);
 
+  private static final UnsignedLong MAX_REQUEST_SIZE = UnsignedLong.valueOf(8);
   private static final List<SignedBeaconBlock> BLOCKS =
       IntStream.rangeClosed(0, 10)
           .mapToObj(slot -> new DataStructureUtil(slot).randomSignedBeaconBlock(slot))
           .collect(Collectors.toList());
+
+  private final Eth2Peer peer = mock(Eth2Peer.class);
 
   @SuppressWarnings("unchecked")
   private final ResponseCallback<SignedBeaconBlock> listener = mock(ResponseCallback.class);
@@ -57,7 +59,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
       mock(CombinedChainDataClient.class);
 
   private final BeaconBlocksByRangeMessageHandler handler =
-      new BeaconBlocksByRangeMessageHandler(combinedChainDataClient);
+      new BeaconBlocksByRangeMessageHandler(combinedChainDataClient, MAX_REQUEST_SIZE);
 
   @Test
   public void shouldReturnNoBlocksWhenThereAreNoBlocksAtOrAfterStartSlot() {
@@ -66,18 +68,13 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final int skip = 1;
     final SignedBeaconBlock headBlock = BLOCKS.get(1);
     // Series of empty blocks leading up to our best slot.
-    withCanonicalHeadBlock(headBlock, UnsignedLong.valueOf(20));
+    withCanonicalHeadBlock(headBlock);
+    withAncestorRoots(startBlock, count, skip, hotBlocks());
 
-    when(combinedChainDataClient.getBlockAtSlotExact(any(), any()))
+    when(combinedChainDataClient.getBlockAtSlotExact(any()))
         .thenReturn(completedFuture(Optional.empty()));
 
-    handler.onIncomingMessage(
-        peer,
-        new BeaconBlocksByRangeRequestMessage(
-            UnsignedLong.valueOf(startBlock),
-            UnsignedLong.valueOf(count),
-            UnsignedLong.valueOf(skip)),
-        listener);
+    requestBlocks(startBlock, count, skip);
 
     verifyNoBlocksReturned();
   }
@@ -88,22 +85,11 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final int count = 5;
     final int skip = 1;
     final SignedBeaconBlock headBlock = BLOCKS.get(10);
-    final Bytes32 headBlockRoot = headBlock.getMessage().hash_tree_root();
 
     withCanonicalHeadBlock(headBlock);
+    withAncestorRoots(startBlock, count, skip, allBlocks());
 
-    BLOCKS.forEach(
-        block ->
-            when(combinedChainDataClient.getBlockAtSlotExact(block.getSlot(), headBlockRoot))
-                .thenReturn(completedFuture(Optional.of(block))));
-
-    handler.onIncomingMessage(
-        peer,
-        new BeaconBlocksByRangeRequestMessage(
-            UnsignedLong.valueOf(startBlock),
-            UnsignedLong.valueOf(count),
-            UnsignedLong.valueOf(skip)),
-        listener);
+    requestBlocks(startBlock, count, skip);
 
     verifyBlocksReturned(3, 4, 5, 6, 7);
   }
@@ -114,22 +100,11 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final int count = 1;
     final int skip = 1;
     final SignedBeaconBlock headBlock = BLOCKS.get(10);
-    final Bytes32 headBlockRoot = headBlock.getMessage().hash_tree_root();
 
     withCanonicalHeadBlock(headBlock);
+    withAncestorRoots(startBlock, count, skip, allBlocks());
 
-    BLOCKS.forEach(
-        block ->
-            when(combinedChainDataClient.getBlockAtSlotExact(block.getSlot(), headBlockRoot))
-                .thenReturn(completedFuture(Optional.of(block))));
-
-    handler.onIncomingMessage(
-        peer,
-        new BeaconBlocksByRangeRequestMessage(
-            UnsignedLong.valueOf(startBlock),
-            UnsignedLong.valueOf(count),
-            UnsignedLong.valueOf(skip)),
-        listener);
+    requestBlocks(startBlock, count, skip);
 
     verifyBlocksReturned(3);
   }
@@ -141,21 +116,11 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final int count = 5;
     final int skip = 2;
     final SignedBeaconBlock headBlock = BLOCKS.get(10);
-    final Bytes32 headBlockRoot = headBlock.getMessage().hash_tree_root();
     withCanonicalHeadBlock(headBlock);
 
-    BLOCKS.forEach(
-        block ->
-            when(combinedChainDataClient.getBlockAtSlotExact(block.getSlot(), headBlockRoot))
-                .thenReturn(completedFuture(Optional.of(block))));
+    withAncestorRoots(startBlock, count, skip, allBlocks());
 
-    handler.onIncomingMessage(
-        peer,
-        new BeaconBlocksByRangeRequestMessage(
-            UnsignedLong.valueOf(startBlock),
-            UnsignedLong.valueOf(count),
-            UnsignedLong.valueOf(skip)),
-        listener);
+    requestBlocks(startBlock, count, skip);
 
     verifyBlocksReturned(2, 4, 6, 8, 10);
   }
@@ -167,24 +132,11 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final int count = 5;
     final int skip = 1;
     final SignedBeaconBlock headBlock = BLOCKS.get(10);
-    final Bytes32 headBlockRoot = headBlock.getMessage().hash_tree_root();
 
     withCanonicalHeadBlock(headBlock);
+    withAncestorRoots(startBlock, count, skip, hotBlocks(2, 3, 5, 6, 7));
 
-    withBlockAtSlot(2, headBlockRoot);
-    withBlockAtSlot(3, headBlockRoot);
-    withEmptySlot(4, headBlockRoot);
-    withBlockAtSlot(5, headBlockRoot);
-    withBlockAtSlot(6, headBlockRoot);
-    withBlockAtSlot(7, headBlockRoot);
-
-    handler.onIncomingMessage(
-        peer,
-        new BeaconBlocksByRangeRequestMessage(
-            UnsignedLong.valueOf(startBlock),
-            UnsignedLong.valueOf(count),
-            UnsignedLong.valueOf(skip)),
-        listener);
+    requestBlocks(startBlock, count, skip);
 
     // Slot 4 is empty so we only return 4 blocks
     verifyBlocksReturned(2, 3, 5, 6);
@@ -196,26 +148,11 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final int count = 4;
     final int skip = 2;
     final SignedBeaconBlock headBlock = BLOCKS.get(10);
-    final Bytes32 headBlockRoot = headBlock.getMessage().hash_tree_root();
 
     withCanonicalHeadBlock(headBlock);
+    withAncestorRoots(startBlock, count, skip, hotBlocks(2, 3, 5, 6, 8, 10));
 
-    withBlockAtSlot(2, headBlockRoot);
-    withBlockAtSlot(3, headBlockRoot);
-    withEmptySlot(4, headBlockRoot);
-    withBlockAtSlot(5, headBlockRoot);
-    withBlockAtSlot(6, headBlockRoot);
-    withEmptySlot(7, headBlockRoot);
-    withBlockAtSlot(8, headBlockRoot);
-    withBlockAtSlot(10, headBlockRoot);
-
-    handler.onIncomingMessage(
-        peer,
-        new BeaconBlocksByRangeRequestMessage(
-            UnsignedLong.valueOf(startBlock),
-            UnsignedLong.valueOf(count),
-            UnsignedLong.valueOf(skip)),
-        listener);
+    requestBlocks(startBlock, count, skip);
 
     // Slot 4 is empty so we only wind up returning 3 blocks, not 4.
     verifyBlocksReturned(2, 6, 8);
@@ -228,13 +165,9 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final int skip = 5;
 
     final SignedBeaconBlock headBlock = BLOCKS.get(5);
-    final Bytes32 headBlockRoot = headBlock.getMessage().hash_tree_root();
 
-    final UnsignedLong bestSlot = UnsignedLong.valueOf(20);
-    withCanonicalHeadBlock(headBlock, bestSlot);
-
-    withEmptySlot(15, headBlockRoot);
-    withEmptySlot(20, headBlockRoot);
+    withCanonicalHeadBlock(headBlock);
+    withAncestorRoots(startBlock, MAX_REQUEST_SIZE.intValue(), skip, hotBlocks());
 
     handler.onIncomingMessage(
         peer,
@@ -243,9 +176,8 @@ class BeaconBlocksByRangeMessageHandlerTest {
         listener);
 
     verifyNoBlocksReturned();
-    verify(combinedChainDataClient).getBlockAtSlotExact(UnsignedLong.valueOf(15), headBlockRoot);
-    verify(combinedChainDataClient).getBlockAtSlotExact(UnsignedLong.valueOf(20), headBlockRoot);
-    verify(combinedChainDataClient, never()).getBlockAtSlotExact(greaterThan(bestSlot), any());
+    // The first block is after the best block available so we shouldn't request anything
+    verify(combinedChainDataClient, never()).getBlockAtSlotExact(any(), any());
   }
 
   @Test
@@ -256,8 +188,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
 
     final SignedBeaconBlock headBlock = BLOCKS.get(5);
 
-    final UnsignedLong bestSlot = UnsignedLong.valueOf(20);
-    withCanonicalHeadBlock(headBlock, bestSlot);
+    withCanonicalHeadBlock(headBlock);
 
     handler.onIncomingMessage(
         peer,
@@ -272,25 +203,61 @@ class BeaconBlocksByRangeMessageHandlerTest {
 
   @Test
   void shouldLimitNumberOfBlocksReturned() {
-    final RequestState requestState =
-        new RequestState(
-            new BeaconBlocksByRangeRequestMessage(
-                UnsignedLong.ZERO,
-                Constants.MAX_BLOCK_BY_RANGE_REQUEST_SIZE.plus(UnsignedLong.ONE),
-                UnsignedLong.ONE),
-            UnsignedLong.valueOf(10000),
-            Bytes32.ZERO,
-            listener);
-    // -1 because the start block is sent before we incrementCurrentSlot.
-    for (int i = 0; i < Constants.MAX_BLOCK_BY_RANGE_REQUEST_SIZE.intValue() - 1; i++) {
-      assertThat(requestState.isComplete()).isFalse();
-      requestState.incrementCurrentSlot();
-    }
-    assertThat(requestState.isComplete()).isTrue();
+    final int startBlock = 1;
+    final UnsignedLong count = MAX_REQUEST_SIZE.plus(ONE);
+    final int skip = 1;
+
+    final SignedBeaconBlock headBlock = BLOCKS.get(10);
+
+    withCanonicalHeadBlock(headBlock);
+    withAncestorRoots(
+        startBlock, MAX_REQUEST_SIZE.intValue(), skip, hotBlocks(1, 2, 3, 6, 7, 8, 9));
+
+    handler.onIncomingMessage(
+        peer,
+        new BeaconBlocksByRangeRequestMessage(
+            UnsignedLong.valueOf(startBlock), count, UnsignedLong.valueOf(skip)),
+        listener);
+
+    verifyBlocksReturned(1, 2, 3, 6, 7, 8);
   }
 
-  private void withCanonicalHeadBlock(final SignedBeaconBlock headBlock) {
-    withCanonicalHeadBlock(headBlock, headBlock.getSlot());
+  @Test
+  void shouldReturnBlocksFromFinalizedPeriod() {
+    final int startBlock = 1;
+    final int count = 5;
+    final int skip = 1;
+    withCanonicalHeadBlock(BLOCKS.get(8));
+    withFinalizedBlocks(0, 1, 2, 3, 4, 5, 6, 7);
+
+    requestBlocks(startBlock, count, skip);
+
+    verifyBlocksReturned(1, 2, 3, 4, 5);
+    verify(combinedChainDataClient, never()).getAncestorRoots(any(), any(), any());
+  }
+
+  @Test
+  void shouldReturnMixOfFinalizedAndHotBlocks() {
+    final int startBlock = 1;
+    final int count = 5;
+    final int skip = 1;
+    withCanonicalHeadBlock(BLOCKS.get(8));
+    withAncestorRoots(startBlock, count, skip, hotBlocks(4, 5, 6));
+    withFinalizedBlocks(0, 1, 2, 3);
+
+    requestBlocks(startBlock, count, skip);
+
+    verifyBlocksReturned(1, 2, 3, 4, 5);
+  }
+
+  private void requestBlocks(final int startBlock, final int count, final int skip) {
+    handler.onIncomingMessage(
+        peer,
+        new BeaconBlocksByRangeRequestMessage(
+            UnsignedLong.valueOf(startBlock),
+            UnsignedLong.valueOf(count),
+            UnsignedLong.valueOf(skip)),
+        listener);
   }
 
   private void verifyNoBlocksReturned() {
@@ -306,27 +273,49 @@ class BeaconBlocksByRangeMessageHandlerTest {
     verifyNoMoreInteractions(listener);
   }
 
-  private void withCanonicalHeadBlock(
-      final SignedBeaconBlock headBlock, final UnsignedLong bestSlot) {
-    Bytes32 bestBlockRoot = headBlock.getMessage().hash_tree_root();
-    when(combinedChainDataClient.getBestBlockRoot()).thenReturn(Optional.of(bestBlockRoot));
-    when(combinedChainDataClient.getBlockByBlockRoot(bestBlockRoot))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                Optional.of(dataStructureUtil.randomSignedBeaconBlock(bestSlot))));
+  private void withAncestorRoots(
+      final int startBlock,
+      final int count,
+      final int skip,
+      final NavigableMap<UnsignedLong, Bytes32> blockRoots) {
+    when(combinedChainDataClient.getAncestorRoots(
+            UnsignedLong.valueOf(startBlock),
+            UnsignedLong.valueOf(skip),
+            UnsignedLong.valueOf(count)))
+        .thenReturn(blockRoots);
   }
 
-  private void withBlockAtSlot(final int slot, final Bytes32 headBlockRoot) {
-    when(combinedChainDataClient.getBlockAtSlotExact(UnsignedLong.valueOf(slot), headBlockRoot))
-        .thenReturn(completedFuture(Optional.of(BLOCKS.get(slot))));
+  private NavigableMap<UnsignedLong, Bytes32> allBlocks() {
+    return hotBlocks(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
   }
 
-  private void withEmptySlot(final int slot, final Bytes32 headBlockRoot) {
-    when(combinedChainDataClient.getBlockAtSlotExact(UnsignedLong.valueOf(slot), headBlockRoot))
-        .thenReturn(completedFuture(Optional.empty()));
+  private NavigableMap<UnsignedLong, Bytes32> hotBlocks(final int... slots) {
+    final NavigableMap<UnsignedLong, Bytes32> blockRoots = new TreeMap<>();
+    IntStream.of(slots)
+        .forEach(
+            slot -> {
+              final SignedBeaconBlock block = BLOCKS.get(slot);
+              blockRoots.put(UnsignedLong.valueOf(slot), block.getRoot());
+              when(combinedChainDataClient.getBlockByBlockRoot(block.getRoot()))
+                  .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
+            });
+    return blockRoots;
   }
 
-  private UnsignedLong greaterThan(final UnsignedLong bestSlot) {
-    return argThat(argument -> argument.compareTo(bestSlot) > 0);
+  private void withFinalizedBlocks(final int... slots) {
+    IntStream.of(slots)
+        .forEach(
+            slot -> {
+              final SignedBeaconBlock block = BLOCKS.get(slot);
+              final SafeFuture<Optional<SignedBeaconBlock>> result =
+                  completedFuture(Optional.of(block));
+              when(combinedChainDataClient.getBlockByBlockRoot(block.getRoot())).thenReturn(result);
+              when(combinedChainDataClient.getBlockAtSlotExact(block.getSlot())).thenReturn(result);
+              when(combinedChainDataClient.isFinalized(block.getSlot())).thenReturn(true);
+            });
+  }
+
+  private void withCanonicalHeadBlock(final SignedBeaconBlock headBlock) {
+    when(combinedChainDataClient.getBestBlock()).thenReturn(Optional.of(headBlock));
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -37,7 +36,6 @@ import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BeaconBlocksByRangeMessageHandler.RequestState;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.util.async.SafeFuture;

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -195,6 +195,10 @@ public class CombinedChainDataClient {
     return recentChainData.getBestBlockRoot();
   }
 
+  public Optional<SignedBeaconBlock> getBestBlock() {
+    return recentChainData.getBestBlock();
+  }
+
   public boolean isStoreAvailable() {
     return recentChainData != null && recentChainData.getStore() != null;
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NavigableMap;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -224,6 +225,11 @@ public class CombinedChainDataClient {
   @VisibleForTesting
   public UpdatableStore getStore() {
     return recentChainData.getStore();
+  }
+
+  public NavigableMap<UnsignedLong, Bytes32> getAncestorRoots(
+      final UnsignedLong startSlot, final UnsignedLong step, final UnsignedLong count) {
+    return recentChainData.getAncestorRoots(startSlot, step, count);
   }
 
   public SafeFuture<Optional<SignedBeaconBlock>> getBlockByBlockRoot(final Bytes32 blockRoot) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -18,7 +18,9 @@ import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoc
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.primitives.UnsignedLong;
+import java.util.NavigableMap;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
@@ -134,6 +136,16 @@ public abstract class RecentChainData implements StoreUpdateHandler {
 
   public UpdatableStore getStore() {
     return store;
+  }
+
+  public NavigableMap<UnsignedLong, Bytes32> getAncestorRoots(
+      final UnsignedLong startSlot, final UnsignedLong step, final UnsignedLong count) {
+    return chainHead
+        .map(
+            head ->
+                ForkChoiceUtil.getAncestors(
+                    forkChoiceStrategy.orElseThrow(), head.getRoot(), startSlot, step, count))
+        .orElseGet(TreeMap::new);
   }
 
   public Optional<ForkChoiceStrategy> getForkChoiceStrategy() {


### PR DESCRIPTION
## PR Description
Since finding the block root at a slot requires walking backwards through the protoarray, do it once and gather all the required roots in one pass.  This also ensures a consistent view of the chain.  Finalised blocks which have been pruned from the protoarray are still loaded by slot (and being finalised are always consistent).

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.