### PR TITLE
Enable snappy by default

### DIFF
--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -63,6 +63,16 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  public void snappyCompressionDefaultsToTrueForCustomNetwork() {
+    final String[] args = {"--network=/tmp/foo.yaml"};
+
+    beaconNodeCommand.parse(args);
+
+    final TekuConfiguration tekuConfiguration = getResultingTekuConfiguration();
+    assertThat(tekuConfiguration.isP2pSnappyEnabled()).isTrue();
+  }
+
+  @Test
   public void mainnetNetworkDefaultsSnappyCompressionOn() {
     final String[] args = {"--network", "mainnet"};
 

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
@@ -21,7 +21,7 @@ import org.apache.tuweni.bytes.Bytes32;
 
 public class TekuConfigurationBuilder {
 
-  private static final boolean DEFAULT_P2P_SNAPPY_ENABLED = false;
+  private static final boolean DEFAULT_P2P_SNAPPY_ENABLED = true;
   private String constants;
   private Integer startupTargetPeerCount;
   private Integer startupTimeoutSeconds;


### PR DESCRIPTION
## PR Description
Enable snappy by default to reduce confusion.

## Fixed Issue(s)
fixes #2443 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.