### PR TITLE
Fix and reenable some deposit processing tests

### DIFF
--- a/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/util/DataStructureUtil.java
+++ b/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/util/DataStructureUtil.java
@@ -501,6 +501,21 @@ public final class DataStructureUtil {
     return new VoluntaryExit(randomUnsignedLong(), randomUnsignedLong());
   }
 
+  public List<DepositData> newDepositList(int numDeposits) {
+    final DepositGenerator depositGenerator = new DepositGenerator();
+    List<DepositData> depositData = new ArrayList<>();
+
+    for (int i = 0; i < numDeposits; i++) {
+      BLSKeyPair keypair = BLSKeyPair.random(i);
+      depositData.add(
+          depositGenerator.createDepositData(
+              keypair,
+              UnsignedLong.valueOf(Constants.MAX_EFFECTIVE_BALANCE),
+              keypair.getPublicKey()));
+    }
+    return depositData;
+  }
+
   public SSZList<DepositWithIndex> newDeposits(int numDeposits) {
     SSZMutableList<DepositWithIndex> deposits =
         SSZList.createMutable(DepositWithIndex.class, Constants.MAX_DEPOSITS);

--- a/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/util/DataStructureUtil.java
+++ b/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/util/DataStructureUtil.java
@@ -501,21 +501,6 @@ public final class DataStructureUtil {
     return new VoluntaryExit(randomUnsignedLong(), randomUnsignedLong());
   }
 
-  public List<DepositData> newDepositList(int numDeposits) {
-    final DepositGenerator depositGenerator = new DepositGenerator();
-    List<DepositData> depositData = new ArrayList<>();
-
-    for (int i = 0; i < numDeposits; i++) {
-      BLSKeyPair keypair = BLSKeyPair.random(i);
-      depositData.add(
-          depositGenerator.createDepositData(
-              keypair,
-              UnsignedLong.valueOf(Constants.MAX_EFFECTIVE_BALANCE),
-              keypair.getPublicKey()));
-    }
-    return depositData;
-  }
-
   public SSZList<DepositWithIndex> newDeposits(int numDeposits) {
     SSZMutableList<DepositWithIndex> deposits =
         SSZList.createMutable(DepositWithIndex.class, Constants.MAX_DEPOSITS);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockProcessorUtilTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockProcessorUtilTest.java
@@ -49,7 +49,7 @@ class BlockProcessorUtilTest {
   void processDepositAddsNewValidatorWhenPubkeyIsNotFoundInRegistry()
       throws BlockProcessingException {
     // Create a deposit
-    DepositData depositInput = dataStructureUtil.newDepositList(1).get(0);
+    DepositData depositInput = dataStructureUtil.randomDepositData();
     BLSPublicKey pubkey = depositInput.getPubkey();
     Bytes32 withdrawalCredentials = depositInput.getWithdrawal_credentials();
     UnsignedLong amount = depositInput.getAmount();
@@ -103,7 +103,7 @@ class BlockProcessorUtilTest {
   void processDepositTopsUpValidatorBalanceWhenPubkeyIsFoundInRegistry()
       throws BlockProcessingException {
     // Create a deposit
-    DepositData depositInput = dataStructureUtil.newDepositList(1).get(0);
+    DepositData depositInput = dataStructureUtil.randomDepositData();
     BLSPublicKey pubkey = depositInput.getPubkey();
     Bytes32 withdrawalCredentials = depositInput.getWithdrawal_credentials();
     UnsignedLong amount = depositInput.getAmount();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockProcessorUtilTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockProcessorUtilTest.java
@@ -194,8 +194,7 @@ class BlockProcessorUtilTest {
     int originalValidatorRegistrySize = beaconState.getValidators().size();
     int originalValidatorBalancesSize = beaconState.getBalances().size();
 
-    // Attempt to process deposit with above data. We expect this to fail, but not to throw and
-    // exception.
+    // Attempt to process deposit with above data. We expect to fail, but not throw an exception.
     beaconState =
         beaconState.updated(state -> BlockProcessorUtil.process_deposits(state, deposits));
 


### PR DESCRIPTION
## Description

1. Fix and reenable a couple of deposit processing tests by adding deposit contract Merkle root calculation logic.
2. Add a test to ensure that a deposit with an invalid public key (not in G1) is handled correctly (i.e. silently ignored).

Resolves #2375

## Documentation

- [x ] I thought about documentation and added the `documentation` label to this PR if updates are required.