### PR TITLE
Implement a no-op database

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseVersion.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseVersion.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.storage.server;
 import java.util.Optional;
 
 public enum DatabaseVersion {
+  NOOP("noop"),
   V1("1.0"),
   V2("2.0"),
   V3("3.0"),

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.storage.server.metadata.DatabaseMetadata;
+import tech.pegasys.teku.storage.server.noop.NoOpDatabase;
 import tech.pegasys.teku.storage.server.rocksdb.RocksDbConfiguration;
 import tech.pegasys.teku.storage.server.rocksdb.RocksDbDatabase;
 import tech.pegasys.teku.util.config.StateStorageMode;
@@ -85,6 +86,10 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
 
     Database database;
     switch (dbVersion) {
+      case NOOP:
+        database = new NoOpDatabase();
+        LOG.trace("Created no-op database");
+        break;
       case V3:
         database = createV3Database();
         LOG.trace(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.noop;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
+import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
+import tech.pegasys.teku.protoarray.ProtoArraySnapshot;
+import tech.pegasys.teku.storage.events.AnchorPoint;
+import tech.pegasys.teku.storage.events.StorageUpdate;
+import tech.pegasys.teku.storage.server.Database;
+import tech.pegasys.teku.storage.store.StoreBuilder;
+
+public class NoOpDatabase implements Database {
+
+  @Override
+  public void storeGenesis(final AnchorPoint genesis) {}
+
+  @Override
+  public void update(final StorageUpdate event) {}
+
+  @Override
+  public Optional<StoreBuilder> createMemoryStore() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<UnsignedLong> getSlotForFinalizedBlockRoot(final Bytes32 blockRoot) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<SignedBeaconBlock> getFinalizedBlockAtSlot(final UnsignedLong slot) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<SignedBeaconBlock> getLatestFinalizedBlockAtSlot(final UnsignedLong slot) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<SignedBeaconBlock> getSignedBlock(final Bytes32 root) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Map<Bytes32, SignedBeaconBlock> getHotBlocks(final Set<Bytes32> blockRoots) {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public Stream<SignedBeaconBlock> streamFinalizedBlocks(
+      final UnsignedLong startSlot, final UnsignedLong endSlot) {
+    return Stream.empty();
+  }
+
+  @Override
+  public List<Bytes32> getStateRootsBeforeSlot(final UnsignedLong slot) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void addHotStateRoots(
+      final Map<Bytes32, SlotAndBlockRoot> stateRootToSlotAndBlockRootMap) {}
+
+  @Override
+  public Optional<SlotAndBlockRoot> getSlotAndBlockRootFromStateRoot(final Bytes32 stateRoot) {
+    return Optional.empty();
+  }
+
+  @Override
+  public void pruneHotStateRoots(final List<Bytes32> stateRoots) {}
+
+  @Override
+  public Optional<BeaconState> getLatestAvailableFinalizedState(final UnsignedLong maxSlot) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<MinGenesisTimeBlockEvent> getMinGenesisTimeBlock() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Stream<DepositsFromBlockEvent> streamDepositsFromBlocks() {
+    return Stream.empty();
+  }
+
+  @Override
+  public Optional<ProtoArraySnapshot> getProtoArraySnapshot() {
+    return Optional.empty();
+  }
+
+  @Override
+  public void addMinGenesisTimeBlock(final MinGenesisTimeBlockEvent event) {}
+
+  @Override
+  public void addDepositsFromBlockEvent(final DepositsFromBlockEvent event) {}
+
+  @Override
+  public void putProtoArraySnapshot(final ProtoArraySnapshot protoArray) {}
+
+  @Override
+  public void close() {}
+}


### PR DESCRIPTION
## PR Description
Implements a no-op database which does not store any chain data (the database directory is still created with db.version).

Useful for testing in isolation of RocksDB but also for local runs during development to avoid having to delete the data dir before each run.
Opt-in to using it with `--Xdata-storage-create-db-version=noop`

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.