### PR TITLE
Cache regenerated finalized states

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -13,35 +13,39 @@
 
 package tech.pegasys.teku.storage.server;
 
-import static com.google.common.primitives.UnsignedLong.ONE;
-
 import com.google.common.eventbus.EventBus;
 import com.google.common.primitives.UnsignedLong;
 import java.util.Optional;
-import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.core.StreamingStateRegenerator;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.events.StorageUpdate;
+import tech.pegasys.teku.storage.server.state.FinalizedStateCache;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.util.async.SafeFuture;
+import tech.pegasys.teku.util.config.Constants;
 
 public class ChainStorage implements StorageUpdateChannel, StorageQueryChannel {
   private final EventBus eventBus;
 
   private final Database database;
+  private final FinalizedStateCache finalizedStateCache;
   private volatile Optional<UpdatableStore> cachedStore = Optional.empty();
 
-  private ChainStorage(final EventBus eventBus, final Database database) {
+  private ChainStorage(
+      final EventBus eventBus,
+      final Database database,
+      final FinalizedStateCache finalizedStateCache) {
     this.eventBus = eventBus;
     this.database = database;
+    this.finalizedStateCache = finalizedStateCache;
   }
 
   public static ChainStorage create(final EventBus eventBus, final Database database) {
-    return new ChainStorage(eventBus, database);
+    return new ChainStorage(
+        eventBus, database, new FinalizedStateCache(database, Constants.SLOTS_PER_EPOCH * 3, true));
   }
 
   public void start() {
@@ -119,18 +123,6 @@ public class ChainStorage implements StorageUpdateChannel, StorageQueryChannel {
   }
 
   private Optional<BeaconState> getLatestFinalizedStateAtSlotSync(final UnsignedLong slot) {
-    return database
-        .getLatestAvailableFinalizedState(slot)
-        .map(state -> regenerateState(slot, state));
-  }
-
-  private BeaconState regenerateState(final UnsignedLong slot, final BeaconState state) {
-    if (state.getSlot().equals(slot)) {
-      return state;
-    }
-    try (final Stream<SignedBeaconBlock> blocks =
-        database.streamFinalizedBlocks(state.getSlot().plus(ONE), slot)) {
-      return StreamingStateRegenerator.regenerate(state, blocks);
-    }
+    return finalizedStateCache.getFinalizedState(slot);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -28,6 +28,9 @@ import tech.pegasys.teku.util.async.SafeFuture;
 import tech.pegasys.teku.util.config.Constants;
 
 public class ChainStorage implements StorageUpdateChannel, StorageQueryChannel {
+
+  private static final int FINALIZED_STATE_CACHE_SIZE = Constants.SLOTS_PER_EPOCH * 3;
+
   private final EventBus eventBus;
 
   private final Database database;
@@ -45,7 +48,7 @@ public class ChainStorage implements StorageUpdateChannel, StorageQueryChannel {
 
   public static ChainStorage create(final EventBus eventBus, final Database database) {
     return new ChainStorage(
-        eventBus, database, new FinalizedStateCache(database, Constants.SLOTS_PER_EPOCH * 3, true));
+        eventBus, database, new FinalizedStateCache(database, FINALIZED_STATE_CACHE_SIZE, true));
   }
 
   public void start() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/state/FinalizedStateCache.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/state/FinalizedStateCache.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.state;
+
+import static com.google.common.primitives.UnsignedLong.ONE;
+
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalCause;
+import com.google.common.cache.RemovalNotification;
+import com.google.common.primitives.UnsignedLong;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.util.NavigableSet;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.stream.Stream;
+import tech.pegasys.teku.core.StreamingStateRegenerator;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.storage.server.Database;
+
+public class FinalizedStateCache {
+  /**
+   * Note this is a best effort basis to track what states are cached. Slots are added here slightly
+   * before the stateCache is actually updated and removed slightly after they are evicted from the
+   * cache.
+   */
+  private final NavigableSet<UnsignedLong> availableSlots = new ConcurrentSkipListSet<>();
+
+  private final LoadingCache<UnsignedLong, BeaconState> stateCache;
+  private final Database database;
+
+  public FinalizedStateCache(
+      final Database database, final int maximumCacheSize, final boolean useSoftReferences) {
+    this.database = database;
+    final CacheBuilder<UnsignedLong, BeaconState> cacheBuilder =
+        CacheBuilder.newBuilder()
+            .maximumSize(maximumCacheSize)
+            .removalListener(this::onRemovedFromCache);
+    if (useSoftReferences) {
+      cacheBuilder.softValues();
+    }
+    this.stateCache = cacheBuilder.build(new StateCacheLoader());
+  }
+
+  private void onRemovedFromCache(
+      final RemovalNotification<UnsignedLong, BeaconState> removalNotification) {
+    if (removalNotification.getCause() != RemovalCause.REPLACED) {
+      availableSlots.remove(removalNotification.getKey());
+    }
+  }
+
+  public Optional<BeaconState> getFinalizedState(final UnsignedLong slot) {
+    try {
+      return Optional.of(stateCache.getUnchecked(slot));
+    } catch (final UncheckedExecutionException e) {
+      if (Throwables.getRootCause(e) instanceof StateUnavailableException) {
+        return Optional.empty();
+      }
+      throw new RuntimeException("Error while regenerating state", e);
+    }
+  }
+
+  private Optional<BeaconState> getLatestStateFromCache(final UnsignedLong slot) {
+    return Optional.ofNullable(availableSlots.floor(slot)).map(stateCache::getIfPresent);
+  }
+
+  private class StateCacheLoader extends CacheLoader<UnsignedLong, BeaconState> {
+
+    @Override
+    public BeaconState load(final UnsignedLong key) {
+      return regenerateState(key).orElseThrow(StateUnavailableException::new);
+    }
+
+    private Optional<BeaconState> regenerateState(final UnsignedLong slot) {
+      return database
+          .getLatestAvailableFinalizedState(slot)
+          .map(state -> regenerateState(slot, state));
+    }
+
+    private BeaconState regenerateState(final UnsignedLong slot, final BeaconState stateFromDisk) {
+      final Optional<BeaconState> latestStateFromCache = getLatestStateFromCache(slot);
+      final BeaconState preState =
+          latestStateFromCache
+              .filter(
+                  stateFromCache ->
+                      stateFromCache.getSlot().compareTo(stateFromDisk.getSlot()) >= 0)
+              .orElse(stateFromDisk);
+      if (preState.getSlot().equals(slot)) {
+        return preState;
+      }
+      try (final Stream<SignedBeaconBlock> blocks =
+          database.streamFinalizedBlocks(preState.getSlot().plus(ONE), slot)) {
+        final BeaconState state = StreamingStateRegenerator.regenerate(preState, blocks);
+        availableSlots.add(state.getSlot());
+        return state;
+      }
+    }
+  }
+
+  /**
+   * Cache doesn't allow returning null but we may not be able to regenerate a state so throw this
+   * exception and catch it in {@link #getFinalizedState(UnsignedLong)}
+   */
+  private static class StateUnavailableException extends RuntimeException {}
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/state/FinalizedStateCacheTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/state/FinalizedStateCacheTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.state;
+
+import static com.google.common.primitives.UnsignedLong.ONE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSKeyGenerator;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.core.ChainBuilder;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.storage.server.Database;
+
+class FinalizedStateCacheTest {
+  private static final int MAXIMUM_CACHE_SIZE = 3;
+  protected static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(3);
+  private final ChainBuilder chainBuilder = ChainBuilder.create(VALIDATOR_KEYS);
+  private final Database database = mock(Database.class);
+  // We don't use soft references in unit tests to avoid intermittency
+  private final FinalizedStateCache cache =
+      new FinalizedStateCache(database, MAXIMUM_CACHE_SIZE, false);
+
+  @BeforeEach
+  public void setUp() {
+    chainBuilder.generateGenesis();
+  }
+
+  @Test
+  void shouldUseCachedStateWhenAvailable() throws Exception {
+    final BeaconState state = chainBuilder.generateBlockAtSlot(ONE).getState();
+    when(database.getLatestAvailableFinalizedState(state.getSlot())).thenReturn(Optional.of(state));
+
+    final Optional<BeaconState> initialResult = cache.getFinalizedState(state.getSlot());
+    assertThat(initialResult).contains(state);
+
+    assertThat(cache.getFinalizedState(state.getSlot())).contains(state);
+    verify(database, times(1)).getLatestAvailableFinalizedState(state.getSlot());
+    verifyNoMoreInteractions(database);
+  }
+
+  @Test
+  void shouldRegenerateFromMoreRecentCachedState() throws Exception {
+    final UnsignedLong databaseSlot = UnsignedLong.valueOf(1);
+    final UnsignedLong cachedSlot = UnsignedLong.valueOf(2);
+    final UnsignedLong requestedSlot = UnsignedLong.valueOf(3);
+    chainBuilder.generateBlocksUpToSlot(requestedSlot);
+
+    // Latest state available from the database is at databaseSlot (1)
+    when(database.getLatestAvailableFinalizedState(any()))
+        .thenReturn(Optional.of(chainBuilder.getStateAtSlot(databaseSlot)));
+    allowStreamingBlocks();
+
+    // Should regenerate the same state
+    assertThat(cache.getFinalizedState(cachedSlot))
+        .contains(chainBuilder.getStateAtSlot(cachedSlot));
+    verify(database).streamFinalizedBlocks(databaseSlot.plus(ONE), cachedSlot);
+
+    // Should only need the blocks from the cached state forward
+    assertThat(cache.getFinalizedState(requestedSlot))
+        .contains(chainBuilder.getStateAtSlot(requestedSlot));
+    verify(database).streamFinalizedBlocks(cachedSlot.plus(ONE), requestedSlot);
+  }
+
+  @Test
+  void shouldLimitNumberOfCachedStates() throws Exception {
+    chainBuilder.generateBlocksUpToSlot(MAXIMUM_CACHE_SIZE + 1);
+    when(database.getLatestAvailableFinalizedState(any()))
+        .thenReturn(Optional.of(chainBuilder.getGenesis().getState()));
+    allowStreamingBlocks();
+
+    // Fill up the cache
+    for (int i = 1; i <= MAXIMUM_CACHE_SIZE; i++) {
+      cache.getFinalizedState(UnsignedLong.valueOf(i));
+    }
+    // Evict the least recently used item (should be genesis state)
+    cache.getFinalizedState(UnsignedLong.valueOf(MAXIMUM_CACHE_SIZE + 1));
+
+    cache.getFinalizedState(ONE);
+    verify(database, times(2)).streamFinalizedBlocks(ONE, ONE);
+  }
+
+  @Test
+  void shouldReturnEmptyWhenStateIsNotAvailable() {
+    when(database.getLatestAvailableFinalizedState(any())).thenReturn(Optional.empty());
+
+    assertThat(cache.getFinalizedState(ONE)).isEmpty();
+  }
+
+  private void allowStreamingBlocks() {
+    when(database.streamFinalizedBlocks(any(), any()))
+        .thenAnswer(
+            invocation ->
+                chainBuilder
+                    .streamBlocksAndStates(invocation.getArgument(0), invocation.getArgument(1))
+                    .map(SignedBlockAndState::getBlock));
+  }
+}


### PR DESCRIPTION
## PR Description
To improve speed of accessing finalised states, cache regenerated states.  Soft references are used so that the states are automatically dropped when memory is tight.

This makes walking forwards through finalised states fast even when there are big gaps between snapshots:
```
$ for SLOT in {1000..0}; do echo -n "$SLOT: "; time curl -s --fail http://localhost:19501/beacon/state\?slot\=$SLOT > /dev/null ; done
SLOT=1000 curl -s --fail http://localhost:19501/beacon/state\?slot\=$SLOT > /dev/null  0.01s user 0.04s system 0% cpu 11.994 total
SLOT=999 curl -s --fail http://localhost:19501/beacon/state\?slot\=$SLOT > /dev/null  0.01s user 0.01s system 0% cpu 12.255 total



$ for SLOT in {1000..1005}; do echo -n "$SLOT: "; time curl -s --fail http://localhost:19501/beacon/state\?slot\=$SLOT > /dev/null ; done
SLOT=1000 curl -s --fail http://localhost:19501/beacon/state\?slot\=$SLOT > /dev/null  0.01s user 0.01s system 6% cpu 0.306 total
SLOT=1001 curl -s --fail http://localhost:19501/beacon/state\?slot\=$SLOT > /dev/null  0.01s user 0.01s system 3% cpu 0.623 total
SLOT=1002 curl -s --fail http://localhost:19501/beacon/state\?slot\=$SLOT > /dev/null  0.01s user 0.01s system 5% cpu 0.331 total
SLOT=1003 curl -s --fail http://localhost:19501/beacon/state\?slot\=$SLOT > /dev/null  0.01s user 0.02s system 4% cpu 0.571 total
SLOT=1004 curl -s --fail http://localhost:19501/beacon/state\?slot\=$SLOT > /dev/null  0.01s user 0.02s system 5% cpu 0.540 total
SLOT=1005 curl -s --fail http://localhost:19501/beacon/state\?slot\=$SLOT > /dev/null  0.01s user 0.02s system 6% cpu 0.434 total
```

## Fixed Issue(s)
fixes #2198 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.