### PR TITLE
Include peer count in time until genesis message

### DIFF
--- a/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
@@ -117,10 +117,11 @@ public class StatusLogger {
         () -> size);
   }
 
-  public void timeUntilGenesis(final long timeToGenesis) {
+  public void timeUntilGenesis(final long timeToGenesis, final int peerCount) {
     log.info(
-        "{} until genesis time is reached",
-        () -> DurationFormatUtils.formatDurationWords(timeToGenesis * 1000, true, true));
+        "{} until genesis time is reached. Peers: {}",
+        () -> DurationFormatUtils.formatDurationWords(timeToGenesis * 1000, true, true),
+        () -> peerCount);
   }
 
   public void loadingGenesisFile(final String genesisFile) {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -524,7 +524,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     } else {
       UnsignedLong timeUntilGenesis = genesisTime.minus(currentTime);
       genesisTimeTracker = currentTime;
-      STATUS_LOG.timeUntilGenesis(timeUntilGenesis.longValue());
+      STATUS_LOG.timeUntilGenesis(timeUntilGenesis.longValue(), p2pNetwork.getPeerCount());
     }
     slotProcessor.setCurrentSlot(currentSlot);
   }
@@ -544,7 +544,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
       // notify every 10 minutes
       if (genesisTimeTracker.plus(UnsignedLong.valueOf(600L)).compareTo(currentTime) <= 0) {
         genesisTimeTracker = currentTime;
-        STATUS_LOG.timeUntilGenesis(genesisTime.minus(currentTime).longValue());
+        STATUS_LOG.timeUntilGenesis(
+            genesisTime.minus(currentTime).longValue(), p2pNetwork.getPeerCount());
       }
     }
 


### PR DESCRIPTION
## PR Description
So that users know they have successfully connected to the network pre-genesis, include the current peer count in the time until genesis message.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.