### PR TITLE
Add debug subcommand to dump the current fork choice state

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
@@ -38,6 +39,8 @@ public interface Database extends AutoCloseable {
   void update(StorageUpdate event);
 
   Optional<StoreBuilder> createMemoryStore();
+
+  Map<UInt64, VoteTracker> getVotes();
 
   Optional<UInt64> getSlotForFinalizedBlockRoot(Bytes32 blockRoot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -54,14 +54,15 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
   public VersionedDatabaseFactory(
       final MetricsSystem metricsSystem,
       final String dataPath,
-      final StateStorageMode dataStorageMode) {
+      final StateStorageMode dataStorageMode,
+      final Eth1Address depositContractAddress) {
     this(
         metricsSystem,
         dataPath,
         dataStorageMode,
         DatabaseVersion.DEFAULT_VERSION.getValue(),
         DEFAULT_STORAGE_FREQUENCY,
-        Eth1Address.fromHexString("0x77f7bED277449F51505a4C54550B074030d989bC"));
+        depositContractAddress);
   }
 
   public VersionedDatabaseFactory(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
@@ -43,6 +44,11 @@ public class NoOpDatabase implements Database {
   @Override
   public Optional<StoreBuilder> createMemoryStore() {
     return Optional.empty();
+  }
+
+  @Override
+  public Map<UInt64, VoteTracker> getVotes() {
+    return Collections.emptyMap();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -218,6 +218,11 @@ public class RocksDbDatabase implements Database {
   }
 
   @Override
+  public Map<UInt64, VoteTracker> getVotes() {
+    return hotDao.getVotes();
+  }
+
+  @Override
   public Optional<UInt64> getSlotForFinalizedBlockRoot(final Bytes32 blockRoot) {
     return finalizedDao.getSlotForFinalizedBlockRoot(blockRoot);
   }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
@@ -39,7 +39,7 @@ public class VersionedDatabaseFactoryTest {
   public void createDatabase_fromEmptyDataDir() throws Exception {
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE);
+            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, eth1Address);
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
 
@@ -52,14 +52,13 @@ public class VersionedDatabaseFactoryTest {
     createDbDirectory(dataDir);
     createVersionFile(dataDir, DatabaseVersion.V3);
 
-    final DatabaseFactory dbFactory =
+    final VersionedDatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE);
+            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, eth1Address);
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
     }
-    assertThat(((VersionedDatabaseFactory) dbFactory).getDatabaseVersion())
-        .isEqualTo(DatabaseVersion.V3);
+    assertThat(dbFactory.getDatabaseVersion()).isEqualTo(DatabaseVersion.V3);
   }
 
   @Test
@@ -102,7 +101,7 @@ public class VersionedDatabaseFactoryTest {
 
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE);
+            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, eth1Address);
     assertThatThrownBy(dbFactory::createDatabase)
         .isInstanceOf(DatabaseStorageException.class)
         .hasMessageContaining("Unrecognized database version: bla");
@@ -114,7 +113,7 @@ public class VersionedDatabaseFactoryTest {
 
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE);
+            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, eth1Address);
     assertThatThrownBy(dbFactory::createDatabase)
         .isInstanceOf(DatabaseStorageException.class)
         .hasMessageContaining("No database version file was found");

--- a/teku/build.gradle
+++ b/teku/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   implementation project(':infrastructure:async')
   implementation project(':logging')
   implementation project(':networking:p2p')
+  implementation project(':protoarray')
   implementation project(':pow')
   implementation project(':services:beaconchain')
   implementation project(':services:chainstorage')

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -14,8 +14,10 @@
 package tech.pegasys.teku.cli.subcommand.debug;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import picocli.CommandLine;
@@ -25,9 +27,11 @@ import picocli.CommandLine.Option;
 import tech.pegasys.teku.cli.options.DataOptions;
 import tech.pegasys.teku.cli.options.NetworkOptions;
 import tech.pegasys.teku.core.lookup.BlockProvider;
+import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.util.SimpleOffsetSerializer;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.protoarray.ProtoArraySnapshot;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.server.DepositStorage;
 import tech.pegasys.teku.storage.server.VersionedDatabaseFactory;
@@ -65,9 +69,11 @@ public class DebugDbCommand implements Runnable {
       optionListHeading = "%nOptions:%n",
       footerHeading = "%n",
       footer = "Teku is licensed under the Apache License 2.0")
-  public int getDeposits(@Mixin final DataOptions dataOptions) throws Exception {
+  public int getDeposits(
+      @Mixin final DataOptions dataOptions, @Mixin final NetworkOptions networkOptions)
+      throws Exception {
     try (final YamlEth1EventsChannel eth1EventsChannel = new YamlEth1EventsChannel(System.out);
-        final Database database = createDatabase(dataOptions)) {
+        final Database database = createDatabase(dataOptions, networkOptions)) {
       final DepositStorage depositStorage =
           DepositStorage.create(eth1EventsChannel, database, true);
       depositStorage.replayDepositEvents().join();
@@ -103,7 +109,7 @@ public class DebugDbCommand implements Runnable {
           final long slot)
       throws Exception {
     setConstants(networkOptions);
-    try (final Database database = createDatabase(dataOptions)) {
+    try (final Database database = createDatabase(dataOptions, networkOptions)) {
       return writeState(
           outputFile, database.getLatestAvailableFinalizedState(UInt64.valueOf(slot)));
     }
@@ -131,7 +137,7 @@ public class DebugDbCommand implements Runnable {
           final Path outputFile)
       throws Exception {
     setConstants(networkOptions);
-    try (final Database database = createDatabase(dataOptions)) {
+    try (final Database database = createDatabase(dataOptions, networkOptions)) {
       final Optional<BeaconState> state =
           database
               .createMemoryStore()
@@ -141,15 +147,59 @@ public class DebugDbCommand implements Runnable {
     }
   }
 
+  @Command(
+      name = "get-forkchoice-snapshot",
+      description = "Get the stored fork choice data",
+      mixinStandardHelpOptions = true,
+      showDefaultValues = true,
+      abbreviateSynopsis = true,
+      versionProvider = PicoCliVersionProvider.class,
+      synopsisHeading = "%n",
+      descriptionHeading = "%nDescription:%n%n",
+      optionListHeading = "%nOptions:%n",
+      footerHeading = "%n",
+      footer = "Teku is licensed under the Apache License 2.0")
+  public int getForkChoiceSnapshot(
+      @Mixin final DataOptions dataOptions,
+      @Mixin final NetworkOptions networkOptions,
+      @Option(
+              names = {"--output", "-o"},
+              description = "File to write output to")
+          final Path outputFile)
+      throws Exception {
+    setConstants(networkOptions);
+    try (final Database database = createDatabase(dataOptions, networkOptions)) {
+      final Optional<ProtoArraySnapshot> snapshot = database.getProtoArraySnapshot();
+      if (snapshot.isEmpty()) {
+        System.err.println("No fork choice snapshot available.");
+        return 2;
+      }
+      final Map<UInt64, VoteTracker> votes = database.getVotes();
+      final String report = ForkChoiceDataWriter.writeForkChoiceData(snapshot.get(), votes);
+      if (outputFile != null) {
+        Files.writeString(outputFile, report, StandardCharsets.UTF_8);
+      } else {
+        System.out.println(report);
+      }
+      return 0;
+    }
+  }
+
   private void setConstants(@Mixin final NetworkOptions networkOptions) {
     Constants.setConstants(
         NetworkDefinition.fromCliArg(networkOptions.getNetwork()).getConstants());
   }
 
-  private Database createDatabase(final DataOptions dataOptions) {
+  private Database createDatabase(
+      final DataOptions dataOptions, final NetworkOptions networkOptions) {
     final VersionedDatabaseFactory databaseFactory =
         new VersionedDatabaseFactory(
-            new NoOpMetricsSystem(), dataOptions.getDataPath(), dataOptions.getDataStorageMode());
+            new NoOpMetricsSystem(),
+            dataOptions.getDataPath(),
+            dataOptions.getDataStorageMode(),
+            NetworkDefinition.fromCliArg(networkOptions.getNetwork())
+                .getEth1DepositContractAddress()
+                .orElse(null));
     return databaseFactory.createDatabase();
   }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/ForkChoiceDataWriter.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/ForkChoiceDataWriter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.subcommand.debug;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Map;
+import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.protoarray.BlockInformation;
+import tech.pegasys.teku.protoarray.ProtoArraySnapshot;
+
+public class ForkChoiceDataWriter {
+
+  public static String writeForkChoiceData(
+      final ProtoArraySnapshot snapshot, final Map<UInt64, VoteTracker> votes) throws IOException {
+    final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    mapper.registerModule(
+        new SimpleModule()
+            .addSerializer(ProtoArraySnapshot.class, new ProtoArraySnapshotSerializer())
+            .addSerializer(VoteTracker.class, new VoteSerializer()));
+    try (final StringWriter out = new StringWriter()) {
+      mapper.writeValue(out, Map.of("snapshot", snapshot, "votes", votes));
+      return out.toString();
+    }
+  }
+
+  private static class VoteSerializer extends JsonSerializer<VoteTracker> {
+
+    @Override
+    public void serialize(
+        final VoteTracker value, final JsonGenerator gen, final SerializerProvider serializers)
+        throws IOException {
+      gen.writeStartObject();
+      gen.writeStringField("currentRoot", value.getCurrentRoot().toHexString());
+      gen.writeStringField("nextRoot", value.getNextRoot().toHexString());
+      gen.writeNumberField("nextEpoch", value.getNextEpoch().bigIntegerValue());
+      gen.writeEndObject();
+    }
+  }
+
+  private static class ProtoArraySnapshotSerializer extends JsonSerializer<ProtoArraySnapshot> {
+    @Override
+    public void serialize(
+        final ProtoArraySnapshot value,
+        final JsonGenerator gen,
+        final SerializerProvider serializers)
+        throws IOException {
+      gen.writeStartObject();
+      gen.writeNumberField("justifiedEpoch", value.getJustifiedEpoch().bigIntegerValue());
+      gen.writeNumberField("finalizedEpoch", value.getFinalizedEpoch().bigIntegerValue());
+      gen.writeArrayFieldStart("blockInformation");
+      for (BlockInformation blockInformation : value.getBlockInformationList()) {
+        gen.writeStartObject();
+        gen.writeNumberField("blockSlot", blockInformation.getBlockSlot().bigIntegerValue());
+        gen.writeStringField("blockRoot", blockInformation.getBlockRoot().toHexString());
+        gen.writeStringField("parentRoot", blockInformation.getParentRoot().toHexString());
+        gen.writeStringField("stateRoot", blockInformation.getStateRoot().toHexString());
+        gen.writeNumberField(
+            "justifiedEpoch", blockInformation.getJustifiedEpoch().bigIntegerValue());
+        gen.writeNumberField(
+            "finalizedEpoch", blockInformation.getFinalizedEpoch().bigIntegerValue());
+        gen.writeEndObject();
+      }
+      gen.writeEndArray();
+      gen.writeEndObject();
+    }
+  }
+}


### PR DESCRIPTION
## PR Description
Adds a `teku debug-tools db get-forkchoice-snapshot` subcommand to print out the protoarray snapshot and current validator votes to aid in debugging issues.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.