### PR TITLE
Avoid reading from closed RocksDB Statistics instance

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstanceFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstanceFactory.java
@@ -53,11 +53,11 @@ public class RocksDbInstanceFactory {
 
     // Create options
     final TransactionDBOptions txOptions = new TransactionDBOptions();
-    final Statistics stats = new Statistics();
-    final DBOptions dbOptions = createDBOptions(configuration, stats);
+    final RocksDbStats rocksDbStats = new RocksDbStats(metricsSystem, metricCategory);
+    final DBOptions dbOptions = createDBOptions(configuration, rocksDbStats.getStats());
     final ColumnFamilyOptions columnFamilyOptions = createColumnFamilyOptions(configuration);
     final List<AutoCloseable> resources =
-        new ArrayList<>(List.of(txOptions, dbOptions, columnFamilyOptions, stats));
+        new ArrayList<>(List.of(txOptions, dbOptions, columnFamilyOptions, rocksDbStats));
 
     List<ColumnFamilyDescriptor> columnDescriptors =
         createColumnFamilyDescriptors(schema, columnFamilyOptions);
@@ -92,7 +92,7 @@ public class RocksDbInstanceFactory {
       final ColumnFamilyHandle defaultHandle = getDefaultHandle(columnHandles);
       resources.add(db);
 
-      RocksDbStats.registerRocksDBMetrics(stats, metricsSystem, metricCategory);
+      rocksDbStats.registerMetrics();
 
       return new RocksDbInstance(db, defaultHandle, columnHandlesMap, resources);
     } catch (RocksDBException e) {


### PR DESCRIPTION
## PR Description
The metrics service was still requesting data from the RocksDB `Statistics` instance after the database was closed.  Fixed by encapsulating inside our `RocksDbStats` object which tracks when the stats have been closed and returns empty data back to the metrics system.

## Fixed Issue(s)
fixes #2255

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.