### PR TITLE
Prioritise more recent attestations when creating blocks

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
@@ -108,7 +109,10 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
   public synchronized SSZList<Attestation> getAttestationsForBlock(
       final BeaconState stateAtBlockSlot) {
     final SSZMutableList<Attestation> attestations = BeaconBlockBodyLists.createAttestations();
-    attestationGroupByDataHash.values().stream()
+    dataHashBySlot.descendingMap().values().stream()
+        .flatMap(Collection::stream)
+        .map(attestationGroupByDataHash::get)
+        .filter(Objects::nonNull)
         .filter(group -> isValid(stateAtBlockSlot, group.getAttestationData()))
         .flatMap(MatchingDataAttestationGroup::stream)
         .limit(attestations.getMaxSize())

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -149,6 +149,25 @@ class AggregatingAttestationPoolTest {
   }
 
   @Test
+  void getAttestationsForBlock_shouldIncludeMoreRecentAttestationsFirst() {
+    final AttestationData attestationData1 =
+        dataStructureUtil.randomAttestationData(UnsignedLong.valueOf(5));
+    final AttestationData attestationData2 =
+        dataStructureUtil.randomAttestationData(UnsignedLong.valueOf(6));
+    final AttestationData attestationData3 =
+        dataStructureUtil.randomAttestationData(UnsignedLong.valueOf(7));
+    final Attestation attestation1 = addAttestationFromValidators(attestationData1, 1, 2);
+    final Attestation attestation2 = addAttestationFromValidators(attestationData2, 3, 4);
+    final Attestation attestation3 = addAttestationFromValidators(attestationData3, 5, 6);
+
+    final BeaconState stateAtBlockSlot =
+        dataStructureUtil.randomBeaconState(UnsignedLong.valueOf(10));
+
+    assertThat(aggregatingPool.getAttestationsForBlock(stateAtBlockSlot))
+        .containsExactly(attestation3, attestation2, attestation1);
+  }
+
+  @Test
   public void getAttestationsForBlock_shouldNotAddMoreAttestationsThanAllowedInBlock() {
     final BeaconState state = dataStructureUtil.randomBeaconState();
     Constants.MAX_ATTESTATIONS = 2;


### PR DESCRIPTION
## PR Description
When creating blocks, include attestations from more recent slots first as they will have a lower inclusion delay and thus pay greater rewards.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.