### PR TITLE
Perform local signing asynchronously to maximise CPU resources

### DIFF
--- a/ethereum/core/build.gradle
+++ b/ethereum/core/build.gradle
@@ -28,6 +28,7 @@ dependencies {
   testFixturesImplementation project(':ethereum:datastructures')
   testFixturesImplementation testFixtures(project(':ethereum:datastructures'))
   testFixturesImplementation project(':infrastructure:async')
+  testFixturesImplementation testFixtures(project(':infrastructure:async'))
   testFixturesImplementation project(':ssz')
   testFixturesImplementation project(':util')
 

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalMessageSignerService.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalMessageSignerService.java
@@ -17,13 +17,16 @@ import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
 public class LocalMessageSignerService implements MessageSignerService {
   private final BLSKeyPair keypair;
+  private final AsyncRunner asyncRunner;
 
-  public LocalMessageSignerService(final BLSKeyPair keypair) {
+  public LocalMessageSignerService(final BLSKeyPair keypair, final AsyncRunner asyncRunner) {
     this.keypair = keypair;
+    this.asyncRunner = asyncRunner;
   }
 
   @Override
@@ -62,6 +65,7 @@ public class LocalMessageSignerService implements MessageSignerService {
   }
 
   private SafeFuture<BLSSignature> sign(final Bytes signing_root) {
-    return SafeFuture.completedFuture(BLS.sign(keypair.getSecretKey(), signing_root));
+    return asyncRunner.runAsync(
+        () -> SafeFuture.completedFuture(BLS.sign(keypair.getSecretKey(), signing_root)));
   }
 }

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/LocalMessageSignerServiceTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/LocalMessageSignerServiceTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.core.signatures;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.bls.BLS;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+
+class LocalMessageSignerServiceTest {
+  private static final Bytes MESSAGE = Bytes.fromHexString("0x123456");
+  private static final BLSKeyPair KEYPAIR = BLSKeyPair.random(1234);
+  private static final BLSSignature EXPECTED_SIGNATURE = BLS.sign(KEYPAIR.getSecretKey(), MESSAGE);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+
+  private final LocalMessageSignerService signerService =
+      new LocalMessageSignerService(KEYPAIR, asyncRunner);
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("signMethods")
+  @SuppressWarnings("unchecked")
+  void shouldSignAsynchronously(@SuppressWarnings("unused") final String name, final Method method)
+      throws Exception {
+    final SafeFuture<BLSSignature> result =
+        (SafeFuture<BLSSignature>) method.invoke(signerService, MESSAGE);
+    assertThat(result).isNotDone();
+
+    asyncRunner.executeQueuedActions();
+
+    assertThat(result).isCompletedWithValue(EXPECTED_SIGNATURE);
+  }
+
+  static List<Arguments> signMethods() {
+    return Stream.of(MessageSignerService.class.getMethods())
+        .filter(method -> method.getName().startsWith("sign"))
+        .map(method -> Arguments.of(method.getName(), method))
+        .collect(Collectors.toList());
+  }
+}

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AggregateGenerator.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AggregateGenerator.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.util.CommitteeUtil;
+import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class AggregateGenerator {
@@ -58,7 +59,9 @@ public class AggregateGenerator {
   }
 
   private Signer getSignerForValidatorIndex(final int validatorIndex) {
-    return new UnprotectedSigner(new LocalMessageSignerService(validatorKeys.get(validatorIndex)));
+    return new UnprotectedSigner(
+        new LocalMessageSignerService(
+            validatorKeys.get(validatorIndex), DelayedExecutorAsyncRunner.create()));
   }
 
   public class Generator {

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AttestationGenerator.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AttestationGenerator.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Committee;
 import tech.pegasys.teku.datastructures.state.CommitteeAssignment;
 import tech.pegasys.teku.datastructures.util.AttestationUtil;
+import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.SSZTypes.Bitlist;
 import tech.pegasys.teku.util.config.Constants;
@@ -321,7 +322,9 @@ public class AttestationGenerator {
           AttestationUtil.getAggregationBits(committeSize, indexIntoCommittee);
 
       BLSSignature signature =
-          new UnprotectedSigner(new LocalMessageSignerService(attesterKeyPair))
+          new UnprotectedSigner(
+                  new LocalMessageSignerService(
+                      attesterKeyPair, DelayedExecutorAsyncRunner.create()))
               .signAttestationData(attestationData, state.getForkInfo())
               .join();
       return new Attestation(aggregationBitfield, attestationData, signature);

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/VoluntaryExitGenerator.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/VoluntaryExitGenerator.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.util.config.Constants;
 
@@ -39,7 +40,9 @@ public class VoluntaryExitGenerator {
     VoluntaryExit exit = new VoluntaryExit(epoch, UInt64.valueOf(validatorIndex));
 
     BLSSignature exitSignature =
-        new UnprotectedSigner(new LocalMessageSignerService(getKeypair(validatorIndex, valid)))
+        new UnprotectedSigner(
+                new LocalMessageSignerService(
+                    getKeypair(validatorIndex, valid), DelayedExecutorAsyncRunner.create()))
             .signVoluntaryExit(exit, forkInfo)
             .join();
 

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.Logger;
 
 public class ScheduledExecutorAsyncRunner implements AsyncRunner {
   private static final Logger LOG = LogManager.getLogger();
-  private static final int QUEUE_CAPACITY = 500;
+  private static final int QUEUE_CAPACITY = 5000;
   private final AtomicBoolean shutdown = new AtomicBoolean(false);
   private final ScheduledExecutorService scheduler;
   private final ExecutorService workerPool;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -51,7 +51,7 @@ public class ValidatorClientService extends Service {
         new SlashingProtector(
             new SyncDataAccessor(),
             Path.of(config.getConfig().getDataPath(), "validators", "slashprotection"));
-    final ValidatorLoader validatorLoader = new ValidatorLoader(slashingProtector);
+    final ValidatorLoader validatorLoader = new ValidatorLoader(slashingProtector, asyncRunner);
     final Map<BLSPublicKey, Validator> validators =
         validatorLoader.initializeValidators(config.getConfig());
     final ValidatorApiChannel validatorApiChannel =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorLoader.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.core.signatures.Signer;
 import tech.pegasys.teku.core.signatures.SlashingProtectedSigner;
 import tech.pegasys.teku.core.signatures.SlashingProtector;
 import tech.pegasys.teku.core.signatures.UnprotectedSigner;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.util.bytes.KeyFormatter;
 import tech.pegasys.teku.util.config.TekuConfiguration;
 import tech.pegasys.teku.validator.client.Validator;
@@ -41,9 +42,11 @@ import tech.pegasys.teku.validator.client.signer.ExternalMessageSignerService;
 public class ValidatorLoader {
 
   private final SlashingProtector slashingProtector;
+  private final AsyncRunner asyncRunner;
 
-  public ValidatorLoader(final SlashingProtector slashingProtector) {
+  public ValidatorLoader(final SlashingProtector slashingProtector, final AsyncRunner asyncRunner) {
     this.slashingProtector = slashingProtector;
+    this.asyncRunner = asyncRunner;
   }
 
   public Map<BLSPublicKey, Validator> initializeValidators(TekuConfiguration config) {
@@ -69,7 +72,8 @@ public class ValidatorLoader {
                 new Validator(
                     blsKeyPair.getPublicKey(),
                     createSigner(
-                        blsKeyPair.getPublicKey(), new LocalMessageSignerService(blsKeyPair)),
+                        blsKeyPair.getPublicKey(),
+                        new LocalMessageSignerService(blsKeyPair, asyncRunner)),
                     Optional.ofNullable(config.getGraffiti())))
         .collect(toMap(Validator::getPublicKey, Function.identity()));
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.core.signatures.SlashingProtector;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.util.config.TekuConfiguration;
 import tech.pegasys.teku.validator.client.Validator;
 
@@ -41,8 +42,10 @@ class ValidatorLoaderTest {
           + "  pubkey: '0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c'}";
 
   private final SlashingProtector slashingProtector = mock(SlashingProtector.class);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
 
-  private final ValidatorLoader validatorLoader = new ValidatorLoader(slashingProtector);
+  private final ValidatorLoader validatorLoader =
+      new ValidatorLoader(slashingProtector, asyncRunner);
 
   @Test
   void initializeValidatorsWithExternalMessageSignerWhenConfigHasExternalSigningPublicKeys() {


### PR DESCRIPTION
## PR Description
Perform local signing using an `AsyncRunner` to take advantage of parallelism rather than signing each message sequentially.

Note that the max queue size for `ScheduledExecutorAsyncRunner` was increased (a lot) because when running multiple validators a lot of events get fired through the executor very rapidly especially when signing slot numbers to determine if the validator is the aggregator for a committee.  We want to ensure there's some limit but want to be very sure to avoid rejecting executions purely because of these short term spikes in demand.

## Fixed Issue(s)
fixes #1916 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.