### PR TITLE
[issue 2003] added a new option to load keystore files in bulk

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -324,6 +324,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setInteropEnabled(interopOptions.isInteropEnabled())
         .setValidatorKeystoreFiles(validatorOptions.getValidatorKeystoreFiles())
         .setValidatorKeystorePasswordFiles(validatorOptions.getValidatorKeystorePasswordFiles())
+        .setValidatorKeys(validatorOptions.getValidatorKeys())
         .setValidatorExternalSignerPublicKeys(
             validatorOptions.getValidatorExternalSignerPublicKeys())
         .setValidatorExternalSignerUrl(validatorOptions.getValidatorExternalSignerUrl())

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -30,7 +30,7 @@ public class ValidatorOptions {
               + "The path separator is operating system dependent, and should be ';' in windows rather than ':'.",
       split = ",",
       arity = "1..*")
-  private List<String> validatorKeys;
+  private List<String> validatorKeys = new ArrayList<>();
 
   @Option(
       names = {"--validators-key-files"},

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -20,12 +20,23 @@ import picocli.CommandLine.Option;
 import tech.pegasys.teku.util.cli.GraffitiConverter;
 
 public class ValidatorOptions {
+  @Option(
+      names = {"--validator-keys"},
+      paramLabel = "<KEY_PATH>:<PASS_PATH>",
+      description =
+          "Where key is either a folder or file, and the password associated. "
+              + "If a folder is passed, the password file should be named the same as the key file, "
+              + "with a '.txt' extension for password text file (password will be first line of file).",
+      split = ",",
+      arity = "1..*")
+  private List<String> validatorKeys;
 
   @Option(
       names = {"--validators-key-files"},
       paramLabel = "<FILENAMES>",
       description = "The list of encrypted keystore files to load the validator keys from",
       split = ",",
+      hidden = true,
       arity = "0..*")
   private List<String> validatorKeystoreFiles = new ArrayList<>();
 
@@ -34,6 +45,7 @@ public class ValidatorOptions {
       paramLabel = "<FILENAMES>",
       description = "The list of password files to decrypt the validator keystore files",
       split = ",",
+      hidden = true,
       arity = "0..*")
   private List<String> validatorKeystorePasswordFiles = new ArrayList<>();
 
@@ -90,5 +102,9 @@ public class ValidatorOptions {
 
   public Bytes32 getGraffiti() {
     return graffiti;
+  }
+
+  public List<String> getValidatorKeys() {
+    return validatorKeys;
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -22,12 +22,11 @@ import tech.pegasys.teku.util.cli.GraffitiConverter;
 public class ValidatorOptions {
   @Option(
       names = {"--validator-keys"},
-      paramLabel = "<KEY_PATH>:<PASS_PATH>",
+      paramLabel = "<KEY_DIR>:<PASS_DIR> | <KEY_FILE>:<PASS_FILE>",
       description =
-          "Where KEY_PATH is either a directory or file, and PASS_PATH is the associated password path. "
-              + "keysDir:passDir will find keysDir/**.json, and expect to find passDir/**.txt. "
-              + "keyFile:passFile will expect that the file 'keyFile' exists, "
-              + "and the file containing the password for it is 'passFile'. "
+          "<KEY_DIR>:<PASS_DIR> will find <KEY_DIR>/**.json, and expect to find <PASS_DIR>/**.txt.\n"
+              + "<KEY_FILE>:<PASS_FILE> will expect that the file <KEY_FILE> exists, "
+              + "and the file containing the password for it is <PASS_FILE>.\n"
               + "The path separator is operating system dependent, and should be ';' in windows rather than ':'.",
       split = ",",
       arity = "1..*")

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -24,9 +24,11 @@ public class ValidatorOptions {
       names = {"--validator-keys"},
       paramLabel = "<KEY_PATH>:<PASS_PATH>",
       description =
-          "Where key is either a folder or file, and the password associated. "
-              + "If a folder is passed, the password file should be named the same as the key file, "
-              + "with a '.txt' extension for password text file (password will be first line of file).",
+          "Where KEY_PATH is either a directory or file, and PASS_PATH is the associated password path. "
+              + "keysDir:passDir will find keysDir/**.json, and expect to find passDir/**.txt. "
+              + "keyFile:passFile will expect that the file 'keyFile' exists, "
+              + "and the file containing the password for it is 'passFile'. "
+              + "The path separator is operating system dependent, and should be ';' in windows rather than ':'.",
       split = ",",
       arity = "1..*")
   private List<String> validatorKeys;

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -317,8 +317,6 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setLogFileNamePattern(DEFAULT_LOG_FILE_NAME_PATTERN)
         .setLogIncludeEventsEnabled(true)
         .setLogIncludeValidatorDutiesEnabled(true)
-        .setValidatorKeystoreFiles(Collections.emptyList())
-        .setValidatorKeystorePasswordFiles(Collections.emptyList())
         .setValidatorExternalSignerTimeout(1000)
         .setDataPath(dataPath.toString())
         .setDataStorageMode(PRUNE)

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -17,6 +17,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
+
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
@@ -40,6 +42,7 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(config.getValidatorKeystoreFiles()).containsExactly("a.key", "b.key");
     assertThat(config.getValidatorKeystorePasswordFiles())
         .containsExactly("a.password", "b.password");
+    assertThat(config.getValidatorKeys()).containsExactlyInAnyOrder("a.key:a.password","b.json:b.txt");
     assertThat(config.getValidatorExternalSignerPublicKeys()).containsExactly(publicKey);
     assertThat(config.getValidatorExternalSignerUrl()).isEqualTo(new URL("https://signer.url/"));
     assertThat(config.getValidatorExternalSignerTimeout()).isEqualTo(1234);

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -17,8 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.List;
-
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
@@ -42,7 +40,8 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(config.getValidatorKeystoreFiles()).containsExactly("a.key", "b.key");
     assertThat(config.getValidatorKeystorePasswordFiles())
         .containsExactly("a.password", "b.password");
-    assertThat(config.getValidatorKeys()).containsExactlyInAnyOrder("a.key:a.password","b.json:b.txt");
+    assertThat(config.getValidatorKeys())
+        .containsExactlyInAnyOrder("a.key:a.password", "b.json:b.txt");
     assertThat(config.getValidatorExternalSignerPublicKeys()).containsExactly(publicKey);
     assertThat(config.getValidatorExternalSignerUrl()).isEqualTo(new URL("https://signer.url/"));
     assertThat(config.getValidatorExternalSignerTimeout()).isEqualTo(1234);

--- a/teku/src/test/resources/validatorOptions_config.yaml
+++ b/teku/src/test/resources/validatorOptions_config.yaml
@@ -1,5 +1,6 @@
 validators-key-files: ["a.key", "b.key"]
 validators-key-password-files: ["a.password", "b.password"]
+validator-keys: "a.key:a.password,b.json:b.txt"
 validators-external-signer-public-keys: ["0xad113a7d152dc74ae2b26db65bfb89ed07501c818bf47671c6d34e5a2f7224e4c5525dd4fddaa93aa328da86b7205009"]
 validators-external-signer-url: "https://signer.url/"
 validators-external-signer-timeout: 1234

--- a/util/src/main/java/tech/pegasys/teku/util/config/KeyStoreFilesLocator.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/KeyStoreFilesLocator.java
@@ -97,7 +97,7 @@ public class KeyStoreFilesLocator {
       walk.filter(Files::isRegularFile)
           .filter(
               (path) ->
-                  !path.getFileName().toString().startsWith(".")
+                  !path.toFile().isHidden()
                       && path.getFileName().toString().endsWith(".json"))
           .forEach(
               path -> {

--- a/util/src/main/java/tech/pegasys/teku/util/config/KeyStoreFilesLocator.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/KeyStoreFilesLocator.java
@@ -97,8 +97,7 @@ public class KeyStoreFilesLocator {
       walk.filter(Files::isRegularFile)
           .filter(
               (path) ->
-                  !path.toFile().isHidden()
-                      && path.getFileName().toString().endsWith(".json"))
+                  !path.toFile().isHidden() && path.getFileName().toString().endsWith(".json"))
           .forEach(
               path -> {
                 final Path relativeDirectoryPath =

--- a/util/src/main/java/tech/pegasys/teku/util/config/KeyStoreFilesLocator.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/KeyStoreFilesLocator.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.util.config;
+
+import com.google.common.base.Splitter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class KeyStoreFilesLocator {
+  private static final Logger LOG = LogManager.getLogger();
+  private final List<Pair<Path, Path>> filePairs;
+  private final Map<Path, Path> pathMap;
+  private final List<String> colonSeparatedPairs;
+  private final String pathSeparator;
+
+  public KeyStoreFilesLocator(
+      Optional<List<String>> maybeColonSeparatedPairs, final String pathSeparator) {
+    this.filePairs = new ArrayList<>();
+    this.colonSeparatedPairs = maybeColonSeparatedPairs.orElse(List.of());
+    this.pathMap = new HashMap<>();
+    this.pathSeparator = pathSeparator;
+  }
+
+  public void parse() {
+    for (final String currentEntry : colonSeparatedPairs) {
+      if (!currentEntry.contains(pathSeparator)) {
+        throw new InvalidConfigurationException(
+            "validatorKeys entry ("
+                + currentEntry
+                + ") did not contain key and password separated by '"
+                + pathSeparator
+                + "' as expected.");
+      }
+      if (currentEntry.matches(".*:.*:.*")) {
+        throw new InvalidConfigurationException(
+            "validatorKeys entry ("
+                + currentEntry
+                + ") contained more than one '"
+                + pathSeparator
+                + "', not keyFile'"
+                + pathSeparator
+                + "'passFile as expected.");
+      }
+      final List<String> entry = Splitter.on(pathSeparator).splitToList(currentEntry);
+      parseEntry(entry.get(0), entry.get(1));
+    }
+  }
+
+  public void parseKeyAndPasswordList(
+      final List<String> keystoreFiles, final List<String> keystorePasswordFiles) {
+    for (int i = 0; i < keystoreFiles.size(); i++) {
+      parseEntry(keystoreFiles.get(i), keystorePasswordFiles.get(i));
+    }
+  }
+
+  void parseEntry(final String keyFileName, final String passwordFileName) {
+    final File keyFile = new File(keyFileName);
+    final File passwordFile = new File(passwordFileName);
+
+    if (!keyFile.exists()) {
+      throw new InvalidConfigurationException(
+          String.format("Invalid configuration. could not find the key file (%s).", keyFileName));
+    }
+    if (!passwordFile.exists()) {
+      throw new InvalidConfigurationException(
+          String.format(
+              "Invalid configuration. could not find the password file (%s).", passwordFileName));
+    }
+    if (keyFile.isDirectory() != passwordFile.isDirectory()) {
+      throw new InvalidConfigurationException(
+          String.format(
+              "Invalid configuration. validatorKeys entry (%s"
+                  + pathSeparator
+                  + "%s) must be both directories or both files",
+              keyFileName,
+              passwordFileName));
+    }
+    if (keyFile.isFile()) {
+      pathMap.putIfAbsent(keyFile.toPath(), passwordFile.toPath());
+      filePairs.add(Pair.of(keyFile.toPath(), passwordFile.toPath()));
+    } else {
+      parseDirectory(keyFile, passwordFile);
+    }
+  }
+
+  void parseDirectory(final File keyDirectory, final File passwordDirectory) {
+    final String keyBasePath = keyDirectory.getAbsolutePath();
+    final String passwordBasePath = passwordDirectory.getAbsolutePath();
+    try (Stream<Path> walk = Files.walk(keyDirectory.toPath())) {
+      walk.filter(Files::isRegularFile)
+          .filter(
+              (path) ->
+                  !path.getFileName().toString().startsWith(".")
+                      && path.toString().endsWith(".json"))
+          .forEach(
+              path -> {
+                final String keyFilename = path.toAbsolutePath().toString();
+                final String passwordFileExpectedLocation =
+                    keyFilename
+                        .substring(0, keyFilename.length() - 5)
+                        .replace(keyBasePath, passwordBasePath);
+                final Optional<File> maybePassFile = findPassFile(passwordFileExpectedLocation);
+                if (maybePassFile.isEmpty()) {
+                  throw new InvalidConfigurationException(
+                      String.format(
+                          "Invalid configuration. No matching password file for (%s) in the key path. "
+                              + "For key file 'f.json', expect to see password 'f.txt'.",
+                          path.toAbsolutePath().toString()));
+                }
+                pathMap.putIfAbsent(path, maybePassFile.get().toPath());
+              });
+    } catch (IOException e) {
+      LOG.fatal("Failed to load keys from keystore", e);
+    }
+  }
+
+  private Optional<File> findPassFile(final String absolutePassPathWithoutExtension) {
+    // bin type will be added here soon most likely.
+    List<String> extensions = List.of("txt");
+    for (String ext : extensions) {
+      final File file = new File(absolutePassPathWithoutExtension + "." + ext);
+      if (file.exists() && file.isFile()) {
+        return Optional.of(file);
+      }
+    }
+    return Optional.empty();
+  }
+
+  public List<Pair<Path, Path>> getFilePairs() {
+    final List<Pair<Path, Path>> pairs = new ArrayList<>();
+    pathMap.forEach((k, v) -> pairs.add(Pair.of(k, v)));
+    return pairs;
+  }
+}

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
@@ -64,7 +64,6 @@ public class TekuConfiguration implements MetricsConfig {
 
   // Validator
   private final String validatorsKeyFile;
-  // TODO (#1918): The following two options will eventually be moved to the validator subcommand
   private final List<String> validatorKeystoreFiles;
   private final List<String> validatorKeystorePasswordFiles;
   private final List<String> validatorKeys;
@@ -542,7 +541,7 @@ public class TekuConfiguration implements MetricsConfig {
 
   public List<Pair<Path, Path>> getValidatorKeystorePasswordFilePairs() {
     final KeyStoreFilesLocator processor =
-        new KeyStoreFilesLocator(Optional.ofNullable(validatorKeys), File.pathSeparator);
+        new KeyStoreFilesLocator(validatorKeys, File.pathSeparator);
     processor.parse();
     if (validatorKeystoreFiles != null) {
       validateKeyStoreFilesAndPasswordFilesConfig();

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
@@ -13,10 +13,10 @@
 
 package tech.pegasys.teku.util.config;
 
+import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -66,6 +66,7 @@ public class TekuConfiguration implements MetricsConfig {
   // TODO (#1918): The following two options will eventually be moved to the validator subcommand
   private final List<String> validatorKeystoreFiles;
   private final List<String> validatorKeystorePasswordFiles;
+  private final List<String> validatorKeys;
   private final List<String> validatorExternalSignerPublicKeys;
   private final String validatorExternalSignerUrl;
   private final int validatorExternalSignerTimeout;
@@ -148,6 +149,7 @@ public class TekuConfiguration implements MetricsConfig {
       final String validatorsKeyFile,
       final List<String> validatorKeystoreFiles,
       final List<String> validatorKeystorePasswordFiles,
+      final List<String> validatorKeys,
       final List<String> validatorExternalSignerPublicKeys,
       final String validatorExternalSignerUrl,
       final int validatorExternalSignerTimeout,
@@ -210,6 +212,7 @@ public class TekuConfiguration implements MetricsConfig {
     this.validatorsKeyFile = validatorsKeyFile;
     this.validatorKeystoreFiles = validatorKeystoreFiles;
     this.validatorKeystorePasswordFiles = validatorKeystorePasswordFiles;
+    this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeys = validatorExternalSignerPublicKeys;
     this.validatorExternalSignerUrl = validatorExternalSignerUrl;
     this.validatorExternalSignerTimeout = validatorExternalSignerTimeout;
@@ -358,6 +361,10 @@ public class TekuConfiguration implements MetricsConfig {
 
   public List<String> getValidatorKeystorePasswordFiles() {
     return validatorKeystorePasswordFiles;
+  }
+
+  public List<String> getValidatorKeys() {
+    return validatorKeys;
   }
 
   public List<BLSPublicKey> getValidatorExternalSignerPublicKeys() {
@@ -527,21 +534,16 @@ public class TekuConfiguration implements MetricsConfig {
   }
 
   public List<Pair<Path, Path>> getValidatorKeystorePasswordFilePairs() {
-    final List<String> keystoreFiles = getValidatorKeystoreFiles();
-    final List<String> keystorePasswordFiles = getValidatorKeystorePasswordFiles();
-
-    if (keystoreFiles.isEmpty() || keystorePasswordFiles.isEmpty()) {
-      return null;
+    final KeyStoreFilesLocator processor =
+        new KeyStoreFilesLocator(Optional.ofNullable(validatorKeys), File.pathSeparator);
+    processor.parse();
+    if (validatorKeystoreFiles != null) {
+      validateKeyStoreFilesAndPasswordFilesConfig();
+      processor.parseKeyAndPasswordList(
+          getValidatorKeystoreFiles(), getValidatorKeystorePasswordFiles());
     }
 
-    validateKeyStoreFilesAndPasswordFilesConfig();
-
-    final List<Pair<Path, Path>> keystoreFilePasswordFilePairs = new ArrayList<>();
-    for (int i = 0; i < keystoreFiles.size(); i++) {
-      keystoreFilePasswordFilePairs.add(
-          Pair.of(Path.of(keystoreFiles.get(i)), Path.of(keystorePasswordFiles.get(i))));
-    }
-    return keystoreFilePasswordFilePairs;
+    return processor.getFilePairs();
   }
 
   public void validateConfig() throws IllegalArgumentException {

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
@@ -48,6 +48,7 @@ public class TekuConfigurationBuilder {
   private String validatorsKeyFile;
   private List<String> validatorKeystoreFiles;
   private List<String> validatorKeystorePasswordFiles;
+  private List<String> validatorKeys;
   private List<String> validatorExternalSignerPublicKeys;
   private String validatorExternalSignerUrl;
   private int validatorExternalSignerTimeout;
@@ -219,6 +220,11 @@ public class TekuConfigurationBuilder {
   public TekuConfigurationBuilder setValidatorKeystorePasswordFiles(
       final List<String> validatorKeystorePasswordFiles) {
     this.validatorKeystorePasswordFiles = validatorKeystorePasswordFiles;
+    return this;
+  }
+
+  public TekuConfigurationBuilder setValidatorKeys(final List<String> validatorKeys) {
+    this.validatorKeys = validatorKeys;
     return this;
   }
 
@@ -465,6 +471,7 @@ public class TekuConfigurationBuilder {
         validatorsKeyFile,
         validatorKeystoreFiles,
         validatorKeystorePasswordFiles,
+        validatorKeys,
         validatorExternalSignerPublicKeys,
         validatorExternalSignerUrl,
         validatorExternalSignerTimeout,

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.util.config;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -47,9 +48,9 @@ public class TekuConfigurationBuilder {
   private int interopNumberOfValidators;
   private boolean interopEnabled;
   private String validatorsKeyFile;
-  private List<String> validatorKeystoreFiles;
-  private List<String> validatorKeystorePasswordFiles;
-  private List<String> validatorKeys;
+  private List<String> validatorKeystoreFiles = new ArrayList<>();
+  private List<String> validatorKeystorePasswordFiles = new ArrayList<>();
+  private List<String> validatorKeys = new ArrayList<>();
   private List<String> validatorExternalSignerPublicKeys;
   private String validatorExternalSignerUrl;
   private int validatorExternalSignerTimeout;

--- a/util/src/test/java/tech/pegasys/teku/util/config/KeyStoreFilesLocatorTest.java
+++ b/util/src/test/java/tech/pegasys/teku/util/config/KeyStoreFilesLocatorTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.util.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class KeyStoreFilesLocatorTest {
+  @Test
+  public void shouldFindPairsAtDepth(@TempDir final Path tempDir) throws IOException {
+    createFolders(tempDir, "key/1/2/3", "pass/1/2/3");
+    createFiles(tempDir, "key/a.json", "pass/a.txt", "key/1/2/3/b.json", "pass/1/2/3/b.bin");
+    final String tempStr = tempDir.toString();
+    KeyStoreFilesLocator locator =
+        new KeyStoreFilesLocator(
+            Optional.of(List.of(String.format("%s/key:%s/pass", tempStr, tempStr))), ":");
+    locator.parse();
+    assertThat(locator.getFilePairs())
+        .containsExactlyInAnyOrder(
+            tuple(tempStr, "key/a.json", "pass/a.txt"),
+            tuple(tempStr, "key/1/2/3/b.json", "pass/1/2/3/b.bin"));
+  }
+
+  @Test
+  public void shouldFindMissingPasswordAtDepth(@TempDir final Path tempDir) throws IOException {
+    createFolders(tempDir, "key/1/2/3", "pass/1/2/3");
+    createFiles(tempDir, "key/a.json", "pass/a.txt", "key/1/2/3/b.json");
+    final String tempStr = tempDir.toString();
+    KeyStoreFilesLocator locator =
+        new KeyStoreFilesLocator(
+            Optional.of(List.of(String.format("%s/key:%s/pass", tempStr, tempStr))), ":");
+    assertThatThrownBy(locator::parse).isInstanceOf(InvalidConfigurationException.class);
+  }
+
+  @Test
+  public void shouldFindKeyPairOfFiles(@TempDir final Path tempDir) throws IOException {
+    createFolders(tempDir, "key", "pass");
+    createFiles(tempDir, "key/a", "pass/a.txt");
+    final String tempStr = tempDir.toString();
+    KeyStoreFilesLocator locator =
+        new KeyStoreFilesLocator(
+            Optional.of(List.of(String.format("%s/key/a;%s/pass/a.txt", tempStr, tempStr))), ";");
+    locator.parse();
+    assertThat(locator.getFilePairs()).containsExactly(tuple(tempStr, "key/a", "pass/a.txt"));
+  }
+
+  @Test
+  public void shouldIgnoreSomeFiles(@TempDir final Path tempDir) throws IOException {
+    createFolders(tempDir, "key", "pass");
+    createFiles(
+        tempDir, "key/.asdf.json", "key/.hidden2", "key/ignored", "key/a.json", "pass/a.txt");
+    final String tempStr = tempDir.toString();
+    KeyStoreFilesLocator locator =
+        new KeyStoreFilesLocator(
+            Optional.of(List.of(String.format("%s/key;%s/pass", tempStr, tempStr))), ";");
+    locator.parse();
+    assertThat(locator.getFilePairs()).containsExactly(tuple(tempStr, "key/a.json", "pass/a.txt"));
+  }
+
+  @Test
+  public void shouldHandleFilesAndFoldersInOneArgument(@TempDir final Path tempDir)
+      throws IOException {
+    createFolders(tempDir, "key", "pass");
+    createFiles(tempDir, "key/a", "pass/a.txt", "keyStore", "password");
+    final String tempStr = tempDir.toString();
+    KeyStoreFilesLocator locator =
+        new KeyStoreFilesLocator(
+            Optional.of(
+                List.of(
+                    String.format("%s/key/a:%s/pass/a.txt", tempStr, tempStr),
+                    String.format("%s/keyStore:%s/password", tempStr, tempStr))),
+            ":");
+    locator.parse();
+    assertThat(locator.getFilePairs().size()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldDetectMissingPasswordFileWhenDirectoryIsPresent(@TempDir final Path tempDir)
+      throws IOException {
+    createFolders(tempDir, "key", "pass/a.txt");
+    createFiles(tempDir, "key/a");
+    final String tempStr = tempDir.toString();
+    KeyStoreFilesLocator locator =
+        new KeyStoreFilesLocator(
+            Optional.of(List.of(String.format("%s/key/a;%s/pass/a.txt", tempStr, tempStr))), ";");
+    assertThatThrownBy(locator::parse).isInstanceOf(InvalidConfigurationException.class);
+  }
+
+  @Test
+  public void shouldDetectMissingPasswordFile(@TempDir final Path tempDir) throws IOException {
+    createFolders(tempDir, "key", "pass");
+    createFiles(tempDir, "pass/a.txt");
+    final String tempStr = tempDir.toString();
+    KeyStoreFilesLocator locator =
+        new KeyStoreFilesLocator(
+            Optional.of(List.of(String.format("%s/key/a:%s/pass/a.txt", tempStr, tempStr))), ":");
+    assertThatThrownBy(locator::parse).isInstanceOf(InvalidConfigurationException.class);
+  }
+
+  @Test
+  public void shouldDetectMissingKeyFile(@TempDir final Path tempDir) throws IOException {
+    createFolders(tempDir, "key", "pass");
+    createFiles(tempDir, "key/a");
+    final String tempStr = tempDir.toString();
+    KeyStoreFilesLocator locator =
+        new KeyStoreFilesLocator(
+            Optional.of(List.of(String.format("%s/key/a:%s/pass/a.txt", tempStr, tempStr))), ":");
+    assertThatThrownBy(locator::parse).isInstanceOf(InvalidConfigurationException.class);
+  }
+
+  @Test
+  public void shouldSucceedCallingParseOnEmptyList() {
+    KeyStoreFilesLocator locator = new KeyStoreFilesLocator(Optional.empty(), ":");
+    locator.parse();
+    assertThat(locator.getFilePairs()).isEmpty();
+  }
+
+  @Test
+  public void shouldHandleOldArgs(@TempDir final Path tempDir) throws IOException {
+    createFolders(tempDir, "key", "pass");
+    createFiles(tempDir, "key/a", "pass/a.txt");
+    final String tempStr = tempDir.toString();
+    KeyStoreFilesLocator locator = new KeyStoreFilesLocator(Optional.empty(), ":");
+    locator.parseKeyAndPasswordList(List.of(tempStr + "/key/a"), List.of(tempStr + "/pass/a.txt"));
+    assertThat(locator.getFilePairs())
+        .containsExactly(tuple(tempDir.toString(), "key/a", "pass/a.txt"));
+  }
+
+  private void createFolders(final Path tempDir, String... paths) {
+    for (String path : paths) {
+      File file = new File(tempDir.toString() + File.separator + path);
+      file.mkdirs();
+    }
+  }
+
+  private void createFiles(final Path tempDir, String... paths) throws IOException {
+    for (String path : paths) {
+      File file = new File(tempDir.toString() + File.separator + path);
+      file.createNewFile();
+    }
+  }
+
+  private Pair<Path, Path> tuple(final String tempStr, final String k, final String p) {
+    return Pair.of(
+        new File(String.format("%s/%s", tempStr, k)).toPath(),
+        new File(String.format("%s/%s", tempStr, p)).toPath());
+  }
+}

--- a/util/src/test/java/tech/pegasys/teku/util/config/KeyStoreFilesLocatorTest.java
+++ b/util/src/test/java/tech/pegasys/teku/util/config/KeyStoreFilesLocatorTest.java
@@ -29,7 +29,7 @@ public class KeyStoreFilesLocatorTest {
   @Test
   public void shouldFindPairsAtDepth(@TempDir final Path tempDir) throws IOException {
     createFolders(tempDir, "key/1/2/3", "pass/1/2/3");
-    createFiles(tempDir, "key/a.json", "pass/a.txt", "key/1/2/3/b.json", "pass/1/2/3/b.bin");
+    createFiles(tempDir, "key/a.json", "pass/a.txt", "key/1/2/3/b.json", "pass/1/2/3/b.txt");
     final String tempStr = tempDir.toString();
     KeyStoreFilesLocator locator =
         new KeyStoreFilesLocator(
@@ -38,7 +38,7 @@ public class KeyStoreFilesLocatorTest {
     assertThat(locator.getFilePairs())
         .containsExactlyInAnyOrder(
             tuple(tempStr, "key/a.json", "pass/a.txt"),
-            tuple(tempStr, "key/1/2/3/b.json", "pass/1/2/3/b.bin"));
+            tuple(tempStr, "key/1/2/3/b.json", "pass/1/2/3/b.txt"));
   }
 
   @Test

--- a/util/src/test/java/tech/pegasys/teku/util/config/KeyStoreFilesLocatorTest.java
+++ b/util/src/test/java/tech/pegasys/teku/util/config/KeyStoreFilesLocatorTest.java
@@ -20,149 +20,227 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class KeyStoreFilesLocatorTest {
+  private static final String PATH_SEP = ":";
+  private static final String PATH_SEP_WIN = ";";
+
   @Test
   public void shouldFindPairsAtDepth(@TempDir final Path tempDir) throws IOException {
-    createFolders(tempDir, "key/1/2/3", "pass/1/2/3");
-    createFiles(tempDir, "key/a.json", "pass/a.txt", "key/1/2/3/b.json", "pass/1/2/3/b.txt");
-    final String tempStr = tempDir.toString();
-    KeyStoreFilesLocator locator =
-        new KeyStoreFilesLocator(
-            Optional.of(List.of(String.format("%s/key:%s/pass", tempStr, tempStr))), ":");
+    createFolders(tempDir, Path.of("key", "1", "2", "3"), Path.of("pass", "1", "2", "3"));
+    createFiles(
+        tempDir,
+        Path.of("key", "a.json"),
+        Path.of("pass", "a.txt"),
+        Path.of("key", "1", "2", "3", "b.json"),
+        Path.of("pass", "1", "2", "3", "b.txt"));
+    final String p1 = generatePath(tempDir, PATH_SEP, "key", "pass");
+    final KeyStoreFilesLocator locator = new KeyStoreFilesLocator(List.of(p1), PATH_SEP);
     locator.parse();
+
     assertThat(locator.getFilePairs())
         .containsExactlyInAnyOrder(
-            tuple(tempStr, "key/a.json", "pass/a.txt"),
-            tuple(tempStr, "key/1/2/3/b.json", "pass/1/2/3/b.txt"));
+            tuple(
+                tempDir, Path.of("key", "a.json").toString(), Path.of("pass", "a.txt").toString()),
+            tuple(
+                tempDir,
+                Path.of("key", "1", "2", "3", "b.json").toString(),
+                Path.of("pass", "1", "2", "3", "b.txt").toString()));
   }
 
   @Test
   public void shouldFindMissingPasswordAtDepth(@TempDir final Path tempDir) throws IOException {
-    createFolders(tempDir, "key/1/2/3", "pass/1/2/3");
-    createFiles(tempDir, "key/a.json", "pass/a.txt", "key/1/2/3/b.json");
-    final String tempStr = tempDir.toString();
-    KeyStoreFilesLocator locator =
-        new KeyStoreFilesLocator(
-            Optional.of(List.of(String.format("%s/key:%s/pass", tempStr, tempStr))), ":");
+    createFolders(tempDir, Path.of("key", "1", "2", "3"), Path.of("pass", "1", "2", "3"));
+    createFiles(
+        tempDir,
+        Path.of("key", "a.json"),
+        Path.of("pass", "a.txt"),
+        Path.of("key", "1", "2", "3", "b.json"));
+    final String p1 = generatePath(tempDir, PATH_SEP, "key", "pass");
+    final KeyStoreFilesLocator locator = new KeyStoreFilesLocator(List.of(p1), PATH_SEP);
+
     assertThatThrownBy(locator::parse).isInstanceOf(InvalidConfigurationException.class);
   }
 
   @Test
   public void shouldFindKeyPairOfFiles(@TempDir final Path tempDir) throws IOException {
     createFolders(tempDir, "key", "pass");
-    createFiles(tempDir, "key/a", "pass/a.txt");
-    final String tempStr = tempDir.toString();
-    KeyStoreFilesLocator locator =
-        new KeyStoreFilesLocator(
-            Optional.of(List.of(String.format("%s/key/a;%s/pass/a.txt", tempStr, tempStr))), ";");
+    createFiles(tempDir, Path.of("key", "a"), Path.of("pass", "a.txt"));
+    final String p1 =
+        generatePath(tempDir, PATH_SEP_WIN, List.of("key", "a"), List.of("pass", "a.txt"));
+    KeyStoreFilesLocator locator = new KeyStoreFilesLocator(List.of(p1), PATH_SEP_WIN);
     locator.parse();
-    assertThat(locator.getFilePairs()).containsExactly(tuple(tempStr, "key/a", "pass/a.txt"));
+
+    assertThat(locator.getFilePairs())
+        .containsExactly(
+            tuple(tempDir, Path.of("key", "a").toString(), Path.of("pass", "a.txt").toString()));
   }
 
   @Test
   public void shouldIgnoreSomeFiles(@TempDir final Path tempDir) throws IOException {
     createFolders(tempDir, "key", "pass");
     createFiles(
-        tempDir, "key/.asdf.json", "key/.hidden2", "key/ignored", "key/a.json", "pass/a.txt");
-    final String tempStr = tempDir.toString();
-    KeyStoreFilesLocator locator =
-        new KeyStoreFilesLocator(
-            Optional.of(List.of(String.format("%s/key;%s/pass", tempStr, tempStr))), ";");
+        tempDir,
+        Path.of("key", ".asdf.json"),
+        Path.of("key", ".hidden2"),
+        Path.of("key", "ignored"),
+        Path.of("key", "a.json"),
+        Path.of("pass", "a.txt"));
+    final String p1 = generatePath(tempDir, PATH_SEP_WIN, "key", "pass");
+    final KeyStoreFilesLocator locator = new KeyStoreFilesLocator(List.of(p1), PATH_SEP_WIN);
     locator.parse();
-    assertThat(locator.getFilePairs()).containsExactly(tuple(tempStr, "key/a.json", "pass/a.txt"));
+
+    assertThat(locator.getFilePairs())
+        .containsExactly(
+            tuple(
+                tempDir, Path.of("key", "a.json").toString(), Path.of("pass", "a.txt").toString()));
   }
 
   @Test
   public void shouldHandleFilesAndFoldersInOneArgument(@TempDir final Path tempDir)
       throws IOException {
     createFolders(tempDir, "key", "pass");
-    createFiles(tempDir, "key/a", "pass/a.txt", "keyStore", "password");
-    final String tempStr = tempDir.toString();
-    KeyStoreFilesLocator locator =
-        new KeyStoreFilesLocator(
-            Optional.of(
-                List.of(
-                    String.format("%s/key/a:%s/pass/a.txt", tempStr, tempStr),
-                    String.format("%s/keyStore:%s/password", tempStr, tempStr))),
-            ":");
+    createFiles(
+        tempDir,
+        Path.of("key", "a"),
+        Path.of("pass", "a.txt"),
+        Path.of("keyStore"),
+        Path.of("password"));
+    final String p1 =
+        generatePath(tempDir, PATH_SEP, List.of("key", "a"), List.of("pass", "a.txt"));
+    final String p2 = generatePath(tempDir, PATH_SEP, "keyStore", "password");
+    KeyStoreFilesLocator locator = new KeyStoreFilesLocator(List.of(p1, p2), PATH_SEP);
     locator.parse();
-    assertThat(locator.getFilePairs().size()).isEqualTo(2);
+
+    assertThat(locator.getFilePairs())
+        .containsExactlyInAnyOrder(
+            tuple(tempDir, Path.of("key", "a").toString(), Path.of("pass", "a.txt").toString()),
+            tuple(tempDir, "keyStore", "password"));
   }
 
   @Test
   public void shouldDetectMissingPasswordFileWhenDirectoryIsPresent(@TempDir final Path tempDir)
       throws IOException {
-    createFolders(tempDir, "key", "pass/a.txt");
-    createFiles(tempDir, "key/a");
-    final String tempStr = tempDir.toString();
-    KeyStoreFilesLocator locator =
-        new KeyStoreFilesLocator(
-            Optional.of(List.of(String.format("%s/key/a;%s/pass/a.txt", tempStr, tempStr))), ";");
+    createFolders(tempDir, Path.of("key"), Path.of("pass", "a.txt"));
+    createFiles(tempDir, Path.of("key", "a"));
+    final String p1 =
+        generatePath(tempDir, PATH_SEP_WIN, List.of("key", "a"), List.of("pass", "a.txt"));
+    KeyStoreFilesLocator locator = new KeyStoreFilesLocator(List.of(p1), PATH_SEP_WIN);
+
     assertThatThrownBy(locator::parse).isInstanceOf(InvalidConfigurationException.class);
   }
 
   @Test
   public void shouldDetectMissingPasswordFile(@TempDir final Path tempDir) throws IOException {
     createFolders(tempDir, "key", "pass");
-    createFiles(tempDir, "pass/a.txt");
-    final String tempStr = tempDir.toString();
-    KeyStoreFilesLocator locator =
-        new KeyStoreFilesLocator(
-            Optional.of(List.of(String.format("%s/key/a:%s/pass/a.txt", tempStr, tempStr))), ":");
+    createFiles(tempDir, Path.of("pass", "a.txt"));
+    final String p1 =
+        generatePath(tempDir, PATH_SEP, List.of("key", "a"), List.of("pass", "a.txt"));
+    KeyStoreFilesLocator locator = new KeyStoreFilesLocator(List.of(p1), PATH_SEP);
+
     assertThatThrownBy(locator::parse).isInstanceOf(InvalidConfigurationException.class);
   }
 
   @Test
   public void shouldDetectMissingKeyFile(@TempDir final Path tempDir) throws IOException {
     createFolders(tempDir, "key", "pass");
-    createFiles(tempDir, "key/a");
-    final String tempStr = tempDir.toString();
-    KeyStoreFilesLocator locator =
-        new KeyStoreFilesLocator(
-            Optional.of(List.of(String.format("%s/key/a:%s/pass/a.txt", tempStr, tempStr))), ":");
+    createFiles(tempDir, Path.of("key", "a"));
+    final String p1 =
+        generatePath(tempDir, PATH_SEP, List.of("key", "a"), List.of("pass", "a.txt"));
+    KeyStoreFilesLocator locator = new KeyStoreFilesLocator(List.of(p1), PATH_SEP);
+
     assertThatThrownBy(locator::parse).isInstanceOf(InvalidConfigurationException.class);
   }
 
   @Test
   public void shouldSucceedCallingParseOnEmptyList() {
-    KeyStoreFilesLocator locator = new KeyStoreFilesLocator(Optional.empty(), ":");
+    KeyStoreFilesLocator locator = new KeyStoreFilesLocator(List.of(), PATH_SEP);
     locator.parse();
     assertThat(locator.getFilePairs()).isEmpty();
   }
 
   @Test
+  public void shouldFailWhenSplittingTooManySeparators() {
+    KeyStoreFilesLocator locator = new KeyStoreFilesLocator(List.of("a:b:c"), PATH_SEP);
+    assertThatThrownBy(locator::parse).isInstanceOf(InvalidConfigurationException.class);
+  }
+
+  @Test
+  public void shouldFailWhenStringContainsOnlyKey() {
+    KeyStoreFilesLocator locator = new KeyStoreFilesLocator(List.of("key"), PATH_SEP);
+    assertThatThrownBy(locator::parse).isInstanceOf(InvalidConfigurationException.class);
+  }
+
+  @Test
   public void shouldHandleOldArgs(@TempDir final Path tempDir) throws IOException {
-    createFolders(tempDir, "key", "pass");
-    createFiles(tempDir, "key/a", "pass/a.txt");
+    createFolders(tempDir, Path.of("key"), Path.of("pass"));
+    createFiles(tempDir, Path.of("key", "a"), Path.of("pass", "a.txt"));
     final String tempStr = tempDir.toString();
-    KeyStoreFilesLocator locator = new KeyStoreFilesLocator(Optional.empty(), ":");
-    locator.parseKeyAndPasswordList(List.of(tempStr + "/key/a"), List.of(tempStr + "/pass/a.txt"));
+    KeyStoreFilesLocator locator = new KeyStoreFilesLocator(List.of(), PATH_SEP);
+    locator.parseKeyAndPasswordList(
+        List.of(Path.of(tempStr, "key", "a").toString()),
+        List.of(Path.of(tempStr, "pass", "a.txt").toString()));
+
     assertThat(locator.getFilePairs())
-        .containsExactly(tuple(tempDir.toString(), "key/a", "pass/a.txt"));
+        .containsExactly(tuple(tempDir, List.of("key", "a"), List.of("pass", "a.txt")));
   }
 
   private void createFolders(final Path tempDir, String... paths) {
     for (String path : paths) {
-      File file = new File(tempDir.toString() + File.separator + path);
-      file.mkdirs();
+      File file = tempDir.resolve(path).toFile();
+      if (!file.mkdirs() && !file.isDirectory()) {
+        Assertions.fail("Failed to create directory " + file);
+      }
     }
   }
 
-  private void createFiles(final Path tempDir, String... paths) throws IOException {
-    for (String path : paths) {
-      File file = new File(tempDir.toString() + File.separator + path);
+  private void createFolders(final Path tempDir, Path... paths) {
+    for (Path path : paths) {
+      File file = tempDir.resolve(path).toFile();
+      if (!file.mkdirs() && !file.isDirectory()) {
+        Assertions.fail("Failed to create directory " + file);
+      }
+    }
+  }
+
+  private void createFiles(final Path tempDir, Path... paths) throws IOException {
+    for (Path path : paths) {
+      File file = tempDir.resolve(path).toFile();
       file.createNewFile();
     }
   }
 
-  private Pair<Path, Path> tuple(final String tempStr, final String k, final String p) {
+  private String generatePath(
+      final Path tempDir, final String separator, final String key, final String pass) {
+    return generatePath(tempDir, separator, List.of(key), List.of(pass));
+  }
+
+  private String generatePath(
+      final Path tempDir,
+      final String separator,
+      final List<String> keyList,
+      final List<String> passList) {
+    final String tempStr = tempDir.toString();
+    return String.join(
+        separator,
+        Path.of(tempStr, keyList.toArray(new String[0])).toString(),
+        Path.of(tempStr, passList.toArray(new String[0])).toString());
+  }
+
+  private Pair<Path, Path> tuple(
+      final Path tempDir, final List<String> key, final List<String> path) {
+    final String tempStr = tempDir.toString();
     return Pair.of(
-        new File(String.format("%s/%s", tempStr, k)).toPath(),
-        new File(String.format("%s/%s", tempStr, p)).toPath());
+        Path.of(tempStr, key.toArray(new String[0])),
+        Path.of(tempStr, path.toArray(new String[0])));
+  }
+
+  private Pair<Path, Path> tuple(final Path tempDir, final String k, final String p) {
+    final String tempStr = tempDir.toString();
+    return Pair.of(new File(tempStr, k).toPath(), new File(tempStr, p).toPath());
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -52,6 +52,7 @@ class ValidatorLoaderTest {
             .setValidatorExternalSignerPublicKeys(Collections.singletonList(PUBLIC_KEY1))
             .setValidatorKeystoreFiles(emptyList())
             .setValidatorKeystorePasswordFiles(emptyList())
+            .setValidatorKeys(emptyList())
             .build();
     final Map<BLSPublicKey, Validator> validators =
         validatorLoader.initializeValidators(tekuConfiguration);
@@ -75,6 +76,7 @@ class ValidatorLoaderTest {
             .setValidatorKeyFile(validatorKeyFile.toAbsolutePath().toString())
             .setValidatorKeystoreFiles(emptyList())
             .setValidatorKeystorePasswordFiles(emptyList())
+            .setValidatorKeys(emptyList())
             .build();
     final Map<BLSPublicKey, Validator> validators =
         validatorLoader.initializeValidators(tekuConfiguration);
@@ -132,6 +134,7 @@ class ValidatorLoaderTest {
             .setValidatorKeyFile(validatorKeyFile.toAbsolutePath().toString())
             .setValidatorKeystoreFiles(emptyList())
             .setValidatorKeystorePasswordFiles(emptyList())
+            .setValidatorKeys(emptyList())
             .build();
     final Map<BLSPublicKey, Validator> validators =
         validatorLoader.initializeValidators(tekuConfiguration);
@@ -156,6 +159,7 @@ class ValidatorLoaderTest {
             .setInteropOwnedValidatorCount(ownedValidatorCount)
             .setValidatorKeystoreFiles(emptyList())
             .setValidatorKeystorePasswordFiles(emptyList())
+            .setValidatorKeys(emptyList())
             .build();
     final Map<BLSPublicKey, Validator> validators =
         validatorLoader.initializeValidators(tekuConfiguration);
@@ -172,6 +176,7 @@ class ValidatorLoaderTest {
             .setInteropOwnedValidatorCount(ownedValidatorCount)
             .setValidatorKeystoreFiles(emptyList())
             .setValidatorKeystorePasswordFiles(emptyList())
+            .setValidatorKeys(emptyList())
             .build();
     final Map<BLSPublicKey, Validator> validators =
         validatorLoader.initializeValidators(tekuConfiguration);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.validator.client.loader;
 
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -50,9 +49,6 @@ class ValidatorLoaderTest {
         TekuConfiguration.builder()
             .setValidatorExternalSignerUrl("http://localhost:9000")
             .setValidatorExternalSignerPublicKeys(Collections.singletonList(PUBLIC_KEY1))
-            .setValidatorKeystoreFiles(emptyList())
-            .setValidatorKeystorePasswordFiles(emptyList())
-            .setValidatorKeys(emptyList())
             .build();
     final Map<BLSPublicKey, Validator> validators =
         validatorLoader.initializeValidators(tekuConfiguration);
@@ -74,9 +70,6 @@ class ValidatorLoaderTest {
     final TekuConfiguration tekuConfiguration =
         TekuConfiguration.builder()
             .setValidatorKeyFile(validatorKeyFile.toAbsolutePath().toString())
-            .setValidatorKeystoreFiles(emptyList())
-            .setValidatorKeystorePasswordFiles(emptyList())
-            .setValidatorKeys(emptyList())
             .build();
     final Map<BLSPublicKey, Validator> validators =
         validatorLoader.initializeValidators(tekuConfiguration);
@@ -100,8 +93,6 @@ class ValidatorLoaderTest {
             .setValidatorExternalSignerUrl("http://localhost:9000")
             .setValidatorExternalSignerPublicKeys(Collections.singletonList(PUBLIC_KEY2))
             .setValidatorKeyFile(validatorKeyFile.toAbsolutePath().toString())
-            .setValidatorKeystoreFiles(emptyList())
-            .setValidatorKeystorePasswordFiles(emptyList())
             .build();
     final Map<BLSPublicKey, Validator> validators =
         validatorLoader.initializeValidators(tekuConfiguration);
@@ -132,9 +123,6 @@ class ValidatorLoaderTest {
             .setValidatorExternalSignerUrl("http://localhost:9000")
             .setValidatorExternalSignerPublicKeys(Collections.singletonList(PUBLIC_KEY1))
             .setValidatorKeyFile(validatorKeyFile.toAbsolutePath().toString())
-            .setValidatorKeystoreFiles(emptyList())
-            .setValidatorKeystorePasswordFiles(emptyList())
-            .setValidatorKeys(emptyList())
             .build();
     final Map<BLSPublicKey, Validator> validators =
         validatorLoader.initializeValidators(tekuConfiguration);
@@ -157,9 +145,6 @@ class ValidatorLoaderTest {
         TekuConfiguration.builder()
             .setInteropEnabled(true)
             .setInteropOwnedValidatorCount(ownedValidatorCount)
-            .setValidatorKeystoreFiles(emptyList())
-            .setValidatorKeystorePasswordFiles(emptyList())
-            .setValidatorKeys(emptyList())
             .build();
     final Map<BLSPublicKey, Validator> validators =
         validatorLoader.initializeValidators(tekuConfiguration);
@@ -174,9 +159,6 @@ class ValidatorLoaderTest {
         TekuConfiguration.builder()
             .setInteropEnabled(false)
             .setInteropOwnedValidatorCount(ownedValidatorCount)
-            .setValidatorKeystoreFiles(emptyList())
-            .setValidatorKeystorePasswordFiles(emptyList())
-            .setValidatorKeys(emptyList())
             .build();
     final Map<BLSPublicKey, Validator> validators =
         validatorLoader.initializeValidators(tekuConfiguration);


### PR DESCRIPTION

- `--validator-keys` takes a path separated list of paths to allow bulk loading of key files and password files

- each pair keyDir:passDir (separated by ; on windows)  will be loaded as one logical grouping of key and password files.

- the file locator looks for json files if a directory was passed in, and matches all json files with a .txt password file in the password path.

- the old password file options have been hidden (--validators-key-files, --validators-key-password-files) and will later be superseded by this implementation.

Fixes #2003

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.