### PR TITLE
[Issue-2291] Migrate block import logic

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -160,7 +160,7 @@ public class ValidatorDataProvider {
   public SafeFuture<ValidatorBlockResult> submitSignedBlock(
       final SignedBeaconBlock signedBeaconBlock) {
     return blockImporter
-        .importBlockAsync(signedBeaconBlock.asInternalSignedBeaconBlock())
+        .importBlock(signedBeaconBlock.asInternalSignedBeaconBlock())
         .thenApply(
             blockImportResult -> {
               int responseCode;

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -325,7 +325,7 @@ public class ValidatorDataProviderTest {
         SafeFuture.completedFuture(
             new SuccessfulBlockImportResult(internalSignedBeaconBlock, Optional.empty()));
 
-    when(blockImporter.importBlockAsync(any())).thenReturn(successImportResult);
+    when(blockImporter.importBlock(any())).thenReturn(successImportResult);
 
     final SafeFuture<ValidatorBlockResult> validatorBlockResultSafeFuture =
         provider.submitSignedBlock(signedBeaconBlock);
@@ -351,7 +351,7 @@ public class ValidatorDataProviderTest {
                   SafeFuture.completedFuture(
                       new FailedBlockImportResult(failureReason, Optional.empty()));
 
-              when(blockImporter.importBlockAsync(any())).thenReturn(failImportResult);
+              when(blockImporter.importBlock(any())).thenReturn(failImportResult);
 
               final SafeFuture<ValidatorBlockResult> validatorBlockResultSafeFuture =
                   provider.submitSignedBlock(signedBeaconBlock);
@@ -379,7 +379,7 @@ public class ValidatorDataProviderTest {
         SafeFuture.completedFuture(
             new FailedBlockImportResult(FailureReason.INTERNAL_ERROR, Optional.empty()));
 
-    when(blockImporter.importBlockAsync(any())).thenReturn(failImportResult);
+    when(blockImporter.importBlock(any())).thenReturn(failImportResult);
 
     final SafeFuture<ValidatorBlockResult> validatorBlockResultSafeFuture =
         provider.submitSignedBlock(signedBeaconBlock);

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
@@ -95,7 +95,7 @@ public class ProfilingRun {
           }
           long s = System.currentTimeMillis();
           localChain.setSlot(block.getSlot());
-          BlockImportResult result = blockImporter.importBlock(block);
+          BlockImportResult result = blockImporter.importBlock(block).join();
           System.out.println(
               "Imported block at #"
                   + block.getSlot()
@@ -157,7 +157,7 @@ public class ProfilingRun {
         for (SignedBeaconBlock block : blockReader) {
           long s = System.currentTimeMillis();
           localChain.setSlot(block.getSlot());
-          BlockImportResult result = blockImporter.importBlock(block);
+          BlockImportResult result = blockImporter.importBlock(block).join();
           System.out.println(
               "Imported block at #"
                   + block.getSlot()

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
@@ -104,7 +104,7 @@ public abstract class TransitionBenchmark {
       prefetchedBlock = null;
     }
     localChain.setSlot(block.getSlot());
-    lastResult = blockImporter.importBlock(block);
+    lastResult = blockImporter.importBlock(block).join();
     if (!lastResult.isSuccessful()) {
       throw new RuntimeException("Unable to import block: " + lastResult);
     }

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -195,6 +195,7 @@ public class ForkChoiceUtil {
   /**
    * @param store
    * @param signed_block
+   * @param maybePreState
    * @param st
    * @see
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.1/specs/core/0_fork-choice.md#on_block</a>
@@ -203,17 +204,18 @@ public class ForkChoiceUtil {
   public static BlockImportResult on_block(
       final MutableStore store,
       final SignedBeaconBlock signed_block,
+      Optional<BeaconState> maybePreState,
       final StateTransition st,
       final ForkChoiceStrategy forkChoiceStrategy) {
     final BeaconBlock block = signed_block.getMessage();
-    final BeaconState preState = store.getBlockState(block.getParent_root());
 
     // Return early if precondition checks fail;
     final Optional<BlockImportResult> maybeFailure =
-        checkOnBlockConditions(block, preState, store, forkChoiceStrategy);
+        checkOnBlockConditions(block, maybePreState.orElse(null), store, forkChoiceStrategy);
     if (maybeFailure.isPresent()) {
       return maybeFailure.get();
     }
+    final BeaconState preState = maybePreState.orElseThrow();
 
     // Make a copy of the state to avoid mutability issues
     BeaconState state;

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/results/BlockImportResult.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/results/BlockImportResult.java
@@ -30,7 +30,7 @@ public interface BlockImportResult {
     return new FailedBlockImportResult(FailureReason.FAILED_STATE_TRANSITION, Optional.of(cause));
   }
 
-  static BlockImportResult internalError(final Exception cause) {
+  static BlockImportResult internalError(final Throwable cause) {
     return new FailedBlockImportResult(FailureReason.INTERNAL_ERROR, Optional.of(cause));
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/BlockImporter.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.statetransition.events.block.ImportedBlockEvent;
 import tech.pegasys.teku.statetransition.events.block.ProposedBlockEvent;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -67,7 +68,8 @@ public class BlockImporter {
         return BlockImportResult.knownBlock(block);
       }
 
-      BlockImportResult result = forkChoice.onBlock(block);
+      final Optional<BeaconState> preState = recentChainData.getBlockState(block.getParent_root());
+      BlockImportResult result = forkChoice.onBlock(block, preState);
       if (!result.isSuccessful()) {
         LOG.trace(
             "Failed to import block for reason {}: {}",

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blockimport/BlockImporter.java
@@ -26,7 +26,6 @@ import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.datastructures.operations.SignedVoluntaryExit;
-import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.statetransition.events.block.ImportedBlockEvent;
 import tech.pegasys.teku.statetransition.events.block.ProposedBlockEvent;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -58,58 +57,63 @@ public class BlockImporter {
   }
 
   @CheckReturnValue
-  public BlockImportResult importBlock(SignedBeaconBlock block) {
+  public SafeFuture<BlockImportResult> importBlock(SignedBeaconBlock block) {
     LOG.trace("Import block at slot {}: {}", block.getMessage().getSlot(), block);
-    try {
-      if (recentChainData.containsBlock(block.getMessage().hash_tree_root())) {
-        LOG.trace(
-            "Importing known block {}.  Return successful result without re-processing.",
-            block.getMessage().hash_tree_root());
-        return BlockImportResult.knownBlock(block);
-      }
-
-      final Optional<BeaconState> preState = recentChainData.getBlockState(block.getParent_root());
-      BlockImportResult result = forkChoice.onBlock(block, preState);
-      if (!result.isSuccessful()) {
-        LOG.trace(
-            "Failed to import block for reason {}: {}",
-            result.getFailureReason(),
-            block.getMessage());
-        return result;
-      }
-      LOG.trace("Successfully imported block {}", block.getMessage().hash_tree_root());
-
-      final Optional<BlockProcessingRecord> record = result.getBlockProcessingRecord();
-      eventBus.post(new ImportedBlockEvent(block));
-      notifyBlockOperationSubscribers(block);
-      record.ifPresent(eventBus::post);
-
-      return result;
-    } catch (Exception e) {
-      LOG.error("Internal error while importing block: " + block.getMessage(), e);
-      return BlockImportResult.internalError(e);
+    if (recentChainData.containsBlock(block.getMessage().hash_tree_root())) {
+      LOG.trace(
+          "Importing known block {}.  Return successful result without re-processing.",
+          block.getMessage().hash_tree_root());
+      return SafeFuture.completedFuture(BlockImportResult.knownBlock(block));
     }
-  }
 
-  public SafeFuture<BlockImportResult> importBlockAsync(final SignedBeaconBlock block) {
-    return SafeFuture.of(() -> importBlock(block));
+    return recentChainData
+        .retrieveBlockState(block.getParent_root())
+        .thenApply(
+            preState -> {
+              BlockImportResult result = forkChoice.onBlock(block, preState);
+              if (!result.isSuccessful()) {
+                LOG.trace(
+                    "Failed to import block for reason {}: {}",
+                    result.getFailureReason(),
+                    block.getMessage());
+                return result;
+              }
+              LOG.trace("Successfully imported block {}", block.getMessage().hash_tree_root());
+
+              final Optional<BlockProcessingRecord> record = result.getBlockProcessingRecord();
+              eventBus.post(new ImportedBlockEvent(block));
+              notifyBlockOperationSubscribers(block);
+              record.ifPresent(eventBus::post);
+
+              return result;
+            })
+        .exceptionally(
+            (e) -> {
+              LOG.error("Internal error while importing block: " + block.getMessage(), e);
+              return BlockImportResult.internalError(e);
+            });
   }
 
   @Subscribe
   @SuppressWarnings("unused")
   private void onBlockProposed(final ProposedBlockEvent blockProposedEvent) {
     LOG.trace("Preparing to import proposed block: {}", blockProposedEvent.getBlock());
-    final BlockImportResult result = importBlock(blockProposedEvent.getBlock());
-    if (result.isSuccessful()) {
-      LOG.trace("Successfully imported proposed block: {}", blockProposedEvent.getBlock());
-    } else {
-      LOG.error(
-          "Failed to import proposed block for reason + "
-              + result.getFailureReason()
-              + ": "
-              + blockProposedEvent,
-          result.getFailureCause().orElse(null));
-    }
+    importBlock(blockProposedEvent.getBlock())
+        .thenAccept(
+            (result) -> {
+              if (result.isSuccessful()) {
+                LOG.trace(
+                    "Successfully imported proposed block: {}", blockProposedEvent.getBlock());
+              } else {
+                LOG.error(
+                    "Failed to import proposed block for reason + "
+                        + result.getFailureReason()
+                        + ": "
+                        + blockProposedEvent,
+                    result.getFailureCause().orElse(null));
+              }
+            })
+        .reportExceptions();
   }
 
   private void notifyBlockOperationSubscribers(SignedBeaconBlock block) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.forkchoice.MutableStore;
 import tech.pegasys.teku.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -70,11 +71,12 @@ public class ForkChoice {
     return headBlockRoot;
   }
 
-  public synchronized BlockImportResult onBlock(final SignedBeaconBlock block) {
+  public synchronized BlockImportResult onBlock(
+      final SignedBeaconBlock block, Optional<BeaconState> preState) {
     final ForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();
     StoreTransaction transaction = recentChainData.startStoreTransaction();
     final BlockImportResult result =
-        on_block(transaction, block, stateTransition, forkChoiceStrategy);
+        on_block(transaction, block, preState, stateTransition, forkChoiceStrategy);
 
     if (!result.isSuccessful()) {
       return result;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
@@ -87,7 +87,7 @@ public class BlockImporterTest {
     final SignedBeaconBlock block = otherChain.createBlockAtSlot(UnsignedLong.ONE);
     localChain.setSlot(block.getSlot());
 
-    final BlockImportResult result = blockImporter.importBlock(block);
+    final BlockImportResult result = blockImporter.importBlock(block).get();
     assertSuccessfulResult(result);
   }
 
@@ -96,8 +96,8 @@ public class BlockImporterTest {
     final SignedBeaconBlock block = otherChain.createBlockAtSlot(UnsignedLong.ONE);
     localChain.setSlot(block.getSlot());
 
-    assertThat(blockImporter.importBlock(block).isSuccessful()).isTrue();
-    BlockImportResult result = blockImporter.importBlock(block);
+    assertThat(blockImporter.importBlock(block).get().isSuccessful()).isTrue();
+    BlockImportResult result = blockImporter.importBlock(block).get();
     assertSuccessfulResult(result);
   }
 
@@ -171,7 +171,7 @@ public class BlockImporterTest {
     tx.commit().join();
 
     // Known blocks should report as successfully imported
-    final BlockImportResult result = blockImporter.importBlock(blocks.get(blocks.size() - 1));
+    final BlockImportResult result = blockImporter.importBlock(blocks.get(blocks.size() - 1)).get();
     assertSuccessfulResult(result);
   }
 
@@ -197,7 +197,7 @@ public class BlockImporterTest {
     tx.commit().join();
 
     // Import a block prior to the latest finalized block
-    final BlockImportResult result = blockImporter.importBlock(blocks.get(1));
+    final BlockImportResult result = blockImporter.importBlock(blocks.get(1)).get();
     assertImportFailed(result, FailureReason.UNKNOWN_PARENT);
   }
 
@@ -206,7 +206,7 @@ public class BlockImporterTest {
     // First import a valid block at slot 1
     final SignedBeaconBlock block = otherChain.createAndImportBlockAtSlot(UnsignedLong.ONE);
     localChain.setSlot(block.getSlot());
-    assertSuccessfulResult(blockImporter.importBlock(block));
+    assertSuccessfulResult(blockImporter.importBlock(block).get());
 
     // Now create an alternate block 1 with the real block one as the parent block
     final BeaconBlock invalidAncestryUnsignedBlock =
@@ -226,7 +226,7 @@ public class BlockImporterTest {
                     invalidAncestryUnsignedBlock, otherStorage.getHeadForkInfo().orElseThrow())
                 .join());
 
-    final BlockImportResult result = blockImporter.importBlock(invalidAncestryBlock);
+    final BlockImportResult result = blockImporter.importBlock(invalidAncestryBlock).get();
     assertThat(result.isSuccessful()).isFalse();
     assertThat(result.getFailureReason())
         .isEqualTo(BlockImportResult.FAILED_INVALID_ANCESTRY.getFailureReason());
@@ -243,7 +243,7 @@ public class BlockImporterTest {
   public void importBlock_fromFuture() throws Exception {
     final SignedBeaconBlock block = otherChain.createBlockAtSlot(UnsignedLong.ONE);
 
-    final BlockImportResult result = blockImporter.importBlock(block);
+    final BlockImportResult result = blockImporter.importBlock(block).get();
     assertImportFailed(result, FailureReason.BLOCK_IS_FROM_FUTURE);
   }
 
@@ -253,7 +253,7 @@ public class BlockImporterTest {
     final SignedBeaconBlock block2 = otherChain.createAndImportBlockAtSlot(UnsignedLong.valueOf(2));
     localChain.setSlot(block2.getSlot());
 
-    final BlockImportResult result = blockImporter.importBlock(block2);
+    final BlockImportResult result = blockImporter.importBlock(block2).get();
     assertImportFailed(result, FailureReason.UNKNOWN_PARENT);
   }
 
@@ -279,7 +279,7 @@ public class BlockImporterTest {
     final SignedBeaconBlock block =
         otherChain.createAndImportBlockAtSlotWithAttestations(currentSlot, List.of(attestation));
 
-    final BlockImportResult result = blockImporter.importBlock(block);
+    final BlockImportResult result = blockImporter.importBlock(block).get();
     assertImportFailed(result, FailureReason.UNKNOWN_PARENT);
   }
 
@@ -289,7 +289,7 @@ public class BlockImporterTest {
     block.getMessage().setState_root(Bytes32.ZERO);
     localChain.setSlot(block.getSlot());
 
-    final BlockImportResult result = blockImporter.importBlock(block);
+    final BlockImportResult result = blockImporter.importBlock(block).get();
     assertImportFailed(result, FailureReason.FAILED_STATE_TRANSITION);
   }
 

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -183,7 +183,8 @@ public class BeaconChainUtil {
     final SignedBeaconBlock block =
         createBlockAndStateAtSlot(slot, true, attestations, deposits, exits, eth1Data).getBlock();
     setSlot(slot);
-    final BlockImportResult importResult = forkChoice.onBlock(block);
+    final Optional<BeaconState> preState = recentChainData.getBlockState(block.getParent_root());
+    final BlockImportResult importResult = forkChoice.onBlock(block, preState);
     if (!importResult.isSuccessful()) {
       throw new IllegalStateException(
           "Produced an invalid block ( reason "

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.networking.eth2.rpc.core.ResponseStreamListener;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
@@ -116,7 +117,10 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
     final SafeFuture<Void> res =
         peer1.requestBlocksByRange(
-            UnsignedLong.ONE, UnsignedLong.valueOf(10), UnsignedLong.ONE, blocks::add);
+            UnsignedLong.ONE,
+            UnsignedLong.valueOf(10),
+            UnsignedLong.ONE,
+            ResponseStreamListener.from(blocks::add));
 
     waitFor(() -> assertThat(res).isDone());
     assertThat(res).isCompletedExceptionally();
@@ -136,7 +140,10 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
     final SafeFuture<Void> res =
         peer1.requestBlocksByRange(
-            UnsignedLong.ONE, UnsignedLong.valueOf(10), UnsignedLong.ONE, blocks::add);
+            UnsignedLong.ONE,
+            UnsignedLong.valueOf(10),
+            UnsignedLong.ONE,
+            ResponseStreamListener.from(blocks::add));
 
     waitFor(() -> assertThat(res).isDone());
     assertThat(res).isCompletedExceptionally();
@@ -182,7 +189,10 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
     waitFor(
         peer1.requestBlocksByRange(
-            UnsignedLong.ONE, UnsignedLong.valueOf(10), UnsignedLong.ONE, blocks::add));
+            UnsignedLong.ONE,
+            UnsignedLong.valueOf(10),
+            UnsignedLong.ONE,
+            ResponseStreamListener.from(blocks::add)));
     return blocks;
   }
 

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRootIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRootIntegrationTest.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.networking.eth2.rpc.core.ResponseStreamListener;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
@@ -112,7 +113,8 @@ public abstract class BeaconBlocksByRootIntegrationTest {
 
     peer1.disconnectImmediately(Optional.empty(), false);
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
-    final SafeFuture<Void> res = peer1.requestBlocksByRoot(List.of(blockHash), blocks::add);
+    final SafeFuture<Void> res =
+        peer1.requestBlocksByRoot(List.of(blockHash), ResponseStreamListener.from(blocks::add));
 
     waitFor(() -> assertThat(res).isDone());
     assertThat(res).isCompletedExceptionally();
@@ -127,7 +129,8 @@ public abstract class BeaconBlocksByRootIntegrationTest {
 
     peer1.disconnectCleanly(DisconnectReason.TOO_MANY_PEERS);
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
-    final SafeFuture<Void> res = peer1.requestBlocksByRoot(List.of(blockHash), blocks::add);
+    final SafeFuture<Void> res =
+        peer1.requestBlocksByRoot(List.of(blockHash), ResponseStreamListener.from(blocks::add));
 
     waitFor(() -> assertThat(res).isDone());
     assertThat(res).isCompletedExceptionally();
@@ -221,7 +224,7 @@ public abstract class BeaconBlocksByRootIntegrationTest {
       throws InterruptedException, java.util.concurrent.ExecutionException,
           java.util.concurrent.TimeoutException, RpcException {
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
-    waitFor(peer1.requestBlocksByRoot(blockRoots, blocks::add));
+    waitFor(peer1.requestBlocksByRoot(blockRoots, ResponseStreamListener.from(blocks::add)));
     return blocks;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -42,8 +42,8 @@ import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageFa
 import tech.pegasys.teku.networking.eth2.rpc.core.Eth2OutgoingRequestHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.Eth2RpcMethod;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseStream;
-import tech.pegasys.teku.networking.eth2.rpc.core.ResponseStream.ResponseListener;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseStreamImpl;
+import tech.pegasys.teku.networking.eth2.rpc.core.ResponseStreamListener;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.networking.p2p.peer.DelegatingPeer;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
@@ -148,7 +148,7 @@ public class Eth2Peer extends DelegatingPeer implements Peer {
   }
 
   public SafeFuture<Void> requestBlocksByRoot(
-      final List<Bytes32> blockRoots, final ResponseListener<SignedBeaconBlock> listener)
+      final List<Bytes32> blockRoots, final ResponseStreamListener<SignedBeaconBlock> listener)
       throws RpcException {
     if (blockRoots.size() > MAX_REQUEST_BLOCKS) {
       throw new RpcException(
@@ -177,7 +177,7 @@ public class Eth2Peer extends DelegatingPeer implements Peer {
       final UnsignedLong startSlot,
       final UnsignedLong count,
       final UnsignedLong step,
-      final ResponseListener<SignedBeaconBlock> listener) {
+      final ResponseStreamListener<SignedBeaconBlock> listener) {
     final Eth2RpcMethod<BeaconBlocksByRangeRequestMessage, SignedBeaconBlock> blocksByRange =
         rpcMethods.beaconBlocksByRange();
     return requestStream(
@@ -217,9 +217,7 @@ public class Eth2Peer extends DelegatingPeer implements Peer {
   }
 
   private <I extends RpcRequest, O> SafeFuture<Void> requestStream(
-      final Eth2RpcMethod<I, O> method,
-      final I request,
-      final ResponseStream.ResponseListener<O> listener) {
+      final Eth2RpcMethod<I, O> method, final I request, final ResponseStreamListener<O> listener) {
     final Eth2OutgoingRequestHandler<I, O> handler =
         method.createOutgoingRequestHandler(request.getMaximumRequestChunks());
     SafeFuture<Void> respFuture = handler.getResponseStream().expectMultipleResponses(listener);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/AsyncResponseProcessor.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/AsyncResponseProcessor.java
@@ -105,7 +105,7 @@ class AsyncResponseProcessor<TResponse> {
         .runAsync(
             () -> {
               LOG.trace("Send response to response stream: {}", response);
-              responseStream.respond(response);
+              return responseStream.respond(response);
             })
         .exceptionally(
             (err) -> {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/ResponseStreamImpl.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/ResponseStreamImpl.java
@@ -24,7 +24,7 @@ public class ResponseStreamImpl<O> implements ResponseStream<O> {
 
   private final SafeFuture<Void> completionFuture = new SafeFuture<>();
   private final AtomicInteger receivedResponseCount = new AtomicInteger(0);
-  private volatile ResponseListener<O> responseListener;
+  private volatile ResponseStreamListener<O> responseListener;
 
   @Override
   public SafeFuture<O> expectSingleResponse() {
@@ -35,6 +35,7 @@ public class ResponseStreamImpl<O> implements ResponseStream<O> {
                 throw new IllegalStateException(
                     "Received multiple responses when single response expected");
               }
+              return SafeFuture.COMPLETE;
             })
         .thenApply(
             done -> {
@@ -53,17 +54,17 @@ public class ResponseStreamImpl<O> implements ResponseStream<O> {
   }
 
   @Override
-  public SafeFuture<Void> expectMultipleResponses(final ResponseListener<O> listener) {
+  public SafeFuture<Void> expectMultipleResponses(final ResponseStreamListener<O> listener) {
     Preconditions.checkArgument(
         responseListener == null, "Multiple calls to 'expect' methods not allowed");
     responseListener = listener;
     return completionFuture;
   }
 
-  public void respond(final O data) {
+  public SafeFuture<?> respond(final O data) {
     checkNotNull(responseListener, "Must call an 'expect' method");
     receivedResponseCount.incrementAndGet();
-    responseListener.onResponse(data);
+    return responseListener.onResponse(data);
   }
 
   public int getResponseChunkCount() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/ResponseStreamListener.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/ResponseStreamListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 ConsenSys AG.
+ * Copyright 2020 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,12 +13,14 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.core;
 
+import java.util.function.Consumer;
 import tech.pegasys.teku.util.async.SafeFuture;
 
-public interface ResponseStream<O> {
-  SafeFuture<O> expectSingleResponse();
+@FunctionalInterface
+public interface ResponseStreamListener<O> {
+  static <T> ResponseStreamListener<T> from(Consumer<T> listener) {
+    return (T response) -> SafeFuture.fromRunnable(() -> listener.accept(response));
+  }
 
-  SafeFuture<Void> expectNoResponse();
-
-  SafeFuture<Void> expectMultipleResponses(ResponseStreamListener<O> listener);
+  SafeFuture<?> onResponse(O response);
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/AsyncResponseProcessorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/AsyncResponseProcessorTest.java
@@ -44,7 +44,8 @@ public class AsyncResponseProcessorTest {
   @BeforeEach
   public void setup() {
     responseStream
-        .expectMultipleResponses((s) -> requestProcessor.get().accept(s))
+        .expectMultipleResponses(
+            ResponseStreamListener.from((s) -> requestProcessor.get().accept(s)))
         .reportExceptions();
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
-import tech.pegasys.teku.networking.eth2.rpc.core.ResponseStream.ResponseListener;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.ExtraDataAppendedException;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.ServerErrorException;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
@@ -47,8 +46,8 @@ public abstract class Eth2OutgoingRequestHandlerTest
   private final StubAsyncRunner timeoutRunner = new StubAsyncRunner();
 
   private final List<SignedBeaconBlock> blocks = new ArrayList<>();
-  private final AtomicReference<ResponseListener<SignedBeaconBlock>> responseListener =
-      new AtomicReference<>(blocks::add);
+  private final AtomicReference<ResponseStreamListener<SignedBeaconBlock>> responseListener =
+      new AtomicReference<>(ResponseStreamListener.from(blocks::add));
   private final int maxChunks = 3;
 
   private RpcEncoder rpcEncoder;

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.api.ReorgEventChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.events.AnchorPoint;
+import tech.pegasys.teku.storage.store.EmptyStoreResults;
 import tech.pegasys.teku.storage.store.StoreBuilder;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
@@ -335,11 +336,24 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     return Optional.ofNullable(store.getSignedBlock(root));
   }
 
+  /**
+   * @deprecated Use {@link #retrieveBlockState} instead
+   * @param blockRoot The root of the block corresponding to this state
+   * @return
+   */
+  @Deprecated
   public Optional<BeaconState> getBlockState(final Bytes32 blockRoot) {
     if (store == null) {
       return Optional.empty();
     }
     return Optional.ofNullable(store.getBlockState(blockRoot));
+  }
+
+  public SafeFuture<Optional<BeaconState>> retrieveBlockState(final Bytes32 blockRoot) {
+    if (store == null) {
+      return EmptyStoreResults.EMPTY_STATE_FUTURE;
+    }
+    return store.retrieveBlockState(blockRoot);
   }
 
   public Optional<BeaconState> getStateInEffectAtSlot(final UnsignedLong slot) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/EmptyStoreResults.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/EmptyStoreResults.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.store;
+
+import java.util.Optional;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.util.async.SafeFuture;
+
+public abstract class EmptyStoreResults {
+
+  public static SafeFuture<Optional<SignedBeaconBlock>> EMPTY_BLOCK_FUTURE =
+      SafeFuture.completedFuture(Optional.empty());
+
+  public static SafeFuture<Optional<BeaconState>> EMPTY_STATE_FUTURE =
+      SafeFuture.completedFuture(Optional.empty());
+
+  public static SafeFuture<Optional<SignedBlockAndState>> EMPTY_BLOCK_AND_STATE_FUTURE =
+      SafeFuture.completedFuture(Optional.empty());
+}

--- a/sync/src/main/java/tech/pegasys/teku/sync/PeerSync.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/PeerSync.java
@@ -193,7 +193,8 @@ public class PeerSync {
     if (stopped.get()) {
       throw new CancellationException("Peer sync was cancelled");
     }
-    final BlockImportResult result = blockImporter.importBlock(block);
+    // TODO - don't join here
+    final BlockImportResult result = blockImporter.importBlock(block).join();
     LOG.trace("Block import result for block at {}: {}", block.getMessage().getSlot(), result);
     if (!result.isSuccessful()) {
       this.blockImportFailureResult.inc();

--- a/sync/src/test/java/tech/pegasys/teku/sync/BlockManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/BlockManagerTest.java
@@ -170,7 +170,7 @@ public class BlockManagerTest {
     assertThat(pendingBlocks.size()).isEqualTo(blockCount - 1);
 
     // Import next block, causing remaining blocks to be imported
-    assertThat(blockImporter.importBlock(blocks.get(0)).isSuccessful()).isTrue();
+    assertThat(blockImporter.importBlock(blocks.get(0)).get().isSuccessful()).isTrue();
     assertThat(importedBlocks.get()).containsExactlyElementsOf(blocks);
     assertThat(pendingBlocks.size()).isEqualTo(0);
   }
@@ -268,7 +268,7 @@ public class BlockManagerTest {
 
     // Import next block, causing next block to be queued for import
     final SignedBeaconBlock firstBlock = blocks.get(0);
-    assertThat(blockImporter.importBlock(firstBlock).isSuccessful()).isTrue();
+    assertThat(blockImporter.importBlock(firstBlock).get().isSuccessful()).isTrue();
     assertThat(importedBlocks.get()).containsExactly(firstBlock);
     assertThat(pendingBlocks.size()).isEqualTo(1);
     assertThat(futureBlocks.size()).isEqualTo(1);

--- a/sync/src/test/java/tech/pegasys/teku/sync/PeerSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/PeerSyncTest.java
@@ -85,7 +85,8 @@ public class PeerSyncTest {
     // By default set up block import to succeed
     final BlockProcessingRecord processingRecord = mock(BlockProcessingRecord.class);
     final SignedBeaconBlock block = mock(SignedBeaconBlock.class);
-    final BlockImportResult result = BlockImportResult.successful(processingRecord);
+    final SafeFuture<BlockImportResult> result =
+        SafeFuture.completedFuture(BlockImportResult.successful(processingRecord));
     when(processingRecord.getBlock()).thenReturn(block);
     when(blockImporter.importBlock(any())).thenReturn(result);
     peerSync = new PeerSync(asyncRunner, storageClient, blockImporter, new NoOpMetricsSystem());
@@ -130,7 +131,8 @@ public class PeerSyncTest {
         responseListenerArgumentCaptor.getValue();
 
     // Importing the returned block fails
-    when(blockImporter.importBlock(BLOCK)).thenReturn(importResult.get());
+    when(blockImporter.importBlock(BLOCK))
+        .thenReturn(SafeFuture.completedFuture(importResult.get()));
     // Probably want to have a specific exception type to indicate bad data.
     try {
       responseListener.onResponse(BLOCK);

--- a/sync/src/test/java/tech/pegasys/teku/sync/PeerSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/PeerSyncTest.java
@@ -41,7 +41,7 @@ import tech.pegasys.teku.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
-import tech.pegasys.teku.networking.eth2.rpc.core.ResponseStream;
+import tech.pegasys.teku.networking.eth2.rpc.core.ResponseStreamListener;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -74,9 +74,8 @@ public class PeerSyncTest {
   private PeerSync peerSync;
 
   @SuppressWarnings("unchecked")
-  private final ArgumentCaptor<ResponseStream.ResponseListener<SignedBeaconBlock>>
-      responseListenerArgumentCaptor =
-          ArgumentCaptor.forClass(ResponseStream.ResponseListener.class);
+  private final ArgumentCaptor<ResponseStreamListener<SignedBeaconBlock>>
+      responseListenerArgumentCaptor = ArgumentCaptor.forClass(ResponseStreamListener.class);
 
   @BeforeEach
   public void setUp() {
@@ -127,7 +126,7 @@ public class PeerSyncTest {
             any(), any(), eq(UnsignedLong.ONE), responseListenerArgumentCaptor.capture());
 
     // Respond with blocks and check they're passed to the block importer.
-    final ResponseStream.ResponseListener<SignedBeaconBlock> responseListener =
+    final ResponseStreamListener<SignedBeaconBlock> responseListener =
         responseListenerArgumentCaptor.getValue();
 
     // Importing the returned block fails
@@ -135,11 +134,12 @@ public class PeerSyncTest {
         .thenReturn(SafeFuture.completedFuture(importResult.get()));
     // Probably want to have a specific exception type to indicate bad data.
     try {
-      responseListener.onResponse(BLOCK);
+      responseListener.onResponse(BLOCK).join();
       fail("Should have thrown an error to indicate the response was bad");
-    } catch (final FailedBlockImportException e) {
+    } catch (final Exception e) {
       // RpcMessageHandler will consider the request complete if there's an error processing a
       // response
+      assertThat(e).hasCauseInstanceOf(FailedBlockImportException.class);
       requestFuture.completeExceptionally(e);
     }
 
@@ -168,14 +168,14 @@ public class PeerSyncTest {
         .requestBlocksByRange(any(), any(), eq(step), responseListenerArgumentCaptor.capture());
 
     // Respond with blocks and check they're passed to the block importer.
-    final ResponseStream.ResponseListener<SignedBeaconBlock> responseListener =
+    final ResponseStreamListener<SignedBeaconBlock> responseListener =
         responseListenerArgumentCaptor.getValue();
 
     // Stop the sync, no further blocks should be imported
     peerSync.stop();
 
     try {
-      responseListener.onResponse(BLOCK);
+      responseListener.onResponse(BLOCK).join();
       fail("Should have thrown an error to indicate the sync was stopped");
     } catch (final CancellationException e) {
       // RpcMessageHandler will consider the request complete if there's an error processing a
@@ -208,7 +208,7 @@ public class PeerSyncTest {
             any(), any(), eq(UnsignedLong.ONE), responseListenerArgumentCaptor.capture());
 
     // Respond with blocks and check they're passed to the block importer.
-    final ResponseStream.ResponseListener<SignedBeaconBlock> responseListener =
+    final ResponseStreamListener<SignedBeaconBlock> responseListener =
         responseListenerArgumentCaptor.getValue();
     final List<SignedBeaconBlock> blocks =
         respondWithBlocksAtSlots(responseListener, 1, PEER_HEAD_SLOT.intValue());
@@ -264,7 +264,7 @@ public class PeerSyncTest {
             eq(UnsignedLong.ONE),
             responseListenerArgumentCaptor.capture());
 
-    final ResponseStream.ResponseListener<SignedBeaconBlock> responseListener1 =
+    final ResponseStreamListener<SignedBeaconBlock> responseListener1 =
         responseListenerArgumentCaptor.getValue();
     final int lastReceivedBlockSlot = peerHeadSlot.intValue() - 2;
     List<SignedBeaconBlock> blocks =
@@ -286,7 +286,7 @@ public class PeerSyncTest {
             responseListenerArgumentCaptor.capture());
 
     // Respond with blocks and check they're passed to the block importer.
-    final ResponseStream.ResponseListener<SignedBeaconBlock> responseListener2 =
+    final ResponseStreamListener<SignedBeaconBlock> responseListener2 =
         responseListenerArgumentCaptor.getValue();
     blocks = respondWithBlocksAtSlots(responseListener2, peerHeadSlot.intValue());
     for (SignedBeaconBlock block : blocks) {
@@ -357,7 +357,7 @@ public class PeerSyncTest {
             responseListenerArgumentCaptor.capture());
 
     // Respond with blocks and check they're passed to the block importer.
-    final ResponseStream.ResponseListener<SignedBeaconBlock> responseListener2 =
+    final ResponseStreamListener<SignedBeaconBlock> responseListener2 =
         responseListenerArgumentCaptor.getValue();
     final List<SignedBeaconBlock> blocks =
         respondWithBlocksAtSlots(responseListener2, peerHeadSlot.intValue());
@@ -419,12 +419,12 @@ public class PeerSyncTest {
   }
 
   private List<SignedBeaconBlock> respondWithBlocksAtSlots(
-      final ResponseStream.ResponseListener<SignedBeaconBlock> responseListener, int... slots) {
+      final ResponseStreamListener<SignedBeaconBlock> responseListener, int... slots) {
     List<SignedBeaconBlock> blocks = new ArrayList<>();
     for (int slot : slots) {
       final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot);
       blocks.add(block);
-      responseListener.onResponse(block);
+      responseListener.onResponse(block).join();
     }
     return blocks;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Update block import processing to use new async method `retrieveBlockState` in place of `getBlockState`:
* Move retrieval of block pre-state out to `BlockImporter`
* Retrieve the pre-state asynchronously via `retrieveBlockState`
* Update `BlockImporter` to return a `SafeFuture` 
* Update `ResponseStreamListener` to return a `SafeFuture`, so that `PeerSync`'s response listener can return the future from `BlockImporter`

## Fixed Issue(s)
Part of #2291 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.