### PR TITLE
Report internal RocksDB metrics via our metrics system

### DIFF
--- a/data/metrics/src/main/java/tech/pegasys/teku/metrics/TekuMetricCategory.java
+++ b/data/metrics/src/main/java/tech/pegasys/teku/metrics/TekuMetricCategory.java
@@ -23,6 +23,8 @@ public enum TekuMetricCategory implements MetricCategory {
   LIBP2P("libp2p"),
   NETWORK("network"),
   STORAGE("storage"),
+  STORAGE_HOT_DB("storage_hot"),
+  STORAGE_FINALIZED_DB("storage_finalized"),
   VALIDATOR("validator");
 
   private final String name;

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -123,8 +123,9 @@ dependencyManagement {
 
     dependency 'org.xerial.snappy:snappy-java:1.1.7.3'
 
-    dependency 'org.hyperledger.besu.internal:metrics-core:1.3.4'
-    dependency 'org.hyperledger.besu:plugin-api:1.3.4'
+    dependency 'io.prometheus:simpleclient:0.9.0'
+    dependency 'org.hyperledger.besu.internal:metrics-core:1.4.5'
+    dependency 'org.hyperledger.besu:plugin-api:1.4.5'
 
     dependency "org.testcontainers:testcontainers:1.12.3"
     dependency "org.testcontainers:junit-jupiter:1.12.3"

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -12,9 +12,11 @@ dependencies {
 
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+  implementation 'io.prometheus:simpleclient'
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-kv'
   implementation 'org.apache.tuweni:tuweni-ssz'
+  implementation 'org.hyperledger.besu.internal:metrics-core'
   implementation 'org.hyperledger.besu:plugin-api'
   implementation 'org.mapdb:mapdb'
   implementation 'org.rocksdb:rocksdbjni'

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.storage.server.rocksdb;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static tech.pegasys.teku.metrics.TekuMetricCategory.STORAGE_FINALIZED_DB;
+import static tech.pegasys.teku.metrics.TekuMetricCategory.STORAGE_HOT_DB;
 
 import com.google.common.primitives.UnsignedLong;
 import com.google.errorprone.annotations.MustBeClosed;
@@ -65,7 +67,8 @@ public class RocksDbDatabase implements Database {
       final MetricsSystem metricsSystem,
       final RocksDbConfiguration configuration,
       final StateStorageMode stateStorageMode) {
-    final RocksDbAccessor db = RocksDbInstanceFactory.create(configuration, V3Schema.class);
+    final RocksDbAccessor db =
+        RocksDbInstanceFactory.create(metricsSystem, STORAGE_HOT_DB, configuration, V3Schema.class);
     return createV3(metricsSystem, db, stateStorageMode);
   }
 
@@ -76,9 +79,11 @@ public class RocksDbDatabase implements Database {
       final StateStorageMode stateStorageMode,
       final long stateStorageFrequency) {
     final RocksDbAccessor hotDb =
-        RocksDbInstanceFactory.create(hotConfiguration, V4SchemaHot.class);
+        RocksDbInstanceFactory.create(
+            metricsSystem, STORAGE_HOT_DB, hotConfiguration, V4SchemaHot.class);
     final RocksDbAccessor finalizedDb =
-        RocksDbInstanceFactory.create(finalizedConfiguration, V4SchemaFinalized.class);
+        RocksDbInstanceFactory.create(
+            metricsSystem, STORAGE_FINALIZED_DB, finalizedConfiguration, V4SchemaFinalized.class);
     return createV4(metricsSystem, hotDb, finalizedDb, stateStorageMode, stateStorageFrequency);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstanceFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstanceFactory.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
@@ -28,6 +30,7 @@ import org.rocksdb.DBOptions;
 import org.rocksdb.Env;
 import org.rocksdb.LRUCache;
 import org.rocksdb.RocksDBException;
+import org.rocksdb.Statistics;
 import org.rocksdb.TransactionDB;
 import org.rocksdb.TransactionDBOptions;
 import tech.pegasys.teku.storage.server.DatabaseStorageException;
@@ -41,16 +44,20 @@ public class RocksDbInstanceFactory {
   }
 
   public static RocksDbAccessor create(
-      final RocksDbConfiguration configuration, final Class<? extends Schema> schema)
+      final MetricsSystem metricsSystem,
+      final MetricCategory metricCategory,
+      final RocksDbConfiguration configuration,
+      final Class<? extends Schema> schema)
       throws DatabaseStorageException {
     // Track resources that need to be closed
 
     // Create options
     final TransactionDBOptions txOptions = new TransactionDBOptions();
-    final DBOptions dbOptions = createDBOptions(configuration);
+    final Statistics stats = new Statistics();
+    final DBOptions dbOptions = createDBOptions(configuration, stats);
     final ColumnFamilyOptions columnFamilyOptions = createColumnFamilyOptions(configuration);
     final List<AutoCloseable> resources =
-        new ArrayList<>(List.of(txOptions, dbOptions, columnFamilyOptions));
+        new ArrayList<>(List.of(txOptions, dbOptions, columnFamilyOptions, stats));
 
     List<ColumnFamilyDescriptor> columnDescriptors =
         createColumnFamilyDescriptors(schema, columnFamilyOptions);
@@ -85,6 +92,8 @@ public class RocksDbInstanceFactory {
       final ColumnFamilyHandle defaultHandle = getDefaultHandle(columnHandles);
       resources.add(db);
 
+      RocksDbStats.registerRocksDBMetrics(stats, metricsSystem, metricCategory);
+
       return new RocksDbInstance(db, defaultHandle, columnHandlesMap, resources);
     } catch (RocksDBException e) {
       throw new DatabaseStorageException(
@@ -106,7 +115,8 @@ public class RocksDbInstanceFactory {
         .orElseThrow(() -> new DatabaseStorageException("No default column defined"));
   }
 
-  private static DBOptions createDBOptions(final RocksDbConfiguration configuration) {
+  private static DBOptions createDBOptions(
+      final RocksDbConfiguration configuration, final Statistics stats) {
     return new DBOptions()
         .setCreateIfMissing(true)
         .setBytesPerSync(1048576L)
@@ -116,7 +126,8 @@ public class RocksDbInstanceFactory {
         .setMaxOpenFiles(configuration.getMaxOpenFiles())
         .setMaxBackgroundCompactions(configuration.getMaxBackgroundCompactions())
         .setCreateMissingColumnFamilies(true)
-        .setEnv(Env.getDefault().setBackgroundThreads(configuration.getBackgroundThreadCount()));
+        .setEnv(Env.getDefault().setBackgroundThreads(configuration.getBackgroundThreadCount()))
+        .setStatistics(stats);
   }
 
   private static ColumnFamilyOptions createColumnFamilyOptions(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbStats.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbStats.java
@@ -25,6 +25,10 @@ import org.rocksdb.HistogramType;
 import org.rocksdb.Statistics;
 import org.rocksdb.TickerType;
 
+/**
+ * Taken from
+ * https://github.com/hyperledger/besu/blob/3d867532deb893fd267fcd5d4e6bf0d42a76e59b/metrics/rocksdb/src/main/java/org/hyperledger/besu/metrics/rocksdb/RocksDBStats.java#L137
+ */
 public class RocksDbStats {
 
   static final List<String> LABELS = Collections.singletonList("quantile");

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbStats.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbStats.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.rocksdb.core;
+
+import io.prometheus.client.Collector;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
+import org.rocksdb.HistogramData;
+import org.rocksdb.HistogramType;
+import org.rocksdb.Statistics;
+import org.rocksdb.TickerType;
+
+public class RocksDbStats {
+
+  static final List<String> LABELS = Collections.singletonList("quantile");
+  static final List<String> LABEL_50 = Collections.singletonList("0.5");
+  static final List<String> LABEL_95 = Collections.singletonList("0.95");
+  static final List<String> LABEL_99 = Collections.singletonList("0.99");
+
+  // Tickers - RocksDB equivalent of counters
+  static final TickerType[] TICKERS = {
+    TickerType.BLOCK_CACHE_ADD,
+    TickerType.BLOCK_CACHE_HIT,
+    TickerType.BLOCK_CACHE_ADD_FAILURES,
+    TickerType.BLOCK_CACHE_INDEX_MISS,
+    TickerType.BLOCK_CACHE_INDEX_HIT,
+    TickerType.BLOCK_CACHE_INDEX_ADD,
+    TickerType.BLOCK_CACHE_INDEX_BYTES_INSERT,
+    TickerType.BLOCK_CACHE_INDEX_BYTES_EVICT,
+    TickerType.BLOCK_CACHE_FILTER_MISS,
+    TickerType.BLOCK_CACHE_FILTER_HIT,
+    TickerType.BLOCK_CACHE_FILTER_ADD,
+    TickerType.BLOCK_CACHE_FILTER_BYTES_INSERT,
+    TickerType.BLOCK_CACHE_FILTER_BYTES_EVICT,
+    TickerType.BLOCK_CACHE_DATA_MISS,
+    TickerType.BLOCK_CACHE_DATA_HIT,
+    TickerType.BLOCK_CACHE_DATA_ADD,
+    TickerType.BLOCK_CACHE_DATA_BYTES_INSERT,
+    TickerType.BLOCK_CACHE_BYTES_READ,
+    TickerType.BLOCK_CACHE_BYTES_WRITE,
+    TickerType.BLOOM_FILTER_USEFUL,
+    TickerType.PERSISTENT_CACHE_HIT,
+    TickerType.PERSISTENT_CACHE_MISS,
+    TickerType.SIM_BLOCK_CACHE_HIT,
+    TickerType.SIM_BLOCK_CACHE_MISS,
+    TickerType.MEMTABLE_HIT,
+    TickerType.MEMTABLE_MISS,
+    TickerType.GET_HIT_L0,
+    TickerType.GET_HIT_L1,
+    TickerType.GET_HIT_L2_AND_UP,
+    TickerType.COMPACTION_KEY_DROP_NEWER_ENTRY,
+    TickerType.COMPACTION_KEY_DROP_OBSOLETE,
+    TickerType.COMPACTION_KEY_DROP_RANGE_DEL,
+    TickerType.COMPACTION_KEY_DROP_USER,
+    TickerType.COMPACTION_RANGE_DEL_DROP_OBSOLETE,
+    TickerType.NUMBER_KEYS_WRITTEN,
+    TickerType.NUMBER_KEYS_READ,
+    TickerType.NUMBER_KEYS_UPDATED,
+    TickerType.BYTES_WRITTEN,
+    TickerType.BYTES_READ,
+    TickerType.NUMBER_DB_SEEK,
+    TickerType.NUMBER_DB_NEXT,
+    TickerType.NUMBER_DB_PREV,
+    TickerType.NUMBER_DB_SEEK_FOUND,
+    TickerType.NUMBER_DB_NEXT_FOUND,
+    TickerType.NUMBER_DB_PREV_FOUND,
+    TickerType.ITER_BYTES_READ,
+    TickerType.NO_FILE_CLOSES,
+    TickerType.NO_FILE_OPENS,
+    TickerType.NO_FILE_ERRORS,
+    // TickerType.STALL_L0_SLOWDOWN_MICROS,
+    // TickerType.STALL_MEMTABLE_COMPACTION_MICROS,
+    // TickerType.STALL_L0_NUM_FILES_MICROS,
+    TickerType.STALL_MICROS,
+    TickerType.DB_MUTEX_WAIT_MICROS,
+    TickerType.RATE_LIMIT_DELAY_MILLIS,
+    TickerType.NO_ITERATORS,
+    TickerType.NUMBER_MULTIGET_BYTES_READ,
+    TickerType.NUMBER_MULTIGET_KEYS_READ,
+    TickerType.NUMBER_MULTIGET_CALLS,
+    TickerType.NUMBER_FILTERED_DELETES,
+    TickerType.NUMBER_MERGE_FAILURES,
+    TickerType.BLOOM_FILTER_PREFIX_CHECKED,
+    TickerType.BLOOM_FILTER_PREFIX_USEFUL,
+    TickerType.NUMBER_OF_RESEEKS_IN_ITERATION,
+    TickerType.GET_UPDATES_SINCE_CALLS,
+    TickerType.BLOCK_CACHE_COMPRESSED_MISS,
+    TickerType.BLOCK_CACHE_COMPRESSED_HIT,
+    TickerType.BLOCK_CACHE_COMPRESSED_ADD,
+    TickerType.BLOCK_CACHE_COMPRESSED_ADD_FAILURES,
+    TickerType.WAL_FILE_SYNCED,
+    TickerType.WAL_FILE_BYTES,
+    TickerType.WRITE_DONE_BY_SELF,
+    TickerType.WRITE_DONE_BY_OTHER,
+    TickerType.WRITE_TIMEDOUT,
+    TickerType.WRITE_WITH_WAL,
+    TickerType.COMPACT_READ_BYTES,
+    TickerType.COMPACT_WRITE_BYTES,
+    TickerType.FLUSH_WRITE_BYTES,
+    TickerType.NUMBER_DIRECT_LOAD_TABLE_PROPERTIES,
+    TickerType.NUMBER_SUPERVERSION_ACQUIRES,
+    TickerType.NUMBER_SUPERVERSION_RELEASES,
+    TickerType.NUMBER_SUPERVERSION_CLEANUPS,
+    TickerType.NUMBER_BLOCK_COMPRESSED,
+    TickerType.NUMBER_BLOCK_DECOMPRESSED,
+    TickerType.NUMBER_BLOCK_NOT_COMPRESSED,
+    TickerType.MERGE_OPERATION_TOTAL_TIME,
+    TickerType.FILTER_OPERATION_TOTAL_TIME,
+    TickerType.ROW_CACHE_HIT,
+    TickerType.ROW_CACHE_MISS,
+    TickerType.READ_AMP_ESTIMATE_USEFUL_BYTES,
+    TickerType.READ_AMP_TOTAL_READ_BYTES,
+    TickerType.NUMBER_RATE_LIMITER_DRAINS,
+    TickerType.NUMBER_ITER_SKIP,
+    TickerType.NUMBER_MULTIGET_KEYS_FOUND,
+  };
+
+  // Histograms - treated as prometheus summaries
+  static final HistogramType[] HISTOGRAMS = {
+    HistogramType.DB_GET,
+    HistogramType.DB_WRITE,
+    HistogramType.COMPACTION_TIME,
+    HistogramType.SUBCOMPACTION_SETUP_TIME,
+    HistogramType.TABLE_SYNC_MICROS,
+    HistogramType.COMPACTION_OUTFILE_SYNC_MICROS,
+    HistogramType.WAL_FILE_SYNC_MICROS,
+    HistogramType.MANIFEST_FILE_SYNC_MICROS,
+    HistogramType.TABLE_OPEN_IO_MICROS,
+    HistogramType.DB_MULTIGET,
+    HistogramType.READ_BLOCK_COMPACTION_MICROS,
+    HistogramType.READ_BLOCK_GET_MICROS,
+    HistogramType.WRITE_RAW_BLOCK_MICROS,
+    HistogramType.STALL_L0_SLOWDOWN_COUNT,
+    HistogramType.STALL_MEMTABLE_COMPACTION_COUNT,
+    HistogramType.STALL_L0_NUM_FILES_COUNT,
+    HistogramType.HARD_RATE_LIMIT_DELAY_COUNT,
+    HistogramType.SOFT_RATE_LIMIT_DELAY_COUNT,
+    HistogramType.NUM_FILES_IN_SINGLE_COMPACTION,
+    HistogramType.DB_SEEK,
+    HistogramType.WRITE_STALL,
+    HistogramType.SST_READ_MICROS,
+    HistogramType.NUM_SUBCOMPACTIONS_SCHEDULED,
+    HistogramType.BYTES_PER_READ,
+    HistogramType.BYTES_PER_WRITE,
+    HistogramType.BYTES_PER_MULTIGET,
+    HistogramType.BYTES_COMPRESSED,
+    HistogramType.BYTES_DECOMPRESSED,
+    HistogramType.COMPRESSION_TIMES_NANOS,
+    HistogramType.DECOMPRESSION_TIMES_NANOS,
+    HistogramType.READ_NUM_MERGE_OPERANDS,
+  };
+
+  public static void registerRocksDBMetrics(
+      final Statistics stats, final MetricsSystem metricsSystem, final MetricCategory category) {
+    for (final TickerType ticker : TICKERS) {
+      final String promCounterName = ticker.name().toLowerCase();
+      metricsSystem.createLongGauge(
+          category,
+          promCounterName,
+          "RocksDB reported statistics for " + ticker.name(),
+          () -> stats.getTickerCount(ticker));
+    }
+
+    if (metricsSystem instanceof PrometheusMetricsSystem) {
+      for (final HistogramType histogram : HISTOGRAMS) {
+        ((PrometheusMetricsSystem) metricsSystem)
+            .addCollector(category, histogramToCollector(category, stats, histogram));
+      }
+    }
+  }
+
+  private static Collector histogramToCollector(
+      final MetricCategory metricCategory, final Statistics stats, final HistogramType histogram) {
+    return new Collector() {
+      final String metricName =
+          metricCategory.getApplicationPrefix().orElse("")
+              + metricCategory.getName()
+              + "_"
+              + histogram.name().toLowerCase();
+
+      @Override
+      public List<MetricFamilySamples> collect() {
+        final HistogramData data = stats.getHistogramData(histogram);
+        return Collections.singletonList(
+            new MetricFamilySamples(
+                metricName,
+                Type.SUMMARY,
+                "RocksDB histogram for " + metricName,
+                Arrays.asList(
+                    new MetricFamilySamples.Sample(metricName, LABELS, LABEL_50, data.getMedian()),
+                    new MetricFamilySamples.Sample(
+                        metricName, LABELS, LABEL_95, data.getPercentile95()),
+                    new MetricFamilySamples.Sample(
+                        metricName, LABELS, LABEL_99, data.getPercentile99()))));
+      }
+    };
+  }
+}


### PR DESCRIPTION
## PR Description
So that we get better insight into what RocksDB is doing and how it affects our memory, cpu and disk usage, report RocksDB statistics out via our prometheus metrics.

## Fixed Issue(s)
fixes #2214 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.