### PR TITLE
Make v4 database the default

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseVersion.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseVersion.java
@@ -21,7 +21,7 @@ public enum DatabaseVersion {
   V3("3.0"),
   V4("4");
 
-  public static final DatabaseVersion DEFAULT_VERSION = DatabaseVersion.V3;
+  public static final DatabaseVersion DEFAULT_VERSION = DatabaseVersion.V4;
   private String value;
 
   DatabaseVersion(final String value) {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/DatabaseVersionTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/DatabaseVersionTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 public class DatabaseVersionTest {
   @Test
   public void defaultVersion() {
-    assertThat(DatabaseVersion.DEFAULT_VERSION).isEqualTo(DatabaseVersion.V3);
+    assertThat(DatabaseVersion.DEFAULT_VERSION).isEqualTo(DatabaseVersion.V4);
   }
 
   @Test

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DataOptions.java
@@ -38,9 +38,8 @@ public class DataOptions {
 
   @Option(
       names = {"--data-storage-archive-frequency"},
-      hidden = true,
       paramLabel = "<FREQUENCY>",
-      description = "Sets the frequency, in slots, at which to store archived states to disk.",
+      description = "Sets the frequency, in slots, at which to store finalized states to disk.",
       arity = "1")
   private long dataStorageFrequency = VersionedDatabaseFactory.DEFAULT_STORAGE_FREQUENCY;
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DataOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DataOptionsTest.java
@@ -71,7 +71,7 @@ public class DataOptionsTest extends AbstractBeaconNodeCommandTest {
   @Test
   public void dataStorageCreateDbVersion_shouldDefault() {
     final TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments();
-    assertThat(tekuConfiguration.getDataStorageCreateDbVersion()).isEqualTo("3.0");
+    assertThat(tekuConfiguration.getDataStorageCreateDbVersion()).isEqualTo("4");
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Make the new v4 database the default as it makes archive mode use a sensible amount of disk space.  v3 is still supported but this way nearly all Altona instances will be on v4.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.