### PR TITLE
Switch from Gitter to Discord

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -12,8 +12,8 @@ Individual Contributor License Agreement.
 3. After creating your first pull request, you will see a merge
    pre-requisite requiring to you read and sign the CLA.
 
-If you have any questions, you can reach us on [Gitter].
+If you have any questions, you can reach us on [Discord].
  
-[Gitter]: https://gitter.im/PegaSysEng/teku
+[Discord]: https://discord.gg/7hPv2T6
 [GitHub]: https://github.com/
 [the current version of the CLA]: https://gist.github.com/rojotek/978b48a5e8b68836856a8961d6887992

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ This project and everyone participating in it is governed by the [Teku Code of C
 
 ## I just have a quick question
 
-You'll find us on [Gitter] and that's the fastest way to get an answer. 
+You'll find us on [Discord] and that's the fastest way to get an answer. 
 
 ## How To Contribute
 
@@ -123,5 +123,5 @@ We have a set of [coding conventions](https://wiki.hyperledger.org/display/BESU/
 * Reference issues and pull requests liberally
 
 [private@pegasys.tech]: mailto:private@pegasys.tech
-[Gitter]: https://gitter.im/PegaSysEng/teku
+[Discord]: https://discord.gg/7hPv2T6
 [CLA.md]: /CLA.md

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
  [![Build Status](https://circleci.com/gh/PegaSysEng/teku.svg?style=svg)](https://circleci.com/gh/PegaSysEng/workflows/teku)
  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/PegasysEng/teku/blob/master/LICENSE)
- [![Gitter chat](https://badges.gitter.im/PegaSysEng/teku.png)](https://gitter.im/PegaSysEng/teku)
+ [![Discord](https://img.shields.io/badge/Chat-on%20Discord-blue)](https://discord.gg/7hPv2T6)
 
 Teku is a Java implementation of the Ethereum 2.0 Beacon Chain. Teku is changing rapidly hence we recommend building from the latest master. See the [Changelog](CHANGELOG.md) for known issues and breaking changes.
 
@@ -19,8 +19,8 @@ Teku is a Java implementation of the Ethereum 2.0 Beacon Chain. Teku is changing
 
 See our [user documentation](https://docs.teku.pegasys.tech/). 
 
-Raise a [documentation issue](https://github.com/PegaSysEng/doc.teku/issues) or get in touch on 
-[Gitter](https://gitter.im/PegaSysEng/teku) if you've got questions or feedback. 
+Raise a [documentation issue](https://github.com/PegaSysEng/doc.teku/issues) or get in touch in 
+the #teku channel on [Discord](https://discord.gg/7hPv2T6) if you've got questions or feedback. 
 
 ## Teku developers 
 

--- a/community-membership.md
+++ b/community-membership.md
@@ -41,7 +41,7 @@ issues and PRs assigned to them.
     - Authoring or reviewing PRs on GitHub
     - Filing or commenting on issues on GitHub
     - Contributing to community discussions (e.g. meetings, Slack, email discussion forums, Stack Overflow)
-- Joined [Teku Gitter]
+- Joined [Teku Discord]
 - Have read the [contributor guide]
 - Signed ICLA, as described in [CLA.md]
 
@@ -128,4 +128,4 @@ This document is adapted from the following sources:
 [contributor guide]: /CONTRIBUTING.md
 [New contributors]: /CONTRIBUTING.md
 [two-factor authentication]: https://help.github.com/articles/about-two-factor-authentication
-[Teku Gitter]: https://gitter.im/PegaSysEng/teku
+[Teku Discord]: https://discord.gg/7hPv2T6


### PR DESCRIPTION
## PR Description
Update links to Gitter to point to Discord instead.

## Documentation

We should check that all our docs also point to Discord instead of Gitter.

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.