### PR TITLE
[Issue 2291] Migrate attestation processing to use async checkpoint state retrieval

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -340,7 +340,7 @@ public class ForkChoiceUtil {
    *
    * @param store
    * @param validateableAttestation
-   * @param stateTransition
+   * @param maybeTargetState The state corresponding to the attestation target
    * @see
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.1/specs/core/0_fork-choice.md#on_attestation</a>
    */
@@ -348,14 +348,13 @@ public class ForkChoiceUtil {
   public static AttestationProcessingResult on_attestation(
       final MutableStore store,
       final ValidateableAttestation validateableAttestation,
-      final StateTransition stateTransition,
+      final Optional<BeaconState> maybeTargetState,
       final ForkChoiceStrategy forkChoiceStrategy) {
 
     Attestation attestation = validateableAttestation.getAttestation();
-    Checkpoint target = attestation.getData().getTarget();
 
     return validateOnAttestation(store, attestation, forkChoiceStrategy)
-        .ifSuccessful(() -> indexAndValidateAttestation(store, validateableAttestation, target))
+        .ifSuccessful(() -> indexAndValidateAttestation(validateableAttestation, maybeTargetState))
         .ifSuccessful(() -> checkIfAttestationShouldBeSavedForFuture(store, attestation))
         .ifSuccessful(
             () -> {
@@ -369,16 +368,14 @@ public class ForkChoiceUtil {
   /**
    * Returns the indexed attestation if attestation is valid, else, returns an empty optional.
    *
-   * @param store
    * @param attestation
-   * @param target
+   * @param maybeTargetState The state corresponding to the attestation target, if it is available
    * @return
    */
   private static AttestationProcessingResult indexAndValidateAttestation(
-      ReadOnlyStore store, ValidateableAttestation attestation, Checkpoint target) {
+      ValidateableAttestation attestation, Optional<BeaconState> maybeTargetState) {
     BeaconState targetState;
     try {
-      Optional<BeaconState> maybeTargetState = store.getCheckpointState(target);
       if (maybeTargetState.isEmpty()) {
         return AttestationProcessingResult.UNKNOWN_BLOCK;
       }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/ForkChoiceAttestationProcessor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/ForkChoiceAttestationProcessor.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.statetransition.attestation;
 import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.datastructures.operations.IndexedAttestation;
 import tech.pegasys.teku.datastructures.util.AttestationProcessingResult;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
@@ -31,13 +32,9 @@ public class ForkChoiceAttestationProcessor {
     this.forkChoice = forkChoice;
   }
 
-  public AttestationProcessingResult processAttestation(final ValidateableAttestation attestation) {
-    final StoreTransaction transaction = recentChainData.startStoreTransaction();
-    final AttestationProcessingResult result = forkChoice.onAttestation(transaction, attestation);
-    if (result.isSuccessful()) {
-      transaction.commit(() -> {}, "Failed to persist attestation result");
-    }
-    return result;
+  public SafeFuture<AttestationProcessingResult> processAttestation(
+      final ValidateableAttestation attestation) {
+    return forkChoice.onAttestation(attestation);
   }
 
   public void applyIndexedAttestationToForkChoice(final IndexedAttestation attestation) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.datastructures.util.AttestationProcessingResult.SAVED_FOR_FUTURE;
 import static tech.pegasys.teku.datastructures.util.AttestationProcessingResult.SUCCESSFUL;
 import static tech.pegasys.teku.datastructures.util.AttestationProcessingResult.UNKNOWN_BLOCK;
+import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.primitives.UnsignedLong;
@@ -79,8 +80,8 @@ class AttestationManagerTest {
   public void shouldProcessAttestationsThatAreReadyImmediately() {
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromAttestation(dataStructureUtil.randomAttestation());
-    when(attestationProcessor.processAttestation(any())).thenReturn(SUCCESSFUL);
-    attestationManager.onAttestation(attestation);
+    when(attestationProcessor.processAttestation(any())).thenReturn(completedFuture(SUCCESSFUL));
+    attestationManager.onAttestation(attestation).reportExceptions();
 
     verifyAttestationProcessed(attestation);
     verify(attestationPool).add(attestation);
@@ -93,8 +94,8 @@ class AttestationManagerTest {
     final ValidateableAttestation aggregate =
         ValidateableAttestation.fromSignedAggregate(
             dataStructureUtil.randomSignedAggregateAndProof());
-    when(attestationProcessor.processAttestation(any())).thenReturn(SUCCESSFUL);
-    attestationManager.onAttestation(aggregate);
+    when(attestationProcessor.processAttestation(any())).thenReturn(completedFuture(SUCCESSFUL));
+    attestationManager.onAttestation(aggregate).reportExceptions();
 
     verifyAttestationProcessed(aggregate);
     verify(attestationPool).add(aggregate);
@@ -107,8 +108,9 @@ class AttestationManagerTest {
     ValidateableAttestation attestation =
         ValidateableAttestation.fromAttestation(attestationFromSlot(100));
     IndexedAttestation randomIndexedAttestation = dataStructureUtil.randomIndexedAttestation();
-    when(attestationProcessor.processAttestation(any())).thenReturn(SAVED_FOR_FUTURE);
-    attestationManager.onAttestation(attestation);
+    when(attestationProcessor.processAttestation(any()))
+        .thenReturn(completedFuture(SAVED_FOR_FUTURE));
+    attestationManager.onAttestation(attestation).reportExceptions();
 
     ArgumentCaptor<ValidateableAttestation> captor =
         ArgumentCaptor.forClass(ValidateableAttestation.class);
@@ -136,9 +138,9 @@ class AttestationManagerTest {
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromAttestation(attestationFromSlot(1, requiredBlockRoot));
     when(attestationProcessor.processAttestation(any()))
-        .thenReturn(UNKNOWN_BLOCK)
-        .thenReturn(SUCCESSFUL);
-    attestationManager.onAttestation(attestation);
+        .thenReturn(completedFuture(UNKNOWN_BLOCK))
+        .thenReturn(completedFuture(SUCCESSFUL));
+    attestationManager.onAttestation(attestation).reportExceptions();
 
     ArgumentCaptor<ValidateableAttestation> captor =
         ArgumentCaptor.forClass(ValidateableAttestation.class);
@@ -167,8 +169,8 @@ class AttestationManagerTest {
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromAttestation(dataStructureUtil.randomAttestation());
     when(attestationProcessor.processAttestation(any()))
-        .thenReturn(AttestationProcessingResult.invalid("Didn't like it"));
-    attestationManager.onAttestation(attestation);
+        .thenReturn(completedFuture(AttestationProcessingResult.invalid("Didn't like it")));
+    attestationManager.onAttestation(attestation).reportExceptions();
 
     verifyAttestationProcessed(attestation);
     assertThat(pendingAttestations.size()).isZero();
@@ -182,8 +184,8 @@ class AttestationManagerTest {
         ValidateableAttestation.fromSignedAggregate(
             dataStructureUtil.randomSignedAggregateAndProof());
     when(attestationProcessor.processAttestation(any()))
-        .thenReturn(AttestationProcessingResult.invalid("Don't wanna"));
-    attestationManager.onAttestation(aggregateAndProof);
+        .thenReturn(completedFuture(AttestationProcessingResult.invalid("Don't wanna")));
+    attestationManager.onAttestation(aggregateAndProof).reportExceptions();
 
     verifyAttestationProcessed(aggregateAndProof);
     assertThat(pendingAttestations.size()).isZero();

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -252,6 +252,17 @@ public class SafeFuture<T> extends CompletableFuture<T> {
         .reportExceptions();
   }
 
+  public void finish(final Consumer<Throwable> onError) {
+    handle(
+            (result, error) -> {
+              if (error != null) {
+                onError.accept(error);
+              }
+              return null;
+            })
+        .reportExceptions();
+  }
+
   /**
    * Returns a new CompletionStage that, when the provided stage completes exceptionally, is
    * executed with the provided stage's exception as the argument to the supplied function.

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -400,8 +400,12 @@ public class BeaconChainController extends Service implements TimeTickChannel {
                   attestation ->
                       attestationManager
                           .onAttestation(attestation)
-                          .ifInvalid(
-                              reason -> LOG.debug("Rejected gossiped attestation: " + reason)))
+                          .finish(
+                              result ->
+                                  result.ifInvalid(
+                                      reason ->
+                                          LOG.debug("Rejected gossiped attestation: " + reason)),
+                              err -> LOG.error("Failed to process gossiped attestation.", err)))
               .gossipedAttesterSlashingConsumer(attesterSlashingPool::add)
               .gossipedProposerSlashingConsumer(proposerSlashingPool::add)
               .gossipedVoluntaryExitConsumer(voluntaryExitPool::add)

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -395,6 +395,14 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     forkChoiceStrategy.ifPresent(strategy -> strategy.maybePrune(finalizedCheckpoint.getRoot()));
   }
 
+  public SafeFuture<Optional<BeaconState>> retrieveCheckpointState(final Checkpoint checkpoint) {
+    if (store == null) {
+      return EmptyStoreResults.EMPTY_STATE_FUTURE;
+    }
+
+    return store.retrieveCheckpointState(checkpoint);
+  }
+
   private static class SignedBlockAndStateAndSlot extends SignedBlockAndState {
     private final UnsignedLong headSlot;
 

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -355,7 +355,7 @@ class ValidatorApiHandlerTest {
   @Test
   public void sendSignedAttestation_shouldAddAttestationToAggregatorAndEventBus() {
     final Attestation attestation = dataStructureUtil.randomAttestation();
-    when(attestationManager.onAttestation(any())).thenReturn(SUCCESSFUL);
+    when(attestationManager.onAttestation(any())).thenReturn(completedFuture(SUCCESSFUL));
     validatorApiHandler.sendSignedAttestation(attestation);
 
     verify(attestationManager).onAttestation(ValidateableAttestation.fromAttestation(attestation));
@@ -373,7 +373,7 @@ class ValidatorApiHandlerTest {
   public void sendAggregateAndProof_shouldPostAggregateAndProof() {
     final SignedAggregateAndProof aggregateAndProof =
         dataStructureUtil.randomSignedAggregateAndProof();
-    when(attestationManager.onAttestation(any())).thenReturn(SUCCESSFUL);
+    when(attestationManager.onAttestation(any())).thenReturn(completedFuture(SUCCESSFUL));
     validatorApiHandler.sendAggregateAndProof(aggregateAndProof);
 
     verify(attestationManager)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Update attestation processing logic to use new async checkpoint state retrieval method.

## Fixed Issue(s)
Part of #2291 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.