### PR TITLE
Make Altona the default network

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/NetworkOptions.java
@@ -22,7 +22,7 @@ public class NetworkOptions {
       paramLabel = "<NETWORK>",
       description = "Represents which network to use.",
       arity = "1")
-  private String network = "minimal";
+  private String network = "altona";
 
   @Option(
       names = {"--initial-state"},

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -243,6 +243,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
 
   private TekuConfigurationBuilder expectedDefaultConfigurationBuilder() {
     return expectedConfigurationBuilder()
+        .setNetwork(NetworkDefinition.fromCliArg("altona"))
         .setEth1DepositContractAddress(null)
         .setEth1Endpoint(null)
         .setMetricsCategories(

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
@@ -60,7 +60,9 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
   public void eth1Deposit_requiredIfEth1Endpoint() {
-    final String[] args = {"--eth1-endpoint", "http://example.com:1234/path/"};
+    final String[] args = {
+      "--network", "minimal", "--eth1-endpoint", "http://example.com:1234/path/"
+    };
 
     beaconNodeCommand.parse(args);
     final String str = getCommandLineOutput();

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/NetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/NetworkOptionsTest.java
@@ -33,7 +33,7 @@ public class NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @ParameterizedTest(name = "{0}")
-  @ValueSource(strings = {"mainnet", "minimal", "topaz"})
+  @ValueSource(strings = {"mainnet", "minimal", "altona", "onyx"})
   public void useDefaultsFromNetworkDefinition(final String networkName) {
     final NetworkDefinition networkDefinition = NetworkDefinition.fromCliArg(networkName);
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -58,7 +58,7 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     beaconNodeCommand.parse(args);
 
     final TekuConfiguration tekuConfiguration = getResultingTekuConfiguration();
-    assertThat(tekuConfiguration.isP2pSnappyEnabled()).isFalse();
+    assertThat(tekuConfiguration.isP2pSnappyEnabled()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## PR Description
The most likely network users will want to use at the moment is Altona so set that as the default.  Currently it still requires an eth1 endpoint but once we have an Altona genesis, just running `teku` with no args will be enough to start it syncing.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.