### PR TITLE
added command line flag for data-storage archive-frequency

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -338,6 +338,8 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setMetricsHostAllowlist(metricsOptions.getMetricsHostAllowlist())
         .setDataPath(dataOptions.getDataPath())
         .setDataStorageMode(dataOptions.getDataStorageMode())
+        .setDataStorageFrequency(dataOptions.getDataStorageFrequency())
+        .setDataStorageCreateDbVersion(dataOptions.getCreateDbVersion())
         .setRestApiPort(beaconRestApiOptions.getRestApiPort())
         .setRestApiDocsEnabled(beaconRestApiOptions.isRestApiDocsEnabled())
         .setRestApiEnabled(beaconRestApiOptions.isRestApiEnabled())

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DataOptions.java
@@ -39,7 +39,7 @@ public class DataOptions {
       hidden = true,
       paramLabel = "<FREQUENCY>",
       description =
-          "Sets the frequency at which to store archived slots to disk. (slot modulo frequency == 0)",
+          "Sets the frequency, in slots, at which to store archived states to disk.",
       defaultValue = "2048",
       arity = "1")
   private long dataStorageFrequency = 2048L;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DataOptions.java
@@ -34,12 +34,39 @@ public class DataOptions {
       arity = "1")
   private StateStorageMode dataStorageMode = StateStorageMode.PRUNE;
 
+  @Option(
+      names = {"--data-storage-archive-frequency"},
+      hidden = true,
+      paramLabel = "<FREQUENCY>",
+      description =
+          "Sets the frequency at which to store archived slots to disk. (slot modulo frequency == 0)",
+      defaultValue = "2048",
+      arity = "1")
+  private long dataStorageFrequency = 2048L;
+
+  @Option(
+      names = {"--Xdata-storage-create-db-version"},
+      paramLabel = "<VERSION>",
+      description = "Database version to create (3 or 4)",
+      arity = "1",
+      defaultValue = "3",
+      hidden = true)
+  private int createDbVersion = 3;
+
   public String getDataPath() {
     return dataPath;
   }
 
   public StateStorageMode getDataStorageMode() {
     return dataStorageMode;
+  }
+
+  public long getDataStorageFrequency() {
+    return dataStorageFrequency;
+  }
+
+  public int getCreateDbVersion() {
+    return createDbVersion;
   }
 
   private static String defaultDataPath() {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DataOptions.java
@@ -38,8 +38,7 @@ public class DataOptions {
       names = {"--data-storage-archive-frequency"},
       hidden = true,
       paramLabel = "<FREQUENCY>",
-      description =
-          "Sets the frequency, in slots, at which to store archived states to disk.",
+      description = "Sets the frequency, in slots, at which to store archived states to disk.",
       defaultValue = "2048",
       arity = "1")
   private long dataStorageFrequency = 2048L;

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -303,6 +303,8 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setValidatorExternalSignerTimeout(1000)
         .setDataPath(dataPath.toString())
         .setDataStorageMode(PRUNE)
+        .setDataStorageFrequency(2048L)
+        .setDataStorageCreateDbVersion(3)
         .setRestApiPort(5051)
         .setRestApiDocsEnabled(false)
         .setRestApiEnabled(false)

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DataOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DataOptionsTest.java
@@ -30,6 +30,8 @@ public class DataOptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromFile("dataOptions_config.yaml");
     assertThat(tekuConfiguration.getDataPath()).isEqualTo(TEST_PATH);
     assertThat(tekuConfiguration.getDataStorageMode()).isEqualTo(ARCHIVE);
+    assertThat(tekuConfiguration.getDataStorageCreateDbVersion()).isEqualTo(4);
+    assertThat(tekuConfiguration.getDataStorageFrequency()).isEqualTo(128L);
   }
 
   @Test
@@ -51,5 +53,31 @@ public class DataOptionsTest extends AbstractBeaconNodeCommandTest {
     final TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--data-path", TEST_PATH);
     assertThat(tekuConfiguration.getDataPath()).isEqualTo(TEST_PATH);
+  }
+
+  @Test
+  public void dataStorageFrequency_shouldDefault() {
+    final TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments();
+    assertThat(tekuConfiguration.getDataStorageFrequency()).isEqualTo(2048L);
+  }
+
+  @Test
+  public void dataStorageFrequency_shouldAcceptNonDefaultValues() {
+    final TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments("--data-storage-archive-frequency", "1024000");
+    assertThat(tekuConfiguration.getDataStorageFrequency()).isEqualTo(1024000L);
+  }
+
+  @Test
+  public void dataStorageCreateDbVersion_shouldDefault() {
+    final TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments();
+    assertThat(tekuConfiguration.getDataStorageCreateDbVersion()).isEqualTo(3);
+  }
+
+  @Test
+  public void dataStorageCreateDbVersion_shouldAcceptNonDefaultValues() {
+    final TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments("--Xdata-storage-create-db-version", "4");
+    assertThat(tekuConfiguration.getDataStorageCreateDbVersion()).isEqualTo(4);
   }
 }

--- a/teku/src/test/resources/dataOptions_config.yaml
+++ b/teku/src/test/resources/dataOptions_config.yaml
@@ -1,3 +1,5 @@
 # database
 data-path: "/tmp/teku"
 data-storage-mode: "archive"
+Xdata-storage-create-db-version: 4
+data-storage-archive-frequency: 128

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
@@ -98,6 +98,8 @@ public class TekuConfiguration {
   // Database
   private final String dataPath;
   private final StateStorageMode dataStorageMode;
+  private final long dataStorageFrequency;
+  private final int dataStorageCreateDbVersion;
 
   // Beacon REST API
   private final int restApiPort;
@@ -159,6 +161,8 @@ public class TekuConfiguration {
       final List<String> metricsHostAllowlist,
       final String dataPath,
       final StateStorageMode dataStorageMode,
+      final long dataStorageFrequency,
+      final int dataStorageCreateDbVersion,
       final int restApiPort,
       final boolean restApiDocsEnabled,
       final boolean restApiEnabled,
@@ -213,6 +217,8 @@ public class TekuConfiguration {
     this.metricsHostAllowlist = metricsHostAllowlist;
     this.dataPath = dataPath;
     this.dataStorageMode = dataStorageMode;
+    this.dataStorageFrequency = dataStorageFrequency;
+    this.dataStorageCreateDbVersion = dataStorageCreateDbVersion;
     this.restApiPort = restApiPort;
     this.restApiDocsEnabled = restApiDocsEnabled;
     this.restApiEnabled = restApiEnabled;
@@ -432,6 +438,14 @@ public class TekuConfiguration {
 
   public StateStorageMode getDataStorageMode() {
     return dataStorageMode;
+  }
+
+  public long getDataStorageFrequency() {
+    return dataStorageFrequency;
+  }
+
+  public int getDataStorageCreateDbVersion() {
+    return dataStorageCreateDbVersion;
   }
 
   public int getRestApiPort() {

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
@@ -69,6 +69,8 @@ public class TekuConfigurationBuilder {
   private List<String> metricsHostAllowlist;
   private String dataPath;
   private StateStorageMode dataStorageMode;
+  private int dataStorageCreateDbVersion;
+  private long dataStorageFrequency;
   private int restApiPort;
   private boolean restApiDocsEnabled;
   private boolean restApiEnabled;
@@ -331,6 +333,17 @@ public class TekuConfigurationBuilder {
     return this;
   }
 
+  public TekuConfigurationBuilder setDataStorageFrequency(final long dataStorageFrequency) {
+    this.dataStorageFrequency = dataStorageFrequency;
+    return this;
+  }
+
+  public TekuConfigurationBuilder setDataStorageCreateDbVersion(
+      final int dataStorageCreateDbVersion) {
+    this.dataStorageCreateDbVersion = dataStorageCreateDbVersion;
+    return this;
+  }
+
   public TekuConfigurationBuilder setRestApiPort(final int restApiPort) {
     this.restApiPort = restApiPort;
     return this;
@@ -437,6 +450,8 @@ public class TekuConfigurationBuilder {
         metricsHostAllowlist,
         dataPath,
         dataStorageMode,
+        dataStorageFrequency,
+        dataStorageCreateDbVersion,
         restApiPort,
         restApiDocsEnabled,
         restApiEnabled,


### PR DESCRIPTION
 - a hidden flag that will accept the version of db to create, this is --Xdata-storage-create-db-version <VER> (default: 3)

 - a flag that will become visible in help once the feature is done, --data-storage-archive-frequency=<FREQUENCY> (default: 2048)

 Addresses #2180

Signed-off-by: Paul Harris <paul.harris@consensys.net>


## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.