### PR TITLE
[Issue 2334] Fix state transition committee cache

### DIFF
--- a/data/provider/build.gradle
+++ b/data/provider/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation 'com.google.code.gson:gson'
     implementation 'org.apache.tuweni:tuweni-units'
 
+    testImplementation testFixtures(project(':ethereum:core'))
     testImplementation testFixtures(project(':ethereum:datastructures'))
     testImplementation testFixtures(project(':storage'))
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -13,10 +13,7 @@
 
 package tech.pegasys.teku.api;
 
-import static com.google.common.primitives.UnsignedLong.ONE;
-import static com.google.common.primitives.UnsignedLong.ZERO;
 import static tech.pegasys.teku.api.DataProviderFailures.chainUnavailable;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.List;
@@ -32,18 +29,22 @@ import tech.pegasys.teku.api.schema.BeaconValidators;
 import tech.pegasys.teku.api.schema.Committee;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.ValidatorsRequest;
+import tech.pegasys.teku.core.StateTransition;
+import tech.pegasys.teku.core.exceptions.EpochProcessingException;
+import tech.pegasys.teku.core.exceptions.SlotProcessingException;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.datastructures.util.BeaconStateUtil;
+import tech.pegasys.teku.datastructures.util.CommitteeUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
-import tech.pegasys.teku.util.config.Constants;
 
 public class ChainDataProvider {
   private final CombinedChainDataClient combinedChainDataClient;
 
   private final RecentChainData recentChainData;
+  private final StateTransition stateTransition = new StateTransition();
 
   public ChainDataProvider(
       final RecentChainData recentChainData,
@@ -83,27 +84,26 @@ public class ChainDataProvider {
     if (!combinedChainDataClient.isChainDataFullyAvailable()) {
       return chainUnavailable();
     }
-    final UnsignedLong committeesCalculatedAtEpoch = epoch.equals(ZERO) ? ZERO : epoch.minus(ONE);
-    final UnsignedLong startingSlot = compute_start_slot_at_epoch(committeesCalculatedAtEpoch);
-    final UnsignedLong slot = compute_start_slot_at_epoch(epoch);
 
-    // one epoch in future is available, beyond that cannot be calculated
-    if (slot.compareTo(
-            recentChainData.getBestSlot().plus(UnsignedLong.valueOf(Constants.SLOTS_PER_EPOCH)))
-        > 0) {
+    final UnsignedLong earliestQueryableSlot =
+        CommitteeUtil.getEarliestQueryableSlotForTargetEpoch(epoch);
+    if (recentChainData.getBestSlot().compareTo(earliestQueryableSlot) < 0) {
       return SafeFuture.completedFuture(Optional.empty());
     }
 
     return combinedChainDataClient
-        .getBlockAndStateInEffectAtSlot(startingSlot)
+        .getBlockAndStateInEffectAtSlot(earliestQueryableSlot)
         .thenApply(
             maybeResult ->
                 maybeResult.map(
-                    result ->
-                        combinedChainDataClient.getCommitteesFromState(result.getState(), epoch)
-                            .stream()
-                            .map(Committee::new)
-                            .collect(Collectors.toList())));
+                    result -> {
+                      final tech.pegasys.teku.datastructures.state.BeaconState queryableState =
+                          processSlots(result.getState(), earliestQueryableSlot);
+                      return combinedChainDataClient.getCommitteesFromState(queryableState, epoch)
+                          .stream()
+                          .map(Committee::new)
+                          .collect(Collectors.toList());
+                    }));
   }
 
   public SafeFuture<Optional<GetBlockResponse>> getBlockBySlot(final UnsignedLong slot) {
@@ -218,5 +218,18 @@ public class ChainDataProvider {
       throw new ChainDataUnavailableException();
     }
     return recentChainData.getBestBlockAndState().map(BeaconChainHead::new);
+  }
+
+  private tech.pegasys.teku.datastructures.state.BeaconState processSlots(
+      final tech.pegasys.teku.datastructures.state.BeaconState startingState,
+      final UnsignedLong targetSlot) {
+    if (startingState.getSlot().compareTo(targetSlot) >= 0) {
+      return startingState;
+    }
+    try {
+      return stateTransition.process_slots(startingState, targetSlot);
+    } catch (SlotProcessingException | EpochProcessingException e) {
+      throw new IllegalStateException("Unable to process slots", e);
+    }
   }
 }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -45,8 +45,11 @@ import tech.pegasys.teku.api.schema.Committee;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.ValidatorWithIndex;
 import tech.pegasys.teku.api.schema.ValidatorsRequest;
+import tech.pegasys.teku.core.stategenerator.CheckpointStateGenerator;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
+import tech.pegasys.teku.datastructures.state.CheckpointState;
 import tech.pegasys.teku.datastructures.state.CommitteeAssignment;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
@@ -118,8 +121,17 @@ public class ChainDataProviderTest {
       throws ExecutionException, InterruptedException {
     final List<CommitteeAssignment> committeeAssignments =
         List.of(new CommitteeAssignment(List.of(1), ZERO, ONE));
-    final UnsignedLong currentEpoch =
-        bestBlock.getSlot().dividedBy(UnsignedLong.valueOf(SLOTS_PER_EPOCH));
+    final UnsignedLong currentEpoch = compute_epoch_at_slot(bestBlock.getSlot());
+
+    // Setup data
+    final UnsignedLong queryEpoch =
+        currentEpoch.equals(ZERO) ? currentEpoch : currentEpoch.minus(ONE);
+    final Checkpoint checkpoint =
+        storageSystem.chainBuilder().getCurrentCheckpointForEpoch(queryEpoch);
+    final SignedBlockAndState checkpointBlockAndState =
+        storageSystem.chainBuilder().getBlockAndState(checkpoint.getRoot()).orElseThrow();
+    final CheckpointState checkpointState =
+        CheckpointStateGenerator.generate(checkpoint, checkpointBlockAndState);
 
     final ChainDataProvider provider =
         new ChainDataProvider(mockRecentChainData, mockCombinedChainDataClient);
@@ -129,8 +141,8 @@ public class ChainDataProviderTest {
     when(mockCombinedChainDataClient.getCommitteesFromState(any(), any()))
         .thenReturn(committeeAssignments);
     when(mockRecentChainData.getBestSlot()).thenReturn(bestBlock.getSlot());
-    when(mockCombinedChainDataClient.getBlockAndStateInEffectAtSlot(any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(bestBlock.toUnsigned())));
+    when(mockCombinedChainDataClient.getCheckpointStateAtEpoch(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(checkpointState)));
     final SafeFuture<Optional<List<Committee>>> future =
         provider.getCommitteesAtEpoch(currentEpoch);
 

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/stategenerator/CheckpointStateGenerator.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/stategenerator/CheckpointStateGenerator.java
@@ -31,8 +31,8 @@ public abstract class CheckpointStateGenerator {
     checkArgument(
         blockAndState.getRoot().equals(checkpoint.getRoot()), "Block must match checkpoint root");
 
-    final BeaconState state = regenerateCheckpointState(checkpoint, blockAndState.getState());
     // Derive checkpoint state
+    final BeaconState state = regenerateCheckpointState(checkpoint, blockAndState.getState());
     return new CheckpointState(checkpoint, blockAndState.getBlock(), state);
   }
 

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/stategenerator/CheckpointStateGenerator.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/stategenerator/CheckpointStateGenerator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.core.stategenerator;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import tech.pegasys.teku.core.StateTransition;
+import tech.pegasys.teku.core.exceptions.EpochProcessingException;
+import tech.pegasys.teku.core.exceptions.SlotProcessingException;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.datastructures.forkchoice.InvalidCheckpointException;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
+import tech.pegasys.teku.datastructures.state.CheckpointState;
+
+public abstract class CheckpointStateGenerator {
+
+  public static CheckpointState generate(
+      final Checkpoint checkpoint, final SignedBlockAndState blockAndState) {
+    checkArgument(
+        blockAndState.getRoot().equals(checkpoint.getRoot()), "Block must match checkpoint root");
+
+    final BeaconState state = regenerateCheckpointState(checkpoint, blockAndState.getState());
+    // Derive checkpoint state
+    return new CheckpointState(checkpoint, blockAndState.getBlock(), state);
+  }
+
+  public static BeaconState regenerateCheckpointState(
+      final Checkpoint checkpoint, BeaconState baseState) {
+    checkArgument(
+        baseState.getSlot().compareTo(checkpoint.getEpochStartSlot()) <= 0,
+        "Checkpoint state must be at or prior to checkpoint slot boundary");
+    try {
+      if (baseState.getSlot().equals(checkpoint.getEpochStartSlot())) {
+        return baseState;
+      }
+
+      return new StateTransition().process_slots(baseState, checkpoint.getEpochStartSlot());
+    } catch (SlotProcessingException | EpochProcessingException | IllegalArgumentException e) {
+      throw new InvalidCheckpointException(e);
+    }
+  }
+}

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/stategenerator/CheckpointStateGeneratorTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/stategenerator/CheckpointStateGeneratorTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.core.stategenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.core.ChainBuilder;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
+import tech.pegasys.teku.datastructures.state.CheckpointState;
+
+public class CheckpointStateGeneratorTest {
+  private final ChainBuilder chainBuilder = ChainBuilder.createDefault();
+
+  @BeforeEach
+  public void setup() {
+    chainBuilder.generateGenesis();
+  }
+
+  @Test
+  public void generate_withBlockPriorToEpoch() {
+    final SignedBlockAndState checkpointBlockAndState = chainBuilder.generateNextBlock();
+
+    final Checkpoint checkpoint = chainBuilder.getCurrentCheckpointForEpoch(5);
+    final CheckpointState result =
+        CheckpointStateGenerator.generate(checkpoint, checkpointBlockAndState);
+
+    assertThat(result.getBlock()).isEqualTo(checkpointBlockAndState.getBlock());
+    assertThat(result.getState()).isNotEqualTo(checkpointBlockAndState.getState());
+    assertThat(result.getState().getSlot()).isEqualTo(checkpoint.getEpochStartSlot());
+  }
+
+  @Test
+  public void generate_withBlockAtEpochBoundary() {
+    final UnsignedLong epoch = UnsignedLong.valueOf(2);
+    final UnsignedLong epochStartSlot = compute_start_slot_at_epoch(epoch);
+
+    chainBuilder.generateBlocksUpToSlot(epochStartSlot);
+
+    final Checkpoint checkpoint = chainBuilder.getCurrentCheckpointForEpoch(epoch);
+    final SignedBlockAndState checkpointBlockAndState = chainBuilder.getLatestBlockAndState();
+    final CheckpointState result =
+        CheckpointStateGenerator.generate(checkpoint, checkpointBlockAndState);
+
+    assertThat(result.getBlock()).isEqualTo(checkpointBlockAndState.getBlock());
+    assertThat(result.getState()).isEqualTo(checkpointBlockAndState.getState());
+    assertThat(result.getState().getSlot()).isEqualTo(checkpoint.getEpochStartSlot());
+  }
+
+  @Test
+  public void generate_withInvalidBlockPastTheEpochBoundary() {
+    final UnsignedLong epoch = UnsignedLong.valueOf(2);
+    final UnsignedLong epochStartSlot = compute_start_slot_at_epoch(epoch);
+
+    chainBuilder.generateBlocksUpToSlot(epochStartSlot);
+
+    final SignedBlockAndState checkpointBlockAndState = chainBuilder.generateNextBlock();
+    final Checkpoint checkpoint = new Checkpoint(epoch, checkpointBlockAndState.getRoot());
+    assertThatThrownBy(() -> CheckpointStateGenerator.generate(checkpoint, checkpointBlockAndState))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/CheckpointState.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/CheckpointState.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.datastructures.state;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.datastructures.blocks.BeaconBlockHeader;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+
+public class CheckpointState {
+
+  private final Checkpoint checkpoint;
+  private final SignedBeaconBlock block;
+  private final BeaconState state;
+
+  public CheckpointState(
+      final Checkpoint checkpoint, final SignedBeaconBlock block, final BeaconState state) {
+    checkNotNull(checkpoint);
+    checkNotNull(block);
+    checkNotNull(state);
+    checkArgument(checkpoint.getRoot().equals(block.getRoot()), "Block must match checkpoint root");
+    checkArgument(
+        state.getSlot().equals(checkpoint.getEpochStartSlot()),
+        "State must be advanced to checkpoint epoch boundary slot");
+    validateState(checkpoint, state);
+
+    this.checkpoint = checkpoint;
+    this.block = block;
+    this.state = state;
+  }
+
+  private static void validateState(final Checkpoint checkpoint, final BeaconState state) {
+    final Bytes32 blockRootFromState = deriveBlockHeaderFromState(state).hash_tree_root();
+    checkArgument(
+        blockRootFromState.equals(checkpoint.getRoot()), "State must derive from checkpoint block");
+  }
+
+  private static BeaconBlockHeader deriveBlockHeaderFromState(final BeaconState state) {
+    BeaconBlockHeader latestHeader = state.getLatest_block_header();
+
+    if (latestHeader.getState_root().isZero()) {
+      // If the state root is empty, replace it with the current state root
+      final Bytes32 stateRoot = state.hash_tree_root();
+      latestHeader =
+          new BeaconBlockHeader(
+              latestHeader.getSlot(),
+              latestHeader.getProposer_index(),
+              latestHeader.getParent_root(),
+              stateRoot,
+              latestHeader.getBody_root());
+    }
+
+    return latestHeader;
+  }
+
+  public Checkpoint getCheckpoint() {
+    return checkpoint;
+  }
+
+  public SignedBeaconBlock getBlock() {
+    return block;
+  }
+
+  /** @return The checkpoint state which is advanced to the checkpoint epoch boundary */
+  public BeaconState getState() {
+    return state;
+  }
+}

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/CheckpointState.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/CheckpointState.java
@@ -16,6 +16,8 @@ package tech.pegasys.teku.datastructures.state;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
@@ -77,5 +79,33 @@ public class CheckpointState {
   /** @return The checkpoint state which is advanced to the checkpoint epoch boundary */
   public BeaconState getState() {
     return state;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof CheckpointState)) {
+      return false;
+    }
+    final CheckpointState that = (CheckpointState) o;
+    return Objects.equals(checkpoint, that.checkpoint)
+        && Objects.equals(block, that.block)
+        && Objects.equals(state, that.state);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(checkpoint, block, state);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("checkpoint", checkpoint)
+        .add("block", block)
+        .add("state", state)
+        .toString();
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/CheckpointState.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/CheckpointState.java
@@ -18,8 +18,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import java.util.Objects;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 
 public class CheckpointState {
@@ -37,35 +35,10 @@ public class CheckpointState {
     checkArgument(
         state.getSlot().equals(checkpoint.getEpochStartSlot()),
         "State must be advanced to checkpoint epoch boundary slot");
-    validateState(checkpoint, state);
 
     this.checkpoint = checkpoint;
     this.block = block;
     this.state = state;
-  }
-
-  private static void validateState(final Checkpoint checkpoint, final BeaconState state) {
-    final Bytes32 blockRootFromState = deriveBlockHeaderFromState(state).hash_tree_root();
-    checkArgument(
-        blockRootFromState.equals(checkpoint.getRoot()), "State must derive from checkpoint block");
-  }
-
-  private static BeaconBlockHeader deriveBlockHeaderFromState(final BeaconState state) {
-    BeaconBlockHeader latestHeader = state.getLatest_block_header();
-
-    if (latestHeader.getState_root().isZero()) {
-      // If the state root is empty, replace it with the current state root
-      final Bytes32 stateRoot = state.hash_tree_root();
-      latestHeader =
-          new BeaconBlockHeader(
-              latestHeader.getSlot(),
-              latestHeader.getProposer_index(),
-              latestHeader.getParent_root(),
-              stateRoot,
-              latestHeader.getBody_root());
-    }
-
-    return latestHeader;
   }
 
   public Checkpoint getCheckpoint() {

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
@@ -276,19 +276,32 @@ public class CommitteeUtil {
   }
 
   private static void validateStateForCommitteeQuery(BeaconState state, UnsignedLong slot) {
-    final UnsignedLong currentEpoch = compute_epoch_at_slot(slot);
+    final UnsignedLong oldestQueryableSlot = getEarliestQueryableSlotForTargetSlot(slot);
     checkArgument(
-        state.getSlot().compareTo(getEarliestQueryableSlot(currentEpoch)) >= 0,
-        "Committee information must be derived from a state no older than the previous epoch");
+        state.getSlot().compareTo(oldestQueryableSlot) >= 0,
+        "Committee information must be derived from a state no older than the previous epoch. State at slot %s is older than cutoff slot %s",
+        state.getSlot(),
+        oldestQueryableSlot);
   }
 
   /**
-   * Given the current epoch, calculates the earliest slot queryable for assignments at this epoch
+   * Calculates the earliest slot queryable for assignments at the given slot
+   *
+   * @param slot The slot for which we want to retrieve committee information
+   * @return The earliest slot from which we can query committee assignments
+   */
+  public static UnsignedLong getEarliestQueryableSlotForTargetSlot(final UnsignedLong slot) {
+    final UnsignedLong epoch = compute_epoch_at_slot(slot);
+    return getEarliestQueryableSlotForTargetEpoch(epoch);
+  }
+
+  /**
+   * Calculates the earliest slot queryable for assignments at the given epoch
    *
    * @param epoch The epoch for which we want to retrieve committee information
    * @return The earliest slot from which we can query committee assignments
    */
-  public static UnsignedLong getEarliestQueryableSlot(final UnsignedLong epoch) {
+  public static UnsignedLong getEarliestQueryableSlotForTargetEpoch(final UnsignedLong epoch) {
     final UnsignedLong previousEpoch =
         epoch.compareTo(UnsignedLong.ZERO) > 0 ? epoch.minus(UnsignedLong.ONE) : epoch;
     return compute_start_slot_at_epoch(previousEpoch);

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/CommitteeUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/CommitteeUtilTest.java
@@ -13,13 +13,20 @@
 
 package tech.pegasys.teku.datastructures.util;
 
+import static com.google.common.primitives.UnsignedLong.ONE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 
+import com.google.common.primitives.UnsignedLong;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.state.BeaconState;
 
 public class CommitteeUtilTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
 
   @Test
   void testListShuffleAndShuffledIndexCompatibility() {
@@ -33,5 +40,55 @@ public class CommitteeUtilTest {
             IntStream.range(0, index_count)
                 .map(i -> CommitteeUtil.compute_shuffled_index(i, indexes.length, seed))
                 .toArray());
+  }
+
+  @Test
+  public void getBeaconCommittee_stateIsTooOld() {
+    final UnsignedLong epoch = ONE;
+    final UnsignedLong epochSlot = compute_start_slot_at_epoch(epoch);
+    final BeaconState state = dataStructureUtil.randomBeaconState(epochSlot);
+
+    final UnsignedLong outOfRangeSlot =
+        compute_start_slot_at_epoch(epoch.plus(UnsignedLong.valueOf(2)));
+    assertThatThrownBy(() -> CommitteeUtil.get_beacon_committee(state, outOfRangeSlot, ONE))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Committee information must be derived from a state no older than the previous epoch");
+  }
+
+  @Test
+  public void getBeaconCommittee_stateFromEpochThatIsTooOld() {
+    final UnsignedLong epoch = UnsignedLong.ONE;
+    final UnsignedLong epochSlot = compute_start_slot_at_epoch(epoch.plus(ONE)).minus(ONE);
+    final BeaconState state = dataStructureUtil.randomBeaconState(epochSlot);
+
+    final UnsignedLong outOfRangeSlot =
+        compute_start_slot_at_epoch(epoch.plus(UnsignedLong.valueOf(2)));
+    assertThatThrownBy(() -> CommitteeUtil.get_beacon_committee(state, outOfRangeSlot, ONE))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Committee information must be derived from a state no older than the previous epoch");
+  }
+
+  @Test
+  public void getBeaconCommittee_stateIsJustNewEnough() {
+    final UnsignedLong epoch = ONE;
+    final UnsignedLong epochSlot = compute_start_slot_at_epoch(epoch);
+    final BeaconState state = dataStructureUtil.randomBeaconState(epochSlot);
+
+    final UnsignedLong outOfRangeSlot =
+        compute_start_slot_at_epoch(epoch.plus(UnsignedLong.valueOf(2)));
+    final UnsignedLong inRangeSlot = outOfRangeSlot.minus(ONE);
+    assertDoesNotThrow(() -> CommitteeUtil.get_beacon_committee(state, inRangeSlot, ONE));
+  }
+
+  @Test
+  public void getBeaconCommittee_stateIsNewerThanSlot() {
+    final UnsignedLong epoch = ONE;
+    final UnsignedLong epochSlot = compute_start_slot_at_epoch(epoch);
+    final BeaconState state = dataStructureUtil.randomBeaconState(epochSlot);
+
+    final UnsignedLong oldSlot = epochSlot.minus(ONE);
+    assertDoesNotThrow(() -> CommitteeUtil.get_beacon_committee(state, oldSlot, ONE));
   }
 }

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest_pruningMode.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest_pruningMode.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.storage.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
 import com.google.common.primitives.UnsignedLong;
 import java.util.Optional;
@@ -24,6 +25,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.core.ChainProperties;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.datastructures.state.CheckpointState;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.util.config.StateStorageMode;
 
@@ -78,5 +80,25 @@ public class CombinedChainDataClientTest_pruningMode extends AbstractCombinedCha
     final SafeFuture<Optional<BeaconBlockAndState>> result =
         client.getBlockAndStateInEffectAtSlot(targetBlock.getSlot());
     assertThat(result).isCompletedWithValue(Optional.empty());
+  }
+
+  @Test
+  public void getCheckpointStateAtEpoch_historicalCheckpointWithSkippedBoundarySlot() {
+    final UnsignedLong finalizedEpoch = UnsignedLong.valueOf(3);
+    final UnsignedLong finalizedSlot = compute_start_slot_at_epoch(finalizedEpoch);
+    final UnsignedLong nextEpoch = finalizedEpoch.plus(UnsignedLong.ONE);
+
+    chainUpdater.initializeGenesis();
+    // Setup chain at epoch to be queried
+    chainUpdater.advanceChain(finalizedSlot.minus(UnsignedLong.ONE));
+    chainUpdater.finalizeEpoch(finalizedEpoch);
+    // Bury queried epoch behind another finalized epoch
+    chainUpdater.advanceChain(compute_start_slot_at_epoch(nextEpoch));
+    chainUpdater.finalizeEpoch(nextEpoch);
+    chainUpdater.addNewBestBlock();
+
+    final SafeFuture<Optional<CheckpointState>> actual =
+        client.getCheckpointStateAtEpoch(finalizedEpoch);
+    assertThatSafeFuture(actual).isCompletedWithEmptyOptional();
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -31,11 +31,14 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.exceptions.EpochProcessingException;
 import tech.pegasys.teku.core.exceptions.SlotProcessingException;
-import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.core.stategenerator.CheckpointStateGenerator;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
+import tech.pegasys.teku.datastructures.state.CheckpointState;
 import tech.pegasys.teku.datastructures.state.CommitteeAssignment;
 import tech.pegasys.teku.datastructures.util.CommitteeUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -134,11 +137,16 @@ public class CombinedChainDataClient {
 
   public SafeFuture<Optional<BeaconBlockAndState>> getBlockAndStateInEffectAtSlot(
       final UnsignedLong slot) {
+    return getSignedBlockAndStateInEffectAtSlot(slot)
+        .thenApply(result -> result.map(SignedBlockAndState::toUnsigned));
+  }
+
+  public SafeFuture<Optional<SignedBlockAndState>> getSignedBlockAndStateInEffectAtSlot(
+      final UnsignedLong slot) {
     return getBlockInEffectAtSlot(slot)
         .thenCompose(
             maybeBlock ->
                 maybeBlock
-                    .map(SignedBeaconBlock::getMessage)
                     .map(this::getStateForBlock)
                     .orElseGet(() -> SafeFuture.completedFuture(Optional.empty())));
   }
@@ -151,9 +159,36 @@ public class CombinedChainDataClient {
                     blockAndState -> regenerateBeaconState(blockAndState.getState(), slot)));
   }
 
-  private SafeFuture<Optional<BeaconBlockAndState>> getStateForBlock(final BeaconBlock block) {
-    return getStateByBlockRoot(block.hash_tree_root())
-        .thenApply(maybeState -> maybeState.map(state -> new BeaconBlockAndState(block, state)));
+  public SafeFuture<Optional<CheckpointState>> getCheckpointStateAtEpoch(final UnsignedLong epoch) {
+    final UnsignedLong epochSlot = compute_start_slot_at_epoch(epoch);
+    return getSignedBlockAndStateInEffectAtSlot(epochSlot)
+        .thenCompose(
+            maybeBlockAndState -> {
+              if (maybeBlockAndState.isEmpty()) {
+                return completedFuture(Optional.empty());
+              }
+              final SignedBlockAndState blockAndState = maybeBlockAndState.get();
+              final Checkpoint checkpoint = new Checkpoint(epoch, blockAndState.getRoot());
+              return recentChainData
+                  .getStore()
+                  .retrieveCheckpointState(checkpoint)
+                  .thenApply(
+                      checkpointState -> {
+                        if (checkpointState.isEmpty()) {
+                          return Optional.of(
+                              CheckpointStateGenerator.generate(checkpoint, blockAndState));
+                        }
+                        final SignedBeaconBlock block = blockAndState.getBlock();
+                        return checkpointState.map(
+                            state -> new CheckpointState(checkpoint, block, state));
+                      });
+            });
+  }
+
+  private SafeFuture<Optional<SignedBlockAndState>> getStateForBlock(
+      final SignedBeaconBlock block) {
+    return getStateByBlockRoot(block.getRoot())
+        .thenApply(maybeState -> maybeState.map(state -> new SignedBlockAndState(block, state)));
   }
 
   public boolean isFinalized(final UnsignedLong slot) {

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -172,36 +172,43 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     if (isSyncActive()) {
       return NodeSyncingException.failedFuture();
     }
-    return createFromBlockAndState(
-        slot,
-        blockAndState -> {
-          final BeaconState state = blockAndState.getState();
-          final BeaconBlock block = blockAndState.getBlock();
 
-          final UnsignedLong querySlot = CommitteeUtil.getEarliestQueryableSlotForTargetSlot(slot);
-          final BeaconState queryableState = processSlots(state, querySlot);
+    final UnsignedLong querySlot = CommitteeUtil.getEarliestQueryableSlotForTargetSlot(slot);
+    final UnsignedLong epoch = compute_epoch_at_slot(querySlot);
 
-          final int committeeCount =
-              get_committee_count_per_slot(queryableState, compute_epoch_at_slot(slot)).intValue();
+    return combinedChainDataClient
+        .getCheckpointStateAtEpoch(epoch)
+        .thenApply(
+            result ->
+                result.map(
+                    checkpointState -> {
+                      final BeaconBlock block = checkpointState.getBlock().getMessage();
+                      final BeaconState state = checkpointState.getState();
 
-          if (committeeIndex < 0 || committeeIndex >= committeeCount) {
-            throw new IllegalArgumentException(
-                "Invalid committee index "
-                    + committeeIndex
-                    + " - expected between 0 and "
-                    + (committeeCount - 1));
-          }
-          final UnsignedLong committeeIndexUnsigned = UnsignedLong.valueOf(committeeIndex);
-          final AttestationData attestationData =
-              AttestationUtil.getGenericAttestationData(
-                  slot, queryableState, block, committeeIndexUnsigned);
-          final List<Integer> committee =
-              CommitteeUtil.get_beacon_committee(queryableState, slot, committeeIndexUnsigned);
+                      final int committeeCount =
+                          get_committee_count_per_slot(state, compute_epoch_at_slot(slot))
+                              .intValue();
 
-          final Bitlist aggregationBits =
-              new Bitlist(committee.size(), MAX_VALIDATORS_PER_COMMITTEE);
-          return new Attestation(aggregationBits, attestationData, BLSSignature.empty());
-        });
+                      if (committeeIndex < 0 || committeeIndex >= committeeCount) {
+                        throw new IllegalArgumentException(
+                            "Invalid committee index "
+                                + committeeIndex
+                                + " - expected between 0 and "
+                                + (committeeCount - 1));
+                      }
+                      final UnsignedLong committeeIndexUnsigned =
+                          UnsignedLong.valueOf(committeeIndex);
+                      final AttestationData attestationData =
+                          AttestationUtil.getGenericAttestationData(
+                              slot, state, block, committeeIndexUnsigned);
+                      final List<Integer> committee =
+                          CommitteeUtil.get_beacon_committee(state, slot, committeeIndexUnsigned);
+
+                      final Bitlist aggregationBits =
+                          new Bitlist(committee.size(), MAX_VALIDATORS_PER_COMMITTEE);
+                      return new Attestation(
+                          aggregationBits, attestationData, BLSSignature.empty());
+                    }));
   }
 
   @Override

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -116,9 +116,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     if (publicKeys.isEmpty()) {
       return SafeFuture.completedFuture(Optional.of(emptyList()));
     }
-    final UnsignedLong slot =
-        compute_start_slot_at_epoch(
-            epoch.compareTo(UnsignedLong.ZERO) > 0 ? epoch.minus(UnsignedLong.ONE) : epoch);
+    final UnsignedLong slot = CommitteeUtil.getEarliestQueryableSlot(epoch);
     LOG.trace("Retrieving duties from epoch {} using state at slot {}", epoch, slot);
     return combinedChainDataClient
         .getLatestStateAtSlot(slot)

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -41,7 +41,6 @@ import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
@@ -286,7 +285,6 @@ class ValidatorApiHandlerTest {
     final BeaconState state = createStateWithActiveValidators(PREVIOUS_EPOCH_START_SLOT);
     final SignedBeaconBlock block =
         dataStructureUtil.randomSignedBeaconBlock(state.getSlot(), state);
-    final SignedBlockAndState blockAndState = new SignedBlockAndState(block, state);
 
     final CheckpointState checkpointState = mock(CheckpointState.class);
     when(checkpointState.getState()).thenReturn(state);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR fixes an issue where our state transition caches were being corrupted with invalid committee data.

I was able to reproduce this corrupted cache issue as follows:
* Start a single node network with 64 validators
* Let the network run for a bit and finalize some epochs
* Stop the node and let several epoch pass
* Restart the node, at which point we would get "Invalid attestation: Signature is invalid" errors

On restart, the node would calculate and schedule upcoming validator duties correctly.  However, when we went to produce our attestations, we would try to calculate committee information using an old state (from the head of the chain) without processing slots forward to the slot being queried.  The calculated committee information from the stale state would then end up being cached by our `TransitionCaches` object.  This caused subsequent queries to pull committee information to return invalid data.  This then caused us to view our produced attestations as invalid because the corrupted committee information was inconsistent with the produced attestation. 

The fix is to ensure that any state used to calculate committee information is in range of the slot being queried (the state must be from at least the previous epoch).  Checks have been added to `CommitteeUtil.get_beacon_committee()` to make sure we don't allow old states to be used for this calculation. `ChainDataProvider` and `ValidatorApiHandler` have been updated to run with states that have been processed up to an appropriate epoch before trying to calculate committee information.

## Fixed Issue(s)
Fixes #2334 
Fixes #2446

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.