### PR TITLE
Avoid reprocessing the last stored deposit block on startup

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/genesis/GenesisHandler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/genesis/GenesisHandler.java
@@ -19,6 +19,8 @@ import static tech.pegasys.teku.logging.StatusLogger.STATUS_LOG;
 import com.google.common.primitives.UnsignedLong;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.operations.DepositWithIndex;
 import tech.pegasys.teku.datastructures.state.BeaconState;
@@ -32,7 +34,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.util.config.Constants;
 
 public class GenesisHandler implements Eth1EventsChannel {
-
+  private static final Logger LOG = LogManager.getLogger();
   private final RecentChainData recentChainData;
   private final GenesisGenerator genesisGenerator = new GenesisGenerator();
 
@@ -46,6 +48,8 @@ public class GenesisHandler implements Eth1EventsChannel {
       return;
     }
 
+    LOG.trace(
+        "Processing {} deposits from block {}", event.getDeposits().size(), event.getBlockNumber());
     final List<DepositWithIndex> deposits =
         event.getDeposits().stream()
             .map(DepositUtil::convertDepositEventToOperationDeposit)

--- a/pow/src/main/java/tech/pegasys/teku/pow/DepositProcessingController.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/DepositProcessingController.java
@@ -78,11 +78,6 @@ public class DepositProcessingController {
     headTracker.unsubscribe(newBlockSubscription);
   }
 
-  // Inclusive
-  public synchronized SafeFuture<Void> fetchDepositsFromGenesisTo(BigInteger toBlockNumber) {
-    return depositFetcher.fetchDepositsInRange(BigInteger.ZERO, toBlockNumber);
-  }
-
   // inclusive
   public synchronized SafeFuture<Void> fetchDepositsInRange(
       final BigInteger fromBlockNumber, final BigInteger toBlockNumber) {

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1DepositManager.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1DepositManager.java
@@ -72,8 +72,8 @@ public class Eth1DepositManager {
 
   private SafeFuture<Void> processStart(
       final EthBlock.Block headBlock, final ReplayDepositsResult replayDepositsResult) {
-    BigInteger startBlockNumber = replayDepositsResult.getBlockNumber();
-    if (headBlock.getNumber().compareTo(startBlockNumber) > 0) {
+    BigInteger startBlockNumber = replayDepositsResult.getFirstUnprocessedBlockNumber();
+    if (headBlock.getNumber().compareTo(startBlockNumber) >= 0) {
       if (isBlockAfterMinGenesis(headBlock)) {
         return headAfterMinGenesisMode(headBlock, replayDepositsResult);
       } else {
@@ -84,7 +84,8 @@ public class Eth1DepositManager {
     if (replayDepositsResult.isPastMinGenesisBlock()) {
       depositProcessingController.startSubscription(startBlockNumber);
     } else {
-      preGenesisSubscription(startBlockNumber);
+      // preGenesisSubscription starts processing from the next block
+      preGenesisSubscription(replayDepositsResult.getLastProcessedBlockNumber());
     }
     return SafeFuture.COMPLETE;
   }
@@ -93,7 +94,9 @@ public class Eth1DepositManager {
       final EthBlock.Block headBlock, final BigInteger startBlockNumber) {
     LOG.debug("Eth1DepositsManager initiating head before genesis mode");
     BigInteger headBlockNumber = headBlock.getNumber();
-    if (startBlockNumber.compareTo(headBlockNumber) < 0) {
+    // Ensure we have processed all blocks up to and including headBlock
+    // preGenesisSubscription will then pick up from the block after headBlock
+    if (startBlockNumber.compareTo(headBlockNumber) <= 0) {
       return depositProcessingController
           .fetchDepositsInRange(startBlockNumber, headBlockNumber)
           .thenRun(() -> preGenesisSubscription(headBlockNumber));
@@ -103,9 +106,9 @@ public class Eth1DepositManager {
     return SafeFuture.COMPLETE;
   }
 
-  private void preGenesisSubscription(final BigInteger headBlockNumber) {
+  private void preGenesisSubscription(final BigInteger lastProcessedBlockNumber) {
     depositProcessingController.switchToBlockByBlockMode();
-    depositProcessingController.startSubscription(headBlockNumber.add(BigInteger.ONE));
+    depositProcessingController.startSubscription(lastProcessedBlockNumber.add(BigInteger.ONE));
   }
 
   private SafeFuture<Void> headAfterMinGenesisMode(
@@ -113,17 +116,21 @@ public class Eth1DepositManager {
     LOG.debug("Eth1DepositsManager initiating head after genesis mode");
 
     if (replayDepositsResult.isPastMinGenesisBlock()) {
-      depositProcessingController.startSubscription(replayDepositsResult.getBlockNumber());
+      depositProcessingController.startSubscription(
+          replayDepositsResult.getFirstUnprocessedBlockNumber());
       return SafeFuture.COMPLETE;
     }
 
     return minimumGenesisTimeBlockFinder
-        .findMinGenesisTimeBlockInHistory(headBlock)
+        .findMinGenesisTimeBlockInHistory(headBlock.getNumber())
         .thenCompose(block -> sendDepositsUpToMinGenesis(block, replayDepositsResult))
         .thenAccept(
             minGenesisTimeBlock -> {
               notifyMinGenesisTimeBlockReached(eth1EventsChannel, minGenesisTimeBlock);
-              depositProcessingController.startSubscription(minGenesisTimeBlock.getNumber());
+              // Start the subscription from the block after min genesis as we've already processed
+              // the min genesis block
+              depositProcessingController.startSubscription(
+                  minGenesisTimeBlock.getNumber().add(BigInteger.ONE));
             });
   }
 
@@ -131,7 +138,7 @@ public class Eth1DepositManager {
       final EthBlock.Block minGenesisTimeBlock, final ReplayDepositsResult replayDepositsResult) {
     return depositProcessingController
         .fetchDepositsInRange(
-            replayDepositsResult.getBlockNumber(), minGenesisTimeBlock.getNumber())
+            replayDepositsResult.getFirstUnprocessedBlockNumber(), minGenesisTimeBlock.getNumber())
         .thenApply(__ -> minGenesisTimeBlock);
   }
 

--- a/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
@@ -42,11 +42,12 @@ public class MinimumGenesisTimeBlockFinder {
   /**
    * Find first block in history that has timestamp greater than MIN_GENESIS_TIME
    *
-   * @param headBlock block at current chain head
+   * @param headBlockNumber block number at current chain head (respecting follow distance)
    * @return min genesis time block
    */
-  public SafeFuture<EthBlock.Block> findMinGenesisTimeBlockInHistory(EthBlock.Block headBlock) {
-    return binarySearchLoop(new SearchContext(headBlock));
+  public SafeFuture<EthBlock.Block> findMinGenesisTimeBlockInHistory(
+      final BigInteger headBlockNumber) {
+    return binarySearchLoop(new SearchContext(headBlockNumber));
   }
 
   private SafeFuture<EthBlock.Block> binarySearchLoop(final SearchContext searchContext) {
@@ -109,8 +110,8 @@ public class MinimumGenesisTimeBlockFinder {
     private UnsignedLong low = UnsignedLong.ZERO;
     private UnsignedLong high;
 
-    public SearchContext(final EthBlock.Block chainHead) {
-      this.high = UnsignedLong.valueOf(chainHead.getNumber());
+    public SearchContext(final BigInteger headBlockNumber) {
+      this.high = UnsignedLong.valueOf(headBlockNumber);
     }
   }
 }

--- a/pow/src/test/java/tech/pegasys/teku/pow/Eth1DepositManagerTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/Eth1DepositManagerTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.pow;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.util.async.SafeFuture.COMPLETE;
+
+import com.google.common.primitives.UnsignedLong;
+import java.math.BigInteger;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.web3j.protocol.core.methods.response.EthBlock.Block;
+import tech.pegasys.teku.pow.api.Eth1EventsChannel;
+import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
+import tech.pegasys.teku.storage.api.Eth1DepositStorageChannel;
+import tech.pegasys.teku.storage.api.schema.ReplayDepositsResult;
+import tech.pegasys.teku.util.async.SafeFuture;
+import tech.pegasys.teku.util.async.StubAsyncRunner;
+import tech.pegasys.teku.util.config.Constants;
+
+class Eth1DepositManagerTest {
+
+  private static final BigInteger NEGATIVE_ONE = BigInteger.valueOf(-1);
+  private static final SafeFuture<ReplayDepositsResult> NOTHING_REPLAYED =
+      SafeFuture.completedFuture(new ReplayDepositsResult(NEGATIVE_ONE, false));
+  private static final int MIN_GENESIS_BLOCK_TIMESTAMP = 10_000;
+  private final Eth1Provider eth1Provider = mock(Eth1Provider.class);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+  private final Eth1EventsChannel eth1EventsChannel = mock(Eth1EventsChannel.class);
+  private final Eth1DepositStorageChannel eth1DepositStorageChannel =
+      mock(Eth1DepositStorageChannel.class);
+  private final DepositProcessingController depositProcessingController =
+      mock(DepositProcessingController.class);
+  private final MinimumGenesisTimeBlockFinder minimumGenesisTimeBlockFinder =
+      mock(MinimumGenesisTimeBlockFinder.class);
+
+  private final InOrder inOrder =
+      inOrder(
+          eth1DepositStorageChannel,
+          depositProcessingController,
+          eth1EventsChannel,
+          minimumGenesisTimeBlockFinder);
+
+  private final Eth1DepositManager manager =
+      new Eth1DepositManager(
+          eth1Provider,
+          asyncRunner,
+          eth1EventsChannel,
+          eth1DepositStorageChannel,
+          depositProcessingController,
+          minimumGenesisTimeBlockFinder);
+
+  @BeforeAll
+  static void setConstants() {
+    Constants.MIN_GENESIS_TIME = UnsignedLong.valueOf(10_000).plus(Constants.GENESIS_DELAY);
+  }
+
+  @AfterAll
+  static void resetConstants() {
+    Constants.setConstants("minimal");
+  }
+
+  @Test
+  void shouldStartWithNoStoredDepositsAndHeadBeforeMinGenesisTime() {
+    final BigInteger headBlockNumber = BigInteger.valueOf(100);
+    when(eth1DepositStorageChannel.replayDepositEvents()).thenReturn(NOTHING_REPLAYED);
+    withFollowDistanceHead(headBlockNumber, MIN_GENESIS_BLOCK_TIMESTAMP - 1);
+    when(depositProcessingController.fetchDepositsInRange(any(), any())).thenReturn(COMPLETE);
+
+    manager.start();
+
+    inOrder.verify(eth1DepositStorageChannel).replayDepositEvents();
+    // Process blocks up to the current chain head
+    inOrder
+        .verify(depositProcessingController)
+        .fetchDepositsInRange(BigInteger.ZERO, headBlockNumber);
+
+    // Then start the subscription from the block after head
+    inOrder.verify(depositProcessingController).switchToBlockByBlockMode();
+    inOrder.verify(depositProcessingController).startSubscription(BigInteger.valueOf(101));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  void shouldStartWithStoredDepositsAndHeadBeforeMinGenesisTime() {
+    final BigInteger headBlockNumber = BigInteger.valueOf(100);
+    final BigInteger lastReplayedBlock = BigInteger.valueOf(10);
+    when(eth1DepositStorageChannel.replayDepositEvents())
+        .thenReturn(SafeFuture.completedFuture(new ReplayDepositsResult(lastReplayedBlock, false)));
+    withFollowDistanceHead(headBlockNumber, MIN_GENESIS_BLOCK_TIMESTAMP - 1);
+    when(depositProcessingController.fetchDepositsInRange(any(), any())).thenReturn(COMPLETE);
+
+    manager.start();
+
+    inOrder.verify(eth1DepositStorageChannel).replayDepositEvents();
+    // Process blocks up to the current chain head
+    inOrder
+        .verify(depositProcessingController)
+        .fetchDepositsInRange(lastReplayedBlock.add(BigInteger.ONE), headBlockNumber);
+
+    // Then start the subscription from the block after head
+    inOrder.verify(depositProcessingController).switchToBlockByBlockMode();
+    inOrder.verify(depositProcessingController).startSubscription(BigInteger.valueOf(101));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  void shouldStartWithStoredDepositsAndHeadAfterMinGenesisTime() {
+    final BigInteger headBlockNumber = BigInteger.valueOf(100);
+    final BigInteger minGenesisBlockNumber = BigInteger.valueOf(60);
+    final BigInteger lastReplayedBlock = BigInteger.valueOf(10);
+    when(eth1DepositStorageChannel.replayDepositEvents())
+        .thenReturn(SafeFuture.completedFuture(new ReplayDepositsResult(lastReplayedBlock, false)));
+    withFollowDistanceHead(headBlockNumber, MIN_GENESIS_BLOCK_TIMESTAMP + 1000);
+    withMinGenesisBlock(headBlockNumber, minGenesisBlockNumber);
+    when(depositProcessingController.fetchDepositsInRange(any(), any())).thenReturn(COMPLETE);
+
+    manager.start();
+
+    inOrder.verify(eth1DepositStorageChannel).replayDepositEvents();
+    // Find min genesis block
+    inOrder.verify(minimumGenesisTimeBlockFinder).findMinGenesisTimeBlockInHistory(headBlockNumber);
+    // Process blocks from after the last stored block to min genesis
+    inOrder
+        .verify(depositProcessingController)
+        .fetchDepositsInRange(lastReplayedBlock.add(BigInteger.ONE), minGenesisBlockNumber);
+
+    // Send min genesis event
+    inOrder
+        .verify(eth1EventsChannel)
+        .onMinGenesisTimeBlock(
+            new MinGenesisTimeBlockEvent(
+                UnsignedLong.valueOf(MIN_GENESIS_BLOCK_TIMESTAMP),
+                UnsignedLong.valueOf(minGenesisBlockNumber),
+                Bytes32.ZERO));
+
+    // Then start the subscription to process any blocks after min genesis
+    // Adding one to ensure we don't process the min genesis block a second time
+    inOrder
+        .verify(depositProcessingController)
+        .startSubscription(minGenesisBlockNumber.add(BigInteger.ONE));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  void shouldStartWithNoStoredDepositsAndHeadAfterMinGenesisTime() {
+    final BigInteger headBlockNumber = BigInteger.valueOf(100);
+    final BigInteger minGenesisBlockNumber = BigInteger.valueOf(60);
+    when(eth1DepositStorageChannel.replayDepositEvents()).thenReturn(NOTHING_REPLAYED);
+    withFollowDistanceHead(headBlockNumber, MIN_GENESIS_BLOCK_TIMESTAMP + 1000);
+    withMinGenesisBlock(headBlockNumber, minGenesisBlockNumber);
+    when(depositProcessingController.fetchDepositsInRange(any(), any())).thenReturn(COMPLETE);
+
+    manager.start();
+
+    inOrder.verify(eth1DepositStorageChannel).replayDepositEvents();
+    // Find min genesis block
+    inOrder.verify(minimumGenesisTimeBlockFinder).findMinGenesisTimeBlockInHistory(headBlockNumber);
+    // Process blocks from genesis to min genesis block
+    inOrder
+        .verify(depositProcessingController)
+        .fetchDepositsInRange(BigInteger.ZERO, minGenesisBlockNumber);
+
+    // Send min genesis event
+    inOrder
+        .verify(eth1EventsChannel)
+        .onMinGenesisTimeBlock(
+            new MinGenesisTimeBlockEvent(
+                UnsignedLong.valueOf(MIN_GENESIS_BLOCK_TIMESTAMP),
+                UnsignedLong.valueOf(minGenesisBlockNumber),
+                Bytes32.ZERO));
+
+    // Then start the subscription to process any blocks after min genesis
+    // Adding one to ensure we don't process the min genesis block a second time
+    inOrder
+        .verify(depositProcessingController)
+        .startSubscription(minGenesisBlockNumber.add(BigInteger.ONE));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  void shouldStartWithStoredDepositsAndMinGenesisReachedLongerChain() {
+    final BigInteger headBlockNumber = BigInteger.valueOf(100);
+    final BigInteger lastReplayedBlock = BigInteger.valueOf(70);
+    when(eth1DepositStorageChannel.replayDepositEvents())
+        .thenReturn(SafeFuture.completedFuture(new ReplayDepositsResult(lastReplayedBlock, true)));
+    withFollowDistanceHead(headBlockNumber, MIN_GENESIS_BLOCK_TIMESTAMP + 1000);
+    when(depositProcessingController.fetchDepositsInRange(any(), any())).thenReturn(COMPLETE);
+
+    manager.start();
+
+    inOrder.verify(eth1DepositStorageChannel).replayDepositEvents();
+    // Just start processing blocks from after the last replayed block.
+    inOrder
+        .verify(depositProcessingController)
+        .startSubscription(lastReplayedBlock.add(BigInteger.ONE));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  void shouldStartWithStoredDepositsAndMinGenesisReachedChainReorgedToBeShorter() {
+    // Head block number has wound up being before the last block we already processed
+    final BigInteger headBlockNumber = BigInteger.valueOf(60);
+    final BigInteger lastReplayedBlock = BigInteger.valueOf(70);
+    when(eth1DepositStorageChannel.replayDepositEvents())
+        .thenReturn(SafeFuture.completedFuture(new ReplayDepositsResult(lastReplayedBlock, true)));
+    withFollowDistanceHead(headBlockNumber, MIN_GENESIS_BLOCK_TIMESTAMP + 1000);
+    when(depositProcessingController.fetchDepositsInRange(any(), any())).thenReturn(COMPLETE);
+
+    manager.start();
+
+    inOrder.verify(eth1DepositStorageChannel).replayDepositEvents();
+    // Just start processing blocks from after the last replayed block.
+    inOrder
+        .verify(depositProcessingController)
+        .startSubscription(lastReplayedBlock.add(BigInteger.ONE));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  void shouldStartWithStoredDepositsChainReorgedToBeShorter() {
+    // Head block number has wound up being before the last block we already processed
+    final BigInteger headBlockNumber = BigInteger.valueOf(60);
+    final BigInteger lastReplayedBlock = BigInteger.valueOf(70);
+    when(eth1DepositStorageChannel.replayDepositEvents())
+        .thenReturn(SafeFuture.completedFuture(new ReplayDepositsResult(lastReplayedBlock, false)));
+    withFollowDistanceHead(headBlockNumber, MIN_GENESIS_BLOCK_TIMESTAMP + 1000);
+    when(depositProcessingController.fetchDepositsInRange(any(), any())).thenReturn(COMPLETE);
+
+    manager.start();
+
+    inOrder.verify(eth1DepositStorageChannel).replayDepositEvents();
+    // Min genesis not reached so process block by block after the last replayed block
+    inOrder.verify(depositProcessingController).switchToBlockByBlockMode();
+    inOrder
+        .verify(depositProcessingController)
+        .startSubscription(lastReplayedBlock.add(BigInteger.ONE));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  private void withMinGenesisBlock(
+      final BigInteger headBlockNumber, final BigInteger minGenesisBlockNumber) {
+    final Block minGenesisBlock = block(minGenesisBlockNumber, MIN_GENESIS_BLOCK_TIMESTAMP);
+    when(minimumGenesisTimeBlockFinder.findMinGenesisTimeBlockInHistory(headBlockNumber))
+        .thenReturn(SafeFuture.completedFuture(minGenesisBlock));
+  }
+
+  private void withFollowDistanceHead(final BigInteger number, final long timestamp) {
+    final Block latestBlock =
+        block(number.add(Constants.ETH1_FOLLOW_DISTANCE.bigIntegerValue()), timestamp + 100000);
+    final Block followDistanceHead = block(number, timestamp);
+    when(eth1Provider.getLatestEth1Block()).thenReturn(SafeFuture.completedFuture(latestBlock));
+    when(eth1Provider.getGuaranteedEth1Block(UnsignedLong.valueOf(number)))
+        .thenReturn(SafeFuture.completedFuture(followDistanceHead));
+  }
+
+  private Block block(final BigInteger number, final long timestamp) {
+    final Block block = mock(Block.class);
+    when(block.getNumber()).thenReturn(number);
+    when(block.getTimestamp()).thenReturn(BigInteger.valueOf(timestamp));
+    when(block.getHash()).thenReturn(Bytes32.ZERO.toHexString());
+    return block;
+  }
+}

--- a/pow/src/test/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinderTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinderTest.java
@@ -82,7 +82,8 @@ public class MinimumGenesisTimeBlockFinderTest {
       final Block[] blocks, final long minGenesisTime, final Block expectedMinGenesisTimeBlock) {
     Constants.MIN_GENESIS_TIME = UnsignedLong.valueOf(minGenesisTime);
     final SafeFuture<Block> result =
-        minimumGenesisTimeBlockFinder.findMinGenesisTimeBlockInHistory(blocks[blocks.length - 1]);
+        minimumGenesisTimeBlockFinder.findMinGenesisTimeBlockInHistory(
+            blocks[blocks.length - 1].getNumber());
     assertThat(result).isCompletedWithValue(expectedMinGenesisTimeBlock);
   }
 

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/schema/ReplayDepositsResult.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/schema/ReplayDepositsResult.java
@@ -24,8 +24,12 @@ public class ReplayDepositsResult {
     this.pastMinGenesisBlock = pastMinGenesisBlock;
   }
 
-  public BigInteger getBlockNumber() {
+  public BigInteger getLastProcessedBlockNumber() {
     return blockNumber;
+  }
+
+  public BigInteger getFirstUnprocessedBlockNumber() {
+    return blockNumber.add(BigInteger.ONE);
   }
 
   public boolean isPastMinGenesisBlock() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/DepositStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/DepositStorage.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.storage.server;
 
 import com.google.common.base.Suppliers;
-import com.google.common.primitives.UnsignedLong;
 import java.math.BigInteger;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -27,9 +26,11 @@ import tech.pegasys.teku.storage.api.schema.ReplayDepositsResult;
 import tech.pegasys.teku.util.async.SafeFuture;
 
 public class DepositStorage implements Eth1DepositStorageChannel, Eth1EventsChannel {
+
+  private static final BigInteger NEGATIVE_ONE = BigInteger.valueOf(-1L);
   private final Database database;
   private final Eth1EventsChannel eth1EventsChannel;
-  private volatile Optional<BigInteger> startingBlock = Optional.empty();
+  private volatile Optional<BigInteger> lastReplayedBlock = Optional.empty();
   private final Supplier<SafeFuture<ReplayDepositsResult>> replayResult;
   private final boolean eth1DepositsFromStorageEnabled;
 
@@ -61,8 +62,8 @@ public class DepositStorage implements Eth1DepositStorageChannel, Eth1EventsChan
 
   private ReplayDepositsResult replayDeposits() {
     if (!eth1DepositsFromStorageEnabled) {
-      startingBlock = Optional.of(BigInteger.valueOf(-1L));
-      return new ReplayDepositsResult(BigInteger.ZERO, false);
+      lastReplayedBlock = Optional.of(NEGATIVE_ONE);
+      return new ReplayDepositsResult(NEGATIVE_ONE, false);
     }
 
     final DepositSequencer depositSequencer =
@@ -71,19 +72,12 @@ public class DepositStorage implements Eth1DepositStorageChannel, Eth1EventsChan
       eventStream.forEach(depositSequencer::depositEvent);
     }
     ReplayDepositsResult result = depositSequencer.depositsComplete();
-    startingBlock = Optional.of(getStartingBlockFromDepositsResult(result));
+    lastReplayedBlock = Optional.of(result.getLastProcessedBlockNumber());
     return result;
   }
 
-  private BigInteger getStartingBlockFromDepositsResult(
-      final ReplayDepositsResult replayDepositsResult) {
-    return replayDepositsResult.getBlockNumber().equals(BigInteger.ZERO)
-        ? BigInteger.valueOf(-1L)
-        : replayDepositsResult.getBlockNumber().add(BigInteger.ONE);
-  }
-
   private boolean shouldProcessEvent(final BigInteger blockNumber) {
-    return startingBlock.map(block -> block.compareTo(blockNumber) < 0).orElse(false);
+    return lastReplayedBlock.map(startBlock -> startBlock.compareTo(blockNumber) < 0).orElse(false);
   }
 
   @Override
@@ -104,14 +98,14 @@ public class DepositStorage implements Eth1DepositStorageChannel, Eth1EventsChan
     private final Eth1EventsChannel eth1EventsChannel;
     private final Optional<MinGenesisTimeBlockEvent> genesis;
     private boolean isGenesisDone;
-    private UnsignedLong lastDeposit;
+    private BigInteger lastDeposit;
 
     public DepositSequencer(
         final Eth1EventsChannel eventChannel, final Optional<MinGenesisTimeBlockEvent> genesis) {
       this.eth1EventsChannel = eventChannel;
       this.genesis = genesis;
       this.isGenesisDone = false;
-      this.lastDeposit = UnsignedLong.ZERO;
+      this.lastDeposit = BigInteger.valueOf(-1);
     }
 
     public void depositEvent(final DepositsFromBlockEvent event) {
@@ -122,16 +116,16 @@ public class DepositStorage implements Eth1DepositStorageChannel, Eth1EventsChan
         isGenesisDone = true;
       }
       eth1EventsChannel.onDepositsFromBlock(event);
-      lastDeposit = event.getBlockNumber();
+      lastDeposit = event.getBlockNumber().bigIntegerValue();
     }
 
     public ReplayDepositsResult depositsComplete() {
       if (genesis.isPresent() && !isGenesisDone) {
         this.eth1EventsChannel.onMinGenesisTimeBlock(genesis.get());
-        lastDeposit = genesis.get().getBlockNumber();
+        lastDeposit = genesis.get().getBlockNumber().bigIntegerValue();
         isGenesisDone = true;
       }
-      return new ReplayDepositsResult(lastDeposit.bigIntegerValue(), isGenesisDone);
+      return new ReplayDepositsResult(lastDeposit, isGenesisDone);
     }
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/DepositStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/DepositStorage.java
@@ -105,7 +105,7 @@ public class DepositStorage implements Eth1DepositStorageChannel, Eth1EventsChan
       this.eth1EventsChannel = eventChannel;
       this.genesis = genesis;
       this.isGenesisDone = false;
-      this.lastDeposit = BigInteger.valueOf(-1);
+      this.lastDeposit = NEGATIVE_ONE;
     }
 
     public void depositEvent(final DepositsFromBlockEvent event) {

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -13,15 +13,26 @@
 
 package tech.pegasys.teku.cli.subcommand.debug;
 
+import com.google.common.primitives.UnsignedLong;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
 import tech.pegasys.teku.cli.options.DataOptions;
+import tech.pegasys.teku.cli.options.NetworkOptions;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.util.SimpleOffsetSerializer;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.server.DepositStorage;
 import tech.pegasys.teku.storage.server.VersionedDatabaseFactory;
 import tech.pegasys.teku.util.cli.PicoCliVersionProvider;
+import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.util.config.NetworkDefinition;
 
 @Command(
     name = "db",
@@ -53,7 +64,7 @@ public class DebugDbCommand implements Runnable {
       optionListHeading = "%nOptions:%n",
       footerHeading = "%n",
       footer = "Teku is licensed under the Apache License 2.0")
-  public int blocks(@Mixin final DataOptions dataOptions) throws Exception {
+  public int getDeposits(@Mixin final DataOptions dataOptions) throws Exception {
     try (final YamlEth1EventsChannel eth1EventsChannel = new YamlEth1EventsChannel(System.out);
         final Database database = createDatabase(dataOptions)) {
       final DepositStorage depositStorage =
@@ -63,10 +74,94 @@ public class DebugDbCommand implements Runnable {
     return 0;
   }
 
+  @Command(
+      name = "get-finalized-state",
+      description = "Get the finalized state, if available, as SSZ",
+      mixinStandardHelpOptions = true,
+      showDefaultValues = true,
+      abbreviateSynopsis = true,
+      versionProvider = PicoCliVersionProvider.class,
+      synopsisHeading = "%n",
+      descriptionHeading = "%nDescription:%n%n",
+      optionListHeading = "%nOptions:%n",
+      footerHeading = "%n",
+      footer = "Teku is licensed under the Apache License 2.0")
+  public int getFinalizedState(
+      @Mixin final DataOptions dataOptions,
+      @Mixin final NetworkOptions networkOptions,
+      @Option(
+              required = true,
+              names = {"--output", "-o"},
+              description = "File to write state to")
+          final Path outputFile,
+      @Option(
+              required = true,
+              names = {"--slot", "-s"},
+              description =
+                  "The slot to retrive the state for. If unavailable the closest available state will be returned")
+          final long slot)
+      throws Exception {
+    setConstants(networkOptions);
+    try (final Database database = createDatabase(dataOptions)) {
+      return writeState(
+          outputFile, database.getLatestAvailableFinalizedState(UnsignedLong.valueOf(slot)));
+    }
+  }
+
+  @Command(
+      name = "get-latest-finalized-state",
+      description = "Get the latest finalized state, if available, as SSZ",
+      mixinStandardHelpOptions = true,
+      showDefaultValues = true,
+      abbreviateSynopsis = true,
+      versionProvider = PicoCliVersionProvider.class,
+      synopsisHeading = "%n",
+      descriptionHeading = "%nDescription:%n%n",
+      optionListHeading = "%nOptions:%n",
+      footerHeading = "%n",
+      footer = "Teku is licensed under the Apache License 2.0")
+  public int getLatestFinalizedState(
+      @Mixin final DataOptions dataOptions,
+      @Mixin final NetworkOptions networkOptions,
+      @Option(
+              required = true,
+              names = {"--output", "-o"},
+              description = "File to write state to")
+          final Path outputFile)
+      throws Exception {
+    setConstants(networkOptions);
+    try (final Database database = createDatabase(dataOptions)) {
+      final Optional<BeaconState> state =
+          database
+              .createMemoryStore()
+              .map(store -> store.getLatestFinalizedBlockAndState().getState());
+      return writeState(outputFile, state);
+    }
+  }
+
+  private void setConstants(@Mixin final NetworkOptions networkOptions) {
+    Constants.setConstants(
+        NetworkDefinition.fromCliArg(networkOptions.getNetwork()).getConstants());
+  }
+
   private Database createDatabase(final DataOptions dataOptions) {
     final VersionedDatabaseFactory databaseFactory =
         new VersionedDatabaseFactory(
             new NoOpMetricsSystem(), dataOptions.getDataPath(), dataOptions.getDataStorageMode());
     return databaseFactory.createDatabase();
+  }
+
+  private int writeState(final Path outputFile, final Optional<BeaconState> state) {
+    if (state.isEmpty()) {
+      System.err.println("No state available.");
+      return 2;
+    }
+    try {
+      Files.write(outputFile, SimpleOffsetSerializer.serialize(state.get()).toArrayUnsafe());
+    } catch (IOException e) {
+      System.err.println("Unable to write state to " + outputFile + ": " + e.getMessage());
+      return 1;
+    }
+    return 0;
   }
 }


### PR DESCRIPTION
## PR Description
When Teku is restarted it replays deposits from it's local database and then resumes importing blocks from the ETH1 chain from there.  Previously it was incorrectly starting from the block the last stored deposit was from instead of the block after, resulting in the deposit being processed twice.

* Tidied up the block number processing so it's easier to understand and fix the off by one errors.  
* Added tests for `Eth1DepositManager`.
* Added a couple of debug utilities to be able to get finalised states in SSZ format.

## Fixed Issue(s)
fixes #2243 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.