### PR TITLE
Update JRE used in docker image to Java 14

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.2-jre-slim-stretch
+FROM openjdk:14-slim-buster
 
 RUN adduser --disabled-password --gecos "" --home /opt/teku teku && \
     chown teku:teku /opt/teku


### PR DESCRIPTION
## PR Description
Upgrade the base image used in our docker file to Java 14. Generally includes lots of GC improvements but particularly useful is the ability to use -XX:SoftMaxHeapSize to set a target max heap size but allow it to be exceeded when necessary.  Leads to lower memory usage without risk of high GC costs.

Since the version of Java is controlled in docker, we may as well use a more recent one rather than sticking to Java 11.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

Would be useful to note the ability to set -XX:SoftMaxHeapSize though probably should be part of a guide to memory usage which may need to wait until we have sorted out #2303 