### PR TITLE
[Issue-2157] Tie-break forkchoice by chain height

### DIFF
--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
@@ -50,6 +50,10 @@ public class ProtoArray {
     return indices;
   }
 
+  public boolean contains(final Bytes32 blockRoot) {
+    return indices.containsKey(blockRoot);
+  }
+
   public List<ProtoNode> getNodes() {
     return nodes;
   }
@@ -308,7 +312,8 @@ public class ProtoArray {
                   // No change.
                 } else if (child.getWeight().equals(bestChild.getWeight())) {
                   // Tie-break by longest chain
-                  if (child.getLongestDescendantChain() > bestChild.getLongestDescendantChain()) {
+                  if (child.getBestDescendantChainHeight()
+                      > bestChild.getBestDescendantChainHeight()) {
                     changeToChild(parent, childIndex);
                   }
                   // Then tie-break by root
@@ -352,7 +357,7 @@ public class ProtoArray {
     ProtoNode child = nodes.get(childIndex);
     parent.setBestChildIndex(Optional.of(childIndex));
     parent.setBestDescendantIndex(Optional.of(child.getBestDescendantIndex().orElse(childIndex)));
-    parent.updateLongestDescendantChain(child.getLongestDescendantChain() + 1);
+    parent.setBestDescendantChainHeight(child.getBestDescendantChainHeight() + 1);
   }
 
   /**
@@ -363,7 +368,7 @@ public class ProtoArray {
   private void changeToNone(ProtoNode parent) {
     parent.setBestChildIndex(Optional.empty());
     parent.setBestDescendantIndex(Optional.empty());
-    parent.clearLongestDescendantChain();
+    parent.setBestDescendantChainHeight(0);
   }
 
   /**

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
@@ -307,8 +307,12 @@ public class ProtoArray {
                   // The best child leads to a viable head, but the child doesn't.
                   // No change.
                 } else if (child.getWeight().equals(bestChild.getWeight())) {
-                  // Tie-breaker of equal weights by root.
-                  if (child
+                  // Tie-break by longest chain
+                  if (child.getLongestDescendantChain() > bestChild.getLongestDescendantChain()) {
+                    changeToChild(parent, childIndex);
+                  }
+                  // Then tie-break by root
+                  else if (child
                           .getBlockRoot()
                           .toHexString()
                           .compareTo(bestChild.getBlockRoot().toHexString())
@@ -348,6 +352,7 @@ public class ProtoArray {
     ProtoNode child = nodes.get(childIndex);
     parent.setBestChildIndex(Optional.of(childIndex));
     parent.setBestDescendantIndex(Optional.of(child.getBestDescendantIndex().orElse(childIndex)));
+    parent.updateLongestDescendantChain(child.getLongestDescendantChain() + 1);
   }
 
   /**
@@ -358,6 +363,7 @@ public class ProtoArray {
   private void changeToNone(ProtoNode parent) {
     parent.setBestChildIndex(Optional.empty());
     parent.setBestDescendantIndex(Optional.empty());
+    parent.clearLongestDescendantChain();
   }
 
   /**

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategy.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategy.java
@@ -244,7 +244,7 @@ public class ProtoArrayForkChoiceStrategy implements ForkChoiceStrategy {
   public boolean contains(Bytes32 blockRoot) {
     protoArrayLock.readLock().lock();
     try {
-      return protoArray.getIndices().containsKey(blockRoot);
+      return protoArray.contains(blockRoot);
     } finally {
       protoArrayLock.readLock().unlock();
     }

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoNode.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoNode.java
@@ -32,6 +32,7 @@ public class ProtoNode {
   private final UnsignedLong finalizedEpoch;
 
   private UnsignedLong weight;
+  private int longestDescendantChain = 0;
   private Optional<Integer> parentIndex;
   private Optional<Integer> bestChildIndex;
   private Optional<Integer> bestDescendantIndex;
@@ -80,6 +81,10 @@ public class ProtoNode {
     return weight;
   }
 
+  public int getLongestDescendantChain() {
+    return longestDescendantChain;
+  }
+
   public UnsignedLong getBlockSlot() {
     return blockSlot;
   }
@@ -114,6 +119,16 @@ public class ProtoNode {
 
   public void setBestChildIndex(Optional<Integer> bestChildIndex) {
     this.bestChildIndex = bestChildIndex;
+  }
+
+  public void clearLongestDescendantChain() {
+    longestDescendantChain = 0;
+  }
+
+  public void updateLongestDescendantChain(int descendantChainLength) {
+    if (descendantChainLength > this.longestDescendantChain) {
+      longestDescendantChain = descendantChainLength;
+    }
   }
 
   public Optional<Integer> getBestDescendantIndex() {

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoNode.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoNode.java
@@ -32,7 +32,7 @@ public class ProtoNode {
   private final UnsignedLong finalizedEpoch;
 
   private UnsignedLong weight;
-  private int longestDescendantChain = 0;
+  private int bestDescendantChainHeight = 0;
   private Optional<Integer> parentIndex;
   private Optional<Integer> bestChildIndex;
   private Optional<Integer> bestDescendantIndex;
@@ -81,8 +81,8 @@ public class ProtoNode {
     return weight;
   }
 
-  public int getLongestDescendantChain() {
-    return longestDescendantChain;
+  public int getBestDescendantChainHeight() {
+    return bestDescendantChainHeight;
   }
 
   public UnsignedLong getBlockSlot() {
@@ -121,14 +121,14 @@ public class ProtoNode {
     this.bestChildIndex = bestChildIndex;
   }
 
-  public void clearLongestDescendantChain() {
-    longestDescendantChain = 0;
-  }
-
-  public void updateLongestDescendantChain(int descendantChainLength) {
-    if (descendantChainLength > this.longestDescendantChain) {
-      longestDescendantChain = descendantChainLength;
-    }
+  /**
+   * The height (number of blocks) in the best descendant chain
+   *
+   * @param descendantChainLength The number of blocks in the best chain descending from this node
+   *     (defined by bestDescendantIndex)
+   */
+  public void setBestDescendantChainHeight(int descendantChainLength) {
+    bestDescendantChainHeight = descendantChainLength;
   }
 
   public Optional<Integer> getBestDescendantIndex() {

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayTest.java
@@ -40,7 +40,7 @@ public class ProtoArrayTest {
     ProtoArrayChainBuilder forkA = builder;
     ProtoArrayChainBuilder forkB = builder.fork();
 
-    // Advance forks and check that longer chain is chosen as head
+    // Advance forks to different heights
     forkA.advanceToSlot(7);
     forkB.advanceToSlot(10);
 
@@ -71,7 +71,7 @@ public class ProtoArrayTest {
     ProtoArrayChainBuilder forkA = builder;
     ProtoArrayChainBuilder forkB = builder.fork();
 
-    // Advance forks and check that longer chain is chosen as head
+    // Advance forks to different heights
     forkA.advanceToSlot(7);
     forkB.advanceToSlot(10);
 
@@ -81,6 +81,7 @@ public class ProtoArrayTest {
         protoArray.getIndices().get(forkA.getBlockAtSlot(6).hash_tree_root());
     deltas.set(forkABlock6Index, 10L);
 
+    // We should choose the head from the shorter, weightier chain
     protoArray.applyScoreChanges(deltas, GENESIS_EPOCH, GENESIS_EPOCH);
     final BeaconBlock expectedHead = forkA.getBlockAtSlot(7);
     Bytes32 head = protoArray.findHead(genesisRoot);
@@ -99,11 +100,11 @@ public class ProtoArrayTest {
     ProtoArrayChainBuilder forkA = builder;
     ProtoArrayChainBuilder forkB = builder.fork();
 
-    // Advance forks
+    // Advance forks to different heights
     forkA.advanceToSlot(7);
     forkB.advanceToSlot(10);
 
-    // Use justified root that is incompatible with forkB
+    // Select a justified root that is incompatible with forkB
     final Bytes32 justifiedRoot = forkA.getBlockAtSlot(6).hash_tree_root();
 
     protoArray.applyScoreChanges(getEmptyScoreDeltas(protoArray), GENESIS_EPOCH, GENESIS_EPOCH);

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.protoarray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.util.config.Constants;
+
+public class ProtoArrayTest {
+  private static final UnsignedLong GENESIS_EPOCH = UnsignedLong.valueOf(Constants.GENESIS_EPOCH);
+
+  @Test
+  public void findHead_tieBreakUsingChainHeight() {
+    final ProtoArrayChainBuilder builder = ProtoArrayChainBuilder.createGenesisChain();
+    final ProtoArray protoArray = builder.protoArray();
+    final Bytes32 genesisRoot = builder.getBlockAtSlot(Constants.GENESIS_SLOT).hash_tree_root();
+
+    // Build small chain
+    builder.advanceToSlot(5);
+
+    // Create a few forks
+    ProtoArrayChainBuilder forkA = builder;
+    ProtoArrayChainBuilder forkB = builder.fork();
+
+    // Advance forks and check that longer chain is chosen as head
+    forkA.advanceToSlot(7);
+    forkB.advanceToSlot(10);
+
+    // We should select the longest chain
+    protoArray.applyScoreChanges(getEmptyScoreDeltas(protoArray), GENESIS_EPOCH, GENESIS_EPOCH);
+    final BeaconBlock expectedHead = forkB.getBlockAtSlot(10);
+    Bytes32 head = protoArray.findHead(genesisRoot);
+    assertThat(head).isEqualTo(expectedHead.hash_tree_root());
+
+    // Grow the other fork - we should now choose the tallest fork
+    forkA.advanceToSlot(11);
+    protoArray.applyScoreChanges(getEmptyScoreDeltas(protoArray), GENESIS_EPOCH, GENESIS_EPOCH);
+    final BeaconBlock expectedHead2 = forkA.getBlockAtSlot(11);
+    Bytes32 head2 = protoArray.findHead(genesisRoot);
+    assertThat(head2).isEqualTo(expectedHead2.hash_tree_root());
+  }
+
+  @Test
+  public void findHead_ignoreHeightInFavorOfWeight() {
+    final ProtoArrayChainBuilder builder = ProtoArrayChainBuilder.createGenesisChain();
+    final ProtoArray protoArray = builder.protoArray();
+    final Bytes32 genesisRoot = builder.getBlockAtSlot(Constants.GENESIS_SLOT).hash_tree_root();
+
+    // Build small chain
+    builder.advanceToSlot(5);
+
+    // Create a few forks
+    ProtoArrayChainBuilder forkA = builder;
+    ProtoArrayChainBuilder forkB = builder.fork();
+
+    // Advance forks and check that longer chain is chosen as head
+    forkA.advanceToSlot(7);
+    forkB.advanceToSlot(10);
+
+    // Update the shorter chain to be weightier
+    List<Long> deltas = getEmptyScoreDeltas(protoArray);
+    Integer forkABlock6Index =
+        protoArray.getIndices().get(forkA.getBlockAtSlot(6).hash_tree_root());
+    deltas.set(forkABlock6Index, 10L);
+
+    protoArray.applyScoreChanges(deltas, GENESIS_EPOCH, GENESIS_EPOCH);
+    final BeaconBlock expectedHead = forkA.getBlockAtSlot(7);
+    Bytes32 head = protoArray.findHead(genesisRoot);
+    assertThat(head).isEqualTo(expectedHead.hash_tree_root());
+  }
+
+  @Test
+  public void findHead_ignoreLongerForkNotDescendingFromJustifiedRoot() {
+    final ProtoArrayChainBuilder builder = ProtoArrayChainBuilder.createGenesisChain();
+    final ProtoArray protoArray = builder.protoArray();
+
+    // Build small chain
+    builder.advanceToSlot(5);
+
+    // Create a few forks
+    ProtoArrayChainBuilder forkA = builder;
+    ProtoArrayChainBuilder forkB = builder.fork();
+
+    // Advance forks
+    forkA.advanceToSlot(7);
+    forkB.advanceToSlot(10);
+
+    // Use justified root that is incompatible with forkB
+    final Bytes32 justifiedRoot = forkA.getBlockAtSlot(6).hash_tree_root();
+
+    protoArray.applyScoreChanges(getEmptyScoreDeltas(protoArray), GENESIS_EPOCH, GENESIS_EPOCH);
+    final BeaconBlock expectedHead = forkA.getBlockAtSlot(7);
+    Bytes32 head = protoArray.findHead(justifiedRoot);
+    assertThat(head).isEqualTo(expectedHead.hash_tree_root());
+  }
+
+  @Test
+  public void findHead_ignoreLongForkWithIncompatibleJustifiedCheckpoint() {
+    final ProtoArrayChainBuilder builder = ProtoArrayChainBuilder.createGenesisChain();
+    final ProtoArray protoArray = builder.protoArray();
+    final Bytes32 genesisRoot = builder.getBlockAtSlot(Constants.GENESIS_SLOT).hash_tree_root();
+
+    // Build small chain
+    builder.advanceToSlot(5);
+
+    // Create a few forks
+    ProtoArrayChainBuilder forkA = builder;
+    ProtoArrayChainBuilder forkB = builder.fork();
+
+    // Build very long fork
+    forkB.advanceToSlot(20);
+    protoArray.applyScoreChanges(getEmptyScoreDeltas(protoArray), GENESIS_EPOCH, GENESIS_EPOCH);
+
+    // Advance finalized / justified epoch and build other chain from here
+    final UnsignedLong newFinalizedEpoch = protoArray.getJustifiedEpoch().plus(UnsignedLong.ONE);
+    protoArray.applyScoreChanges(
+        getEmptyScoreDeltas(protoArray), newFinalizedEpoch, newFinalizedEpoch);
+    forkA.advanceToSlot(10);
+
+    // We should choose the chain that is consistent with the new justified epoch
+    protoArray.applyScoreChanges(
+        getEmptyScoreDeltas(protoArray), newFinalizedEpoch, newFinalizedEpoch);
+    final BeaconBlock expectedHead = forkA.getBlockAtSlot(10);
+    Bytes32 head = protoArray.findHead(genesisRoot);
+    assertThat(head).isEqualTo(expectedHead.hash_tree_root());
+  }
+
+  private List<Long> getEmptyScoreDeltas(final ProtoArray protoArray) {
+    return new ArrayList<>(Collections.nCopies(protoArray.getNodes().size(), 0L));
+  }
+}

--- a/protoarray/src/testFixtures/java/tech/pegasys/teku/protoarray/ProtoArrayChainBuilder.java
+++ b/protoarray/src/testFixtures/java/tech/pegasys/teku/protoarray/ProtoArrayChainBuilder.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.protoarray;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.TreeMap;
+import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.util.config.Constants;
+
+public class ProtoArrayChainBuilder {
+  private static UnsignedLong GENESIS_EPOCH = UnsignedLong.valueOf(Constants.GENESIS_EPOCH);
+
+  private final DataStructureUtil dataStructureUtil;
+  private final ProtoArray protoArray;
+  private final NavigableMap<UnsignedLong, BeaconBlock> chain;
+
+  private ProtoArrayChainBuilder(
+      ProtoArray protoArray,
+      DataStructureUtil dataStructureUtil,
+      Map<UnsignedLong, BeaconBlock> chain) {
+    this.protoArray = protoArray;
+    this.dataStructureUtil = dataStructureUtil;
+    this.chain = new TreeMap<>(chain);
+  }
+
+  public static ProtoArrayChainBuilder createGenesisChain() {
+    final ProtoArrayChainBuilder chainBuilder = createEmpty();
+    chainBuilder.initializeGenesis();
+    return chainBuilder;
+  }
+
+  public static ProtoArrayChainBuilder createEmpty() {
+    final ProtoArray protoArray =
+        new ProtoArray(0, GENESIS_EPOCH, GENESIS_EPOCH, new ArrayList<>(), new HashMap<>());
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+    final ProtoArrayChainBuilder chainBuilder =
+        new ProtoArrayChainBuilder(protoArray, dataStructureUtil, new HashMap<>());
+    return chainBuilder;
+  }
+
+  public ProtoArray protoArray() {
+    return protoArray;
+  }
+
+  public ProtoArrayChainBuilder fork() {
+    return new ProtoArrayChainBuilder(protoArray, dataStructureUtil, chain);
+  }
+
+  public void initializeGenesis() {
+    checkState(chain.size() == 0, "Chain must be empty");
+    final BeaconBlock genesis = dataStructureUtil.randomBeaconBlock(Constants.GENESIS_SLOT);
+    processBlock(genesis);
+  }
+
+  public void advanceToSlot(final long slot) {
+    advanceToSlot(UnsignedLong.valueOf(slot));
+  }
+
+  public void advanceToSlot(final UnsignedLong slot) {
+    assertChainIsInitialized();
+    while (getLatestSlot().compareTo(slot) < 0) {
+      advanceChain();
+    }
+  }
+
+  public void advanceChain() {
+    assertChainIsInitialized();
+    BeaconBlock prevBlock = getLastBlock().orElseThrow();
+    final BeaconBlock nextBlock =
+        dataStructureUtil.randomBeaconBlock(
+            prevBlock.getSlot().plus(UnsignedLong.ONE).longValue(), prevBlock.hash_tree_root());
+    processBlock(nextBlock);
+  }
+
+  public UnsignedLong getLatestSlot() {
+    return getLastBlock()
+        .map(BeaconBlock::getSlot)
+        .orElseThrow(() -> new IllegalStateException("Chain is empty"));
+  }
+
+  public BeaconBlock getBlockAtSlot(final long slot) {
+    return getBlockAtSlot(UnsignedLong.valueOf(slot));
+  }
+
+  public BeaconBlock getBlockAtSlot(final UnsignedLong slot) {
+    return chain.get(slot);
+  }
+
+  private void processBlock(final BeaconBlock block) {
+    protoArray.onBlock(
+        block.getSlot(),
+        block.hash_tree_root(),
+        block.getParent_root(),
+        block.getState_root(),
+        protoArray.getJustifiedEpoch(),
+        protoArray.getFinalizedEpoch());
+    chain.put(block.getSlot(), block);
+  }
+
+  private Optional<BeaconBlock> getLastBlock() {
+    if (chain.size() == 0) {
+      return Optional.empty();
+    }
+    return Optional.of(chain.lastEntry().getValue());
+  }
+
+  private void assertChainIsInitialized() {
+    checkState(chain.size() > 0, "Must initialize genesis");
+  }
+}


### PR DESCRIPTION
## PR Description
When choosing between two nodes with equal "weight" during fork-choice head processing, tie-break based on the height of each node's best descendant chain.  This fixes an issue where the chain head can appear to get stuck during long periods of non-finalization during sync.

## Fixed Issue(s)
Fixes #2157 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.