### PR TITLE
[Issue-2438] Rework checks to trigger peer sync

### DIFF
--- a/sync/src/main/java/tech/pegasys/teku/sync/SyncManager.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/SyncManager.java
@@ -273,15 +273,15 @@ public class SyncManager extends Service {
     final UInt64 currentEpoch = compute_epoch_at_slot(currentSlot);
     final UInt64 slotErrorThreshold = UInt64.ONE;
 
-    return peerStatus.getFinalizedEpoch().compareTo(currentEpoch) <= 0
-        && peerStatus.getHeadSlot().compareTo(currentSlot.plus(slotErrorThreshold)) <= 0;
+    return peerStatus.getFinalizedEpoch().isLessThanOrEqualTo(currentEpoch)
+        && peerStatus.getHeadSlot().isLessThanOrEqualTo(currentSlot.plus(slotErrorThreshold));
   }
 
   private boolean peerIsAheadOfOurNode(
       final PeerStatus peerStatus, final UInt64 ourFinalizedEpoch) {
     final UInt64 finalizedEpochThreshold = ourFinalizedEpoch.plus(SYNC_THRESHOLD_IN_EPOCHS);
 
-    return peerStatus.getFinalizedEpoch().compareTo(finalizedEpochThreshold) > 0
+    return peerStatus.getFinalizedEpoch().isGreaterThan(finalizedEpochThreshold)
         || isPeerHeadSlotAhead(peerStatus);
   }
 
@@ -289,6 +289,6 @@ public class SyncManager extends Service {
     final UInt64 ourHeadSlot = storageClient.getBestSlot();
     final UInt64 headSlotThreshold = ourHeadSlot.plus(SYNC_THRESHOLD_IN_SLOTS);
 
-    return peerStatus.getHeadSlot().compareTo(headSlotThreshold) > 0;
+    return peerStatus.getHeadSlot().isGreaterThan(headSlotThreshold);
   }
 }

--- a/sync/src/main/java/tech/pegasys/teku/sync/SyncManager.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/SyncManager.java
@@ -46,6 +46,8 @@ public class SyncManager extends Service {
   private static final Duration SHORT_DELAY = Duration.ofSeconds(5);
   private static final Duration LONG_DELAY = Duration.ofSeconds(20);
   private static final UInt64 SYNC_THRESHOLD_IN_EPOCHS = UInt64.ONE;
+  private static final UInt64 SYNC_THRESHOLD_IN_SLOTS =
+      SYNC_THRESHOLD_IN_EPOCHS.times(SLOTS_PER_EPOCH);
 
   private static final Logger LOG = LogManager.getLogger();
   private final P2PNetwork<Eth2Peer> network;
@@ -285,8 +287,7 @@ public class SyncManager extends Service {
 
   private boolean isPeerHeadSlotAhead(final PeerStatus peerStatus) {
     final UInt64 ourHeadSlot = storageClient.getBestSlot();
-    final UInt64 headSlotThreshold =
-        ourHeadSlot.plus(SYNC_THRESHOLD_IN_EPOCHS.times(SLOTS_PER_EPOCH));
+    final UInt64 headSlotThreshold = ourHeadSlot.plus(SYNC_THRESHOLD_IN_SLOTS);
 
     return peerStatus.getHeadSlot().compareTo(headSlotThreshold) > 0;
   }

--- a/sync/src/test/java/tech/pegasys/teku/sync/SyncManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/SyncManagerTest.java
@@ -109,7 +109,7 @@ public class SyncManagerTest {
     // We're almost in sync with the peer
     final UInt64 oldHeadSlot =
         PEER_STATUS.getHeadSlot().minus(UInt64.valueOf(Constants.SLOTS_PER_EPOCH));
-    setLocalChainState(oldHeadSlot, PEER_STATUS.getFinalizedEpoch().minus(UInt64.ONE));
+    setLocalChainState(oldHeadSlot, PEER_STATUS.getFinalizedEpoch().minus(1));
 
     when(network.streamPeers()).thenReturn(Stream.of(peer));
     // Should be immediately completed as there is nothing to do.
@@ -122,7 +122,7 @@ public class SyncManagerTest {
   @Test
   void sync_noSuitablePeers_remoteEpochInTheFuture() {
     // Remote peer finalized epoch is too far ahead
-    final UInt64 headSlot = compute_start_slot_at_epoch(PEER_FINALIZED_EPOCH).minus(UInt64.ONE);
+    final UInt64 headSlot = compute_start_slot_at_epoch(PEER_FINALIZED_EPOCH).minus(1);
     localSlot.set(headSlot);
 
     when(network.streamPeers()).thenReturn(Stream.of(peer));
@@ -136,7 +136,7 @@ public class SyncManagerTest {
   @Test
   void sync_noSuitablePeers_remoteHeadSlotInTheFuture() {
     // Remote peer head slot is too far ahead
-    final UInt64 headSlot = PEER_HEAD_SLOT.minus(UInt64.valueOf(2));
+    final UInt64 headSlot = PEER_HEAD_SLOT.minus(2);
     localSlot.set(headSlot);
 
     when(network.streamPeers()).thenReturn(Stream.of(peer));
@@ -170,7 +170,7 @@ public class SyncManagerTest {
 
   @Test
   void sync_existingPeers_remoteHeadSlotIsAheadButWithinErrorThreshold() {
-    final UInt64 headSlot = PEER_HEAD_SLOT.minus(UInt64.ONE);
+    final UInt64 headSlot = PEER_HEAD_SLOT.minus(1);
     localSlot.set(headSlot);
 
     when(network.streamPeers()).thenReturn(Stream.of(peer));
@@ -194,8 +194,7 @@ public class SyncManagerTest {
 
   @Test
   void sync_existingPeers_peerFinalizedEpochMoreThan1EpochAhead() {
-    setLocalChainState(
-        PEER_STATUS.getHeadSlot(), PEER_STATUS.getFinalizedEpoch().minus(UInt64.valueOf(2)));
+    setLocalChainState(PEER_STATUS.getHeadSlot(), PEER_STATUS.getFinalizedEpoch().minus(2));
     when(network.streamPeers()).thenReturn(Stream.of(peer));
 
     final SafeFuture<PeerSyncResult> syncFuture = new SafeFuture<>();
@@ -218,8 +217,7 @@ public class SyncManagerTest {
   @Test
   void sync_existingPeerWithSameFinalizedEpochButMuchBetterHeadSlot() {
     when(network.streamPeers()).thenReturn(Stream.of(peer));
-    final UInt64 oldHeadSlot =
-        PEER_STATUS.getHeadSlot().minus(UInt64.valueOf(Constants.SLOTS_PER_EPOCH + 1));
+    final UInt64 oldHeadSlot = PEER_STATUS.getHeadSlot().minus(Constants.SLOTS_PER_EPOCH + 1);
     setLocalChainState(oldHeadSlot, PEER_STATUS.getFinalizedEpoch());
 
     final SafeFuture<PeerSyncResult> syncFuture = new SafeFuture<>();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Rework logic to trigger peer sync:
* Add some sanity checks to make sure peers aren't broadcasting a chain state from the future
* Be more consistent wrt how head slot / finalized epoch triggers sync: 
  * A peer's finalized epoch must now be > 1 epoch ahead, in line with the head slot check which only triggers a sync if the peer's head slot is > 1 epoch ahead.

The change to the finalized epoch trigger helps us avoid triggering a sync too aggressively in the following scenario:
* Our local node is missing a very recent block at an epoch boundary that will cause our finalized block to advance
* A peer has this additional block, causing us to see that the peer's finalized epoch is ahead of our node

## Fixed Issue(s)
Fixes #2438

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.