### PR TITLE
Fix incorrectly marking the node as syncing

### DIFF
--- a/sync/src/main/java/tech/pegasys/teku/sync/SyncManager.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/SyncManager.java
@@ -52,6 +52,14 @@ public class SyncManager extends Service {
 
   private boolean syncActive = false;
   private boolean syncQueued = false;
+  /**
+   * Tracks the last state we notified subscribers of. It differs from syncActive at the start of a
+   * sync because we set syncActive as soon as we begin, but only notify subscribers once we've
+   * actually found a valid peer to sync off to avoid briefly toggling to syncing and back off each
+   * time we look for sync targets.
+   */
+  private boolean subscribersSyncActive = false;
+
   private volatile long peerConnectSubscriptionId;
 
   private final AsyncRunner asyncRunner;
@@ -110,7 +118,6 @@ public class SyncManager extends Service {
         return;
       }
       syncActive = true;
-      syncSubscribers.deliver(SyncSubscriber::onSyncingChange, syncActive);
     }
 
     startSync();
@@ -126,7 +133,10 @@ public class SyncManager extends Service {
                   startSync();
                 } else {
                   syncActive = false;
-                  syncSubscribers.deliver(SyncSubscriber::onSyncingChange, syncActive);
+                  if (subscribersSyncActive) {
+                    subscribersSyncActive = false;
+                    syncSubscribers.deliver(SyncSubscriber::onSyncingChange, false);
+                  }
                 }
               }
             },
@@ -181,6 +191,12 @@ public class SyncManager extends Service {
 
   private SafeFuture<Void> syncToPeer(final Eth2Peer syncPeer) {
     LOG.trace("Sync to peer {}", syncPeer.getId());
+    synchronized (this) {
+      if (!subscribersSyncActive) {
+        subscribersSyncActive = true;
+        syncSubscribers.deliver(SyncSubscriber::onSyncingChange, true);
+      }
+    }
     return peerSync
         .sync(syncPeer)
         .thenCompose(

--- a/sync/src/main/java/tech/pegasys/teku/sync/SyncStateTracker.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/SyncStateTracker.java
@@ -32,7 +32,7 @@ public class SyncStateTracker extends Service {
   private final Duration startupTimeout;
   private final int startupTargetPeerCount;
 
-  private boolean startingUp = true;
+  private boolean startingUp;
   private boolean syncActive = false;
   private long peerConnectedSubscriptionId;
   private long syncSubscriptionId;
@@ -50,10 +50,13 @@ public class SyncStateTracker extends Service {
     this.network = network;
     this.startupTargetPeerCount = startupTargetPeerCount;
     this.startupTimeout = startupTimeout;
-    currentState =
-        startupTargetPeerCount == 0 || startupTimeout.toMillis() == 0
-            ? SyncState.IN_SYNC
-            : SyncState.START_UP;
+    if (startupTargetPeerCount == 0 || startupTimeout.toMillis() == 0) {
+      startingUp = false;
+      currentState = SyncState.IN_SYNC;
+    } else {
+      startingUp = true;
+      currentState = SyncState.START_UP;
+    }
   }
 
   public SyncState getCurrentSyncState() {

--- a/sync/src/test/java/tech/pegasys/teku/sync/SyncManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/SyncManagerTest.java
@@ -318,4 +318,16 @@ public class SyncManagerTest {
     assertThat(syncManager.isSyncActive()).isTrue();
     verifyNoMoreInteractions(syncSubscriber);
   }
+
+  @Test
+  void subscribeToSyncChanges_notNotifiedWhenSyncFailsToFindPeersToSyncTo() {
+    syncManager.subscribeToSyncChanges(syncSubscriber);
+
+    when(network.streamPeers()).thenReturn(Stream.empty());
+
+    final SafeFuture<PeerSyncResult> sync1Future = new SafeFuture<>();
+    when(peerSync.sync(peer)).thenReturn(sync1Future);
+    assertThat(syncManager.start()).isCompleted();
+    verifyNoInteractions(syncSubscriber);
+  }
 }

--- a/sync/src/test/java/tech/pegasys/teku/sync/SyncStateTrackerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/SyncStateTrackerTest.java
@@ -103,7 +103,7 @@ class SyncStateTrackerTest {
     final SyncStateTracker tracker =
         new SyncStateTracker(
             asyncRunner, syncService, network, STARTUP_TARGET_PEER_COUNT, Duration.ofSeconds(0));
-    tracker.start();
+    tracker.start().join();
 
     final ArgumentCaptor<SyncSubscriber> syncSubscriberArgumentCaptor =
         ArgumentCaptor.forClass(SyncSubscriber.class);


### PR DESCRIPTION
## PR Description
Avoid a couple of situations where the node would incorrectly mark itself as syncing when it should have been marked as in-sync.

* Don't switch to syncing when searching for peers, only when a suitable sync target is found.
* Don't switch to startup mode after syncing if startup timeout is set to 0.


## Fixed Issue(s)
fixes #2438 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.