### PR TITLE
Restrict size of epoch parameter so that it can be converted to slot without overflow

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/SingleQueryParameterUtils.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/SingleQueryParameterUtils.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.util.config.Constants;
 
 public class SingleQueryParameterUtils {
 
@@ -57,7 +58,7 @@ public class SingleQueryParameterUtils {
       throws IllegalArgumentException {
     String stringValue = validateQueryParameter(parameterMap, key);
     try {
-      return Integer.valueOf(stringValue);
+      return Integer.parseInt(stringValue);
     } catch (IllegalArgumentException ex) {
       throw new IllegalArgumentException(INVALID_NUMERIC_VALUE);
     }
@@ -74,12 +75,23 @@ public class SingleQueryParameterUtils {
     }
   }
 
+  public static UInt64 getParameterValueAsEpoch(
+      final Map<String, List<String>> parameterMap, final String key)
+      throws IllegalArgumentException {
+    final UInt64 value = getParameterValueAsUInt64(parameterMap, key);
+    // Restrict valid epoch values to ones that can be converted to slot without overflowing
+    if (value.isGreaterThan(UInt64.MAX_VALUE.dividedBy(Constants.SLOTS_PER_EPOCH))) {
+      throw new IllegalArgumentException(INVALID_NUMERIC_VALUE);
+    }
+    return value;
+  }
+
   public static long getParameterValueAsLong(
       final Map<String, List<String>> parameterMap, final String key)
       throws IllegalArgumentException {
     String stringValue = validateQueryParameter(parameterMap, key);
     try {
-      return Long.valueOf(stringValue);
+      return Long.parseLong(stringValue);
     } catch (IllegalArgumentException ex) {
       throw new IllegalArgumentException(INVALID_NUMERIC_VALUE);
     }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetBlock.java
@@ -27,6 +27,7 @@ import static tech.pegasys.teku.beaconrestapi.RestApiConstants.SLOT;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.SLOT_QUERY_DESCRIPTION;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_BEACON;
 import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsBytes32;
+import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsEpoch;
 import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsUInt64;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 
@@ -105,7 +106,7 @@ public class GetBlock implements Handler {
 
       final UInt64 slot;
       if (queryParamMap.containsKey(EPOCH)) {
-        UInt64 epoch = getParameterValueAsUInt64(queryParamMap, EPOCH);
+        UInt64 epoch = getParameterValueAsEpoch(queryParamMap, EPOCH);
         slot = compute_start_slot_at_epoch(epoch);
       } else if (queryParamMap.containsKey(SLOT)) {
         slot = getParameterValueAsUInt64(queryParamMap, SLOT);

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetCommittees.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetCommittees.java
@@ -23,7 +23,7 @@ import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERRO
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_NO_CONTENT;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_BEACON;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsUInt64;
+import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsEpoch;
 
 import io.javalin.core.util.Header;
 import io.javalin.http.Context;
@@ -75,7 +75,7 @@ public class GetCommittees extends AbstractHandler implements Handler {
   @Override
   public void handle(Context ctx) throws Exception {
     try {
-      UInt64 epoch = getParameterValueAsUInt64(ctx.queryParamMap(), EPOCH);
+      UInt64 epoch = getParameterValueAsEpoch(ctx.queryParamMap(), EPOCH);
       final SafeFuture<Optional<List<Committee>>> future = provider.getCommitteesAtEpoch(epoch);
       UInt64 slot = BeaconStateUtil.compute_start_slot_at_epoch(epoch);
       ctx.header(Header.CACHE_CONTROL, getMaxAgeForSlot(provider, slot));

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetValidators.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetValidators.java
@@ -27,8 +27,8 @@ import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERRO
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_NO_CONTENT;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_BEACON;
+import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsEpoch;
 import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsInt;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsUInt64;
 
 import io.javalin.core.util.Header;
 import io.javalin.http.Context;
@@ -116,7 +116,7 @@ public class GetValidators extends AbstractHandler implements Handler {
       boolean isFinalized = false;
       final SafeFuture<Optional<BeaconState>> future;
       if (parameters.containsKey(EPOCH)) {
-        UInt64 epoch = getParameterValueAsUInt64(parameters, EPOCH);
+        UInt64 epoch = getParameterValueAsEpoch(parameters, EPOCH);
         UInt64 slot = BeaconStateUtil.compute_start_slot_at_epoch(epoch);
         isFinalized = chainDataProvider.isFinalized(slot);
         future = chainDataProvider.getStateAtSlot(slot);
@@ -133,7 +133,7 @@ public class GetValidators extends AbstractHandler implements Handler {
         this.handlePossiblyMissingResult(
             ctx, future, getResultProcessor(activeOnly, pageSize, pageToken));
       }
-    } catch (final IllegalArgumentException | ArithmeticException e) {
+    } catch (final IllegalArgumentException e) {
       ctx.result(jsonProvider.objectToJSON(new BadRequest(e.getMessage())));
       ctx.status(SC_BAD_REQUEST);
     }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetBlockTest.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.util.config.Constants;
 
 public class GetBlockTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
@@ -177,5 +178,15 @@ public class GetBlockTest {
 
     handler.handle(context);
     verify(context).status(SC_NOT_FOUND);
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenEpochTooLarge() throws Exception {
+    final Map<String, List<String>> params =
+        Map.of(EPOCH, List.of(Constants.FAR_FUTURE_EPOCH.toString()));
+    when(context.queryParamMap()).thenReturn(params);
+
+    handler.handle(context);
+    verify(context).status(SC_BAD_REQUEST);
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetCommitteesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetCommitteesTest.java
@@ -43,6 +43,7 @@ import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystem;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
+import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.util.config.StateStorageMode;
 
 public class GetCommitteesTest {
@@ -72,6 +73,17 @@ public class GetCommitteesTest {
 
   @Test
   public void shouldReturnBadRequestWhenNoEpochIsSupplied() throws Exception {
+    ChainDataProvider provider = new ChainDataProvider(null, combinedChainDataClient);
+    final GetCommittees handler = new GetCommittees(provider, jsonProvider);
+
+    handler.handle(context);
+    verify(context).status(SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenEpochIsTooLarge() throws Exception {
+    when(context.queryParamMap())
+        .thenReturn(Map.of(EPOCH, List.of(Constants.FAR_FUTURE_EPOCH.toString())));
     ChainDataProvider provider = new ChainDataProvider(null, combinedChainDataClient);
     final GetCommittees handler = new GetCommittees(provider, jsonProvider);
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetValidatorsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/GetValidatorsTest.java
@@ -275,6 +275,21 @@ public class GetValidatorsTest {
   }
 
   @Test
+  public void shouldReturnBadRequestWhenTooBigEpochParameterSpecified() throws Exception {
+    final GetValidators handler = new GetValidators(provider, jsonProvider);
+    // It's a valid uint64 but is too big to be converted to a slot
+    final String tooBigEpoch = Constants.FAR_FUTURE_EPOCH.toString();
+    when(context.queryParamMap())
+        .thenReturn(Map.of(ACTIVE, List.of("true"), EPOCH, List.of(tooBigEpoch)));
+    when(provider.isStoreAvailable()).thenReturn(true);
+    when(provider.getBestBlockRoot()).thenReturn(Optional.of(blockRoot));
+
+    handler.handle(context);
+
+    verify(context).status(SC_BAD_REQUEST);
+  }
+
+  @Test
   public void shouldReturnEmptyListWhenQueryByActiveAndFarFutureEpoch() throws Exception {
     final GetValidators handler = new GetValidators(provider, jsonProvider);
     final UInt64 futureEpoch = UInt64.valueOf(294829482492L);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/PostValidatorsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/beacon/PostValidatorsTest.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.util.config.Constants;
 
 public class PostValidatorsTest {
   private static final String EMPTY_LIST = "[]";
@@ -86,6 +87,17 @@ public class PostValidatorsTest {
   @Test
   void shouldReturnBadRequestIfBadObject() throws Exception {
     when(context.body()).thenReturn("{}");
+    handler.handle(context);
+
+    verify(context).status(SC_BAD_REQUEST);
+    verify(context).body();
+    verifyNoMoreInteractions(context);
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenEpochTooHigh() throws Exception {
+    final String body = "{\"epoch\":" + Constants.FAR_FUTURE_EPOCH + ",\"pubkeys\":[]}";
+    when(context.body()).thenReturn(body);
     handler.handle(context);
 
     verify(context).status(SC_BAD_REQUEST);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/validator/PostDutiesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/validator/PostDutiesTest.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.util.config.Constants;
 
 public class PostDutiesTest {
   private static final List<BLSKeyPair> keyPairs = BLSKeyGenerator.generateKeyPairs(1);
@@ -69,6 +70,15 @@ public class PostDutiesTest {
     PostDuties handler = new PostDuties(provider, jsonProvider);
     when(provider.isStoreAvailable()).thenReturn(true);
     when(context.body()).thenReturn("{\"epoch\":\"-1\"}");
+    handler.handle(context);
+    verify(context).status(SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenEpochNumberTooLargeInBody() throws Exception {
+    PostDuties handler = new PostDuties(provider, jsonProvider);
+    when(provider.isStoreAvailable()).thenReturn(true);
+    when(context.body()).thenReturn("{\"epoch\":\"" + Constants.FAR_FUTURE_EPOCH + "\"}");
     handler.handle(context);
     verify(context).status(SC_BAD_REQUEST);
   }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/ValidatorsRequest.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/ValidatorsRequest.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.util.config.Constants;
 
 public class ValidatorsRequest {
   @Schema(type = "string", format = "uint64")
@@ -36,5 +37,10 @@ public class ValidatorsRequest {
       @JsonProperty(value = "pubkeys", required = true) final List<BLSPubKey> pubkeys) {
     this.epoch = epoch;
     this.pubkeys = pubkeys;
+    // Restrict valid epoch values to ones that can be converted to slot without overflowing
+    if (epoch != null
+        && epoch.isGreaterThan(UInt64.MAX_VALUE.dividedBy(Constants.SLOTS_PER_EPOCH))) {
+      throw new IllegalArgumentException("Epoch is too large.");
+    }
   }
 }


### PR DESCRIPTION
## PR Description
Validate all EPOCH parameters in the REST API, restricting them to be less than `UInt64.MAX_VALUE / Constants.SLOTS_PER_EPOCH`. This ensures that they can be converted to a slot without overflowing.

While a generic handler fo `ArithmeticException` could have been added to respond with BAD_REQUEST on any overflow, that feels too generic as a there are a range of programming errors which could lead to `ArithmeticException` being thrown and we don't want to obscure those problem by just treating them as a bad request.

## Fixed Issue(s)
fixes #2537 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.