### PR TITLE
[Refactor] Extract factory to create thread pools

### DIFF
--- a/data/metrics/build.gradle
+++ b/data/metrics/build.gradle
@@ -1,7 +1,4 @@
 dependencies {
-    implementation project(':infrastructure:async')
-    implementation project(':util')
-
     api 'org.hyperledger.besu:plugin-api'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.vertx:vertx-core'

--- a/data/metrics/src/main/java/tech/pegasys/teku/metrics/MetricsConfig.java
+++ b/data/metrics/src/main/java/tech/pegasys/teku/metrics/MetricsConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.metrics;
+
+import java.util.List;
+
+public interface MetricsConfig {
+  boolean isMetricsEnabled();
+
+  int getMetricsPort();
+
+  String getMetricsInterface();
+
+  List<String> getMetricsCategories();
+
+  List<String> getMetricsHostAllowlist();
+}

--- a/data/metrics/src/main/java/tech/pegasys/teku/metrics/MetricsEndpoint.java
+++ b/data/metrics/src/main/java/tech/pegasys/teku/metrics/MetricsEndpoint.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.metrics;
 
 import static java.util.stream.Collectors.toSet;
-import static tech.pegasys.teku.infrastructure.async.SafeFuture.reportExceptions;
 
 import com.google.common.collect.ImmutableMap;
 import io.vertx.core.Vertx;
@@ -23,13 +22,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import org.hyperledger.besu.metrics.StandardMetricCategory;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.metrics.prometheus.MetricsService;
 import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
-import tech.pegasys.teku.util.config.TekuConfiguration;
 
 public class MetricsEndpoint {
 
@@ -44,8 +43,8 @@ public class MetricsEndpoint {
     SUPPORTED_CATEGORIES = builder.build();
   }
 
-  public MetricsEndpoint(final TekuConfiguration tekuConfig, final Vertx vertx) {
-    final MetricsConfiguration metricsConfig = createMetricsConfiguration(tekuConfig);
+  public MetricsEndpoint(final MetricsConfig config, final Vertx vertx) {
+    final MetricsConfiguration metricsConfig = createMetricsConfiguration(config);
     metricsSystem = PrometheusMetricsSystem.init(metricsConfig);
     if (metricsConfig.isEnabled()) {
       metricsService = Optional.of(MetricsService.create(vertx, metricsConfig, metricsSystem));
@@ -54,30 +53,32 @@ public class MetricsEndpoint {
     }
   }
 
-  public void start() {
-    metricsService.ifPresent(reportExceptions(MetricsService::start));
+  public CompletableFuture<?> start() {
+    return metricsService
+        .map(MetricsService::start)
+        .orElse(CompletableFuture.completedFuture(null));
   }
 
-  public void stop() {
-    metricsService.ifPresent(reportExceptions(MetricsService::stop));
+  public CompletableFuture<?> stop() {
+    return metricsService.map(MetricsService::stop).orElse(CompletableFuture.completedFuture(null));
   }
 
   public MetricsSystem getMetricsSystem() {
     return metricsSystem;
   }
 
-  private MetricsConfiguration createMetricsConfiguration(final TekuConfiguration tekuConfig) {
+  private MetricsConfiguration createMetricsConfiguration(final MetricsConfig config) {
     return MetricsConfiguration.builder()
-        .enabled(tekuConfig.isMetricsEnabled())
-        .port(tekuConfig.getMetricsPort())
-        .host(tekuConfig.getMetricsInterface())
-        .metricCategories(getEnabledMetricCategories(tekuConfig))
-        .hostsWhitelist(tekuConfig.getMetricsHostAllowlist())
+        .enabled(config.isMetricsEnabled())
+        .port(config.getMetricsPort())
+        .host(config.getMetricsInterface())
+        .metricCategories(getEnabledMetricCategories(config))
+        .hostsWhitelist(config.getMetricsHostAllowlist())
         .build();
   }
 
-  private Set<MetricCategory> getEnabledMetricCategories(final TekuConfiguration tekuConfig) {
-    return tekuConfig.getMetricsCategories().stream()
+  private Set<MetricCategory> getEnabledMetricCategories(final MetricsConfig config) {
+    return config.getMetricsCategories().stream()
         .map(SUPPORTED_CATEGORIES::get)
         .filter(Objects::nonNull)
         .collect(toSet());

--- a/infrastructure/async/build.gradle
+++ b/infrastructure/async/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
+  implementation project(":data:metrics")
   implementation 'com.google.guava:guava'
 
+  testImplementation testFixtures(project(":data:metrics"))
   testImplementation 'org.apache.logging.log4j:log4j-core'
 
   testFixturesApi 'com.google.guava:guava'

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/MetricTrackingExecutorFactory.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/MetricTrackingExecutorFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.async;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.metrics.TekuMetricCategory;
+
+public class MetricTrackingExecutorFactory {
+
+  private final MetricsSystem metricsSystem;
+
+  public MetricTrackingExecutorFactory(final MetricsSystem metricsSystem) {
+    this.metricsSystem = metricsSystem;
+  }
+
+  /**
+   * Creates a new {@link ExecutorService} which creates up to {@code maxThreads} threads as needed
+   * and when all threads are busy, queues up to {@code maxQueueSize} further tasks to execute when
+   * threads are available. When the maximum thread count and queue size are reached tasks are
+   * rejected with {@link java.util.concurrent.RejectedExecutionException}
+   *
+   * <p>Metrics about the number of threads and queue length are automatically captured.
+   *
+   * @param name the name to use as a prefix in metric names. Must be unique.
+   * @param maxThreads the maximum number of threads to run at any one time.
+   * @param maxQueueSize the maximum capacity of the pending task queue.
+   * @param threadFactory the thread factory to use when creating threads.
+   * @return the new {@link ExecutorService}
+   */
+  public ExecutorService newCachedThreadPool(
+      final String name,
+      final int maxThreads,
+      final int maxQueueSize,
+      final ThreadFactory threadFactory) {
+
+    // ThreadPoolExecutor has a weird API. maximumThreadCount only applies if you use a
+    // SynchronousQueue but then tasks are rejected once max threads are reached instead of being
+    // queued. So we use a blocking queue to ensure there is some limit on the queue size but that
+    // means that the maximum number of threads is ignored and only the core thread pool size is
+    // used. So, we set maximum and core thread pool to the same value and allow core threads to
+    // time out and exit if they are unused.
+
+    final ThreadPoolExecutor executor =
+        new ThreadPoolExecutor(
+            maxThreads,
+            maxThreads,
+            60,
+            TimeUnit.SECONDS,
+            new ArrayBlockingQueue<>(maxQueueSize),
+            threadFactory);
+    executor.allowCoreThreadTimeOut(true);
+
+    metricsSystem.createIntegerGauge(
+        TekuMetricCategory.EXECUTOR,
+        name + "_queue_size",
+        "Current size of the executor task queue",
+        () -> executor.getQueue().size());
+    metricsSystem.createIntegerGauge(
+        TekuMetricCategory.EXECUTOR,
+        name + "_thread_pool_size",
+        "Current number of threads in the executor thread pool",
+        executor::getPoolSize);
+    metricsSystem.createIntegerGauge(
+        TekuMetricCategory.EXECUTOR,
+        name + "_thread_active_count",
+        "Current number of threads executing tasks for this executor",
+        executor::getActiveCount);
+
+    return executor;
+  }
+}

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
@@ -11,26 +11,20 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.service.serviceutils;
+package tech.pegasys.teku.infrastructure.async;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.metrics.TekuMetricCategory;
 
-class ScheduledExecutorAsyncRunner implements AsyncRunner {
+public class ScheduledExecutorAsyncRunner implements AsyncRunner {
   private static final Logger LOG = LogManager.getLogger();
   private static final int QUEUE_CAPACITY = 500;
   private final AtomicBoolean shutdown = new AtomicBoolean(false);
@@ -43,45 +37,22 @@ class ScheduledExecutorAsyncRunner implements AsyncRunner {
     this.workerPool = workerPool;
   }
 
-  static AsyncRunner create(
-      final String name, final int maxThreads, final MetricsSystem metricsSystem) {
+  public static AsyncRunner create(
+      final String name,
+      final int maxThreads,
+      final MetricTrackingExecutorFactory executorFactory) {
     final ScheduledExecutorService scheduler =
         Executors.newSingleThreadScheduledExecutor(
             new ThreadFactoryBuilder()
                 .setNameFormat(name + "-async-scheduler-%d")
                 .setDaemon(true)
                 .build());
-    // ThreadPoolExecutor has a weird API. maximumThreadCount only applies if you use a
-    // SynchronousQueue but then tasks are rejected once max threads are reached instead of being
-    // queued. So we use a blocking queue to ensure there is some limit on the queue size but that
-    // means that the maximum number of threads is ignored and only the core thread pool size is
-    // used. So, we set maximum and core thread pool to the same value and allow core threads to
-    // time out and exit if they are unused.
-    final ThreadPoolExecutor workerPool =
-        new ThreadPoolExecutor(
+    final ExecutorService workerPool =
+        executorFactory.newCachedThreadPool(
+            name,
             maxThreads,
-            maxThreads,
-            60,
-            TimeUnit.SECONDS,
-            new ArrayBlockingQueue<>(QUEUE_CAPACITY),
+            QUEUE_CAPACITY,
             new ThreadFactoryBuilder().setNameFormat(name + "-async-%d").setDaemon(true).build());
-    workerPool.allowCoreThreadTimeOut(true);
-
-    metricsSystem.createIntegerGauge(
-        TekuMetricCategory.EXECUTOR,
-        name + "_queue_size",
-        "Current size of the executor task queue",
-        () -> workerPool.getQueue().size());
-    metricsSystem.createIntegerGauge(
-        TekuMetricCategory.EXECUTOR,
-        name + "_thread_pool_size",
-        "Current number of threads in the executor thread pool",
-        workerPool::getPoolSize);
-    metricsSystem.createIntegerGauge(
-        TekuMetricCategory.EXECUTOR,
-        name + "_thread_active_count",
-        "Current number of threads executing tasks for this executor",
-        workerPool::getActiveCount);
 
     return new ScheduledExecutorAsyncRunner(scheduler, workerPool);
   }

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/MetricTrackingExecutorFactoryTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/MetricTrackingExecutorFactoryTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.metrics.StubMetricsSystem;
+import tech.pegasys.teku.metrics.TekuMetricCategory;
+
+class MetricTrackingExecutorFactoryTest {
+  private final StubMetricsSystem metricSystem = new StubMetricsSystem();
+  private final ThreadFactory threadFactory =
+      new ThreadFactoryBuilder()
+          .setNameFormat(MetricTrackingExecutorFactoryTest.class.getSimpleName() + "-%d")
+          .setDaemon(true)
+          .build();
+  private final List<ExecutorService> executors = new ArrayList<>();
+
+  private final MetricTrackingExecutorFactory factory =
+      new MetricTrackingExecutorFactory(metricSystem);
+
+  @AfterEach
+  void tearDown() {
+    executors.forEach(ExecutorService::shutdownNow);
+  }
+
+  @Test
+  void shouldQueueTasksOnceAllThreadsAreFull() throws Exception {
+    final Task task1 = new Task();
+    final Task task2 = new Task();
+    final Task task3 = new Task();
+    final ExecutorService executorService = newCachedThreadPool(2, 5);
+    executorService.execute(task1);
+    executorService.execute(task2);
+    executorService.execute(task3);
+
+    task1.assertStarted();
+    task2.assertStarted();
+    assertThat(task3.isStarted()).isFalse();
+
+    assertThat(metricSystem.getGauge(TekuMetricCategory.EXECUTOR, "foo_queue_size").getValue())
+        .isEqualTo(1);
+    assertThat(
+            metricSystem
+                .getGauge(TekuMetricCategory.EXECUTOR, "foo_thread_active_count")
+                .getValue())
+        .isEqualTo(2);
+    assertThat(
+            metricSystem.getGauge(TekuMetricCategory.EXECUTOR, "foo_thread_pool_size").getValue())
+        .isEqualTo(2);
+
+    task1.allowCompletion();
+
+    task3.assertStarted();
+    assertThat(metricSystem.getGauge(TekuMetricCategory.EXECUTOR, "foo_queue_size").getValue())
+        .isEqualTo(0);
+
+    task2.allowCompletion();
+    task3.allowCompletion();
+  }
+
+  private ExecutorService newCachedThreadPool(final int maxThreads, final int maxQueueSize) {
+    final ExecutorService executorService =
+        factory.newCachedThreadPool("foo", maxThreads, maxQueueSize, threadFactory);
+    executors.add(executorService);
+    return executorService;
+  }
+
+  private static class Task implements Runnable {
+    private final CountDownLatch started = new CountDownLatch(1);
+    private final CountDownLatch allowCompletion = new CountDownLatch(1);
+
+    @Override
+    public void run() {
+      started.countDown();
+      try {
+        allowCompletion.await(30, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        // Ignore
+      }
+    }
+
+    public void assertStarted() throws Exception {
+      assertThat(started.await(10, TimeUnit.SECONDS)).describedAs("task started").isTrue();
+    }
+
+    public boolean isStarted() {
+      return started.getCount() == 0;
+    }
+
+    public void allowCompletion() {
+      allowCompletion.countDown();
+    }
+  }
+}

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunnerTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunnerTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.service.serviceutils;
+package tech.pegasys.teku.infrastructure.async;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -38,10 +38,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
-import tech.pegasys.teku.infrastructure.async.Cancellable;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 
 class ScheduledExecutorAsyncRunnerTest {
 

--- a/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/AsyncRunnerFactory.java
+++ b/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/AsyncRunnerFactory.java
@@ -15,16 +15,22 @@ package tech.pegasys.teku.service.serviceutils;
 
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArrayList;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.MetricTrackingExecutorFactory;
+import tech.pegasys.teku.infrastructure.async.ScheduledExecutorAsyncRunner;
 
 public class AsyncRunnerFactory {
   private final Collection<AsyncRunner> asyncRunners = new CopyOnWriteArrayList<>();
 
-  public AsyncRunner create(
-      final String name, final int maxThreads, final MetricsSystem metricsSystem) {
+  private final MetricTrackingExecutorFactory executorFactory;
+
+  public AsyncRunnerFactory(final MetricTrackingExecutorFactory executorFactory) {
+    this.executorFactory = executorFactory;
+  }
+
+  public AsyncRunner create(final String name, final int maxThreads) {
     final AsyncRunner asyncRunner =
-        ScheduledExecutorAsyncRunner.create(name, maxThreads, metricsSystem);
+        ScheduledExecutorAsyncRunner.create(name, maxThreads, executorFactory);
     asyncRunners.add(asyncRunner);
     return asyncRunner;
   }

--- a/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
+++ b/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
@@ -71,6 +71,6 @@ public class ServiceConfig {
   }
 
   public AsyncRunner createAsyncRunner(final String name, final int maxThreads) {
-    return asyncRunnerFactory.create(name, maxThreads, metricsSystem);
+    return asyncRunnerFactory.create(name, maxThreads);
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/BeaconNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/BeaconNode.java
@@ -26,6 +26,8 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.data.recorder.SSZTransitionRecorder;
 import tech.pegasys.teku.events.EventChannels;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.MetricTrackingExecutorFactory;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.logging.LoggingConfiguration;
 import tech.pegasys.teku.logging.LoggingConfigurator;
 import tech.pegasys.teku.metrics.MetricsEndpoint;
@@ -44,7 +46,7 @@ public class BeaconNode {
       Executors.newCachedThreadPool(
           new ThreadFactoryBuilder().setDaemon(true).setNameFormat("events-%d").build());
 
-  private final AsyncRunnerFactory asyncRunnerFactory = new AsyncRunnerFactory();
+  private final AsyncRunnerFactory asyncRunnerFactory;
   private final ServiceController serviceController;
   private final EventChannels eventChannels;
   private final MetricsEndpoint metricsEndpoint;
@@ -68,6 +70,7 @@ public class BeaconNode {
     this.eventChannels = new EventChannels(subscriberExceptionHandler, metricsSystem);
     final EventBus eventBus = new AsyncEventBus(threadPool, subscriberExceptionHandler);
 
+    asyncRunnerFactory = new AsyncRunnerFactory(new MetricTrackingExecutorFactory(metricsSystem));
     final ServiceConfig serviceConfig =
         new ServiceConfig(
             asyncRunnerFactory,
@@ -91,7 +94,7 @@ public class BeaconNode {
   }
 
   public void start() {
-    metricsEndpoint.start();
+    metricsEndpoint.start().join();
     serviceController.start().join();
   }
 
@@ -105,7 +108,7 @@ public class BeaconNode {
 
     // Stop services. This includes closing the database.
     serviceController.stop().reportExceptions();
-    metricsEndpoint.stop();
+    SafeFuture.of(metricsEndpoint.stop()).reportExceptions();
     vertx.close();
   }
 }

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
   api 'org.bouncycastle:bcprov-jdk15on'
+  api project(':data:metrics')
 
   implementation project(':bls')
   implementation project(':infrastructure:async')

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
@@ -28,9 +28,10 @@ import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.metrics.MetricsConfig;
 
 /** Configuration of an instance of Teku. */
-public class TekuConfiguration {
+public class TekuConfiguration implements MetricsConfig {
   // Network
   private final String constants;
   private final String initialState;
@@ -416,22 +417,27 @@ public class TekuConfiguration {
     return transitionRecordDirectory;
   }
 
+  @Override
   public boolean isMetricsEnabled() {
     return metricsEnabled;
   }
 
+  @Override
   public int getMetricsPort() {
     return metricsPort;
   }
 
+  @Override
   public String getMetricsInterface() {
     return metricsInterface;
   }
 
+  @Override
   public List<String> getMetricsCategories() {
     return metricsCategories;
   }
 
+  @Override
   public List<String> getMetricsHostAllowlist() {
     return metricsHostAllowlist;
   }


### PR DESCRIPTION
## PR Description
Given the difficulties getting a thread pool to work the way we need, extract a factory to create them with predictable behaviour and automatically track useful metrics.

Adds a test to confirm the thread pool behaviour is as we expect.

The `metrics` module no longer depends on `util` which makes it possible for things in `util` or other modules that `util` uses to use metrics. The one key piece of this is that it can no longer use `TekuConfiguration` so exposes a `MetricsConfig` interface which `TekuConfiguration` implements.  Happy to have push back on this if others disagree but it feels like a reasonable way forward to gradually split up `TekuConfiguration` instead of having one giant config object for everything.

Having `metrics` not depend on `utils` allows `ScheduledExecutorAsyncRunner` to be moved to the `async` package rather than having to be in service utils and the new `MetricsTrackingExecutorFactory` can be extracted out to the `async` package as well rather than also having to be in service utils.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.