### PR TITLE
add a metric to track connected eth2 nodes similar to api and console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ we recommend most users use the latest `master` branch of Teku.
  - Anyone using `/node/version` should switch to use
    the new `/v1/node/version` endpoint, as `/node/version` will be removed in a future release.
 
+## 0.12.1
+
+### Breaking Changes
+ 
+### Additions and Improvements
+
+ - added a metric `beacon_peer_count` that tracks the same counter used for `/network/peer_count` and console `Peers:` output.
+
+### Bug Fixes
+
+### Known Issues
+
+- Validator may produce attestations in the incorrect slot or committee resulting in `Produced invalid attestation` messages ([#2179](https://github.com/PegaSysEng/teku/issues/2179))
+
 ## 0.12.0
 
 ### Breaking Changes

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -270,7 +270,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     LOG.debug("BeaconChainController.initMetrics()");
     eventChannels.subscribe(
         SlotEventsChannel.class,
-        new BeaconChainMetrics(recentChainData, slotProcessor.getNodeSlot(), metricsSystem));
+        new BeaconChainMetrics(
+            recentChainData, slotProcessor.getNodeSlot(), metricsSystem, p2pNetwork));
   }
 
   public void initDepositProvider() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
@@ -111,7 +111,7 @@ public class BeaconChainMetrics implements SlotEventsChannel {
     metricsSystem.createGauge(
         TekuMetricCategory.BEACON,
         "peer_count",
-        "Tracks number of connected peers",
+        "Tracks number of connected peers, verified to be on the same chain",
         p2pNetwork::getPeerCount);
 
     previousLiveValidators =

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.metrics.SettableGauge;
 import tech.pegasys.teku.metrics.TekuMetricCategory;
+import tech.pegasys.teku.networking.eth2.Eth2Network;
 import tech.pegasys.teku.ssz.SSZTypes.Bitlist;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -47,7 +48,10 @@ public class BeaconChainMetrics implements SlotEventsChannel {
   private final SettableGauge currentLiveValidators;
 
   public BeaconChainMetrics(
-      final RecentChainData recentChainData, NodeSlot nodeSlot, final MetricsSystem metricsSystem) {
+      final RecentChainData recentChainData,
+      final NodeSlot nodeSlot,
+      final MetricsSystem metricsSystem,
+      final Eth2Network p2pNetwork) {
     this.recentChainData = recentChainData;
     this.nodeSlot = nodeSlot;
 
@@ -104,6 +108,11 @@ public class BeaconChainMetrics implements SlotEventsChannel {
         "previous_justified_root",
         "Current previously justified root",
         this::getPreviousJustifiedRootValue);
+    metricsSystem.createGauge(
+        TekuMetricCategory.BEACON,
+        "peer_count",
+        "Tracks number of connected peers",
+        p2pNetwork::getPeerCount);
 
     previousLiveValidators =
         SettableGauge.create(

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.datastructures.state.Validator;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.metrics.StubMetricsSystem;
+import tech.pegasys.teku.networking.eth2.Eth2Network;
 import tech.pegasys.teku.ssz.SSZTypes.Bitlist;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
@@ -63,10 +64,11 @@ class BeaconChainMetricsTest {
   private final RecentChainData recentChainData = mock(RecentChainData.class);
   private final RecentChainData preGenesisChainData =
       MemoryOnlyRecentChainData.create(mock(EventBus.class));
+  private final Eth2Network eth2Network = mock(Eth2Network.class);
 
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   private final BeaconChainMetrics beaconChainMetrics =
-      new BeaconChainMetrics(recentChainData, nodeSlot, metricsSystem);
+      new BeaconChainMetrics(recentChainData, nodeSlot, metricsSystem, eth2Network);
 
   @Test
   void getLongFromRoot_shouldParseNegativeOne() {
@@ -117,6 +119,12 @@ class BeaconChainMetricsTest {
     when(recentChainData.getFinalizedEpoch()).thenReturn(ONE);
 
     assertThat(metricsSystem.getGauge(BEACON, "finalized_epoch").getValue()).isEqualTo(1);
+  }
+
+  @Test
+  void getPeerCount_shouldSupplyValue() {
+    when(eth2Network.getPeerCount()).thenReturn(1);
+    assertThat(metricsSystem.getGauge(BEACON, "peer_count").getValue()).isEqualTo(1);
   }
 
   @Test


### PR DESCRIPTION
 - added beacon_peer_count to track connections in the same way the API does

 - added regression test to show metric working.

fixes #2177

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.