### PR TITLE
Load validator keys in parallel

### DIFF
--- a/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
@@ -79,9 +79,7 @@ public class StatusLogger {
   }
 
   public void loadingValidators(final int validatorCount) {
-    if (validatorCount > 100) {
-      log.info("Loading {} validator keys...", validatorCount);
-    }
+    log.info("Loading {} validator keys...", validatorCount);
   }
 
   public void validatorsInitialised(final List<String> validators) {

--- a/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
@@ -78,6 +78,12 @@ public class StatusLogger {
     log.error(message, file.toString(), cause);
   }
 
+  public void loadingValidators(final int validatorCount) {
+    if (validatorCount > 100) {
+      log.info("Loading {} validator keys...", validatorCount);
+    }
+  }
+
   public void validatorsInitialised(final List<String> validators) {
     if (validators.size() > 100) {
       log.info("Loaded {} validators", validators.size());

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/KeystoresValidatorKeyProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/KeystoresValidatorKeyProvider.java
@@ -33,6 +33,7 @@ import tech.pegasys.signers.bls.keystore.KeyStoreValidationException;
 import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSecretKey;
+import tech.pegasys.teku.logging.StatusLogger;
 import tech.pegasys.teku.util.config.TekuConfiguration;
 
 public class KeystoresValidatorKeyProvider implements ValidatorKeyProvider {
@@ -43,8 +44,10 @@ public class KeystoresValidatorKeyProvider implements ValidatorKeyProvider {
         config.getValidatorKeystorePasswordFilePairs();
     checkNotNull(keystorePasswordFilePairs, "validator keystore and password pairs cannot be null");
 
+    StatusLogger.STATUS_LOG.loadingValidators(keystorePasswordFilePairs.size());
     // return distinct loaded key pairs
     return keystorePasswordFilePairs.stream()
+        .parallel()
         .map(pair -> loadBLSPrivateKey(pair.getLeft(), loadPassword(pair.getRight())))
         .distinct()
         .map(privKey -> new BLSKeyPair(BLSSecretKey.fromBytes(privKey)))

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/KeystoresValidatorKeyProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/KeystoresValidatorKeyProviderTest.java
@@ -67,14 +67,12 @@ class KeystoresValidatorKeyProviderTest {
   void emptyPasswordFileThrowsError(@TempDir final Path tempDir) throws Exception {
     // load keystores from resources
     final Path scryptKeystore = Path.of(Resources.getResource("scryptTestVector.json").toURI());
-    final Path pbkdf2Keystore = Path.of(Resources.getResource("pbkdf2TestVector.json").toURI());
 
     // create password file
     final Path tempPasswordFile = createTempFile(tempDir, "pass", ".txt");
 
     final List<Pair<Path, Path>> keystorePasswordFilePairs =
-        List.of(
-            Pair.of(scryptKeystore, tempPasswordFile), Pair.of(pbkdf2Keystore, tempPasswordFile));
+        List.of(Pair.of(scryptKeystore, tempPasswordFile));
 
     when(config.getValidatorKeystorePasswordFilePairs()).thenReturn(keystorePasswordFilePairs);
 
@@ -87,15 +85,13 @@ class KeystoresValidatorKeyProviderTest {
   void invalidPasswordThrowsError(@TempDir final Path tempDir) throws Exception {
     // load keystores from resources
     final Path scryptKeystore = Path.of(Resources.getResource("scryptTestVector.json").toURI());
-    final Path pbkdf2Keystore = Path.of(Resources.getResource("pbkdf2TestVector.json").toURI());
 
     // create password file
     final Path tempPasswordFile = createTempFile(tempDir, "pass", ".txt");
     writeString(tempPasswordFile, "invalidpassword");
 
     final List<Pair<Path, Path>> keystorePasswordFilePairs =
-        List.of(
-            Pair.of(scryptKeystore, tempPasswordFile), Pair.of(pbkdf2Keystore, tempPasswordFile));
+        List.of(Pair.of(scryptKeystore, tempPasswordFile));
 
     when(config.getValidatorKeystorePasswordFilePairs()).thenReturn(keystorePasswordFilePairs);
 
@@ -108,14 +104,12 @@ class KeystoresValidatorKeyProviderTest {
   void nonExistentPasswordFileThrowsError(@TempDir final Path tempDir) throws Exception {
     // load keystores from resources
     final Path scryptKeystore = Path.of(Resources.getResource("scryptTestVector.json").toURI());
-    final Path pbkdf2Keystore = Path.of(Resources.getResource("pbkdf2TestVector.json").toURI());
 
     // create password file
     final Path tempPasswordFile = tempDir.resolve("nonexistent.txt");
 
     final List<Pair<Path, Path>> keystorePasswordFilePairs =
-        List.of(
-            Pair.of(scryptKeystore, tempPasswordFile), Pair.of(pbkdf2Keystore, tempPasswordFile));
+        List.of(Pair.of(scryptKeystore, tempPasswordFile));
 
     when(config.getValidatorKeystorePasswordFilePairs()).thenReturn(keystorePasswordFilePairs);
 
@@ -128,15 +122,13 @@ class KeystoresValidatorKeyProviderTest {
   void nonExistentKeystoreFileThrowsError(@TempDir final Path tempDir) throws IOException {
     // load keystores from resources
     final Path scryptKeystore = tempDir.resolve("scryptTestVector.json");
-    final Path pbkdf2Keystore = tempDir.resolve("pbkdf2TestVector.json");
 
     // create password file
     final Path tempPasswordFile = createTempFile(tempDir, "pass", ".txt");
     writeString(tempPasswordFile, EXPECTED_PASSWORD);
 
     final List<Pair<Path, Path>> keystorePasswordFilePairs =
-        List.of(
-            Pair.of(scryptKeystore, tempPasswordFile), Pair.of(pbkdf2Keystore, tempPasswordFile));
+        List.of(Pair.of(scryptKeystore, tempPasswordFile));
 
     when(config.getValidatorKeystorePasswordFilePairs()).thenReturn(keystorePasswordFilePairs);
 


### PR DESCRIPTION
## PR Description
Load validator keys in parallel.  Print a message to indicate keys are loading beforehand so it looks a bit less like we've stalled.

Loading 256 Keys:
```
                Normal: 517996 ms
              Parallel: 159851 ms
```

## Fixed Issue(s)
Easy parts of #2435  Suspect we do need to provide progress updates when there are a lot of keys.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.