### PR TITLE
Fix empty RPC request handling

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
@@ -81,7 +81,13 @@ public class Eth2IncomingRequestHandler<TRequest extends RpcRequest, TResponse>
   @Override
   public void complete(NodeId nodeId, RpcStream rpcStream) {
     try {
-      requestDecoder.complete();
+      Optional<Eth2Peer> peer = peerLookup.getConnectedPeer(nodeId);
+      requestDecoder
+          .complete()
+          .ifPresent(
+              request ->
+                  handleRequest(peer, request, new RpcResponseCallback<>(rpcStream, rpcEncoder)));
+      ;
     } catch (RpcException e) {
       new RpcResponseCallback<>(rpcStream, rpcEncoder).completeWithErrorResponse(e);
       LOG.debug("RPC Request stream closed prematurely", e);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcRequestDecoder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcRequestDecoder.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2.rpc.core;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import java.util.Optional;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.RpcRequest;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcByteBufDecoder;
@@ -53,8 +54,13 @@ public class RpcRequestDecoder<T extends RpcRequest> {
     return request;
   }
 
-  public void complete() throws RpcException {
+  public Optional<T> complete() throws RpcException {
+    Optional<T> maybeRequest = Optional.empty();
+    if (!complete) {
+      maybeRequest = decodeRequest(Unpooled.EMPTY_BUFFER);
+    }
     decoder.complete();
     if (!complete) throw RpcException.PAYLOAD_TRUNCATED;
+    return maybeRequest;
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.rpc.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -27,6 +28,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage;
+import tech.pegasys.teku.datastructures.networking.libp2p.rpc.EmptyMessage;
+import tech.pegasys.teku.datastructures.networking.libp2p.rpc.MetadataMessage;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.networking.eth2.rpc.Utils;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
@@ -68,6 +71,17 @@ public abstract class Eth2IncomingRequestHandlerTest
   private SafeFuture<Optional<SignedBeaconBlock>> getBlockAtSlot(final UnsignedLong slot) {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot.longValue());
     return SafeFuture.completedFuture(Optional.of(block));
+  }
+
+  @Test
+  public void testEmptyRequestMessage() {
+    Eth2IncomingRequestHandler<EmptyMessage, MetadataMessage> requestHandler =
+        beaconChainMethods.getMetadata().createIncomingRequestHandler();
+    requestHandler.complete(nodeId, rpcStream);
+    asyncRunner.executeQueuedActions();
+    // verify non-error response
+    verify(rpcStream).writeBytes(argThat(bytes -> bytes.get(0) == 0));
+    verify(rpcStream).close();
   }
 
   @Test

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcRequestDecoderTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcRequestDecoderTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
+import tech.pegasys.teku.datastructures.networking.libp2p.rpc.EmptyMessage;
 
 class RpcRequestDecoderTest extends RpcDecoderTestBase {
 
@@ -37,7 +38,7 @@ class RpcRequestDecoderTest extends RpcDecoderTestBase {
         decoder.decodeRequest(bufSlice).ifPresent(msgs::add);
         bufSlice.release();
       }
-      decoder.complete();
+      assertThat(decoder.complete()).isEmpty();
       for (ByteBuf bufSlice : bufSlices) {
         assertThat(bufSlice.refCnt()).isEqualTo(0);
       }
@@ -65,5 +66,11 @@ class RpcRequestDecoderTest extends RpcDecoderTestBase {
               })
           .isEqualTo(RpcException.EXTRA_DATA_APPENDED);
     }
+  }
+
+  @Test
+  public void shouldProcessEmptyMessage() throws Exception {
+    RpcRequestDecoder<EmptyMessage> decoder = new RpcRequestDecoder<>(EmptyMessage.class, ENCODING);
+    assertThat(decoder.complete()).isNotEmpty().contains(EmptyMessage.EMPTY_MESSAGE);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Handle the case when RPC request is empty and the `Eth2IncomingRequestHandler.complete()` method might be called without any prior processData() invocation.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.