### PR TITLE
[Issue 2241] Prevent tx updates after db is closed

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -59,9 +59,9 @@ public class RocksDbDatabase implements Database {
   private final MetricsSystem metricsSystem;
   private final StateStorageMode stateStorageMode;
 
-  private final RocksDbHotDao hotDao;
-  private final RocksDbFinalizedDao finalizedDao;
-  private final RocksDbEth1Dao eth1Dao;
+  final RocksDbHotDao hotDao;
+  final RocksDbFinalizedDao finalizedDao;
+  final RocksDbEth1Dao eth1Dao;
 
   public static Database createV3(
       final MetricsSystem metricsSystem,

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/rocksdb/core/MockRocksDbInstance.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/rocksdb/core/MockRocksDbInstance.java
@@ -258,6 +258,9 @@ public class MockRocksDbInstance implements RocksDbAccessor {
 
     private void assertOpen() {
       checkState(!closed, "Attempt to modify a closed transaction");
+      if (dbInstance.closed.get()) {
+        throw new ShuttingDownException();
+      }
     }
 
     @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Prevent `Transaction`'s from being modified after the rocksdb database is closed. 

## Fixed Issue(s)
Fixes #2241 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.