### PR TITLE
Enable validator duties logs by default

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
@@ -51,7 +51,7 @@ public class LoggingOptions {
       description = "Whether events are logged when validators perform duties",
       fallbackValue = "true",
       arity = "0..1")
-  private boolean logIncludeValidatorDutiesEnabled = false;
+  private boolean logIncludeValidatorDutiesEnabled = true;
 
   @CommandLine.Option(
       names = {"--log-destination"},

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -315,6 +315,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setLogFile(DEFAULT_LOG_FILE)
         .setLogFileNamePattern(DEFAULT_LOG_FILE_NAME_PATTERN)
         .setLogIncludeEventsEnabled(true)
+        .setLogIncludeValidatorDutiesEnabled(true)
         .setValidatorKeystoreFiles(Collections.emptyList())
         .setValidatorKeystorePasswordFiles(Collections.emptyList())
         .setValidatorExternalSignerTimeout(1000)


### PR DESCRIPTION
## PR Description

Enable validator duties logs by default. They're really useful and much easier to disable them if they're annoying than discover them when they're not on.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.