### PR TITLE
Fix DepositStorageTest: make sure we're running across db versions

### DIFF
--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -40,6 +40,8 @@ dependencies {
   testFixturesImplementation testFixtures(project(':pow'))
   testFixturesImplementation project(':protoarray')
   testFixturesImplementation testFixtures(project(':util'))
+  testFixturesImplementation 'org.junit.jupiter:junit-jupiter-api'
+  testFixturesImplementation 'org.junit.jupiter:junit-jupiter-params'
   testFixturesImplementation 'com.google.guava:guava'
   testFixturesImplementation 'org.apache.tuweni:tuweni-bytes'
   testFixturesImplementation 'org.hyperledger.besu.internal:metrics-core'

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/FileBackedStorageSystem.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/FileBackedStorageSystem.java
@@ -58,6 +58,12 @@ public class FileBackedStorageSystem extends AbstractStorageSystem {
   }
 
   public static StorageSystem createV5StorageSystem(
+      final Path dataDir, final StateStorageMode storageMode, final long stateStorageFrequency) {
+    return createV5StorageSystem(
+        dataDir.resolve("hot"), dataDir.resolve("archive"), storageMode, stateStorageFrequency);
+  }
+
+  public static StorageSystem createV5StorageSystem(
       final Path hotDir,
       final Path archiveDir,
       final StateStorageMode storageMode,
@@ -71,6 +77,12 @@ public class FileBackedStorageSystem extends AbstractStorageSystem {
             stateStorageFrequency);
     return create(
         database, (mode) -> createV5StorageSystem(hotDir, archiveDir, mode, stateStorageFrequency));
+  }
+
+  public static StorageSystem createV4StorageSystem(
+      final Path dataDir, final StateStorageMode storageMode, final long stateStorageFrequency) {
+    return createV4StorageSystem(
+        dataDir.resolve("hot"), dataDir.resolve("archive"), storageMode, stateStorageFrequency);
   }
 
   public static StorageSystem createV4StorageSystem(

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystemArgumentsProvider.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystemArgumentsProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.storageSystem;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import tech.pegasys.teku.storage.server.VersionedDatabaseFactory;
+import tech.pegasys.teku.util.config.StateStorageMode;
+
+public class StorageSystemArgumentsProvider implements ArgumentsProvider {
+  private final List<Long> stateStorageFrequencyOptions =
+      List.of(VersionedDatabaseFactory.DEFAULT_STORAGE_FREQUENCY);
+
+  @Override
+  public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+    final Map<String, StorageSystemSupplier> storageSystems = new HashMap<>();
+    for (StateStorageMode mode : StateStorageMode.values()) {
+      storageSystems.put(
+          "v3 (in-memory)", (dataPath) -> InMemoryStorageSystem.createEmptyV3StorageSystem(mode));
+      storageSystems.put(
+          "v3 (file-backed)",
+          (dataPath) -> FileBackedStorageSystem.createV3StorageSystem(dataPath, mode));
+      for (Long storageFrequency : stateStorageFrequencyOptions) {
+        storageSystems.put(
+            "v4 (in-memory)",
+            (dataPath) -> InMemoryStorageSystem.createEmptyV4StorageSystem(mode, storageFrequency));
+        storageSystems.put(
+            "v5 (in-memory)",
+            (dataPath) -> InMemoryStorageSystem.createEmptyV5StorageSystem(mode, storageFrequency));
+        storageSystems.put(
+            "v4 (file-backed)",
+            (dataPath) ->
+                FileBackedStorageSystem.createV4StorageSystem(dataPath, mode, storageFrequency));
+        storageSystems.put(
+            "v5 (file-backed)",
+            (dataPath) ->
+                FileBackedStorageSystem.createV5StorageSystem(dataPath, mode, storageFrequency));
+      }
+    }
+    return storageSystems.entrySet().stream()
+        .map((entry) -> Arguments.of("storage type: " + entry.getKey(), entry.getValue()));
+  }
+
+  @FunctionalInterface
+  public interface StorageSystemSupplier {
+    StorageSystem get(final Path dataDirectory);
+  }
+}

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystemArgumentsProvider.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystemArgumentsProvider.java
@@ -39,23 +39,27 @@ public class StorageSystemArgumentsProvider implements ArgumentsProvider {
           (dataPath) -> FileBackedStorageSystem.createV3StorageSystem(dataPath, mode));
       for (Long storageFrequency : stateStorageFrequencyOptions) {
         storageSystems.put(
-            "v4 (in-memory)",
+            describeStorage("v4 (in-memory)", storageFrequency),
             (dataPath) -> InMemoryStorageSystem.createEmptyV4StorageSystem(mode, storageFrequency));
         storageSystems.put(
-            "v5 (in-memory)",
+            describeStorage("v5 (in-memory)", storageFrequency),
             (dataPath) -> InMemoryStorageSystem.createEmptyV5StorageSystem(mode, storageFrequency));
         storageSystems.put(
-            "v4 (file-backed)",
+            describeStorage("v4 (file-backed)", storageFrequency),
             (dataPath) ->
                 FileBackedStorageSystem.createV4StorageSystem(dataPath, mode, storageFrequency));
         storageSystems.put(
-            "v5 (file-backed)",
+            describeStorage("v5 (file-backed)", storageFrequency),
             (dataPath) ->
                 FileBackedStorageSystem.createV5StorageSystem(dataPath, mode, storageFrequency));
       }
     }
     return storageSystems.entrySet().stream()
         .map((entry) -> Arguments.of("storage type: " + entry.getKey(), entry.getValue()));
+  }
+
+  private String describeStorage(final String baseName, final long storageFrequency) {
+    return String.format("%s (storage freq %s)", baseName, storageFrequency);
   }
 
   @FunctionalInterface


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As part of #2194 , `DepositStorageTest` was modified to be a standalone test to avoid running unnecessary tests from the base class.  However, that change also had the side-effect of preventing these tests from running against different database versions.  This PR updates this test to run across database implementations.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.