### PR TITLE
Print genesis parameters at startup

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/genesis/GenesisHandler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/genesis/GenesisHandler.java
@@ -90,6 +90,7 @@ public class GenesisHandler implements Eth1EventsChannel {
   private void eth2Genesis(BeaconState genesisState) {
     recentChainData.initializeFromGenesis(genesisState);
     Bytes32 genesisBlockRoot = recentChainData.getBestBlockRoot().orElseThrow();
-    EVENT_LOG.genesisEvent(genesisState.hash_tree_root(), genesisBlockRoot);
+    EVENT_LOG.genesisEvent(
+        genesisState.hash_tree_root(), genesisBlockRoot, genesisState.getGenesis_time());
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/StartupUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/StartupUtil.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.statetransition.util;
 
+import static tech.pegasys.teku.logging.EventLogger.EVENT_LOG;
 import static tech.pegasys.teku.logging.StatusLogger.STATUS_LOG;
 
 import com.google.common.primitives.UnsignedLong;
@@ -80,6 +81,7 @@ public final class StartupUtil {
       try {
         STATUS_LOG.loadingGenesisFile(startState);
         initialState = StartupUtil.loadBeaconState(startState);
+
       } catch (final IOException e) {
         throw new IllegalStateException("Failed to load initial state", e);
       }
@@ -91,5 +93,9 @@ public final class StartupUtil {
     }
 
     recentChainData.initializeFromGenesis(initialState);
+    EVENT_LOG.genesisEvent(
+        initialState.hashTreeRoot(),
+        recentChainData.getBestBlockRoot().orElseThrow(),
+        initialState.getGenesis_time());
   }
 }

--- a/logging/src/main/java/tech/pegasys/teku/logging/EventLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/EventLogger.java
@@ -18,6 +18,11 @@ import static tech.pegasys.teku.logging.LogFormatter.formatHashRoot;
 import static tech.pegasys.teku.logging.LoggingConfigurator.EVENT_LOGGER_NAME;
 
 import com.google.common.primitives.UnsignedLong;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
+import java.util.Locale;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -33,11 +38,27 @@ public class EventLogger {
     this.log = LogManager.getLogger(name);
   }
 
-  public void genesisEvent(final Bytes32 hashTreeRoot, final Bytes32 genesisBlockRoot) {
+  public void genesisEvent(
+      final Bytes32 hashTreeRoot, final Bytes32 genesisBlockRoot, final UnsignedLong genesisTime) {
+    final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    final ZoneId systemDefaultZoneId = ZoneId.systemDefault();
+    final String formattedGenesisTime =
+        Instant.ofEpochSecond(genesisTime.longValue())
+            .atZone(systemDefaultZoneId)
+            .format(formatter);
+
+    System.out.println(formattedGenesisTime);
     final String genesisEventLog =
         String.format(
-            "Genesis Event *** Initial state root: %s, Genesis block root: %s",
-            hashTreeRoot.toHexString(), genesisBlockRoot.toHexString());
+            "Genesis Event *** \n"
+                + "Genesis state root: %s \n"
+                + "Genesis block root: %s \n"
+                + "Genesis time: %s %s",
+            hashTreeRoot.toHexString(),
+            genesisBlockRoot.toHexString(),
+            formattedGenesisTime,
+            systemDefaultZoneId.getDisplayName(TextStyle.FULL, Locale.ENGLISH));
     info(genesisEventLog, Color.CYAN);
   }
 

--- a/logging/src/main/java/tech/pegasys/teku/logging/EventLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/EventLogger.java
@@ -21,8 +21,6 @@ import com.google.common.primitives.UnsignedLong;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.time.format.TextStyle;
-import java.util.Locale;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -42,23 +40,16 @@ public class EventLogger {
       final Bytes32 hashTreeRoot, final Bytes32 genesisBlockRoot, final UnsignedLong genesisTime) {
     final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
-    final ZoneId systemDefaultZoneId = ZoneId.systemDefault();
     final String formattedGenesisTime =
-        Instant.ofEpochSecond(genesisTime.longValue())
-            .atZone(systemDefaultZoneId)
-            .format(formatter);
+        Instant.ofEpochSecond(genesisTime.longValue()).atZone(ZoneId.of("GMT")).format(formatter);
 
-    System.out.println(formattedGenesisTime);
     final String genesisEventLog =
         String.format(
             "Genesis Event *** \n"
                 + "Genesis state root: %s \n"
                 + "Genesis block root: %s \n"
-                + "Genesis time: %s %s",
-            hashTreeRoot.toHexString(),
-            genesisBlockRoot.toHexString(),
-            formattedGenesisTime,
-            systemDefaultZoneId.getDisplayName(TextStyle.FULL, Locale.ENGLISH));
+                + "Genesis time: %s GMT",
+            hashTreeRoot.toHexString(), genesisBlockRoot.toHexString(), formattedGenesisTime);
     info(genesisEventLog, Color.CYAN);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Print genesis parameters at startup:

```
2020-06-29 10:48:40,331 main INFO Logging includes color: true
10:48:40.383 INFO  - Teku version: teku/v0.12.0-dev-5dd16956/osx-x86_64/oracle_openjdk-java-11
10:48:40.653 INFO  - Using data path: /Users/cemozer/Library/teku/data
10:48:41.075 INFO  - Initializing storage
10:48:41.079 INFO  - Storage initialization complete
10:48:41.272 INFO  - Loading genesis from jar:file:/Users/cemozer/Projects/teku/build/install/teku/lib/teku-util-0.12.0-SNAPSHOT.jar!/tech/pegasys/teku/util/config/altona-genesis.ssz
2020-06-29 08:30:05
10:48:41.884 INFO  - Genesis Event *** 
Genesis state root: 0x939d98077986a9f6eccae33614e2da1008a2f300f1aac36bc65ef710550eec4a 
Genesis block root: 0x9e2ffe8ab9316e03e45409eaaffab10cf02e1b60e609276113e07240d4a31b7a 
Genesis time: 2020-06-29 08:30:05 Eastern Time
10:48:42.271 INFO  - PreGenesis Local ENR: enr:-KG4QBZ6vFwB0VJEqBFArC-3SqL8S_WJ9_XLIT17rwUKAgahUkXoGEVUI47n9G9wLwzwB-C6beiwFVtPtJil0AJGCWwChGV0aDKQthN3YwAAASH__________4JpZIJ2NIJpcIQAAAAAiXNlY3AyNTZrMaEDZdn0vvugYkwaUjKaTcm0CalcJBV9lLB5xzfaEjYtQLqDdGNwgiMog3VkcIIjKA
10:48:42.417 INFO  - Listening for connections on: /ip4/192.168.1.172/tcp/9000/p2p/16Uiu2HAmKWaHkE2A1kyvtxLLkwZWVuDgwovLv66bvvVrRXZPregh
10:48:42.513 INFO  - Local ENR: enr:-KG4QL0VVwOFu05NOGClYeC5hwcO6AiHTHmKVsfgGbUpy-ZpIRrFjXXCLWowFRNhQJoiJfrAu8aqli37ThXHqaVnmIoDhGV0aDKQ_co5sAAAASH__________4JpZIJ2NIJpcIQAAAAAiXNlY3AyNTZrMaEDZdn0vvugYkwaUjKaTcm0CalcJBV9lLB5xzfaEjYtQLqDdGNwgiMog3VkcIIjKA
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes https://github.com/PegaSysEng/teku/issues/2245

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.