### PR TITLE
Implement Validator API GetAggregate method

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/validator/GetAggregateIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/validator/GetAggregateIntegrationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.Map;
+import java.util.Optional;
+import okhttp3.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
+import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAggregate;
+import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+public class GetAggregateIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
+
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+
+  @BeforeEach
+  public void setup() {
+    startRestAPIAtGenesis();
+  }
+
+  @Test
+  public void shouldReturnNotFoundWhenCreateAggregateReturnsEmpty() throws Exception {
+    final Attestation attestation = dataStructureUtil.randomAttestation();
+    final Map<String, String> params =
+        Map.of(
+            "attestation_data_root", attestation.hash_tree_root().toHexString(),
+            "slot", UnsignedLong.valueOf(1).toString());
+
+    when(validatorApiChannel.createAggregate(eq(attestation.hash_tree_root())))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+
+    Response response = getResponse(GetAggregate.ROUTE, params);
+    assertThat(response.code()).isEqualTo(404);
+  }
+
+  @Test
+  public void shouldSucceedWhenCreateAggregateReturnsAttestation() throws Exception {
+    final Attestation attestation = dataStructureUtil.randomAttestation();
+    final Map<String, String> params =
+        Map.of(
+            "attestation_data_root", attestation.hash_tree_root().toHexString(),
+            "slot", UnsignedLong.valueOf(1).toString());
+
+    when(validatorApiChannel.createAggregate(eq(attestation.hash_tree_root())))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(attestation)));
+
+    Response response = getResponse(GetAggregate.ROUTE, params);
+    assertThat(response.code()).isEqualTo(200);
+    tech.pegasys.teku.api.schema.Attestation schemaAttestation =
+        new tech.pegasys.teku.api.schema.Attestation(attestation);
+    assertThat(response.body().string()).isEqualTo(jsonProvider.objectToJSON(schemaAttestation));
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -57,6 +57,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.node.GetGenesisTime;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetSyncing;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetVersion;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetIdentity;
+import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAggregate;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAttestation;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetNewBlock;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.PostAttestation;
@@ -222,6 +223,7 @@ public class BeaconRestApi {
     app.get(GetAttestation.ROUTE, new GetAttestation(validatorDataProvider, jsonProvider));
     app.get(GetValidators.ROUTE, new GetValidators(provider, jsonProvider));
     app.get(GetNewBlock.ROUTE, new GetNewBlock(dataProvider, jsonProvider));
+    app.get(GetAggregate.ROUTE, new GetAggregate(validatorDataProvider, jsonProvider));
 
     app.post(PostAttestation.ROUTE, new PostAttestation(dataProvider, jsonProvider));
     app.post(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/RestApiConstants.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/RestApiConstants.java
@@ -24,6 +24,7 @@ public class RestApiConstants {
   public static final String COMMITTEE_INDEX = "committee_index";
   public static final String RANDAO_REVEAL = "randao_reveal";
   public static final String GRAFFITI = "graffiti";
+  public static final String ATTESTATION_DATA_ROOT = "attestation_data_root";
 
   public static final String TAG_ADMIN = "Admin";
   public static final String TAG_BEACON = "Beacon";
@@ -37,6 +38,7 @@ public class RestApiConstants {
   public static final String RES_ACCEPTED = "202"; // SC_ACCEPTED
   public static final String RES_NO_CONTENT = "204"; // SC_NO_CONTENT
   public static final String RES_BAD_REQUEST = "400"; // SC_BAD_REQUEST
+  public static final String RES_FORBIDDEN = "403"; // SC_FORBIDDEN
   public static final String RES_NOT_FOUND = "404"; // SC_NOT_FOUND
   public static final String RES_CONFLICT = "406"; // SC_CONFLICT
   public static final String RES_INTERNAL_ERROR = "500"; // SC_INTERNAL_SERVER_ERROR

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/validator/GetAggregate.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/validator/GetAggregate.java
@@ -28,7 +28,6 @@ import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParam
 import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsUnsignedLong;
 
 import com.google.common.base.Throwables;
-import com.google.common.primitives.UnsignedLong;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
@@ -99,8 +98,9 @@ public class GetAggregate implements Handler {
             String.format("Please specify both %s and %s", ATTESTATION_DATA_ROOT, SLOT));
       }
       Bytes32 beacon_block_root = getParameterValueAsBytes32(parameters, ATTESTATION_DATA_ROOT);
-      @SuppressWarnings("unused")
-      UnsignedLong slot = getParameterValueAsUnsignedLong(parameters, SLOT);
+      // Teku isn't using this parameter at the moment. We are enforcing it to stay compatible with
+      // the standard api
+      getParameterValueAsUnsignedLong(parameters, SLOT);
 
       ctx.result(
           provider
@@ -126,7 +126,7 @@ public class GetAggregate implements Handler {
   }
 
   /*
-   At the moment we aren't handling the error:
+   At the moment we aren't enforcing:
    `Beacon node was not assigned to aggregate on that subnet` that should return a status code 403
   */
   private CompletionStage<String> handleError(final Context ctx, final Throwable error) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/validator/GetAggregate.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/validator/GetAggregate.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.validator;
+
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.ATTESTATION_DATA_ROOT;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_FORBIDDEN;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.SLOT;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR;
+import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsBytes32;
+import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsUnsignedLong;
+
+import com.google.common.base.Throwables;
+import com.google.common.primitives.UnsignedLong;
+import io.javalin.http.Context;
+import io.javalin.http.Handler;
+import io.javalin.plugin.openapi.annotations.HttpMethod;
+import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiContent;
+import io.javalin.plugin.openapi.annotations.OpenApiParam;
+import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.ValidatorDataProvider;
+import tech.pegasys.teku.api.schema.Attestation;
+import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
+import tech.pegasys.teku.beaconrestapi.schema.ErrorResponse;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.provider.JsonProvider;
+
+public class GetAggregate implements Handler {
+
+  public static final String ROUTE = "/validator/aggregate_attestation";
+
+  private final ValidatorDataProvider provider;
+  private final JsonProvider jsonProvider;
+
+  public GetAggregate(final ValidatorDataProvider provider, final JsonProvider jsonProvider) {
+    this.jsonProvider = jsonProvider;
+    this.provider = provider;
+  }
+
+  @OpenApi(
+      path = ROUTE,
+      method = HttpMethod.GET,
+      summary = "Aggregates all attestations matching given attestation data root and slot.",
+      tags = {TAG_VALIDATOR},
+      queryParams = {
+        @OpenApiParam(
+            name = ATTESTATION_DATA_ROOT,
+            description =
+                "`String` HashTreeRoot of AttestationData that validator want's aggregated.",
+            required = true),
+        @OpenApiParam(
+            name = SLOT,
+            description = "`UnsignedLong` Non-finalized slot for which to create the aggregation.",
+            required = true)
+      },
+      description = "Aggregates all attestations matching given attestation data root and slot.",
+      responses = {
+        @OpenApiResponse(
+            status = RES_OK,
+            content = @OpenApiContent(from = Attestation.class, isArray = true),
+            description =
+                "Returns aggregated `Attestation` object with same `AttestationData` root."),
+        @OpenApiResponse(status = RES_BAD_REQUEST, description = "Invalid parameter supplied"),
+        @OpenApiResponse(
+            status = RES_FORBIDDEN,
+            description = "Beacon node was not assigned to aggregate on that subnet"),
+        @OpenApiResponse(status = RES_INTERNAL_ERROR, description = "Beacon node internal error.")
+      })
+  @Override
+  public void handle(Context ctx) throws Exception {
+
+    try {
+      final Map<String, List<String>> parameters = ctx.queryParamMap();
+      if (parameters.size() < 2) {
+        throw new IllegalArgumentException(
+            String.format("Please specify both %s and %s", ATTESTATION_DATA_ROOT, SLOT));
+      }
+      Bytes32 beacon_block_root = getParameterValueAsBytes32(parameters, ATTESTATION_DATA_ROOT);
+      @SuppressWarnings("unused")
+      UnsignedLong slot = getParameterValueAsUnsignedLong(parameters, SLOT);
+
+      ctx.result(
+          provider
+              .createAggregate(beacon_block_root)
+              .thenApplyChecked(optionalAttestation -> serializeResult(ctx, optionalAttestation))
+              .exceptionallyCompose(error -> handleError(ctx, error)));
+    } catch (final IllegalArgumentException e) {
+      ctx.result(jsonProvider.objectToJSON(new BadRequest(e.getMessage())));
+      ctx.status(SC_BAD_REQUEST);
+    }
+  }
+
+  private String serializeResult(final Context ctx, final Optional<Attestation> optionalAttestation)
+      throws com.fasterxml.jackson.core.JsonProcessingException {
+    if (optionalAttestation.isPresent()) {
+      ctx.status(SC_OK);
+      String json = jsonProvider.objectToJSON(optionalAttestation.get());
+      return json;
+    } else {
+      ctx.status(SC_NOT_FOUND);
+      return "";
+    }
+  }
+
+  /*
+   At the moment we aren't handling the error:
+   `Beacon node was not assigned to aggregate on that subnet` that should return a status code 403
+  */
+  private CompletionStage<String> handleError(final Context ctx, final Throwable error) {
+    if (Throwables.getRootCause(error) instanceof IllegalArgumentException) {
+      ctx.status(SC_BAD_REQUEST);
+      return error(SC_BAD_REQUEST, error);
+    } else {
+      ctx.status(SC_INTERNAL_SERVER_ERROR);
+      return error(SC_INTERNAL_SERVER_ERROR, error);
+    }
+  }
+
+  private SafeFuture<String> error(final int code, final Throwable error) {
+    return SafeFuture.of(
+        () -> jsonProvider.objectToJSON(new ErrorResponse(code, error.getMessage())));
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/validator/GetAggregate.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/validator/GetAggregate.java
@@ -69,7 +69,7 @@ public class GetAggregate implements Handler {
         @OpenApiParam(
             name = ATTESTATION_DATA_ROOT,
             description =
-                "`String` HashTreeRoot of AttestationData that validator want's aggregated.",
+                "`String` HashTreeRoot of AttestationData that validator wants aggregated.",
             required = true),
         @OpenApiParam(
             name = SLOT,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/schema/ErrorResponse.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/schema/ErrorResponse.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ErrorResponse {
+  private final Integer status;
+  private final String message;
+
+  @JsonCreator
+  public ErrorResponse(
+      @JsonProperty("status") Integer status, @JsonProperty("message") String message) {
+    this.status = status;
+    this.message = message;
+  }
+
+  @JsonProperty("status")
+  public final Integer getStatus() {
+    return status;
+  }
+
+  @JsonProperty("message")
+  public final String getMessage() {
+    return message;
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.node.GetGenesisTime;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetSyncing;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetVersion;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetIdentity;
+import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAggregate;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.PostBlock;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.PostDuties;
 import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
@@ -181,6 +182,11 @@ class BeaconRestApiTest {
   @Test
   public void shouldHaveValidatorDutiesEndpoint() {
     verify(app).post(eq(PostDuties.ROUTE), any(PostDuties.class));
+  }
+
+  @Test
+  public void shouldHaveValidatorCreateAggregateEndpoint() {
+    verify(app).get(eq(GetAggregate.ROUTE), any(GetAggregate.class));
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/validator/GetAggregateTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/validator/GetAggregateTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.validator;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.javalin.http.Context;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import tech.pegasys.teku.api.ValidatorDataProvider;
+import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.provider.JsonProvider;
+
+class GetAggregateTest {
+
+  @SuppressWarnings("unchecked")
+  private final ArgumentCaptor<SafeFuture<String>> args = ArgumentCaptor.forClass(SafeFuture.class);
+
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Context context = mock(Context.class);
+  private final ValidatorDataProvider provider = mock(ValidatorDataProvider.class);
+  private final JsonProvider jsonProvider = new JsonProvider();
+
+  private GetAggregate handler;
+
+  @BeforeEach
+  public void beforeEach() {
+    handler = new GetAggregate(provider, jsonProvider);
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenNoParameters() throws Exception {
+    when(context.queryParamMap()).thenReturn(emptyMap());
+
+    handler.handle(context);
+    verify(context).status(SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenMissingAttestationDataRoot() throws Exception {
+    final Map<String, List<String>> queryParamsMissingDataRoot =
+        Map.of(
+            "attestation_data_root", emptyList(),
+            "slot", List.of("1"));
+    when(context.queryParamMap()).thenReturn(queryParamsMissingDataRoot);
+
+    handler.handle(context);
+    verify(context).status(SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenMissingSlot() throws Exception {
+    final Bytes32 attestationHashTreeRoot = dataStructureUtil.randomAttestation().hash_tree_root();
+    final Map<String, List<String>> queryParamsMissingSlot =
+        Map.of(
+            "attestation_data_root", List.of(attestationHashTreeRoot.toHexString()),
+            "slot", emptyList());
+    when(context.queryParamMap()).thenReturn(queryParamsMissingSlot);
+
+    handler.handle(context);
+    verify(context).status(SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void shouldReturnNotFoundWhenAttestationIsNotPresent() throws Exception {
+    final Attestation attestation = dataStructureUtil.randomAttestation();
+    mockContextWithAttestationParams(attestation);
+    when(provider.createAggregate(eq(attestation.hash_tree_root())))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+
+    handler.handle(context);
+    verify(context).status(SC_NOT_FOUND);
+  }
+
+  @Test
+  public void shouldReturnAttestationWhenProviderSuccessfullyCreatesAggregation() throws Exception {
+    final Attestation attestation = dataStructureUtil.randomAttestation();
+    mockContextWithAttestationParams(attestation);
+    final tech.pegasys.teku.api.schema.Attestation schemaAttestation =
+        new tech.pegasys.teku.api.schema.Attestation(attestation);
+    when(provider.createAggregate(eq(attestation.hash_tree_root())))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(schemaAttestation)));
+
+    handler.handle(context);
+
+    verify(context).status(SC_OK);
+    verify(context).result(args.capture());
+
+    SafeFuture<String> future = args.getValue();
+    String data = future.get();
+    assertThat(data).isEqualTo(jsonProvider.objectToJSON(schemaAttestation));
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenFutureExceptionIsIllegalArgument() throws Exception {
+    final Attestation attestation = dataStructureUtil.randomAttestation();
+    mockContextWithAttestationParams(attestation);
+    when(provider.createAggregate(eq(attestation.hash_tree_root())))
+        .thenReturn(SafeFuture.failedFuture(new IllegalArgumentException()));
+
+    handler.handle(context);
+    verify(context).status(SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void shouldReturnServerErrorWhenFutureHasUnmappedException() throws Exception {
+    final Attestation attestation = dataStructureUtil.randomAttestation();
+    mockContextWithAttestationParams(attestation);
+    when(provider.createAggregate(eq(attestation.hash_tree_root())))
+        .thenReturn(SafeFuture.failedFuture(new RuntimeException()));
+
+    handler.handle(context);
+    verify(context).status(SC_INTERNAL_SERVER_ERROR);
+  }
+
+  private void mockContextWithAttestationParams(final Attestation attestation) {
+    final Map<String, List<String>> validQueryParams =
+        Map.of(
+            "attestation_data_root", List.of(attestation.hash_tree_root().toHexString()),
+            "slot", List.of("1"));
+    when(context.queryParamMap()).thenReturn(validQueryParams);
+  }
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -184,4 +184,10 @@ public class ValidatorDataProvider {
                   responseCode, blockImportResult.getFailureCause(), Optional.ofNullable(hashRoot));
             });
   }
+
+  public SafeFuture<Optional<Attestation>> createAggregate(final Bytes32 attestationHashTreeRoot) {
+    return validatorApiChannel
+        .createAggregate(attestationHashTreeRoot)
+        .thenApply(maybeAttestation -> maybeAttestation.map(Attestation::new));
+  }
 }


### PR DESCRIPTION
## PR Description
- Implemented GetAggregate method (based on https://ethereum.github.io/eth2.0-APIs/#/Validator/getAggregatedAttestation)
- At the moment, we are not verifying if the Beacon Node is subscribed to the subnet (error 403). Technically this isn't necessary atm. We might decide to add this in the future to be compliant with the spec.

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.