### PR TITLE
Tiny optimisation when adding points

### DIFF
--- a/bls/src/main/java/tech/pegasys/teku/bls/hashToG2/JacobianPoint.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/hashToG2/JacobianPoint.java
@@ -145,9 +145,9 @@ final class JacobianPoint {
     FP2Immutable s1 = y1.mul(z2).mul(z2z2);
     FP2Immutable s2 = y2.mul(z1).mul(z1z1);
 
-    // detect exceptional case P == Q
-    if (u1.equals(u2) && s1.equals(s2)) {
-      return dbl();
+    // Shortcut for x1 == x2 case. Either P == Q or P == -Q.
+    if (u1.equals(u2)) {
+      return s1.equals(s2) ? dbl() : INFINITY;
     }
 
     FP2Immutable h = u2.sub(u1);
@@ -159,7 +159,7 @@ final class JacobianPoint {
     FP2Immutable y3 = rr.mul(v.sub(x3)).sub(s1.mul(j).dbl());
     FP2Immutable z3 = z1.mul(z2).mul(h).dbl();
 
-    return z3.iszilch() ? INFINITY : new JacobianPoint(x3, y3, z3);
+    return new JacobianPoint(x3, y3, z3);
   }
 
   /**

--- a/bls/src/main/java/tech/pegasys/teku/bls/hashToG2/JacobianPoint.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/hashToG2/JacobianPoint.java
@@ -145,7 +145,7 @@ final class JacobianPoint {
     FP2Immutable s1 = y1.mul(z2).mul(z2z2);
     FP2Immutable s2 = y2.mul(z1).mul(z1z1);
 
-    // Shortcut for x1 == x2 case. Either P == Q or P == -Q.
+    // Shortcut for equal X coordinates case. Either P == Q or P == -Q.
     if (u1.equals(u2)) {
       return s1.equals(s2) ? dbl() : INFINITY;
     }


### PR DESCRIPTION
## PR Description

A miniscule optimisation to Jacobian point addition: refactor to remove a branch from the dominant path. It may be tiny on its own, but this method is used heavily in the addition chain calculations so is worth doing.

Explanation:
  - `z3` can be zero only if `h` is zero or `z1` is zero or `z2` is zero. We check for each of these cases further up, so we can move the check from the end and hide it inside the `u1 == u2` branch

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.