### PR TITLE
Limit Netty direct memory to 32Mb

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -276,7 +276,9 @@ application {
       "-Dlog4j.shutdownHookEnabled=false",
       "-XX:+HeapDumpOnOutOfMemoryError",
       // run `jcmd <PID> VM.native_memory` to check JVM native memory consumption
-      "-XX:NativeMemoryTracking=summary"
+      "-XX:NativeMemoryTracking=summary",
+      // 32Mb for Netty Direct ByteBuf
+      "-Dio.netty.maxDirectMemory=33554432"
   ]
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Limit max Netty Direct `ByteBuf` memory to 32Mb. Currently its upper bound is `-Xmx`, though effectively it allocates 'just' 256Mb. This is too much for non high-load app. 

## Fixed Issue(s)
Relates #2303 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.