### PR TITLE
Reduce default value for RocksDB max open files

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbConfiguration.java
@@ -41,7 +41,7 @@ import org.rocksdb.CompressionType;
 @SuppressWarnings("FieldMayBeFinal")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RocksDbConfiguration {
-  public static final int DEFAULT_MAX_OPEN_FILES = 1024;
+  public static final int DEFAULT_MAX_OPEN_FILES = 128;
   public static final int DEFAULT_MAX_BACKGROUND_JOBS = 6;
   public static final int DEFAULT_BACKGROUND_THREAD_COUNT = 6;
   public static final long DEFAULT_CACHE_CAPACITY = 8 << 20;


### PR DESCRIPTION
## PR Description
The default of 1024 max open files is pretty high given 1024 is the default limit for the entire process.  Also RocksDB tends to use more memory the more open files it has so targeting a lower number should reduce its memory overhead.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.