### PR TITLE
teku-2451 Add metrics to the Remote Validator service

### DIFF
--- a/data/metrics/src/main/java/tech/pegasys/teku/metrics/TekuMetricCategory.java
+++ b/data/metrics/src/main/java/tech/pegasys/teku/metrics/TekuMetricCategory.java
@@ -25,6 +25,7 @@ public enum TekuMetricCategory implements MetricCategory {
   STORAGE("storage"),
   STORAGE_HOT_DB("storage_hot"),
   STORAGE_FINALIZED_DB("storage_finalized"),
+  REMOTE_VALIDATOR("remote_validator"),
   VALIDATOR("validator");
 
   private final String name;

--- a/services/remote-validator/build.gradle
+++ b/services/remote-validator/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+  implementation project(':data:metrics')
   implementation project(':data:provider')
   implementation project(':ethereum:statetransition')
   implementation project(':ethereum:datastructures')

--- a/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorMetrics.java
+++ b/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorMetrics.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.services.remotevalidator;
+
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.metrics.SettableGauge;
+import tech.pegasys.teku.metrics.TekuMetricCategory;
+
+public class RemoteValidatorMetrics {
+
+  private final SettableGauge connectedValidatorsGauge;
+
+  RemoteValidatorMetrics(final MetricsSystem metricsSystem) {
+    connectedValidatorsGauge =
+        SettableGauge.create(
+            metricsSystem,
+            TekuMetricCategory.REMOTE_VALIDATOR,
+            "connected_validators",
+            "Number of validators connected to the Remote Validator Service");
+  }
+
+  public void updateConnectedValidators(final int value) {
+    connectedValidatorsGauge.set(value);
+  }
+}

--- a/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorMetrics.java
+++ b/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorMetrics.java
@@ -26,8 +26,8 @@ public class RemoteValidatorMetrics {
         SettableGauge.create(
             metricsSystem,
             TekuMetricCategory.REMOTE_VALIDATOR,
-            "connected_validators",
-            "Number of validators connected to the Remote Validator Service");
+            "connected_validator_nodes",
+            "Number of validator nodes connected to the Remote Validator Service");
   }
 
   public void updateConnectedValidators(final int value) {

--- a/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorService.java
+++ b/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorService.java
@@ -24,7 +24,9 @@ public class RemoteValidatorService extends Service {
   private final RemoteValidatorBeaconChainEventsAdapter beaconChainEventsAdapter;
 
   public RemoteValidatorService(ServiceConfig serviceConfig) {
-    subscriptions = new RemoteValidatorSubscriptions(serviceConfig.getConfig());
+    final RemoteValidatorMetrics metrics =
+        new RemoteValidatorMetrics(serviceConfig.getMetricsSystem());
+    subscriptions = new RemoteValidatorSubscriptions(serviceConfig.getConfig(), metrics);
     api = new RemoteValidatorApi(serviceConfig.getConfig(), subscriptions);
     beaconChainEventsAdapter =
         new RemoteValidatorBeaconChainEventsAdapter(serviceConfig, subscriptions);

--- a/services/remote-validator/src/test/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorMetricsTest.java
+++ b/services/remote-validator/src/test/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorMetricsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.services.remotevalidator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import org.assertj.core.util.introspection.FieldSupport;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.metrics.SettableGauge;
+
+class RemoteValidatorMetricsTest {
+
+  private final MetricsSystem metricsSystem = mock(MetricsSystem.class);
+
+  private final RemoteValidatorMetrics metrics = new RemoteValidatorMetrics(metricsSystem);
+
+  @Test
+  public void newMetricsInstance_ShouldCreateConnectedValidatorGauge() {
+    // field is initialized during RemoteValidatorMetrics construction
+    final SettableGauge connectedValidatorsGauge = getConnectedValidatorsGauge();
+    assertThat(connectedValidatorsGauge).isNotNull();
+  }
+
+  @Test
+  public void updateConnectedValidators_ShouldSetCorrectGaugeValue() {
+    metrics.updateConnectedValidators(123);
+
+    assertThat(getConnectedValidatorsGaugeValue()).isEqualTo(123.0);
+  }
+
+  private SettableGauge getConnectedValidatorsGauge() {
+    return FieldSupport.EXTRACTION.fieldValue(
+        "connectedValidatorsGauge", SettableGauge.class, metrics);
+  }
+
+  private double getConnectedValidatorsGaugeValue() {
+    return FieldSupport.EXTRACTION
+        .fieldValue("valueHolder", AtomicDouble.class, getConnectedValidatorsGauge())
+        .get();
+  }
+}


### PR DESCRIPTION
## PR Description
• Adding metric with the number of connected validator nodes to the Remove Validator service

## Fixed Issue(s)
fixes #2451 

## Documentation
- N/A work is in progress