### PR TITLE
added block importer metrics

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -485,7 +485,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
               recentChainData,
               blockImporter);
       SyncManager syncManager =
-          SyncManager.create(asyncRunner, p2pNetwork, recentChainData, blockImporter);
+          SyncManager.create(
+              asyncRunner, p2pNetwork, recentChainData, blockImporter, metricsSystem);
       syncService = new DefaultSyncService(blockManager, syncManager, recentChainData);
       eventChannels
           .subscribe(SlotEventsChannel.class, blockManager)

--- a/sync/build.gradle
+++ b/sync/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation project(':data')
+    implementation project(':data:metrics')
     implementation project(':ethereum:core')
     implementation project(':ethereum:datastructures')
     implementation project(':ethereum:statetransition')
@@ -20,6 +21,7 @@ dependencies {
     testImplementation testFixtures(project('::networking:eth2'))
     testImplementation testFixtures(project('::networking:p2p'))
     testImplementation testFixtures(project(':util'))
+    testImplementation 'org.hyperledger.besu.internal:metrics-core'
 
     integrationTestImplementation testFixtures(project(':bls'))
     integrationTestImplementation testFixtures(project(':ethereum:statetransition'))

--- a/sync/src/main/java/tech/pegasys/teku/sync/PeerSync.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/PeerSync.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.core.results.BlockImportResult;
 import tech.pegasys.teku.core.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
@@ -62,18 +63,14 @@ public class PeerSync {
     this.asyncRunner = asyncRunner;
     this.storageClient = storageClient;
     this.blockImporter = blockImporter;
-
-    this.blockImportSuccessResult =
-        metricsSystem.createCounter(
+    final LabelledMetric<Counter> blockImportCounter =
+        metricsSystem.createLabelledCounter(
             TekuMetricCategory.BEACON,
-            "block_import_success_result",
-            "The number of block imports that have been successfully completed");
-
-    this.blockImportFailureResult =
-        metricsSystem.createCounter(
-            TekuMetricCategory.BEACON,
-            "block_import_failure_result",
-            "The number of block imports that have failed");
+            "block_import_total",
+            "The number of block imports performed",
+            "result");
+    this.blockImportSuccessResult = blockImportCounter.labels("imported");
+    this.blockImportFailureResult = blockImportCounter.labels("rejected");
   }
 
   public SafeFuture<PeerSyncResult> sync(final Eth2Peer peer) {

--- a/sync/src/main/java/tech/pegasys/teku/sync/SyncManager.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/SyncManager.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
@@ -71,12 +72,13 @@ public class SyncManager extends Service {
       final AsyncRunner asyncRunner,
       final P2PNetwork<Eth2Peer> network,
       final RecentChainData storageClient,
-      final BlockImporter blockImporter) {
+      final BlockImporter blockImporter,
+      final MetricsSystem metricsSystem) {
     return new SyncManager(
         asyncRunner,
         network,
         storageClient,
-        new PeerSync(asyncRunner, storageClient, blockImporter));
+        new PeerSync(asyncRunner, storageClient, blockImporter, metricsSystem));
   }
 
   @Override

--- a/sync/src/test/java/tech/pegasys/teku/sync/PeerSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/PeerSyncTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -87,7 +88,7 @@ public class PeerSyncTest {
     final BlockImportResult result = BlockImportResult.successful(processingRecord);
     when(processingRecord.getBlock()).thenReturn(block);
     when(blockImporter.importBlock(any())).thenReturn(result);
-    peerSync = new PeerSync(asyncRunner, storageClient, blockImporter);
+    peerSync = new PeerSync(asyncRunner, storageClient, blockImporter, new NoOpMetricsSystem());
   }
 
   @Test
@@ -242,7 +243,7 @@ public class PeerSyncTest {
                 peerHeadSlot));
 
     when(peer.getStatus()).thenReturn(peer_status);
-    peerSync = new PeerSync(asyncRunner, storageClient, blockImporter);
+    peerSync = new PeerSync(asyncRunner, storageClient, blockImporter, new NoOpMetricsSystem());
 
     final SafeFuture<Void> requestFuture1 = new SafeFuture<>();
     final SafeFuture<Void> requestFuture2 = new SafeFuture<>();
@@ -315,7 +316,7 @@ public class PeerSyncTest {
                 peerHeadSlot));
 
     when(peer.getStatus()).thenReturn(peer_status);
-    peerSync = new PeerSync(asyncRunner, storageClient, blockImporter);
+    peerSync = new PeerSync(asyncRunner, storageClient, blockImporter, new NoOpMetricsSystem());
 
     final SafeFuture<Void> requestFuture1 = new SafeFuture<>();
     final SafeFuture<Void> requestFuture2 = new SafeFuture<>();

--- a/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
+++ b/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
@@ -102,7 +102,8 @@ public class SyncingNodeManager {
             blockImporter);
 
     SyncManager syncManager =
-        SyncManager.create(asyncRunner, eth2Network, recentChainData, blockImporter);
+        SyncManager.create(
+            asyncRunner, eth2Network, recentChainData, blockImporter, new NoOpMetricsSystem());
     SyncService syncService = new DefaultSyncService(blockManager, syncManager, recentChainData);
 
     eventChannels


### PR DESCRIPTION
added metrics to track import success and failure

- block_import_success_result is a counter of block import success results

- block_import_failure_result is a counter of the block import failures

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.