### PR TITLE
Reduce log level for duplicate peer warning

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -169,7 +169,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
     Eth2Peer eth2Peer = eth2PeerFactory.create(peer, rpcMethods);
     final boolean wasAdded = connectedPeerMap.putIfAbsent(peer.getId(), eth2Peer) == null;
     if (!wasAdded) {
-      LOG.warn("Duplicate peer connection detected. Ignoring peer.");
+      LOG.debug("Duplicate peer connection detected for peer {}. Ignoring peer.", peer.getId());
       return;
     }
 


### PR DESCRIPTION
## PR Description
Reduce log level for message about duplicate peer connections being detected.  Teku handles it correctly so it doesn't need to warn the user.

## Fixed Issue(s)
fixes #2384 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.