### PR TITLE
Fix expose port list in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,9 +27,9 @@ ARG VERSION
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.name="Teku" \
       org.label-schema.description="Ethereum 2.0 Beacon Chain Client" \
-      org.label-schema.url="https://pegasys.tech/" \
+      org.label-schema.url="https://pegasys.tech/teku/" \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url="https://github.com/PegaSysEng/teku.git" \
-      org.label-schema.vendor="Pegasys" \
+      org.label-schema.vendor="PegaSys" \
       org.label-schema.version=$VERSION \
       org.label-schema.schema-version="1.0"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,8 @@ ENV TEKU_REST_API_INTERFACE="0.0.0.0"
 ENV TEKU_METRICS_INTERFACE="0.0.0.0"
 
 # List Exposed Ports
-EXPOSE 8008 8084 8545 30303 30303/udp
+# Metrics, Rest API, LibP2P, Discv5
+EXPOSE 8008 5051 9000 9000/udp
 
 # specify default command
 ENTRYPOINT ["/opt/teku/bin/teku"]


### PR DESCRIPTION
## PR Description
Our docker file had outdated ports listed in its `EXPOSE` entry. Update them to the latest values and fix a couple of minor issues in the metadata.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.