### PR TITLE
Report errors that occur when executing a task on the worker thread pool

### DIFF
--- a/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ScheduledExecutorAsyncRunner.java
+++ b/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ScheduledExecutorAsyncRunner.java
@@ -16,12 +16,12 @@ package tech.pegasys.teku.service.serviceutils;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -80,15 +80,43 @@ class ScheduledExecutorAsyncRunner implements AsyncRunner {
 
   @Override
   public <U> SafeFuture<U> runAsync(final Supplier<SafeFuture<U>> action) {
-    return runTask(action, workerPool::execute);
+    if (shutdown.get()) {
+      LOG.debug("Ignoring async task because shutdown is in progress");
+      return new SafeFuture<>();
+    }
+    final SafeFuture<U> result = new SafeFuture<>();
+    try {
+      workerPool.execute(createRunnableForAction(action, result));
+    } catch (final Throwable t) {
+      handleExecutorError(result, t);
+    }
+    return result;
   }
 
   @Override
   @SuppressWarnings("FutureReturnValueIgnored")
   public <U> SafeFuture<U> runAfterDelay(
       final Supplier<SafeFuture<U>> action, final long delayAmount, final TimeUnit delayUnit) {
-    return runTask(
-        action, task -> scheduler.schedule(() -> workerPool.execute(task), delayAmount, delayUnit));
+    if (shutdown.get()) {
+      LOG.debug("Ignoring async task because shutdown is in progress");
+      return new SafeFuture<>();
+    }
+    final SafeFuture<U> result = new SafeFuture<>();
+    try {
+      scheduler.schedule(
+          () -> {
+            try {
+              workerPool.execute(createRunnableForAction(action, result));
+            } catch (final Throwable t) {
+              handleExecutorError(result, t);
+            }
+          },
+          delayAmount,
+          delayUnit);
+    } catch (final Throwable t) {
+      handleExecutorError(result, t);
+    }
+    return result;
   }
 
   @Override
@@ -99,18 +127,16 @@ class ScheduledExecutorAsyncRunner implements AsyncRunner {
     workerPool.shutdownNow();
   }
 
-  private <U> SafeFuture<U> runTask(
-      final Supplier<SafeFuture<U>> action, final Consumer<Runnable> executor) {
-    if (shutdown.get()) {
-      LOG.debug("Ignoring async task because shutdown is in progress");
-      return new SafeFuture<>();
-    }
-    final SafeFuture<U> result = new SafeFuture<>();
-    try {
-      executor.accept(() -> SafeFuture.ofComposed(action::get).propagateTo(result));
-    } catch (final Throwable t) {
+  private <U> void handleExecutorError(final SafeFuture<U> result, final Throwable t) {
+    if (t instanceof RejectedExecutionException && shutdown.get()) {
+      LOG.trace("Ignoring RejectedExecutionException because shutdown is in progress", t);
+    } else {
       result.completeExceptionally(t);
     }
-    return result;
+  }
+
+  private <U> Runnable createRunnableForAction(
+      final Supplier<SafeFuture<U>> action, final SafeFuture<U> result) {
+    return () -> SafeFuture.ofComposed(action::get).propagateTo(result);
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
+++ b/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
@@ -19,7 +19,6 @@ import com.google.common.eventbus.SubscriberExceptionHandler;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.lang.reflect.Method;
 import java.nio.channels.ClosedChannelException;
-import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.events.ChannelExceptionHandler;
@@ -27,10 +26,7 @@ import tech.pegasys.teku.logging.StatusLogger;
 import tech.pegasys.teku.storage.server.ShuttingDownException;
 
 public final class TekuDefaultExceptionHandler
-    implements SubscriberExceptionHandler,
-        ChannelExceptionHandler,
-        UncaughtExceptionHandler,
-        Function<Throwable, Void> {
+    implements SubscriberExceptionHandler, ChannelExceptionHandler, UncaughtExceptionHandler {
   private static final Logger LOG = LogManager.getLogger();
 
   private final StatusLogger statusLog;
@@ -102,10 +98,5 @@ public final class TekuDefaultExceptionHandler
 
   private static boolean isSpecFailure(final Throwable exception) {
     return exception instanceof IllegalArgumentException;
-  }
-
-  @Override
-  public Void apply(final Throwable throwable) {
-    return null;
   }
 }


### PR DESCRIPTION
##  PR Description

When `ScheduledExecutorAsyncRunner` run a delayed task, if when the task became due, the worker thread pool rejected it the error would be silently ignored. This resulted in tasks executed via `runWithFixedDelay` no longer repeating as the last execution never completed.

Now the rejection exception is reported back to the caller so it will be handled correctly and repeating tasks will continue repeating.  #2362 includes a fix to make it dramatically less likely that tasks will be rejected.

## Fixed Issue(s)
Fixes at least one part of #2200 because the `ConnectionManager` uses `runWithFixedDelay` and when it stops executing Teku stops making new connections to peers.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.