### PR TITLE
Optimize: use validators pubKeys cache in process_deposit()

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/BeaconStateUtil.java
@@ -81,7 +81,6 @@ import tech.pegasys.teku.ssz.SSZTypes.SSZVector;
 import tech.pegasys.teku.util.cache.Cache;
 import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.util.hashtree.HashTreeUtil;
-import tech.pegasys.teku.util.hashtree.HashTreeUtil.SSZTypes;
 import tech.pegasys.teku.util.hashtree.Merkleizable;
 
 public class BeaconStateUtil {
@@ -189,7 +188,7 @@ public class BeaconStateUtil {
                   pubkey,
                   deposit.getData().getWithdrawal_credentials(),
                   min(
-                      amount.minus(amount.mod(EFFECTIVE_BALANCE_INCREMENT)),
+                      amount.minus(amount.mod(Constants.EFFECTIVE_BALANCE_INCREMENT)),
                       UnsignedLong.valueOf(MAX_EFFECTIVE_BALANCE)),
                   false,
                   FAR_FUTURE_EPOCH,
@@ -380,7 +379,8 @@ public class BeaconStateUtil {
   public static Bytes compute_signing_root(long number, Bytes domain) {
     SigningData domain_wrapped_object =
         new SigningData(
-            HashTreeUtil.hash_tree_root(SSZTypes.BASIC, SSZ.encodeUInt64(number)), domain);
+            HashTreeUtil.hash_tree_root(HashTreeUtil.SSZTypes.BASIC, SSZ.encodeUInt64(number)),
+            domain);
     return domain_wrapped_object.hash_tree_root();
   }
 
@@ -395,7 +395,8 @@ public class BeaconStateUtil {
    */
   public static Bytes compute_signing_root(Bytes bytes, Bytes domain) {
     SigningData domain_wrapped_object =
-        new SigningData(HashTreeUtil.hash_tree_root(SSZTypes.VECTOR_OF_BASIC, bytes), domain);
+        new SigningData(
+            HashTreeUtil.hash_tree_root(HashTreeUtil.SSZTypes.VECTOR_OF_BASIC, bytes), domain);
     return domain_wrapped_object.hash_tree_root();
   }
 
@@ -408,7 +409,7 @@ public class BeaconStateUtil {
    *     https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#compute_epoch_of_slot</a>
    */
   public static UnsignedLong compute_epoch_at_slot(UnsignedLong slot) {
-    return slot.dividedBy(UnsignedLong.valueOf(SLOTS_PER_EPOCH));
+    return slot.dividedBy(UnsignedLong.valueOf(Constants.SLOTS_PER_EPOCH));
   }
 
   /**


### PR DESCRIPTION
## PR Description

With remerkable backing tree the Validator pubKey is normally stored in a serialized form. Deserializing pubkey is a pretty heavy operation (due to `isInGroup` validation), that's why the `TransitionCaches.getValidatorsPubKeys()` cache was introduced. That cache should be used in `process_deposit` function. 

The PR is build on top of #2172 

## Fixed Issue(s)
Relates to #2158 (comment https://github.com/PegaSysEng/teku/issues/2158#issuecomment-645930728)

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.