### PR TITLE
Updated `createAggregateFor` method to take attestation hash_tree_root param

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -123,8 +123,8 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
   }
 
   public synchronized Optional<ValidateableAttestation> createAggregateFor(
-      final AttestationData attestationData) {
-    return Optional.ofNullable(attestationGroupByDataHash.get(attestationData.hash_tree_root()))
+      final Bytes32 attestationHashTreeRoot) {
+    return Optional.ofNullable(attestationGroupByDataHash.get(attestationHashTreeRoot))
         .flatMap(attestations -> attestations.stream().findFirst());
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -55,7 +55,8 @@ class AggregatingAttestationPoolTest {
   @Test
   public void createAggregateFor_shouldReturnEmptyWhenNoAttestationsMatchGivenData() {
     final Optional<ValidateableAttestation> result =
-        aggregatingPool.createAggregateFor(dataStructureUtil.randomAttestationData());
+        aggregatingPool.createAggregateFor(
+            dataStructureUtil.randomAttestationData().hashTreeRoot());
     assertThat(result).isEmpty();
   }
 
@@ -66,7 +67,7 @@ class AggregatingAttestationPoolTest {
     final Attestation attestation2 = addAttestationFromValidators(attestationData, 2, 4, 6);
 
     final Optional<ValidateableAttestation> result =
-        aggregatingPool.createAggregateFor(attestationData);
+        aggregatingPool.createAggregateFor(attestationData.hashTreeRoot());
     assertThat(result.map(ValidateableAttestation::getAttestation))
         .contains(aggregateAttestations(attestation1, attestation2));
   }
@@ -79,7 +80,7 @@ class AggregatingAttestationPoolTest {
     addAttestationFromValidators(attestationData, 2, 3, 9);
 
     final Optional<ValidateableAttestation> result =
-        aggregatingPool.createAggregateFor(attestationData);
+        aggregatingPool.createAggregateFor(attestationData.hashTreeRoot());
     assertThat(result.map(ValidateableAttestation::getAttestation))
         .contains(aggregateAttestations(attestation1, attestation2));
   }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -24,7 +24,6 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.operations.Attestation;
-import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.datastructures.validator.SubnetSubscription;
@@ -43,7 +42,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
   SafeFuture<Optional<Attestation>> createUnsignedAttestation(
       UnsignedLong slot, int committeeIndex);
 
-  SafeFuture<Optional<Attestation>> createAggregate(AttestationData attestationData);
+  SafeFuture<Optional<Attestation>> createAggregate(Bytes32 attestationHashTreeRoot);
 
   void subscribeToBeaconCommitteeForAggregation(int committeeIndex, UnsignedLong aggregationSlot);
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
@@ -106,7 +106,7 @@ public class AggregationDuty implements Duty {
                     new IllegalStateException(
                         "Unable to perform aggregation for committee because no attestation was produced"))
             .getData();
-    return validatorApiChannel.createAggregate(attestationData);
+    return validatorApiChannel.createAggregate(attestationData.hashTreeRoot());
   }
 
   private SafeFuture<DutyResult> sendAggregate(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/metrics/MetricRecordingValidatorApiChannel.java
@@ -26,7 +26,6 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.operations.Attestation;
-import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.datastructures.validator.SubnetSubscription;
@@ -149,8 +148,9 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Attestation>> createAggregate(final AttestationData attestationData) {
-    return countRequest(delegate.createAggregate(attestationData), aggregateRequestsCounter);
+  public SafeFuture<Optional<Attestation>> createAggregate(final Bytes32 attestationHashTreeRoot) {
+    return countRequest(
+        delegate.createAggregate(attestationHashTreeRoot), aggregateRequestsCounter);
   }
 
   @Override

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
@@ -113,7 +113,7 @@ class AggregationDutyTest {
         attestationCommitteeIndex,
         completedFuture(Optional.of(unsignedAttestation)));
 
-    when(validatorApiChannel.createAggregate(unsignedAttestation.getData()))
+    when(validatorApiChannel.createAggregate(unsignedAttestation.getData().hashTreeRoot()))
         .thenReturn(completedFuture(Optional.of(aggregate)));
 
     final AggregateAndProof expectedAggregateAndProof =
@@ -156,9 +156,11 @@ class AggregationDutyTest {
         validator2CommitteeIndex,
         completedFuture(Optional.of(committee2UnsignedAttestation)));
 
-    when(validatorApiChannel.createAggregate(committee1UnsignedAttestation.getData()))
+    when(validatorApiChannel.createAggregate(
+            committee1UnsignedAttestation.getData().hashTreeRoot()))
         .thenReturn(completedFuture(Optional.of(committee1Aggregate)));
-    when(validatorApiChannel.createAggregate(committee2UnsignedAttestation.getData()))
+    when(validatorApiChannel.createAggregate(
+            committee2UnsignedAttestation.getData().hashTreeRoot()))
         .thenReturn(completedFuture(Optional.of(committee2Aggregate)));
 
     final AggregateAndProof aggregateAndProof1 =
@@ -210,7 +212,7 @@ class AggregationDutyTest {
         committeeIndex,
         completedFuture(Optional.of(unsignedAttestation)));
 
-    when(validatorApiChannel.createAggregate(unsignedAttestation.getData()))
+    when(validatorApiChannel.createAggregate(unsignedAttestation.getData().hashTreeRoot()))
         .thenReturn(completedFuture(Optional.of(aggregate)));
 
     final AggregateAndProof aggregateAndProof =
@@ -265,7 +267,7 @@ class AggregationDutyTest {
         dataStructureUtil.randomSignature(),
         2,
         completedFuture(Optional.of(unsignedAttestation)));
-    when(validatorApiChannel.createAggregate(unsignedAttestation.getData()))
+    when(validatorApiChannel.createAggregate(unsignedAttestation.getData().hashTreeRoot()))
         .thenReturn(completedFuture(Optional.empty()));
 
     assertThat(duty.performDuty()).isCompleted();
@@ -284,7 +286,7 @@ class AggregationDutyTest {
         dataStructureUtil.randomSignature(),
         2,
         completedFuture(Optional.of(unsignedAttestation)));
-    when(validatorApiChannel.createAggregate(unsignedAttestation.getData()))
+    when(validatorApiChannel.createAggregate(unsignedAttestation.getData().hashTreeRoot()))
         .thenReturn(failedFuture(exception));
 
     performAndReportDuty();

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -168,7 +168,7 @@ class MetricRecordingValidatorApiChannelTest {
             dataStructureUtil.randomAttestation()),
         requestDataTest(
             "createAggregate",
-            channel -> channel.createAggregate(attestationData),
+            channel -> channel.createAggregate(attestationData.hashTreeRoot()),
             MetricRecordingValidatorApiChannel.AGGREGATE_REQUESTS_COUNTER_NAME,
             dataStructureUtil.randomAttestation()));
   }

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -202,13 +202,13 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Attestation>> createAggregate(final AttestationData attestationData) {
+  public SafeFuture<Optional<Attestation>> createAggregate(final Bytes32 attestationHashTreeRoot) {
     if (isSyncActive()) {
       return NodeSyncingException.failedFuture();
     }
     return SafeFuture.completedFuture(
         attestationPool
-            .createAggregateFor(attestationData)
+            .createAggregateFor(attestationHashTreeRoot)
             .map(ValidateableAttestation::getAttestation));
   }
 

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -18,6 +18,7 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -309,7 +310,8 @@ class ValidatorApiHandlerTest {
   public void createAggregate_shouldFailWhenNodeIsSyncing() {
     when(syncStateTracker.getCurrentSyncState()).thenReturn(SyncState.SYNCING);
     final SafeFuture<Optional<Attestation>> result =
-        validatorApiHandler.createAggregate(dataStructureUtil.randomAttestationData());
+        validatorApiHandler.createAggregate(
+            dataStructureUtil.randomAttestationData().hashTreeRoot());
 
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get).hasRootCauseInstanceOf(NodeSyncingException.class);
@@ -319,10 +321,10 @@ class ValidatorApiHandlerTest {
   public void createAggregate_shouldReturnAggregateFromAttestationPool() {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     final Optional<Attestation> aggregate = Optional.of(dataStructureUtil.randomAttestation());
-    when(attestationPool.createAggregateFor(attestationData))
+    when(attestationPool.createAggregateFor(eq(attestationData.hashTreeRoot())))
         .thenReturn(aggregate.map(ValidateableAttestation::fromAttestation));
 
-    assertThat(validatorApiHandler.createAggregate(attestationData))
+    assertThat(validatorApiHandler.createAggregate(attestationData.hashTreeRoot()))
         .isCompletedWithValue(aggregate);
   }
 


### PR DESCRIPTION
## PR Description
- Updated `createAggregateFor` method to take attestation hash_tree_root param. This work will help the follow up changes for the Validator API implementation.

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required. (no changes in docs required)