### PR TITLE
Handle ClosedChannelException so it doesn't log as an error

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/ResponseCallback.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/ResponseCallback.java
@@ -18,9 +18,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 public interface ResponseCallback<T> {
   SafeFuture<Void> respond(T data);
 
-  default void respondAndCompleteSuccessfully(T data) {
-    respond(data).thenRun(this::completeSuccessfully).reportExceptions();
-  }
+  void respondAndCompleteSuccessfully(T data);
 
   void completeSuccessfully();
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallback.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallback.java
@@ -13,8 +13,10 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.core;
 
+import java.nio.channels.ClosedChannelException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.async.RootCauseExceptionHandler;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.ServerErrorException;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
@@ -34,6 +36,18 @@ class RpcResponseCallback<TResponse> implements ResponseCallback<TResponse> {
   @Override
   public SafeFuture<Void> respond(final TResponse data) {
     return rpcStream.writeBytes(rpcEncoder.encodeSuccessfulResponse(data));
+  }
+
+  @Override
+  public void respondAndCompleteSuccessfully(TResponse data) {
+    respond(data)
+        .thenRun(this::completeSuccessfully)
+        .finish(
+            RootCauseExceptionHandler.builder()
+                .addCatch(
+                    ClosedChannelException.class,
+                    err -> LOG.trace("Failed to write because channel was closed", err))
+                .defaultCatch(err -> LOG.error("Failed to write req/resp response", err)));
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Instead of using `reportExceptions()`, handle them manually in `RpcResponseCallback` so that we can report closed connection exceptions at trace level and provide a more specific message for other errors when we fail to write the response.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.