### PR TITLE
Connection management improvements

### DIFF
--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
@@ -21,6 +21,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
-import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
@@ -111,7 +112,7 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
     final Bytes32 block2Root = block2.getMessage().hash_tree_root();
     recentChainData1.updateBestBlock(block2Root, block2.getSlot());
 
-    peer1.disconnectImmediately();
+    peer1.disconnectImmediately(Optional.empty(), false);
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
     final SafeFuture<Void> res =
         peer1.requestBlocksByRange(
@@ -151,7 +152,7 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
     final Bytes32 block2Root = block2.getMessage().hash_tree_root();
     recentChainData1.updateBestBlock(block2Root, block2.getSlot());
 
-    peer1.disconnectImmediately();
+    peer1.disconnectImmediately(Optional.empty(), false);
     final SafeFuture<SignedBeaconBlock> res = peer1.requestBlockBySlot(UnsignedLong.ONE);
 
     waitFor(() -> assertThat(res).isDone());

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRootIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRootIntegrationTest.java
@@ -22,6 +22,7 @@ import static tech.pegasys.teku.util.Waiter.waitFor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
@@ -35,7 +36,7 @@ import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
-import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystem;
@@ -109,7 +110,7 @@ public abstract class BeaconBlocksByRootIntegrationTest {
     final SignedBeaconBlock block = addBlock();
     final Bytes32 blockHash = block.getMessage().hash_tree_root();
 
-    peer1.disconnectImmediately();
+    peer1.disconnectImmediately(Optional.empty(), false);
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
     final SafeFuture<Void> res = peer1.requestBlocksByRoot(List.of(blockHash), blocks::add);
 
@@ -139,7 +140,7 @@ public abstract class BeaconBlocksByRootIntegrationTest {
     final SignedBeaconBlock block = addBlock();
     final Bytes32 blockHash = block.getMessage().hash_tree_root();
 
-    peer1.disconnectImmediately();
+    peer1.disconnectImmediately(Optional.empty(), false);
     final SafeFuture<SignedBeaconBlock> res = peer1.requestBlockByRoot(blockHash);
 
     waitFor(() -> assertThat(res).isDone());

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GoodbyeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GoodbyeIntegrationTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
-import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.util.Waiter;
 
 public class GoodbyeIntegrationTest {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
@@ -29,7 +29,7 @@ import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.metrics.TekuMetricCategory;
-import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.client.RecentChainData;

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
-import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -184,7 +185,7 @@ public class Eth2PeerManagerTest {
 
     peerManager.onConnect(peer);
 
-    verify(eth2Peer).disconnectImmediately();
+    verify(eth2Peer).disconnectImmediately(Optional.of(DisconnectReason.REMOTE_FAULT), true);
   }
 
   @Test
@@ -197,7 +198,7 @@ public class Eth2PeerManagerTest {
 
     peerManager.onConnect(peer);
 
-    verify(eth2Peer).disconnectImmediately();
+    verify(eth2Peer).disconnectImmediately(Optional.empty(), true);
   }
 
   @Test

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
@@ -33,7 +33,7 @@ import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
-import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.client.RecentChainData;

--- a/networking/p2p/src/integration-test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkIntegrationTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.p2p;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,10 @@ public class DiscoveryNetworkIntegrationTest {
     assertConnected(network1, network2);
 
     // Peers disconnect
-    network1.getPeer(network2.getNodeId()).orElseThrow().disconnectImmediately();
+    network1
+        .getPeer(network2.getNodeId())
+        .orElseThrow()
+        .disconnectImmediately(Optional.empty(), true);
 
     // But are automatically reconnected
     assertConnected(network1, network2);
@@ -62,7 +66,10 @@ public class DiscoveryNetworkIntegrationTest {
     // Already connected, but now tell network1 to maintain a persistent connection to network2.
     network1.addStaticPeer(network2.getNodeAddress());
 
-    network1.getPeer(network2.getNodeId()).orElseThrow().disconnectImmediately();
+    network1
+        .getPeer(network2.getNodeId())
+        .orElseThrow()
+        .disconnectImmediately(Optional.empty(), true);
     assertConnected(network1, network2);
 
     // Check we remain connected and didn't just briefly reconnect.

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManager.java
@@ -31,7 +31,7 @@ import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryService;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.networking.p2p.network.PeerAddress;
-import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.util.async.AsyncRunner;
@@ -125,7 +125,7 @@ public class ConnectionManager extends Service {
         .finish(
             this::connectToKnownPeers,
             error -> {
-              LOG.warn("Discovery failed", error);
+              LOG.debug("Discovery failed", error);
               connectToKnownPeers();
             });
   }
@@ -190,7 +190,7 @@ public class ConnectionManager extends Service {
               LOG.debug("Connection to peer {} was successful", peer.getId());
               successfulConnectionCounter.inc();
               peer.subscribeDisconnect(
-                  () -> {
+                  (reason, locallyInitiated) -> {
                     LOG.debug(
                         "Peer {} disconnected. Will try to reconnect in {} sec",
                         peerAddress,
@@ -224,6 +224,7 @@ public class ConnectionManager extends Service {
   }
 
   private boolean isPeerValid(DiscoveryPeer peer) {
-    return peerPredicates.stream().allMatch(predicate -> predicate.test(peer));
+    return !peer.getNodeAddress().getAddress().isAnyLocalAddress()
+        && peerPredicates.stream().allMatch(predicate -> predicate.test(peer));
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManager.java
@@ -84,6 +84,7 @@ public class ConnectionManager extends Service {
 
   @Override
   protected SafeFuture<?> doStart() {
+    LOG.trace("Starting discovery manager");
     synchronized (this) {
       staticPeers.forEach(this::createPersistentConnection);
     }
@@ -101,6 +102,7 @@ public class ConnectionManager extends Service {
 
   private void connectToKnownPeers() {
     final int maxAttempts = targetPeerCountRange.getPeersToAdd(network.getPeerCount());
+    LOG.trace("Connecting to up to {} known peers", maxAttempts);
     discoveryService
         .streamKnownPeers()
         .filter(this::isPeerValid)
@@ -113,8 +115,10 @@ public class ConnectionManager extends Service {
 
   private void searchForPeers() {
     if (!isRunning()) {
+      LOG.trace("Not running so not searching for peers");
       return;
     }
+    LOG.trace("Searching for peers");
     discoveryService
         .searchForPeers()
         .orTimeout(10, TimeUnit.SECONDS)
@@ -127,6 +131,7 @@ public class ConnectionManager extends Service {
   }
 
   private void attemptConnection(final PeerAddress discoveryPeer) {
+    LOG.trace("Attempting to connect to {}", discoveryPeer.getId());
     attemptedConnectionCounter.inc();
     network
         .connect(discoveryPeer)

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ReputationManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ReputationManager.java
@@ -15,16 +15,21 @@ package tech.pegasys.teku.networking.p2p.connection;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.metrics.TekuMetricCategory;
 import tech.pegasys.teku.networking.p2p.network.PeerAddress;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
+import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.util.cache.Cache;
 import tech.pegasys.teku.util.cache.LRUCache;
 import tech.pegasys.teku.util.time.TimeProvider;
 
 public class ReputationManager {
+  static final UnsignedLong FAILURE_BAN_PERIOD =
+      UnsignedLong.valueOf(TimeUnit.MINUTES.toSeconds(2));
   private final TimeProvider timeProvider;
-  private final Cache<PeerAddress, Reputation> peerReputations;
+  private final Cache<NodeId, Reputation> peerReputations;
 
   public ReputationManager(
       final MetricsSystem metricsSystem, final TimeProvider timeProvider, final int capacity) {
@@ -44,7 +49,7 @@ public class ReputationManager {
 
   public boolean isConnectionInitiationAllowed(final PeerAddress peerAddress) {
     return peerReputations
-        .getCached(peerAddress)
+        .getCached(peerAddress.getId())
         .map(reputation -> reputation.shouldInitiateConnection(timeProvider.getTimeInSeconds()))
         .orElse(true);
   }
@@ -53,28 +58,55 @@ public class ReputationManager {
     getOrCreateReputation(peerAddress).reportInitiatedConnectionSuccessful();
   }
 
+  public void reportDisconnection(
+      final PeerAddress peerAddress,
+      final Optional<DisconnectReason> reason,
+      final boolean locallyInitiated) {
+    getOrCreateReputation(peerAddress)
+        .reportDisconnection(timeProvider.getTimeInSeconds(), reason, locallyInitiated);
+  }
+
   private Reputation getOrCreateReputation(final PeerAddress peerAddress) {
-    return peerReputations.get(peerAddress, key -> new Reputation());
+    return peerReputations.get(peerAddress.getId(), key -> new Reputation());
   }
 
   private static class Reputation {
-    private static final UnsignedLong FAILURE_BAN_PERIOD = UnsignedLong.valueOf(60); // Seconds
     private volatile Optional<UnsignedLong> lastInitiationFailure = Optional.empty();
+    private volatile boolean unsuitable = false;
 
     public void reportInitiatedConnectionFailed(final UnsignedLong failureTime) {
       lastInitiationFailure = Optional.of(failureTime);
     }
 
     public boolean shouldInitiateConnection(final UnsignedLong currentTime) {
-      return lastInitiationFailure
-          .map(
-              lastFailureTime ->
-                  lastFailureTime.plus(FAILURE_BAN_PERIOD).compareTo(currentTime) < 0)
-          .orElse(true);
+      return !unsuitable
+          && lastInitiationFailure
+              .map(
+                  lastFailureTime ->
+                      lastFailureTime.plus(FAILURE_BAN_PERIOD).compareTo(currentTime) < 0)
+              .orElse(true);
     }
 
     public void reportInitiatedConnectionSuccessful() {
       lastInitiationFailure = Optional.empty();
+    }
+
+    public void reportDisconnection(
+        final UnsignedLong disconnectTime,
+        final Optional<DisconnectReason> reason,
+        final boolean locallyInitiated) {
+      if (isLocallyConsideredUnsuitable(reason, locallyInitiated)
+          || reason.map(DisconnectReason::isPermanent).orElse(false)) {
+        unsuitable = true;
+      } else {
+        lastInitiationFailure = Optional.of(disconnectTime);
+      }
+    }
+
+    private boolean isLocallyConsideredUnsuitable(
+        final Optional<DisconnectReason> reason, final boolean locallyInitiated) {
+      return locallyInitiated
+          && reason.map(r -> r != DisconnectReason.TOO_MANY_PEERS).orElse(false);
     }
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
@@ -16,12 +16,14 @@ package tech.pegasys.teku.networking.p2p.libp2p;
 import io.libp2p.core.Connection;
 import io.libp2p.core.PeerId;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.networking.p2p.libp2p.rpc.RpcHandler;
 import tech.pegasys.teku.networking.p2p.network.PeerAddress;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
@@ -39,9 +41,11 @@ public class LibP2PPeer implements Peer {
   private final AtomicBoolean connected = new AtomicBoolean(true);
   private final MultiaddrPeerAddress peerAddress;
 
+  private volatile Optional<DisconnectReason> disconnectReason = Optional.empty();
+  private volatile boolean disconnectLocallyInitiated = false;
   private volatile DisconnectRequestHandler disconnectRequestHandler =
       reason -> {
-        disconnectImmediately();
+        disconnectImmediately(Optional.of(reason), true);
         return SafeFuture.COMPLETE;
       };
 
@@ -71,8 +75,11 @@ public class LibP2PPeer implements Peer {
   }
 
   @Override
-  public void disconnectImmediately() {
+  public void disconnectImmediately(
+      final Optional<DisconnectReason> reason, final boolean locallyInitiated) {
     connected.set(false);
+    disconnectReason = reason;
+    disconnectLocallyInitiated = locallyInitiated;
     SafeFuture.of(connection.close())
         .finish(
             () -> LOG.trace("Disconnected from {}", getId()),
@@ -80,15 +87,18 @@ public class LibP2PPeer implements Peer {
   }
 
   @Override
-  public void disconnectCleanly(final DisconnectRequestHandler.DisconnectReason reason) {
+  public void disconnectCleanly(final DisconnectReason reason) {
     connected.set(false);
+    disconnectReason = Optional.of(reason);
+    disconnectLocallyInitiated = true;
     disconnectRequestHandler
         .requestDisconnect(reason)
         .finish(
-            this::disconnectImmediately, // Request sent now close our side
+            () ->
+                disconnectImmediately(Optional.of(reason), true), // Request sent now close our side
             error -> {
               LOG.debug("Failed to disconnect from " + getId() + " cleanly.", error);
-              disconnectImmediately();
+              disconnectImmediately(Optional.of(reason), true);
             });
   }
 
@@ -99,7 +109,8 @@ public class LibP2PPeer implements Peer {
 
   @Override
   public void subscribeDisconnect(final PeerDisconnectedSubscriber subscriber) {
-    SafeFuture.of(connection.closeFuture()).always(subscriber::onDisconnected);
+    SafeFuture.of(connection.closeFuture())
+        .always(() -> subscriber.onDisconnected(disconnectReason, disconnectLocallyInitiated));
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/PeerManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/PeerManager.java
@@ -135,7 +135,7 @@ public class PeerManager implements ConnectionHandler {
       peer.subscribeDisconnect(
           (reason, locallyInitiated) -> onDisconnectedPeer(peer, reason, locallyInitiated));
     } else {
-      LOG.info("Disconnecting duplicate connection to {}", peer::getId);
+      LOG.trace("Disconnecting duplicate connection to {}", peer::getId);
       peer.disconnectImmediately(Optional.empty(), true);
       throw new PeerAlreadyConnectedException(peer);
     }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/DelegatingPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/DelegatingPeer.java
@@ -14,9 +14,9 @@
 package tech.pegasys.teku.networking.p2p.peer;
 
 import java.util.Objects;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.networking.p2p.network.PeerAddress;
-import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.teku.networking.p2p.rpc.RpcRequestHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStream;
@@ -61,8 +61,9 @@ public class DelegatingPeer implements Peer {
   }
 
   @Override
-  public void disconnectImmediately() {
-    peer.disconnectImmediately();
+  public void disconnectImmediately(
+      final Optional<DisconnectReason> reason, final boolean locallyInitiated) {
+    peer.disconnectImmediately(reason, locallyInitiated);
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/DisconnectReason.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/DisconnectReason.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.p2p.peer;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.Optional;
+import java.util.stream.Stream;
+import tech.pegasys.teku.datastructures.networking.libp2p.rpc.GoodbyeMessage;
+
+public enum DisconnectReason {
+  IRRELEVANT_NETWORK(GoodbyeMessage.REASON_IRRELEVANT_NETWORK, true),
+  UNABLE_TO_VERIFY_NETWORK(GoodbyeMessage.REASON_UNABLE_TO_VERIFY_NETWORK, true),
+  TOO_MANY_PEERS(GoodbyeMessage.REASON_TOO_MANY_PEERS, false),
+  REMOTE_FAULT(GoodbyeMessage.REASON_FAULT_ERROR, false),
+  SHUTTING_DOWN(GoodbyeMessage.REASON_CLIENT_SHUT_DOWN, false);
+
+  private final UnsignedLong reasonCode;
+  private final boolean isPermanent;
+
+  DisconnectReason(final UnsignedLong reasonCode, final boolean isPermanent) {
+    this.reasonCode = reasonCode;
+    this.isPermanent = isPermanent;
+  }
+
+  public static Optional<DisconnectReason> fromReasonCode(final UnsignedLong reasonCode) {
+    return Stream.of(values())
+        .filter(reason -> reason.getReasonCode().equals(reasonCode))
+        .findAny();
+  }
+
+  public UnsignedLong getReasonCode() {
+    return reasonCode;
+  }
+
+  public boolean isPermanent() {
+    return isPermanent;
+  }
+}

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/DisconnectRequestHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/DisconnectRequestHandler.java
@@ -18,12 +18,4 @@ import tech.pegasys.teku.util.async.SafeFuture;
 public interface DisconnectRequestHandler {
 
   SafeFuture<Void> requestDisconnect(DisconnectReason reason);
-
-  enum DisconnectReason {
-    IRRELEVANT_NETWORK,
-    UNABLE_TO_VERIFY_NETWORK,
-    TOO_MANY_PEERS,
-    REMOTE_FAULT,
-    SHUTTING_DOWN
-  }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Peer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Peer.java
@@ -14,9 +14,9 @@
 package tech.pegasys.teku.networking.p2p.peer;
 
 import java.util.Objects;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.networking.p2p.network.PeerAddress;
-import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.teku.networking.p2p.rpc.RpcRequestHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStream;
@@ -32,7 +32,7 @@ public interface Peer {
 
   boolean isConnected();
 
-  void disconnectImmediately();
+  void disconnectImmediately(Optional<DisconnectReason> reason, boolean locallyInitiated);
 
   void disconnectCleanly(DisconnectReason reason);
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/PeerDisconnectedSubscriber.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/PeerDisconnectedSubscriber.java
@@ -13,8 +13,10 @@
 
 package tech.pegasys.teku.networking.p2p.peer;
 
+import java.util.Optional;
+
 @FunctionalInterface
 public interface PeerDisconnectedSubscriber {
 
-  void onDisconnected();
+  void onDisconnected(Optional<DisconnectReason> reason, boolean locallyInitiated);
 }

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/connection/ReputationManagerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/connection/ReputationManagerTest.java
@@ -15,15 +15,20 @@ package tech.pegasys.teku.networking.p2p.connection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.metrics.StubGauge;
 import tech.pegasys.teku.metrics.StubMetricsSystem;
 import tech.pegasys.teku.metrics.TekuMetricCategory;
 import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
 import tech.pegasys.teku.networking.p2p.network.PeerAddress;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.util.time.StubTimeProvider;
 
 class ReputationManagerTest {
+
+  private static final int MORE_THAN_DISALLOW_PERIOD =
+      ReputationManager.FAILURE_BAN_PERIOD.intValue() + 1;
   private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(10_000);
   private final PeerAddress peerAddress = new PeerAddress(new MockNodeId(1));
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
@@ -54,7 +59,7 @@ class ReputationManagerTest {
   public void shouldAllowConnectionInitiationAfterTimePasses() {
     reputationManager.reportInitiatedConnectionFailed(peerAddress);
 
-    timeProvider.advanceTimeBySeconds(61);
+    timeProvider.advanceTimeBySeconds(MORE_THAN_DISALLOW_PERIOD);
 
     assertThat(reputationManager.isConnectionInitiationAllowed(peerAddress)).isTrue();
   }
@@ -72,5 +77,34 @@ class ReputationManagerTest {
     reputationManager.reportInitiatedConnectionFailed(new PeerAddress(new MockNodeId(2)));
     reputationManager.reportInitiatedConnectionSuccessful(new PeerAddress(new MockNodeId(2)));
     assertThat(cacheSizeGauge.getValue()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldNotAllowConnectionAfterDisconnect() {
+    reputationManager.reportDisconnection(peerAddress, Optional.empty(), true);
+
+    assertThat(reputationManager.isConnectionInitiationAllowed(new PeerAddress(new MockNodeId(1))))
+        .isFalse();
+  }
+
+  @Test
+  void shouldAllowConnectionAfterDisconnectAfterTimePasses() {
+    reputationManager.reportDisconnection(peerAddress, Optional.empty(), true);
+
+    timeProvider.advanceTimeBySeconds(MORE_THAN_DISALLOW_PERIOD);
+
+    assertThat(reputationManager.isConnectionInitiationAllowed(new PeerAddress(new MockNodeId(1))))
+        .isTrue();
+  }
+
+  @Test
+  void shouldNeverAllowReconnectionForPermanentDisconnectReasons() {
+    reputationManager.reportDisconnection(
+        peerAddress, Optional.of(DisconnectReason.IRRELEVANT_NETWORK), true);
+
+    timeProvider.advanceTimeBySeconds(MORE_THAN_DISALLOW_PERIOD);
+
+    assertThat(reputationManager.isConnectionInitiationAllowed(new PeerAddress(new MockNodeId(1))))
+        .isFalse();
   }
 }

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/ConnectionManagerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/ConnectionManagerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Optional;
@@ -37,7 +38,7 @@ import tech.pegasys.teku.networking.p2p.connection.TargetPeerRange;
 import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.networking.p2p.network.PeerAddress;
-import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
 import tech.pegasys.teku.util.async.SafeFuture;
@@ -51,13 +52,17 @@ class ConnectionManagerTest {
   private static final PeerAddress PEER3 = new PeerAddress(new MockNodeId(3));
   private static final PeerAddress PEER4 = new PeerAddress(new MockNodeId(4));
   private static final DiscoveryPeer DISCOVERY_PEER1 =
-      new DiscoveryPeer(Bytes.of(1), new InetSocketAddress(1), ENR_FORK_ID);
+      new DiscoveryPeer(
+          Bytes.of(1), new InetSocketAddress(InetAddress.getLoopbackAddress(), 1), ENR_FORK_ID);
   private static final DiscoveryPeer DISCOVERY_PEER2 =
-      new DiscoveryPeer(Bytes.of(2), new InetSocketAddress(2), ENR_FORK_ID);
+      new DiscoveryPeer(
+          Bytes.of(2), new InetSocketAddress(InetAddress.getLoopbackAddress(), 2), ENR_FORK_ID);
   private static final DiscoveryPeer DISCOVERY_PEER3 =
-      new DiscoveryPeer(Bytes.of(3), new InetSocketAddress(3), ENR_FORK_ID);
+      new DiscoveryPeer(
+          Bytes.of(3), new InetSocketAddress(InetAddress.getLoopbackAddress(), 3), ENR_FORK_ID);
   private static final DiscoveryPeer DISCOVERY_PEER4 =
-      new DiscoveryPeer(Bytes.of(4), new InetSocketAddress(4), ENR_FORK_ID);
+      new DiscoveryPeer(
+          Bytes.of(4), new InetSocketAddress(InetAddress.getLoopbackAddress(), 4), ENR_FORK_ID);
 
   @SuppressWarnings("unchecked")
   private final P2PNetwork<Peer> network = mock(P2PNetwork.class);
@@ -122,7 +127,7 @@ class ConnectionManagerTest {
     asyncRunner.executeQueuedActions();
     verify(network, times(2)).connect(PEER1);
 
-    peer.disconnectImmediately();
+    peer.disconnectImmediately(Optional.empty(), true);
     assertThat(asyncRunner.hasDelayedActions()).isTrue();
     asyncRunner.executeQueuedActions();
     verify(network, times(3)).connect(PEER1);
@@ -139,7 +144,7 @@ class ConnectionManagerTest {
         .thenReturn(new SafeFuture<>());
     manager.start().join();
     verify(network).connect(PEER1);
-    peer.disconnectImmediately();
+    peer.disconnectImmediately(Optional.empty(), true);
 
     assertThat(asyncRunner.hasDelayedActions()).isTrue();
     asyncRunner.executeQueuedActions();
@@ -159,7 +164,7 @@ class ConnectionManagerTest {
 
     manager.addStaticPeer(PEER1);
     verify(network).connect(PEER1);
-    peer.disconnectImmediately();
+    peer.disconnectImmediately(Optional.empty(), true);
 
     assertThat(asyncRunner.hasDelayedActions()).isTrue();
     asyncRunner.executeQueuedActions();
@@ -226,7 +231,7 @@ class ConnectionManagerTest {
     final StubPeer peer = new StubPeer(new MockNodeId(DISCOVERY_PEER1.getPublicKey()));
     connectionFuture.complete(peer);
 
-    peer.disconnectImmediately();
+    peer.disconnectImmediately(Optional.empty(), true);
     asyncRunner.executeQueuedActions();
     verify(network, times(1)).connect(PEER1); // No further attempts to connect
   }

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/ConnectionManagerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/ConnectionManagerTest.java
@@ -209,7 +209,7 @@ class ConnectionManagerTest {
 
     connectionFuture.completeExceptionally(new RuntimeException("Failed"));
 
-    assertThat(asyncRunner.hasDelayedActions()).isFalse();
+    asyncRunner.executeQueuedActions();
     verify(network, times(1)).connect(PEER1); // No further attempts to connect
   }
 
@@ -227,7 +227,7 @@ class ConnectionManagerTest {
     connectionFuture.complete(peer);
 
     peer.disconnectImmediately();
-    assertThat(asyncRunner.hasDelayedActions()).isFalse();
+    asyncRunner.executeQueuedActions();
     verify(network, times(1)).connect(PEER1); // No further attempts to connect
   }
 

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/peer/StubPeer.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/peer/StubPeer.java
@@ -18,8 +18,8 @@ import javax.naming.OperationNotSupportedException;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
 import tech.pegasys.teku.networking.p2p.network.PeerAddress;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler;
-import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedSubscriber;
@@ -32,7 +32,7 @@ import tech.pegasys.teku.util.events.Subscribers;
 public class StubPeer implements Peer {
 
   private final PeerAddress peerAddress;
-  private Subscribers<PeerDisconnectedSubscriber> disconnectedSubscribers =
+  private final Subscribers<PeerDisconnectedSubscriber> disconnectedSubscribers =
       Subscribers.create(false);
   private boolean connected = true;
   private Optional<DisconnectReason> disconnectReason = Optional.empty();
@@ -56,15 +56,18 @@ public class StubPeer implements Peer {
   }
 
   @Override
-  public void disconnectImmediately() {
-    disconnectedSubscribers.forEach(PeerDisconnectedSubscriber::onDisconnected);
+  public void disconnectImmediately(
+      final Optional<DisconnectReason> reason, final boolean locallyInitiated) {
+    disconnectedSubscribers.forEach(
+        subscriber -> subscriber.onDisconnected(reason, locallyInitiated));
     connected = false;
   }
 
   @Override
   public void disconnectCleanly(final DisconnectReason reason) {
     disconnectReason = Optional.of(reason);
-    disconnectedSubscribers.forEach(PeerDisconnectedSubscriber::onDisconnected);
+    disconnectedSubscribers.forEach(
+        subscriber -> subscriber.onDisconnected(Optional.of(reason), true));
     connected = false;
   }
 

--- a/sync/src/main/java/tech/pegasys/teku/sync/PeerSync.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/PeerSync.java
@@ -33,7 +33,7 @@ import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.metrics.TekuMetricCategory;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
-import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.util.async.AsyncRunner;

--- a/sync/src/test/java/tech/pegasys/teku/sync/PeerSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/PeerSyncTest.java
@@ -42,7 +42,7 @@ import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseStream;
-import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler.DisconnectReason;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.util.async.SafeFuture;

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -131,7 +131,7 @@ public class Constants {
   public static final long ETH1_INDIVIDUAL_BLOCK_RETRY_TIMEOUT = 500; // in milli sec
   public static final long ETH1_DEPOSIT_REQUEST_RETRY_TIMEOUT = 2; // in sec
   public static final int MAXIMUM_CONCURRENT_ETH1_REQUESTS = 5;
-  public static final int REPUTATION_MANAGER_CAPACITY = 100;
+  public static final int REPUTATION_MANAGER_CAPACITY = 1024;
   public static final long STORAGE_REQUEST_TIMEOUT = 5; // in sec
   public static final int STORAGE_QUERY_CHANNEL_PARALLELISM = 10; // # threads
   public static final int PROTOARRAY_FORKCHOICE_PRUNE_THRESHOLD = 256;


### PR DESCRIPTION
## PR Description
Use `AsyncRunner.runWithFixedDelay` to ensure we periodically search for and connect to new peers rather than manually creating a loop with futures.

## Fixed Issue(s)

Hoping this will help with #2200 and #2287 but continuing to verify as they're hard to reproduce.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.