### PR TITLE
Update Gossip params to spec v0.12.2

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/GossipConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/GossipConfig.java
@@ -21,13 +21,13 @@ import java.time.Duration;
  */
 public class GossipConfig {
   public static final int DEFAULT_D = 6;
-  public static final int DEFAULT_D_LOW = 4;
+  public static final int DEFAULT_D_LOW = 5;
   public static final int DEFAULT_D_HIGH = 12;
   public static final int DEFAULT_D_LAZY = 6;
   public static final Duration DEFAULT_FANOUT_TTL = Duration.ofSeconds(60);
   public static final int DEFAULT_ADVERTISE = 3;
-  public static final int DEFAULT_HISTORY = 5;
-  public static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofSeconds(1);
+  public static final int DEFAULT_HISTORY = 6;
+  public static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(700);
 
   public static final GossipConfig DEFAULT_CONFIG =
       new GossipConfig(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Adjust Gossip params values according to spec v0.12.2: https://github.com/ethereum/eth2.0-specs/pull/1958
- Rename  `GossipConfig` members to match the spec names 

The `seen_ttl` param is currently not applicable to jvm-libp2p. Created an issue on this: https://github.com/libp2p/jvm-libp2p/issues/130

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.