### PR TITLE
Make the target number of subscribers per attestation subnet a config option

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
@@ -143,7 +143,9 @@ public class Eth2NetworkBuilder {
         p2pNetwork,
         new Eth2PeerSelectionStrategy(
             config.getTargetPeerRange(),
-            network -> PeerSubnetSubscriptions.create(network, subnetTopicProvider),
+            network ->
+                PeerSubnetSubscriptions.create(
+                    network, subnetTopicProvider, config.getTargetSubnetSubscriberCount()),
             reputationManager,
             Collections::shuffle),
         config);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetScorer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetScorer.java
@@ -32,9 +32,11 @@ public class AttestationSubnetScorer implements PeerScorer {
   }
 
   public static AttestationSubnetScorer create(
-      final GossipNetwork gossipNetwork, final AttestationSubnetTopicProvider topicProvider) {
+      final GossipNetwork gossipNetwork,
+      final AttestationSubnetTopicProvider topicProvider,
+      final int targetSubnetSubscriberCount) {
     return new AttestationSubnetScorer(
-        PeerSubnetSubscriptions.create(gossipNetwork, topicProvider));
+        PeerSubnetSubscriptions.create(gossipNetwork, topicProvider, targetSubnetSubscriberCount));
   }
 
   @Override

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptionsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptionsTest.java
@@ -38,6 +38,7 @@ class PeerSubnetSubscriptionsTest {
   private static final NodeId PEER1 = new MockNodeId(1);
   private static final NodeId PEER2 = new MockNodeId(2);
   private static final NodeId PEER3 = new MockNodeId(3);
+  private static final int TARGET_SUBSCRIBER_COUNT = 2;
 
   private final GossipNetwork gossipNetwork = mock(GossipNetwork.class);
   private final AttestationSubnetTopicProvider topicProvider =
@@ -60,7 +61,7 @@ class PeerSubnetSubscriptionsTest {
             .build();
     when(gossipNetwork.getSubscribersByTopic()).thenReturn(subscribersByTopic);
     final PeerSubnetSubscriptions subscriptions =
-        PeerSubnetSubscriptions.create(gossipNetwork, topicProvider);
+        PeerSubnetSubscriptions.create(gossipNetwork, topicProvider, TARGET_SUBSCRIBER_COUNT);
     assertThat(subscriptions.getSubscriberCountForSubnet(0)).isEqualTo(3);
     assertThat(subscriptions.getSubscriberCountForSubnet(1)).isEqualTo(1);
     assertThat(subscriptions.getSubscriberCountForSubnet(2)).isEqualTo(2);
@@ -73,37 +74,42 @@ class PeerSubnetSubscriptionsTest {
   @Test
   void shouldReturnEmptyBitvectorWhenPeerHasNoSubscriptions() {
     final Bitvector subscriptions =
-        PeerSubnetSubscriptions.create(gossipNetwork, topicProvider).getSubscriptionsForPeer(PEER1);
+        PeerSubnetSubscriptions.create(gossipNetwork, topicProvider, TARGET_SUBSCRIBER_COUNT)
+            .getSubscriptionsForPeer(PEER1);
     assertThat(subscriptions).isEqualTo(createBitvector());
   }
 
   @Test
   void shouldReturnZeroWhenSubnetHasNoSubscribers() {
     final int subscriberCount =
-        PeerSubnetSubscriptions.create(gossipNetwork, topicProvider).getSubscriberCountForSubnet(1);
+        PeerSubnetSubscriptions.create(gossipNetwork, topicProvider, TARGET_SUBSCRIBER_COUNT)
+            .getSubscriberCountForSubnet(1);
     assertThat(subscriberCount).isEqualTo(0);
   }
 
   @Test
   void shouldRequireAdditionalPeersWhenNotAllSubnetsHaveEnoughSubscribers() {
     final int requiredPeers =
-        PeerSubnetSubscriptions.create(gossipNetwork, topicProvider).getSubscribersRequired();
-    assertThat(requiredPeers).isEqualTo(PeerSubnetSubscriptions.TARGET_SUBSCRIBER_COUNT);
+        PeerSubnetSubscriptions.create(gossipNetwork, topicProvider, TARGET_SUBSCRIBER_COUNT)
+            .getSubscribersRequired();
+    assertThat(requiredPeers).isEqualTo(TARGET_SUBSCRIBER_COUNT);
   }
 
   @Test
   void shouldRequireAdditionalPeersWhenAllSubnetsHaveSomeButNotEnoughSubscribers() {
     withSubscriberCountForAllSubnets(1);
     final int requiredPeers =
-        PeerSubnetSubscriptions.create(gossipNetwork, topicProvider).getSubscribersRequired();
-    assertThat(requiredPeers).isEqualTo(PeerSubnetSubscriptions.TARGET_SUBSCRIBER_COUNT - 1);
+        PeerSubnetSubscriptions.create(gossipNetwork, topicProvider, TARGET_SUBSCRIBER_COUNT)
+            .getSubscribersRequired();
+    assertThat(requiredPeers).isEqualTo(TARGET_SUBSCRIBER_COUNT - 1);
   }
 
   @Test
   void shouldRequireAdditionalPeersWhenAllSubnetsHaveEnoughSubscribers() {
-    withSubscriberCountForAllSubnets(PeerSubnetSubscriptions.TARGET_SUBSCRIBER_COUNT);
+    withSubscriberCountForAllSubnets(TARGET_SUBSCRIBER_COUNT);
     final int requiredPeers =
-        PeerSubnetSubscriptions.create(gossipNetwork, topicProvider).getSubscribersRequired();
+        PeerSubnetSubscriptions.create(gossipNetwork, topicProvider, TARGET_SUBSCRIBER_COUNT)
+            .getSubscribersRequired();
     assertThat(requiredPeers).isZero();
   }
 

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
@@ -196,7 +196,10 @@ public class Eth2NetworkFactory {
                 new Eth2PeerSelectionStrategy(
                     config.getTargetPeerRange(),
                     gossipNetwork ->
-                        PeerSubnetSubscriptions.create(gossipNetwork, subnetTopicProvider),
+                        PeerSubnetSubscriptions.create(
+                            gossipNetwork,
+                            subnetTopicProvider,
+                            config.getTargetSubnetSubscriberCount()),
                     reputationManager,
                     Collections::shuffle),
                 config);
@@ -235,6 +238,7 @@ public class Eth2NetworkFactory {
           false,
           emptyList(),
           new TargetPeerRange(20, 30, 0),
+          2,
           GossipConfig.DEFAULT_CONFIG,
           new WireLogsConfig(false, false, true, false));
     }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/NetworkConfig.java
@@ -39,6 +39,7 @@ public class NetworkConfig {
   private final TargetPeerRange targetPeerRange;
   private final GossipConfig gossipConfig;
   private final WireLogsConfig wireLogsConfig;
+  private final int targetSubnetSubscriberCount;
 
   public NetworkConfig(
       final PrivKey privateKey,
@@ -49,7 +50,8 @@ public class NetworkConfig {
       final List<String> staticPeers,
       final boolean isDiscoveryEnabled,
       final List<String> bootnodes,
-      final TargetPeerRange targetPeerRange) {
+      final TargetPeerRange targetPeerRange,
+      final int targetSubnetSubscriberCount) {
     this(
         privateKey,
         networkInterface,
@@ -60,6 +62,7 @@ public class NetworkConfig {
         isDiscoveryEnabled,
         bootnodes,
         targetPeerRange,
+        targetSubnetSubscriberCount,
         GossipConfig.DEFAULT_CONFIG,
         WireLogsConfig.DEFAULT_CONFIG);
   }
@@ -74,6 +77,7 @@ public class NetworkConfig {
       final boolean isDiscoveryEnabled,
       final List<String> bootnodes,
       final TargetPeerRange targetPeerRange,
+      final int targetSubnetSubscriberCount,
       final GossipConfig gossipConfig,
       final WireLogsConfig wireLogsConfig) {
 
@@ -81,6 +85,7 @@ public class NetworkConfig {
     this.networkInterface = networkInterface;
 
     this.advertisedIp = advertisedIp.filter(ip -> !ip.isBlank());
+    this.targetSubnetSubscriberCount = targetSubnetSubscriberCount;
     if (this.advertisedIp.map(ip -> !isInetAddress(ip)).orElse(false)) {
       throw new IllegalArgumentException("Advertised ip is set incorrectly.");
     }
@@ -129,6 +134,10 @@ public class NetworkConfig {
 
   public TargetPeerRange getTargetPeerRange() {
     return targetPeerRange;
+  }
+
+  public int getTargetSubnetSubscriberCount() {
+    return targetSubnetSubscriberCount;
   }
 
   public GossipConfig getGossipConfig() {

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkTest.java
@@ -151,7 +151,8 @@ class DiscoveryNetworkTest {
             Collections.emptyList(),
             false,
             Collections.emptyList(),
-            new TargetPeerRange(20, 30, 0));
+            new TargetPeerRange(20, 30, 0),
+            2);
     final DiscoveryNetwork<Peer> network =
         DiscoveryNetwork.create(
             new NoOpMetricsSystem(),

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/NetworkConfigTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/NetworkConfigTest.java
@@ -71,6 +71,7 @@ class NetworkConfigTest {
         emptyList(),
         false,
         emptyList(),
-        new TargetPeerRange(20, 30, 0));
+        new TargetPeerRange(20, 30, 0),
+        2);
   }
 }

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
@@ -87,7 +87,8 @@ public class DiscoveryNetworkFactory {
                 staticPeers,
                 true,
                 bootnodes,
-                new TargetPeerRange(20, 30, 0));
+                new TargetPeerRange(20, 30, 0),
+                2);
         final NoOpMetricsSystem metricsSystem = new NoOpMetricsSystem();
         final ReputationManager reputationManager =
             new ReputationManager(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -382,6 +382,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
                   config.getP2pPeerLowerBound(),
                   config.getP2pPeerUpperBound(),
                   config.getMinimumRandomlySelectedPeerCount()),
+              config.getTargetSubnetSubscriberCount(),
               GossipConfig.DEFAULT_CONFIG,
               new WireLogsConfig(
                   config.isLogWireCipher(),

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -314,6 +314,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setP2pPrivateKeyFile(p2POptions.getP2pPrivateKeyFile())
         .setP2pPeerLowerBound(p2POptions.getP2pLowerBound())
         .setP2pPeerUpperBound(p2POptions.getP2pUpperBound())
+        .setTargetSubnetSubscriberCount(p2POptions.getP2pTargetSubnetSubscriberCount())
         .setP2pStaticPeers(p2POptions.getP2pStaticPeers())
         .setP2pSnappyEnabled(p2POptions.isP2pSnappyEnabled())
         .setInteropGenesisTime(interopOptions.getInteropGenesisTime())

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -95,6 +95,14 @@ public class P2POptions {
   private int p2pUpperBound = 74;
 
   @Option(
+      names = {"--Xp2p-target-subnet-subscriber-count"},
+      paramLabel = "<INTEGER>",
+      description = "Target number of peers subscribed to each attestation subnet",
+      arity = "1",
+      hidden = true)
+  private int p2pTargetSubnetSubscriberCount = 2;
+
+  @Option(
       names = {"--p2p-static-peers"},
       paramLabel = "<PEER_ADDRESSES>",
       description = "Static peers",
@@ -147,6 +155,10 @@ public class P2POptions {
 
   public int getP2pUpperBound() {
     return p2pUpperBound;
+  }
+
+  public int getP2pTargetSubnetSubscriberCount() {
+    return p2pTargetSubnetSubscriberCount;
   }
 
   public List<String> getP2pStaticPeers() {

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -295,6 +295,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setP2pPrivateKeyFile("path/to/file")
         .setP2pPeerLowerBound(64)
         .setP2pPeerUpperBound(74)
+        .setTargetSubnetSubscriberCount(2)
         .setP2pStaticPeers(Collections.emptyList())
         .setInteropGenesisTime(1)
         .setInteropOwnedValidatorStartIndex(0)

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -36,6 +36,7 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(config.getP2pStaticPeers()).isEqualTo(List.of("127.1.0.1", "127.1.1.1"));
     assertThat(config.getP2pPeerLowerBound()).isEqualTo(70);
     assertThat(config.getP2pPeerUpperBound()).isEqualTo(85);
+    assertThat(config.getTargetSubnetSubscriberCount()).isEqualTo(5);
   }
 
   @Test

--- a/teku/src/test/resources/P2POptions_config.yaml
+++ b/teku/src/test/resources/P2POptions_config.yaml
@@ -9,3 +9,4 @@ p2p-advertised-ip: "127.200.0.1"
 p2p-static-peers: "127.1.0.1,127.1.1.1"
 p2p-peer-lower-bound: 70
 p2p-peer-upper-bound: 85
+Xp2p-target-subnet-subscriber-count: 5

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
@@ -51,6 +51,7 @@ public class TekuConfiguration implements MetricsConfig {
   private final String p2pPrivateKeyFile;
   private final int p2pPeerLowerBound;
   private final int p2pPeerUpperBound;
+  private final int targetSubnetSubscriberCount;
   private final List<String> p2pStaticPeers;
   private final boolean p2pSnappyEnabled;
 
@@ -137,6 +138,7 @@ public class TekuConfiguration implements MetricsConfig {
       final String p2pPrivateKeyFile,
       final int p2pPeerLowerBound,
       final int p2pPeerUpperBound,
+      final int targetSubnetSubscriberCount,
       final List<String> p2pStaticPeers,
       final boolean p2pSnappyEnabled,
       final Integer interopGenesisTime,
@@ -199,6 +201,7 @@ public class TekuConfiguration implements MetricsConfig {
     this.p2pPrivateKeyFile = p2pPrivateKeyFile;
     this.p2pPeerLowerBound = p2pPeerLowerBound;
     this.p2pPeerUpperBound = p2pPeerUpperBound;
+    this.targetSubnetSubscriberCount = targetSubnetSubscriberCount;
     this.p2pStaticPeers = p2pStaticPeers;
     this.p2pSnappyEnabled = p2pSnappyEnabled;
     this.interopGenesisTime = interopGenesisTime;
@@ -310,6 +313,10 @@ public class TekuConfiguration implements MetricsConfig {
 
   public int getMinimumRandomlySelectedPeerCount() {
     return Math.min(1, p2pPeerLowerBound * 2 / 10);
+  }
+
+  public int getTargetSubnetSubscriberCount() {
+    return targetSubnetSubscriberCount;
   }
 
   public List<String> getP2pStaticPeers() {

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
@@ -37,6 +37,7 @@ public class TekuConfigurationBuilder {
   private String p2pPrivateKeyFile;
   private int p2pPeerLowerBound;
   private int p2pPeerUpperBound;
+  private int targetSubnetSubscriberCount;
   private List<String> p2pStaticPeers;
   private Boolean p2pSnappyEnabled;
   private Integer interopGenesisTime;
@@ -159,6 +160,12 @@ public class TekuConfigurationBuilder {
 
   public TekuConfigurationBuilder setP2pPeerUpperBound(final int p2pPeerUpperBound) {
     this.p2pPeerUpperBound = p2pPeerUpperBound;
+    return this;
+  }
+
+  public TekuConfigurationBuilder setTargetSubnetSubscriberCount(
+      final int targetSubnetSubscriberCount) {
+    this.targetSubnetSubscriberCount = targetSubnetSubscriberCount;
     return this;
   }
 
@@ -454,6 +461,7 @@ public class TekuConfigurationBuilder {
         p2pPrivateKeyFile,
         p2pPeerLowerBound,
         p2pPeerUpperBound,
+        targetSubnetSubscriberCount,
         p2pStaticPeers,
         p2pSnappyEnabled,
         interopGenesisTime,


### PR DESCRIPTION
## PR Description
So that we can experiment with the target subscribers per subnet option to see how it affects inclusion rates, make it a `--X` config option.

## Fixed Issue(s)
Part of investigations on #2521 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.