### PR TITLE
Resolve the listen address if it is an any local address

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -41,9 +41,7 @@ import io.libp2p.transport.tcp.TcpTransport;
 import io.netty.channel.ChannelHandler;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -104,7 +102,9 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
     this.nodeId = new LibP2PNodeId(PeerId.fromPubKey(privKey.publicKey()));
     this.config = config;
 
-    advertisedAddr = getAdvertisedAddr(config, nodeId);
+    advertisedAddr =
+        MultiaddrUtil.fromInetSocketAddress(
+            new InetSocketAddress(config.getAdvertisedIp(), config.getAdvertisedPort()), nodeId);
     this.listenPort = config.getListenPort();
 
     // Setup gossip
@@ -213,24 +213,6 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
               STATUS_LOG.listeningForLibP2P(getNodeAddress());
               return null;
             });
-  }
-
-  private Multiaddr getAdvertisedAddr(NetworkConfig config, final NodeId nodeId) {
-    try {
-      final InetSocketAddress advertisedAddress =
-          new InetSocketAddress(config.getAdvertisedIp(), config.getAdvertisedPort());
-      final InetSocketAddress resolvedAddress;
-      if (advertisedAddress.getAddress().isAnyLocalAddress()) {
-        resolvedAddress =
-            new InetSocketAddress(InetAddress.getLocalHost(), advertisedAddress.getPort());
-      } else {
-        resolvedAddress = advertisedAddress;
-      }
-      return MultiaddrUtil.fromInetSocketAddress(resolvedAddress, nodeId);
-    } catch (UnknownHostException err) {
-      throw new RuntimeException(
-          "Unable to start LibP2PNetwork due to failed attempt at obtaining host address", err);
-    }
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/NetworkConfig.java
@@ -16,12 +16,17 @@ package tech.pegasys.teku.networking.p2p.network;
 import static com.google.common.net.InetAddresses.isInetAddress;
 
 import io.libp2p.core.crypto.PrivKey;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.networking.p2p.connection.TargetPeerRange;
 
 public class NetworkConfig {
+  private static final Logger LOG = LogManager.getLogger();
 
   private final PrivKey privateKey;
   private final String networkInterface;
@@ -99,7 +104,7 @@ public class NetworkConfig {
   }
 
   public String getAdvertisedIp() {
-    return advertisedIp.orElse(networkInterface);
+    return advertisedIp.orElseGet(() -> resolveAnyLocalAddress(networkInterface));
   }
 
   public int getListenPort() {
@@ -132,5 +137,20 @@ public class NetworkConfig {
 
   public WireLogsConfig getWireLogsConfig() {
     return wireLogsConfig;
+  }
+
+  private String resolveAnyLocalAddress(final String ipAddress) {
+    try {
+      final InetAddress advertisedAddress = InetAddress.getByName(ipAddress);
+      if (advertisedAddress.isAnyLocalAddress()) {
+        return InetAddress.getLocalHost().getHostAddress();
+      } else {
+        return ipAddress;
+      }
+    } catch (UnknownHostException err) {
+      LOG.error(
+          "Unable to start LibP2PNetwork due to failed attempt at obtaining host address", err);
+      return ipAddress;
+    }
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/NetworkConfig.java
@@ -104,7 +104,7 @@ public class NetworkConfig {
   }
 
   public String getAdvertisedIp() {
-    return advertisedIp.orElseGet(() -> resolveAnyLocalAddress(networkInterface));
+    return resolveAnyLocalAddress(advertisedIp.orElse(networkInterface));
   }
 
   public int getListenPort() {

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/NetworkConfigTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/NetworkConfigTest.java
@@ -30,9 +30,16 @@ class NetworkConfigTest {
   private String listenIp = "0.0.0.0";
 
   @Test
-  void getAdvertisedIp_shouldNotChangeSpecificallySetAdvertisedAddress() {
-    final String expected = "0.0.0.0";
+  void getAdvertisedIp_shouldUseAdvertisedAddressWhenSet() {
+    final String expected = "1.2.3.4";
     advertisedIp = Optional.of(expected);
+    assertThat(createConfig().getAdvertisedIp()).isEqualTo(expected);
+  }
+
+  @Test
+  void getAdvertisedIp_shouldResolveAnyLocalAdvertisedAddress() throws Exception {
+    advertisedIp = Optional.of("0.0.0.0");
+    final String expected = InetAddress.getLocalHost().getHostAddress();
     assertThat(createConfig().getAdvertisedIp()).isEqualTo(expected);
   }
 

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/NetworkConfigTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/NetworkConfigTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.p2p.network;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.libp2p.core.crypto.KEY_TYPE;
+import io.libp2p.core.crypto.KeyKt;
+import java.net.InetAddress;
+import java.util.Optional;
+import java.util.OptionalInt;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.networking.p2p.connection.TargetPeerRange;
+
+class NetworkConfigTest {
+
+  private Optional<String> advertisedIp = Optional.empty();
+  private String listenIp = "0.0.0.0";
+
+  @Test
+  void getAdvertisedIp_shouldNotChangeSpecificallySetAdvertisedAddress() {
+    final String expected = "0.0.0.0";
+    advertisedIp = Optional.of(expected);
+    assertThat(createConfig().getAdvertisedIp()).isEqualTo(expected);
+  }
+
+  @Test
+  void getAdvertisedIp_shouldReturnInterfaceIpWhenNotSet() {
+    listenIp = "127.0.0.1";
+    assertThat(createConfig().getAdvertisedIp()).isEqualTo(listenIp);
+  }
+
+  @Test
+  void getAdvertisedIp_shouldResolveLocalhostIpWhenInterfaceIpIsAnyLocal() throws Exception {
+    listenIp = "0.0.0.0";
+    final String expected = InetAddress.getLocalHost().getHostAddress();
+    assertThat(createConfig().getAdvertisedIp()).isEqualTo(expected);
+  }
+
+  @Test
+  void getAdvertisedIp_shouldResolveLocalhostIpWhenInterfaceIpIsAnyLocalIpv6() throws Exception {
+    listenIp = "::0";
+    final String expected = InetAddress.getLocalHost().getHostAddress();
+    assertThat(createConfig().getAdvertisedIp()).isEqualTo(expected);
+  }
+
+  private NetworkConfig createConfig() {
+    return new NetworkConfig(
+        KeyKt.generateKeyPair(KEY_TYPE.SECP256K1).component1(),
+        listenIp,
+        advertisedIp,
+        9000,
+        OptionalInt.empty(),
+        emptyList(),
+        false,
+        emptyList(),
+        new TargetPeerRange(20, 30));
+  }
+}


### PR DESCRIPTION
## PR Description
If advertised IP is not set and the P2P interface is set to an any local address (e.g 0.0.0.0), use the localhost IP as the advertised IP.

If the advertised IP is set explicitly we always use it as-is.

## Fixed Issue(s)
fixes #1896 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.