### PR TITLE
Medalla fixes

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -30,7 +30,7 @@ dependencyManagement {
     dependency 'io.protostuff:protostuff-core:1.6.2'
     dependency 'io.protostuff:protostuff-runtime:1.6.2'
 
-    dependency 'io.libp2p:jvm-libp2p-minimal:0.5.3-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p-minimal:0.5.4-RELEASE'
     dependency 'tech.pegasys:jblst:0.1.0-RELEASE'
 
     dependency 'org.jetbrains.kotlin:kotlin-stdlib:1.3.72'

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/LengthPrefixedEncoding.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/LengthPrefixedEncoding.java
@@ -54,6 +54,9 @@ public class LengthPrefixedEncoding implements RpcEncoding {
   @Override
   @SuppressWarnings("unchecked")
   public <T> Bytes encodePayload(final T message) {
+    if (message instanceof EmptyMessage) {
+      return Bytes.EMPTY;
+    }
     final RpcPayloadEncoder<T> payloadEncoder =
         payloadEncoders.getEncoder((Class<T>) message.getClass());
     final Bytes payload = payloadEncoder.encode(message);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/LengthPrefixedEncodingTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/LengthPrefixedEncodingTest.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.util.config.Constants.MAX_CHUNK_SIZE;
 
 import com.google.common.primitives.UnsignedLong;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +28,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
+import tech.pegasys.teku.datastructures.networking.libp2p.rpc.EmptyMessage;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.teku.networking.eth2.rpc.Utils;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
@@ -246,6 +248,20 @@ class LengthPrefixedEncodingTest {
         encoding.encodePayload(new BeaconBlocksByRootRequestMessage(singletonList(Bytes32.ZERO)));
     // Just the length prefix and the hash itself.
     assertThat(encoded).isEqualTo(Bytes.wrap(Bytes.fromHexString("0x20"), Bytes32.ZERO));
+  }
+
+  @Test
+  void encodePayload_shouldReturnZeroBytesForEmptyMessages() {
+    final Bytes result = encoding.encodePayload(new EmptyMessage());
+    assertThat(result).isEqualTo(Bytes.EMPTY);
+  }
+
+  @Test
+  void shouldDecodeEmptyMessage() throws Exception {
+    final RpcByteBufDecoder<EmptyMessage> decoder = encoding.createDecoder(EmptyMessage.class);
+    final Optional<EmptyMessage> message =
+        decoder.decodeOneMessage(Unpooled.wrappedBuffer(new byte[0]));
+    assertThat(message).contains(EmptyMessage.EMPTY_MESSAGE);
   }
 
   @Test

--- a/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
@@ -69,6 +69,7 @@ public class NetworkDefinition {
               builder()
                   .constants("medalla")
                   .snappyCompressionEnabled(true)
+                  .initialStateFromClasspath("medalla-genesis.ssz")
                   .startupTimeoutSeconds(120)
                   .eth1DepositContractAddress("0x07b39F4fDE4A38bACe212b546dAc87C58DfE3fDC")
                   .discoveryBootnodes(

--- a/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
@@ -73,7 +73,7 @@ public class NetworkDefinition {
                   .eth1DepositContractAddress("0x07b39F4fDE4A38bACe212b546dAc87C58DfE3fDC")
                   .discoveryBootnodes(
                       // PegaSys Teku
-                      "enr:-KG4QIOJRu0BBlcXJcn3lI34Ub1aBLYipbnDaxBnr2uf2q6nE1TWnKY5OAajg3eG6mHheQSfRhXLuy-a8V5rqXKSoUEChGV0aDKQGK5MywAAAAH__________4JpZIJ2NIJpcIQKAAFhiXNlY3AyNTZrMaEDESplmV9c2k73v0DjxVXJ6__2bWyP-tK28_80lf7dUhqDdGNwgiMog3VkcIIjKA",
+                      "enr:-KG4QFuKQ9eeXDTf8J4tBxFvs3QeMrr72mvS7qJgL9ieO6k9Rq5QuGqtGK4VlXMNHfe34Khhw427r7peSoIbGcN91fUDhGV0aDKQD8XYjwAAAAH__________4JpZIJ2NIJpcIQDhMExiXNlY3AyNTZrMaEDESplmV9c2k73v0DjxVXJ6__2bWyP-tK28_80lf7dUhqDdGNwgiMog3VkcIIjKA",
 
                       // Sigp Lighthouse
                       "enr:-LK4QKWk9yZo258PQouLshTOEEGWVHH7GhKwpYmB5tmKE4eHeSfman0PZvM2Rpp54RWgoOagAsOfKoXgZSbiCYzERWABh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAAAAAAAAAAAAAAAAAAAAAAgmlkgnY0gmlwhDQlA5CJc2VjcDI1NmsxoQOYiWqrQtQksTEtS3qY6idxJE5wkm0t9wKqpzv2gCR21oN0Y3CCIyiDdWRwgiMo",
@@ -82,7 +82,10 @@ public class NetworkDefinition {
                       // Prysmatic
                       "enr:-Ku4QLglCMIYAgHd51uFUqejD9DWGovHOseHQy7Od1SeZnHnQ3fSpE4_nbfVs8lsy8uF07ae7IgrOOUFU0NFvZp5D4wBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAYrkzLAAAAAf__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQJxCnE6v_x2ekgY_uoE1rtwzvGy40mq9eD66XfHPBWgIIN1ZHCCD6A",
                       "enr:-Ku4QOzU2MY51tYFcoByfULugCu2mepfqAbB0DajbRzg8xlILLfi5Iv_Wx-ARn8SiFoZZb3yp2x05cnUDYSoDYZupjIBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAYrkzLAAAAAf__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQLEq16KLm1vPjUKYGkHq296D60i7y209NYPUpwZPXDVgYN1ZHCCD6A",
-                      "enr:-Ku4QOYFmi2BW_YPDew_CKdfMvsrcRY1ARA-ImtcqFl-lgoxOFbxte4PU44-1M3uRNSRM-6rVa8USGohmWwtgwalEt8Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAYrkzLAAAAAf__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQKH3lxnglLqrA7L6sl5r7XFnckr3XCnlZMaBTYSdE8SHIN1ZHCCD6A")
+                      "enr:-Ku4QOYFmi2BW_YPDew_CKdfMvsrcRY1ARA-ImtcqFl-lgoxOFbxte4PU44-1M3uRNSRM-6rVa8USGohmWwtgwalEt8Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAYrkzLAAAAAf__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQKH3lxnglLqrA7L6sl5r7XFnckr3XCnlZMaBTYSdE8SHIN1ZHCCD6A",
+
+                      // Proto
+                      "enr:-Ku4QFVactU18ogiqPPasKs3jhUm5ISszUrUMK2c6SUPbGtANXVJ2wFapsKwVEVnVKxZ7Gsr9yEc4PYF-a14ahPa1q0Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAYrkzLAAAAAf__________gmlkgnY0gmlwhGQbAHyJc2VjcDI1NmsxoQILF-Ya2i5yowVkQtlnZLjG0kqC4qtwmSk8ha7tKLuME4N1ZHCCIyg")
                   .build())
           .build();
 


### PR DESCRIPTION
## PR Description
Add fixed bootnodes for Medalla.
Upgrade jvm-libp2p to 0.5.4-RELEASE which has a number of fix, most importantly for the Jonny attack and not requiring the seqno field.

## Documentation

- [ ] I thought about documentation and added the `documentation` label to this PR if updates are required.