### PR TITLE
Don't try to load database statistics when the db is closed

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbStats.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbStats.java
@@ -220,12 +220,16 @@ public class RocksDbStats implements AutoCloseable {
   }
 
   private long getLongProperty(final RocksDB database, final String name) {
-    try {
-      return database.getLongProperty(name);
-    } catch (RocksDBException e) {
-      LOG.warn("Failed to load " + name + " property for RocksDB metrics");
-      return 0;
-    }
+    return ifOpen(
+        () -> {
+          try {
+            return database.getLongProperty(name);
+          } catch (RocksDBException e) {
+            LOG.warn("Failed to load " + name + " property for RocksDB metrics");
+            return 0L;
+          }
+        },
+        0L);
   }
 
   private Collector histogramToCollector(

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbStatsTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbStatsTest.java
@@ -1,0 +1,41 @@
+package tech.pegasys.teku.storage.server.rocksdb.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.hyperledger.besu.metrics.ObservableMetricsSystem;
+import org.hyperledger.besu.metrics.Observation;
+import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
+import org.junit.jupiter.api.Test;
+import org.rocksdb.RocksDB;
+import tech.pegasys.teku.metrics.TekuMetricCategory;
+
+class RocksDbStatsTest {
+
+  private final RocksDB database = mock(RocksDB.class);
+
+  @Test
+  void shouldNotCrashIfMetricsRequestedAfterClose() throws Exception {
+    final ObservableMetricsSystem metricsSystem =
+        PrometheusMetricsSystem.init(
+            MetricsConfiguration.builder()
+                .enabled(true)
+                .metricCategories(Set.of(TekuMetricCategory.STORAGE_HOT_DB))
+                .timersEnabled(true)
+                .build());
+
+    try (RocksDbStats stats = new RocksDbStats(metricsSystem, TekuMetricCategory.STORAGE_HOT_DB)) {
+      stats.registerMetrics(database);
+    }
+    when(database.getLongProperty(any())).thenThrow(new IllegalStateException("Database shutdown"));
+    final List<Observation> metrics =
+        metricsSystem.streamObservations().collect(Collectors.toList());
+    assertThat(metrics).isNotEmpty();
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbStatsTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbStatsTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.storage.server.rocksdb.core;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION

## PR Description
Fix the couple of calls to get stats from the database which weren't correctly checking if it was still open.

## Fixed Issue(s)
fixes #2516 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.