### PR TITLE
[Issue 2291] Remove synchronous Store state retrieval methods

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
@@ -53,8 +53,6 @@ public interface ReadOnlyStore {
 
   SignedBeaconBlock getSignedBlock(Bytes32 blockRoot);
 
-  Optional<SignedBlockAndState> getBlockAndState(Bytes32 blockRoot);
-
   BeaconState getBlockState(Bytes32 blockRoot);
 
   boolean containsBlock(Bytes32 blockRoot);

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
@@ -53,8 +53,6 @@ public interface ReadOnlyStore {
 
   SignedBeaconBlock getSignedBlock(Bytes32 blockRoot);
 
-  BeaconState getBlockState(Bytes32 blockRoot);
-
   boolean containsBlock(Bytes32 blockRoot);
 
   Set<Bytes32> getBlockRoots();

--- a/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreImpl.java
@@ -116,8 +116,7 @@ class TestStoreImpl implements MutablePrunableStore {
     return blocks.get(blockRoot);
   }
 
-  @Override
-  public Optional<SignedBlockAndState> getBlockAndState(final Bytes32 blockRoot) {
+  private Optional<SignedBlockAndState> getBlockAndState(final Bytes32 blockRoot) {
     final SignedBeaconBlock block = getSignedBlock(blockRoot);
     final BeaconState state = getBlockState(blockRoot);
     if (block == null || state == null) {

--- a/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreImpl.java
@@ -143,8 +143,7 @@ class TestStoreImpl implements MutablePrunableStore {
         .collect(Collectors.toList());
   }
 
-  @Override
-  public BeaconState getBlockState(final Bytes32 blockRoot) {
+  private BeaconState getBlockState(final Bytes32 blockRoot) {
     return block_states.get(blockRoot);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -317,12 +317,6 @@ class Store implements UpdatableStore {
   }
 
   @Override
-  public BeaconState getBlockState(Bytes32 blockRoot) {
-    // TODO(#2291) - replace this with retrieveBlockState
-    return retrieveBlockState(blockRoot).join().orElse(null);
-  }
-
-  @Override
   public Optional<BeaconState> getCheckpointState(Checkpoint checkpoint) {
     // TODO(#2291) - replace this with retrieveCheckpointState
     return retrieveCheckpointState(checkpoint).join();
@@ -704,7 +698,7 @@ class Store implements UpdatableStore {
       final Lock writeLock = Store.this.lock.writeLock();
       writeLock.lock();
       try {
-        updates = StoreTransactionUpdates.calculate(Store.this, this);
+        updates = StoreTransactionUpdatesFactory.create(Store.this, this).join();
       } finally {
         writeLock.unlock();
       }
@@ -824,11 +818,6 @@ class Store implements UpdatableStore {
       } finally {
         Store.this.lock.readLock().unlock();
       }
-    }
-
-    @Override
-    public BeaconState getBlockState(final Bytes32 blockRoot) {
-      return either(blockRoot, block_states::get, Store.this::getBlockState);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
@@ -32,7 +32,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.storage.events.FinalizedChainData;
 import tech.pegasys.teku.storage.store.Store.Transaction;
 
-public class StoreTransactionUpdatesFactory {
+class StoreTransactionUpdatesFactory {
   private final Store baseStore;
   private final Store.Transaction tx;
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.store;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.datastructures.hashtree.HashTree;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.state.CheckpointAndBlock;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.storage.events.FinalizedChainData;
+import tech.pegasys.teku.storage.store.Store.Transaction;
+
+public class StoreTransactionUpdatesFactory {
+  private final Store baseStore;
+  private final Store.Transaction tx;
+
+  private final Map<Bytes32, SignedBeaconBlock> hotBlocks;
+  private final Map<Bytes32, BeaconState> hotStates;
+  private final Map<Bytes32, SlotAndBlockRoot> stateRoots;
+
+  private Optional<FinalizedChainData> finalizedChainData;
+  private Optional<HashTree> updatedBlockTree;
+  private Set<Bytes32> prunedHotBlockRoots;
+
+  private StoreTransactionUpdatesFactory(final Store baseStore, final Transaction tx) {
+    this.baseStore = baseStore;
+    this.tx = tx;
+    // Save copy of tx data that may be pruned
+    hotBlocks = new HashMap<>(tx.blocks);
+    hotStates = new HashMap<>(tx.block_states);
+    stateRoots = new HashMap<>(tx.stateRoots);
+  }
+
+  public static SafeFuture<StoreTransactionUpdates> create(
+      final Store baseStore, final Transaction tx) {
+    return new StoreTransactionUpdatesFactory(baseStore, tx).build();
+  }
+
+  private SafeFuture<StoreTransactionUpdates> build() {
+    // If a new checkpoint has been finalized, calculated what to finalize and what to prune
+    final CheckpointAndBlock prevFinalizedCheckpoint = baseStore.getFinalizedCheckpointAndBlock();
+    final Optional<CheckpointAndBlock> newFinalizedCheckpoint =
+        Optional.of(tx.getFinalizedCheckpointAndBlock())
+            .filter(c -> c.getEpoch().compareTo(prevFinalizedCheckpoint.getEpoch()) > 0);
+
+    // Calculate new tree structure
+    if (newFinalizedCheckpoint.isPresent() || hotBlocks.size() > 0) {
+      final Bytes32 updatedRoot =
+          newFinalizedCheckpoint
+              .map(CheckpointAndBlock::getRoot)
+              .orElse(baseStore.blockTree.getRootHash());
+      HashTree.Builder blockTreeUpdater =
+          baseStore.blockTree.withRoot(updatedRoot).blocks(hotBlocks.values());
+      newFinalizedCheckpoint.ifPresent(finalized -> blockTreeUpdater.block(finalized.getBlock()));
+      updatedBlockTree = Optional.of(blockTreeUpdater.build());
+    } else {
+      updatedBlockTree = Optional.empty();
+    }
+
+    if (newFinalizedCheckpoint.isPresent()) {
+      return buildFinalizedUpdates(newFinalizedCheckpoint.get());
+    } else {
+      finalizedChainData = Optional.empty();
+      prunedHotBlockRoots = Collections.emptySet();
+      return SafeFuture.completedFuture(createStoreTransactionUpdates());
+    }
+  }
+
+  private SafeFuture<StoreTransactionUpdates> buildFinalizedUpdates(
+      final CheckpointAndBlock finalizedCheckpoint) {
+    final SignedBeaconBlock finalizedBlock = finalizedCheckpoint.getBlock();
+    final Map<Bytes32, Bytes32> finalizedChildToParent =
+        collectFinalizedRoots(baseStore, finalizedBlock, hotBlocks.values());
+    Set<SignedBeaconBlock> finalizedBlocks = collectFinalizedBlocks(tx, finalizedChildToParent);
+    Map<Bytes32, BeaconState> finalizedStates = collectFinalizedStates(tx, finalizedChildToParent);
+
+    prunedHotBlockRoots =
+        calculatePrunedHotBlockRoots(baseStore, tx, updatedBlockTree.orElseThrow());
+
+    // Prune transaction collections
+    prunedHotBlockRoots.forEach(hotBlocks::remove);
+    prunedHotBlockRoots.forEach(hotStates::remove);
+
+    return tx.retrieveBlockState(finalizedBlock.getRoot())
+        .thenApply(
+            maybeLatestFinalizedState -> {
+              final BeaconState latestFinalizedState =
+                  maybeLatestFinalizedState.orElseThrow(
+                      () -> new IllegalStateException("Missing latest finalized state"));
+              finalizedChainData =
+                  Optional.of(
+                      FinalizedChainData.builder()
+                          .finalizedCheckpoint(finalizedCheckpoint.getCheckpoint())
+                          .finalizedBlock(finalizedCheckpoint.getBlock())
+                          .latestFinalizedState(latestFinalizedState)
+                          .finalizedChildAndParent(finalizedChildToParent)
+                          .finalizedBlocks(finalizedBlocks)
+                          .finalizedStates(finalizedStates)
+                          .build());
+
+              return createStoreTransactionUpdates();
+            });
+  }
+
+  private static Map<Bytes32, Bytes32> collectFinalizedRoots(
+      final Store baseStore,
+      final SignedBeaconBlock newlyFinalizedBlock,
+      final Collection<SignedBeaconBlock> newBlocks) {
+
+    final HashTree finalizedTree =
+        baseStore.blockTree.contains(newlyFinalizedBlock.getRoot())
+            ? baseStore.blockTree
+            : baseStore.blockTree.updater().blocks(newBlocks).build();
+
+    final HashMap<Bytes32, Bytes32> childToParent = new HashMap<>();
+    finalizedTree.processHashesInChain(newlyFinalizedBlock.getRoot(), childToParent::put);
+    return childToParent;
+  }
+
+  private Set<SignedBeaconBlock> collectFinalizedBlocks(
+      final Store.Transaction tx, final Map<Bytes32, Bytes32> finalizedChildToParent) {
+    return finalizedChildToParent.keySet().stream()
+        .map(root -> tx.getBlockIfAvailable(root).orElse(null))
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+  }
+
+  private Map<Bytes32, BeaconState> collectFinalizedStates(
+      final Store.Transaction tx, final Map<Bytes32, Bytes32> finalizedChildToParent) {
+    final Map<Bytes32, BeaconState> states = new HashMap<>();
+    for (Bytes32 finalizedRoot : finalizedChildToParent.keySet()) {
+      tx.getBlockStateIfAvailable(finalizedRoot)
+          .ifPresent(state -> states.put(finalizedRoot, state));
+    }
+    return states;
+  }
+
+  private Set<Bytes32> calculatePrunedHotBlockRoots(
+      final Store baseStore, Transaction tx, final HashTree prunedTree) {
+
+    Set<Bytes32> roots =
+        baseStore.blockTree.getAllRoots().stream()
+            .filter(root -> !prunedTree.contains(root))
+            .collect(Collectors.toSet());
+
+    tx.getBlockRoots().stream().filter(root -> !prunedTree.contains(root)).forEach(roots::add);
+    return roots;
+  }
+
+  private StoreTransactionUpdates createStoreTransactionUpdates() {
+    return new StoreTransactionUpdates(
+        tx,
+        finalizedChainData,
+        hotBlocks,
+        hotStates,
+        prunedHotBlockRoots,
+        updatedBlockTree,
+        stateRoots);
+  };
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -377,26 +377,27 @@ class RecentChainDataTest {
   }
 
   @Test
-  public void getBlockAndState_withBlockAndStateAvailable() throws Exception {
+  public void retrieveBlockAndState_withBlockAndStateAvailable() throws Exception {
     final SignedBlockAndState block = advanceChain(storageClient);
-    assertThat(storageClient.getStore().getBlockAndState(block.getRoot())).contains(block);
+    assertThat(storageClient.getStore().retrieveBlockAndState(block.getRoot()))
+        .isCompletedWithValue(Optional.of(block));
   }
 
   @Test
-  public void getBlockAndState_withinTxFromUnderlyingStore() throws Exception {
+  public void retrieveBlockAndState_withinTxFromUnderlyingStore() throws Exception {
     final SignedBlockAndState block = advanceChain(storageClient);
     final StoreTransaction tx = storageClient.startStoreTransaction();
-    assertThat(tx.getBlockAndState(block.getRoot())).contains(block);
+    assertThat(tx.retrieveBlockAndState(block.getRoot())).isCompletedWithValue(Optional.of(block));
   }
 
   @Test
-  public void getBlockAndState_withinTxFromUpdates() throws Exception {
+  public void retrieveBlockAndState_withinTxFromUpdates() throws Exception {
     final SignedBlockAndState block = chainBuilder.generateNextBlock();
 
     final StoreTransaction tx = storageClient.startStoreTransaction();
     tx.putBlockAndState(block);
 
-    assertThat(tx.getBlockAndState(block.getRoot())).contains(block);
+    assertThat(tx.retrieveBlockAndState(block.getRoot())).isCompletedWithValue(Optional.of(block));
   }
 
   @Test

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
@@ -50,7 +50,6 @@ import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -719,8 +718,11 @@ public abstract class AbstractDatabaseTest {
       final List<BeaconState> hotStates =
           currentStore.getBlockRoots().stream()
               .map(currentStore::retrieveBlockState)
-              .filter(SafeFuture::isDone)
-              .map(SafeFuture::join)
+              .map(
+                  f -> {
+                    assertThat(f).isCompleted();
+                    return f.join();
+                  })
               .flatMap(Optional::stream)
               .collect(toList());
 
@@ -739,8 +741,11 @@ public abstract class AbstractDatabaseTest {
     final List<BeaconState> hotStates =
         memoryStore.getBlockRoots().stream()
             .map(memoryStore::retrieveBlockState)
-            .filter(SafeFuture::isDone)
-            .map(SafeFuture::join)
+            .map(
+                f -> {
+                  assertThat(f).isCompleted();
+                  return f.join();
+                })
             .flatMap(Optional::stream)
             .collect(toList());
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/AbstractRocksDbDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/AbstractRocksDbDatabaseTest.java
@@ -13,8 +13,8 @@
 
 package tech.pegasys.teku.storage.server.rocksdb;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.stream.Stream;
@@ -49,7 +49,8 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
 
     final SignedBlockAndState newValue = chainBuilder.generateBlockAtSlot(1);
     // Sanity check
-    assertThat(store.getBlockState(newValue.getRoot())).isNull();
+    assertThatSafeFuture(store.retrieveBlockState(newValue.getRoot()))
+        .isCompletedWithEmptyOptional();
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
     transaction.putBlockAndState(newValue);
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -50,20 +50,6 @@ class StoreTest extends AbstractStoreTest {
   }
 
   @Test
-  public void getBlockState_withLimitedCache() {
-    processChainWithLimitedCache(
-        (store, blockAndState) -> {
-          final BeaconState result = store.getBlockState(blockAndState.getRoot());
-          assertThat(result)
-              .withFailMessage(
-                  "Expected state for block %s to be available", blockAndState.getSlot())
-              .isNotNull();
-          assertThat(result.hash_tree_root())
-              .isEqualTo(blockAndState.getBlock().getMessage().getState_root());
-        });
-  }
-
-  @Test
   public void retrieveSignedBlock_withLimitedCache() throws Exception {
     processChainWithLimitedCache(
         (store, blockAndState) -> {

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -244,7 +244,10 @@ class StoreTest extends AbstractStoreTest {
     // Check that transaction is updated
     chainBuilder
         .streamBlocksAndStates(1, chainBuilder.getLatestSlot().longValue())
-        .forEach(b -> assertThat(tx.getBlockAndState(b.getRoot())).isEqualTo(Optional.of(b)));
+        .forEach(
+            b ->
+                assertThat(tx.retrieveBlockAndState(b.getRoot()))
+                    .isCompletedWithValue(Optional.of(b)));
     // Check checkpoints
     assertThat(tx.getFinalizedCheckpoint()).isEqualTo(checkpoint1);
     assertThat(tx.getJustifiedCheckpoint()).isEqualTo(checkpoint2);
@@ -275,7 +278,10 @@ class StoreTest extends AbstractStoreTest {
     // Check store is updated
     chainBuilder
         .streamBlocksAndStates(checkpoint3.getEpochStartSlot(), chainBuilder.getLatestSlot())
-        .forEach(b -> assertThat(store.getBlockAndState(b.getRoot())).isEqualTo(Optional.of(b)));
+        .forEach(
+            b ->
+                assertThat(store.retrieveBlockAndState(b.getRoot()))
+                    .isCompletedWithValue(Optional.of(b)));
     // Check checkpoints
     assertThat(store.getFinalizedCheckpoint()).isEqualTo(checkpoint1);
     assertThat(store.getJustifiedCheckpoint()).isEqualTo(checkpoint2);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Remove `Store.getBlockAndState()` and `Store.getBlockState()`.

## Fixed Issue(s)
Part of #2291

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.