### PR TITLE
tweak write buffer down to 128MB after some extra testing

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbConfiguration.java
@@ -23,7 +23,7 @@ public class RocksDbConfiguration {
   public static final int DEFAULT_MAX_BACKGROUND_COMPACTIONS = 4;
   public static final int DEFAULT_BACKGROUND_THREAD_COUNT = 4;
   public static final long DEFAULT_CACHE_CAPACITY = 8 << 20;
-  public static final long DEFAULT_WRITE_BUFFER_CAPACITY = 256 << 20;
+  public static final long DEFAULT_WRITE_BUFFER_CAPACITY = 128 << 20;
 
   private final Path databaseDir;
   private final int maxOpenFiles;


### PR DESCRIPTION

When testing with 256MB write buffer, we get into a weird situation where the write buffer uses over 1GB of disk, then goes back down. Seen around slot 34000 on witti syncing.

When i reduced the write buffer to 128MB, the disk usage doesn't seem to spike like that, it goes a little way forward then goes back to a better level. It also doesn't have a whole stack of flushes, though there's a couple a minute. This should be a good starting point, but it may need to be a user settable feature in the future.

The archive database definitely doesn't need a large write buffer, so we should also consider reducing that to around 16MB by default, but that was not done in this PR.

Signed-off-by: Paul Harris <paul.harris@consensys.net>


## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.