### PR TITLE
Use finally to schedule the next execution

### DIFF
--- a/util/src/main/java/tech/pegasys/teku/util/async/FutureUtil.java
+++ b/util/src/main/java/tech/pegasys/teku/util/async/FutureUtil.java
@@ -44,8 +44,10 @@ public class FutureUtil {
                   } catch (Exception e) {
                     LOG.warn("Exception in exception handler", e);
                   }
+                } finally {
+                  runWithFixedDelay(
+                      runner, runnable, task, delayAmount, delayUnit, exceptionHandler);
                 }
-                runWithFixedDelay(runner, runnable, task, delayAmount, delayUnit, exceptionHandler);
               }
             },
             delayAmount,
@@ -55,7 +57,7 @@ public class FutureUtil {
 
   static Cancellable createCancellable() {
     return new Cancellable() {
-      private boolean cancelled;
+      private volatile boolean cancelled;
 
       @Override
       public void cancel() {


### PR DESCRIPTION
## PR Description
Shouldn't make any difference because it was catching `Throwable` anyway but for good measure, use `finally` to ensure we always schedule the next execution in `runWithFixedDelay`.

And make `cancelled` `volatile` in `Cancellable` since the cancel call will happen on a different thread to where the value is checked.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.