### PR TITLE
Add network metrics

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
@@ -121,8 +121,9 @@ public class Eth2NetworkBuilder {
 
   protected DiscoveryNetwork<?> buildNetwork() {
     final ReputationManager reputationManager =
-        new ReputationManager(timeProvider, Constants.REPUTATION_MANAGER_CAPACITY);
+        new ReputationManager(metricsSystem, timeProvider, Constants.REPUTATION_MANAGER_CAPACITY);
     return DiscoveryNetwork.create(
+        metricsSystem,
         asyncRunner,
         new LibP2PNetwork(
             asyncRunner, config, reputationManager, metricsSystem, rpcMethods, peerHandlers),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -107,7 +107,8 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
       Duration eth2StatusUpdateInterval) {
     final PeerValidatorFactory peerValidatorFactory =
         (peer, status) ->
-            PeerChainValidator.create(storageClient, historicalChainData, peer, status);
+            PeerChainValidator.create(
+                metricsSystem, storageClient, historicalChainData, peer, status);
     return new Eth2PeerManager(
         asyncRunner,
         new CombinedChainDataClient(storageClient, historicalChainData),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
@@ -23,8 +23,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
+import tech.pegasys.teku.metrics.TekuMetricCategory;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
 import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
@@ -40,9 +44,14 @@ public class PeerChainValidator {
   private final Eth2Peer peer;
   private final AtomicBoolean hasRun = new AtomicBoolean(false);
   private final PeerStatus status;
+  private final Counter validationStartedCounter;
+  private final Counter chainValidCounter;
+  private final Counter chainInvalidCounter;
+  private final Counter validationErrorCounter;
   private SafeFuture<Boolean> result;
 
   private PeerChainValidator(
+      final MetricsSystem metricsSystem,
       final RecentChainData storageClient,
       final StorageQueryChannel historicalChainData,
       final Eth2Peer peer,
@@ -51,14 +60,26 @@ public class PeerChainValidator {
     this.historicalChainData = historicalChainData;
     this.peer = peer;
     this.status = status;
+
+    final LabelledMetric<Counter> validationCounter =
+        metricsSystem.createLabelledCounter(
+            TekuMetricCategory.NETWORK,
+            "peer_chain_validation_attempts",
+            "Number of peers chain verification has been performed on",
+            "status");
+    validationStartedCounter = validationCounter.labels("started");
+    chainValidCounter = validationCounter.labels("valid");
+    chainInvalidCounter = validationCounter.labels("invalid");
+    validationErrorCounter = validationCounter.labels("error");
   }
 
   public static PeerChainValidator create(
+      final MetricsSystem metricsSystem,
       final RecentChainData storageClient,
       final StorageQueryChannel historicalChainData,
       final Eth2Peer peer,
       final PeerStatus status) {
-    return new PeerChainValidator(storageClient, historicalChainData, peer, status);
+    return new PeerChainValidator(metricsSystem, storageClient, historicalChainData, peer, status);
   }
 
   public SafeFuture<Boolean> run() {
@@ -70,15 +91,18 @@ public class PeerChainValidator {
 
   private SafeFuture<Boolean> executeCheck() {
     LOG.trace("Validate chain of peer: {}", peer);
+    validationStartedCounter.inc();
     return checkRemoteChain()
         .thenApply(
             isValid -> {
               if (!isValid) {
                 // We are not on the same chain
                 LOG.trace("Disconnecting peer on different chain: {}", peer);
+                chainInvalidCounter.inc();
                 peer.disconnectCleanly(DisconnectReason.IRRELEVANT_NETWORK);
               } else {
                 LOG.trace("Validated peer's chain: {}", peer);
+                chainValidCounter.inc();
                 peer.markChainValidated();
               }
               return isValid;
@@ -86,6 +110,7 @@ public class PeerChainValidator {
         .exceptionally(
             err -> {
               LOG.debug("Unable to validate peer's chain, disconnecting: " + peer, err);
+              validationErrorCounter.inc();
               peer.disconnectCleanly(DisconnectReason.UNABLE_TO_VERIFY_NETWORK);
               return false;
             });

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
@@ -24,6 +24,7 @@ import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_star
 import com.google.common.primitives.UnsignedLong;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
@@ -229,7 +230,8 @@ public class PeerChainValidatorTest {
     // Setup peer to report a pre-genesis status
     remoteStatus = PeerStatus.createPreGenesisStatus();
     peerChainValidator =
-        PeerChainValidator.create(recentChainData, historicalChainData, peer, remoteStatus);
+        PeerChainValidator.create(
+            new NoOpMetricsSystem(), recentChainData, historicalChainData, peer, remoteStatus);
 
     // Setup mocks
     forksMatch();
@@ -409,6 +411,7 @@ public class PeerChainValidatorTest {
 
     remoteStatus = status;
     peerChainValidator =
-        PeerChainValidator.create(recentChainData, historicalChainData, peer, status);
+        PeerChainValidator.create(
+            new NoOpMetricsSystem(), recentChainData, historicalChainData, peer, status);
   }
 }

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
@@ -167,11 +167,15 @@ public class Eth2NetworkFactory {
 
         this.peerHandler(eth2PeerManager);
 
+        final NoOpMetricsSystem metricsSystem = new NoOpMetricsSystem();
         final ReputationManager reputationManager =
             new ReputationManager(
-                StubTimeProvider.withTimeInSeconds(1000), Constants.REPUTATION_MANAGER_CAPACITY);
+                metricsSystem,
+                StubTimeProvider.withTimeInSeconds(1000),
+                Constants.REPUTATION_MANAGER_CAPACITY);
         final DiscoveryNetwork<?> network =
             DiscoveryNetwork.create(
+                metricsSystem,
                 asyncRunner,
                 new LibP2PNetwork(
                     asyncRunner,

--- a/networking/p2p/build.gradle
+++ b/networking/p2p/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
   testImplementation testFixtures(project(':ethereum:statetransition'))
   testImplementation testFixtures(project(':ethereum:datastructures'))
+  testImplementation testFixtures(project(':data:metrics'))
   testImplementation testFixtures(project(':util'))
 
   testImplementation 'org.hyperledger.besu.internal:metrics-core'

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/DiscoveryNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/DiscoveryNetwork.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.EnrForkId;
 import tech.pegasys.teku.datastructures.state.Fork;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
@@ -80,6 +81,7 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
   }
 
   public static <P extends Peer> DiscoveryNetwork<P> create(
+      final MetricsSystem metricsSystem,
       final AsyncRunner asyncRunner,
       final P2PNetwork<P> p2pNetwork,
       final ReputationManager reputationManager,
@@ -87,6 +89,7 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
     final DiscoveryService discoveryService = createDiscoveryService(p2pConfig);
     final ConnectionManager connectionManager =
         new ConnectionManager(
+            metricsSystem,
             discoveryService,
             reputationManager,
             asyncRunner,

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ReputationManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ReputationManager.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.networking.p2p.connection;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.Optional;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.metrics.TekuMetricCategory;
 import tech.pegasys.teku.networking.p2p.network.PeerAddress;
 import tech.pegasys.teku.util.cache.Cache;
 import tech.pegasys.teku.util.cache.LRUCache;
@@ -24,9 +26,15 @@ public class ReputationManager {
   private final TimeProvider timeProvider;
   private final Cache<PeerAddress, Reputation> peerReputations;
 
-  public ReputationManager(final TimeProvider timeProvider, final int capacity) {
+  public ReputationManager(
+      final MetricsSystem metricsSystem, final TimeProvider timeProvider, final int capacity) {
     this.timeProvider = timeProvider;
     this.peerReputations = new LRUCache<>(capacity);
+    metricsSystem.createIntegerGauge(
+        TekuMetricCategory.NETWORK,
+        "peer_reputation_cache_size",
+        "Total number of peer reputations tracked",
+        peerReputations::size);
   }
 
   public void reportInitiatedConnectionFailed(final PeerAddress peerAddress) {

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkTest.java
@@ -34,6 +34,7 @@ import java.util.OptionalInt;
 import java.util.function.Predicate;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -142,6 +143,7 @@ class DiscoveryNetworkTest {
   public void shouldNotEnableDiscoveryWhenDiscoveryIsDisabled() {
     final DiscoveryNetwork<Peer> network =
         DiscoveryNetwork.create(
+            new NoOpMetricsSystem(),
             DelayedExecutorAsyncRunner.create(),
             p2pNetwork,
             reputationManager,

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/ConnectionManagerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/ConnectionManagerTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -474,6 +475,7 @@ class ConnectionManagerTest {
   private ConnectionManager createManager(
       final TargetPeerRange targetPeerCount, final PeerAddress... peers) {
     return new ConnectionManager(
+        new NoOpMetricsSystem(),
         discoveryService,
         reputationManager,
         asyncRunner,

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
@@ -87,11 +87,15 @@ public class DiscoveryNetworkFactory {
                 true,
                 bootnodes,
                 new TargetPeerRange(20, 30));
+        final NoOpMetricsSystem metricsSystem = new NoOpMetricsSystem();
         final ReputationManager reputationManager =
             new ReputationManager(
-                StubTimeProvider.withTimeInSeconds(1000), Constants.REPUTATION_MANAGER_CAPACITY);
+                metricsSystem,
+                StubTimeProvider.withTimeInSeconds(1000),
+                Constants.REPUTATION_MANAGER_CAPACITY);
         final DiscoveryNetwork<Peer> network =
             DiscoveryNetwork.create(
+                metricsSystem,
                 DelayedExecutorAsyncRunner.create(),
                 new LibP2PNetwork(
                     DelayedExecutorAsyncRunner.create(),

--- a/util/src/main/java/tech/pegasys/teku/util/cache/Cache.java
+++ b/util/src/main/java/tech/pegasys/teku/util/cache/Cache.java
@@ -56,4 +56,7 @@ public interface Cache<K, V> {
 
   /** Clears all cached values */
   void clear();
+
+  /** Returns the current number of items in the cache */
+  int size();
 }

--- a/util/src/main/java/tech/pegasys/teku/util/cache/LRUCache.java
+++ b/util/src/main/java/tech/pegasys/teku/util/cache/LRUCache.java
@@ -93,4 +93,9 @@ public class LRUCache<K, V> implements Cache<K, V> {
   public void clear() {
     cacheData.clear();
   }
+
+  @Override
+  public int size() {
+    return cacheData.size();
+  }
 }

--- a/util/src/main/java/tech/pegasys/teku/util/cache/NoOpCache.java
+++ b/util/src/main/java/tech/pegasys/teku/util/cache/NoOpCache.java
@@ -62,4 +62,9 @@ public class NoOpCache<K, V> implements Cache<K, V> {
 
   @Override
   public void clear() {}
+
+  @Override
+  public int size() {
+    return 0;
+  }
 }


### PR DESCRIPTION
## PR Description
To help diagnose issues where we aren't connecting to new peers, add metrics to report:
* the number of outbound connection attempts
* the number and result of peer chain validations
* the size of the peer reputation cache

## Fixed Issue(s)
Hoping this will shed some light on #2200 and #2287 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.