### PR TITLE
Limit the number of requests allowed per client per minute.

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
@@ -75,6 +75,7 @@ public class Eth2NetworkBuilder {
   private int eth2RpcOutstandingPingThreshold = DEFAULT_ETH2_RPC_OUTSTANDING_PING_THRESHOLD;
   private Duration eth2StatusUpdateInterval = DEFAULT_ETH2_STATUS_UPDATE_INTERVAL;
   private int peerRateLimit = 500;
+  private int peerRequestLimit = 50;
 
   private Eth2NetworkBuilder() {}
 
@@ -101,7 +102,8 @@ public class Eth2NetworkBuilder {
             eth2RpcOutstandingPingThreshold,
             eth2StatusUpdateInterval,
             timeProvider,
-            peerRateLimit);
+            peerRateLimit,
+            peerRequestLimit);
     final Collection<RpcMethod> eth2RpcMethods = eth2PeerManager.getBeaconChainMethods().all();
     rpcMethods.addAll(eth2RpcMethods);
     peerHandlers.add(eth2PeerManager);
@@ -172,6 +174,11 @@ public class Eth2NetworkBuilder {
 
   public Eth2NetworkBuilder peerRateLimit(final int peerRateLimit) {
     this.peerRateLimit = peerRateLimit;
+    return this;
+  }
+
+  public Eth2NetworkBuilder peerRequestLimit(final int peerRequestLimit) {
+    this.peerRequestLimit = peerRequestLimit;
     return this;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
@@ -25,16 +25,19 @@ public class Eth2PeerFactory {
   private final MetadataMessagesFactory metadataMessagesFactory;
   private final TimeProvider timeProvider;
   private final int peerRateLimit;
+  private final int peerRequestLimit;
 
   public Eth2PeerFactory(
       final StatusMessageFactory statusMessageFactory,
       final MetadataMessagesFactory metadataMessagesFactory,
       final TimeProvider timeProvider,
-      final int peerRateLimit) {
+      final int peerRateLimit,
+      final int peerRequestLimit) {
     this.timeProvider = timeProvider;
     this.statusMessageFactory = statusMessageFactory;
     this.metadataMessagesFactory = metadataMessagesFactory;
     this.peerRateLimit = peerRateLimit;
+    this.peerRequestLimit = peerRequestLimit;
   }
 
   public Eth2Peer create(final Peer peer, final BeaconChainMethods rpcMethods) {
@@ -44,6 +47,7 @@ public class Eth2PeerFactory {
         statusMessageFactory,
         metadataMessagesFactory,
         timeProvider,
-        peerRateLimit);
+        peerRateLimit,
+        peerRequestLimit);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -107,7 +107,8 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
       final int eth2RpcOutstandingPingThreshold,
       final Duration eth2StatusUpdateInterval,
       final TimeProvider timeProvider,
-      final int peerRateLimit) {
+      final int peerRateLimit,
+      final int peerRequestLimit) {
 
     final PeerValidatorFactory peerValidatorFactory =
         (peer, status) ->
@@ -122,7 +123,11 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
         recentChainData,
         metricsSystem,
         new Eth2PeerFactory(
-            statusMessageFactory, metadataMessagesFactory, timeProvider, peerRateLimit),
+            statusMessageFactory,
+            metadataMessagesFactory,
+            timeProvider,
+            peerRateLimit,
+            peerRequestLimit),
         peerValidatorFactory,
         statusMessageFactory,
         metadataMessagesFactory,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -73,7 +73,9 @@ public class BeaconBlocksByRangeMessageHandler
               "Only a maximum of " + MAX_REQUEST_BLOCKS + " blocks can be requested per request"));
       return;
     }
-    if (!peer.wantToReceiveObjects(callback, min(maxRequestSize, message.getCount()).longValue())) {
+    if (!peer.wantToMakeRequest()
+        || !peer.wantToReceiveObjects(
+            callback, min(maxRequestSize, message.getCount()).longValue())) {
       return;
     }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
@@ -43,7 +43,8 @@ public class BeaconBlocksByRootMessageHandler
         "Peer {} requested BeaconBlocks with roots: {}", peer.getId(), message.getBlockRoots());
     if (storageClient.getStore() != null) {
       SafeFuture<Void> future = SafeFuture.COMPLETE;
-      if (!peer.wantToReceiveObjects(callback, message.getBlockRoots().size())) {
+      if (!peer.wantToMakeRequest()
+          || !peer.wantToReceiveObjects(callback, message.getBlockRoots().size())) {
         peer.disconnectCleanly(DisconnectReason.RATE_LIMITING);
         return;
       }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/MetadataMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/MetadataMessageHandler.java
@@ -30,6 +30,9 @@ public class MetadataMessageHandler
   @Override
   public void onIncomingMessage(
       Eth2Peer peer, EmptyMessage message, ResponseCallback<MetadataMessage> callback) {
+    if (!peer.wantToMakeRequest()) {
+      return;
+    }
     callback.respondAndCompleteSuccessfully(metadataMessagesFactory.createMetadataMessage());
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/PingMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/PingMessageHandler.java
@@ -34,6 +34,9 @@ public class PingMessageHandler extends PeerRequiredLocalMessageHandler<PingMess
       final PingMessage message,
       final ResponseCallback<PingMessage> callback) {
     LOG.trace("Peer {} sent ping.", peer.getId());
+    if (!peer.wantToMakeRequest()) {
+      return;
+    }
     peer.updateMetadataSeqNumber(message.getSeqNumber());
     callback.respondAndCompleteSuccessfully(metadataMessagesFactory.createPingMessage());
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageHandler.java
@@ -43,6 +43,9 @@ public class StatusMessageHandler
       final StatusMessage message,
       final ResponseCallback<StatusMessage> callback) {
     LOG.trace("Peer {} sent status {}", peer.getId(), message);
+    if (!peer.wantToMakeRequest()) {
+      return;
+    }
     final PeerStatus status = PeerStatus.fromStatusMessage(message);
     peer.updateStatus(status);
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -33,6 +33,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
@@ -63,6 +64,12 @@ class BeaconBlocksByRangeMessageHandlerTest {
 
   private final BeaconBlocksByRangeMessageHandler handler =
       new BeaconBlocksByRangeMessageHandler(combinedChainDataClient, MAX_REQUEST_SIZE);
+
+  @BeforeEach
+  public void setup() {
+    when(peer.wantToMakeRequest()).thenReturn(true);
+    when(peer.wantToReceiveObjects(any(), anyLong())).thenReturn(true);
+  }
 
   @Test
   public void shouldReturnNoBlocksWhenThereAreNoBlocksAtOrAfterStartSlot() {
@@ -167,7 +174,6 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final UnsignedLong count = UnsignedLong.valueOf(MAX_REQUEST_BLOCKS);
     final int skip = 5;
 
-    when(peer.wantToReceiveObjects(any(), anyLong())).thenReturn(true);
     final SignedBeaconBlock headBlock = BLOCKS.get(5);
 
     withCanonicalHeadBlock(headBlock);
@@ -190,7 +196,6 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final UnsignedLong count = UnsignedLong.valueOf(MAX_REQUEST_BLOCKS);
     final int skip = 0;
 
-    when(peer.wantToReceiveObjects(any(), anyLong())).thenReturn(true);
     final SignedBeaconBlock headBlock = BLOCKS.get(5);
 
     withCanonicalHeadBlock(headBlock);
@@ -214,7 +219,6 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final UnsignedLong count = MAX_REQUEST_SIZE.plus(ONE);
     final int skip = 1;
 
-    when(peer.wantToReceiveObjects(any(), anyLong())).thenReturn(true);
     final SignedBeaconBlock headBlock = BLOCKS.get(10);
 
     withCanonicalHeadBlock(headBlock);
@@ -260,7 +264,6 @@ class BeaconBlocksByRangeMessageHandlerTest {
 
   private void requestBlocks(final int startBlock, final long count, final int skip) {
 
-    when(peer.wantToReceiveObjects(any(), anyLong())).thenReturn(true);
     handler.onIncomingMessage(
         peer,
         new BeaconBlocksByRangeRequestMessage(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
@@ -51,6 +51,8 @@ public class BeaconBlocksByRootMessageHandlerTest {
 
   @BeforeEach
   public void setup() {
+    when(peer.wantToMakeRequest()).thenReturn(true);
+    when(peer.wantToReceiveObjects(any(), anyLong())).thenReturn(true);
     when(recentChainData.getStore()).thenReturn(store);
   }
 
@@ -59,7 +61,6 @@ public class BeaconBlocksByRootMessageHandlerTest {
     final List<SignedBeaconBlock> blocks = mockChain(5);
 
     final BeaconBlocksByRootRequestMessage message = createRequest(blocks);
-    when(peer.wantToReceiveObjects(any(), anyLong())).thenReturn(true);
     handler.onIncomingMessage(peer, message, callback);
 
     for (SignedBeaconBlock block : blocks) {
@@ -74,7 +75,6 @@ public class BeaconBlocksByRootMessageHandlerTest {
 
     // Mock callback to appear to be closed
     doThrow(new StreamClosedException()).when(callback).respond(any());
-    when(peer.wantToReceiveObjects(any(), anyLong())).thenReturn(true);
 
     final BeaconBlocksByRootRequestMessage message = createRequest(blocks);
     handler.onIncomingMessage(peer, message, callback);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageHandlerTest.java
@@ -60,6 +60,7 @@ class StatusMessageHandlerTest {
   @BeforeEach
   public void setUp() {
     when(statusMessageFactory.createStatusMessage()).thenReturn(Optional.of(LOCAL_STATUS));
+    when(peer.wantToMakeRequest()).thenReturn(true);
   }
 
   @Test

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.Optional;
@@ -57,6 +58,7 @@ public abstract class Eth2IncomingRequestHandlerTest
     lenient()
         .when(combinedChainDataClient.getBlockAtSlotExact(any(), any()))
         .thenAnswer(i -> getBlockAtSlot(i.getArgument(0)));
+    when(peer.wantToMakeRequest()).thenReturn(true);
   }
 
   @Override

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
@@ -164,7 +164,8 @@ public class Eth2NetworkFactory {
                 eth2RpcOutstandingPingThreshold,
                 eth2StatusUpdateInterval,
                 StubTimeProvider.withTimeInSeconds(1000),
-                500);
+                500,
+                50);
 
         List<RpcMethod> rpcMethods =
             eth2PeerManager.getBeaconChainMethods().all().stream()

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -419,6 +419,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
               .timeProvider(timeProvider)
               .asyncRunner(networkAsyncRunner)
               .peerRateLimit(config.getPeerRateLimit())
+              .peerRequestLimit(config.getPeerRequestLimit())
               .build();
     }
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -302,6 +302,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setStartupTargetPeerCount(networkOptions.getStartupTargetPeerCount())
         .setStartupTimeoutSeconds(networkOptions.getStartupTimeoutSeconds())
         .setPeerRateLimit(networkOptions.getPeerRateLimit())
+        .setPeerRequestLimit(networkOptions.getPeerRequestLimit())
         .setP2pEnabled(p2POptions.isP2pEnabled())
         .setP2pInterface(p2POptions.getP2pInterface())
         .setP2pPort(p2POptions.getP2pPort())

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/NetworkOptions.java
@@ -55,6 +55,15 @@ public class NetworkOptions {
       hidden = true)
   private Integer peerRateLimit = 500;
 
+  @Option(
+      names = {"--Xpeer-request-limit"},
+      paramLabel = "<NUMBER>",
+      description =
+          "The number of requests per peer to allow per minute before disconnecting the peer.",
+      arity = "1",
+      hidden = true)
+  private Integer peerRequestLimit = 50;
+
   public String getNetwork() {
     return network;
   }
@@ -73,5 +82,9 @@ public class NetworkOptions {
 
   public Integer getPeerRateLimit() {
     return peerRateLimit;
+  }
+
+  public Integer getPeerRequestLimit() {
+    return peerRequestLimit;
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -246,7 +246,8 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
       "--Xremote-validator-api-port", "9999",
       "--Xremote-validator-api-max-subscribers", "1000",
       "--Xremote-validator-api-enabled", "false",
-      "--Xpeer-rate-limit", "500"
+      "--Xpeer-rate-limit", "500",
+      "--Xpeer-request-limit", "50"
     };
   }
 
@@ -264,6 +265,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setP2pPrivateKeyFile(null)
         .setInteropEnabled(false)
         .setPeerRateLimit(500)
+        .setPeerRequestLimit(50)
         .setInteropGenesisTime(0)
         .setInteropOwnedValidatorCount(0)
         .setLogDestination(DEFAULT_BOTH)
@@ -285,6 +287,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setP2pEnabled(false)
         .setP2pInterface("1.2.3.4")
         .setPeerRateLimit(500)
+        .setPeerRequestLimit(50)
         .setP2pPort(1234)
         .setP2pDiscoveryEnabled(false)
         .setP2pAdvertisedPort(OptionalInt.of(9000))

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/NetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/NetworkOptionsTest.java
@@ -84,4 +84,11 @@ public class NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
     final TekuConfiguration config = getTekuConfigurationFromArguments("--Xpeer-rate-limit", "10");
     assertThat(config.getPeerRateLimit()).isEqualTo(10);
   }
+
+  @Test
+  public void setPeerRequestLimit() {
+    final TekuConfiguration config =
+        getTekuConfigurationFromArguments("--Xpeer-request-limit", "10");
+    assertThat(config.getPeerRequestLimit()).isEqualTo(10);
+  }
 }

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
@@ -38,6 +38,7 @@ public class TekuConfiguration implements MetricsConfig {
   private final Integer startupTargetPeerCount;
   private final Integer startupTimeoutSeconds;
   private final Integer peerRateLimit;
+  private final Integer peerRequestLimit;
 
   // P2P
   private final boolean p2pEnabled;
@@ -125,6 +126,7 @@ public class TekuConfiguration implements MetricsConfig {
       final Integer startupTargetPeerCount,
       final Integer startupTimeoutSeconds,
       final Integer peerRateLimit,
+      final Integer peerRequestLimit,
       final boolean p2pEnabled,
       final String p2pInterface,
       final int p2pPort,
@@ -186,6 +188,7 @@ public class TekuConfiguration implements MetricsConfig {
     this.startupTargetPeerCount = startupTargetPeerCount;
     this.startupTimeoutSeconds = startupTimeoutSeconds;
     this.peerRateLimit = peerRateLimit;
+    this.peerRequestLimit = peerRequestLimit;
     this.p2pEnabled = p2pEnabled;
     this.p2pInterface = p2pInterface;
     this.p2pPort = p2pPort;
@@ -259,6 +262,10 @@ public class TekuConfiguration implements MetricsConfig {
 
   public int getPeerRateLimit() {
     return peerRateLimit;
+  }
+
+  public int getPeerRequestLimit() {
+    return peerRequestLimit;
   }
 
   public boolean isP2pEnabled() {

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
@@ -26,6 +26,7 @@ public class TekuConfigurationBuilder {
   private Integer startupTargetPeerCount;
   private Integer startupTimeoutSeconds;
   private Integer peerRateLimit;
+  private Integer peerRequestLimit;
   private boolean p2pEnabled;
   private String p2pInterface;
   private int p2pPort;
@@ -102,6 +103,11 @@ public class TekuConfigurationBuilder {
 
   public TekuConfigurationBuilder setPeerRateLimit(final Integer peerRateLimit) {
     this.peerRateLimit = peerRateLimit;
+    return this;
+  }
+
+  public TekuConfigurationBuilder setPeerRequestLimit(final Integer peerRequestLimit) {
+    this.peerRequestLimit = peerRequestLimit;
     return this;
   }
 
@@ -437,6 +443,7 @@ public class TekuConfigurationBuilder {
         startupTargetPeerCount,
         startupTimeoutSeconds,
         peerRateLimit,
+        peerRequestLimit,
         p2pEnabled,
         p2pInterface,
         p2pPort,


### PR DESCRIPTION
 - ensure that incoming requests can't be too excessive.

 - --Xpeer-request-limit=NUMBER added to allow command line customisation from the default of 50 requests per minute.

Between -Xpeer-rate-limit=NUMBER (default 500) limiting blocks, and --Xpeer-request-limit=NUMBER (default 50), most scenarios of flooding should be covered to try to ensure that rates of request by peer can be kept within sane limits.

partially addresses #2481

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.