### PR TITLE
Publish attestations when not subscribed to the topic

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
@@ -167,8 +167,7 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
         new BlockGossipManager(
             discoveryNetwork, gossipEncoding, forkInfo, blockValidator, eventBus);
 
-    attestationGossipManager =
-        new AttestationGossipManager(gossipEncoding, attestationSubnetSubscriptions);
+    attestationGossipManager = new AttestationGossipManager(attestationSubnetSubscriptions);
 
     aggregateGossipManager =
         new AggregateGossipManager(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2TopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2TopicHandler.java
@@ -31,12 +31,7 @@ public interface Eth2TopicHandler<T extends SimpleOffsetSerializable> extends To
   }
 
   default String getTopic() {
-    return "/eth2/"
-        + getForkDigest().toUnprefixedHexString()
-        + "/"
-        + getTopicName()
-        + "/"
-        + getGossipEncoding().getName();
+    return TopicNames.getTopic(getForkDigest(), getTopicName(), getGossipEncoding());
   }
 
   Bytes4 getForkDigest();

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandler.java
@@ -88,7 +88,7 @@ public class SingleAttestationTopicHandler implements Eth2TopicHandler<Attestati
 
   @Override
   public String getTopicName() {
-    return "beacon_attestation_" + subnetId;
+    return TopicNames.getAttestationSubnetTopicName(subnetId);
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/TopicNames.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/TopicNames.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.gossip.topics;
+
+import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
+import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
+
+public class TopicNames {
+
+  public static String getTopic(
+      final Bytes4 forkDigest, final String topicName, final GossipEncoding gossipEncoding) {
+
+    return "/eth2/"
+        + forkDigest.toUnprefixedHexString()
+        + "/"
+        + topicName
+        + "/"
+        + gossipEncoding.getName();
+  }
+
+  public static String getAttestationSubnetTopic(
+      final Bytes4 forkDigest, final int subnetId, final GossipEncoding gossipEncoding) {
+    return getTopic(forkDigest, getAttestationSubnetTopicName(subnetId), gossipEncoding);
+  }
+
+  public static String getAttestationSubnetTopicName(final int subnetId) {
+    return "beacon_attestation_" + subnetId;
+  }
+}

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
@@ -14,13 +14,8 @@
 package tech.pegasys.teku.networking.eth2.gossip;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.primitives.UnsignedLong;
@@ -33,9 +28,10 @@ import tech.pegasys.teku.datastructures.util.CommitteeUtil;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipedOperationConsumer;
+import tech.pegasys.teku.networking.eth2.gossip.topics.TopicNames;
 import tech.pegasys.teku.networking.eth2.gossip.topics.validation.AttestationValidator;
 import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
-import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
+import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -53,7 +49,6 @@ public class AttestationGossipManagerTest {
       MemoryOnlyRecentChainData.create(mock(EventBus.class));
   private final GossipNetwork gossipNetwork = mock(GossipNetwork.class);
   private final GossipEncoding gossipEncoding = GossipEncoding.SSZ_SNAPPY;
-  private final TopicChannel topicChannel = mock(TopicChannel.class);
   private AttestationGossipManager attestationGossipManager;
   private final AttestationSubnetSubscriptions attestationSubnetSubscriptions =
       new AttestationSubnetSubscriptions(
@@ -62,11 +57,12 @@ public class AttestationGossipManagerTest {
           attestationValidator,
           recentChainData,
           gossipedAttestationConsumer);
+  private Bytes4 forkDigest;
 
   @BeforeEach
   public void setup() {
     BeaconChainUtil.create(0, recentChainData).initializeStorage();
-    doReturn(topicChannel).when(gossipNetwork).subscribe(contains("beacon_attestation_"), any());
+    forkDigest = recentChainData.getHeadForkInfo().orElseThrow().getForkDigest();
     attestationGossipManager = new AttestationGossipManager(attestationSubnetSubscriptions);
   }
 
@@ -88,14 +84,14 @@ public class AttestationGossipManagerTest {
     final Bytes serialized = gossipEncoding.encode(attestation);
     attestationGossipManager.onNewAttestation(ValidateableAttestation.fromAttestation(attestation));
 
-    verify(topicChannel).gossip(serialized);
+    verify(gossipNetwork).gossip(getSubnetTopic(subnetId), serialized);
 
     // We should process attestations for different committees on the same subnet
     final Bytes serialized2 = gossipEncoding.encode(attestation2);
     attestationGossipManager.onNewAttestation(
         ValidateableAttestation.fromAttestation(attestation2));
 
-    verify(topicChannel).gossip(serialized2);
+    verify(gossipNetwork).gossip(getSubnetTopic(subnetId), serialized2);
   }
 
   @Test
@@ -108,7 +104,7 @@ public class AttestationGossipManagerTest {
     // Post new attestation
     attestationGossipManager.onNewAttestation(ValidateableAttestation.fromAttestation(attestation));
 
-    verifyNoInteractions(topicChannel);
+    verify(gossipNetwork).gossip(getSubnetTopic(subnetId), gossipEncoding.encode(attestation));
   }
 
   @Test
@@ -127,18 +123,22 @@ public class AttestationGossipManagerTest {
     final Bytes serialized = gossipEncoding.encode(attestation);
     attestationGossipManager.onNewAttestation(ValidateableAttestation.fromAttestation(attestation));
 
-    verify(topicChannel, never()).gossip(serialized);
+    verify(gossipNetwork).gossip(getSubnetTopic(dismissedSubnetId), serialized);
 
     // Attestation for remaining assignment should be processed
     final Bytes serialized2 = gossipEncoding.encode(attestation2);
     attestationGossipManager.onNewAttestation(
         ValidateableAttestation.fromAttestation(attestation2));
 
-    verify(topicChannel).gossip(serialized2);
+    verify(gossipNetwork).gossip(getSubnetTopic(subnetId), serialized2);
   }
 
   private Integer computeSubnetId(final Attestation attestation) {
     return CommitteeUtil.computeSubnetForAttestation(
         recentChainData.getBestState().orElseThrow(), attestation);
+  }
+
+  private String getSubnetTopic(final int subnetId) {
+    return TopicNames.getAttestationSubnetTopic(forkDigest, subnetId, gossipEncoding);
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
@@ -67,8 +67,7 @@ public class AttestationGossipManagerTest {
   public void setup() {
     BeaconChainUtil.create(0, recentChainData).initializeStorage();
     doReturn(topicChannel).when(gossipNetwork).subscribe(contains("beacon_attestation_"), any());
-    attestationGossipManager =
-        new AttestationGossipManager(gossipEncoding, attestationSubnetSubscriptions);
+    attestationGossipManager = new AttestationGossipManager(attestationSubnetSubscriptions);
   }
 
   @Test

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/GossipNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/GossipNetwork.java
@@ -13,7 +13,11 @@
 
 package tech.pegasys.teku.networking.p2p.gossip;
 
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.util.async.SafeFuture;
+
 public interface GossipNetwork {
+  SafeFuture<?> gossip(String topic, Bytes data);
 
   TopicChannel subscribe(String topic, TopicHandler topicHandler);
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -52,6 +52,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.crypto.Hash;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.networking.p2p.connection.ReputationManager;
@@ -298,6 +299,11 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
   @Override
   public Optional<String> getDiscoveryAddress() {
     return Optional.empty();
+  }
+
+  @Override
+  public SafeFuture<?> gossip(final String topic, final Bytes data) {
+    return gossipNetwork.gossip(topic, data);
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandler.java
@@ -34,9 +34,9 @@ import tech.pegasys.teku.util.collections.LimitStrategy;
 public class GossipHandler implements Function<MessageApi, CompletableFuture<ValidationResult>> {
   private static final Logger LOG = LogManager.getLogger();
 
-  private static SafeFuture<ValidationResult> VALIDATION_FAILED =
+  private static final SafeFuture<ValidationResult> VALIDATION_FAILED =
       SafeFuture.completedFuture(ValidationResult.Invalid);
-  private static SafeFuture<ValidationResult> VALIDATION_IGNORED =
+  private static final SafeFuture<ValidationResult> VALIDATION_IGNORED =
       SafeFuture.completedFuture(ValidationResult.Ignore);
 
   private static final int MAX_SENT_MESSAGES = 2048;

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetwork.java
@@ -17,10 +17,13 @@ import io.libp2p.core.pubsub.PubsubPublisherApi;
 import io.libp2p.core.pubsub.PubsubSubscription;
 import io.libp2p.core.pubsub.Topic;
 import io.libp2p.pubsub.gossip.Gossip;
+import io.netty.buffer.Unpooled;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
 import tech.pegasys.teku.networking.p2p.gossip.TopicHandler;
+import tech.pegasys.teku.util.async.SafeFuture;
 
 public class LibP2PGossipNetwork implements tech.pegasys.teku.networking.p2p.gossip.GossipNetwork {
   private static final Logger LOG = LogManager.getLogger();
@@ -31,6 +34,12 @@ public class LibP2PGossipNetwork implements tech.pegasys.teku.networking.p2p.gos
   public LibP2PGossipNetwork(final Gossip gossip, final PubsubPublisherApi publisher) {
     this.gossip = gossip;
     this.publisher = publisher;
+  }
+
+  @Override
+  public SafeFuture<?> gossip(final String topic, final Bytes data) {
+    return SafeFuture.of(
+        publisher.publish(Unpooled.wrappedBuffer(data.toArrayUnsafe()), new Topic(topic)));
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/mock/MockP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/mock/MockP2PNetwork.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.p2p.mock;
 
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
 import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
 import tech.pegasys.teku.networking.p2p.gossip.TopicHandler;
@@ -97,7 +98,7 @@ public class MockP2PNetwork<P extends Peer> implements P2PNetwork<P> {
   @Override
   public int getListenPort() {
     return 0;
-  };
+  }
 
   /** Stops the P2P network layer. */
   @Override
@@ -111,5 +112,11 @@ public class MockP2PNetwork<P extends Peer> implements P2PNetwork<P> {
   @Override
   public TopicChannel subscribe(final String topic, final TopicHandler topicHandler) {
     return new MockTopicChannel();
+  }
+
+  @Override
+  public SafeFuture<?> gossip(final String topic, final Bytes data) {
+    // Do nothing
+    return SafeFuture.COMPLETE;
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/DelegatingP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/DelegatingP2PNetwork.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.p2p.network;
 
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
 import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
 import tech.pegasys.teku.networking.p2p.gossip.TopicHandler;
@@ -76,7 +77,7 @@ public abstract class DelegatingP2PNetwork<T extends Peer> implements P2PNetwork
   @Override
   public int getListenPort() {
     return network.getListenPort();
-  };
+  }
 
   @Override
   public SafeFuture<?> start() {
@@ -86,6 +87,11 @@ public abstract class DelegatingP2PNetwork<T extends Peer> implements P2PNetwork
   @Override
   public void stop() {
     network.stop();
+  }
+
+  @Override
+  public SafeFuture<?> gossip(final String topic, final Bytes data) {
+    return network.gossip(topic, data);
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Teku was only publishing attestations when it had a subscription to the topic involved.  Instead, publish via the `PubsubPublisherApi` directly so that it will be sent even if we aren't subscribed.
## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.