### PR TITLE
[Issue-2523] Interpret response code as a positive value

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoder.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.rpc.core;
 
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.SUCCESS_RESPONSE_CODE;
 import static tech.pegasys.teku.util.bytes.ByteUtil.toByteExactUnsigned;
+import static tech.pegasys.teku.util.bytes.ByteUtil.toUnsignedInt;
 
 import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
@@ -62,7 +63,7 @@ public class RpcResponseDecoder<T> {
     }
 
     if (respCodeMaybe.isEmpty()) {
-      respCodeMaybe = Optional.of((int) data.readByte());
+      respCodeMaybe = Optional.of(toUnsignedInt(data.readByte()));
     }
     int respCode = respCodeMaybe.get();
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoderTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoderTest.java
@@ -87,4 +87,22 @@ class RpcResponseDecoderTest extends RpcDecoderTestBase {
           .isEqualTo(new RpcException(ERROR_CODE.get(0), ERROR_MESSAGE));
     }
   }
+
+  @Test
+  public void decodeNextResponse_shouldThrowErrorIfStatusCodeIsNotSuccess_largeErrorCode()
+      throws Exception {
+    final Bytes errorCode = Bytes.of(255);
+    for (Iterable<ByteBuf> testByteBufSlice :
+        testByteBufSlices(errorCode, ERROR_MESSAGE_LENGTH_PREFIX, ERROR_MESSAGE_DATA)) {
+
+      assertThatThrownBy(
+              () -> {
+                for (ByteBuf byteBuf : testByteBufSlice) {
+                  decoder.decodeNextResponses(byteBuf);
+                }
+                decoder.complete();
+              })
+          .isEqualTo(new RpcException(errorCode.get(0), ERROR_MESSAGE));
+    }
+  }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Interpret rpc response code as a positive value.

## Fixed Issue(s)
#2523 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.