### PR TITLE
Set the user agent for Web3j requests

### DIFF
--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.storage.api.Eth1DepositStorageChannel;
 import tech.pegasys.teku.util.async.AsyncRunner;
 import tech.pegasys.teku.util.async.SafeFuture;
+import tech.pegasys.teku.util.cli.VersionProvider;
 import tech.pegasys.teku.util.config.TekuConfiguration;
 
 public class PowchainService extends Service {
@@ -47,7 +48,9 @@ public class PowchainService extends Service {
 
     AsyncRunner asyncRunner = config.createAsyncRunner("powchain");
 
-    Web3j web3j = Web3j.build(new HttpService(tekuConfig.getEth1Endpoint()));
+    final HttpService web3jService = new HttpService(tekuConfig.getEth1Endpoint());
+    web3jService.addHeader("User-Agent", VersionProvider.VERSION);
+    Web3j web3j = Web3j.build(web3jService);
 
     final Eth1Provider eth1Provider =
         new ThrottlingEth1Provider(


### PR DESCRIPTION
## PR Description
Set the user agent header when sending web3j HTTP requests so we can identify them as coming from teku. Not strictly required but it's just good behaviour for web user agents.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.