### PR TITLE
Ensure BLSPublicKey.hashCode works for invalid keys

### DIFF
--- a/bls/src/main/java/tech/pegasys/teku/bls/mikuli/PublicKey.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/mikuli/PublicKey.java
@@ -143,7 +143,12 @@ public final class PublicKey {
 
   @Override
   public int hashCode() {
-    return point.get().hashCode();
+    try {
+      return point.get().hashCode();
+    } catch (final IllegalArgumentException e) {
+      // Invalid point so only equal if it has the same raw data, hence use that hashCode.
+      return rawData.hashCode();
+    }
   }
 
   @Override

--- a/bls/src/test/java/tech/pegasys/teku/bls/BLSPublicKeyTest.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/BLSPublicKeyTest.java
@@ -89,6 +89,7 @@ class BLSPublicKeyTest {
             Bytes.fromHexString(
                 "0xb51aa9cdb40ed3e7e5a9b3323550fe323ecd5c7f5cb3d8b47af55a061811bc7da0397986cad0d565c0bdbbe99af24355"));
     assertNotEquals(invalidPublicKey.hashCode(), validPublicKey.hashCode());
+    assertEquals(invalidPublicKey.hashCode(), invalidPublicKey.hashCode());
   }
 
   @Test

--- a/bls/src/test/java/tech/pegasys/teku/bls/BLSPublicKeyTest.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/BLSPublicKeyTest.java
@@ -79,6 +79,19 @@ class BLSPublicKeyTest {
   }
 
   @Test
+  void succeedsWhenInvalidPublicReturnsHashCode() {
+    BLSPublicKey invalidPublicKey =
+        BLSPublicKey.fromBytesCompressed(
+            Bytes.fromHexString(
+                "0x9378a6e3984e96d2cd50450c76ca14732f1300efa04aecdb805b22e6d6926a85ef409e8f3acf494a1481090bf32ce3bd"));
+    BLSPublicKey validPublicKey =
+        BLSPublicKey.fromBytesCompressed(
+            Bytes.fromHexString(
+                "0xb51aa9cdb40ed3e7e5a9b3323550fe323ecd5c7f5cb3d8b47af55a061811bc7da0397986cad0d565c0bdbbe99af24355"));
+    assertNotEquals(invalidPublicKey.hashCode(), validPublicKey.hashCode());
+  }
+
+  @Test
   void succeedsIfSerializationOfEmptyPublicKeyIsCorrect() {
     BLSPublicKey emptyPublicKey = BLSPublicKey.empty();
     assertEquals(


### PR DESCRIPTION
## PR Description
Follow up to #2373 to ensure that the hashCode method also works for invalid BLS public keys.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.