### PR TITLE
Access genesis data through genesis event rather than Store

### DIFF
--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetStateTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetStateTest.java
@@ -25,7 +25,6 @@ import static tech.pegasys.teku.beaconrestapi.RestApiConstants.EPOCH;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.ROOT;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.SLOT;
 
-import com.google.common.eventbus.EventBus;
 import com.google.common.primitives.UnsignedLong;
 import io.javalin.http.Context;
 import java.util.Collections;
@@ -34,37 +33,40 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.schema.BeaconState;
-import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.provider.JsonProvider;
-import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
-import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystem;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.util.async.SafeFuture;
+import tech.pegasys.teku.util.config.StateStorageMode;
 
 public class GetStateTest {
-  private static final DataStructureUtil dataStructureUtil = new DataStructureUtil();
-  private static tech.pegasys.teku.datastructures.state.BeaconState beaconStateInternal;
-  private static BeaconState beaconState;
-  private static Bytes32 blockRoot;
-  private static UnsignedLong slot;
+  private final StorageSystem storageSystem =
+      InMemoryStorageSystem.createEmptyLatestStorageSystem(StateStorageMode.ARCHIVE);
+  private tech.pegasys.teku.datastructures.state.BeaconState beaconStateInternal;
+  private BeaconState beaconState;
+  private Bytes32 blockRoot;
+  private UnsignedLong slot;
 
   private final JsonProvider jsonProvider = new JsonProvider();
   private final Context context = mock(Context.class);
   private final String missingRoot = Bytes32.leftPad(Bytes.fromHexString("0xff")).toHexString();
   private final ChainDataProvider dataProvider = mock(ChainDataProvider.class);
 
-  @BeforeAll
-  public static void setup() {
-    final EventBus localEventBus = new EventBus();
-    final RecentChainData storageClient = MemoryOnlyRecentChainData.create(localEventBus);
-    beaconStateInternal = dataStructureUtil.randomBeaconState();
-    storageClient.initializeFromGenesis(beaconStateInternal);
-    blockRoot = storageClient.getBestBlockRoot().orElseThrow();
-    slot = beaconStateInternal.getSlot();
+  @BeforeEach
+  public void setup() {
+    slot = UnsignedLong.valueOf(10);
+    storageSystem.chainUpdater().initializeGenesis();
+    SignedBlockAndState bestBlock = storageSystem.chainUpdater().advanceChain(slot);
+    storageSystem.chainUpdater().updateBestBlock(bestBlock);
+
+    beaconStateInternal = bestBlock.getState();
+    blockRoot = bestBlock.getRoot();
     beaconState = new BeaconState(beaconStateInternal);
   }
 

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -28,13 +28,12 @@ import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoc
 import static tech.pegasys.teku.util.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_EPOCH;
 
-import com.google.common.eventbus.EventBus;
 import com.google.common.primitives.UnsignedLong;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.response.GetBlockResponse;
 import tech.pegasys.teku.api.schema.BLSPubKey;
@@ -47,42 +46,48 @@ import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.ValidatorWithIndex;
 import tech.pegasys.teku.api.schema.ValidatorsRequest;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.state.CommitteeAssignment;
-import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
-import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystem;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.util.async.SafeFuture;
+import tech.pegasys.teku.util.config.StateStorageMode;
 
 public class ChainDataProviderTest {
-  private static final DataStructureUtil dataStructureUtil = new DataStructureUtil();
-  private static CombinedChainDataClient combinedChainDataClient;
-  private static StorageQueryChannel historicalChainData = mock(StorageQueryChannel.class);
-  private static tech.pegasys.teku.datastructures.state.BeaconState beaconStateInternal;
-  private static BeaconState beaconState;
-  private static Bytes32 blockRoot;
-  private static UnsignedLong slot;
-  private static EventBus localEventBus;
-  private static RecentChainData recentChainData;
-  private final tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock signedBeaconBlock =
-      dataStructureUtil.randomSignedBeaconBlock(999);
+  private final StorageSystem storageSystem =
+      InMemoryStorageSystem.createEmptyLatestStorageSystem(StateStorageMode.ARCHIVE);
+  private CombinedChainDataClient combinedChainDataClient;
+  private StorageQueryChannel historicalChainData = mock(StorageQueryChannel.class);
+  private tech.pegasys.teku.datastructures.state.BeaconState beaconStateInternal;
+
+  private SignedBlockAndState bestBlock;
+  private tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock signedBeaconBlock;
+  private BeaconState beaconState;
+  private Bytes32 blockRoot;
+  private UnsignedLong slot;
+  private RecentChainData recentChainData;
   private CombinedChainDataClient mockCombinedChainDataClient = mock(CombinedChainDataClient.class);
   private RecentChainData mockRecentChainData = mock(RecentChainData.class);
 
-  @BeforeAll
-  public static void setup() {
-    localEventBus = new EventBus();
-    recentChainData = MemoryOnlyRecentChainData.create(localEventBus);
-    beaconStateInternal = dataStructureUtil.randomBeaconState();
+  @BeforeEach
+  public void setup() {
+    slot = UnsignedLong.valueOf(SLOTS_PER_EPOCH * 3);
+    storageSystem.chainUpdater().initializeGenesis();
+    bestBlock = storageSystem.chainUpdater().advanceChain(slot);
+    storageSystem.chainUpdater().updateBestBlock(bestBlock);
 
+    recentChainData = storageSystem.recentChainData();
+    beaconStateInternal = bestBlock.getState();
+
+    signedBeaconBlock = bestBlock.getBlock();
     beaconState = new BeaconState(beaconStateInternal);
-    recentChainData.initializeFromGenesis(beaconStateInternal);
-    combinedChainDataClient = new CombinedChainDataClient(recentChainData, historicalChainData);
-    blockRoot = recentChainData.getBestBlockRoot().orElseThrow();
-    slot = recentChainData.getBestSlot();
+    combinedChainDataClient = storageSystem.combinedChainDataClient();
+    blockRoot = bestBlock.getRoot();
   }
 
   @Test
@@ -111,21 +116,21 @@ public class ChainDataProviderTest {
       throws ExecutionException, InterruptedException {
     final List<CommitteeAssignment> committeeAssignments =
         List.of(new CommitteeAssignment(List.of(1), ZERO, ONE));
+    final UnsignedLong currentEpoch =
+        bestBlock.getSlot().dividedBy(UnsignedLong.valueOf(SLOTS_PER_EPOCH));
+
     final ChainDataProvider provider =
         new ChainDataProvider(mockRecentChainData, mockCombinedChainDataClient);
-    final Bytes32 bestBlockRoot = dataStructureUtil.randomBytes32();
-    final BeaconBlockAndState blockAndState =
-        dataStructureUtil.randomBlockAndState(1, beaconStateInternal);
-
     when(mockCombinedChainDataClient.isChainDataFullyAvailable()).thenReturn(true);
-    when(mockCombinedChainDataClient.getBestBlockRoot()).thenReturn(Optional.of(bestBlockRoot));
+    when(mockCombinedChainDataClient.getBestBlockRoot())
+        .thenReturn(Optional.of(bestBlock.getRoot()));
     when(mockCombinedChainDataClient.getCommitteesFromState(any(), any()))
         .thenReturn(committeeAssignments);
-    when(mockRecentChainData.getBestSlot()).thenReturn(beaconStateInternal.getSlot());
+    when(mockRecentChainData.getBestSlot()).thenReturn(bestBlock.getSlot());
     when(mockCombinedChainDataClient.getBlockAndStateInEffectAtSlot(any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(blockAndState)));
+        .thenReturn(SafeFuture.completedFuture(Optional.of(bestBlock.toUnsigned())));
     final SafeFuture<Optional<List<Committee>>> future =
-        provider.getCommitteesAtEpoch(beaconStateInternal.getSlot());
+        provider.getCommitteesAtEpoch(currentEpoch);
 
     final Committee result = future.get().get().get(0);
     assertEquals(ONE, result.slot);
@@ -312,16 +317,15 @@ public class ChainDataProviderTest {
   @Test
   void getStateBySlot_shouldReturnBeaconStateWhenFound()
       throws ExecutionException, InterruptedException {
-    final Bytes32 chainHead = dataStructureUtil.randomBytes32();
-    final BeaconBlockAndState blockAndState =
-        dataStructureUtil.randomBlockAndState(beaconStateInternal.getSlot(), beaconStateInternal);
+    final BeaconBlockAndState blockAndState = bestBlock.toUnsigned();
     final SafeFuture<Optional<BeaconBlockAndState>> safeFuture =
         completedFuture(Optional.of(blockAndState));
 
     final ChainDataProvider provider =
         new ChainDataProvider(recentChainData, mockCombinedChainDataClient);
     when(mockCombinedChainDataClient.isChainDataFullyAvailable()).thenReturn(true);
-    when(mockCombinedChainDataClient.getBestBlockRoot()).thenReturn(Optional.of(chainHead));
+    when(mockCombinedChainDataClient.getBestBlockRoot())
+        .thenReturn(Optional.of(bestBlock.getRoot()));
     when(mockCombinedChainDataClient.getBlockAndStateInEffectAtSlot(ZERO)).thenReturn(safeFuture);
 
     final SafeFuture<Optional<BeaconState>> future = provider.getStateAtSlot(ZERO);
@@ -362,10 +366,8 @@ public class ChainDataProviderTest {
       throws ExecutionException, InterruptedException {
     final ChainDataProvider provider =
         new ChainDataProvider(recentChainData, mockCombinedChainDataClient);
-    final BeaconBlockAndState blockAndState =
-        dataStructureUtil.randomBlockAndState(1, beaconStateInternal);
     final SafeFuture<Optional<BeaconBlockAndState>> safeFuture =
-        completedFuture(Optional.of(blockAndState));
+        completedFuture(Optional.of(bestBlock.toUnsigned()));
     final ValidatorsRequest smallRequest =
         new ValidatorsRequest(compute_epoch_at_slot(beaconState.slot), List.of(BLSPubKey.empty()));
     when(mockCombinedChainDataClient.isChainDataFullyAvailable()).thenReturn(true);
@@ -386,18 +388,13 @@ public class ChainDataProviderTest {
       throws ExecutionException, InterruptedException {
     final ChainDataProvider provider =
         new ChainDataProvider(recentChainData, mockCombinedChainDataClient);
-    final BeaconBlockAndState blockAndState =
-        dataStructureUtil.randomBlockAndState(1, beaconStateInternal);
-    final tech.pegasys.teku.datastructures.state.BeaconState state = blockAndState.getState();
+    final tech.pegasys.teku.datastructures.state.BeaconState state = bestBlock.getState();
     final SafeFuture<Optional<BeaconBlockAndState>> safeFuture =
-        completedFuture(Optional.of(blockAndState));
+        completedFuture(Optional.of(bestBlock.toUnsigned()));
     final ValidatorsRequest validatorsRequest =
         new ValidatorsRequest(
             compute_epoch_at_slot(beaconState.slot),
-            List.of(
-                beaconState.validators.get(0).pubkey,
-                beaconState.validators.get(11).pubkey,
-                beaconState.validators.get(99).pubkey));
+            List.of(beaconState.validators.get(0).pubkey, beaconState.validators.get(2).pubkey));
     when(mockCombinedChainDataClient.isChainDataFullyAvailable()).thenReturn(true);
     when(mockCombinedChainDataClient.getBlockAndStateInEffectAtSlot(any())).thenReturn(safeFuture);
     final SafeFuture<Optional<BeaconValidators>> future =
@@ -406,16 +403,13 @@ public class ChainDataProviderTest {
     final Optional<BeaconValidators> optionalValidators = future.get();
     final BeaconValidators validators = optionalValidators.get();
 
-    assertThat(validators.validators.size()).isEqualTo(3);
+    assertThat(validators.validators.size()).isEqualTo(2);
     assertThat(validators.validators.get(0))
         .usingRecursiveComparison()
         .isEqualTo(new ValidatorWithIndex(state.getValidators().get(0), state));
     assertThat(validators.validators.get(1))
         .usingRecursiveComparison()
-        .isEqualTo(new ValidatorWithIndex(state.getValidators().get(11), state));
-    assertThat(validators.validators.get(2))
-        .usingRecursiveComparison()
-        .isEqualTo(new ValidatorWithIndex(state.getValidators().get(99), state));
+        .isEqualTo(new ValidatorWithIndex(state.getValidators().get(2), state));
   }
 
   @Test

--- a/data/recorder/src/main/java/tech/pegasys/teku/data/recorder/SSZTransitionRecorder.java
+++ b/data/recorder/src/main/java/tech/pegasys/teku/data/recorder/SSZTransitionRecorder.java
@@ -24,10 +24,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.data.BlockProcessingRecord;
 import tech.pegasys.teku.datastructures.state.BeaconState;
-import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.ssz.sos.SimpleOffsetSerializable;
-import tech.pegasys.teku.storage.events.GenesisEvent;
-import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.storage.events.AnchorPoint;
 
 public class SSZTransitionRecorder {
 
@@ -40,19 +38,12 @@ public class SSZTransitionRecorder {
   }
 
   @Subscribe
-  public void onGenesis(final GenesisEvent genesis) {
-    final Checkpoint finalizedCheckpoint = genesis.getCheckpoint();
-    if (isNotGenesis(finalizedCheckpoint)) {
+  public void onGenesis(final AnchorPoint anchor) {
+    if (!anchor.isGenesis()) {
       return;
     }
-    final BeaconState genesisState = genesis.getState();
+    final BeaconState genesisState = anchor.getState();
     store(outputDirectory.resolve("genesis.ssz"), genesisState);
-  }
-
-  private boolean isNotGenesis(final Checkpoint finalizedCheckpoint) {
-    final UnsignedLong genesisEpoch = UnsignedLong.valueOf(Constants.GENESIS_EPOCH);
-    return finalizedCheckpoint == null
-        || finalizedCheckpoint.getEpoch().compareTo(genesisEpoch) != 0;
   }
 
   @Subscribe

--- a/data/recorder/src/main/java/tech/pegasys/teku/data/recorder/SSZTransitionRecorder.java
+++ b/data/recorder/src/main/java/tech/pegasys/teku/data/recorder/SSZTransitionRecorder.java
@@ -22,12 +22,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.data.BlockProcessingRecord;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.ssz.sos.SimpleOffsetSerializable;
-import tech.pegasys.teku.storage.store.UpdatableStore;
+import tech.pegasys.teku.storage.events.GenesisEvent;
 import tech.pegasys.teku.util.config.Constants;
 
 public class SSZTransitionRecorder {
@@ -41,13 +40,12 @@ public class SSZTransitionRecorder {
   }
 
   @Subscribe
-  public void onGenesis(final UpdatableStore store) {
-    final Checkpoint finalizedCheckpoint = store.getFinalizedCheckpoint();
+  public void onGenesis(final GenesisEvent genesis) {
+    final Checkpoint finalizedCheckpoint = genesis.getCheckpoint();
     if (isNotGenesis(finalizedCheckpoint)) {
       return;
     }
-    final Bytes32 genesisRoot = finalizedCheckpoint.getRoot();
-    final BeaconState genesisState = store.getBlockState(genesisRoot);
+    final BeaconState genesisState = genesis.getState();
     store(outputDirectory.resolve("genesis.ssz"), genesisState);
   }
 

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -49,7 +49,7 @@ import tech.pegasys.teku.util.time.channels.SlotEventsChannel;
 public class SlotProcessorTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
 
-  private final BeaconState beaconState = dataStructureUtil.randomBeaconState();
+  private final BeaconState beaconState = dataStructureUtil.randomBeaconState(ZERO);
   private final EventLogger eventLogger = mock(EventLogger.class);
 
   private final StorageSystem storageSystem =

--- a/storage/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
@@ -14,9 +14,9 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Optional;
+import tech.pegasys.teku.storage.events.GenesisEvent;
 import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.store.StoreBuilder;
-import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.util.async.SafeFuture;
 
 public interface StorageUpdateChannel {
@@ -25,5 +25,5 @@ public interface StorageUpdateChannel {
 
   SafeFuture<Void> onStorageUpdate(StorageUpdate event);
 
-  void onGenesis(UpdatableStore store);
+  void onGenesis(GenesisEvent genesis);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Optional;
-import tech.pegasys.teku.storage.events.GenesisEvent;
+import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.store.StoreBuilder;
 import tech.pegasys.teku.util.async.SafeFuture;
@@ -25,5 +25,5 @@ public interface StorageUpdateChannel {
 
   SafeFuture<Void> onStorageUpdate(StorageUpdate event);
 
-  void onGenesis(GenesisEvent genesis);
+  void onGenesis(AnchorPoint genesis);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -45,7 +45,7 @@ import tech.pegasys.teku.protoarray.ProtoArrayStorageChannel;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.api.ReorgEventChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
-import tech.pegasys.teku.storage.events.GenesisEvent;
+import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.store.StoreBuilder;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
@@ -106,7 +106,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   }
 
   public void initializeFromGenesis(final BeaconState genesisState) {
-    final GenesisEvent genesis = GenesisEvent.fromGenesisState(genesisState);
+    final AnchorPoint genesis = AnchorPoint.fromGenesisState(genesisState);
     final UpdatableStore store =
         StoreBuilder.buildForkChoiceStore(metricsSystem, blockProvider, genesis);
     final boolean result = setStore(store);

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.protoarray.ProtoArrayForkChoiceStrategy;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.api.ReorgEventChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
+import tech.pegasys.teku.storage.events.GenesisEvent;
 import tech.pegasys.teku.storage.store.StoreBuilder;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
@@ -93,16 +94,17 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   }
 
   public void initializeFromGenesis(final BeaconState genesisState) {
+    final GenesisEvent genesis = GenesisEvent.fromGenesisState(genesisState);
     final UpdatableStore store =
-        StoreBuilder.buildForkChoiceStore(metricsSystem, blockProvider, genesisState);
+        StoreBuilder.buildForkChoiceStore(metricsSystem, blockProvider, genesis);
     final boolean result = setStore(store);
     if (!result) {
       throw new IllegalStateException(
           "Failed to set genesis state: store has already been initialized");
     }
 
-    storageUpdateChannel.onGenesis(store);
-    eventBus.post(store);
+    storageUpdateChannel.onGenesis(genesis);
+    eventBus.post(genesis);
 
     // The genesis state is by definition finalized so just get the root from there.
     Bytes32 headBlockRoot = store.getFinalizedCheckpoint().getRoot();

--- a/storage/src/main/java/tech/pegasys/teku/storage/events/AnchorPoint.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/events/AnchorPoint.java
@@ -48,15 +48,19 @@ public class AnchorPoint {
   }
 
   public static AnchorPoint fromGenesisState(final BeaconState genesisState) {
-    final BeaconBlock anchorBlock = new BeaconBlock(genesisState.hash_tree_root());
-    final SignedBeaconBlock signedAnchorBlock =
-        new SignedBeaconBlock(anchorBlock, BLSSignature.empty());
+    checkArgument(
+        genesisState.getSlot().equals(UnsignedLong.valueOf(Constants.GENESIS_SLOT)),
+        "Invalid genesis state supplied");
 
-    final Bytes32 anchorRoot = anchorBlock.hash_tree_root();
-    final UnsignedLong anchorEpoch = BeaconStateUtil.get_current_epoch(genesisState);
-    final Checkpoint anchorCheckpoint = new Checkpoint(anchorEpoch, anchorRoot);
+    final BeaconBlock genesisBlock = new BeaconBlock(genesisState.hash_tree_root());
+    final SignedBeaconBlock signedGenesisBlock =
+        new SignedBeaconBlock(genesisBlock, BLSSignature.empty());
 
-    return new AnchorPoint(anchorCheckpoint, signedAnchorBlock, genesisState);
+    final Bytes32 genesisBlockRoot = genesisBlock.hash_tree_root();
+    final UnsignedLong genesisEpoch = BeaconStateUtil.get_current_epoch(genesisState);
+    final Checkpoint genesisCheckpoint = new Checkpoint(genesisEpoch, genesisBlockRoot);
+
+    return new AnchorPoint(genesisCheckpoint, signedGenesisBlock, genesisState);
   }
 
   public boolean isGenesis() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/events/GenesisEvent.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/events/GenesisEvent.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.events;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.primitives.UnsignedLong;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
+import tech.pegasys.teku.datastructures.util.BeaconStateUtil;
+
+public class GenesisEvent {
+  private final Checkpoint checkpoint;
+  private final SignedBeaconBlock block;
+  private final BeaconState state;
+
+  private GenesisEvent(Checkpoint checkpoint, SignedBeaconBlock block, BeaconState state) {
+    checkArgument(
+        block.getStateRoot().equals(state.hash_tree_root()), "Block and state must match");
+    checkArgument(checkpoint.getRoot().equals(block.getRoot()), "Checkpoint and block must match");
+
+    this.checkpoint = checkpoint;
+    this.block = block;
+    this.state = state;
+  }
+
+  public static GenesisEvent fromGenesisState(final BeaconState genesisState) {
+    final BeaconBlock anchorBlock = new BeaconBlock(genesisState.hash_tree_root());
+    final SignedBeaconBlock signedAnchorBlock =
+        new SignedBeaconBlock(anchorBlock, BLSSignature.empty());
+
+    final Bytes32 anchorRoot = anchorBlock.hash_tree_root();
+    final UnsignedLong anchorEpoch = BeaconStateUtil.get_current_epoch(genesisState);
+    final Checkpoint anchorCheckpoint = new Checkpoint(anchorEpoch, anchorRoot);
+
+    return new GenesisEvent(anchorCheckpoint, signedAnchorBlock, genesisState);
+  }
+
+  public Checkpoint getCheckpoint() {
+    return checkpoint;
+  }
+
+  public SignedBeaconBlock getBlock() {
+    return block;
+  }
+
+  public BeaconState getState() {
+    return state;
+  }
+
+  public Bytes32 getRoot() {
+    return block.getRoot();
+  }
+
+  public Bytes32 getParentRoot() {
+    return block.getParent_root();
+  }
+
+  public SignedBlockAndState toSignedBlockAndState() {
+    return new SignedBlockAndState(block, state);
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -23,10 +23,10 @@ import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
+import tech.pegasys.teku.storage.events.GenesisEvent;
 import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.server.state.FinalizedStateCache;
 import tech.pegasys.teku.storage.store.StoreBuilder;
-import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.util.async.SafeFuture;
 import tech.pegasys.teku.util.config.Constants;
 
@@ -94,8 +94,8 @@ public class ChainStorage implements StorageUpdateChannel, StorageQueryChannel {
   }
 
   @Override
-  public void onGenesis(final UpdatableStore store) {
-    database.storeGenesis(store);
+  public void onGenesis(final GenesisEvent genesis) {
+    database.storeGenesis(genesis);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -23,7 +23,7 @@ import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
-import tech.pegasys.teku.storage.events.GenesisEvent;
+import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.server.state.FinalizedStateCache;
 import tech.pegasys.teku.storage.store.StoreBuilder;
@@ -94,7 +94,7 @@ public class ChainStorage implements StorageUpdateChannel, StorageQueryChannel {
   }
 
   @Override
-  public void onGenesis(final GenesisEvent genesis) {
+  public void onGenesis(final AnchorPoint genesis) {
     database.storeGenesis(genesis);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -25,13 +25,13 @@ import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.protoarray.ProtoArraySnapshot;
-import tech.pegasys.teku.storage.events.GenesisEvent;
+import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.store.StoreBuilder;
 
 public interface Database extends AutoCloseable {
 
-  void storeGenesis(GenesisEvent genesis);
+  void storeGenesis(AnchorPoint genesis);
 
   void update(StorageUpdate event);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -25,13 +25,13 @@ import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.protoarray.ProtoArraySnapshot;
+import tech.pegasys.teku.storage.events.GenesisEvent;
 import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.store.StoreBuilder;
-import tech.pegasys.teku.storage.store.UpdatableStore;
 
 public interface Database extends AutoCloseable {
 
-  void storeGenesis(UpdatableStore store);
+  void storeGenesis(GenesisEvent genesis);
 
   void update(StorageUpdate event);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -41,7 +41,7 @@ import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.protoarray.ProtoArraySnapshot;
-import tech.pegasys.teku.storage.events.GenesisEvent;
+import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.server.rocksdb.core.RocksDbAccessor;
@@ -133,7 +133,7 @@ public class RocksDbDatabase implements Database {
   }
 
   @Override
-  public void storeGenesis(final GenesisEvent genesis) {
+  public void storeGenesis(final AnchorPoint genesis) {
     try (final HotUpdater hotUpdater = hotDao.hotUpdater();
         final FinalizedUpdater finalizedUpdater = finalizedDao.finalizedUpdater()) {
       // We should only have a single block / state / checkpoint at genesis

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.protoarray.ProtoArraySnapshot;
+import tech.pegasys.teku.storage.events.GenesisEvent;
 import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.server.rocksdb.core.RocksDbAccessor;
@@ -59,7 +60,6 @@ import tech.pegasys.teku.storage.server.rocksdb.schema.V3Schema;
 import tech.pegasys.teku.storage.server.rocksdb.schema.V4SchemaFinalized;
 import tech.pegasys.teku.storage.server.rocksdb.schema.V4SchemaHot;
 import tech.pegasys.teku.storage.store.StoreBuilder;
-import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.util.async.SafeFuture;
 import tech.pegasys.teku.util.config.StateStorageMode;
 
@@ -133,16 +133,16 @@ public class RocksDbDatabase implements Database {
   }
 
   @Override
-  public void storeGenesis(final UpdatableStore store) {
+  public void storeGenesis(final GenesisEvent genesis) {
     try (final HotUpdater hotUpdater = hotDao.hotUpdater();
         final FinalizedUpdater finalizedUpdater = finalizedDao.finalizedUpdater()) {
       // We should only have a single block / state / checkpoint at genesis
-      final Checkpoint genesisCheckpoint = store.getFinalizedCheckpoint();
+      final Checkpoint genesisCheckpoint = genesis.getCheckpoint();
       final Bytes32 genesisRoot = genesisCheckpoint.getRoot();
-      final BeaconState genesisState = store.getBlockState(genesisRoot);
-      final SignedBeaconBlock genesisBlock = store.getSignedBlock(genesisRoot);
+      final BeaconState genesisState = genesis.getState();
+      final SignedBeaconBlock genesisBlock = genesis.getBlock();
 
-      hotUpdater.setGenesisTime(store.getGenesisTime());
+      hotUpdater.setGenesisTime(genesisState.getGenesis_time());
       hotUpdater.setJustifiedCheckpoint(genesisCheckpoint);
       hotUpdater.setBestJustifiedCheckpoint(genesisCheckpoint);
       hotUpdater.setFinalizedCheckpoint(genesisCheckpoint);

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.api.StubFinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.api.StubReorgEventChannel;
+import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.store.StoreBuilder;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.util.async.SafeFuture;
@@ -81,7 +82,9 @@ public class StorageBackedRecentChainDataTest {
     // Post a store response to complete initialization
     final StoreBuilder genesisStoreBuilder =
         StoreBuilder.forkChoiceStoreBuilder(
-            new StubMetricsSystem(), BlockProvider.NOOP, INITIAL_STATE);
+            new StubMetricsSystem(),
+            BlockProvider.NOOP,
+            AnchorPoint.fromGenesisState(INITIAL_STATE));
     storeRequestFuture.complete(Optional.of(genesisStoreBuilder));
     assertThat(client).isCompleted();
     assertStoreInitialized(client.get());
@@ -121,7 +124,9 @@ public class StorageBackedRecentChainDataTest {
     // Now set the genesis state
     final UpdatableStore genesisStore =
         StoreBuilder.buildForkChoiceStore(
-            new StubMetricsSystem(), BlockProvider.NOOP, INITIAL_STATE);
+            new StubMetricsSystem(),
+            BlockProvider.NOOP,
+            AnchorPoint.fromGenesisState(INITIAL_STATE));
     client.get().initializeFromGenesis(INITIAL_STATE);
     assertStoreInitialized(client.get());
     assertStoreIsSet(client.get());
@@ -159,7 +164,9 @@ public class StorageBackedRecentChainDataTest {
     // Now set the genesis state
     final StoreBuilder genesisStoreBuilder =
         StoreBuilder.forkChoiceStoreBuilder(
-            new StubMetricsSystem(), BlockProvider.NOOP, INITIAL_STATE);
+            new StubMetricsSystem(),
+            BlockProvider.NOOP,
+            AnchorPoint.fromGenesisState(INITIAL_STATE));
     storeRequestFuture.complete(Optional.of(genesisStoreBuilder));
     assertThat(client).isCompleted();
     assertStoreInitialized(client.get());

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
@@ -53,7 +53,7 @@ import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.storage.client.RecentChainData;
-import tech.pegasys.teku.storage.events.GenesisEvent;
+import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.storage.store.StorePruningOptions;
 import tech.pegasys.teku.storage.store.UpdatableStore;
@@ -67,7 +67,7 @@ public abstract class AbstractDatabaseTest {
 
   protected final ChainBuilder chainBuilder = ChainBuilder.create(VALIDATOR_KEYS);
 
-  protected GenesisEvent genesisEvent;
+  protected AnchorPoint genesisAnchor;
   protected SignedBlockAndState genesisBlockAndState;
   protected SignedBlockAndState checkpoint1BlockAndState;
   protected SignedBlockAndState checkpoint2BlockAndState;
@@ -94,7 +94,7 @@ public abstract class AbstractDatabaseTest {
 
     genesisBlockAndState = chainBuilder.generateGenesis();
     genesisCheckpoint = getCheckpointForBlock(genesisBlockAndState.getBlock());
-    genesisEvent = GenesisEvent.fromGenesisState(genesisBlockAndState.getState());
+    genesisAnchor = AnchorPoint.fromGenesisState(genesisBlockAndState.getState());
 
     // Initialize genesis store
     initGenesis();

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
@@ -53,6 +53,7 @@ import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.events.GenesisEvent;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.storage.store.StorePruningOptions;
 import tech.pegasys.teku.storage.store.UpdatableStore;
@@ -66,6 +67,7 @@ public abstract class AbstractDatabaseTest {
 
   protected final ChainBuilder chainBuilder = ChainBuilder.create(VALIDATOR_KEYS);
 
+  protected GenesisEvent genesisEvent;
   protected SignedBlockAndState genesisBlockAndState;
   protected SignedBlockAndState checkpoint1BlockAndState;
   protected SignedBlockAndState checkpoint2BlockAndState;
@@ -92,6 +94,7 @@ public abstract class AbstractDatabaseTest {
 
     genesisBlockAndState = chainBuilder.generateGenesis();
     genesisCheckpoint = getCheckpointForBlock(genesisBlockAndState.getBlock());
+    genesisEvent = GenesisEvent.fromGenesisState(genesisBlockAndState.getState());
 
     // Initialize genesis store
     initGenesis();

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/AbstractRocksDbDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/AbstractRocksDbDatabaseTest.java
@@ -38,13 +38,13 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfClosedDatabaseIsModified_setGenesis() throws Exception {
     database.close();
-    assertThatThrownBy(() -> database.storeGenesis(genesisEvent))
+    assertThatThrownBy(() -> database.storeGenesis(genesisAnchor))
         .isInstanceOf(ShuttingDownException.class);
   }
 
   @Test
   public void shouldThrowIfClosedDatabaseIsModified_update() throws Exception {
-    database.storeGenesis(genesisEvent);
+    database.storeGenesis(genesisAnchor);
     database.close();
 
     final SignedBlockAndState newValue = chainBuilder.generateBlockAtSlot(1);
@@ -59,7 +59,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
 
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_createMemoryStore() throws Exception {
-    database.storeGenesis(genesisEvent);
+    database.storeGenesis(genesisAnchor);
     database.close();
 
     assertThatThrownBy(database::createMemoryStore).isInstanceOf(ShuttingDownException.class);
@@ -67,7 +67,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
 
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_getSlotForFinalizedBlockRoot() throws Exception {
-    database.storeGenesis(genesisEvent);
+    database.storeGenesis(genesisAnchor);
     database.close();
 
     assertThatThrownBy(() -> database.getSlotForFinalizedBlockRoot(Bytes32.ZERO))
@@ -76,7 +76,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
 
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_getSignedBlock() throws Exception {
-    database.storeGenesis(genesisEvent);
+    database.storeGenesis(genesisAnchor);
     database.close();
 
     assertThatThrownBy(() -> database.getSignedBlock(genesisCheckpoint.getRoot()))
@@ -85,7 +85,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
 
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_streamFinalizedBlocks() throws Exception {
-    database.storeGenesis(genesisEvent);
+    database.storeGenesis(genesisAnchor);
     database.close();
 
     assertThatThrownBy(() -> database.streamFinalizedBlocks(UnsignedLong.ZERO, UnsignedLong.ONE))
@@ -95,7 +95,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_streamFinalizedBlocksShuttingDown()
       throws Exception {
-    database.storeGenesis(genesisEvent);
+    database.storeGenesis(genesisAnchor);
     try (final Stream<SignedBeaconBlock> stream =
         database.streamFinalizedBlocks(UnsignedLong.ZERO, UnsignedLong.valueOf(1000L))) {
       database.close();
@@ -106,7 +106,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfTransactionModifiedAfterDatabaseIsClosed_updateHotDao()
       throws Exception {
-    database.storeGenesis(genesisEvent);
+    database.storeGenesis(genesisAnchor);
 
     try (final RocksDbHotDao.HotUpdater updater =
         ((RocksDbDatabase) database).hotDao.hotUpdater()) {
@@ -120,7 +120,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfTransactionModifiedAfterDatabaseIsClosed_updateFinalizedDao()
       throws Exception {
-    database.storeGenesis(genesisEvent);
+    database.storeGenesis(genesisAnchor);
 
     try (final RocksDbFinalizedDao.FinalizedUpdater updater =
         ((RocksDbDatabase) database).finalizedDao.finalizedUpdater()) {
@@ -134,7 +134,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfTransactionModifiedAfterDatabaseIsClosed_updateEth1Dao()
       throws Exception {
-    database.storeGenesis(genesisEvent);
+    database.storeGenesis(genesisAnchor);
 
     final DataStructureUtil dataStructureUtil = new DataStructureUtil();
     try (final RocksDbEth1Dao.Eth1Updater updater =
@@ -150,7 +150,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_getHistoricalState() throws Exception {
     // Store genesis
-    database.storeGenesis(genesisEvent);
+    database.storeGenesis(genesisAnchor);
     // Add a new finalized block to supersede genesis
     final SignedBlockAndState newBlock = chainBuilder.generateBlockAtSlot(1);
     final Checkpoint newCheckpoint = getCheckpointForBlock(newBlock.getBlock());

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/AbstractRocksDbDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/AbstractRocksDbDatabaseTest.java
@@ -38,13 +38,13 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfClosedDatabaseIsModified_setGenesis() throws Exception {
     database.close();
-    assertThatThrownBy(() -> database.storeGenesis(store))
+    assertThatThrownBy(() -> database.storeGenesis(genesisEvent))
         .isInstanceOf(ShuttingDownException.class);
   }
 
   @Test
   public void shouldThrowIfClosedDatabaseIsModified_update() throws Exception {
-    database.storeGenesis(store);
+    database.storeGenesis(genesisEvent);
     database.close();
 
     final SignedBlockAndState newValue = chainBuilder.generateBlockAtSlot(1);
@@ -59,7 +59,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
 
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_createMemoryStore() throws Exception {
-    database.storeGenesis(store);
+    database.storeGenesis(genesisEvent);
     database.close();
 
     assertThatThrownBy(database::createMemoryStore).isInstanceOf(ShuttingDownException.class);
@@ -67,7 +67,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
 
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_getSlotForFinalizedBlockRoot() throws Exception {
-    database.storeGenesis(store);
+    database.storeGenesis(genesisEvent);
     database.close();
 
     assertThatThrownBy(() -> database.getSlotForFinalizedBlockRoot(Bytes32.ZERO))
@@ -76,7 +76,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
 
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_getSignedBlock() throws Exception {
-    database.storeGenesis(store);
+    database.storeGenesis(genesisEvent);
     database.close();
 
     assertThatThrownBy(() -> database.getSignedBlock(genesisCheckpoint.getRoot()))
@@ -85,7 +85,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
 
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_streamFinalizedBlocks() throws Exception {
-    database.storeGenesis(store);
+    database.storeGenesis(genesisEvent);
     database.close();
 
     assertThatThrownBy(() -> database.streamFinalizedBlocks(UnsignedLong.ZERO, UnsignedLong.ONE))
@@ -95,7 +95,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_streamFinalizedBlocksShuttingDown()
       throws Exception {
-    database.storeGenesis(store);
+    database.storeGenesis(genesisEvent);
     try (final Stream<SignedBeaconBlock> stream =
         database.streamFinalizedBlocks(UnsignedLong.ZERO, UnsignedLong.valueOf(1000L))) {
       database.close();
@@ -106,7 +106,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfTransactionModifiedAfterDatabaseIsClosed_updateHotDao()
       throws Exception {
-    database.storeGenesis(store);
+    database.storeGenesis(genesisEvent);
 
     try (final RocksDbHotDao.HotUpdater updater =
         ((RocksDbDatabase) database).hotDao.hotUpdater()) {
@@ -120,7 +120,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfTransactionModifiedAfterDatabaseIsClosed_updateFinalizedDao()
       throws Exception {
-    database.storeGenesis(store);
+    database.storeGenesis(genesisEvent);
 
     try (final RocksDbFinalizedDao.FinalizedUpdater updater =
         ((RocksDbDatabase) database).finalizedDao.finalizedUpdater()) {
@@ -134,7 +134,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfTransactionModifiedAfterDatabaseIsClosed_updateEth1Dao()
       throws Exception {
-    database.storeGenesis(store);
+    database.storeGenesis(genesisEvent);
 
     final DataStructureUtil dataStructureUtil = new DataStructureUtil();
     try (final RocksDbEth1Dao.Eth1Updater updater =
@@ -150,7 +150,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_getHistoricalState() throws Exception {
     // Store genesis
-    database.storeGenesis(store);
+    database.storeGenesis(genesisEvent);
     // Add a new finalized block to supersede genesis
     final SignedBlockAndState newBlock = chainBuilder.generateBlockAtSlot(1);
     final Checkpoint newCheckpoint = getCheckpointForBlock(newBlock.getBlock());

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/DatabaseBackedStorageUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/DatabaseBackedStorageUpdateChannel.java
@@ -14,10 +14,10 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Optional;
+import tech.pegasys.teku.storage.events.GenesisEvent;
 import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.store.StoreBuilder;
-import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.util.async.SafeFuture;
 
 public class DatabaseBackedStorageUpdateChannel implements StorageUpdateChannel {
@@ -38,7 +38,7 @@ public class DatabaseBackedStorageUpdateChannel implements StorageUpdateChannel 
   }
 
   @Override
-  public void onGenesis(UpdatableStore store) {
-    database.storeGenesis(store);
+  public void onGenesis(GenesisEvent genesis) {
+    database.storeGenesis(genesis);
   }
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/DatabaseBackedStorageUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/DatabaseBackedStorageUpdateChannel.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Optional;
-import tech.pegasys.teku.storage.events.GenesisEvent;
+import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.store.StoreBuilder;
@@ -38,7 +38,7 @@ public class DatabaseBackedStorageUpdateChannel implements StorageUpdateChannel 
   }
 
   @Override
-  public void onGenesis(GenesisEvent genesis) {
+  public void onGenesis(AnchorPoint genesis) {
     database.storeGenesis(genesis);
   }
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
@@ -14,9 +14,9 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Optional;
+import tech.pegasys.teku.storage.events.GenesisEvent;
 import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.store.StoreBuilder;
-import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.util.async.SafeFuture;
 
 public class StubStorageUpdateChannel implements StorageUpdateChannel {
@@ -32,5 +32,5 @@ public class StubStorageUpdateChannel implements StorageUpdateChannel {
   }
 
   @Override
-  public void onGenesis(UpdatableStore store) {}
+  public void onGenesis(GenesisEvent genesis) {}
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Optional;
-import tech.pegasys.teku.storage.events.GenesisEvent;
+import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.store.StoreBuilder;
 import tech.pegasys.teku.util.async.SafeFuture;
@@ -32,5 +32,5 @@ public class StubStorageUpdateChannel implements StorageUpdateChannel {
   }
 
   @Override
-  public void onGenesis(GenesisEvent genesis) {}
+  public void onGenesis(AnchorPoint genesis) {}
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
@@ -14,9 +14,9 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Optional;
+import tech.pegasys.teku.storage.events.GenesisEvent;
 import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.store.StoreBuilder;
-import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.util.async.SafeFuture;
 import tech.pegasys.teku.util.async.StubAsyncRunner;
 
@@ -38,5 +38,5 @@ public class StubStorageUpdateChannelWithDelays implements StorageUpdateChannel 
   }
 
   @Override
-  public void onGenesis(UpdatableStore store) {}
+  public void onGenesis(GenesisEvent genesis) {}
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Optional;
-import tech.pegasys.teku.storage.events.GenesisEvent;
+import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.events.StorageUpdate;
 import tech.pegasys.teku.storage.store.StoreBuilder;
 import tech.pegasys.teku.util.async.SafeFuture;
@@ -38,5 +38,5 @@ public class StubStorageUpdateChannelWithDelays implements StorageUpdateChannel 
   }
 
   @Override
-  public void onGenesis(GenesisEvent genesis) {}
+  public void onGenesis(AnchorPoint genesis) {}
 }


### PR DESCRIPTION
## PR Description
As part of #2291, reduce dependencies on `Store` API's by creating an `AnchorPoint` object that is now used to encapsulate genesis-related data.  This means we no longer need to query the `Store` to pull genesis-related data.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.