### PR TITLE
Disconnect when initial status exchange fails

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.peers;
+
+import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
+import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.MetadataMessagesFactory;
+import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
+import tech.pegasys.teku.networking.p2p.peer.Peer;
+
+public class Eth2PeerFactory {
+
+  private final StatusMessageFactory statusMessageFactory;
+  private final MetadataMessagesFactory metadataMessagesFactory;
+
+  public Eth2PeerFactory(
+      final StatusMessageFactory statusMessageFactory,
+      final MetadataMessagesFactory metadataMessagesFactory) {
+    this.statusMessageFactory = statusMessageFactory;
+    this.metadataMessagesFactory = metadataMessagesFactory;
+  }
+
+  public Eth2Peer create(final Peer peer, final BeaconChainMethods rpcMethods) {
+    return new Eth2Peer(peer, rpcMethods, statusMessageFactory, metadataMessagesFactory);
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -49,7 +49,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
   private static final Logger LOG = LogManager.getLogger();
 
   private final AsyncRunner asyncRunner;
-  private final StatusMessageFactory statusMessageFactory;
+  private final Eth2PeerFactory eth2PeerFactory;
   private final MetadataMessagesFactory metadataMessagesFactory;
 
   private final Subscribers<PeerConnectedSubscriber<Eth2Peer>> connectSubscribers =
@@ -69,17 +69,18 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
       final CombinedChainDataClient combinedChainDataClient,
       final RecentChainData storageClient,
       final MetricsSystem metricsSystem,
+      final Eth2PeerFactory eth2PeerFactory,
       final PeerValidatorFactory peerValidatorFactory,
-      final AttestationSubnetService attestationSubnetService,
+      final StatusMessageFactory statusMessageFactory,
+      final MetadataMessagesFactory metadataMessagesFactory,
       final RpcEncoding rpcEncoding,
       final Duration eth2RpcPingInterval,
       final int eth2RpcOutstandingPingThreshold,
       Duration eth2StatusUpdateInterval) {
     this.asyncRunner = asyncRunner;
-    this.statusMessageFactory = new StatusMessageFactory(storageClient);
-    metadataMessagesFactory = new MetadataMessagesFactory();
-    attestationSubnetService.subscribeToUpdates(metadataMessagesFactory);
+    this.eth2PeerFactory = eth2PeerFactory;
     this.peerValidatorFactory = peerValidatorFactory;
+    this.metadataMessagesFactory = metadataMessagesFactory;
     this.rpcMethods =
         BeaconChainMethods.create(
             asyncRunner,
@@ -97,7 +98,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
 
   public static Eth2PeerManager create(
       final AsyncRunner asyncRunner,
-      final RecentChainData storageClient,
+      final RecentChainData recentChainData,
       final StorageQueryChannel historicalChainData,
       final MetricsSystem metricsSystem,
       final AttestationSubnetService attestationSubnetService,
@@ -105,17 +106,23 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
       final Duration eth2RpcPingInterval,
       final int eth2RpcOutstandingPingThreshold,
       Duration eth2StatusUpdateInterval) {
+
     final PeerValidatorFactory peerValidatorFactory =
         (peer, status) ->
             PeerChainValidator.create(
-                metricsSystem, storageClient, historicalChainData, peer, status);
+                metricsSystem, recentChainData, historicalChainData, peer, status);
+    final StatusMessageFactory statusMessageFactory = new StatusMessageFactory(recentChainData);
+    final MetadataMessagesFactory metadataMessagesFactory = new MetadataMessagesFactory();
+    attestationSubnetService.subscribeToUpdates(metadataMessagesFactory);
     return new Eth2PeerManager(
         asyncRunner,
-        new CombinedChainDataClient(storageClient, historicalChainData),
-        storageClient,
+        new CombinedChainDataClient(recentChainData, historicalChainData),
+        recentChainData,
         metricsSystem,
+        new Eth2PeerFactory(statusMessageFactory, metadataMessagesFactory),
         peerValidatorFactory,
-        attestationSubnetService,
+        statusMessageFactory,
+        metadataMessagesFactory,
         rpcEncoding,
         eth2RpcPingInterval,
         eth2RpcOutstandingPingThreshold,
@@ -158,8 +165,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
 
   @Override
   public void onConnect(final Peer peer) {
-    Eth2Peer eth2Peer =
-        new Eth2Peer(peer, rpcMethods, statusMessageFactory, metadataMessagesFactory);
+    Eth2Peer eth2Peer = eth2PeerFactory.create(peer, rpcMethods);
     final boolean wasAdded = connectedPeerMap.putIfAbsent(peer.getId(), eth2Peer) == null;
     if (!wasAdded) {
       LOG.warn("Duplicate peer connection detected. Ignoring peer.");
@@ -176,9 +182,15 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
               RootCauseExceptionHandler.builder()
                   .addCatch(
                       RpcException.class,
-                      err -> LOG.trace("Status message rejected by {}: {}", peer.getId(), err))
+                      err -> {
+                        LOG.trace("Status message rejected by {}: {}", peer.getId(), err);
+                        eth2Peer.disconnectImmediately();
+                      })
                   .defaultCatch(
-                      err -> LOG.debug("Failed to send status to {}: {}", peer.getId(), err)));
+                      err -> {
+                        LOG.debug("Failed to send status to {}: {}", peer.getId(), err);
+                        eth2Peer.disconnectImmediately();
+                      }));
     }
 
     eth2Peer.subscribeInitialStatus(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -43,6 +43,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.util.async.AsyncRunner;
 import tech.pegasys.teku.util.async.Cancellable;
 import tech.pegasys.teku.util.async.RootCauseExceptionHandler;
+import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.util.events.Subscribers;
 
 public class Eth2PeerManager implements PeerLookup, PeerHandler {
@@ -191,6 +192,15 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
                         LOG.debug("Failed to send status to {}: {}", peer.getId(), err);
                         eth2Peer.disconnectImmediately();
                       }));
+    } else {
+      asyncRunner.runAfterDelay(
+          () -> {
+            if (!eth2Peer.hasStatus()) {
+              eth2Peer.disconnectCleanly(DisconnectReason.REMOTE_FAULT);
+            }
+          },
+          Constants.RESP_TIMEOUT,
+          TimeUnit.SECONDS);
     }
 
     eth2Peer.subscribeInitialStatus(


### PR DESCRIPTION
##  PR Description
We were failing to disconnect peers if the initial status exchange failed. Because we only setup the periodic pings to check liveness after the initial status exchange, these peers could wind up as zombies that never got disconnected but were never useful. This led to a permanent difference between the number of libp2p connections and the number of actually useful peers.

If you managed to get 20 peers into this state, it may explain why Teku didn't recover after network outages (#2200) but can't be sure of that.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.