### PR TITLE
Set the TRUNCATE_EXISTING flag when writing validator record

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SyncDataAccessor.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SyncDataAccessor.java
@@ -56,6 +56,11 @@ public class SyncDataAccessor {
     if (!parentDirectory.mkdirs() && !parentDirectory.isDirectory()) {
       throw new IOException("Unable to create directory " + parentDirectory);
     }
-    Files.write(path, data.toArrayUnsafe(), StandardOpenOption.SYNC, StandardOpenOption.CREATE);
+    Files.write(
+        path,
+        data.toArrayUnsafe(),
+        StandardOpenOption.SYNC,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING);
   }
 }


### PR DESCRIPTION
## PR Description
Ensure the existing validator record file is fully overwritten even if the new record is shorter, otherwise the YAML may become confused.  The file doesn't normally get shorted because the slot numbers keep getting bigger but better safe than sorry.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.