### PR TITLE
add conversion to internal objects to BeaconState and objects it relies on.

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/README.md
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/README.md
@@ -2,9 +2,10 @@
 
 ## Resources
 
+* [eth2-spec]("https://github.com/ethereum/eth2.0-specs")
 * [Prysm API]("https://api.prylabs.net/#")
 * [Lighthouse API]("https://lighthouse-book.sigmaprime.io/http.html")
-* [eth2-api]("https://github.com/ethereum/eth2.0-specs")
+* [eth2-api]("https://github.com/ethereum/eth2.0-APIs")
 
 ## /node/genesis_time
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/README.md
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/README.md
@@ -3,9 +3,9 @@
 ## Resources
 
 * [eth2-spec]("https://github.com/ethereum/eth2.0-specs")
+* [eth2-api]("https://github.com/ethereum/eth2.0-APIs")
 * [Prysm API]("https://api.prylabs.net/#")
 * [Lighthouse API]("https://lighthouse-book.sigmaprime.io/http.html")
-* [eth2-api]("https://github.com/ethereum/eth2.0-APIs")
 
 ## /node/genesis_time
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/schema/BLSPubKey.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/schema/BLSPubKey.java
@@ -81,4 +81,8 @@ public class BLSPubKey {
   public static BLSPubKey empty() {
     return new BLSPubKey(Bytes.wrap(new byte[SIZE]));
   }
+
+  public BLSPublicKey asBLSPublicKey() {
+    return BLSPublicKey.fromBytes(bytes);
+  }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/schema/Eth1Data.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/schema/Eth1Data.java
@@ -46,4 +46,9 @@ public class Eth1Data {
     this.deposit_count = deposit_count;
     this.block_hash = block_hash;
   }
+
+  public tech.pegasys.teku.datastructures.blocks.Eth1Data asInternalEth1Data() {
+    return new tech.pegasys.teku.datastructures.blocks.Eth1Data(
+        deposit_root, deposit_count, block_hash);
+  }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/schema/Fork.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/schema/Fork.java
@@ -46,4 +46,9 @@ public class Fork {
     this.current_version = fork.getCurrent_version();
     this.epoch = fork.getEpoch();
   }
+
+  public tech.pegasys.teku.datastructures.state.Fork asInternalFork() {
+    return new tech.pegasys.teku.datastructures.state.Fork(
+        previous_version, current_version, epoch);
+  }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/schema/PendingAttestation.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/schema/PendingAttestation.java
@@ -52,4 +52,9 @@ public class PendingAttestation {
     this.inclusion_delay = pendingAttestation.getInclusion_delay();
     this.proposer_index = pendingAttestation.getProposer_index();
   }
+
+  public tech.pegasys.teku.datastructures.state.PendingAttestation asInternalPendingAttestation() {
+    return new tech.pegasys.teku.datastructures.state.PendingAttestation(
+        aggregation_bits, data.asInternalAttestationData(), inclusion_delay, proposer_index);
+  }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/schema/Validator.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/schema/Validator.java
@@ -76,4 +76,16 @@ public class Validator {
     this.exit_epoch = validator.getExit_epoch();
     this.withdrawable_epoch = validator.getWithdrawable_epoch();
   }
+
+  public tech.pegasys.teku.datastructures.state.Validator asInternalValidator() {
+    return tech.pegasys.teku.datastructures.state.Validator.create(
+        pubkey.asBLSPublicKey(),
+        withdrawal_credentials,
+        effective_balance,
+        slashed,
+        activation_eligibility_epoch,
+        activation_epoch,
+        exit_epoch,
+        withdrawable_epoch);
+  }
 }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/schema/BLSPubKeyTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/schema/BLSPubKeyTest.java
@@ -1,14 +1,28 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.api.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class BLSPubKeyTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final BLSPublicKey blsPublicKey = dataStructureUtil.randomPublicKey();
+
   @Test
   public void shouldConvertToInternalObject() {
     final BLSPubKey blsPubKey = new BLSPubKey(blsPublicKey);

--- a/data/provider/src/test/java/tech/pegasys/teku/api/schema/BLSPubKeyTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/schema/BLSPubKeyTest.java
@@ -1,0 +1,17 @@
+package tech.pegasys.teku.api.schema;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BLSPubKeyTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final BLSPublicKey blsPublicKey = dataStructureUtil.randomPublicKey();
+  @Test
+  public void shouldConvertToInternalObject() {
+    final BLSPubKey blsPubKey = new BLSPubKey(blsPublicKey);
+    assertThat(blsPubKey.asBLSPublicKey()).isEqualTo(blsPublicKey);
+  }
+}

--- a/data/provider/src/test/java/tech/pegasys/teku/api/schema/BeaconStateTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/schema/BeaconStateTest.java
@@ -1,0 +1,19 @@
+package tech.pegasys.teku.api.schema;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeaconStateTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final tech.pegasys.teku.datastructures.state.BeaconState beaconStateInternal = dataStructureUtil.randomBeaconState();
+
+  @Test
+  public void shouldConvertToInternalObject() {
+    BeaconState beaconState = new BeaconState(beaconStateInternal);
+
+    assertThat(beaconState.asInternalBeaconState())
+        .isEqualTo(beaconStateInternal);
+  }
+}

--- a/data/provider/src/test/java/tech/pegasys/teku/api/schema/BeaconStateTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/schema/BeaconStateTest.java
@@ -1,19 +1,32 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.api.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class BeaconStateTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
-  private final tech.pegasys.teku.datastructures.state.BeaconState beaconStateInternal = dataStructureUtil.randomBeaconState();
+  private final tech.pegasys.teku.datastructures.state.BeaconState beaconStateInternal =
+      dataStructureUtil.randomBeaconState();
 
   @Test
   public void shouldConvertToInternalObject() {
     BeaconState beaconState = new BeaconState(beaconStateInternal);
 
-    assertThat(beaconState.asInternalBeaconState())
-        .isEqualTo(beaconStateInternal);
+    assertThat(beaconState.asInternalBeaconState()).isEqualTo(beaconStateInternal);
   }
 }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/schema/Eth1DataTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/schema/Eth1DataTest.java
@@ -1,0 +1,16 @@
+package tech.pegasys.teku.api.schema;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Eth1DataTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final tech.pegasys.teku.datastructures.blocks.Eth1Data eth1DataInternal = dataStructureUtil.randomEth1Data();
+  @Test
+  public void shouldConvertToInternalObject() {
+    final Eth1Data eth1Data = new Eth1Data(eth1DataInternal);
+    assertThat(eth1Data.asInternalEth1Data()).isEqualTo(eth1DataInternal);
+  }
+}

--- a/data/provider/src/test/java/tech/pegasys/teku/api/schema/Eth1DataTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/schema/Eth1DataTest.java
@@ -1,13 +1,28 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.api.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class Eth1DataTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
-  private final tech.pegasys.teku.datastructures.blocks.Eth1Data eth1DataInternal = dataStructureUtil.randomEth1Data();
+  private final tech.pegasys.teku.datastructures.blocks.Eth1Data eth1DataInternal =
+      dataStructureUtil.randomEth1Data();
+
   @Test
   public void shouldConvertToInternalObject() {
     final Eth1Data eth1Data = new Eth1Data(eth1DataInternal);

--- a/data/provider/src/test/java/tech/pegasys/teku/api/schema/ForkTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/schema/ForkTest.java
@@ -1,0 +1,18 @@
+package tech.pegasys.teku.api.schema;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class ForkTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final tech.pegasys.teku.datastructures.state.Fork forkInternal = dataStructureUtil.randomFork();
+
+  @Test
+  public void shouldConvertToInternalObject() {
+    Fork fork = new Fork(forkInternal);
+    assertThat(fork.asInternalFork()).isEqualTo(forkInternal);
+  }
+}

--- a/data/provider/src/test/java/tech/pegasys/teku/api/schema/ForkTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/schema/ForkTest.java
@@ -1,14 +1,27 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.api.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-
 public class ForkTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
-  private final tech.pegasys.teku.datastructures.state.Fork forkInternal = dataStructureUtil.randomFork();
+  private final tech.pegasys.teku.datastructures.state.Fork forkInternal =
+      dataStructureUtil.randomFork();
 
   @Test
   public void shouldConvertToInternalObject() {

--- a/data/provider/src/test/java/tech/pegasys/teku/api/schema/PendingAttestationTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/schema/PendingAttestationTest.java
@@ -1,0 +1,17 @@
+package tech.pegasys.teku.api.schema;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PendingAttestationTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final tech.pegasys.teku.datastructures.state.PendingAttestation attestationInternal = dataStructureUtil.randomPendingAttestation();
+
+  @Test
+  public void shouldConvertToInternalObject() {
+    final PendingAttestation pendingAttestation = new PendingAttestation(attestationInternal);
+    assertThat(pendingAttestation.asInternalPendingAttestation()).isEqualTo(attestationInternal);
+  }
+}

--- a/data/provider/src/test/java/tech/pegasys/teku/api/schema/PendingAttestationTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/schema/PendingAttestationTest.java
@@ -1,13 +1,27 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.api.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class PendingAttestationTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
-  private final tech.pegasys.teku.datastructures.state.PendingAttestation attestationInternal = dataStructureUtil.randomPendingAttestation();
+  private final tech.pegasys.teku.datastructures.state.PendingAttestation attestationInternal =
+      dataStructureUtil.randomPendingAttestation();
 
   @Test
   public void shouldConvertToInternalObject() {

--- a/data/provider/src/test/java/tech/pegasys/teku/api/schema/ValidatorTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/schema/ValidatorTest.java
@@ -1,0 +1,16 @@
+package tech.pegasys.teku.api.schema;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ValidatorTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final tech.pegasys.teku.datastructures.state.Validator validatorInternal = dataStructureUtil.randomValidator();
+  @Test
+  public void shouldConvertToInternalObject() {
+    final Validator validator = new Validator(validatorInternal);
+    assertThat(validator.asInternalValidator()).isEqualTo(validatorInternal);
+  }
+}

--- a/data/provider/src/test/java/tech/pegasys/teku/api/schema/ValidatorTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/schema/ValidatorTest.java
@@ -1,13 +1,28 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.api.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class ValidatorTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
-  private final tech.pegasys.teku.datastructures.state.Validator validatorInternal = dataStructureUtil.randomValidator();
+  private final tech.pegasys.teku.datastructures.state.Validator validatorInternal =
+      dataStructureUtil.randomValidator();
+
   @Test
   public void shouldConvertToInternalObject() {
     final Validator validator = new Validator(validatorInternal);


### PR DESCRIPTION

 - added round trip conversion tests

 - added genesis_validators_root to api level beaconState as it was missing.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.