### PR TITLE
Use separate transactions when updating finalized state vs hot state

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -36,8 +36,12 @@ import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.server.rocksdb.core.RocksDbAccessor;
 import tech.pegasys.teku.storage.server.rocksdb.core.RocksDbInstanceFactory;
-import tech.pegasys.teku.storage.server.rocksdb.dataaccess.RocksDbDao;
-import tech.pegasys.teku.storage.server.rocksdb.dataaccess.RocksDbDao.Updater;
+import tech.pegasys.teku.storage.server.rocksdb.dataaccess.RocksDbEth1Dao;
+import tech.pegasys.teku.storage.server.rocksdb.dataaccess.RocksDbEth1Dao.Eth1Updater;
+import tech.pegasys.teku.storage.server.rocksdb.dataaccess.RocksDbFinalizedDao;
+import tech.pegasys.teku.storage.server.rocksdb.dataaccess.RocksDbFinalizedDao.FinalizedUpdater;
+import tech.pegasys.teku.storage.server.rocksdb.dataaccess.RocksDbHotDao;
+import tech.pegasys.teku.storage.server.rocksdb.dataaccess.RocksDbHotDao.HotUpdater;
 import tech.pegasys.teku.storage.server.rocksdb.dataaccess.V3RocksDbDao;
 import tech.pegasys.teku.storage.server.rocksdb.schema.V3Schema;
 import tech.pegasys.teku.storage.store.StoreFactory;
@@ -49,7 +53,9 @@ public class RocksDbDatabase implements Database {
   private final MetricsSystem metricsSystem;
   private final StateStorageMode stateStorageMode;
 
-  private final RocksDbDao dao;
+  private final RocksDbHotDao hotDao;
+  private final RocksDbFinalizedDao finalizedDao;
+  private final RocksDbEth1Dao eth1Dao;
 
   public static Database createV3(
       final MetricsSystem metricsSystem,
@@ -63,32 +69,37 @@ public class RocksDbDatabase implements Database {
       final MetricsSystem metricsSystem,
       final RocksDbAccessor db,
       final StateStorageMode stateStorageMode) {
-    final RocksDbDao dao = new V3RocksDbDao(db);
-    return new RocksDbDatabase(metricsSystem, dao, stateStorageMode);
+    final V3RocksDbDao dao = new V3RocksDbDao(db);
+    return new RocksDbDatabase(metricsSystem, dao, dao, dao, stateStorageMode);
   }
 
   private RocksDbDatabase(
       final MetricsSystem metricsSystem,
-      final RocksDbDao dao,
+      final RocksDbHotDao hotDao,
+      final RocksDbFinalizedDao finalizedDao,
+      final RocksDbEth1Dao eth1Dao,
       final StateStorageMode stateStorageMode) {
     this.metricsSystem = metricsSystem;
+    this.finalizedDao = finalizedDao;
+    this.eth1Dao = eth1Dao;
     this.stateStorageMode = stateStorageMode;
-    this.dao = dao;
+    this.hotDao = hotDao;
   }
 
   @Override
   public void storeGenesis(final UpdatableStore store) {
-    try (final Updater updater = dao.updater()) {
-      updater.setGenesisTime(store.getGenesisTime());
-      updater.setJustifiedCheckpoint(store.getJustifiedCheckpoint());
-      updater.setBestJustifiedCheckpoint(store.getBestJustifiedCheckpoint());
-      updater.setFinalizedCheckpoint(store.getFinalizedCheckpoint());
+    try (final HotUpdater hotUpdater = hotDao.hotUpdater();
+        final FinalizedUpdater finalizedUpdater = finalizedDao.finalizedUpdater()) {
+      hotUpdater.setGenesisTime(store.getGenesisTime());
+      hotUpdater.setJustifiedCheckpoint(store.getJustifiedCheckpoint());
+      hotUpdater.setBestJustifiedCheckpoint(store.getBestJustifiedCheckpoint());
+      hotUpdater.setFinalizedCheckpoint(store.getFinalizedCheckpoint());
 
       // We should only have a single checkpoint state at genesis
       final BeaconState genesisState =
           store.getBlockState(store.getFinalizedCheckpoint().getRoot());
-      updater.addCheckpointState(store.getFinalizedCheckpoint(), genesisState);
-      updater.setLatestFinalizedState(genesisState);
+      hotUpdater.addCheckpointState(store.getFinalizedCheckpoint(), genesisState);
+      finalizedUpdater.setLatestFinalizedState(genesisState);
 
       for (Bytes32 root : store.getBlockRoots()) {
         // Since we're storing genesis, we should only have 1 root here corresponding to genesis
@@ -98,13 +109,14 @@ public class RocksDbDatabase implements Database {
         // We need to store the genesis block in both hot and cold storage so that on restart
         // we're guaranteed to have at least one block / state to load into RecentChainData.
         // Save to hot storage
-        updater.addHotBlock(block);
+        hotUpdater.addHotBlock(block);
         // Save to cold storage
-        updater.addFinalizedBlock(block);
-        putFinalizedState(updater, root, state);
+        finalizedUpdater.addFinalizedBlock(block);
+        putFinalizedState(finalizedUpdater, root, state);
       }
 
-      updater.commit();
+      finalizedUpdater.commit();
+      hotUpdater.commit();
     }
   }
 
@@ -118,20 +130,20 @@ public class RocksDbDatabase implements Database {
 
   @Override
   public Optional<UpdatableStore> createMemoryStore() {
-    Optional<UnsignedLong> maybeGenesisTime = dao.getGenesisTime();
+    Optional<UnsignedLong> maybeGenesisTime = hotDao.getGenesisTime();
     if (maybeGenesisTime.isEmpty()) {
       // If genesis time hasn't been set, genesis hasn't happened and we have no data
       return Optional.empty();
     }
     final UnsignedLong genesisTime = maybeGenesisTime.get();
-    final Checkpoint justifiedCheckpoint = dao.getJustifiedCheckpoint().orElseThrow();
-    final Checkpoint finalizedCheckpoint = dao.getFinalizedCheckpoint().orElseThrow();
-    final Checkpoint bestJustifiedCheckpoint = dao.getBestJustifiedCheckpoint().orElseThrow();
-    final BeaconState finalizedState = dao.getLatestFinalizedState().orElseThrow();
+    final Checkpoint justifiedCheckpoint = hotDao.getJustifiedCheckpoint().orElseThrow();
+    final Checkpoint finalizedCheckpoint = hotDao.getFinalizedCheckpoint().orElseThrow();
+    final Checkpoint bestJustifiedCheckpoint = hotDao.getBestJustifiedCheckpoint().orElseThrow();
+    final BeaconState finalizedState = finalizedDao.getLatestFinalizedState().orElseThrow();
 
-    final Map<Bytes32, SignedBeaconBlock> hotBlocksByRoot = dao.getHotBlocks();
-    final Map<Checkpoint, BeaconState> checkpointStates = dao.getCheckpointStates();
-    final Map<UnsignedLong, VoteTracker> votes = dao.getVotes();
+    final Map<Bytes32, SignedBeaconBlock> hotBlocksByRoot = hotDao.getHotBlocks();
+    final Map<Checkpoint, BeaconState> checkpointStates = hotDao.getCheckpointStates();
+    final Map<UnsignedLong, VoteTracker> votes = hotDao.getVotes();
 
     // Validate finalized data is consistent and available
     final SignedBeaconBlock finalizedBlock = hotBlocksByRoot.get(finalizedCheckpoint.getRoot());
@@ -156,56 +168,58 @@ public class RocksDbDatabase implements Database {
 
   @Override
   public Optional<Bytes32> getFinalizedRootAtSlot(final UnsignedLong slot) {
-    return dao.getFinalizedRootAtSlot(slot);
+    return finalizedDao.getFinalizedRootAtSlot(slot);
   }
 
   @Override
   public Optional<Bytes32> getLatestFinalizedRootAtSlot(final UnsignedLong slot) {
-    return dao.getLatestFinalizedRootAtSlot(slot);
+    return finalizedDao.getLatestFinalizedRootAtSlot(slot);
   }
 
   @Override
   public Optional<SignedBeaconBlock> getSignedBlock(final Bytes32 root) {
-    return dao.getHotBlock(root).or(() -> dao.getFinalizedBlock(root));
+    return hotDao.getHotBlock(root).or(() -> finalizedDao.getFinalizedBlock(root));
   }
 
   @Override
   public Optional<BeaconState> getFinalizedState(final Bytes32 root) {
-    return dao.getFinalizedState(root);
+    return finalizedDao.getFinalizedState(root);
   }
 
   @Override
   public Optional<MinGenesisTimeBlockEvent> getMinGenesisTimeBlock() {
-    return dao.getMinGenesisTimeBlock();
+    return eth1Dao.getMinGenesisTimeBlock();
   }
 
   @Override
   @MustBeClosed
   public Stream<DepositsFromBlockEvent> streamDepositsFromBlocks() {
-    return dao.streamDepositsFromBlocks();
+    return eth1Dao.streamDepositsFromBlocks();
   }
 
   @Override
   public void addMinGenesisTimeBlock(final MinGenesisTimeBlockEvent event) {
-    try (final Updater updater = dao.updater()) {
+    try (final Eth1Updater updater = eth1Dao.eth1Updater()) {
       updater.addMinGenesisTimeBlock(event);
+      updater.commit();
     }
   }
 
   @Override
   public void addDepositsFromBlockEvent(final DepositsFromBlockEvent event) {
-    try (final Updater updater = dao.updater()) {
+    try (final Eth1Updater updater = eth1Dao.eth1Updater()) {
       updater.addDepositsFromBlockEvent(event);
+      updater.commit();
     }
   }
 
   @Override
   public void close() throws Exception {
-    dao.close();
+    hotDao.close();
   }
 
   private void doUpdate(final StorageUpdate update) {
-    try (final Updater updater = dao.updater()) {
+    try (final FinalizedUpdater updater = finalizedDao.finalizedUpdater()) {
       // Update finalized blocks and states
       putFinalizedStates(updater, update.getFinalizedBlocks(), update.getFinalizedStates());
       update.getFinalizedBlocks().values().forEach(updater::addFinalizedBlock);
@@ -213,7 +227,7 @@ public class RocksDbDatabase implements Database {
       updater.commit();
     }
 
-    try (final Updater updater = dao.updater()) {
+    try (final HotUpdater updater = hotDao.hotUpdater()) {
       // Store new hot data
       update.getGenesisTime().ifPresent(updater::setGenesisTime);
       update.getFinalizedCheckpoint().ifPresent(updater::setFinalizedCheckpoint);
@@ -233,7 +247,7 @@ public class RocksDbDatabase implements Database {
   }
 
   private void putFinalizedStates(
-      Updater updater,
+      FinalizedUpdater updater,
       final Map<Bytes32, SignedBeaconBlock> finalizedBlocks,
       final Map<Bytes32, BeaconState> finalizedStates) {
     if (finalizedBlocks.isEmpty()) {
@@ -243,9 +257,10 @@ public class RocksDbDatabase implements Database {
     switch (stateStorageMode) {
       case ARCHIVE:
         // Get previously finalized block to build on top of
-        final Bytes32 baseBlockRoot = dao.getFinalizedCheckpoint().get().getRoot();
-        final SignedBeaconBlock baseBlock = dao.getFinalizedBlock(baseBlockRoot).orElseThrow();
-        final BeaconState baseState = dao.getLatestFinalizedState().orElseThrow();
+        final Bytes32 baseBlockRoot = hotDao.getFinalizedCheckpoint().orElseThrow().getRoot();
+        final SignedBeaconBlock baseBlock =
+            finalizedDao.getFinalizedBlock(baseBlockRoot).orElseThrow();
+        final BeaconState baseState = finalizedDao.getLatestFinalizedState().orElseThrow();
 
         final BlockTree blockTree =
             BlockTree.builder().rootBlock(baseBlock).blocks(finalizedBlocks.values()).build();
@@ -262,7 +277,7 @@ public class RocksDbDatabase implements Database {
   }
 
   private void putFinalizedState(
-      Updater updater, final Bytes32 blockRoot, final BeaconState state) {
+      FinalizedUpdater updater, final Bytes32 blockRoot, final BeaconState state) {
     switch (stateStorageMode) {
       case ARCHIVE:
         updater.addFinalizedState(blockRoot, state);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbEth1Dao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbEth1Dao.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.rocksdb.dataaccess;
+
+import com.google.errorprone.annotations.MustBeClosed;
+import java.util.Optional;
+import java.util.stream.Stream;
+import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
+import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
+
+public interface RocksDbEth1Dao extends AutoCloseable {
+
+  @MustBeClosed
+  Stream<DepositsFromBlockEvent> streamDepositsFromBlocks();
+
+  Optional<MinGenesisTimeBlockEvent> getMinGenesisTimeBlock();
+
+  Eth1Updater eth1Updater();
+
+  interface Eth1Updater extends AutoCloseable {
+    void addMinGenesisTimeBlock(final MinGenesisTimeBlockEvent event);
+
+    void addDepositsFromBlockEvent(final DepositsFromBlockEvent event);
+
+    void commit();
+
+    void cancel();
+
+    @Override
+    void close();
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbEth1Dao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbEth1Dao.java
@@ -19,6 +19,10 @@ import java.util.stream.Stream;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 
+/**
+ * Provides an abstract "data access object" interface for working with ETH1 data from the
+ * underlying database.
+ */
 public interface RocksDbEth1Dao extends AutoCloseable {
 
   @MustBeClosed

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbFinalizedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbFinalizedDao.java
@@ -19,6 +19,10 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 
+/**
+ * Provides an abstract "data access object" interface for working with finalized data from the
+ * underlying database.
+ */
 public interface RocksDbFinalizedDao extends AutoCloseable {
 
   Optional<Bytes32> getFinalizedRootAtSlot(final UnsignedLong slot);
@@ -29,12 +33,9 @@ public interface RocksDbFinalizedDao extends AutoCloseable {
 
   Optional<BeaconState> getFinalizedState(final Bytes32 root);
 
-  Optional<BeaconState> getLatestFinalizedState();
-
   FinalizedUpdater finalizedUpdater();
 
   interface FinalizedUpdater extends AutoCloseable {
-    void setLatestFinalizedState(final BeaconState state);
 
     void addFinalizedBlock(final SignedBeaconBlock block);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbFinalizedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbFinalizedDao.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.rocksdb.dataaccess;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+
+public interface RocksDbFinalizedDao extends AutoCloseable {
+
+  Optional<Bytes32> getFinalizedRootAtSlot(final UnsignedLong slot);
+
+  Optional<Bytes32> getLatestFinalizedRootAtSlot(final UnsignedLong slot);
+
+  Optional<SignedBeaconBlock> getFinalizedBlock(final Bytes32 root);
+
+  Optional<BeaconState> getFinalizedState(final Bytes32 root);
+
+  Optional<BeaconState> getLatestFinalizedState();
+
+  FinalizedUpdater finalizedUpdater();
+
+  interface FinalizedUpdater extends AutoCloseable {
+    void setLatestFinalizedState(final BeaconState state);
+
+    void addFinalizedBlock(final SignedBeaconBlock block);
+
+    void addFinalizedState(final Bytes32 blockRoot, final BeaconState state);
+
+    void commit();
+
+    void cancel();
+
+    @Override
+    void close();
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbHotDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbHotDao.java
@@ -14,24 +14,15 @@
 package tech.pegasys.teku.storage.server.rocksdb.dataaccess;
 
 import com.google.common.primitives.UnsignedLong;
-import com.google.errorprone.annotations.MustBeClosed;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
-import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
-import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 
-/**
- * A RocksDB "data access object" interface to abstract interactions with underlying database.
- *
- * @see <a href="https://en.wikipedia.org/wiki/Data_access_object">DAO</a>
- */
-public interface RocksDbDao extends AutoCloseable {
+public interface RocksDbHotDao extends AutoCloseable {
 
   Optional<UnsignedLong> getGenesisTime();
 
@@ -41,17 +32,7 @@ public interface RocksDbDao extends AutoCloseable {
 
   Optional<Checkpoint> getFinalizedCheckpoint();
 
-  Optional<Bytes32> getFinalizedRootAtSlot(final UnsignedLong slot);
-
-  Optional<Bytes32> getLatestFinalizedRootAtSlot(final UnsignedLong slot);
-
   Optional<SignedBeaconBlock> getHotBlock(final Bytes32 root);
-
-  Optional<SignedBeaconBlock> getFinalizedBlock(final Bytes32 root);
-
-  Optional<BeaconState> getFinalizedState(final Bytes32 root);
-
-  Optional<BeaconState> getLatestFinalizedState();
 
   Map<Bytes32, SignedBeaconBlock> getHotBlocks();
 
@@ -59,14 +40,9 @@ public interface RocksDbDao extends AutoCloseable {
 
   Map<UnsignedLong, VoteTracker> getVotes();
 
-  @MustBeClosed
-  Stream<DepositsFromBlockEvent> streamDepositsFromBlocks();
+  HotUpdater hotUpdater();
 
-  Optional<MinGenesisTimeBlockEvent> getMinGenesisTimeBlock();
-
-  Updater updater();
-
-  interface Updater extends AutoCloseable {
+  interface HotUpdater extends AutoCloseable {
 
     void setGenesisTime(final UnsignedLong genesisTime);
 
@@ -76,17 +52,11 @@ public interface RocksDbDao extends AutoCloseable {
 
     void setFinalizedCheckpoint(final Checkpoint checkpoint);
 
-    void setLatestFinalizedState(final BeaconState state);
-
     void addCheckpointState(final Checkpoint checkpoint, final BeaconState state);
 
     void addCheckpointStates(Map<Checkpoint, BeaconState> checkpointStates);
 
     void addHotBlock(final SignedBeaconBlock block);
-
-    void addFinalizedBlock(final SignedBeaconBlock block);
-
-    void addFinalizedState(final Bytes32 blockRoot, final BeaconState state);
 
     void addVotes(final Map<UnsignedLong, VoteTracker> states);
 
@@ -95,10 +65,6 @@ public interface RocksDbDao extends AutoCloseable {
     void deleteCheckpointState(final Checkpoint checkpoint);
 
     void deleteHotBlock(final Bytes32 blockRoot);
-
-    void addMinGenesisTimeBlock(final MinGenesisTimeBlockEvent event);
-
-    void addDepositsFromBlockEvent(final DepositsFromBlockEvent event);
 
     void commit();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbHotDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbHotDao.java
@@ -22,6 +22,10 @@ import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 
+/**
+ * Provides an abstract "data access object" interface for working with hot data (non-finalized)
+ * data from the underlying database.
+ */
 public interface RocksDbHotDao extends AutoCloseable {
 
   Optional<UnsignedLong> getGenesisTime();
@@ -31,6 +35,9 @@ public interface RocksDbHotDao extends AutoCloseable {
   Optional<Checkpoint> getBestJustifiedCheckpoint();
 
   Optional<Checkpoint> getFinalizedCheckpoint();
+
+  // In hot dao because it must be in sync with the finalized checkpoint
+  Optional<BeaconState> getLatestFinalizedState();
 
   Optional<SignedBeaconBlock> getHotBlock(final Bytes32 root);
 
@@ -51,6 +58,8 @@ public interface RocksDbHotDao extends AutoCloseable {
     void setBestJustifiedCheckpoint(final Checkpoint checkpoint);
 
     void setFinalizedCheckpoint(final Checkpoint checkpoint);
+
+    void setLatestFinalizedState(final BeaconState state);
 
     void addCheckpointState(final Checkpoint checkpoint, final BeaconState state);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V3RocksDbDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V3RocksDbDao.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.storage.server.rocksdb.core.RocksDbAccessor;
 import tech.pegasys.teku.storage.server.rocksdb.core.RocksDbAccessor.RocksDbTransaction;
 import tech.pegasys.teku.storage.server.rocksdb.schema.V3Schema;
 
-public class V3RocksDbDao implements RocksDbDao {
+public class V3RocksDbDao implements RocksDbHotDao, RocksDbFinalizedDao, RocksDbEth1Dao {
   // Persistent data
   private final RocksDbAccessor db;
 
@@ -115,7 +115,17 @@ public class V3RocksDbDao implements RocksDbDao {
   }
 
   @Override
-  public Updater updater() {
+  public HotUpdater hotUpdater() {
+    return new V3Updater(db);
+  }
+
+  @Override
+  public FinalizedUpdater finalizedUpdater() {
+    return new V3Updater(db);
+  }
+
+  @Override
+  public Eth1Updater eth1Updater() {
     return new V3Updater(db);
   }
 
@@ -124,7 +134,7 @@ public class V3RocksDbDao implements RocksDbDao {
     db.close();
   }
 
-  private static class V3Updater implements Updater {
+  private static class V3Updater implements HotUpdater, FinalizedUpdater, Eth1Updater {
 
     private final RocksDbTransaction transaction;
 
@@ -209,13 +219,11 @@ public class V3RocksDbDao implements RocksDbDao {
     @Override
     public void addMinGenesisTimeBlock(final MinGenesisTimeBlockEvent event) {
       transaction.put(V3Schema.MIN_GENESIS_TIME_BLOCK, event);
-      transaction.commit();
     }
 
     @Override
     public void addDepositsFromBlockEvent(final DepositsFromBlockEvent event) {
       transaction.put(V3Schema.DEPOSITS_FROM_BLOCK_EVENTS, event.getBlockNumber(), event);
-      transaction.commit();
     }
 
     @Override

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
@@ -544,7 +544,7 @@ public abstract class AbstractDatabaseTest {
     // Then finalize
     final StoreTransaction tx = store.startTransaction(storageUpdateChannel);
     tx.setFinalizedCheckpoint(finalizedCheckpoint);
-    tx.commit().reportExceptions();
+    assertThat(tx.commit()).isCompleted();
 
     // All finalized blocks and states should be available
     assertFinalizedBlocksAndStatesAvailable(newBlocks);
@@ -610,7 +610,7 @@ public abstract class AbstractDatabaseTest {
       final StoreTransaction transaction = store.startTransaction(storageUpdateChannel);
       add(transaction, allBlocksAndStates);
       transaction.setFinalizedCheckpoint(finalizedCheckpoint);
-      transaction.commit().reportExceptions();
+      assertThat(transaction.commit()).isCompleted();
     } else {
       add(allBlocksAndStates);
       finalizeCheckpoint(finalizedCheckpoint);


### PR DESCRIPTION
## PR Description
Use separate database transactions when updating finalised data vs hot data.  This will pave the way for them being in different RocksDB instances in the future.

If we crash between writing finalised state and hot state, when we restart and finalise an epoch we'll wind up rewriting the finalised data as part of that update but everything works out.

## Fixed Issue(s)
fixes #2182 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.