### PR TITLE
Add reorg counter to metrics

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
 import tech.pegasys.teku.core.ForkChoiceUtil;
 import tech.pegasys.teku.core.lookup.BlockProvider;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
@@ -37,6 +38,7 @@ import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.state.Fork;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.metrics.TekuMetricCategory;
 import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
 import tech.pegasys.teku.protoarray.ProtoArrayForkChoiceStrategy;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
@@ -63,6 +65,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   private final AtomicBoolean storeInitialized = new AtomicBoolean(false);
   private final SafeFuture<Void> storeInitializedFuture = new SafeFuture<>();
   private final SafeFuture<Void> bestBlockInitialized = new SafeFuture<>();
+  private final Counter reorgCounter;
 
   private volatile UpdatableStore store;
   private volatile Optional<ProtoArrayForkChoiceStrategy> forkChoiceStrategy;
@@ -82,6 +85,11 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     this.eventBus = eventBus;
     this.storageUpdateChannel = storageUpdateChannel;
     this.finalizedCheckpointChannel = finalizedCheckpointChannel;
+    reorgCounter =
+        metricsSystem.createCounter(
+            TekuMetricCategory.BEACON,
+            "reorgs_total",
+            "Total occurrences of reorganizations of the chain");
   }
 
   public void subscribeStoreInitialized(Runnable runnable) {
@@ -166,8 +174,8 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   /**
    * Update Best Block
    *
-   * @param root
-   * @param slot
+   * @param root the new best block root
+   * @param slot the new best slot
    */
   public void updateBestBlock(Bytes32 root, UnsignedLong slot) {
     synchronized (this) {
@@ -192,6 +200,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
       if (originalBestRoot
           .map(original -> hasReorgedFrom(original, originalBestSlot))
           .orElse(false)) {
+        reorgCounter.inc();
         reorgEventChannel.reorgOccurred(root, newChainHead.getSlot());
       }
     }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/AbstractStorageSystem.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/AbstractStorageSystem.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.storage.storageSystem;
 
 import tech.pegasys.teku.core.ChainBuilder;
+import tech.pegasys.teku.metrics.StubMetricsSystem;
 import tech.pegasys.teku.storage.client.ChainUpdater;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -21,11 +22,19 @@ public abstract class AbstractStorageSystem implements StorageSystem {
   protected final ChainBuilder chainBuilder = ChainBuilder.createDefault();
   protected final ChainUpdater chainUpdater;
 
+  private final StubMetricsSystem metricsSystem;
   protected final RecentChainData recentChainData;
 
-  protected AbstractStorageSystem(RecentChainData recentChainData) {
+  protected AbstractStorageSystem(
+      final StubMetricsSystem metricsSystem, RecentChainData recentChainData) {
+    this.metricsSystem = metricsSystem;
     this.recentChainData = recentChainData;
     chainUpdater = new ChainUpdater(this.recentChainData, chainBuilder);
+  }
+
+  @Override
+  public StubMetricsSystem getMetricsSystem() {
+    return metricsSystem;
   }
 
   @Override

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/FileBackedStorageSystem.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/FileBackedStorageSystem.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.storage.storageSystem;
 
 import com.google.common.eventbus.EventBus;
 import java.nio.file.Path;
-import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import tech.pegasys.teku.metrics.StubMetricsSystem;
 import tech.pegasys.teku.pow.api.TrackingEth1EventsChannel;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
@@ -44,6 +43,7 @@ public class FileBackedStorageSystem extends AbstractStorageSystem {
   private final RestartedStorageSupplier restartedSupplier;
 
   public FileBackedStorageSystem(
+      final StubMetricsSystem metricsSystem,
       final EventBus eventBus,
       final TrackingReorgEventChannel reorgEventChannel,
       final StateStorageMode storageMode,
@@ -51,8 +51,7 @@ public class FileBackedStorageSystem extends AbstractStorageSystem {
       final RecentChainData recentChainData,
       final CombinedChainDataClient combinedChainDataClient,
       final RestartedStorageSupplier restartedSupplier) {
-    super(recentChainData);
-
+    super(metricsSystem, recentChainData);
     this.eventBus = eventBus;
     this.reorgEventChannel = reorgEventChannel;
     this.storageMode = storageMode;
@@ -121,6 +120,7 @@ public class FileBackedStorageSystem extends AbstractStorageSystem {
       final Database database,
       final RestartedStorageSupplier restartedSupplier,
       final StateStorageMode storageMode) {
+    final StubMetricsSystem metricsSystem = new StubMetricsSystem();
     final EventBus eventBus = new EventBus();
 
     // Create and start storage server
@@ -133,7 +133,7 @@ public class FileBackedStorageSystem extends AbstractStorageSystem {
     final TrackingReorgEventChannel reorgEventChannel = new TrackingReorgEventChannel();
     final RecentChainData recentChainData =
         StorageBackedRecentChainData.createImmediately(
-            new NoOpMetricsSystem(),
+            metricsSystem,
             chainStorageServer,
             chainStorageServer,
             finalizedCheckpointChannel,
@@ -146,6 +146,7 @@ public class FileBackedStorageSystem extends AbstractStorageSystem {
 
     // Return storage system
     return new FileBackedStorageSystem(
+        metricsSystem,
         eventBus,
         reorgEventChannel,
         storageMode,

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/InMemoryStorageSystem.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/InMemoryStorageSystem.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.storage.storageSystem;
 
 import com.google.common.eventbus.EventBus;
-import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import tech.pegasys.teku.metrics.StubMetricsSystem;
 import tech.pegasys.teku.pow.api.TrackingEth1EventsChannel;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.api.StubFinalizedCheckpointChannel;
@@ -33,6 +33,7 @@ import tech.pegasys.teku.storage.server.rocksdb.schema.V4SchemaHot;
 import tech.pegasys.teku.util.config.StateStorageMode;
 
 public class InMemoryStorageSystem extends AbstractStorageSystem {
+
   private final EventBus eventBus;
   private final TrackingReorgEventChannel reorgEventChannel;
   private final TrackingEth1EventsChannel eth1EventsChannel = new TrackingEth1EventsChannel();
@@ -43,6 +44,7 @@ public class InMemoryStorageSystem extends AbstractStorageSystem {
   private final RestartedStorageSupplier restartedStorageSupplier;
 
   public InMemoryStorageSystem(
+      final StubMetricsSystem metricsSystem,
       final EventBus eventBus,
       final TrackingReorgEventChannel reorgEventChannel,
       final StateStorageMode storageMode,
@@ -50,7 +52,7 @@ public class InMemoryStorageSystem extends AbstractStorageSystem {
       final RecentChainData recentChainData,
       final CombinedChainDataClient combinedChainDataClient,
       final RestartedStorageSupplier restartedStorageSupplier) {
-    super(recentChainData);
+    super(metricsSystem, recentChainData);
 
     this.eventBus = eventBus;
     this.reorgEventChannel = reorgEventChannel;
@@ -58,6 +60,17 @@ public class InMemoryStorageSystem extends AbstractStorageSystem {
     this.database = database;
     this.combinedChainDataClient = combinedChainDataClient;
     this.restartedStorageSupplier = restartedStorageSupplier;
+  }
+
+  /**
+   * Create an in memory version of the latest storage system. Designed for tests that need a
+   * storage system but aren't likely to be affected by the version used.
+   *
+   * @param storageMode storage mode to use
+   * @return the new storage system
+   */
+  public static StorageSystem createEmptyLatestStorageSystem(final StateStorageMode storageMode) {
+    return createEmptyV5StorageSystem(storageMode, 1);
   }
 
   // V5 only differs by the RocksDB configuration which doesn't apply to the in-memory version
@@ -104,6 +117,7 @@ public class InMemoryStorageSystem extends AbstractStorageSystem {
       final Database database,
       final RestartedStorageSupplier restartedStorageSupplier,
       final StateStorageMode storageMode) {
+    final StubMetricsSystem metricsSystem = new StubMetricsSystem();
     final EventBus eventBus = new EventBus();
 
     // Create and start storage server
@@ -116,7 +130,7 @@ public class InMemoryStorageSystem extends AbstractStorageSystem {
     final TrackingReorgEventChannel reorgEventChannel = new TrackingReorgEventChannel();
     final RecentChainData recentChainData =
         StorageBackedRecentChainData.createImmediately(
-            new NoOpMetricsSystem(),
+            metricsSystem,
             chainStorageServer,
             chainStorageServer,
             finalizedCheckpointChannel,
@@ -129,6 +143,7 @@ public class InMemoryStorageSystem extends AbstractStorageSystem {
 
     // Return storage system
     return new InMemoryStorageSystem(
+        metricsSystem,
         eventBus,
         reorgEventChannel,
         storageMode,

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.storage.storageSystem;
 
 import com.google.common.eventbus.EventBus;
 import tech.pegasys.teku.core.ChainBuilder;
+import tech.pegasys.teku.metrics.StubMetricsSystem;
 import tech.pegasys.teku.pow.api.TrackingEth1EventsChannel;
 import tech.pegasys.teku.storage.api.TrackingReorgEventChannel;
 import tech.pegasys.teku.storage.client.ChainUpdater;
@@ -36,6 +37,8 @@ public interface StorageSystem extends AutoCloseable {
   StorageSystem restarted(StateStorageMode storageMode);
 
   StorageSystem restarted();
+
+  StubMetricsSystem getMetricsSystem();
 
   RecentChainData recentChainData();
 


### PR DESCRIPTION
## PR Description
Support the `beacon_reorgs_total` metric.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.