### PR TITLE
Increase parallelism for unit tests and acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,7 @@ jobs:
             ./gradlew --no-daemon --parallel spotlessCheck
 
   unitTests:
+    parallelism: 2
     executor: medium_plus_executor
     steps:
       - prepare
@@ -148,7 +149,15 @@ jobs:
           name: UnitTests
           no_output_timeout: 20m
           command: |
-            ./gradlew --no-daemon --parallel test
+            CLASSNAMES=$(circleci tests glob "**/src/test/java/**/*.java" \
+              | sed 's@.*/src/test/java/@@' \
+              | sed 's@/@.@g' \
+              | sed 's/.\{5\}$//' \
+              | circleci tests split --split-by=timings --timings-type=classname)
+            # Format the arguments to "./gradlew test"
+            GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
+            echo "Prepared arguments for Gradle: $GRADLE_ARGS"
+            ./gradlew --no-daemon --parallel test $GRADLE_ARGS
       - capture_test_results
 
   integrationTests:
@@ -165,7 +174,7 @@ jobs:
       - capture_test_results
 
   acceptanceTests:
-    parallelism: 1
+    parallelism: 2
     executor: machine_executor
     steps:
       - prepare

--- a/build.gradle
+++ b/build.gradle
@@ -359,6 +359,11 @@ subprojects {
     reports {
       junitXml.enabled = true
     }
+    filter {
+      // Support filtering tests with the --tests option to gradle
+      // Without this the build fails if you filter out all the tests for any module
+      setFailOnNoMatchingTests(false)
+    }
   }
 
   tasks.withType(JavaCompile) {


### PR DESCRIPTION
## PR Description
See if running unit and acceptance tests in parallel improves the build times.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.