### PR TITLE
Add metric to report delay publishing attestations

### DIFF
--- a/data/metrics/build.gradle
+++ b/data/metrics/build.gradle
@@ -1,10 +1,12 @@
 dependencies {
     api 'org.hyperledger.besu:plugin-api'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'io.prometheus:simpleclient'
     implementation 'io.vertx:vertx-core'
     implementation 'io.vertx:vertx-web'
     implementation 'org.apache.tuweni:tuweni-crypto'
     implementation 'org.apache.tuweni:tuweni-units'
+    implementation 'org.hdrhistogram:HdrHistogram'
     implementation 'org.hyperledger.besu.internal:metrics-core'
 
     testFixturesApi 'org.hyperledger.besu:plugin-api'

--- a/data/metrics/src/main/java/tech/pegasys/teku/metrics/MetricsHistogram.java
+++ b/data/metrics/src/main/java/tech/pegasys/teku/metrics/MetricsHistogram.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.metrics;
+
+import io.prometheus.client.Collector;
+import java.util.Collections;
+import java.util.List;
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.SynchronizedHistogram;
+import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
+
+/**
+ * A histogram metric that automatically selects bucket sizes based on simple configuration and the
+ * values actually received. Only records values when the metrics system is a {@link
+ * PrometheusMetricsSystem}.
+ *
+ * <p>Backing is an HdrHistogram.
+ *
+ * @see <a href="https://github.com/HdrHistogram/HdrHistogram">HdrHistogram docs</a>
+ */
+public class MetricsHistogram {
+  static final List<String> LABELS = Collections.singletonList("quantile");
+  static final List<String> LABEL_50 = Collections.singletonList("50%");
+  static final List<String> LABEL_95 = Collections.singletonList("95%");
+  static final List<String> LABEL_99 = Collections.singletonList("99%");
+  static final List<String> LABEL_1 = Collections.singletonList("100%");
+
+  private final Histogram histogram;
+
+  private MetricsHistogram(final Histogram histogram) {
+    this.histogram = histogram;
+  }
+
+  /**
+   * Create a new histogram metric which autoresizes to fit any values supplied and maintains at
+   * least {@code numberOfSignificantValueDigits} of precision.
+   *
+   * @param category the metrics category
+   * @param metricsSystem the metrics system to register with
+   * @param name the name of the metric
+   * @param help the help text describing the metric
+   * @param numberOfSignificantValueDigits the number of digits of precision to preserve
+   * @return the new metric
+   */
+  public static MetricsHistogram create(
+      final MetricCategory category,
+      final MetricsSystem metricsSystem,
+      final String name,
+      final String help,
+      final int numberOfSignificantValueDigits) {
+    final SynchronizedHistogram histogram =
+        new SynchronizedHistogram(numberOfSignificantValueDigits);
+    return createMetric(category, metricsSystem, name, help, histogram);
+  }
+
+  /**
+   * Create a new histogram metric with a fixed maximum value, maintaining at least {@code
+   * numberOfSignificantValueDigits} of precision.
+   *
+   * <p>Values above the specified highestTrackableValue will be recorded as being equal to that
+   * value.
+   *
+   * @param category the metrics category
+   * @param metricsSystem the metrics system to register with
+   * @param name the name of the metric
+   * @param help the help text describing the metric
+   * @param numberOfSignificantValueDigits the number of digits of precision to preserve
+   * @param highestTrackableValue the highest value that can be recorded by this histogram
+   * @return the new metric
+   */
+  public static MetricsHistogram create(
+      final MetricCategory category,
+      final MetricsSystem metricsSystem,
+      final String name,
+      final String help,
+      final int numberOfSignificantValueDigits,
+      final long highestTrackableValue) {
+    final SynchronizedHistogram histogram =
+        new SynchronizedHistogram(highestTrackableValue, numberOfSignificantValueDigits);
+    return createMetric(category, metricsSystem, name, help, histogram);
+  }
+
+  private static MetricsHistogram createMetric(
+      final MetricCategory category,
+      final MetricsSystem metricsSystem,
+      final String name,
+      final String help,
+      final SynchronizedHistogram histogram1) {
+    final MetricsHistogram histogram = new MetricsHistogram(histogram1);
+    if (metricsSystem instanceof PrometheusMetricsSystem) {
+      ((PrometheusMetricsSystem) metricsSystem)
+          .addCollector(category, histogram.histogramToCollector(category, name, help));
+    }
+    return histogram;
+  }
+
+  public void recordValue(final long value) {
+    if (histogram.isAutoResize()) {
+      histogram.recordValue(value);
+    } else {
+      histogram.recordValue(Math.min(histogram.getHighestTrackableValue(), value));
+    }
+  }
+
+  private Collector histogramToCollector(
+      final MetricCategory metricCategory, final String name, final String help) {
+    return new Collector() {
+      final String metricName =
+          metricCategory.getApplicationPrefix().orElse("") + metricCategory.getName() + "_" + name;
+
+      @Override
+      public List<MetricFamilySamples> collect() {
+        final List<MetricFamilySamples.Sample> samples =
+            List.of(
+                new MetricFamilySamples.Sample(
+                    metricName, LABELS, LABEL_50, histogram.getValueAtPercentile(50)),
+                new MetricFamilySamples.Sample(
+                    metricName, LABELS, LABEL_95, histogram.getValueAtPercentile(95d)),
+                new MetricFamilySamples.Sample(
+                    metricName, LABELS, LABEL_99, histogram.getValueAtPercentile(99d)),
+                new MetricFamilySamples.Sample(
+                    metricName, LABELS, LABEL_1, histogram.getMaxValueAsDouble()));
+        return Collections.singletonList(
+            new MetricFamilySamples(metricName, Type.SUMMARY, help, samples));
+      }
+    };
+  }
+}

--- a/data/metrics/src/test/java/tech/pegasys/teku/metrics/MetricsHistogramTest.java
+++ b/data/metrics/src/test/java/tech/pegasys/teku/metrics/MetricsHistogramTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static tech.pegasys.teku.metrics.MetricsHistogram.LABEL_1;
+import static tech.pegasys.teku.metrics.MetricsHistogram.LABEL_50;
+import static tech.pegasys.teku.metrics.MetricsHistogram.LABEL_95;
+import static tech.pegasys.teku.metrics.MetricsHistogram.LABEL_99;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.hyperledger.besu.metrics.ObservableMetricsSystem;
+import org.hyperledger.besu.metrics.Observation;
+import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
+import org.junit.jupiter.api.Test;
+
+class MetricsHistogramTest {
+
+  private static final TekuMetricCategory CATEGORY = TekuMetricCategory.BEACON;
+  private final ObservableMetricsSystem metricsSystem =
+      PrometheusMetricsSystem.init(
+          MetricsConfiguration.builder().enabled(true).metricCategories(Set.of(CATEGORY)).build());
+
+  @Test
+  void shouldReportValuesWithNoSpecifiedUpperLimit() {
+    final MetricsHistogram histogram =
+        MetricsHistogram.create(CATEGORY, metricsSystem, "test", "Test help", 3);
+
+    for (int i = 1; i <= 100; i++) {
+      histogram.recordValue(i);
+    }
+    final Map<List<String>, Object> values =
+        metricsSystem
+            .streamObservations()
+            .filter(ob -> ob.getCategory() == CATEGORY)
+            .collect(Collectors.toMap(Observation::getLabels, Observation::getValue));
+    assertThat(values)
+        .containsOnly(
+            entry(key(LABEL_50), 50d),
+            entry(key(LABEL_95), 95d),
+            entry(key(LABEL_99), 99d),
+            entry(key(LABEL_1), 100d));
+  }
+
+  @Test
+  void shouldReportValuesWithUpperLimit() {
+    final MetricsHistogram histogram =
+        MetricsHistogram.create(CATEGORY, metricsSystem, "test", "Test help", 2, 80);
+
+    for (int i = 1; i <= 100; i++) {
+      histogram.recordValue(i);
+    }
+    final Map<List<String>, Object> values =
+        metricsSystem
+            .streamObservations()
+            .filter(ob -> ob.getCategory() == CATEGORY)
+            .collect(Collectors.toMap(Observation::getLabels, Observation::getValue));
+    assertThat(values)
+        .containsOnly(
+            entry(key(LABEL_50), 50d),
+            entry(key(LABEL_95), 80d),
+            entry(key(LABEL_99), 80d),
+            entry(key(LABEL_1), 80d));
+  }
+
+  private static List<String> key(final List<String> labelValues) {
+    final List<String> key = new ArrayList<>(MetricsHistogram.LABELS);
+    key.addAll(labelValues);
+    return key;
+  }
+}

--- a/gradle/check-licenses.gradle
+++ b/gradle/check-licenses.gradle
@@ -31,6 +31,7 @@ ext.acceptedLicenses = [
     'Apache License, Version 2.0',
     'Bouncy Castle Licence',
     'Public Domain',
+    'Public Domain, per Creative Commons CC0',
     'Mozilla Public License 1.0',
     'Mozilla Public License Version 1.1',
     'Mozilla Public License Version 2.0',
@@ -94,6 +95,7 @@ downloadLicenses {
       ],
       (bsd2Clause): [
               'BSD 2-Clause',
+              'BSD-2-Clause',
               'BSD 2-Clause "New" or "Revised" License (BSD-2-Clause)',
               license('BSD 2-clause', 'http://opensource.org/licenses/BSD-2-Clause'),
               license('BSD 2-Clause', 'http://www.scala-lang.org/license.html'),

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -33,6 +33,8 @@ dependencyManagement {
     dependency 'io.libp2p:jvm-libp2p-minimal:0.5.5-RELEASE'
     dependency 'tech.pegasys:jblst:0.1.0-RELEASE'
 
+    dependency 'org.hdrhistogram:HdrHistogram:2.1.12'
+
     dependency 'org.jetbrains.kotlin:kotlin-stdlib:1.3.72'
 
     dependency 'io.pkts:pkts-core:3.0.3'

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -95,6 +95,7 @@ import tech.pegasys.teku.util.time.channels.TimeTickChannel;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.DepositProvider;
+import tech.pegasys.teku.validator.coordinator.DutyMetrics;
 import tech.pegasys.teku.validator.coordinator.Eth1DataCache;
 import tech.pegasys.teku.validator.coordinator.Eth1VotingPeriod;
 import tech.pegasys.teku.validator.coordinator.ValidatorApiHandler;
@@ -325,7 +326,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             attestationPool,
             attestationManager,
             attestationTopicSubscriber,
-            eventBus);
+            eventBus,
+            DutyMetrics.create(metricsSystem, timeProvider, recentChainData));
     eventChannels
         .subscribe(SlotEventsChannel.class, attestationTopicSubscriber)
         .subscribe(ValidatorApiChannel.class, validatorApiHandler);

--- a/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -70,7 +70,8 @@ public class ValidatorApiHandlerIntegrationTest {
           attestationPool,
           attestationManager,
           attestationTopicSubscriber,
-          eventBus);
+          eventBus,
+          mock(DutyMetrics.class));
 
   @BeforeEach
   public void setup() {

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/DutyMetrics.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/DutyMetrics.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.metrics.MetricsHistogram;
+import tech.pegasys.teku.metrics.TekuMetricCategory;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.util.time.TimeProvider;
+
+public class DutyMetrics {
+
+  private final TimeProvider timeProvider;
+  private final RecentChainData recentChainData;
+  private final MetricsHistogram attestationHistogram;
+
+  @VisibleForTesting
+  DutyMetrics(
+      final TimeProvider timeProvider,
+      final RecentChainData recentChainData,
+      final MetricsHistogram attestationHistogram) {
+    this.timeProvider = timeProvider;
+    this.recentChainData = recentChainData;
+    this.attestationHistogram = attestationHistogram;
+  }
+
+  public static DutyMetrics create(
+      final MetricsSystem metricsSystem,
+      final TimeProvider timeProvider,
+      final RecentChainData recentChainData) {
+    final MetricsHistogram attestationHistogram =
+        MetricsHistogram.create(
+            TekuMetricCategory.VALIDATOR,
+            metricsSystem,
+            "attestation_publication_delay",
+            "Histogram recording delay in milliseconds from scheduled time to an attestation being published",
+            1);
+    return new DutyMetrics(timeProvider, recentChainData, attestationHistogram);
+  }
+
+  public void onAttestationPublished(final UInt64 slot) {
+    final UInt64 currentTime = timeProvider.getTimeInMillis();
+    final UInt64 expectedTime = calculateExpectedAttestationTimeInMillis(slot);
+    if (currentTime.isGreaterThanOrEqualTo(expectedTime)) {
+      attestationHistogram.recordValue(currentTime.minus(expectedTime).longValue());
+    } else {
+      // The attestation was published ahead of time, likely because the block was received
+      attestationHistogram.recordValue(0);
+    }
+  }
+
+  private UInt64 calculateExpectedAttestationTimeInMillis(final UInt64 slot) {
+    final UInt64 genesisTime = recentChainData.getGenesisTime();
+    return genesisTime
+        .plus(slot.times(Constants.SECONDS_PER_SLOT))
+        .plus(Constants.SECONDS_PER_SLOT / 3)
+        .times(1000);
+  }
+}

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/DutyMetricsTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/DutyMetricsTest.java
@@ -66,8 +66,4 @@ class DutyMetricsTest {
   private UInt64 expectedAttestationTime(final UInt64 slot) {
     return slot.times(SECONDS_PER_SLOT).plus(SECONDS_PER_SLOT / 3).times(1000);
   }
-
-  private UInt64 expectedBlockTime(final UInt64 slot) {
-    return slot.times(SECONDS_PER_SLOT).times(1000);
-  }
 }

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/DutyMetricsTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/DutyMetricsTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.util.config.Constants.SECONDS_PER_SLOT;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.metrics.MetricsHistogram;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.util.time.StubTimeProvider;
+
+class DutyMetricsTest {
+
+  private static final UInt64 GENESIS_TIME = UInt64.valueOf(100_000);
+  private final StubTimeProvider timeProvider =
+      StubTimeProvider.withTimeInSeconds(GENESIS_TIME.longValue());
+  private final RecentChainData recentChainData = mock(RecentChainData.class);
+  private final MetricsHistogram attestationHistogram = mock(MetricsHistogram.class);
+  private final DutyMetrics metrics =
+      new DutyMetrics(timeProvider, recentChainData, attestationHistogram);
+
+  @BeforeEach
+  void setUp() {
+    when(recentChainData.getGenesisTime()).thenReturn(GENESIS_TIME);
+  }
+
+  @Test
+  void shouldRecordDelayWhenAttestationIsPublishedLate() {
+    final UInt64 slotNumber = UInt64.valueOf(30);
+    final UInt64 expectedAttestationTime = expectedAttestationTime(slotNumber);
+    final int publicationDelay = 575;
+    timeProvider.advanceTimeByMillis(expectedAttestationTime.plus(publicationDelay).longValue());
+
+    metrics.onAttestationPublished(UInt64.valueOf(30));
+
+    verify(attestationHistogram).recordValue(publicationDelay);
+  }
+
+  @Test
+  void shouldRecordZeroDelayWhenAttestationIsPublishedEarly() {
+    final UInt64 slotNumber = UInt64.valueOf(30);
+    final UInt64 expectedAttestationTime = expectedAttestationTime(slotNumber);
+    timeProvider.advanceTimeByMillis(expectedAttestationTime.minus(50).longValue());
+
+    metrics.onAttestationPublished(UInt64.valueOf(30));
+
+    verify(attestationHistogram).recordValue(0);
+  }
+
+  private UInt64 expectedAttestationTime(final UInt64 slot) {
+    return slot.times(SECONDS_PER_SLOT).plus(SECONDS_PER_SLOT / 3).times(1000);
+  }
+
+  private UInt64 expectedBlockTime(final UInt64 slot) {
+    return slot.times(SECONDS_PER_SLOT).times(1000);
+  }
+}

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -91,7 +91,8 @@ class ValidatorApiHandlerTest {
           attestationPool,
           attestationManager,
           attestationTopicSubscriptions,
-          eventBus);
+          eventBus,
+          mock(DutyMetrics.class));
 
   @BeforeEach
   public void setUp() {


### PR DESCRIPTION
## PR Description
Add histogram metrics to report the delay between when an attestation was scheduled and when it was actually published. The metric isn't perfectly accurate - the actual write to jvm-libp2p happens on a separate thread so may not have completed by the time we take the measurement, but we have completed all the expensive checks prior to this so should its a useful measure even if it's not perfect.

## Fixed Issue(s)
Part of #2522 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.