### PR TITLE
Removing :data:serializer dependency on :sync module

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/node/GetSyncing.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/node/GetSyncing.java
@@ -26,7 +26,7 @@ import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
 import tech.pegasys.teku.api.SyncDataProvider;
-import tech.pegasys.teku.api.schema.SyncingResponse;
+import tech.pegasys.teku.api.schema.SyncingStatus;
 import tech.pegasys.teku.provider.JsonProvider;
 
 public class GetSyncing implements Handler {
@@ -49,12 +49,13 @@ public class GetSyncing implements Handler {
       description =
           "Returns an object with data about the synchronization status, or false if not synchronizing.",
       responses = {
-        @OpenApiResponse(status = RES_OK, content = @OpenApiContent(from = SyncingResponse.class)),
+        @OpenApiResponse(status = RES_OK, content = @OpenApiContent(from = SyncingStatus.class)),
         @OpenApiResponse(status = RES_INTERNAL_ERROR)
       })
   @Override
   public void handle(Context ctx) throws Exception {
     ctx.header(CACHE_CONTROL, CACHE_NONE);
-    ctx.result(jsonProvider.objectToJSON(new SyncingResponse(syncDataProvider.getSyncStatus())));
+    final SyncingStatus syncingStatus = syncDataProvider.getSyncStatus();
+    ctx.result(jsonProvider.objectToJSON(syncingStatus));
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/validator/PostBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/validator/PostBlock.java
@@ -84,7 +84,7 @@ public class PostBlock implements Handler {
   @Override
   public void handle(final Context ctx) throws Exception {
     try {
-      if (syncDataProvider.getSyncStatus().isSyncing()) {
+      if (syncDataProvider.getSyncStatus().is_syncing) {
         ctx.status(SC_SERVICE_UNAVAILABLE);
         return;
       }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/node/GetSyncingTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/node/GetSyncingTest.java
@@ -23,13 +23,13 @@ import io.javalin.core.util.Header;
 import io.javalin.http.Context;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.SyncDataProvider;
-import tech.pegasys.teku.api.schema.SyncingResponse;
+import tech.pegasys.teku.api.schema.SyncStatus;
+import tech.pegasys.teku.api.schema.SyncingStatus;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.sync.SyncService;
-import tech.pegasys.teku.sync.SyncStatus;
-import tech.pegasys.teku.sync.SyncingStatus;
 
 public class GetSyncingTest {
+
   private Context context = mock(Context.class);
   private final JsonProvider jsonProvider = new JsonProvider();
   private final SyncService syncService = mock(SyncService.class);
@@ -41,10 +41,12 @@ public class GetSyncingTest {
     final UnsignedLong startSlot = UnsignedLong.ONE;
     final UnsignedLong currentSlot = UnsignedLong.valueOf(5);
     final UnsignedLong highestSlot = UnsignedLong.valueOf(10);
-    final SyncingStatus syncingStatus =
-        new SyncingStatus(isSyncing, new SyncStatus(startSlot, currentSlot, highestSlot));
+    final tech.pegasys.teku.sync.SyncingStatus syncingStatus =
+        new tech.pegasys.teku.sync.SyncingStatus(
+            isSyncing, new tech.pegasys.teku.sync.SyncStatus(startSlot, currentSlot, highestSlot));
     final GetSyncing handler = new GetSyncing(syncDataProvider, jsonProvider);
-    final SyncingResponse expectedResponse = new SyncingResponse(syncingStatus);
+    final SyncingStatus expectedResponse =
+        new SyncingStatus(true, new SyncStatus(startSlot, currentSlot, highestSlot));
 
     when(syncService.getSyncStatus()).thenReturn(syncingStatus);
     handler.handle(context);
@@ -55,8 +57,10 @@ public class GetSyncingTest {
   @Test
   public void shouldReturnFalseWhenNotSyncing() throws Exception {
     final boolean isSyncing = false;
-    final SyncingStatus syncingStatus = new SyncingStatus(isSyncing, null);
-    final SyncingResponse expectedResponse = new SyncingResponse(syncingStatus);
+    final tech.pegasys.teku.sync.SyncingStatus syncingStatus =
+        new tech.pegasys.teku.sync.SyncingStatus(isSyncing, null);
+    final SyncingStatus expectedResponse =
+        new SyncingStatus(false, new SyncStatus(null, null, null));
     final GetSyncing handler = new GetSyncing(syncDataProvider, jsonProvider);
 
     when(syncService.getSyncStatus()).thenReturn(syncingStatus);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/validator/PostBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/validator/PostBlockTest.java
@@ -31,12 +31,12 @@ import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
 import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
+import tech.pegasys.teku.api.schema.SyncStatus;
+import tech.pegasys.teku.api.schema.SyncingStatus;
 import tech.pegasys.teku.api.schema.ValidatorBlockResult;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.provider.JsonProvider;
-import tech.pegasys.teku.sync.SyncStatus;
-import tech.pegasys.teku.sync.SyncingStatus;
 
 class PostBlockTest {
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/SyncDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/SyncDataProvider.java
@@ -13,10 +13,12 @@
 
 package tech.pegasys.teku.api;
 
+import tech.pegasys.teku.api.schema.SyncStatus;
+import tech.pegasys.teku.api.schema.SyncingStatus;
 import tech.pegasys.teku.sync.SyncService;
-import tech.pegasys.teku.sync.SyncingStatus;
 
 public class SyncDataProvider {
+
   private final SyncService syncService;
 
   public SyncDataProvider(SyncService syncService) {
@@ -30,7 +32,21 @@ public class SyncDataProvider {
    *     slot, current slot and highest slot.
    */
   public SyncingStatus getSyncStatus() {
-    return syncService.getSyncStatus();
+    final tech.pegasys.teku.sync.SyncingStatus syncingStatus = syncService.getSyncStatus();
+    final tech.pegasys.teku.sync.SyncStatus syncStatus = syncingStatus.getSyncStatus();
+
+    final SyncStatus schemaSyncStatus;
+    if (syncStatus != null) {
+      schemaSyncStatus =
+          new SyncStatus(
+              syncStatus.getStartingSlot(),
+              syncStatus.getCurrentSlot(),
+              syncStatus.getHighestSlot());
+    } else {
+      schemaSyncStatus = new SyncStatus(null, null, null);
+    }
+
+    return new SyncingStatus(syncingStatus.isSyncing(), schemaSyncStatus);
   }
 
   SyncService getSyncService() {

--- a/data/serializer/build.gradle
+++ b/data/serializer/build.gradle
@@ -4,7 +4,6 @@ dependencies {
 
   implementation project(':bls')
   implementation project(':ethereum:datastructures')
-  implementation project(':sync')
 
   testImplementation testFixtures(project(':ethereum:datastructures'))
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SyncStatus.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SyncStatus.java
@@ -34,16 +34,4 @@ public class SyncStatus {
     this.currentSlot = currentSlot;
     this.highestSlot = highestSlot;
   }
-
-  public SyncStatus(final tech.pegasys.teku.sync.SyncStatus syncStatus) {
-    if (syncStatus != null) {
-      this.startingSlot = syncStatus.getStartingSlot();
-      this.currentSlot = syncStatus.getCurrentSlot();
-      this.highestSlot = syncStatus.getHighestSlot();
-    } else {
-      startingSlot = null;
-      currentSlot = null;
-      highestSlot = null;
-    }
-  }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SyncingStatus.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SyncingStatus.java
@@ -16,20 +16,14 @@ package tech.pegasys.teku.api.schema;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import tech.pegasys.teku.sync.SyncingStatus;
 
 @JsonInclude(NON_NULL)
-public class SyncingResponse {
+public class SyncingStatus {
   public final boolean is_syncing;
   public final SyncStatus sync_status;
 
-  public SyncingResponse(final boolean syncing, final SyncStatus sync_status) {
+  public SyncingStatus(final boolean syncing, final SyncStatus sync_status) {
     this.is_syncing = syncing;
     this.sync_status = sync_status;
-  }
-
-  public SyncingResponse(final SyncingStatus syncStatus) {
-    this.is_syncing = syncStatus.isSyncing();
-    this.sync_status = new SyncStatus(syncStatus.getSyncStatus());
   }
 }


### PR DESCRIPTION
## PR Description

- Renamed `SyncingResponse` to `SyncingStatus` to follow other `schema` classes naming convention
- Changed the type of object returned by SyncDataProvider to a `schema` type

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.