### PR TITLE
Fix the bootnode help text to refer to enr not enode://

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -53,7 +53,7 @@ public class P2POptions {
 
   @Option(
       names = {"--p2p-discovery-bootnodes"},
-      paramLabel = "<enode://id@host:port>",
+      paramLabel = "<enr:-...>",
       description = "List of ENRs of the bootnodes",
       split = ",",
       arity = "0..*")


### PR DESCRIPTION
## PR Description
Fix the `--p2p-discovery-bootnodes` option help text.  enode:// is for eth1, eth2 uses enr:-.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.