### PR TITLE
Report unknown block instead of throwing NullPointerException

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -370,29 +370,30 @@ public class ForkChoiceUtil {
    */
   private static AttestationProcessingResult indexAndValidateAttestation(
       MutableStore store, ValidateableAttestation attestation, Checkpoint target) {
-    BeaconState target_state;
+    BeaconState targetState;
     try {
-      target_state = store.getCheckpointState(target);
-      if (target_state == null) {
+      Optional<BeaconState> maybeTargetState = store.getCheckpointState(target);
+      if (maybeTargetState.isEmpty()) {
         return AttestationProcessingResult.UNKNOWN_BLOCK;
       }
+      targetState = maybeTargetState.get();
     } catch (final InvalidCheckpointException e) {
       LOG.debug("on_attestation: Attestation target checkpoint is invalid", e);
       return AttestationProcessingResult.invalid("Invalid target checkpoint: " + e.getMessage());
     }
 
     // Get state at the `target` to validate attestation and calculate the committees
-    IndexedAttestation indexed_attestation;
+    IndexedAttestation indexedAttestation;
     try {
-      indexed_attestation = get_indexed_attestation(target_state, attestation.getAttestation());
+      indexedAttestation = get_indexed_attestation(targetState, attestation.getAttestation());
     } catch (IllegalArgumentException e) {
       LOG.debug("on_attestation: Attestation is not valid: ", e);
       return AttestationProcessingResult.invalid(e.getMessage());
     }
-    return is_valid_indexed_attestation(target_state, indexed_attestation)
+    return is_valid_indexed_attestation(targetState, indexedAttestation)
         .ifSuccessful(
             () -> {
-              attestation.setIndexedAttestation(indexed_attestation);
+              attestation.setIndexedAttestation(indexedAttestation);
               return SUCCESSFUL;
             });
   }

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -382,7 +382,6 @@ public class ForkChoiceUtil {
       return AttestationProcessingResult.invalid("Invalid target checkpoint: " + e.getMessage());
     }
 
-
     IndexedAttestation indexedAttestation;
     try {
       indexedAttestation = get_indexed_attestation(targetState, attestation.getAttestation());

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -373,6 +373,9 @@ public class ForkChoiceUtil {
     BeaconState target_state;
     try {
       target_state = store.getCheckpointState(target);
+      if (target_state == null) {
+        return AttestationProcessingResult.UNKNOWN_BLOCK;
+      }
     } catch (final InvalidCheckpointException e) {
       LOG.debug("on_attestation: Attestation target checkpoint is invalid", e);
       return AttestationProcessingResult.invalid("Invalid target checkpoint: " + e.getMessage());

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -382,7 +382,7 @@ public class ForkChoiceUtil {
       return AttestationProcessingResult.invalid("Invalid target checkpoint: " + e.getMessage());
     }
 
-    // Get state at the `target` to validate attestation and calculate the committees
+
     IndexedAttestation indexedAttestation;
     try {
       indexedAttestation = get_indexed_attestation(targetState, attestation.getAttestation());

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
@@ -60,7 +60,7 @@ public interface ReadOnlyStore {
 
   BeaconState getBlockState(Bytes32 blockRoot);
 
-  BeaconState getCheckpointState(Checkpoint checkpoint);
+  Optional<BeaconState> getCheckpointState(Checkpoint checkpoint);
 
   Set<UnsignedLong> getVotedValidatorIndices();
 }

--- a/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreFactory.java
+++ b/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreFactory.java
@@ -209,8 +209,8 @@ public class TestStoreFactory {
     }
 
     @Override
-    public BeaconState getCheckpointState(final Checkpoint checkpoint) {
-      return checkpoint_states.get(checkpoint);
+    public Optional<BeaconState> getCheckpointState(final Checkpoint checkpoint) {
+      return Optional.ofNullable(checkpoint_states.get(checkpoint));
     }
 
     @Override

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategy.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategy.java
@@ -78,7 +78,7 @@ public class ProtoArrayForkChoiceStrategy implements ForkChoiceStrategy {
         justifiedCheckpoint.getEpoch(),
         justifiedCheckpoint.getRoot(),
         store.getFinalizedCheckpoint().getEpoch(),
-        store.getCheckpointState(justifiedCheckpoint).getBalances().asList());
+        store.getCheckpointState(justifiedCheckpoint).orElseThrow().getBalances().asList());
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -378,10 +378,9 @@ class Store implements UpdatableStore {
   }
 
   @Override
-  public BeaconState getCheckpointState(Checkpoint checkpoint) {
+  public Optional<BeaconState> getCheckpointState(Checkpoint checkpoint) {
     return getCheckpointStateIfAvailable(checkpoint)
-        .or(() -> regenerateAndStoreCheckpointState(checkpoint))
-        .orElse(null);
+        .or(() -> regenerateAndStoreCheckpointState(checkpoint));
   }
 
   private Optional<? extends BeaconState> regenerateAndStoreCheckpointState(
@@ -795,16 +794,10 @@ class Store implements UpdatableStore {
     }
 
     @Override
-    public BeaconState getCheckpointState(final Checkpoint checkpoint) {
-      final BeaconState cachedState = checkpointStateCache.get(checkpoint);
-      if (cachedState != null) {
-        return cachedState;
-      }
-      final Optional<BeaconState> checkpointFromStore =
-          Store.this.getCheckpointStateIfAvailable(checkpoint);
-      return checkpointFromStore
-          .or(() -> regenerateCheckpointState(checkpoint, this::getBlockState))
-          .orElse(null);
+    public Optional<BeaconState> getCheckpointState(final Checkpoint checkpoint) {
+      return Optional.of(checkpointStateCache.get(checkpoint))
+          .or(() -> Store.this.getCheckpointStateIfAvailable(checkpoint))
+          .or(() -> regenerateCheckpointState(checkpoint, this::getBlockState));
     }
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -795,7 +795,7 @@ class Store implements UpdatableStore {
 
     @Override
     public Optional<BeaconState> getCheckpointState(final Checkpoint checkpoint) {
-      return Optional.of(checkpointStateCache.get(checkpoint))
+      return Optional.ofNullable(checkpointStateCache.get(checkpoint))
           .or(() -> Store.this.getCheckpointStateIfAvailable(checkpoint))
           .or(() -> regenerateCheckpointState(checkpoint, this::getBlockState));
     }

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -90,7 +90,7 @@ class StoreTest {
         StoreBuilder.buildForkChoiceStore(
             new StubMetricsSystem(), blockProvider, genesisBlockAndState.getState());
     final Checkpoint checkpoint = new Checkpoint(UnsignedLong.ONE, genesisBlockAndState.getRoot());
-    final BeaconState checkpointState = store.getCheckpointState(checkpoint);
+    final BeaconState checkpointState = store.getCheckpointState(checkpoint).orElseThrow();
     assertThat(checkpointState).isNotNull();
     assertThat(checkpointState.getSlot()).isEqualTo(checkpoint.getEpochStartSlot());
     assertThat(checkpointState.getLatest_block_header().hash_tree_root())


### PR DESCRIPTION
## PR Description
It's possible that the block targeted by an attestation is dropped from the store while we're processing the attestation. We could wind up passing the initial check that the block is known because it hasn't been pruned from protoarray when we do that check and then later fail to create the checkpoint state for that target because the block isn't available in the store resulting in a `NullPointerException`.

If the checkpoint state is unavailable, the target block must be unknown so defer the attestation. Worst case the block is invalid and the attestation gets dropped once it is too old.

To reduce the risk of this in future, `getCheckpointState` now returns an `Optional`.

## Fixed Issue(s)
fixes #2313 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.