### PR TITLE
add a network.yml file to store fork and contract address

### DIFF
--- a/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/util/DataStructureUtil.java
+++ b/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/util/DataStructureUtil.java
@@ -72,6 +72,7 @@ import tech.pegasys.teku.ssz.SSZTypes.SSZMutableList;
 import tech.pegasys.teku.ssz.SSZTypes.SSZMutableVector;
 import tech.pegasys.teku.ssz.SSZTypes.SSZVector;
 import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.util.config.Eth1Address;
 
 public final class DataStructureUtil {
 
@@ -101,6 +102,10 @@ public final class DataStructureUtil {
 
   public UnsignedLong randomUnsignedLong() {
     return UnsignedLong.fromLongBits(randomLong());
+  }
+
+  public Eth1Address randomEth1Address() {
+    return new Eth1Address(randomBytes32().slice(0, 20));
   }
 
   private Bytes4 randomBytes4() {

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -50,7 +50,8 @@ public class StorageService extends Service {
                   serviceConfig.getConfig().getDataPath(),
                   serviceConfig.getConfig().getDataStorageMode(),
                   serviceConfig.getConfig().getDataStorageCreateDbVersion(),
-                  serviceConfig.getConfig().getDataStorageFrequency());
+                  serviceConfig.getConfig().getDataStorageFrequency(),
+                  serviceConfig.getConfig().getEth1DepositContractAddress());
           database = dbFactory.createDatabase();
 
           chainStorage = ChainStorage.create(serviceConfig.getEventBus(), database);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -23,9 +23,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.storage.server.metadata.DatabaseMetadata;
+import tech.pegasys.teku.storage.server.network.DatabaseNetwork;
 import tech.pegasys.teku.storage.server.noop.NoOpDatabase;
 import tech.pegasys.teku.storage.server.rocksdb.RocksDbConfiguration;
 import tech.pegasys.teku.storage.server.rocksdb.RocksDbDatabase;
+import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.util.config.Eth1Address;
 import tech.pegasys.teku.util.config.StateStorageMode;
 
 public class VersionedDatabaseFactory implements DatabaseFactory {
@@ -36,6 +39,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
   @VisibleForTesting static final String ARCHIVE_PATH = "archive";
   @VisibleForTesting static final String DB_VERSION_PATH = "db.version";
   @VisibleForTesting static final String METADATA_FILENAME = "metadata.yml";
+  @VisibleForTesting static final String NETWORK_FILENAME = "network.yml";
 
   private final MetricsSystem metricsSystem;
   private final File dataDirectory;
@@ -45,6 +49,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
   private final StateStorageMode stateStorageMode;
   private final DatabaseVersion createDatabaseVersion;
   private final long stateStorageFrequency;
+  private final Eth1Address eth1Address;
 
   public VersionedDatabaseFactory(
       final MetricsSystem metricsSystem,
@@ -55,7 +60,8 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
         dataPath,
         dataStorageMode,
         DatabaseVersion.DEFAULT_VERSION.getValue(),
-        DEFAULT_STORAGE_FREQUENCY);
+        DEFAULT_STORAGE_FREQUENCY,
+        Eth1Address.fromHexString("0x77f7bED277449F51505a4C54550B074030d989bC"));
   }
 
   public VersionedDatabaseFactory(
@@ -63,7 +69,8 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
       final String dataPath,
       final StateStorageMode dataStorageMode,
       final String createDatabaseVersion,
-      final long stateStorageFrequency) {
+      final long stateStorageFrequency,
+      final Eth1Address eth1Address) {
     this.metricsSystem = metricsSystem;
     this.dataDirectory = Paths.get(dataPath).toFile();
     this.dbDirectory = this.dataDirectory.toPath().resolve(DB_PATH).toFile();
@@ -71,6 +78,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
     this.dbVersionFile = this.dataDirectory.toPath().resolve(DB_VERSION_PATH).toFile();
     this.stateStorageMode = dataStorageMode;
     this.stateStorageFrequency = stateStorageFrequency;
+    this.eth1Address = eth1Address;
 
     this.createDatabaseVersion =
         DatabaseVersion.fromString(createDatabaseVersion).orElse(DatabaseVersion.DEFAULT_VERSION);
@@ -124,18 +132,28 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
   }
 
   private Database createV3Database() {
-    final RocksDbConfiguration rocksDbConfiguration =
-        RocksDbConfiguration.v3And4Settings(dbDirectory.toPath());
-    return RocksDbDatabase.createV3(metricsSystem, rocksDbConfiguration, stateStorageMode);
+    try {
+      DatabaseNetwork.init(getNetworkFile(), Constants.GENESIS_FORK_VERSION, eth1Address);
+      final RocksDbConfiguration rocksDbConfiguration =
+          RocksDbConfiguration.v3And4Settings(dbDirectory.toPath());
+      return RocksDbDatabase.createV3(metricsSystem, rocksDbConfiguration, stateStorageMode);
+    } catch (final IOException e) {
+      throw new DatabaseStorageException("Failed to read network configuration file", e);
+    }
   }
 
   private Database createV4Database() {
-    return RocksDbDatabase.createV4(
-        metricsSystem,
-        RocksDbConfiguration.v3And4Settings(dbDirectory.toPath()),
-        RocksDbConfiguration.v3And4Settings(archiveDirectory.toPath()),
-        stateStorageMode,
-        stateStorageFrequency);
+    try {
+      DatabaseNetwork.init(getNetworkFile(), Constants.GENESIS_FORK_VERSION, eth1Address);
+      return RocksDbDatabase.createV4(
+          metricsSystem,
+          RocksDbConfiguration.v3And4Settings(dbDirectory.toPath()),
+          RocksDbConfiguration.v3And4Settings(archiveDirectory.toPath()),
+          stateStorageMode,
+          stateStorageFrequency);
+    } catch (final IOException e) {
+      throw new DatabaseStorageException("Failed to read configuration file", e);
+    }
   }
 
   /**
@@ -147,6 +165,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
     try {
       final DatabaseMetadata metaData =
           DatabaseMetadata.init(getMetadataFile(), DatabaseMetadata.v5Defaults());
+      DatabaseNetwork.init(getNetworkFile(), Constants.GENESIS_FORK_VERSION, eth1Address);
       return RocksDbDatabase.createV4(
           metricsSystem,
           metaData.getHotDbConfiguration().withDatabaseDir(dbDirectory.toPath()),
@@ -160,6 +179,10 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
 
   private File getMetadataFile() {
     return dataDirectory.toPath().resolve(METADATA_FILENAME).toFile();
+  }
+
+  private File getNetworkFile() {
+    return dataDirectory.toPath().resolve(NETWORK_FILENAME).toFile();
   }
 
   private void validateDataPaths() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/network/DatabaseNetwork.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/network/DatabaseNetwork.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.network;
+
+import static com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature.WRITE_DOC_START_MARKER;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.annotations.VisibleForTesting;
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
+import tech.pegasys.teku.storage.server.DatabaseStorageException;
+import tech.pegasys.teku.util.config.Eth1Address;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DatabaseNetwork {
+  @JsonProperty("fork_version")
+  @VisibleForTesting
+  final String forkVersion;
+
+  @JsonProperty("deposit_contract")
+  @VisibleForTesting
+  final String depositContract;
+
+  @JsonCreator
+  DatabaseNetwork(
+      @JsonProperty("fork_version") final String forkVersion,
+      @JsonProperty("deposit_contract") final String depositContract) {
+    this.forkVersion = forkVersion;
+    this.depositContract = depositContract;
+  }
+
+  public static DatabaseNetwork init(
+      final File source, Bytes4 forkVersion, Eth1Address depositContract) throws IOException {
+    final String forkVersionString = forkVersion.toHexString().toLowerCase();
+    final String depositContractString =
+        depositContract == null ? "" : depositContract.toHexString().toLowerCase();
+    final ObjectMapper objectMapper =
+        new ObjectMapper(new YAMLFactory().disable(WRITE_DOC_START_MARKER));
+    if (source.exists()) {
+      final DatabaseNetwork databaseNetwork =
+          objectMapper.readerFor(DatabaseNetwork.class).readValue(source);
+
+      if (!databaseNetwork.forkVersion.equals(forkVersionString)) {
+        throw new DatabaseStorageException(
+            formatMessage("fork version", forkVersionString, databaseNetwork.forkVersion));
+      }
+      if (databaseNetwork.depositContract != null
+          && !databaseNetwork.depositContract.equals(depositContractString)) {
+        throw new DatabaseStorageException(
+            formatMessage(
+                "deposit contract", depositContractString, databaseNetwork.depositContract));
+      }
+      return databaseNetwork;
+    } else {
+      DatabaseNetwork databaseNetwork =
+          new DatabaseNetwork(forkVersionString, depositContractString);
+      objectMapper.writerFor(DatabaseNetwork.class).writeValue(source, databaseNetwork);
+      return databaseNetwork;
+    }
+  }
+
+  private static String formatMessage(String fieldName, String expected, String actual) {
+    return String.format(
+        "Supplied %s (%s) does not match the stored database (%s). "
+            + "Check that the existing database matches the current network settings.",
+        fieldName, expected, actual);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final DatabaseNetwork that = (DatabaseNetwork) o;
+    return Objects.equals(forkVersion, that.forkVersion)
+        && Objects.equals(depositContract, that.depositContract);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(forkVersion, depositContract);
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/network/DatabaseNetwork.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/network/DatabaseNetwork.java
@@ -57,7 +57,7 @@ public class DatabaseNetwork {
       final DatabaseNetwork databaseNetwork =
           objectMapper.readerFor(DatabaseNetwork.class).readValue(source);
 
-      if (!databaseNetwork.forkVersion.equals(forkVersionString)) {
+      if (!forkVersionString.equals(databaseNetwork.forkVersion)) {
         throw new DatabaseStorageException(
             formatMessage("fork version", forkVersionString, databaseNetwork.forkVersion));
       }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
@@ -25,11 +25,14 @@ import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import tech.pegasys.teku.metrics.StubMetricsSystem;
+import tech.pegasys.teku.util.config.Eth1Address;
 import tech.pegasys.teku.util.config.StateStorageMode;
 
 public class VersionedDatabaseFactoryTest {
 
   private static final StateStorageMode DATA_STORAGE_MODE = PRUNE;
+  private final Eth1Address eth1Address =
+      Eth1Address.fromHexString("0x77f7bED277449F51505a4C54550B074030d989bC");
   @TempDir Path dataDir;
 
   @Test
@@ -63,7 +66,7 @@ public class VersionedDatabaseFactoryTest {
   public void createDatabase_asV4Database() throws Exception {
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, "4", 1L);
+            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, "4", 1L, eth1Address);
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
       assertDbVersionSaved(dataDir, DatabaseVersion.V4);
@@ -78,7 +81,7 @@ public class VersionedDatabaseFactoryTest {
   public void createDatabase_asV5Database() throws Exception {
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, "5", 1L);
+            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, "5", 1L, eth1Address);
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
       assertDbVersionSaved(dataDir, DatabaseVersion.V5);
@@ -122,7 +125,7 @@ public class VersionedDatabaseFactoryTest {
     createDbDirectory(dataDir);
     final VersionedDatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, "4", 1L);
+            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, "4", 1L, eth1Address);
     assertThat(dbFactory.getDatabaseVersion()).isEqualTo(DatabaseVersion.V4);
   }
 
@@ -131,7 +134,7 @@ public class VersionedDatabaseFactoryTest {
     createDbDirectory(dataDir);
     final VersionedDatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, "3.0", 1L);
+            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, "3.0", 1L, eth1Address);
     assertThat(dbFactory.getDatabaseVersion()).isEqualTo(DatabaseVersion.V3);
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/network/DatabaseNetworkTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/network/DatabaseNetworkTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.network;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
+import tech.pegasys.teku.storage.server.DatabaseStorageException;
+import tech.pegasys.teku.util.config.Eth1Address;
+
+public class DatabaseNetworkTest {
+  DataStructureUtil dataStructureUtil = new DataStructureUtil();
+
+  @Test
+  public void shouldCreateNetworkFile(@TempDir final File tempDir) throws IOException {
+    final File networkFile = new File(tempDir, "network.yml");
+    assertThat(networkFile).doesNotExist();
+    final Bytes4 fork = dataStructureUtil.randomFork().getCurrent_version();
+    final Eth1Address eth1Address = dataStructureUtil.randomEth1Address();
+    assertThat(DatabaseNetwork.init(networkFile, fork, eth1Address))
+        .isEqualTo(
+            new DatabaseNetwork(
+                fork.toHexString().toLowerCase(), eth1Address.toHexString().toLowerCase()));
+    assertThat(networkFile).exists();
+  }
+
+  @Test
+  public void shouldTolerateMissingDepositContract(@TempDir final File tempDir) throws IOException {
+    final File networkFile = new File(tempDir, "network.yml");
+    assertThat(networkFile).doesNotExist();
+    final Bytes4 fork = dataStructureUtil.randomFork().getCurrent_version();
+    final Eth1Address eth1Address = null;
+    assertThat(DatabaseNetwork.init(networkFile, fork, eth1Address))
+        .isEqualTo(new DatabaseNetwork(fork.toHexString().toLowerCase(), ""));
+    assertThat(networkFile).exists();
+  }
+
+  @Test
+  public void shouldThrowIfForkDiffers(@TempDir final File tempDir) throws IOException {
+    final File networkFile = new File(tempDir, "network.yml");
+    assertThat(networkFile).doesNotExist();
+    final Bytes4 fork = dataStructureUtil.randomFork().getCurrent_version();
+    final Eth1Address eth1Address = dataStructureUtil.randomEth1Address();
+    DatabaseNetwork.init(
+        networkFile, dataStructureUtil.randomFork().getCurrent_version(), eth1Address);
+
+    assertThatThrownBy(() -> DatabaseNetwork.init(networkFile, fork, eth1Address))
+        .isInstanceOf(DatabaseStorageException.class)
+        .hasMessageStartingWith("Supplied fork version");
+  }
+
+  @Test
+  public void shouldThrowIfDepositContractDiffers(@TempDir final File tempDir) throws IOException {
+    final File networkFile = new File(tempDir, "network.yml");
+    assertThat(networkFile).doesNotExist();
+    final Bytes4 fork = dataStructureUtil.randomFork().getCurrent_version();
+    final Eth1Address eth1Address = dataStructureUtil.randomEth1Address();
+    DatabaseNetwork.init(networkFile, fork, dataStructureUtil.randomEth1Address());
+
+    assertThatThrownBy(() -> DatabaseNetwork.init(networkFile, fork, eth1Address))
+        .isInstanceOf(DatabaseStorageException.class)
+        .hasMessageStartingWith("Supplied deposit contract");
+  }
+
+  @Test
+  public void shouldNotThrowIfForkAndContractMatch(@TempDir final File tempDir) throws IOException {
+    final File networkFile = new File(tempDir, "network.yml");
+    assertThat(networkFile).doesNotExist();
+    final Bytes4 fork = dataStructureUtil.randomFork().getCurrent_version();
+    final Eth1Address eth1Address = dataStructureUtil.randomEth1Address();
+    DatabaseNetwork.init(networkFile, fork, eth1Address);
+
+    assertDoesNotThrow(() -> DatabaseNetwork.init(networkFile, fork, eth1Address));
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -259,7 +259,8 @@ public class BeaconNodeCommand implements Callable<Integer> {
     } catch (InvalidConfigurationException | DatabaseStorageException ex) {
       reportUserError(ex);
     } catch (CompletionException e) {
-      if (Throwables.getRootCause(e) instanceof InvalidConfigurationException) {
+      if (Throwables.getRootCause(e) instanceof InvalidConfigurationException
+          || Throwables.getRootCause(e) instanceof DatabaseStorageException) {
         reportUserError(Throwables.getRootCause(e));
       } else {
         reportUnexpectedError(e);


### PR DESCRIPTION
 - on startup, if a pre-existing file exists, it is validated against the context of the current runtime

 - mis-matching fork or eth1 deposit contract will terminate startup.

 fixes #2493

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.