### PR TITLE
Fix fork choice update head race condition

### DIFF
--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategy.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategy.java
@@ -20,8 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.forkchoice.ForkChoiceState;
 import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
@@ -77,22 +75,22 @@ public class ProtoArrayForkChoiceStrategy implements ForkChoiceState {
 
   @Override
   public Bytes32 getHead() {
-      // justifiedCheckpoint is guarded by justifiedCheckpoint
-      return protoArray.findHead(justifiedCheckpoint.getRoot());
+    // justifiedCheckpoint is guarded by justifiedCheckpoint
+    return protoArray.findHead(justifiedCheckpoint.getRoot());
   }
 
   @VisibleForTesting
   public void setPruneThreshold(int pruneThreshold) {
-      protoArray.setPruneThreshold(pruneThreshold);
+    protoArray.setPruneThreshold(pruneThreshold);
   }
 
   public int size() {
-      return protoArray.getNodes().size();
+    return protoArray.getNodes().size();
   }
 
   @Override
   public boolean containsBlock(Bytes32 blockRoot) {
-      return protoArray.getIndices().containsKey(blockRoot);
+    return protoArray.getIndices().containsKey(blockRoot);
   }
 
   @Override
@@ -102,7 +100,7 @@ public class ProtoArrayForkChoiceStrategy implements ForkChoiceState {
 
   @Override
   public Optional<Bytes32> getBlockParent(Bytes32 blockRoot) {
-      return getProtoNode(blockRoot).map(ProtoNode::getParentRoot);
+    return getProtoNode(blockRoot).map(ProtoNode::getParentRoot);
   }
 
   public ProtoArrayForkChoiceStrategyUpdater updater() {

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategy.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategy.java
@@ -29,9 +29,6 @@ import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.util.config.Constants;
 
 public class ProtoArrayForkChoiceStrategy implements ForkChoiceState {
-  final ReadWriteLock protoArrayLock = new ReentrantReadWriteLock();
-  final ReadWriteLock votesLock = new ReentrantReadWriteLock();
-  final ReadWriteLock balancesLock = new ReentrantReadWriteLock();
   final ProtoArray protoArray;
 
   Checkpoint justifiedCheckpoint;
@@ -80,62 +77,32 @@ public class ProtoArrayForkChoiceStrategy implements ForkChoiceState {
 
   @Override
   public Bytes32 getHead() {
-    protoArrayLock.readLock().lock();
-    try {
       // justifiedCheckpoint is guarded by justifiedCheckpoint
       return protoArray.findHead(justifiedCheckpoint.getRoot());
-    } finally {
-      protoArrayLock.readLock().unlock();
-    }
   }
 
   @VisibleForTesting
   public void setPruneThreshold(int pruneThreshold) {
-    protoArrayLock.writeLock().lock();
-    try {
       protoArray.setPruneThreshold(pruneThreshold);
-    } finally {
-      protoArrayLock.writeLock().unlock();
-    }
   }
 
   public int size() {
-    protoArrayLock.readLock().lock();
-    try {
       return protoArray.getNodes().size();
-    } finally {
-      protoArrayLock.readLock().unlock();
-    }
   }
 
   @Override
   public boolean containsBlock(Bytes32 blockRoot) {
-    protoArrayLock.readLock().lock();
-    try {
       return protoArray.getIndices().containsKey(blockRoot);
-    } finally {
-      protoArrayLock.readLock().unlock();
-    }
   }
 
   @Override
   public Optional<UnsignedLong> getBlockSlot(Bytes32 blockRoot) {
-    protoArrayLock.readLock().lock();
-    try {
-      return getProtoNode(blockRoot).map(ProtoNode::getBlockSlot);
-    } finally {
-      protoArrayLock.readLock().unlock();
-    }
+    return getProtoNode(blockRoot).map(ProtoNode::getBlockSlot);
   }
 
   @Override
   public Optional<Bytes32> getBlockParent(Bytes32 blockRoot) {
-    protoArrayLock.readLock().lock();
-    try {
       return getProtoNode(blockRoot).map(ProtoNode::getParentRoot);
-    } finally {
-      protoArrayLock.readLock().unlock();
-    }
   }
 
   public ProtoArrayForkChoiceStrategyUpdater updater() {

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategyUpdater.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategyUpdater.java
@@ -94,15 +94,15 @@ public class ProtoArrayForkChoiceStrategyUpdater implements MutableForkChoiceSta
       final BeaconState justifiedCheckpointState) {
     checkState(headUpdates.isEmpty(), "Head is already updated");
 
-      List<UnsignedLong> oldBalances = forkChoice.balances;
-      List<UnsignedLong> newBalances = justifiedCheckpointState.getBalances().asList();
+    List<UnsignedLong> oldBalances = forkChoice.balances;
+    List<UnsignedLong> newBalances = justifiedCheckpointState.getBalances().asList();
 
-      List<Long> deltas =
-          computeDeltas(votes, forkChoice.protoArray.getIndices(), oldBalances, newBalances);
-      this.headUpdates =
-          Optional.of(
-              new HeadUpdates(
-                  finalizedCheckpoint, justifiedCheckpoint, justifiedCheckpointState, deltas));
+    List<Long> deltas =
+        computeDeltas(votes, forkChoice.protoArray.getIndices(), oldBalances, newBalances);
+    this.headUpdates =
+        Optional.of(
+            new HeadUpdates(
+                finalizedCheckpoint, justifiedCheckpoint, justifiedCheckpointState, deltas));
   }
 
   @Override
@@ -141,16 +141,16 @@ public class ProtoArrayForkChoiceStrategyUpdater implements MutableForkChoiceSta
 
   @VisibleForTesting
   void updateForkChoiceWeights(final HeadUpdates headUpdates) {
-      final Checkpoint justifiedCheckpoint = headUpdates.getJustifiedCheckpoint();
-      final Checkpoint finalizedCheckpoint = headUpdates.getFinalizedCheckpoint();
-      final BeaconState justifiedState = headUpdates.getJustifiedCheckpointState();
-      final List<UnsignedLong> newBalances = justifiedState.getBalances().asList();
-      final List<Long> deltas = headUpdates.getWeightChanges();
+    final Checkpoint justifiedCheckpoint = headUpdates.getJustifiedCheckpoint();
+    final Checkpoint finalizedCheckpoint = headUpdates.getFinalizedCheckpoint();
+    final BeaconState justifiedState = headUpdates.getJustifiedCheckpointState();
+    final List<UnsignedLong> newBalances = justifiedState.getBalances().asList();
+    final List<Long> deltas = headUpdates.getWeightChanges();
 
-      forkChoice.justifiedCheckpoint = headUpdates.getJustifiedCheckpoint();
-      forkChoice.protoArray.applyScoreChanges(
-          deltas, justifiedCheckpoint.getEpoch(), finalizedCheckpoint.getEpoch());
-      forkChoice.balances = new ArrayList<>(newBalances);
+    forkChoice.justifiedCheckpoint = headUpdates.getJustifiedCheckpoint();
+    forkChoice.protoArray.applyScoreChanges(
+        deltas, justifiedCheckpoint.getEpoch(), finalizedCheckpoint.getEpoch());
+    forkChoice.balances = new ArrayList<>(newBalances);
   }
 
   @VisibleForTesting
@@ -161,8 +161,8 @@ public class ProtoArrayForkChoiceStrategyUpdater implements MutableForkChoiceSta
       Bytes32 stateRoot,
       UnsignedLong justifiedEpoch,
       UnsignedLong finalizedEpoch) {
-      forkChoice.protoArray.onBlock(
-          blockSlot, blockRoot, parentRoot, stateRoot, justifiedEpoch, finalizedEpoch);
+    forkChoice.protoArray.onBlock(
+        blockSlot, blockRoot, parentRoot, stateRoot, justifiedEpoch, finalizedEpoch);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -684,8 +684,7 @@ class Store implements UpdatableStore {
 
     @Override
     public void updateHead() {
-      final Lock writeLock = Store.this.lock.writeLock();
-      writeLock.lock();
+      readLock.lock();
       try {
         final Checkpoint finalized = getFinalizedCheckpoint();
         final Checkpoint justified = getJustifiedCheckpoint();
@@ -693,7 +692,7 @@ class Store implements UpdatableStore {
         forkChoiceUpdater.updateHead(finalized, justified, justifiedState);
         this.headUpdated = true;
       } finally {
-        writeLock.unlock();
+        readLock.unlock();
       }
     }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -684,11 +684,17 @@ class Store implements UpdatableStore {
 
     @Override
     public void updateHead() {
-      final Checkpoint finalized = getFinalizedCheckpoint();
-      final Checkpoint justified = getJustifiedCheckpoint();
-      final BeaconState justifiedState = getCheckpointState(justified);
-      forkChoiceUpdater.updateHead(finalized, justified, justifiedState);
-      this.headUpdated = true;
+      final Lock writeLock = Store.this.lock.writeLock();
+      writeLock.lock();
+      try {
+        final Checkpoint finalized = getFinalizedCheckpoint();
+        final Checkpoint justified = getJustifiedCheckpoint();
+        final BeaconState justifiedState = getCheckpointState(justified);
+        forkChoiceUpdater.updateHead(finalized, justified, justifiedState);
+        this.headUpdated = true;
+      } finally {
+        writeLock.unlock();
+      }
     }
 
     @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fixes the race condition that resulted in `java.lang.IllegalArgumentException: ProtoArray: Invalid delta length`

`Store.updateHead` method, which updates our head block using our `ForkChoiceStrategy` and manipulates internal Store variables when doing so, previously did not have any read or write locks as it accessed and manipulated the Store state. Since this method reads and adds writes to be committed during the `commit` method of the Transaction, it has to make sure that it doesn't read a state that might be now redundant. For that, it needs to obtain a read lock.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes https://github.com/PegaSysEng/teku/issues/2224, https://github.com/PegaSysEng/teku/issues/2208, https://github.com/PegaSysEng/teku/issues/2215

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.