### PR TITLE
[Issue-2521] Don't delay notifications for attestations at current slot

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -462,14 +462,17 @@ public class ForkChoiceUtil {
 
     // Attestations can only affect the fork choice of subsequent slots.
     // Delay consideration in the fork choice until their slot is in the past.
-    if (get_current_slot(store).compareTo(attestation.getData().getSlot()) <= 0) {
+    final UnsignedLong currentSlot = get_current_slot(store);
+    if (currentSlot.compareTo(attestation.getData().getSlot()) < 0) {
       return AttestationProcessingResult.SAVED_FOR_FUTURE;
+    }
+    if (currentSlot.compareTo(attestation.getData().getSlot()) == 0) {
+      return AttestationProcessingResult.DEFER_FOR_FORK_CHOICE;
     }
 
     // Attestations cannot be from future epochs. If they are, delay consideration until the epoch
     // arrives
-    if (get_current_slot(store).compareTo(attestation.getData().getTarget().getEpochStartSlot())
-        < 0) {
+    if (currentSlot.compareTo(attestation.getData().getTarget().getEpochStartSlot()) < 0) {
       return AttestationProcessingResult.SAVED_FOR_FUTURE;
     }
     return SUCCESSFUL;

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/AttestationProcessingResult.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/AttestationProcessingResult.java
@@ -23,6 +23,8 @@ public class AttestationProcessingResult {
       new AttestationProcessingResult(Status.SUCCESSFUL, Optional.empty());
   public static final AttestationProcessingResult SAVED_FOR_FUTURE =
       new AttestationProcessingResult(Status.SAVED_FOR_FUTURE, Optional.empty());
+  public static final AttestationProcessingResult DEFER_FOR_FORK_CHOICE =
+      new AttestationProcessingResult(Status.DEFER_FORK_CHOICE_PROCESSING, Optional.empty());
   public static final AttestationProcessingResult UNKNOWN_BLOCK =
       new AttestationProcessingResult(Status.UNKNOWN_BLOCK, Optional.empty());
 
@@ -71,6 +73,7 @@ public class AttestationProcessingResult {
     SUCCESSFUL,
     UNKNOWN_BLOCK,
     SAVED_FOR_FUTURE,
+    DEFER_FORK_CHOICE_PROCESSING,
     INVALID
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
@@ -136,6 +136,14 @@ public class AttestationManager extends Service implements SlotEventsChannel {
                       attestation::hash_tree_root);
                   pendingAttestations.add(attestation);
                   break;
+                case DEFER_FORK_CHOICE_PROCESSING:
+                  LOG.trace(
+                      "Defer fork choice processing of attestation {}",
+                      attestation::hash_tree_root);
+                  notifySubscribers(attestation);
+                  futureAttestations.add(attestation);
+                  aggregatingAttestationPool.add(attestation);
+                  break;
                 case SAVED_FOR_FUTURE:
                   LOG.trace(
                       "Deferring attestation {} until a future slot", attestation::hash_tree_root);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
It looks like we're currently waiting one slot before we gossip locally produced attestations.  Add a new `AttestationProcessingResult` to distinguish attestations that aren't yet valid for fork-choice processing, but can be gossiped. 

## Fixed Issue(s)
Part of #2521

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.