### PR TITLE
Reduce maximum number of blocks to hold in memory

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StorePruningOptions.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StorePruningOptions.java
@@ -18,7 +18,7 @@ import tech.pegasys.teku.util.config.Constants;
 public class StorePruningOptions {
   public static final int DEFAULT_STATE_CACHE_SIZE = Constants.SLOTS_PER_EPOCH * 5;
   // Max block size is about 20x smaller than the minimum state size
-  public static final int DEFAULT_BLOCK_CACHE_SIZE = DEFAULT_STATE_CACHE_SIZE * 10;
+  public static final int DEFAULT_BLOCK_CACHE_SIZE = DEFAULT_STATE_CACHE_SIZE * 2;
   public static final int DEFAULT_CHECKPOINT_STATE_CACHE_SIZE = 20;
 
   private final int stateCacheSize;


### PR DESCRIPTION
## PR Description
The default cache sizes cause Teku to struggle to run within 1Gb of heap space during periods of non-finalization. Reduce the number of blocks held in memory to reduce memory pressure.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.