### PR TITLE
Start taking advantage of UInt64 helper methods

### DIFF
--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetCommitteesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetCommitteesTest.java
@@ -67,7 +67,7 @@ public class GetCommitteesTest {
     storageSystem.chainUpdater().updateBestBlock(bestBlock);
 
     combinedChainDataClient = storageSystem.combinedChainDataClient();
-    epoch = slot.dividedBy(UInt64.valueOf(SLOTS_PER_EPOCH));
+    epoch = slot.dividedBy(SLOTS_PER_EPOCH);
   }
 
   @Test

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -84,7 +84,7 @@ public class ChainDataProvider {
 
     final UInt64 earliestQueryableSlot =
         CommitteeUtil.getEarliestQueryableSlotForTargetEpoch(epoch);
-    if (recentChainData.getBestSlot().compareTo(earliestQueryableSlot) < 0) {
+    if (recentChainData.getBestSlot().isLessThan(earliestQueryableSlot)) {
       return SafeFuture.completedFuture(Optional.empty());
     }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -84,10 +84,10 @@ public class ValidatorDataProvider {
       throw new IllegalArgumentException(NO_RANDAO_PROVIDED);
     }
     UInt64 bestSlot = combinedChainDataClient.getBestSlot();
-    if (bestSlot.plus(SLOTS_PER_EPOCH).compareTo(slot) < 0) {
+    if (bestSlot.plus(SLOTS_PER_EPOCH).isLessThan(slot)) {
       throw new IllegalArgumentException(CANNOT_PRODUCE_FAR_FUTURE_BLOCK);
     }
-    if (bestSlot.compareTo(slot) > 0) {
+    if (bestSlot.isGreaterThan(slot)) {
       throw new IllegalArgumentException(CANNOT_PRODUCE_HISTORIC_BLOCK);
     }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -84,7 +84,7 @@ public class ValidatorDataProvider {
       throw new IllegalArgumentException(NO_RANDAO_PROVIDED);
     }
     UInt64 bestSlot = combinedChainDataClient.getBestSlot();
-    if (bestSlot.plus(UInt64.valueOf(SLOTS_PER_EPOCH)).compareTo(slot) < 0) {
+    if (bestSlot.plus(SLOTS_PER_EPOCH).compareTo(slot) < 0) {
       throw new IllegalArgumentException(CANNOT_PRODUCE_FAR_FUTURE_BLOCK);
     }
     if (bestSlot.compareTo(slot) > 0) {

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -110,7 +110,7 @@ public class ChainDataProviderTest {
       throws ExecutionException, InterruptedException {
     final ChainDataProvider provider =
         new ChainDataProvider(recentChainData, combinedChainDataClient);
-    final UInt64 futureEpoch = slot.plus(UInt64.valueOf(SLOTS_PER_EPOCH));
+    final UInt64 futureEpoch = slot.plus(SLOTS_PER_EPOCH);
 
     final SafeFuture<Optional<List<Committee>>> future = provider.getCommitteesAtEpoch(futureEpoch);
     assertThat(future.get()).isEmpty();

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanitySlotsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanitySlotsTestExecutor.java
@@ -31,7 +31,7 @@ public class SanitySlotsTestExecutor implements TestExecutor {
     final BeaconState preState = loadStateFromSsz(testDefinition, "pre.ssz");
     final BeaconState expectedState = loadStateFromSsz(testDefinition, "post.ssz");
     final StateTransition stateTransition = new StateTransition();
-    final UInt64 endSlot = preState.getSlot().plus(UInt64.valueOf(numberOfSlots));
+    final UInt64 endSlot = preState.getSlot().plus(numberOfSlots);
 
     final BeaconState result = stateTransition.process_slots(preState, endSlot);
     assertThat(result).isEqualTo(expectedState);

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/BlockProcessorUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/BlockProcessorUtil.java
@@ -125,7 +125,7 @@ public final class BlockProcessorUtil {
 
       Bytes32 mix =
           get_randao_mix(state, epoch).xor(Hash.sha2_256(body.getRandao_reveal().toSSZBytes()));
-      int index = epoch.mod(UInt64.valueOf(EPOCHS_PER_HISTORICAL_VECTOR)).intValue();
+      int index = epoch.mod(EPOCHS_PER_HISTORICAL_VECTOR).intValue();
       state.getRandao_mixes().set(index, mix);
     } catch (IllegalArgumentException e) {
       LOG.warn(e.getMessage());

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/CommitteeAssignmentUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/CommitteeAssignmentUtil.java
@@ -48,7 +48,7 @@ public class CommitteeAssignmentUtil {
     UInt64 start_slot = compute_start_slot_at_epoch(epoch);
     final UInt64 committeeCountPerSlot = get_committee_count_per_slot(state, epoch);
     for (UInt64 slot = start_slot;
-        slot.compareTo(start_slot.plus(UInt64.valueOf(SLOTS_PER_EPOCH))) < 0;
+        slot.isLessThan(start_slot.plus(SLOTS_PER_EPOCH));
         slot = slot.plus(UInt64.ONE)) {
 
       for (UInt64 index = UInt64.ZERO;

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -58,11 +58,11 @@ public class ForkChoiceUtil {
   }
 
   public static UInt64 getCurrentSlot(UInt64 currentTime, UInt64 genesisTime) {
-    return currentTime.minus(genesisTime).dividedBy(UInt64.valueOf(SECONDS_PER_SLOT));
+    return currentTime.minus(genesisTime).dividedBy(SECONDS_PER_SLOT);
   }
 
   public static UInt64 getSlotStartTime(UInt64 slotNumber, UInt64 genesisTime) {
-    return genesisTime.plus(slotNumber.times(UInt64.valueOf(SECONDS_PER_SLOT)));
+    return genesisTime.plus(slotNumber.times(SECONDS_PER_SLOT));
   }
 
   public static UInt64 get_current_slot(ReadOnlyStore store, boolean useUnixTime) {

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/StateTransition.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/StateTransition.java
@@ -147,7 +147,7 @@ public class StateTransition {
         state -> {
           // Cache state root
           Bytes32 previous_state_root = state.hash_tree_root();
-          int index = state.getSlot().mod(UInt64.valueOf(SLOTS_PER_HISTORICAL_ROOT)).intValue();
+          int index = state.getSlot().mod(SLOTS_PER_HISTORICAL_ROOT).intValue();
           state.getState_roots().set(index, previous_state_root);
 
           // Cache latest block header state root
@@ -195,11 +195,7 @@ public class StateTransition {
       while (state.getSlot().compareTo(slot) < 0) {
         state = process_slot(state);
         // Process epoch on the start slot of the next epoch
-        if (state
-            .getSlot()
-            .plus(UInt64.ONE)
-            .mod(UInt64.valueOf(SLOTS_PER_EPOCH))
-            .equals(UInt64.ZERO)) {
+        if (state.getSlot().plus(UInt64.ONE).mod(SLOTS_PER_EPOCH).equals(UInt64.ZERO)) {
           state = EpochProcessor.processEpoch(state);
         }
         state = state.updated(s -> s.setSlot(s.getSlot().plus(UInt64.ONE)));

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/epoch/RewardsAndPenaltiesCalculator.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/epoch/RewardsAndPenaltiesCalculator.java
@@ -84,7 +84,7 @@ public class RewardsAndPenaltiesCalculator {
     UInt64 totalBalanceSquareRoot = get_total_active_balance_with_root(state).getRight();
     UInt64 effectiveBalance = state.getValidators().get(index).getEffective_balance();
     return effectiveBalance
-        .times(UInt64.valueOf(BASE_REWARD_FACTOR))
+        .times(BASE_REWARD_FACTOR)
         .dividedBy(totalBalanceSquareRoot)
         .dividedBy(BASE_REWARDS_PER_EPOCH);
   }

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/operationvalidators/AttestationDataStateTransitionValidator.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/operationvalidators/AttestationDataStateTransitionValidator.java
@@ -24,7 +24,6 @@ import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_EPOCH;
 import java.util.Optional;
 import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.datastructures.state.BeaconState;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.util.config.Constants;
 
 public class AttestationDataStateTransitionValidator
@@ -52,14 +51,13 @@ public class AttestationDataStateTransitionValidator
         () ->
             check(
                 data.getSlot()
-                        .plus(UInt64.valueOf(Constants.MIN_ATTESTATION_INCLUSION_DELAY))
+                        .plus(Constants.MIN_ATTESTATION_INCLUSION_DELAY)
                         .compareTo(state.getSlot())
                     <= 0,
                 AttestationInvalidReason.SUBMITTED_TOO_QUICKLY),
         () ->
             check(
-                state.getSlot().compareTo(data.getSlot().plus(UInt64.valueOf(SLOTS_PER_EPOCH)))
-                    <= 0,
+                state.getSlot().isLessThanOrEqualTo(data.getSlot().plus(SLOTS_PER_EPOCH)),
                 AttestationInvalidReason.SUBMITTED_TOO_LATE),
         () -> {
           if (data.getTarget().getEpoch().equals(get_current_epoch(state))) {

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
@@ -36,8 +36,7 @@ import tech.pegasys.teku.protoarray.StubProtoArrayStorageChannel;
 class ForkChoiceUtilTest {
 
   private static final UInt64 GENESIS_TIME = UInt64.valueOf("1591924193");
-  static final UInt64 SLOT_50 =
-      GENESIS_TIME.plus(UInt64.valueOf(SECONDS_PER_SLOT).times(UInt64.valueOf(50L)));
+  static final UInt64 SLOT_50 = GENESIS_TIME.plus(SECONDS_PER_SLOT * 50L);
   protected static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(16);
   private final ChainBuilder chainBuilder = ChainBuilder.create(VALIDATOR_KEYS);
   private final SignedBlockAndState genesis = chainBuilder.generateGenesis();

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/stategenerator/StateGeneratorTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/stategenerator/StateGeneratorTest.java
@@ -232,8 +232,7 @@ public class StateGeneratorTest {
     final HashTree tree =
         HashTree.builder().rootHash(genesis.getRoot()).blocks(blockMap.values()).build();
     // Create block provider that is missing some blocks
-    final SignedBeaconBlock missingBlock =
-        chainBuilder.getBlockAtSlot(genesis.getSlot().plus(UInt64.valueOf(2)));
+    final SignedBeaconBlock missingBlock = chainBuilder.getBlockAtSlot(genesis.getSlot().plus(2));
     blockMap.remove(missingBlock.getRoot());
     final BlockProvider blockProvider = BlockProvider.fromMap(blockMap);
 

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -254,7 +254,7 @@ public class ChainBuilder {
   public SignedBlockAndState generateNextBlock(final int skipSlots) {
     assertBlockCanBeGenerated();
     final SignedBlockAndState latest = getLatestBlockAndState();
-    final UInt64 nextSlot = latest.getState().getSlot().plus(UInt64.valueOf(1 + skipSlots));
+    final UInt64 nextSlot = latest.getState().getSlot().plus(1 + skipSlots);
     return generateBlockAtSlot(nextSlot);
   }
 

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
@@ -236,8 +236,7 @@ public class CommitteeUtil {
               UInt64 epoch = compute_epoch_at_slot(slot);
               UInt64 committees_per_slot = get_committee_count_per_slot(state, epoch);
               int committeeIndex =
-                  toIntExact(
-                      slot.mod(SLOTS_PER_EPOCH).times(committees_per_slot).plus(index).longValue());
+                  slot.mod(SLOTS_PER_EPOCH).times(committees_per_slot).plus(index).intValue();
               int count = committees_per_slot.times(SLOTS_PER_EPOCH).intValue();
               return compute_committee(
                   state,

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
@@ -177,9 +177,8 @@ public class CommitteeUtil {
       int random_byte = UnsignedBytes.toInt(hash.get(i % 32));
       UInt64 effective_balance = state.getValidators().get(candidate_index).getEffective_balance();
       if (effective_balance
-              .times(MAX_RANDOM_BYTE)
-              .compareTo(UInt64.valueOf(MAX_EFFECTIVE_BALANCE).times(UInt64.valueOf(random_byte)))
-          >= 0) {
+          .times(MAX_RANDOM_BYTE)
+          .isGreaterThanOrEqualTo(UInt64.valueOf(MAX_EFFECTIVE_BALANCE).times(random_byte))) {
         return candidate_index;
       }
       i++;
@@ -238,13 +237,8 @@ public class CommitteeUtil {
               UInt64 committees_per_slot = get_committee_count_per_slot(state, epoch);
               int committeeIndex =
                   toIntExact(
-                      slot.mod(UInt64.valueOf(SLOTS_PER_EPOCH))
-                          .times(committees_per_slot)
-                          .plus(index)
-                          .longValue());
-              int count =
-                  toIntExact(
-                      committees_per_slot.times(UInt64.valueOf(SLOTS_PER_EPOCH)).longValue());
+                      slot.mod(SLOTS_PER_EPOCH).times(committees_per_slot).plus(index).longValue());
+              int count = committees_per_slot.times(SLOTS_PER_EPOCH).intValue();
               return compute_committee(
                   state,
                   get_active_validator_indices(state, epoch),
@@ -314,14 +308,10 @@ public class CommitteeUtil {
 
   public static int computeSubnetForCommittee(
       final BeaconState state, final UInt64 attestationSlot, final UInt64 committeeIndex) {
-    final UInt64 slotsSinceEpochStart = attestationSlot.mod(UInt64.valueOf(SLOTS_PER_EPOCH));
+    final UInt64 slotsSinceEpochStart = attestationSlot.mod(SLOTS_PER_EPOCH);
     final UInt64 committeesSinceEpochStart =
         get_committee_count_per_slot(state, compute_epoch_at_slot(attestationSlot))
             .times(slotsSinceEpochStart);
-    return toIntExact(
-        committeesSinceEpochStart
-            .plus(committeeIndex)
-            .mod(UInt64.valueOf(ATTESTATION_SUBNET_COUNT))
-            .longValue());
+    return committeesSinceEpochStart.plus(committeeIndex).mod(ATTESTATION_SUBNET_COUNT).intValue();
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/SimpleOffsetSerializer.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/SimpleOffsetSerializer.java
@@ -195,7 +195,7 @@ public class SimpleOffsetSerializer {
     for (Bytes part : parts) {
       fixed_parts.add(SSZ.encodeUInt32(offset.longValue()));
       variable_parts.add(part);
-      offset = offset.plus(UInt64.valueOf(part.size()));
+      offset = offset.plus(part.size());
     }
     return Bytes.wrap(
         Bytes.concatenate(fixed_parts.toArray(new Bytes[0])),

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/BeaconStateUtilTest.java
@@ -147,10 +147,10 @@ class BeaconStateUtilTest {
     // Calculate Expected Results
     UInt64 expectedBalance = UInt64.ZERO;
     for (UInt64 balance : state.getBalances()) {
-      if (balance.compareTo(UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE)) < 0) {
+      if (balance.isLessThan(UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE))) {
         expectedBalance = expectedBalance.plus(balance);
       } else {
-        expectedBalance = expectedBalance.plus(UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE));
+        expectedBalance = expectedBalance.plus(Constants.MAX_EFFECTIVE_BALANCE);
       }
     }
 

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/CommitteeUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/CommitteeUtilTest.java
@@ -48,7 +48,7 @@ public class CommitteeUtilTest {
     final UInt64 epochSlot = compute_start_slot_at_epoch(epoch);
     final BeaconState state = dataStructureUtil.randomBeaconState(epochSlot);
 
-    final UInt64 outOfRangeSlot = compute_start_slot_at_epoch(epoch.plus(UInt64.valueOf(2)));
+    final UInt64 outOfRangeSlot = compute_start_slot_at_epoch(epoch.plus(2));
     assertThatThrownBy(() -> CommitteeUtil.get_beacon_committee(state, outOfRangeSlot, ONE))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
@@ -61,7 +61,7 @@ public class CommitteeUtilTest {
     final UInt64 epochSlot = compute_start_slot_at_epoch(epoch.plus(ONE)).minus(ONE);
     final BeaconState state = dataStructureUtil.randomBeaconState(epochSlot);
 
-    final UInt64 outOfRangeSlot = compute_start_slot_at_epoch(epoch.plus(UInt64.valueOf(2)));
+    final UInt64 outOfRangeSlot = compute_start_slot_at_epoch(epoch.plus(2));
     assertThatThrownBy(() -> CommitteeUtil.get_beacon_committee(state, outOfRangeSlot, ONE))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
@@ -74,7 +74,7 @@ public class CommitteeUtilTest {
     final UInt64 epochSlot = compute_start_slot_at_epoch(epoch);
     final BeaconState state = dataStructureUtil.randomBeaconState(epochSlot);
 
-    final UInt64 outOfRangeSlot = compute_start_slot_at_epoch(epoch.plus(UInt64.valueOf(2)));
+    final UInt64 outOfRangeSlot = compute_start_slot_at_epoch(epoch.plus(2));
     final UInt64 inRangeSlot = outOfRangeSlot.minus(ONE);
     assertDoesNotThrow(() -> CommitteeUtil.get_beacon_committee(state, inRangeSlot, ONE));
   }

--- a/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreFactory.java
+++ b/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreFactory.java
@@ -75,9 +75,7 @@ public class TestStoreFactory {
     checkpoint_states.put(anchorCheckpoint, anchorState);
 
     return new TestStoreImpl(
-        anchorState
-            .getGenesis_time()
-            .plus(UInt64.valueOf(SECONDS_PER_SLOT).times(anchorState.getSlot())),
+        anchorState.getGenesis_time().plus(anchorState.getSlot().times(SECONDS_PER_SLOT)),
         anchorState.getGenesis_time(),
         anchorCheckpoint,
         anchorCheckpoint,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -192,7 +192,7 @@ class AggregatingAttestationPoolTest {
     aggregatingPool.onSlot(
         pruneAttestationData
             .getSlot()
-            .plus(UInt64.valueOf(SLOTS_PER_EPOCH * ATTESTATION_RETENTION_EPOCHS))
+            .plus(SLOTS_PER_EPOCH * ATTESTATION_RETENTION_EPOCHS)
             .plus(ONE));
 
     assertThat(aggregatingPool.getAttestationsForBlock(dataStructureUtil.randomBeaconState()))

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockProcessorUtilTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockProcessorUtilTest.java
@@ -102,9 +102,7 @@ class BlockProcessorUtilTest {
         originalValidatorBalancesSize,
         "A new balance was added to the validator balances, but should not have been.");
     assertEquals(knownValidator, postState.getValidators().get(originalValidatorRegistrySize - 1));
-    assertEquals(
-        amount.times(UInt64.valueOf(2L)),
-        postState.getBalances().get(originalValidatorBalancesSize - 1));
+    assertEquals(amount.times(2L), postState.getBalances().get(originalValidatorBalancesSize - 1));
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/PendingPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/PendingPoolTest.java
@@ -32,7 +32,7 @@ public class PendingPoolTest {
   private final UInt64 futureTolerance = UInt64.valueOf(2);
   private final PendingPool<SignedBeaconBlock> pendingPool =
       PendingPool.createForBlocks(historicalTolerance, futureTolerance);
-  private UInt64 currentSlot = historicalTolerance.times(UInt64.valueOf(2));
+  private UInt64 currentSlot = historicalTolerance.times(2);
   private List<Bytes32> requiredRootEvents = new ArrayList<>();
   private List<Bytes32> requiredRootDroppedEvents = new ArrayList<>();
 

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -259,8 +259,7 @@ public class BeaconChainUtil {
     }
 
     AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
-    createAndImportBlockAtSlot(
-        recentChainData.getBestSlot().plus(UInt64.valueOf(MIN_ATTESTATION_INCLUSION_DELAY)));
+    createAndImportBlockAtSlot(recentChainData.getBestSlot().plus(MIN_ATTESTATION_INCLUSION_DELAY));
 
     while (recentChainData.getStore().getFinalizedCheckpoint().getEpoch().compareTo(epoch) < 0) {
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
@@ -98,8 +98,7 @@ public class PeerChainValidatorTest {
 
     when(store.getGenesisTime()).thenReturn(genesisTime);
     when(store.getTime())
-        .thenReturn(
-            genesisTime.plus(laterBlockSlot.times(UInt64.valueOf(Constants.SECONDS_PER_SLOT))));
+        .thenReturn(genesisTime.plus(laterBlockSlot.times(Constants.SECONDS_PER_SLOT)));
 
     when(recentChainData.getStore()).thenReturn(store);
   }
@@ -287,9 +286,7 @@ public class PeerChainValidatorTest {
 
     final UInt64 currentTime =
         genesisTime.plus(
-            remoteFinalizedCheckpoint
-                .getEpochStartSlot()
-                .times(UInt64.valueOf(Constants.SECONDS_PER_SLOT)));
+            remoteFinalizedCheckpoint.getEpochStartSlot().times(Constants.SECONDS_PER_SLOT));
     when(store.getTime()).thenReturn(currentTime);
   }
 
@@ -302,7 +299,7 @@ public class PeerChainValidatorTest {
             remoteFinalizedCheckpoint
                 .getEpochStartSlot()
                 .minus(UInt64.ONE)
-                .times(UInt64.valueOf(Constants.SECONDS_PER_SLOT)));
+                .times(Constants.SECONDS_PER_SLOT));
     when(store.getTime()).thenReturn(currentTime);
   }
 
@@ -392,10 +389,7 @@ public class PeerChainValidatorTest {
     final Bytes32 headRoot = Bytes32.fromHexString("0xeeee");
     // Set a head slot some distance beyond the finalized epoch
     final UInt64 headSlot =
-        remoteFinalizedCheckpoint
-            .getEpoch()
-            .times(UInt64.valueOf(Constants.SLOTS_PER_EPOCH))
-            .plus(UInt64.valueOf(10L));
+        remoteFinalizedCheckpoint.getEpoch().times(Constants.SLOTS_PER_EPOCH).plus(10L);
 
     final PeerStatus status =
         new PeerStatus(

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoNode.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoNode.java
@@ -68,7 +68,7 @@ public class ProtoNode {
       }
       weight = weight.minus(deltaAbsoluteValue);
     } else {
-      weight = weight.plus(UInt64.valueOf(delta));
+      weight = weight.plus(delta);
     }
   }
 

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayScoreCalculatorTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayScoreCalculatorTest.java
@@ -184,7 +184,7 @@ public class ProtoArrayScoreCalculatorTest {
   void computeDeltas_changingBalances() {
 
     final UInt64 OLD_BALANCE = UInt64.valueOf(42);
-    final UInt64 NEW_BALANCE = OLD_BALANCE.times(UInt64.valueOf(2));
+    final UInt64 NEW_BALANCE = OLD_BALANCE.times(2);
 
     int validatorCount = 16;
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -522,7 +522,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     UInt64 currentSlot = ZERO;
     if (currentTime.compareTo(genesisTime) >= 0) {
       UInt64 deltaTime = currentTime.minus(genesisTime);
-      currentSlot = deltaTime.dividedBy(UInt64.valueOf(SECONDS_PER_SLOT));
+      currentSlot = deltaTime.dividedBy(SECONDS_PER_SLOT);
     } else {
       UInt64 timeUntilGenesis = genesisTime.minus(currentTime);
       genesisTimeTracker = currentTime;
@@ -542,9 +542,9 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     transaction.commit().join();
 
     final UInt64 genesisTime = recentChainData.getGenesisTime();
-    if (genesisTime.compareTo(currentTime) > 0) {
+    if (genesisTime.isGreaterThan(currentTime)) {
       // notify every 10 minutes
-      if (genesisTimeTracker.plus(UInt64.valueOf(600L)).compareTo(currentTime) <= 0) {
+      if (genesisTimeTracker.plus(600L).isLessThanOrEqualTo(currentTime)) {
         genesisTimeTracker = currentTime;
         STATUS_LOG.timeUntilGenesis(
             genesisTime.minus(currentTime).longValue(), p2pNetwork.getPeerCount());

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -180,8 +180,7 @@ public class SlotProcessorTest {
     when(syncService.isSyncActive()).thenReturn(false);
     when(p2pNetwork.getPeerCount()).thenReturn(1);
 
-    UInt64 slotProcessingTime =
-        beaconState.getGenesis_time().plus(slot.times(UInt64.valueOf(SECONDS_PER_SLOT)));
+    UInt64 slotProcessingTime = beaconState.getGenesis_time().plus(slot.times(SECONDS_PER_SLOT));
     // slot processor starts at slot 0, but fast forwards to slot 100
     slotProcessor.onTick(slotProcessingTime);
     assertThat(slotProcessor.getNodeSlot().getValue()).isEqualTo(slot);
@@ -212,7 +211,7 @@ public class SlotProcessorTest {
 
     when(p2pNetwork.getPeerCount()).thenReturn(1);
 
-    slotProcessor.onTick(beaconState.getGenesis_time().plus(UInt64.valueOf(SECONDS_PER_SLOT / 3)));
+    slotProcessor.onTick(beaconState.getGenesis_time().plus(SECONDS_PER_SLOT / 3));
     verify(eventLogger)
         .slotEvent(
             ZERO,
@@ -240,8 +239,7 @@ public class SlotProcessorTest {
 
     when(p2pNetwork.getPeerCount()).thenReturn(1);
 
-    slotProcessor.onTick(
-        beaconState.getGenesis_time().plus(UInt64.valueOf(SECONDS_PER_SLOT).minus(ONE)));
+    slotProcessor.onTick(beaconState.getGenesis_time().plus(SECONDS_PER_SLOT - 1));
     assertThat(slotProcessor.getNodeSlot().getValue()).isEqualTo(ONE);
     assertThat(events).containsExactly(new BroadcastAggregatesEvent(slot));
   }

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/client/AbstractCombinedChainDataClientTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/client/AbstractCombinedChainDataClientTest.java
@@ -189,7 +189,7 @@ public abstract class AbstractCombinedChainDataClientTest {
       final String caseName, final QueryBySlotTestCase<T> testCase) {
     final SignedBlockAndState bestBlock = advanceChainAndGetBestBlockAndState(2);
 
-    final UInt64 querySlot = bestBlock.getSlot().plus(UInt64.valueOf(2));
+    final UInt64 querySlot = bestBlock.getSlot().plus(2);
     final Optional<SignedBlockAndState> effectiveBlockAtSlot = Optional.of(bestBlock);
     final SafeFuture<Optional<T>> result = testCase.executeQueryBySlot(client, querySlot);
     final Optional<T> expected =
@@ -279,7 +279,7 @@ public abstract class AbstractCombinedChainDataClientTest {
     chainUpdater.initializeGenesis();
     // Setup chain at epoch to be queried
     final SignedBlockAndState checkpointBlockAndState =
-        chainUpdater.advanceChain(epochSlot.minus(UInt64.valueOf(2)));
+        chainUpdater.advanceChain(epochSlot.minus(2));
     // Bury queried epoch behind additional blocks
     chainUpdater.advanceChain(compute_start_slot_at_epoch(nextEpoch));
     chainUpdater.addNewBestBlock();

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -323,7 +323,7 @@ public class CombinedChainDataClient {
     final UInt64 startingSlot = compute_start_slot_at_epoch(epoch);
     int committeeCount = get_committee_count_per_slot(state, epoch).intValue();
     for (int i = 0; i < SLOTS_PER_EPOCH; i++) {
-      UInt64 slot = startingSlot.plus(UInt64.valueOf(i));
+      UInt64 slot = startingSlot.plus(i);
       for (int j = 0; j < committeeCount; j++) {
         UInt64 idx = UInt64.valueOf(j);
         List<Integer> committee = CommitteeUtil.get_beacon_committee(state, slot, idx);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -355,8 +355,7 @@ public class RocksDbDatabase implements Database {
           .ifPresent(
               checkpoint -> {
                 updater.setFinalizedCheckpoint(checkpoint);
-                UInt64 finalizedSlot =
-                    checkpoint.getEpochStartSlot().plus(UInt64.valueOf(SLOTS_PER_EPOCH));
+                UInt64 finalizedSlot = checkpoint.getEpochStartSlot().plus(SLOTS_PER_EPOCH);
                 updater.pruneHotStateRoots(hotDao.getStateRootsBeforeSlot(finalizedSlot));
               });
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
@@ -61,7 +61,7 @@ public class StoreBuilder {
       final AnchorPoint anchor) {
     final UInt64 genesisTime = anchor.getState().getGenesis_time();
     final UInt64 slot = anchor.getState().getSlot();
-    final UInt64 time = genesisTime.plus(UInt64.valueOf(SECONDS_PER_SLOT).times(slot));
+    final UInt64 time = genesisTime.plus(slot.times(SECONDS_PER_SLOT));
 
     Map<Bytes32, Bytes32> childToParentMap = new HashMap<>();
     childToParentMap.put(anchor.getRoot(), anchor.getParentRoot());

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -462,8 +462,7 @@ class RecentChainDataTest {
     final UInt64 finalizedEpoch =
         ChainProperties.computeBestEpochFinalizableAtSlot(finalizedBlockSlot);
     final UInt64 recentSlot = compute_start_slot_at_epoch(finalizedEpoch).plus(ONE);
-    final UInt64 chainHeight =
-        historicalRoots.times(UInt64.valueOf(2)).plus(recentSlot).plus(UInt64.valueOf(5));
+    final UInt64 chainHeight = historicalRoots.times(2).plus(recentSlot).plus(5);
     // Build historical blocks
     final SignedBlockAndState finalizedBlock;
     while (true) {
@@ -482,7 +481,7 @@ class RecentChainDataTest {
     while (chainBuilder.getLatestSlot().compareTo(chainHeight) < 0) {
       bestBlock = chainBuilder.generateBlockAtSlot(nextSlot);
       saveBlock(storageClient, bestBlock);
-      nextSlot = nextSlot.plus(UInt64.valueOf(skipBlocks));
+      nextSlot = nextSlot.plus(skipBlocks);
     }
     // Update best block and finalized state
     updateBestBlock(storageClient, bestBlock);
@@ -536,8 +535,8 @@ class RecentChainDataTest {
     final ChainBuilder fork = chainBuilder.fork();
     final UInt64 chainSplitSlot = chainBuilder.getLatestSlot();
     for (int i = 0; i < 5; i++) {
-      final UInt64 canonicalBlockSlot = chainSplitSlot.plus(UInt64.valueOf(i * 2 + 2));
-      final UInt64 forkSlot = chainSplitSlot.plus(UInt64.valueOf(i * 2 + 1));
+      final UInt64 canonicalBlockSlot = chainSplitSlot.plus(i * 2 + 2);
+      final UInt64 forkSlot = chainSplitSlot.plus(i * 2 + 1);
       updateBestBlock(storageClient, chainBuilder.generateBlockAtSlot(canonicalBlockSlot));
       saveBlock(storageClient, fork.generateBlockAtSlot(forkSlot));
     }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
@@ -703,7 +703,7 @@ public abstract class AbstractDatabaseTest {
     // Check that last block
     final SignedBeaconBlock lastFinalizedBlock = finalizedBlocks.get(finalizedBlocks.size() - 1);
     for (int i = 0; i < 10; i++) {
-      final UInt64 slot = lastFinalizedBlock.getSlot().plus(UInt64.valueOf(i));
+      final UInt64 slot = lastFinalizedBlock.getSlot().plus(i);
       assertThat(database.getLatestFinalizedBlockAtSlot(slot))
           .describedAs("Latest finalized block at slot %s", slot)
           .contains(lastFinalizedBlock);

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractStorageBackedDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractStorageBackedDatabaseTest.java
@@ -119,7 +119,7 @@ public abstract class AbstractStorageBackedDatabaseTest extends AbstractDatabase
     // Add some more blocks
     final UInt64 firstHotBlockSlot = finalizedCheckpoint.getEpochStartSlot().plus(UInt64.ONE);
     chainBuilder.generateBlockAtSlot(firstHotBlockSlot);
-    chainBuilder.generateBlocksUpToSlot(firstHotBlockSlot.plus(UInt64.valueOf(10)));
+    chainBuilder.generateBlocksUpToSlot(firstHotBlockSlot.plus(10));
 
     // Save new blocks and finalized checkpoint
     final StoreTransaction tx = recentChainData.startStoreTransaction();

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/state/StateRootRecorderTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/state/StateRootRecorderTest.java
@@ -42,15 +42,14 @@ public class StateRootRecorderTest {
   @Test
   public void shouldHandleMultipleSteps() {
     final StateRootRecorder stateRootRecorder =
-        new StateRootRecorder(
-            slot.minus(UInt64.valueOf(2)), (stateRoot, slot) -> stateRoots.put(slot, stateRoot));
+        new StateRootRecorder(slot.minus(2), (stateRoot, slot) -> stateRoots.put(slot, stateRoot));
     stateRootRecorder.acceptNextState(state);
-    assertThat(stateRoots).containsOnlyKeys(slot.minus(UInt64.valueOf(2)), slot.minus(ONE), slot);
+    assertThat(stateRoots).containsOnlyKeys(slot.minus(2), slot.minus(ONE), slot);
   }
 
   @Test
   public void shouldLimitToSlotsPerHistoricalRoot() {
-    final UInt64 history = UInt64.valueOf(SLOTS_PER_HISTORICAL_ROOT).plus(UInt64.valueOf(10));
+    final UInt64 history = UInt64.valueOf(SLOTS_PER_HISTORICAL_ROOT).plus(10);
     final StateRootRecorder stateRootRecorder =
         new StateRootRecorder(
             slot.minus(history), (stateRoot, slot) -> stateRoots.put(slot, stateRoot));

--- a/sync/src/test/java/tech/pegasys/teku/sync/BlockManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/BlockManagerTest.java
@@ -255,7 +255,7 @@ public class BlockManagerTest {
     // Update local slot to match the first new block
     incrementSlot();
     for (int i = 0; i < blockCount; i++) {
-      final UInt64 nextSlot = genesisSlot.plus(UInt64.valueOf(i + 1));
+      final UInt64 nextSlot = genesisSlot.plus(i + 1);
       blocks.add(remoteChain.createAndImportBlockAtSlot(nextSlot));
     }
 

--- a/sync/src/test/java/tech/pegasys/teku/sync/PeerSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/PeerSyncTest.java
@@ -335,7 +335,7 @@ public class PeerSyncTest {
 
     // first non-finalized slot after syncing with peer
     final UInt64 secondSyncStartingSlot =
-        PEER_FINALIZED_EPOCH.times(UInt64.valueOf(Constants.SLOTS_PER_EPOCH)).plus(UInt64.ONE);
+        PEER_FINALIZED_EPOCH.times(Constants.SLOTS_PER_EPOCH).plus(UInt64.ONE);
 
     verify(peer)
         .requestBlocksByRange(

--- a/sync/src/test/java/tech/pegasys/teku/sync/SyncManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/SyncManagerTest.java
@@ -107,8 +107,7 @@ public class SyncManagerTest {
   @Test
   void sync_noSuitablePeers_almostInSync() {
     // We're almost in sync with the peer
-    final UInt64 oldHeadSlot =
-        PEER_STATUS.getHeadSlot().minus(UInt64.valueOf(Constants.SLOTS_PER_EPOCH));
+    final UInt64 oldHeadSlot = PEER_STATUS.getHeadSlot().minus(Constants.SLOTS_PER_EPOCH);
     setLocalChainState(oldHeadSlot, PEER_STATUS.getFinalizedEpoch().minus(1));
 
     when(network.streamPeers()).thenReturn(Stream.of(peer));

--- a/util/src/testFixtures/java/tech/pegasys/teku/util/time/StubTimeProvider.java
+++ b/util/src/testFixtures/java/tech/pegasys/teku/util/time/StubTimeProvider.java
@@ -45,7 +45,7 @@ public class StubTimeProvider implements TimeProvider {
   }
 
   public void advanceTimeByMillis(final long millis) {
-    this.timeInMillis = timeInMillis.plus(UInt64.valueOf(millis));
+    this.timeInMillis = timeInMillis.plus(millis);
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/DutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/DutyScheduler.java
@@ -99,7 +99,7 @@ public class DutyScheduler implements ValidatorTimingChannel {
     // So invalidate any duties for slot.
     // They will be recalculated on the next slot event if required which avoids requesting duties
     // too often if we're syncing a batch of blocks
-    final UInt64 firstInvalidatedEpoch = compute_epoch_at_slot(slot).plus(UInt64.valueOf(2));
+    final UInt64 firstInvalidatedEpoch = compute_epoch_at_slot(slot).plus(2);
     removeEpochs(dutiesByEpoch.tailMap(firstInvalidatedEpoch, true));
   }
 

--- a/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -81,7 +81,7 @@ public class ValidatorApiHandlerIntegrationTest {
   public void createUnsignedAttestation_withRecentBlockAvailable() {
     final UInt64 targetEpoch = UInt64.valueOf(3);
     final UInt64 targetEpochStartSlot = compute_start_slot_at_epoch(targetEpoch);
-    final UInt64 targetSlot = targetEpochStartSlot.plus(UInt64.valueOf(2));
+    final UInt64 targetSlot = targetEpochStartSlot.plus(2);
 
     final SignedBlockAndState genesis = chainUpdater.initializeGenesis();
     final Checkpoint genesisCheckpoint = genesis.getState().getFinalized_checkpoint();
@@ -115,7 +115,7 @@ public class ValidatorApiHandlerIntegrationTest {
     final UInt64 latestSlot = compute_start_slot_at_epoch(latestEpoch).plus(ONE);
     final UInt64 targetEpoch = UInt64.valueOf(latestEpoch.longValue() + 3);
     final UInt64 targetEpochStartSlot = compute_start_slot_at_epoch(targetEpoch);
-    final UInt64 targetSlot = targetEpochStartSlot.plus(UInt64.valueOf(2));
+    final UInt64 targetSlot = targetEpochStartSlot.plus(2);
 
     final SignedBlockAndState genesis = chainUpdater.initializeGenesis();
     final Checkpoint genesisCheckpoint = genesis.getState().getFinalized_checkpoint();

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
@@ -121,10 +121,10 @@ public class DepositProvider implements Eth1EventsChannel, FinalizedCheckpointCh
     // the generated proofs are valid
     checkRequiredDepositsAvailable(eth1DepositCount, eth1DepositIndex);
 
-    UInt64 latestDepositIndexWithMaxBlock = eth1DepositIndex.plus(UInt64.valueOf(MAX_DEPOSITS));
+    UInt64 latestDepositIndexWithMaxBlock = eth1DepositIndex.plus(MAX_DEPOSITS);
 
     UInt64 toDepositIndex =
-        latestDepositIndexWithMaxBlock.compareTo(eth1DepositCount) > 0
+        latestDepositIndexWithMaxBlock.isGreaterThan(eth1DepositCount)
             ? eth1DepositCount
             : latestDepositIndexWithMaxBlock;
 

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/Eth1VotingPeriod.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/Eth1VotingPeriod.java
@@ -32,9 +32,7 @@ public class Eth1VotingPeriod {
 
   public UInt64 getSpecRangeLowerBound(final UInt64 slot, final UInt64 genesisTime) {
     return secondsBeforeCurrentVotingPeriodStartTime(
-        slot,
-        genesisTime,
-        ETH1_FOLLOW_DISTANCE.times(SECONDS_PER_ETH1_BLOCK).times(UInt64.valueOf(2)));
+        slot, genesisTime, ETH1_FOLLOW_DISTANCE.times(SECONDS_PER_ETH1_BLOCK).times(2));
   }
 
   public UInt64 getSpecRangeUpperBound(final UInt64 slot, final UInt64 genesisTime) {
@@ -45,7 +43,7 @@ public class Eth1VotingPeriod {
   private UInt64 secondsBeforeCurrentVotingPeriodStartTime(
       final UInt64 slot, final UInt64 genesisTime, final UInt64 valueToSubtract) {
     final UInt64 currentVotingPeriodStartTime = getVotingPeriodStartTime(slot, genesisTime);
-    if (currentVotingPeriodStartTime.compareTo(valueToSubtract) > 0) {
+    if (currentVotingPeriodStartTime.isGreaterThan(valueToSubtract)) {
       return currentVotingPeriodStartTime.minus(valueToSubtract);
     } else {
       return UInt64.ZERO;
@@ -54,12 +52,12 @@ public class Eth1VotingPeriod {
 
   private UInt64 getVotingPeriodStartTime(final UInt64 slot, final UInt64 genesisTime) {
     final UInt64 eth1VotingPeriodStartSlot =
-        slot.minus(slot.mod(UInt64.valueOf(EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH)));
+        slot.minus(slot.mod(EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH));
     return computeTimeAtSlot(eth1VotingPeriodStartSlot, genesisTime);
   }
 
   private UInt64 computeTimeAtSlot(final UInt64 slot, final UInt64 genesisTime) {
-    return genesisTime.plus(slot.times(UInt64.valueOf(Constants.SECONDS_PER_SLOT)));
+    return genesisTime.plus(slot.times(Constants.SECONDS_PER_SLOT));
   }
 
   public UInt64 getCacheDurationInSeconds() {

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -358,7 +358,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     final UInt64 epochStartSlot = compute_start_slot_at_epoch(epoch);
     // Don't calculate a proposer for the genesis slot
     final UInt64 startSlot = epochStartSlot.max(UInt64.valueOf(GENESIS_SLOT + 1));
-    final UInt64 endSlot = epochStartSlot.plus(UInt64.valueOf(Constants.SLOTS_PER_EPOCH));
+    final UInt64 endSlot = epochStartSlot.plus(Constants.SLOTS_PER_EPOCH);
     final Map<Integer, List<UInt64>> proposalSlotsByValidatorIndex = new HashMap<>();
     for (UInt64 slot = startSlot; slot.compareTo(endSlot) < 0; slot = slot.plus(UInt64.ONE)) {
       final Integer proposer = get_beacon_proposer_index(state, slot);

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
@@ -106,13 +106,13 @@ class BlockFactoryTest {
 
   @Test
   public void shouldCreateBlockAfterSkippedSlot() throws Exception {
-    final UInt64 newSlot = recentChainData.getBestSlot().plus(UInt64.valueOf(2));
+    final UInt64 newSlot = recentChainData.getBestSlot().plus(2);
     assertBlockCreated(newSlot);
   }
 
   @Test
   public void shouldCreateBlockAfterMultipleSkippedSlot() throws Exception {
-    final UInt64 newSlot = recentChainData.getBestSlot().plus(UInt64.valueOf(5));
+    final UInt64 newSlot = recentChainData.getBestSlot().plus(5);
     assertBlockCreated(newSlot);
   }
 

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -420,7 +420,7 @@ class ValidatorApiHandlerTest {
   }
 
   private BeaconState createStateWithMixOfActiveAndInactiveValidators(final UInt64 slot) {
-    final UInt64 futureEpoch = compute_epoch_at_slot(slot).plus(UInt64.valueOf(10));
+    final UInt64 futureEpoch = compute_epoch_at_slot(slot).plus(10);
     return dataStructureUtil
         .randomBeaconState(32)
         .updated(


### PR DESCRIPTION
## PR Description
Replace a bunch of `.plus(UInt64.valueOf(long))` calls with just `.plus(long)` and also for `times`, `dividedBy`, `minus` and `mod`.  Use the comparison convenience functions in a few places too.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.