### PR TITLE
Update external signer endpoint to use data field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ we recommend most users use the latest `master` branch of Teku.
 ### Additions and Improvements
 
  - added a metric `beacon_peer_count` that tracks the same counter used for `/network/peer_count` and console `Peers:` output.
+ - External signing API now uses the data field instead of signingRoot field when making signing requests. Eth2Signer has been updated with this change. 
 
 ### Bug Fixes
 

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/ExternalMessageSignerServiceIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/ExternalMessageSignerServiceIntegrationTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.junit.jupiter.MockServerExtension;
 import org.mockserver.model.Delay;
+import org.mockserver.model.MediaType;
 import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -88,11 +89,7 @@ public class ExternalMessageSignerServiceIntegrationTest {
     final SigningRequestBody signingRequestBody =
         new SigningRequestBody(SIGNING_ROOT.toHexString());
 
-    client.verify(
-        request()
-            .withMethod("POST")
-            .withBody(json(signingRequestBody))
-            .withPath("/signer/sign/" + UNKNOWN_PUBLIC_KEY));
+    verifySignRequest(UNKNOWN_PUBLIC_KEY, signingRequestBody);
   }
 
   @Test
@@ -129,11 +126,7 @@ public class ExternalMessageSignerServiceIntegrationTest {
     final String publicKey = keyPair.getPublicKey().toString();
     final SigningRequestBody signingRequestBody =
         new SigningRequestBody(SIGNING_ROOT.toHexString());
-    client.verify(
-        request()
-            .withMethod("POST")
-            .withBody(json(signingRequestBody))
-            .withPath("/signer/sign/" + publicKey));
+    verifySignRequest(publicKey, signingRequestBody);
   }
 
   @Test
@@ -147,11 +140,7 @@ public class ExternalMessageSignerServiceIntegrationTest {
     final String publicKey = keyPair.getPublicKey().toString();
     final SigningRequestBody signingRequestBody =
         new SigningRequestBody(SIGNING_ROOT.toHexString());
-    client.verify(
-        request()
-            .withMethod("POST")
-            .withBody(json(signingRequestBody))
-            .withPath("/signer/sign/" + publicKey));
+    verifySignRequest(publicKey, signingRequestBody);
   }
 
   @Test
@@ -165,11 +154,7 @@ public class ExternalMessageSignerServiceIntegrationTest {
     final String publicKey = keyPair.getPublicKey().toString();
     final SigningRequestBody signingRequestBody =
         new SigningRequestBody(SIGNING_ROOT.toHexString());
-    client.verify(
-        request()
-            .withMethod("POST")
-            .withBody(json(signingRequestBody))
-            .withPath("/signer/sign/" + publicKey));
+    verifySignRequest(publicKey, signingRequestBody);
   }
 
   @Test
@@ -183,9 +168,15 @@ public class ExternalMessageSignerServiceIntegrationTest {
     final String publicKey = keyPair.getPublicKey().toString();
     final SigningRequestBody signingRequestBody =
         new SigningRequestBody(SIGNING_ROOT.toHexString());
+    verifySignRequest(publicKey, signingRequestBody);
+  }
+
+  private void verifySignRequest(
+      final String publicKey, final SigningRequestBody signingRequestBody) {
     client.verify(
         request()
             .withMethod("POST")
+            .withContentType(MediaType.APPLICATION_JSON)
             .withBody(json(signingRequestBody))
             .withPath("/signer/sign/" + publicKey));
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalMessageSignerService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalMessageSignerService.java
@@ -82,6 +82,7 @@ public class ExternalMessageSignerService implements MessageSignerService {
               HttpRequest.newBuilder()
                   .uri(uri)
                   .timeout(timeout)
+                  .header("Content-Type", "application/json")
                   .POST(BodyPublishers.ofString(requestBody))
                   .build();
           return HttpClient.newHttpClient()

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/SigningRequestBody.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/SigningRequestBody.java
@@ -22,19 +22,19 @@ import org.apache.tuweni.bytes.Bytes;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SigningRequestBody {
 
-  private final Bytes signingRoot;
+  private final Bytes data;
 
   @JsonCreator
-  public SigningRequestBody(@JsonProperty("signingRoot") final String signingRoot) {
-    this.signingRoot = Bytes.fromHexString(signingRoot);
+  public SigningRequestBody(@JsonProperty("data") final String data) {
+    this.data = Bytes.fromHexString(data);
   }
 
-  public Bytes signingRoot() {
-    return signingRoot;
+  public Bytes data() {
+    return data;
   }
 
-  @JsonGetter("signingRoot")
-  public String getSigningRoot() {
-    return signingRoot.toHexString();
+  @JsonGetter("data")
+  public String getdata() {
+    return data.toHexString();
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Update external signer request to use data field instead of signingRoot since Eth2Signer API has been changed. Also sending the correct content-type header now.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.