### PR TITLE
[Issue 2291] Remove RecentChainData.getBlockState()

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/gen/Generator.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/gen/Generator.java
@@ -87,7 +87,10 @@ public class Generator {
                   currentSlot, AttestationGenerator.groupAndAggregateAttestations(attestations));
           writer.accept(block);
           final BeaconState postState =
-              localStorage.getBlockState(block.getMessage().hash_tree_root()).orElseThrow();
+              localStorage
+                  .retrieveBlockState(block.getMessage().hash_tree_root())
+                  .join()
+                  .orElseThrow();
 
           attestations =
               UnsignedLong.ONE.equals(currentSlot)
@@ -106,7 +109,7 @@ public class Generator {
         }
 
         Optional<BeaconState> bestState =
-            localStorage.getBlockState(localStorage.getBestBlockRoot().orElse(null));
+            localStorage.retrieveBlockState(localStorage.getBestBlockRoot().orElse(null)).join();
         System.out.println("Epoch done: " + bestState);
       }
     }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
@@ -109,7 +109,8 @@ public class BlockImporterTest {
     currentSlot = currentSlot.plus(UnsignedLong.ONE);
 
     AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
-    final BeaconState state = recentChainData.getBlockState(block1.getRoot()).orElseThrow();
+    final BeaconState state =
+        recentChainData.retrieveBlockState(block1.getRoot()).join().orElseThrow();
     List<Attestation> attestations =
         attestationGenerator.getAttestationsForSlot(state, block1.getMessage(), currentSlot);
     List<Attestation> aggregatedAttestations =
@@ -128,7 +129,8 @@ public class BlockImporterTest {
     currentSlot = currentSlot.plus(UnsignedLong.ONE);
 
     AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
-    final BeaconState state = recentChainData.getBlockState(block1.getRoot()).orElseThrow();
+    final BeaconState state =
+        recentChainData.retrieveBlockState(block1.getRoot()).join().orElseThrow();
     List<Attestation> attestations =
         attestationGenerator.getAttestationsForSlot(state, block1.getMessage(), currentSlot);
     List<Attestation> aggregatedAttestations =

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -183,7 +183,8 @@ public class BeaconChainUtil {
     final SignedBeaconBlock block =
         createBlockAndStateAtSlot(slot, true, attestations, deposits, exits, eth1Data).getBlock();
     setSlot(slot);
-    final Optional<BeaconState> preState = recentChainData.getBlockState(block.getParent_root());
+    final Optional<BeaconState> preState =
+        recentChainData.retrieveBlockState(block.getParent_root()).join();
     final BlockImportResult importResult = forkChoice.onBlock(block, preState);
     if (!importResult.isSuccessful()) {
       throw new IllegalStateException(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
@@ -55,9 +55,6 @@ public abstract class Eth2IncomingRequestHandlerTest
 
     lenient().when(state.getSlot()).thenReturn(UnsignedLong.ONE);
     lenient()
-        .when(combinedChainDataClient.getNonfinalizedBlockState(any()))
-        .thenReturn(Optional.of(state));
-    lenient()
         .when(combinedChainDataClient.getBlockAtSlotExact(any(), any()))
         .thenAnswer(i -> getBlockAtSlot(i.getArgument(0)));
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -144,10 +144,6 @@ public class CombinedChainDataClient {
     return finalizedEpoch.compareTo(epoch) >= 0;
   }
 
-  public Optional<BeaconState> getNonfinalizedBlockState(final Bytes32 blockRoot) {
-    return recentChainData.getBlockState(blockRoot);
-  }
-
   /**
    * Returns the latest state at the given slot on the current chain.
    *

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -336,19 +336,6 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     return Optional.ofNullable(store.getSignedBlock(root));
   }
 
-  /**
-   * @deprecated Use {@link #retrieveBlockState} instead
-   * @param blockRoot The root of the block corresponding to this state
-   * @return
-   */
-  @Deprecated
-  public Optional<BeaconState> getBlockState(final Bytes32 blockRoot) {
-    if (store == null) {
-      return Optional.empty();
-    }
-    return Optional.ofNullable(store.getBlockState(blockRoot));
-  }
-
   public SafeFuture<Optional<BeaconState>> retrieveBlockState(final Bytes32 blockRoot) {
     if (store == null) {
       return EmptyStoreResults.EMPTY_STATE_FUTURE;

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -605,13 +605,14 @@ class RecentChainDataTest {
     for (SignedBlockAndState expectedBlock : expectedBlocks) {
       assertThat(storageClient.getSignedBlockByRoot(expectedBlock.getRoot()))
           .contains(expectedBlock.getBlock());
-      assertThat(storageClient.getBlockState(expectedBlock.getRoot()))
-          .contains(expectedBlock.getState());
+      assertThat(storageClient.retrieveBlockState(expectedBlock.getRoot()))
+          .isCompletedWithValue(Optional.of(expectedBlock.getState()));
     }
     // Check pruned blocks
     for (Bytes32 prunedBlock : prunedBlocks) {
       assertThat(storageClient.getSignedBlockByRoot(prunedBlock)).isEmpty();
-      assertThat(storageClient.getBlockState(prunedBlock)).isEmpty();
+      assertThat(storageClient.retrieveBlockState(prunedBlock))
+          .isCompletedWithValue(Optional.empty());
     }
   }
 

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
@@ -86,7 +86,8 @@ public class DepositProvider implements Eth1EventsChannel, FinalizedCheckpointCh
         .thenAccept(
             finalizedState -> {
               if (finalizedState.isEmpty()) {
-                throw new IllegalStateException("Finalized Checkpoint state cannot be found.");
+                LOG.error("Finalized checkpoint state not found.");
+                return;
               }
               final UnsignedLong depositIndex = finalizedState.get().getEth1_deposit_index();
               pruneDeposits(depositIndex);

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
@@ -120,7 +120,8 @@ class BlockFactoryTest {
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
     final Bytes32 bestBlockRoot = recentChainData.getBestBlockRoot().orElseThrow();
     final BeaconBlock previousBlock = recentChainData.getBlockByRoot(bestBlockRoot).orElseThrow();
-    final BeaconState previousState = recentChainData.getBlockState(bestBlockRoot).orElseThrow();
+    final BeaconState previousState =
+        recentChainData.retrieveBlockState(bestBlockRoot).join().orElseThrow();
     final BeaconBlock block =
         blockFactory.createUnsignedBlock(
             previousState, previousBlock, newSlot, randaoReveal, Optional.empty());

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.datastructures.util.DepositUtil;
 import tech.pegasys.teku.datastructures.util.MerkleTree;
 import tech.pegasys.teku.datastructures.util.OptimizedMerkleTree;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 import tech.pegasys.teku.ssz.SSZTypes.SSZMutableList;
@@ -132,8 +133,8 @@ public class DepositProviderTest {
     Bytes32 finalizedBlockRoot = Bytes32.fromHexString("0x01");
     mockStateEth1DepositIndex(10);
     mockDepositsFromEth1Block(0, 20);
-    when(recentChainData.getBlockState(eq(finalizedBlockRoot)))
-        .thenReturn(Optional.ofNullable(state));
+    when(recentChainData.retrieveBlockState(eq(finalizedBlockRoot)))
+        .thenReturn(SafeFuture.completedFuture(Optional.ofNullable(state)));
 
     assertThat(depositProvider.getDepositMapSize()).isEqualTo(20);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Replace remaining calls to `RecentChainData.getBlockState()` with the async version `RecentChainData.retrieveBlockState()`.

## Fixed Issue(s)
Part of #2291 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.