### PR TITLE
streams will not be left open when shutting down any more.

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ShuttingDownException.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ShuttingDownException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server;
+
+public class ShuttingDownException extends RuntimeException {}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbIterator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbIterator.java
@@ -20,12 +20,14 @@ import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
+import tech.pegasys.teku.storage.server.ShuttingDownException;
 import tech.pegasys.teku.storage.server.rocksdb.schema.RocksDbColumn;
 
 class RocksDbIterator<TKey, TValue> implements Iterator<ColumnEntry<TKey, TValue>>, AutoCloseable {
@@ -35,21 +37,26 @@ class RocksDbIterator<TKey, TValue> implements Iterator<ColumnEntry<TKey, TValue
   private final RocksIterator rocksIterator;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private final Predicate<TKey> continueTest;
+  private final Supplier<Boolean> isDatabaseClosed;
 
   private RocksDbIterator(
       final RocksDbColumn<TKey, TValue> column,
       final RocksIterator rocksIterator,
-      final Predicate<TKey> continueTest) {
+      final Predicate<TKey> continueTest,
+      final Supplier<Boolean> isDatabaseClosed) {
     this.column = column;
     this.rocksIterator = rocksIterator;
     this.continueTest = continueTest;
+    this.isDatabaseClosed = isDatabaseClosed;
   }
 
+  @MustBeClosed
   public static <K, V> RocksDbIterator<K, V> create(
       final RocksDbColumn<K, V> column,
       final RocksIterator rocksIt,
-      final Predicate<K> continueTest) {
-    return new RocksDbIterator<>(column, rocksIt, continueTest);
+      final Predicate<K> continueTest,
+      final Supplier<Boolean> isDatabaseClosed) {
+    return new RocksDbIterator<>(column, rocksIt, continueTest, isDatabaseClosed);
   }
 
   @Override
@@ -93,6 +100,9 @@ class RocksDbIterator<TKey, TValue> implements Iterator<ColumnEntry<TKey, TValue
   }
 
   private void assertOpen() {
+    if (this.isDatabaseClosed.get()) {
+      throw new ShuttingDownException();
+    }
     if (closed.get()) {
       throw new IllegalStateException("Attempt to update a closed transaction");
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbIterator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbIterator.java
@@ -104,7 +104,8 @@ class RocksDbIterator<TKey, TValue> implements Iterator<ColumnEntry<TKey, TValue
       throw new ShuttingDownException();
     }
     if (closed.get()) {
-      throw new IllegalStateException("Attempt to update a closed transaction");
+      throw new IllegalStateException(
+          "Attempt to update a closed " + this.getClass().getSimpleName());
     }
   }
 

--- a/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
+++ b/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.events.ChannelExceptionHandler;
 import tech.pegasys.teku.logging.StatusLogger;
+import tech.pegasys.teku.storage.server.ShuttingDownException;
 
 public final class TekuDefaultExceptionHandler
     implements SubscriberExceptionHandler,
@@ -84,6 +85,8 @@ public final class TekuDefaultExceptionHandler
     if (exception instanceof OutOfMemoryError) {
       statusLog.fatalError(subscriberDescription, exception);
       System.exit(2);
+    } else if (exception instanceof ShuttingDownException) {
+      LOG.debug("Shutting down", exception);
     } else if (isExpectedNettyError(exception)) {
       LOG.debug("Channel unexpectedly closed", exception);
     } else if (isSpecFailure(exception)) {


### PR DESCRIPTION
- added test case to show behaviour when streams are accessed after the database is closed.

- added DEBUG for when a shutdown exception happens so that it's visible in trace.

fixes #2241

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.