### PR TITLE
Introduce PeerSelectionStrategy to encapsulate decisions on which peers to connect and when

### DIFF
--- a/networking/eth2/build.gradle
+++ b/networking/eth2/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   testImplementation testFixtures(project(':ethereum:core'))
   testImplementation testFixtures(project(':ethereum:datastructures'))
   testImplementation testFixtures(project(':ethereum:statetransition'))
+  testImplementation testFixtures(project(':networking:p2p'))
   testImplementation testFixtures(project(':util'))
   testImplementation testFixtures(project(':storage'))
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.ProcessedAttestationSubsc
 import tech.pegasys.teku.networking.eth2.gossip.topics.TopicNames;
 import tech.pegasys.teku.networking.eth2.gossip.topics.VerifiedBlockAttestationsSubscriptionProvider;
 import tech.pegasys.teku.networking.eth2.peers.Eth2PeerManager;
+import tech.pegasys.teku.networking.eth2.peers.Eth2PeerSelectionStrategy;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.networking.p2p.DiscoveryNetwork;
 import tech.pegasys.teku.networking.p2p.connection.ReputationManager;
@@ -135,8 +136,10 @@ public class Eth2NetworkBuilder {
         metricsSystem,
         asyncRunner,
         p2pNetwork,
-        reputationManager,
-        () -> AttestationSubnetScorer.create(p2pNetwork, subnetTopicProvider),
+        new Eth2PeerSelectionStrategy(
+            config.getTargetPeerRange(),
+            () -> AttestationSubnetScorer.create(p2pNetwork, subnetTopicProvider),
+            reputationManager),
         config);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategy.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.peers;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.networking.p2p.connection.PeerScorer;
+import tech.pegasys.teku.networking.p2p.connection.PeerScorer.PeerScorerFactory;
+import tech.pegasys.teku.networking.p2p.connection.PeerSelectionStrategy;
+import tech.pegasys.teku.networking.p2p.connection.ReputationManager;
+import tech.pegasys.teku.networking.p2p.connection.TargetPeerRange;
+import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
+import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
+import tech.pegasys.teku.networking.p2p.network.PeerAddress;
+import tech.pegasys.teku.networking.p2p.peer.Peer;
+
+public class Eth2PeerSelectionStrategy implements PeerSelectionStrategy {
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final TargetPeerRange targetPeerCountRange;
+  private final PeerScorerFactory peerScorerFactory;
+  private final ReputationManager reputationManager;
+
+  public Eth2PeerSelectionStrategy(
+      final TargetPeerRange targetPeerCountRange,
+      final PeerScorerFactory peerScorerFactory,
+      final ReputationManager reputationManager) {
+    this.targetPeerCountRange = targetPeerCountRange;
+    this.peerScorerFactory = peerScorerFactory;
+    this.reputationManager = reputationManager;
+  }
+
+  @Override
+  public List<PeerAddress> selectPeersToConnect(
+      final P2PNetwork<?> network, final Supplier<List<DiscoveryPeer>> candidates) {
+    final int maxAttempts = targetPeerCountRange.getPeersToAdd(network.getPeerCount());
+    LOG.trace("Connecting to up to {} known peers", maxAttempts);
+    if (maxAttempts == 0) {
+      return emptyList();
+    }
+    final PeerScorer peerScorer = peerScorerFactory.create();
+    return candidates.get().stream()
+        .sorted(
+            Comparator.comparing((Function<DiscoveryPeer, Integer>) peerScorer::scoreCandidatePeer)
+                .reversed())
+        .map(network::createPeerAddress)
+        .filter(reputationManager::isConnectionInitiationAllowed)
+        .filter(peerAddress -> !network.isConnected(peerAddress))
+        .limit(maxAttempts)
+        .collect(toList());
+  }
+
+  @Override
+  public List<Peer> selectPeersToDisconnect(
+      final P2PNetwork<?> network, final Predicate<Peer> canBeDisconnected) {
+    final int peersToDrop = targetPeerCountRange.getPeersToDrop(network.getPeerCount());
+    if (peersToDrop == 0) {
+      return emptyList();
+    }
+    final PeerScorer peerScorer = peerScorerFactory.create();
+    return network
+        .streamPeers()
+        .filter(canBeDisconnected)
+        .sorted(Comparator.comparing(peerScorer::scoreExistingPeer))
+        .limit(peersToDrop)
+        .collect(toList());
+  }
+}

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategyTest.java
@@ -51,7 +51,6 @@ class Eth2PeerSelectionStrategyTest {
   private static final DiscoveryPeer DISCOVERY_PEER1 = createDiscoveryPeer(PEER1);
   private static final DiscoveryPeer DISCOVERY_PEER2 = createDiscoveryPeer(PEER2);
   private static final DiscoveryPeer DISCOVERY_PEER3 = createDiscoveryPeer(PEER3);
-  private static final DiscoveryPeer DISCOVERY_PEER4 = createDiscoveryPeer(PEER4);
 
   @SuppressWarnings("unchecked")
   private final P2PNetwork<Peer> network = mock(P2PNetwork.class);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategyTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.peers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.util.config.Constants.ATTESTATION_SUBNET_COUNT;
+
+import com.google.common.primitives.Ints;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.networking.libp2p.rpc.EnrForkId;
+import tech.pegasys.teku.network.p2p.connection.StubPeerScorer;
+import tech.pegasys.teku.network.p2p.peer.StubPeer;
+import tech.pegasys.teku.networking.p2p.connection.PeerScorer.PeerScorerFactory;
+import tech.pegasys.teku.networking.p2p.connection.ReputationManager;
+import tech.pegasys.teku.networking.p2p.connection.TargetPeerRange;
+import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
+import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
+import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
+import tech.pegasys.teku.networking.p2p.network.PeerAddress;
+import tech.pegasys.teku.networking.p2p.peer.Peer;
+import tech.pegasys.teku.ssz.SSZTypes.Bitvector;
+
+class Eth2PeerSelectionStrategyTest {
+
+  private static final Optional<EnrForkId> ENR_FORK_ID = Optional.empty();
+  private static final PeerAddress PEER1 = new PeerAddress(new MockNodeId(1));
+  private static final PeerAddress PEER2 = new PeerAddress(new MockNodeId(2));
+  private static final PeerAddress PEER3 = new PeerAddress(new MockNodeId(3));
+  private static final PeerAddress PEER4 = new PeerAddress(new MockNodeId(4));
+  private static final DiscoveryPeer DISCOVERY_PEER1 = createDiscoveryPeer(PEER1);
+  private static final DiscoveryPeer DISCOVERY_PEER2 = createDiscoveryPeer(PEER2);
+  private static final DiscoveryPeer DISCOVERY_PEER3 = createDiscoveryPeer(PEER3);
+  private static final DiscoveryPeer DISCOVERY_PEER4 = createDiscoveryPeer(PEER4);
+
+  @SuppressWarnings("unchecked")
+  private final P2PNetwork<Peer> network = mock(P2PNetwork.class);
+
+  private final StubPeerScorer peerScorer = new StubPeerScorer();
+  private final PeerScorerFactory peerScorerFactory = () -> peerScorer;
+  private final ReputationManager reputationManager = mock(ReputationManager.class);
+
+  @BeforeEach
+  void setUp() {
+    when(reputationManager.isConnectionInitiationAllowed(any())).thenReturn(true);
+    when(network.createPeerAddress(any(DiscoveryPeer.class)))
+        .thenAnswer(
+            invocation -> {
+              final DiscoveryPeer peer = invocation.getArgument(0);
+              return new PeerAddress(new MockNodeId(peer.getPublicKey()));
+            });
+  }
+
+  @Test
+  void selectPeersToConnect_shouldNotConnectToPeersWithBadReputation() {
+    final Eth2PeerSelectionStrategy strategy = createStrategy();
+    when(reputationManager.isConnectionInitiationAllowed(PEER1)).thenReturn(false);
+    when(reputationManager.isConnectionInitiationAllowed(PEER2)).thenReturn(true);
+
+    assertThat(
+            strategy.selectPeersToConnect(network, () -> List.of(DISCOVERY_PEER1, DISCOVERY_PEER2)))
+        .containsExactly(PEER2);
+  }
+
+  @Test
+  void selectPeersToConnect_shouldLimitNumberOfNewConnections() {
+    final Eth2PeerSelectionStrategy strategy = createStrategy(1, 2);
+
+    assertThat(
+            strategy.selectPeersToConnect(
+                network, () -> List.of(DISCOVERY_PEER1, DISCOVERY_PEER2, DISCOVERY_PEER3)))
+        .containsExactly(PEER1, PEER2);
+  }
+
+  @Test
+  void selectPeersToConnect_shouldConnectToHighestScoringPeers() {
+    final Eth2PeerSelectionStrategy strategy = createStrategy(2, 2);
+
+    final DiscoveryPeer discoveryPeer1 = createDiscoveryPeer(PEER1, 1);
+    final DiscoveryPeer discoveryPeer2 = createDiscoveryPeer(PEER2, 2);
+    final DiscoveryPeer discoveryPeer3 = createDiscoveryPeer(PEER3, 3);
+    final DiscoveryPeer discoveryPeer4 = createDiscoveryPeer(PEER4, 4);
+    peerScorer.setScore(discoveryPeer1.getPersistentSubnets(), 100);
+    peerScorer.setScore(discoveryPeer2.getPersistentSubnets(), 200);
+    peerScorer.setScore(discoveryPeer3.getPersistentSubnets(), 150);
+    peerScorer.setScore(discoveryPeer4.getPersistentSubnets(), 500);
+
+    assertThat(
+            strategy.selectPeersToConnect(
+                network,
+                () -> List.of(discoveryPeer1, discoveryPeer2, discoveryPeer3, discoveryPeer4)))
+        .containsExactlyInAnyOrder(PEER2, PEER4);
+  }
+
+  @Test
+  void selectPeersToConnect_shouldNotConnectToAlreadyConnectedPeers() {
+    final Eth2PeerSelectionStrategy strategy = createStrategy();
+    when(network.isConnected(PEER1)).thenReturn(true);
+    when(network.isConnected(PEER3)).thenReturn(true);
+
+    assertThat(
+            strategy.selectPeersToConnect(
+                network, () -> List.of(DISCOVERY_PEER1, DISCOVERY_PEER2, DISCOVERY_PEER3)))
+        .containsExactly(PEER2);
+  }
+
+  @Test
+  void selectPeersToDisconnect_shouldDisconnectLowestScoringPeersWhenPeerCountExceedsUpperBound() {
+    final Eth2PeerSelectionStrategy strategy = createStrategy(0, 1);
+    final StubPeer peer1 = new StubPeer(new MockNodeId(1));
+    final StubPeer peer2 = new StubPeer(new MockNodeId(2));
+    final StubPeer peer3 = new StubPeer(new MockNodeId(3));
+    peerScorer.setScore(peer1.getId(), 100);
+    peerScorer.setScore(peer2.getId(), 200);
+    peerScorer.setScore(peer3.getId(), 150);
+
+    when(network.getPeerCount()).thenReturn(3);
+    when(network.streamPeers()).thenReturn(Stream.of(peer1, peer2, peer3));
+
+    assertThat(strategy.selectPeersToDisconnect(network, peer -> true))
+        .containsExactlyInAnyOrder(peer1, peer3);
+  }
+
+  @Test
+  void selectPeersToDisconnect_shouldNotDisconnectFromPeersThatPredicateRejects() {
+    final Eth2PeerSelectionStrategy strategy = createStrategy(0, 0);
+    final StubPeer peer1 = new StubPeer(new MockNodeId(1));
+    final StubPeer peer2 = new StubPeer(new MockNodeId(2));
+    final StubPeer peer3 = new StubPeer(new MockNodeId(3));
+    when(network.getPeerCount()).thenReturn(3);
+    when(network.streamPeers()).thenReturn(Stream.of(peer1, peer2, peer3));
+
+    assertThat(strategy.selectPeersToDisconnect(network, peer -> peer != peer2))
+        .containsExactlyInAnyOrder(peer1, peer3);
+  }
+
+  private Eth2PeerSelectionStrategy createStrategy() {
+    return createStrategy(10, 20);
+  }
+
+  private Eth2PeerSelectionStrategy createStrategy(
+      final int peerCountLowerBound, final int peerCountUpperBound) {
+    return new Eth2PeerSelectionStrategy(
+        new TargetPeerRange(peerCountLowerBound, peerCountUpperBound),
+        peerScorerFactory,
+        reputationManager);
+  }
+
+  private static DiscoveryPeer createDiscoveryPeer(final PeerAddress peer, final int... subnetIds) {
+    return createDiscoveryPeer(peer.getId().toBytes(), subnetIds);
+  }
+
+  private static DiscoveryPeer createDiscoveryPeer(final Bytes peerId, final int... subnetIds) {
+    return new DiscoveryPeer(
+        peerId,
+        new InetSocketAddress(InetAddress.getLoopbackAddress(), peerId.trimLeadingZeros().toInt()),
+        ENR_FORK_ID,
+        new Bitvector(Ints.asList(subnetIds), ATTESTATION_SUBNET_COUNT));
+  }
+}

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
@@ -48,6 +48,7 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.GossipedOperationConsumer
 import tech.pegasys.teku.networking.eth2.gossip.topics.ProcessedAttestationSubscriptionProvider;
 import tech.pegasys.teku.networking.eth2.gossip.topics.VerifiedBlockAttestationsSubscriptionProvider;
 import tech.pegasys.teku.networking.eth2.peers.Eth2PeerManager;
+import tech.pegasys.teku.networking.eth2.peers.Eth2PeerSelectionStrategy;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.networking.p2p.DiscoveryNetwork;
 import tech.pegasys.teku.networking.p2p.connection.ReputationManager;
@@ -185,8 +186,8 @@ public class Eth2NetworkFactory {
                     METRICS_SYSTEM,
                     new ArrayList<>(rpcMethods),
                     peerHandlers),
-                reputationManager,
-                StubPeerScorer::new,
+                new Eth2PeerSelectionStrategy(
+                    config.getTargetPeerRange(), StubPeerScorer::new, reputationManager),
                 config);
 
         return new ActiveEth2Network(

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/DiscoveryNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/DiscoveryNetwork.java
@@ -33,8 +33,7 @@ import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.datastructures.util.SimpleOffsetSerializer;
 import tech.pegasys.teku.logging.StatusLogger;
 import tech.pegasys.teku.networking.p2p.connection.ConnectionManager;
-import tech.pegasys.teku.networking.p2p.connection.PeerScorer.PeerScorerFactory;
-import tech.pegasys.teku.networking.p2p.connection.ReputationManager;
+import tech.pegasys.teku.networking.p2p.connection.PeerSelectionStrategy;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryService;
 import tech.pegasys.teku.networking.p2p.discovery.discv5.DiscV5Service;
@@ -85,22 +84,19 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
       final MetricsSystem metricsSystem,
       final AsyncRunner asyncRunner,
       final P2PNetwork<P> p2pNetwork,
-      final ReputationManager reputationManager,
-      final PeerScorerFactory peerScorerFactory,
+      final PeerSelectionStrategy peerSelectionStrategy,
       final NetworkConfig p2pConfig) {
     final DiscoveryService discoveryService = createDiscoveryService(p2pConfig);
     final ConnectionManager connectionManager =
         new ConnectionManager(
             metricsSystem,
             discoveryService,
-            reputationManager,
             asyncRunner,
             p2pNetwork,
+            peerSelectionStrategy,
             p2pConfig.getStaticPeers().stream()
                 .map(p2pNetwork::createPeerAddress)
-                .collect(toList()),
-            p2pConfig.getTargetPeerRange(),
-            peerScorerFactory);
+                .collect(toList()));
     return new DiscoveryNetwork<>(p2pNetwork, discoveryService, connectionManager);
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/PeerSelectionStrategy.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/PeerSelectionStrategy.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.p2p.connection;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
+import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
+import tech.pegasys.teku.networking.p2p.network.PeerAddress;
+import tech.pegasys.teku.networking.p2p.peer.Peer;
+
+public interface PeerSelectionStrategy {
+  List<PeerAddress> selectPeersToConnect(
+      P2PNetwork<?> network, Supplier<List<DiscoveryPeer>> candidates);
+
+  List<Peer> selectPeersToDisconnect(P2PNetwork<?> network, Predicate<Peer> canBeDisconnected);
+}

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkTest.java
@@ -44,9 +44,8 @@ import tech.pegasys.teku.datastructures.state.Fork;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.datastructures.util.SimpleOffsetSerializer;
-import tech.pegasys.teku.network.p2p.connection.StubPeerScorer;
+import tech.pegasys.teku.network.p2p.peer.SimplePeerSelectionStrategy;
 import tech.pegasys.teku.networking.p2p.connection.ConnectionManager;
-import tech.pegasys.teku.networking.p2p.connection.ReputationManager;
 import tech.pegasys.teku.networking.p2p.connection.TargetPeerRange;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryService;
@@ -63,8 +62,6 @@ class DiscoveryNetworkTest {
 
   @SuppressWarnings("unchecked")
   private final P2PNetwork<Peer> p2pNetwork = mock(P2PNetwork.class);
-
-  private final ReputationManager reputationManager = mock(ReputationManager.class);
 
   private final DiscoveryService discoveryService = mock(DiscoveryService.class);
   private final ConnectionManager connectionManager = mock(ConnectionManager.class);
@@ -144,23 +141,24 @@ class DiscoveryNetworkTest {
 
   @Test
   public void shouldNotEnableDiscoveryWhenDiscoveryIsDisabled() {
+    final NetworkConfig networkConfig =
+        new NetworkConfig(
+            null,
+            "127.0.0.1",
+            Optional.empty(),
+            0,
+            OptionalInt.empty(),
+            Collections.emptyList(),
+            false,
+            Collections.emptyList(),
+            new TargetPeerRange(20, 30));
     final DiscoveryNetwork<Peer> network =
         DiscoveryNetwork.create(
             new NoOpMetricsSystem(),
             DelayedExecutorAsyncRunner.create(),
             p2pNetwork,
-            reputationManager,
-            StubPeerScorer::new,
-            new NetworkConfig(
-                null,
-                "127.0.0.1",
-                Optional.empty(),
-                0,
-                OptionalInt.empty(),
-                Collections.emptyList(),
-                false,
-                Collections.emptyList(),
-                new TargetPeerRange(20, 30)));
+            new SimplePeerSelectionStrategy(networkConfig.getTargetPeerRange()),
+            networkConfig);
     assertThat(network.getEnr()).isEmpty();
   }
 

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtilTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtilTest.java
@@ -75,8 +75,6 @@ class MultiaddrUtilTest {
             PERSISTENT_SUBNETS);
     final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer);
     assertThat(result).isEqualTo(Multiaddr.fromString("/ip4/123.34.58.22/tcp/5883/p2p/" + PEER_ID));
-    System.out.println(Bytes.wrap(result.getComponent(Protocol.P2P)));
-    System.out.println(PUB_KEY);
     assertThat(result.getComponent(Protocol.IP4)).isEqualTo(ipAddress);
     assertThat(result.getComponent(Protocol.TCP)).isEqualTo(Protocol.TCP.addressToBytes("5883"));
     assertThat(result.getComponent(Protocol.P2P)).isEqualTo(NODE_ID.toBytes().toArrayUnsafe());

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtilTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtilTest.java
@@ -75,6 +75,8 @@ class MultiaddrUtilTest {
             PERSISTENT_SUBNETS);
     final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer);
     assertThat(result).isEqualTo(Multiaddr.fromString("/ip4/123.34.58.22/tcp/5883/p2p/" + PEER_ID));
+    System.out.println(Bytes.wrap(result.getComponent(Protocol.P2P)));
+    System.out.println(PUB_KEY);
     assertThat(result.getComponent(Protocol.IP4)).isEqualTo(ipAddress);
     assertThat(result.getComponent(Protocol.TCP)).isEqualTo(Protocol.TCP.addressToBytes("5883"));
     assertThat(result.getComponent(Protocol.P2P)).isEqualTo(NODE_ID.toBytes().toArrayUnsafe());

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
-import tech.pegasys.teku.network.p2p.connection.StubPeerScorer;
+import tech.pegasys.teku.network.p2p.peer.SimplePeerSelectionStrategy;
 import tech.pegasys.teku.networking.p2p.DiscoveryNetwork;
 import tech.pegasys.teku.networking.p2p.connection.ReputationManager;
 import tech.pegasys.teku.networking.p2p.connection.TargetPeerRange;
@@ -105,8 +105,7 @@ public class DiscoveryNetworkFactory {
                     METRICS_SYSTEM,
                     Collections.emptyList(),
                     Collections.emptyList()),
-                reputationManager,
-                StubPeerScorer::new,
+                new SimplePeerSelectionStrategy(config.getTargetPeerRange()),
                 config);
         try {
           network.start().get(30, TimeUnit.SECONDS);

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/peer/SimplePeerSelectionStrategy.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/peer/SimplePeerSelectionStrategy.java
@@ -13,6 +13,9 @@
 
 package tech.pegasys.teku.network.p2p.peer;
 
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -33,12 +36,20 @@ public class SimplePeerSelectionStrategy implements PeerSelectionStrategy {
   @Override
   public List<PeerAddress> selectPeersToConnect(
       final P2PNetwork<?> network, final Supplier<List<DiscoveryPeer>> candidates) {
-    return null;
+    final int peersToAdd = targetPeerRange.getPeersToAdd(network.getPeerCount());
+    if (peersToAdd == 0) {
+      return emptyList();
+    }
+    return candidates.get().stream()
+        .map(network::createPeerAddress)
+        .limit(peersToAdd)
+        .collect(toList());
   }
 
   @Override
   public List<Peer> selectPeersToDisconnect(
       final P2PNetwork<?> network, final Predicate<Peer> canBeDisconnected) {
-    return null;
+    final int peersToDrop = targetPeerRange.getPeersToDrop(network.getPeerCount());
+    return network.streamPeers().filter(canBeDisconnected).limit(peersToDrop).collect(toList());
   }
 }

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/peer/SimplePeerSelectionStrategy.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/peer/SimplePeerSelectionStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.network.p2p.peer;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import tech.pegasys.teku.networking.p2p.connection.PeerSelectionStrategy;
+import tech.pegasys.teku.networking.p2p.connection.TargetPeerRange;
+import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
+import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
+import tech.pegasys.teku.networking.p2p.network.PeerAddress;
+import tech.pegasys.teku.networking.p2p.peer.Peer;
+
+public class SimplePeerSelectionStrategy implements PeerSelectionStrategy {
+  private final TargetPeerRange targetPeerRange;
+
+  public SimplePeerSelectionStrategy(final TargetPeerRange targetPeerRange) {
+    this.targetPeerRange = targetPeerRange;
+  }
+
+  @Override
+  public List<PeerAddress> selectPeersToConnect(
+      final P2PNetwork<?> network, final Supplier<List<DiscoveryPeer>> candidates) {
+    return null;
+  }
+
+  @Override
+  public List<Peer> selectPeersToDisconnect(
+      final P2PNetwork<?> network, final Predicate<Peer> canBeDisconnected) {
+    return null;
+  }
+}

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/peer/StubPeer.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/peer/StubPeer.java
@@ -100,4 +100,9 @@ public class StubPeer implements Peer {
   public boolean connectionInitiatedRemotely() {
     return false;
   }
+
+  @Override
+  public String toString() {
+    return "StubPeer(" + peerAddress.getId().toBase58() + ")";
+  }
 }


### PR DESCRIPTION
## PR Description
No change in policy but moves logic out of `ConnectionManager` into a new `PeerSelectionStrategy` which decides both whether to connect or disconnect peers and which ones to connect/disconnect.

This will make it easier to decide to connect new peers even if we are already within the target range because we aren't connected to all attestation subnets.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.