### PR TITLE
[Issue-2438] Be more careful about disabling validator duties while "syncing"

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -184,7 +184,7 @@ public class ChainDataProvider {
         () -> {
           UInt64 slot =
               request.epoch == null
-                  ? combinedChainDataClient.getBestSlot()
+                  ? combinedChainDataClient.getHeadSlot()
                   : BeaconStateUtil.compute_start_slot_at_epoch(request.epoch);
 
           return combinedChainDataClient

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -62,7 +62,7 @@ public class ChainDataProvider {
       throw new ChainDataUnavailableException();
     }
 
-    return recentChainData.getBestBlockAndState().map(BeaconHead::new);
+    return recentChainData.getHeadBlockAndState().map(BeaconHead::new);
   }
 
   public GetForkResponse getForkInfo() {
@@ -84,7 +84,7 @@ public class ChainDataProvider {
 
     final UInt64 earliestQueryableSlot =
         CommitteeUtil.getEarliestQueryableSlotForTargetEpoch(epoch);
-    if (recentChainData.getBestSlot().isLessThan(earliestQueryableSlot)) {
+    if (recentChainData.getHeadSlot().isLessThan(earliestQueryableSlot)) {
       return SafeFuture.completedFuture(Optional.empty());
     }
 
@@ -212,6 +212,6 @@ public class ChainDataProvider {
     if (!isStoreAvailable()) {
       throw new ChainDataUnavailableException();
     }
-    return recentChainData.getBestBlockAndState().map(BeaconChainHead::new);
+    return recentChainData.getHeadBlockAndState().map(BeaconChainHead::new);
   }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -83,7 +83,7 @@ public class ValidatorDataProvider {
     if (randao == null) {
       throw new IllegalArgumentException(NO_RANDAO_PROVIDED);
     }
-    UInt64 bestSlot = combinedChainDataClient.getBestSlot();
+    UInt64 bestSlot = combinedChainDataClient.getHeadSlot();
     if (bestSlot.plus(UInt64.valueOf(SLOTS_PER_EPOCH)).compareTo(slot) < 0) {
       throw new IllegalArgumentException(CANNOT_PRODUCE_FAR_FUTURE_BLOCK);
     }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -139,7 +139,7 @@ public class ChainDataProviderTest {
         .thenReturn(Optional.of(bestBlock.getRoot()));
     when(mockCombinedChainDataClient.getCommitteesFromState(any(), any()))
         .thenReturn(committeeAssignments);
-    when(mockRecentChainData.getBestSlot()).thenReturn(bestBlock.getSlot());
+    when(mockRecentChainData.getHeadSlot()).thenReturn(bestBlock.getSlot());
     when(mockCombinedChainDataClient.getCheckpointStateAtEpoch(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(checkpointState)));
     final SafeFuture<Optional<List<Committee>>> future =
@@ -177,7 +177,7 @@ public class ChainDataProviderTest {
     final BeaconHead head = optionalBeaconHead.get();
     assertEquals(blockRoot, head.block_root);
     assertEquals(beaconStateInternal.hash_tree_root(), head.state_root);
-    assertEquals(recentChainData.getBestSlot(), head.slot);
+    assertEquals(recentChainData.getHeadSlot(), head.slot);
   }
 
   @Test

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -94,7 +94,7 @@ public class ValidatorDataProviderTest {
 
   @Test
   void getUnsignedBeaconBlockAtSlot_shouldThrowIfHistoricSlotRequested() {
-    when(combinedChainDataClient.getBestSlot()).thenReturn(ONE);
+    when(combinedChainDataClient.getHeadSlot()).thenReturn(ONE);
 
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> provider.getUnsignedBeaconBlockAtSlot(ZERO, signature, Optional.empty()));
@@ -102,7 +102,7 @@ public class ValidatorDataProviderTest {
 
   @Test
   void getUnsignedBeaconBlockAtSlot_shouldThrowIfFarFutureSlotRequested() {
-    when(combinedChainDataClient.getBestSlot()).thenReturn(ONE);
+    when(combinedChainDataClient.getHeadSlot()).thenReturn(ONE);
 
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(
@@ -113,7 +113,7 @@ public class ValidatorDataProviderTest {
 
   @Test
   void getUnsignedBeaconBlockAtSlot_shouldCreateAnUnsignedBlock() {
-    when(combinedChainDataClient.getBestSlot()).thenReturn(ZERO);
+    when(combinedChainDataClient.getHeadSlot()).thenReturn(ZERO);
     when(validatorApiChannel.createUnsignedBlock(ONE, signatureInternal, Optional.empty()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockInternal)));
 

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/gen/Generator.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/gen/Generator.java
@@ -70,7 +70,7 @@ public class Generator {
     localChain.initializeStorage();
     AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
 
-    UInt64 currentSlot = localStorage.getBestSlot();
+    UInt64 currentSlot = localStorage.getHeadSlot();
     List<Attestation> attestations = Collections.emptyList();
 
     String blocksFile =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -73,7 +73,7 @@ public class ForkChoice {
                       justifiedCheckpointState.orElseThrow());
               transaction.commit(() -> {}, "Failed to persist validator vote changes.");
 
-              recentChainData.updateBestBlock(
+              recentChainData.updateHead(
                   headBlockRoot,
                   nodeSlot.orElse(
                       forkChoiceStrategy

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
@@ -157,7 +157,7 @@ public class BlockImporterTest {
     Constants.SLOTS_PER_EPOCH = 6;
 
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
-    UInt64 currentSlot = recentChainData.getBestSlot();
+    UInt64 currentSlot = recentChainData.getHeadSlot();
     for (int i = 0; i < Constants.SLOTS_PER_EPOCH; i++) {
       currentSlot = currentSlot.plus(UInt64.ONE);
       final SignedBeaconBlock block = localChain.createAndImportBlockAtSlot(currentSlot);
@@ -167,7 +167,7 @@ public class BlockImporterTest {
     // Update finalized epoch
     final StoreTransaction tx = recentChainData.startStoreTransaction();
     final Bytes32 bestRoot = recentChainData.getBestBlockRoot().orElseThrow();
-    final UInt64 bestEpoch = compute_epoch_at_slot(recentChainData.getBestSlot());
+    final UInt64 bestEpoch = compute_epoch_at_slot(recentChainData.getHeadSlot());
     assertThat(bestEpoch.longValue()).isEqualTo(Constants.GENESIS_EPOCH + 1L);
     final Checkpoint finalized = new Checkpoint(bestEpoch, bestRoot);
     tx.setFinalizedCheckpoint(finalized);
@@ -183,7 +183,7 @@ public class BlockImporterTest {
     Constants.SLOTS_PER_EPOCH = 6;
 
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
-    UInt64 currentSlot = recentChainData.getBestSlot();
+    UInt64 currentSlot = recentChainData.getHeadSlot();
     for (int i = 0; i < Constants.SLOTS_PER_EPOCH; i++) {
       currentSlot = currentSlot.plus(UInt64.ONE);
       final SignedBeaconBlock block = localChain.createAndImportBlockAtSlot(currentSlot);
@@ -193,7 +193,7 @@ public class BlockImporterTest {
     // Update finalized epoch
     final StoreTransaction tx = recentChainData.startStoreTransaction();
     final Bytes32 bestRoot = recentChainData.getBestBlockRoot().orElseThrow();
-    final UInt64 bestEpoch = compute_epoch_at_slot(recentChainData.getBestSlot());
+    final UInt64 bestEpoch = compute_epoch_at_slot(recentChainData.getHeadSlot());
     assertThat(bestEpoch.longValue()).isEqualTo(Constants.GENESIS_EPOCH + 1L);
     final Checkpoint finalized = new Checkpoint(bestEpoch, bestRoot);
     tx.setFinalizedCheckpoint(finalized);
@@ -263,7 +263,7 @@ public class BlockImporterTest {
 
   @Test
   public void importBlock_wrongChain() throws Exception {
-    UInt64 currentSlot = recentChainData.getBestSlot();
+    UInt64 currentSlot = recentChainData.getHeadSlot();
     for (int i = 0; i < 3; i++) {
       currentSlot = currentSlot.plus(UInt64.ONE);
       localChain.createAndImportBlockAtSlot(currentSlot);
@@ -278,7 +278,7 @@ public class BlockImporterTest {
 
     // Now create a new block that is not descendent from the finalized block
     AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
-    final BeaconBlockAndState blockAndState = otherStorage.getBestBlockAndState().orElseThrow();
+    final BeaconBlockAndState blockAndState = otherStorage.getHeadBlockAndState().orElseThrow();
     final Attestation attestation = attestationGenerator.validAttestation(blockAndState);
     final SignedBeaconBlock block =
         otherChain.createAndImportBlockAtSlotWithAttestations(currentSlot, List.of(attestation));

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -238,7 +238,7 @@ public class BeaconChainUtil {
         withValidProposer || validatorKeys.size() > 1,
         "Must have >1 validator in order to create a block from an invalid proposer.");
     final BeaconBlockAndState bestBlockAndState =
-        recentChainData.getBestBlockAndState().orElseThrow();
+        recentChainData.getHeadBlockAndState().orElseThrow();
     final Bytes32 bestBlockRoot = bestBlockAndState.getRoot();
     final BeaconBlock bestBlock = bestBlockAndState.getBlock();
     final BeaconState preState = bestBlockAndState.getState();
@@ -259,22 +259,22 @@ public class BeaconChainUtil {
     }
 
     AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
-    createAndImportBlockAtSlot(recentChainData.getBestSlot().plus(MIN_ATTESTATION_INCLUSION_DELAY));
+    createAndImportBlockAtSlot(recentChainData.getHeadSlot().plus(MIN_ATTESTATION_INCLUSION_DELAY));
 
     while (recentChainData.getStore().getFinalizedCheckpoint().getEpoch().compareTo(epoch) < 0) {
 
       BeaconState headState =
-          recentChainData.getBestBlockAndState().map(BeaconBlockAndState::getState).orElseThrow();
+          recentChainData.getHeadBlockAndState().map(BeaconBlockAndState::getState).orElseThrow();
       BeaconBlock headBlock =
-          recentChainData.getBestBlock().map(SignedBeaconBlock::getMessage).orElseThrow();
-      UInt64 slot = recentChainData.getBestSlot();
+          recentChainData.getHeadBlock().map(SignedBeaconBlock::getMessage).orElseThrow();
+      UInt64 slot = recentChainData.getHeadSlot();
       SSZList<Attestation> currentSlotAssignments =
           SSZList.createMutable(
               attestationGenerator.getAttestationsForSlot(headState, headBlock, slot),
               Constants.MAX_ATTESTATIONS,
               Attestation.class);
       createAndImportBlockAtSlot(
-          recentChainData.getBestSlot().plus(UInt64.ONE),
+          recentChainData.getHeadSlot().plus(UInt64.ONE),
           Optional.of(currentSlotAssignments),
           Optional.empty(),
           Optional.empty(),

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
@@ -95,11 +95,11 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
   public void shouldRespondWithBlocksFromCanonicalChain() throws Exception {
     final SignedBeaconBlock block1 = beaconChainUtil.createAndImportBlockAtSlot(1);
     final Bytes32 block1Root = block1.getMessage().hash_tree_root();
-    recentChainData1.updateBestBlock(block1Root, block1.getSlot());
+    recentChainData1.updateHead(block1Root, block1.getSlot());
 
     final SignedBeaconBlock block2 = beaconChainUtil.createAndImportBlockAtSlot(2);
     final Bytes32 block2Root = block2.getMessage().hash_tree_root();
-    recentChainData1.updateBestBlock(block2Root, block2.getSlot());
+    recentChainData1.updateHead(block2Root, block2.getSlot());
 
     final List<SignedBeaconBlock> response = requestBlocks();
     assertThat(response).containsExactly(block1, block2);
@@ -111,7 +111,7 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
     beaconChainUtil.createAndImportBlockAtSlot(1);
     final SignedBeaconBlock block2 = beaconChainUtil.createAndImportBlockAtSlot(2);
     final Bytes32 block2Root = block2.getMessage().hash_tree_root();
-    recentChainData1.updateBestBlock(block2Root, block2.getSlot());
+    recentChainData1.updateHead(block2Root, block2.getSlot());
 
     peer1.disconnectImmediately(Optional.empty(), false);
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
@@ -131,7 +131,7 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
     beaconChainUtil.createAndImportBlockAtSlot(1);
     final SignedBeaconBlock block2 = beaconChainUtil.createAndImportBlockAtSlot(2);
     final Bytes32 block2Root = block2.getMessage().hash_tree_root();
-    recentChainData1.updateBestBlock(block2Root, block2.getSlot());
+    recentChainData1.updateHead(block2Root, block2.getSlot());
 
     peer1.disconnectCleanly(DisconnectReason.TOO_MANY_PEERS);
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
@@ -151,7 +151,7 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
     beaconChainUtil.createAndImportBlockAtSlot(1);
     final SignedBeaconBlock block2 = beaconChainUtil.createAndImportBlockAtSlot(2);
     final Bytes32 block2Root = block2.getMessage().hash_tree_root();
-    recentChainData1.updateBestBlock(block2Root, block2.getSlot());
+    recentChainData1.updateHead(block2Root, block2.getSlot());
 
     peer1.disconnectImmediately(Optional.empty(), false);
     final SafeFuture<SignedBeaconBlock> res = peer1.requestBlockBySlot(UInt64.ONE);
@@ -167,7 +167,7 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
     beaconChainUtil.createAndImportBlockAtSlot(1);
     final SignedBeaconBlock block2 = beaconChainUtil.createAndImportBlockAtSlot(2);
     final Bytes32 block2Root = block2.getMessage().hash_tree_root();
-    recentChainData1.updateBestBlock(block2Root, block2.getSlot());
+    recentChainData1.updateHead(block2Root, block2.getSlot());
 
     peer1.disconnectCleanly(DisconnectReason.TOO_MANY_PEERS);
     final SafeFuture<SignedBeaconBlock> res = peer1.requestBlockBySlot(UInt64.ONE);

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GossipMessageHandlerIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GossipMessageHandlerIntegrationTest.java
@@ -188,7 +188,7 @@ public class GossipMessageHandlerIntegrationTest {
     // Propagate attestation from network 1
     AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
     final BeaconBlockAndState bestBlockAndState =
-        node1.storageClient().getBestBlockAndState().orElseThrow();
+        node1.storageClient().getHeadBlockAndState().orElseThrow();
     Attestation validAttestation = attestationGenerator.validAttestation(bestBlockAndState);
     processedAttestationSubscribers.forEach(
         s -> s.accept(ValidateableAttestation.fromAttestation(validAttestation)));
@@ -236,7 +236,7 @@ public class GossipMessageHandlerIntegrationTest {
     // Propagate attestation from network 1
     AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
     final BeaconBlockAndState bestBlockAndState =
-        node1.storageClient().getBestBlockAndState().orElseThrow();
+        node1.storageClient().getHeadBlockAndState().orElseThrow();
     ValidateableAttestation validAttestation =
         ValidateableAttestation.fromAttestation(
             attestationGenerator.validAttestation(bestBlockAndState));
@@ -298,7 +298,7 @@ public class GossipMessageHandlerIntegrationTest {
     // Propagate attestation from network 1
     AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
     final BeaconBlockAndState bestBlockAndState =
-        node1.storageClient().getBestBlockAndState().orElseThrow();
+        node1.storageClient().getHeadBlockAndState().orElseThrow();
     ValidateableAttestation validAttestation =
         ValidateableAttestation.fromAttestation(
             attestationGenerator.validAttestation(bestBlockAndState));

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
@@ -181,7 +181,7 @@ public class PeerStatusIntegrationTest {
         state.getFinalized_checkpoint().getRoot(),
         state.getFinalized_checkpoint().getEpoch(),
         storageClient.getBestBlockRoot().orElseThrow(),
-        storageClient.getBestSlot());
+        storageClient.getHeadSlot());
   }
 
   private void assertStatus(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
@@ -36,7 +36,7 @@ public class StatusMessageFactory {
     }
 
     final BeaconBlockAndState bestBlockAndState =
-        recentChainData.getBestBlockAndState().orElseThrow();
+        recentChainData.getHeadBlockAndState().orElseThrow();
     final ForkInfo forkInfo = recentChainData.getForkInfoAtCurrentTime().orElseThrow();
     final Checkpoint finalizedCheckpoint = bestBlockAndState.getState().getFinalized_checkpoint();
     final BeaconBlock chainHead = bestBlockAndState.getBlock();

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/BlockTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/BlockTopicHandlerTest.java
@@ -57,7 +57,7 @@ public class BlockTopicHandlerTest {
 
   @Test
   public void handleMessage_validBlock() throws Exception {
-    final UInt64 nextSlot = recentChainData.getBestSlot().plus(UInt64.ONE);
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(UInt64.ONE);
     final SignedBeaconBlock block = beaconChainUtil.createBlockAtSlot(nextSlot);
     Bytes serialized = gossipEncoding.encode(block);
     beaconChainUtil.setSlot(nextSlot);
@@ -69,10 +69,10 @@ public class BlockTopicHandlerTest {
 
   @Test
   public void handleMessage_validFutureBlock() throws Exception {
-    final UInt64 nextSlot = recentChainData.getBestSlot().plus(UInt64.ONE);
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(UInt64.ONE);
     final SignedBeaconBlock block = beaconChainUtil.createBlockAtSlot(nextSlot);
     Bytes serialized = gossipEncoding.encode(block);
-    beaconChainUtil.setSlot(recentChainData.getBestSlot());
+    beaconChainUtil.setSlot(recentChainData.getHeadSlot());
 
     final ValidationResult result = topicHandler.handleMessage(serialized).join();
     assertThat(result).isEqualTo(ValidationResult.Ignore);
@@ -99,7 +99,7 @@ public class BlockTopicHandlerTest {
 
   @Test
   public void handleMessage_invalidBlock_wrongProposer() throws Exception {
-    final UInt64 nextSlot = recentChainData.getBestSlot().plus(UInt64.ONE);
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(UInt64.ONE);
     final SignedBeaconBlock block = beaconChainUtil.createBlockAtSlotFromInvalidProposer(nextSlot);
     Bytes serialized = gossipEncoding.encode(block);
     beaconChainUtil.setSlot(nextSlot);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
@@ -74,7 +74,7 @@ public class SingleAttestationTopicHandlerTest {
   @Test
   public void handleMessage_valid() {
     final AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
-    final BeaconBlockAndState blockAndState = recentChainData.getBestBlockAndState().orElseThrow();
+    final BeaconBlockAndState blockAndState = recentChainData.getHeadBlockAndState().orElseThrow();
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromAttestation(
             attestationGenerator.validAttestation(blockAndState));
@@ -90,7 +90,7 @@ public class SingleAttestationTopicHandlerTest {
   @Test
   public void handleMessage_ignored() {
     final AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
-    final BeaconBlockAndState blockAndState = recentChainData.getBestBlockAndState().orElseThrow();
+    final BeaconBlockAndState blockAndState = recentChainData.getHeadBlockAndState().orElseThrow();
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromAttestation(
             attestationGenerator.validAttestation(blockAndState));
@@ -106,7 +106,7 @@ public class SingleAttestationTopicHandlerTest {
   @Test
   public void handleMessage_saveForFuture() {
     final AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
-    final BeaconBlockAndState blockAndState = recentChainData.getBestBlockAndState().orElseThrow();
+    final BeaconBlockAndState blockAndState = recentChainData.getHeadBlockAndState().orElseThrow();
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromAttestation(
             attestationGenerator.validAttestation(blockAndState));
@@ -122,7 +122,7 @@ public class SingleAttestationTopicHandlerTest {
   @Test
   public void handleMessage_invalid() {
     final AttestationGenerator attestationGenerator = new AttestationGenerator(validatorKeys);
-    final BeaconBlockAndState blockAndState = recentChainData.getBestBlockAndState().orElseThrow();
+    final BeaconBlockAndState blockAndState = recentChainData.getHeadBlockAndState().orElseThrow();
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromAttestation(
             attestationGenerator.validAttestation(blockAndState));

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/AttestationValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/AttestationValidatorTest.java
@@ -99,14 +99,14 @@ class AttestationValidatorTest {
   @Test
   public void shouldReturnValidForValidAttestation() {
     final Attestation attestation =
-        attestationGenerator.validAttestation(recentChainData.getBestBlockAndState().orElseThrow());
+        attestationGenerator.validAttestation(recentChainData.getHeadBlockAndState().orElseThrow());
     assertThat(validate(attestation)).isEqualTo(ACCEPT);
   }
 
   @Test
   public void shouldRejectAttestationWithIncorrectAggregateBitsSize() {
     final Attestation attestation =
-        attestationGenerator.validAttestation(recentChainData.getBestBlockAndState().orElseThrow());
+        attestationGenerator.validAttestation(recentChainData.getHeadBlockAndState().orElseThrow());
     final Bitlist validAggregationBits = attestation.getAggregation_bits();
     final Bitlist invalidAggregationBits =
         new Bitlist(validAggregationBits.getCurrentSize() + 1, validAggregationBits.getMaxSize());
@@ -120,7 +120,7 @@ class AttestationValidatorTest {
   @Test
   public void shouldRejectAttestationFromBeforeAttestationPropagationSlotRange() {
     final Attestation attestation =
-        attestationGenerator.validAttestation(recentChainData.getBestBlockAndState().orElseThrow());
+        attestationGenerator.validAttestation(recentChainData.getHeadBlockAndState().orElseThrow());
 
     // In the first slot after
     final UInt64 slot = ATTESTATION_PROPAGATION_SLOT_RANGE.plus(ONE);
@@ -134,7 +134,7 @@ class AttestationValidatorTest {
   @Test
   public void shouldAcceptAttestationWithinClockDisparityOfEarliestPropagationSlot() {
     final Attestation attestation =
-        attestationGenerator.validAttestation(recentChainData.getBestBlockAndState().orElseThrow());
+        attestationGenerator.validAttestation(recentChainData.getHeadBlockAndState().orElseThrow());
 
     // At the very start of the first slot the attestation isn't allowed, but still within
     // the MAXIMUM_GOSSIP_CLOCK_DISPARITY so should be allowed.
@@ -148,7 +148,7 @@ class AttestationValidatorTest {
   public void shouldDeferAttestationFromAfterThePropagationSlotRange() {
     final Attestation attestation =
         attestationGenerator.validAttestation(
-            recentChainData.getBestBlockAndState().orElseThrow(), ONE);
+            recentChainData.getHeadBlockAndState().orElseThrow(), ONE);
     assertThat(attestation.getData().getSlot()).isEqualTo(ONE);
 
     chainUpdater.setCurrentSlot(ZERO);
@@ -160,7 +160,7 @@ class AttestationValidatorTest {
   public void shouldAcceptAttestationWithinClockDisparityOfLatestPropagationSlot() {
     final Attestation attestation =
         attestationGenerator.validAttestation(
-            recentChainData.getBestBlockAndState().orElseThrow(), ONE);
+            recentChainData.getHeadBlockAndState().orElseThrow(), ONE);
     assertThat(attestation.getData().getSlot()).isEqualTo(ONE);
 
     // Ideally we'd rewind the time by a few milliseconds but our Store only keeps time to second
@@ -175,7 +175,7 @@ class AttestationValidatorTest {
     final Attestation attestation =
         AttestationGenerator.groupAndAggregateAttestations(
                 attestationGenerator.getAttestationsForSlot(
-                    recentChainData.getBestBlockAndState().orElseThrow()))
+                    recentChainData.getHeadBlockAndState().orElseThrow()))
             .get(0);
 
     assertThat(validate(attestation)).isEqualTo(REJECT);
@@ -183,12 +183,12 @@ class AttestationValidatorTest {
 
   @Test
   public void shouldRejectAttestationForSameValidatorAndTargetEpoch() throws Exception {
-    final BeaconBlockAndState genesis = recentChainData.getBestBlockAndState().orElseThrow();
+    final BeaconBlockAndState genesis = recentChainData.getHeadBlockAndState().orElseThrow();
     chainUpdater.advanceChain(ONE);
 
     // Slot 1 attestation for the block at slot 1
     final Attestation attestation1 =
-        attestationGenerator.validAttestation(recentChainData.getBestBlockAndState().orElseThrow());
+        attestationGenerator.validAttestation(recentChainData.getHeadBlockAndState().orElseThrow());
     // Slot 1 attestation from the same validator claiming no block at slot 1
     final Attestation attestation2 =
         attestationGenerator
@@ -208,7 +208,7 @@ class AttestationValidatorTest {
 
   @Test
   public void shouldAcceptAttestationForSameValidatorButDifferentTargetEpoch() throws Exception {
-    final BeaconBlockAndState genesis = recentChainData.getBestBlockAndState().orElseThrow();
+    final BeaconBlockAndState genesis = recentChainData.getHeadBlockAndState().orElseThrow();
     final SignedBeaconBlock nextEpochBlock =
         chainUpdater.advanceChain(UInt64.valueOf(SLOTS_PER_EPOCH + 1)).getBlock();
 
@@ -219,7 +219,7 @@ class AttestationValidatorTest {
     final Attestation attestation2 =
         attestationGenerator
             .streamAttestations(
-                recentChainData.getBestBlockAndState().orElseThrow(), nextEpochBlock.getSlot())
+                recentChainData.getHeadBlockAndState().orElseThrow(), nextEpochBlock.getSlot())
             .filter(attestation -> hasSameValidators(attestation1, attestation))
             .findFirst()
             .orElseThrow();
@@ -235,7 +235,7 @@ class AttestationValidatorTest {
 
   @Test
   public void shouldAcceptAttestationForSameSlotButDifferentValidator() {
-    final BeaconBlockAndState genesis = recentChainData.getBestBlockAndState().orElseThrow();
+    final BeaconBlockAndState genesis = recentChainData.getHeadBlockAndState().orElseThrow();
 
     // Slot 0 attestation from one validator
     final Attestation attestation1 = attestationGenerator.validAttestation(genesis, ZERO);
@@ -260,7 +260,7 @@ class AttestationValidatorTest {
   public void shouldRejectAttestationWithInvalidSignature() {
     final Attestation attestation =
         attestationGenerator.attestationWithInvalidSignature(
-            recentChainData.getBestBlockAndState().orElseThrow());
+            recentChainData.getHeadBlockAndState().orElseThrow());
 
     assertThat(validate(attestation)).isEqualTo(REJECT);
   }
@@ -277,7 +277,7 @@ class AttestationValidatorTest {
 
   @Test
   public void shouldRejectAttestationsSentOnTheWrongSubnet() {
-    final BeaconBlockAndState blockAndState = recentChainData.getBestBlockAndState().orElseThrow();
+    final BeaconBlockAndState blockAndState = recentChainData.getHeadBlockAndState().orElseThrow();
     final Attestation attestation = attestationGenerator.validAttestation(blockAndState);
     final int expectedSubnetId = computeSubnetForAttestation(blockAndState.getState(), attestation);
     assertThat(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/BlockValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/BlockValidatorTest.java
@@ -47,7 +47,7 @@ public class BlockValidatorTest {
 
   @Test
   void shouldReturnValidForValidBlock() throws Exception {
-    final UInt64 nextSlot = recentChainData.getBestSlot().plus(ONE);
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
     beaconChainUtil.setSlot(nextSlot);
     final SignedBeaconBlock block = beaconChainUtil.createBlockAtSlot(nextSlot);
 
@@ -57,7 +57,7 @@ public class BlockValidatorTest {
 
   @Test
   void shouldReturnInvalidForSecondValidBlockForSlotAndProposer() throws Exception {
-    final UInt64 nextSlot = recentChainData.getBestSlot().plus(ONE);
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
     beaconChainUtil.setSlot(nextSlot);
     final SignedBeaconBlock block = beaconChainUtil.createBlockAtSlot(nextSlot);
 
@@ -70,7 +70,7 @@ public class BlockValidatorTest {
 
   @Test
   void shouldReturnSavedForFutureForBlockFromFuture() throws Exception {
-    final UInt64 nextSlot = recentChainData.getBestSlot().plus(ONE);
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
     final SignedBeaconBlock block = beaconChainUtil.createBlockAtSlot(nextSlot);
 
     InternalValidationResult result = blockValidator.validate(block).join();
@@ -79,7 +79,7 @@ public class BlockValidatorTest {
 
   @Test
   void shouldReturnSavedForFutureForBlockWithParentUnavailable() throws Exception {
-    final UInt64 nextSlot = recentChainData.getBestSlot().plus(ONE);
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
     beaconChainUtil.setSlot(nextSlot);
 
     final SignedBeaconBlock signedBlock = beaconChainUtil.createBlockAtSlot(nextSlot);
@@ -108,7 +108,7 @@ public class BlockValidatorTest {
     UInt64 finalizedSlot = compute_start_slot_at_epoch(finalizedEpoch);
     final SignedBeaconBlock block = beaconChainUtil.createBlockAtSlot(finalizedSlot.minus(ONE));
     beaconChainUtil.finalizeChainAtEpoch(finalizedEpoch);
-    beaconChainUtil.setSlot(recentChainData.getBestSlot());
+    beaconChainUtil.setSlot(recentChainData.getHeadSlot());
 
     InternalValidationResult result = blockValidator.validate(block).join();
     assertThat(result).isEqualTo(InternalValidationResult.IGNORE);
@@ -116,7 +116,7 @@ public class BlockValidatorTest {
 
   @Test
   void shouldReturnInvalidForBlockWithWrongProposerIndex() throws Exception {
-    final UInt64 nextSlot = recentChainData.getBestSlot().plus(ONE);
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
     beaconChainUtil.setSlot(nextSlot);
 
     final SignedBeaconBlock signedBlock = beaconChainUtil.createBlockAtSlot(nextSlot);
@@ -144,7 +144,7 @@ public class BlockValidatorTest {
 
   @Test
   void shouldReturnInvalidForBlockWithWrongSignature() throws Exception {
-    final UInt64 nextSlot = recentChainData.getBestSlot().plus(ONE);
+    final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
     beaconChainUtil.setSlot(nextSlot);
 
     final SignedBeaconBlock block =

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/SignedAggregateAndProofValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/SignedAggregateAndProofValidatorTest.java
@@ -130,7 +130,7 @@ class SignedAggregateAndProofValidatorTest {
 
   @Test
   public void shouldReturnValidForValidAggregate() {
-    final BeaconBlockAndState chainHead = recentChainData.getBestBlockAndState().orElseThrow();
+    final BeaconBlockAndState chainHead = recentChainData.getHeadBlockAndState().orElseThrow();
     final SignedAggregateAndProof aggregate = generator.validAggregateAndProof(chainHead);
     whenAttestationIsValid(aggregate);
     assertThat(validator.validate(ValidateableAttestation.fromSignedAggregate(aggregate)))
@@ -140,7 +140,7 @@ class SignedAggregateAndProofValidatorTest {
   @Test
   public void shouldRejectWhenAttestationValidatorRejects() {
     final SignedAggregateAndProof aggregate =
-        generator.validAggregateAndProof(recentChainData.getBestBlockAndState().orElseThrow());
+        generator.validAggregateAndProof(recentChainData.getHeadBlockAndState().orElseThrow());
     when(attestationValidator.singleOrAggregateAttestationChecks(
             eq(aggregate.getMessage().getAggregate()), eq(OptionalInt.empty())))
         .thenReturn(SafeFuture.completedFuture(REJECT));
@@ -152,7 +152,7 @@ class SignedAggregateAndProofValidatorTest {
   @Test
   public void shouldIgnoreWhenAttestationValidatorIgnores() {
     final SignedAggregateAndProof aggregate =
-        generator.validAggregateAndProof(recentChainData.getBestBlockAndState().orElseThrow());
+        generator.validAggregateAndProof(recentChainData.getHeadBlockAndState().orElseThrow());
     when(attestationValidator.singleOrAggregateAttestationChecks(
             eq(aggregate.getMessage().getAggregate()), eq(OptionalInt.empty())))
         .thenReturn(SafeFuture.completedFuture(IGNORE));
@@ -164,7 +164,7 @@ class SignedAggregateAndProofValidatorTest {
   @Test
   public void shouldSaveForFutureWhenAttestationValidatorSavesForFuture() {
     final SignedAggregateAndProof aggregate =
-        generator.validAggregateAndProof(recentChainData.getBestBlockAndState().orElseThrow());
+        generator.validAggregateAndProof(recentChainData.getHeadBlockAndState().orElseThrow());
     when(attestationValidator.singleOrAggregateAttestationChecks(
             eq(aggregate.getMessage().getAggregate()), eq(OptionalInt.empty())))
         .thenReturn(SafeFuture.completedFuture(SAVE_FOR_FUTURE));
@@ -190,7 +190,7 @@ class SignedAggregateAndProofValidatorTest {
     final SignedAggregateAndProof aggregate =
         generator
             .generator()
-            .blockAndState(recentChainData.getBestBlockAndState().orElseThrow())
+            .blockAndState(recentChainData.getHeadBlockAndState().orElseThrow())
             .aggregatorIndex(ONE)
             .selectionProof(dataStructureUtil.randomSignature())
             .generate();
@@ -235,7 +235,7 @@ class SignedAggregateAndProofValidatorTest {
 
   @Test
   public void shouldOnlyAcceptFirstAggregateWithSameHashTreeRoot() {
-    final BeaconBlockAndState chainHead = recentChainData.getBestBlockAndState().orElseThrow();
+    final BeaconBlockAndState chainHead = recentChainData.getHeadBlockAndState().orElseThrow();
     final SignedAggregateAndProof aggregateAndProof1 = generator.validAggregateAndProof(chainHead);
     final Attestation attestation = aggregateAndProof1.getMessage().getAggregate();
     final SignedAggregateAndProof aggregateAndProof2 =
@@ -264,7 +264,7 @@ class SignedAggregateAndProofValidatorTest {
 
   @Test
   public void shouldOnlyAcceptFirstAggregateWithSameHashTreeRootWhenPassedSeenAggregates() {
-    final BeaconBlockAndState chainHead = recentChainData.getBestBlockAndState().orElseThrow();
+    final BeaconBlockAndState chainHead = recentChainData.getHeadBlockAndState().orElseThrow();
     final SignedAggregateAndProof aggregateAndProof1 = generator.validAggregateAndProof(chainHead);
     final Attestation attestation = aggregateAndProof1.getMessage().getAggregate();
     final SignedAggregateAndProof aggregateAndProof2 =
@@ -293,7 +293,7 @@ class SignedAggregateAndProofValidatorTest {
 
   @Test
   public void shouldAcceptAggregateWithSameSlotAndDifferentAggregatorIndex() {
-    final BeaconBlockAndState chainHead = recentChainData.getBestBlockAndState().orElseThrow();
+    final BeaconBlockAndState chainHead = recentChainData.getHeadBlockAndState().orElseThrow();
     final SignedAggregateAndProof aggregateAndProof1 = generator.validAggregateAndProof(chainHead);
 
     final List<Attestation> aggregatesForSlot =
@@ -360,7 +360,7 @@ class SignedAggregateAndProofValidatorTest {
 
   @Test
   public void shouldRejectAggregateWhenSelectionProofDoesNotSelectAsAggregator() {
-    final BeaconBlockAndState chainHead = recentChainData.getBestBlockAndState().orElseThrow();
+    final BeaconBlockAndState chainHead = recentChainData.getHeadBlockAndState().orElseThrow();
     int aggregatorIndex = 3;
     final CommitteeAssignment committeeAssignment =
         getCommitteeAssignment(chainHead, aggregatorIndex, ZERO);
@@ -385,7 +385,7 @@ class SignedAggregateAndProofValidatorTest {
 
   @Test
   public void shouldRejectIfAggregatorIndexIsNotWithinTheCommittee() {
-    final BeaconBlockAndState chainHead = recentChainData.getBestBlockAndState().orElseThrow();
+    final BeaconBlockAndState chainHead = recentChainData.getHeadBlockAndState().orElseThrow();
     final int aggregatorIndex = 60;
     final SignedAggregateAndProof aggregate =
         generator
@@ -413,7 +413,7 @@ class SignedAggregateAndProofValidatorTest {
     final SignedAggregateAndProof aggregate =
         generator
             .generator()
-            .blockAndState(recentChainData.getBestBlockAndState().orElseThrow())
+            .blockAndState(recentChainData.getHeadBlockAndState().orElseThrow())
             .aggregatorIndex(ONE)
             .selectionProof(dataStructureUtil.randomSignature())
             .generate();
@@ -426,7 +426,7 @@ class SignedAggregateAndProofValidatorTest {
   @Test
   public void shouldRejectIfAggregateAndProofSignatureIsNotValid() {
     final SignedAggregateAndProof validAggregate =
-        generator.validAggregateAndProof(recentChainData.getBestBlockAndState().orElseThrow());
+        generator.validAggregateAndProof(recentChainData.getHeadBlockAndState().orElseThrow());
     final SignedAggregateAndProof invalidAggregate =
         new SignedAggregateAndProof(
             validAggregate.getMessage(), dataStructureUtil.randomSignature());

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
@@ -183,11 +183,11 @@ public class BeaconChainMetrics implements SlotEventsChannel {
     if (recentChainData.isPreGenesis()) {
       return NOT_SET;
     }
-    return recentChainData.getBestSlot().longValue();
+    return recentChainData.getHeadSlot().longValue();
   }
 
   private long getFinalizedRootValue() {
-    Optional<BeaconBlockAndState> maybeBlockAndState = recentChainData.getBestBlockAndState();
+    Optional<BeaconBlockAndState> maybeBlockAndState = recentChainData.getHeadBlockAndState();
     if (maybeBlockAndState.isPresent()) {
       Bytes32 root = maybeBlockAndState.get().getState().getFinalized_checkpoint().getRoot();
       return getLongFromRoot(root);
@@ -196,7 +196,7 @@ public class BeaconChainMetrics implements SlotEventsChannel {
   }
 
   private long getPreviousJustifiedRootValue() {
-    Optional<BeaconBlockAndState> maybeBlockAndState = recentChainData.getBestBlockAndState();
+    Optional<BeaconBlockAndState> maybeBlockAndState = recentChainData.getHeadBlockAndState();
     if (maybeBlockAndState.isPresent()) {
       Bytes32 root =
           maybeBlockAndState.get().getState().getPrevious_justified_checkpoint().getRoot();
@@ -206,7 +206,7 @@ public class BeaconChainMetrics implements SlotEventsChannel {
   }
 
   private long getJustifiedRootValue() {
-    Optional<BeaconBlockAndState> maybeBlockAndState = recentChainData.getBestBlockAndState();
+    Optional<BeaconBlockAndState> maybeBlockAndState = recentChainData.getHeadBlockAndState();
     if (maybeBlockAndState.isPresent()) {
       Bytes32 root =
           maybeBlockAndState.get().getState().getCurrent_justified_checkpoint().getRoot();
@@ -238,7 +238,7 @@ public class BeaconChainMetrics implements SlotEventsChannel {
   }
 
   private long getPreviousJustifiedEpochValue() {
-    Optional<BeaconBlockAndState> maybeBlockAndState = recentChainData.getBestBlockAndState();
+    Optional<BeaconBlockAndState> maybeBlockAndState = recentChainData.getHeadBlockAndState();
     return maybeBlockAndState
         .map(
             beaconBlockAndState ->

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
@@ -127,7 +127,7 @@ public class SlotProcessor {
   private void processSlotWhileSyncing() {
     UInt64 slot = nodeSlot.getValue();
     this.forkChoice.processHead(slot);
-    eventLog.syncEvent(slot, recentChainData.getBestSlot(), p2pNetwork.getPeerCount());
+    eventLog.syncEvent(slot, recentChainData.getHeadSlot(), p2pNetwork.getPeerCount());
     slotEventsChannelPublisher.onSlot(slot);
   }
 
@@ -182,7 +182,7 @@ public class SlotProcessor {
     onTickSlotAttestation = nodeSlot.getValue();
     this.forkChoice.processHead(onTickSlotAttestation);
     recentChainData
-        .getBestBlock()
+        .getHeadBlock()
         .ifPresent(
             (head) ->
                 eventLog.slotEvent(

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -94,7 +94,7 @@ class BeaconChainMetricsTest {
   @Test
   void getHeadSlotValue_shouldSupplyValueWhenStoreIsPresent() {
     when(recentChainData.isPreGenesis()).thenReturn(false);
-    when(recentChainData.getBestSlot()).thenReturn(ONE);
+    when(recentChainData.getHeadSlot()).thenReturn(ONE);
 
     assertThat(metricsSystem.getGauge(BEACON, "head_slot").getValue()).isEqualTo(1L);
   }
@@ -151,7 +151,7 @@ class BeaconChainMetricsTest {
 
   @Test
   void getFinalizedRootValue_shouldReturnValueWhenStoreIsPresent() {
-    when(recentChainData.getBestBlockAndState()).thenReturn(Optional.of(blockAndState));
+    when(recentChainData.getHeadBlockAndState()).thenReturn(Optional.of(blockAndState));
     when(blockAndState.getState()).thenReturn(state);
     when(state.getFinalized_checkpoint()).thenReturn(checkpoint);
 
@@ -168,7 +168,7 @@ class BeaconChainMetricsTest {
   @Test
   void getPreviousJustifiedEpochValue_shouldSupplyValueWhenStoreIsPresent() {
     when(recentChainData.isPreGenesis()).thenReturn(false);
-    when(recentChainData.getBestBlockAndState()).thenReturn(Optional.of(blockAndState));
+    when(recentChainData.getHeadBlockAndState()).thenReturn(Optional.of(blockAndState));
     when(blockAndState.getState()).thenReturn(state);
     when(state.getPrevious_justified_checkpoint()).thenReturn(checkpoint);
 
@@ -185,7 +185,7 @@ class BeaconChainMetricsTest {
 
   @Test
   void getPreviousJustifiedRootValue_shouldReturnValueWhenStoreIsPresent() {
-    when(recentChainData.getBestBlockAndState()).thenReturn(Optional.of(blockAndState));
+    when(recentChainData.getHeadBlockAndState()).thenReturn(Optional.of(blockAndState));
     when(blockAndState.getState()).thenReturn(state);
     when(state.getPrevious_justified_checkpoint()).thenReturn(checkpoint);
 
@@ -201,7 +201,7 @@ class BeaconChainMetricsTest {
 
   @Test
   void getJustifiedRootValue_shouldReturnValueWhenStoreIsPresent() {
-    when(recentChainData.getBestBlockAndState()).thenReturn(Optional.of(blockAndState));
+    when(recentChainData.getHeadBlockAndState()).thenReturn(Optional.of(blockAndState));
     when(blockAndState.getState()).thenReturn(state);
     when(state.getCurrent_justified_checkpoint()).thenReturn(new Checkpoint(NODE_SLOT_VALUE, root));
 

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -215,7 +215,7 @@ public class SlotProcessorTest {
     verify(eventLogger)
         .slotEvent(
             ZERO,
-            recentChainData.getBestSlot(),
+            recentChainData.getHeadSlot(),
             recentChainData.getBestBlockRoot().get(),
             ZERO,
             recentChainData.getStore().getFinalizedCheckpoint().getEpoch(),

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -308,7 +308,7 @@ public class CombinedChainDataClient {
   }
 
   public Optional<SignedBeaconBlock> getBestBlock() {
-    return recentChainData.getBestBlock();
+    return recentChainData.getHeadBlock();
   }
 
   public boolean isStoreAvailable() {
@@ -334,18 +334,22 @@ public class CombinedChainDataClient {
     return result;
   }
 
+  /** @return The slot at which the chain head block was proposed */
   public UInt64 getHeadSlot() {
-    return this.recentChainData.getBestSlot();
+    return this.recentChainData.getHeadSlot();
   }
 
+  /** @return The epoch in which the chain head block was proposed */
   public UInt64 getHeadEpoch() {
     return compute_epoch_at_slot(getHeadSlot());
   }
 
+  /** @return The current slot according to clock time */
   public UInt64 getCurrentSlot() {
     return this.recentChainData.getCurrentSlot().orElseGet(this::getHeadSlot);
   }
 
+  /** @return The current epoch according to clock time */
   public UInt64 getCurrentEpoch() {
     return compute_epoch_at_slot(getCurrentSlot());
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.storage.client;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_committee_count_per_slot;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
@@ -286,7 +287,7 @@ public class CombinedChainDataClient {
       final BeaconState preState, final UInt64 slot) {
     if (preState.getSlot().equals(slot)) {
       return Optional.of(preState);
-    } else if (slot.compareTo(getBestSlot()) > 0) {
+    } else if (slot.compareTo(getHeadSlot()) > 0) {
       LOG.debug("Attempted to wind forward to a future state: {}", slot.toString());
       return Optional.empty();
     }
@@ -333,8 +334,20 @@ public class CombinedChainDataClient {
     return result;
   }
 
-  public UInt64 getBestSlot() {
+  public UInt64 getHeadSlot() {
     return this.recentChainData.getBestSlot();
+  }
+
+  public UInt64 getHeadEpoch() {
+    return compute_epoch_at_slot(getHeadSlot());
+  }
+
+  public UInt64 getCurrentSlot() {
+    return this.recentChainData.getCurrentSlot().orElseGet(this::getHeadSlot);
+  }
+
+  public UInt64 getCurrentEpoch() {
+    return compute_epoch_at_slot(getCurrentSlot());
   }
 
   @VisibleForTesting

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -34,7 +34,7 @@ public class ChainUpdater {
   }
 
   public UInt64 getHeadSlot() {
-    return recentChainData.getBestSlot();
+    return recentChainData.getHeadSlot();
   }
 
   public void setCurrentSlot(final UInt64 currentSlot) {
@@ -86,7 +86,7 @@ public class ChainUpdater {
   public void updateBestBlock(final SignedBlockAndState bestBlock) {
     saveBlock(bestBlock);
 
-    recentChainData.updateBestBlock(bestBlock.getRoot(), bestBlock.getSlot());
+    recentChainData.updateHead(bestBlock.getRoot(), bestBlock.getSlot());
   }
 
   public SignedBlockAndState advanceChain() {

--- a/sync/src/main/java/tech/pegasys/teku/sync/SyncManager.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/SyncManager.java
@@ -173,7 +173,7 @@ public class SyncManager extends Service {
       if (bestPeer.isPresent()) {
         UInt64 highestSlot = bestPeer.get().getStatus().getHeadSlot();
         final SyncStatus syncStatus =
-            new SyncStatus(peerSync.getStartingSlot(), storageClient.getBestSlot(), highestSlot);
+            new SyncStatus(peerSync.getStartingSlot(), storageClient.getHeadSlot(), highestSlot);
         return new SyncingStatus(true, syncStatus);
       }
     }
@@ -286,7 +286,7 @@ public class SyncManager extends Service {
   }
 
   private boolean isPeerHeadSlotAhead(final PeerStatus peerStatus) {
-    final UInt64 ourHeadSlot = storageClient.getBestSlot();
+    final UInt64 ourHeadSlot = storageClient.getHeadSlot();
     final UInt64 headSlotThreshold = ourHeadSlot.plus(SYNC_THRESHOLD_IN_SLOTS);
 
     return peerStatus.getHeadSlot().isGreaterThan(headSlotThreshold);

--- a/sync/src/main/java/tech/pegasys/teku/sync/SyncState.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/SyncState.java
@@ -21,4 +21,12 @@ public enum SyncState {
   public boolean isInSync() {
     return this == IN_SYNC;
   }
+
+  public boolean isStartingUp() {
+    return this == START_UP;
+  }
+
+  public boolean isSyncing() {
+    return this == SYNCING;
+  }
 }

--- a/sync/src/test/java/tech/pegasys/teku/sync/SyncManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/SyncManagerTest.java
@@ -77,7 +77,7 @@ public class SyncManagerTest {
     when(network.subscribeConnect(any())).thenReturn(SUBSCRIPTION_ID);
     when(storageClient.getFinalizedEpoch()).thenAnswer((__) -> localFinalizedEpoch.get());
     when(storageClient.getCurrentSlot()).thenAnswer((__) -> Optional.ofNullable(localSlot.get()));
-    when(storageClient.getBestSlot()).thenAnswer((__) -> localHeadSlot.get());
+    when(storageClient.getHeadSlot()).thenAnswer((__) -> localHeadSlot.get());
     when(peer.getStatus()).thenReturn(PEER_STATUS);
   }
 

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -66,6 +66,7 @@ import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.events.block.ProposedBlockEvent;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+import tech.pegasys.teku.sync.SyncState;
 import tech.pegasys.teku.sync.SyncStateTracker;
 import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.validator.api.NodeSyncingException;
@@ -310,8 +311,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
 
   @VisibleForTesting
   boolean isSyncActive() {
-    return syncStateTracker.getCurrentSyncState().isStartingUp()
-        || (syncStateTracker.getCurrentSyncState().isSyncing() && headBlockIsTooFarBehind());
+    final SyncState syncState = syncStateTracker.getCurrentSyncState();
+    return syncState.isStartingUp() || (syncState.isSyncing() && headBlockIsTooFarBehind());
   }
 
   private boolean headBlockIsTooFarBehind() {

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
@@ -100,19 +100,19 @@ class BlockFactoryTest {
 
   @Test
   public void shouldCreateBlockAfterNormalSlot() throws Exception {
-    final UInt64 newSlot = recentChainData.getBestSlot().plus(ONE);
+    final UInt64 newSlot = recentChainData.getHeadSlot().plus(ONE);
     assertBlockCreated(newSlot);
   }
 
   @Test
   public void shouldCreateBlockAfterSkippedSlot() throws Exception {
-    final UInt64 newSlot = recentChainData.getBestSlot().plus(2);
+    final UInt64 newSlot = recentChainData.getHeadSlot().plus(2);
     assertBlockCreated(newSlot);
   }
 
   @Test
   public void shouldCreateBlockAfterMultipleSkippedSlot() throws Exception {
-    final UInt64 newSlot = recentChainData.getBestSlot().plus(5);
+    final UInt64 newSlot = recentChainData.getHeadSlot().plus(5);
     assertBlockCreated(newSlot);
   }
 
@@ -120,7 +120,7 @@ class BlockFactoryTest {
       throws EpochProcessingException, SlotProcessingException, StateTransitionException {
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
     final BeaconBlockAndState bestBlockAndState =
-        recentChainData.getBestBlockAndState().orElseThrow();
+        recentChainData.getHeadBlockAndState().orElseThrow();
     final Bytes32 bestBlockRoot = bestBlockAndState.getRoot();
     final BeaconBlock previousBlock = bestBlockAndState.getBlock();
     final BeaconState previousState =


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add an extra check to see where our current chain head is before disabling duties when our sync process is active.  This protects us from the case where a peer sends us a faulty finalized epoch in its status message, tricking our node into initiating a sync and skipping validator duties. 

## Fixed Issue(s)
Relates to #2438 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.