### PR TITLE
[MINOR] Use P2P in help text instead of peer to peer

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/P2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/P2PNetwork.java
@@ -39,13 +39,13 @@ public interface P2PNetwork<T extends Peer> extends GossipNetwork {
    * method of this same implementation.
    *
    * @param peer Peer to connect to.
-   * @return A future which completes when the connection is establish, containing the newly
+   * @return A future which completes when the connection is established, containing the newly
    *     connected peer.
    */
   SafeFuture<Peer> connect(PeerAddress peer);
 
   /**
-   * Parses a peer address in any of this networks supported formats.
+   * Parses a peer address in any of this network's supported formats.
    *
    * @param peerAddress the address to parse
    * @return a {@link PeerAddress} which is supported by {@link #connect(PeerAddress)} for
@@ -91,7 +91,7 @@ public interface P2PNetwork<T extends Peer> extends GossipNetwork {
   Optional<String> getDiscoveryAddress();
 
   /**
-   * starts the p2p network layer
+   * Starts the P2P network layer.
    *
    * @return
    */

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
@@ -52,7 +52,7 @@ public class BeaconRestApiOptions {
   @Option(
       names = {"--rest-api-host-allowlist", "--rest-api-host-whitelist"},
       paramLabel = "<hostname>",
-      description = "Comma separated list of hostnames to allow, or * to allow any host",
+      description = "Comma-separated list of hostnames to allow, or * to allow any host",
       split = ",",
       arity = "0..*")
   private final List<String> restApiHostAllowlist = Arrays.asList("127.0.0.1", "localhost");

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
@@ -28,7 +28,7 @@ public class DepositOptions {
   @Option(
       names = {"--eth1-endpoint"},
       paramLabel = "<NETWORK>",
-      description = "URL for Eth 1.0 node",
+      description = "URL for Eth1 node.",
       arity = "1")
   private String eth1Endpoint = null;
 
@@ -39,7 +39,7 @@ public class DepositOptions {
       paramLabel = "<BOOLEAN>",
       fallbackValue = "true",
       description =
-          "On startup, use eth1 deposits from storage before loading from the remote endpoint.",
+          "On startup, use Eth1 deposits from storage before loading from the remote endpoint.",
       arity = "0..1")
   private boolean eth1DepositsFromStorageEnabled = true;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -65,7 +65,7 @@ public class MetricsOptions {
   @Option(
       names = {"--metrics-host-allowlist", "--metrics-host-whitelist"},
       paramLabel = "<hostname>",
-      description = "Comma separated list of hostnames to allow, or * to allow any host",
+      description = "Comma-separated list of hostnames to allow, or * to allow any host",
       split = ",",
       arity = "0..*")
   private final List<String> metricsHostAllowlist = Arrays.asList("127.0.0.1", "localhost");

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -24,7 +24,7 @@ public class P2POptions {
   @Option(
       names = {"--p2p-enabled"},
       paramLabel = "<BOOLEAN>",
-      description = "Enables peer to peer",
+      description = "Enables P2P",
       fallbackValue = "true",
       arity = "0..1")
   private boolean p2pEnabled = true;
@@ -32,14 +32,14 @@ public class P2POptions {
   @Option(
       names = {"--p2p-interface"},
       paramLabel = "<NETWORK>",
-      description = "Peer to peer network interface",
+      description = "P2P network interface",
       arity = "1")
   private String p2pInterface = "0.0.0.0";
 
   @Option(
       names = {"--p2p-port"},
       paramLabel = "<INTEGER>",
-      description = "Peer to peer port",
+      description = "P2P port",
       arity = "1")
   private int p2pPort = 9000;
 
@@ -54,7 +54,7 @@ public class P2POptions {
   @Option(
       names = {"--p2p-discovery-bootnodes"},
       paramLabel = "<enode://id@host:port>",
-      description = "ENR of the bootnode",
+      description = "List of ENRs of the bootnodes",
       split = ",",
       arity = "0..*")
   private List<String> p2pDiscoveryBootnodes = null;
@@ -62,14 +62,14 @@ public class P2POptions {
   @Option(
       names = {"--p2p-advertised-ip"},
       paramLabel = "<NETWORK>",
-      description = "Peer to peer advertised ip",
+      description = "P2P advertised IP",
       arity = "1")
   private String p2pAdvertisedIp;
 
   @Option(
       names = {"--p2p-advertised-port"},
       paramLabel = "<INTEGER>",
-      description = "Peer to peer advertised port",
+      description = "P2P advertised port",
       arity = "1")
   private Integer p2pAdvertisedPort;
 


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Use P2P consistently in help text instead of peer to peer. Plus some other minor text consistency fixes.

## Documentation

- [x ] I thought about documentation and added the `documentation` label to this PR if updates are required.