### PR TITLE
[Issue-2573] Fix gossiped attestation validation

### DIFF
--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AttestationGenerator.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AttestationGenerator.java
@@ -32,6 +32,8 @@ import java.util.stream.StreamSupport;
 import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.core.exceptions.EpochProcessingException;
+import tech.pegasys.teku.core.exceptions.SlotProcessingException;
 import tech.pegasys.teku.core.signatures.LocalMessageSignerService;
 import tech.pegasys.teku.core.signatures.UnprotectedSigner;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
@@ -200,8 +202,10 @@ public class AttestationGenerator {
    * assigned slot.
    */
   private static class AttestationIterator implements Iterator<Attestation> {
-    // The head block to attest to with its corresponding state
-    private final BeaconBlockAndState headBlockAndState;
+    // The latest block being attested to
+    private final BeaconBlock headBlock;
+    // The latest state processed through to the current slot
+    private final BeaconState headState;
     // The assigned slot to generate attestations for
     private final UInt64 assignedSlot;
     // The epoch containing the assigned slot
@@ -218,12 +222,26 @@ public class AttestationGenerator {
         final UInt64 assignedSlot,
         final List<BLSKeyPair> validatorKeys,
         final Function<Integer, BLSKeyPair> validatorKeySupplier) {
-      this.headBlockAndState = headBlockAndState;
+      this.headBlock = headBlockAndState.getBlock();
+      this.headState = generateHeadState(headBlockAndState.getState(), assignedSlot);
       this.validatorKeys = validatorKeys;
       this.assignedSlot = assignedSlot;
       this.assignedSlotEpoch = compute_epoch_at_slot(assignedSlot);
       this.validatorKeySupplier = validatorKeySupplier;
       generateNextAttestation();
+    }
+
+    private BeaconState generateHeadState(final BeaconState state, final UInt64 slot) {
+      if (state.getSlot().equals(slot)) {
+        return state;
+      }
+
+      StateTransition stateTransition = new StateTransition();
+      try {
+        return stateTransition.process_slots(state, slot);
+      } catch (EpochProcessingException | SlotProcessingException e) {
+        throw new IllegalStateException(e);
+      }
     }
 
     public static AttestationIterator create(
@@ -269,8 +287,6 @@ public class AttestationGenerator {
     private void generateNextAttestation() {
       nextAttestation = Optional.empty();
 
-      final BeaconState headState = headBlockAndState.getState();
-      final BeaconBlock headBlock = headBlockAndState.getBlock();
       int lastProcessedValidatorIndex = currentValidatorIndex;
       for (int validatorIndex = currentValidatorIndex;
           validatorIndex < validatorKeys.size();

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
@@ -86,4 +86,6 @@ public interface ReadOnlyStore {
   SafeFuture<Optional<BeaconState>> retrieveBlockState(Bytes32 blockRoot);
 
   SafeFuture<Optional<BeaconState>> retrieveCheckpointState(Checkpoint checkpoint);
+
+  BeaconState getCheckpointState(final Checkpoint checkpoint, final BeaconState latestStateAtEpoch);
 }

--- a/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreImpl.java
@@ -173,6 +173,15 @@ class TestStoreImpl implements MutableStore {
     return SafeFuture.completedFuture(getCheckpointState(checkpoint));
   }
 
+  @Override
+  public BeaconState getCheckpointState(
+      final Checkpoint checkpoint, final BeaconState latestStateAtEpoch) {
+    if (!latestStateAtEpoch.getSlot().equals(checkpoint.getEpochStartSlot())) {
+      throw new UnsupportedOperationException("Checkpoint state calculation not supported");
+    }
+    return latestStateAtEpoch;
+  }
+
   // Mutable methods
   @Override
   public void putBlockAndState(final SignedBeaconBlock block, final BeaconState state) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/SignedAggregateAndProofValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/SignedAggregateAndProofValidator.java
@@ -108,7 +108,11 @@ public class SignedAggregateAndProofValidator {
                         if (maybeState.isEmpty()) {
                           return SAVE_FOR_FUTURE;
                         }
-                        final BeaconState state = maybeState.get();
+
+                        final BeaconState state =
+                            attestationValidator.resolveStateForAttestation(
+                                aggregate, maybeState.get());
+
                         final Optional<BLSPublicKey> aggregatorPublicKey =
                             ValidatorsUtil.getValidatorPubKey(state, aggregateAndProof.getIndex());
                         if (aggregatorPublicKey.isEmpty()) {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/AttestationValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/AttestationValidatorTest.java
@@ -104,6 +104,17 @@ class AttestationValidatorTest {
   }
 
   @Test
+  public void shouldReturnValidForValidAttestation_whenManyBlocksHaveBeenSkipped() {
+    final BeaconBlockAndState head = recentChainData.getHeadBlockAndState().orElseThrow();
+    final UInt64 currentSlot = head.getSlot().plus(SLOTS_PER_EPOCH * 3);
+    storageSystem.chainUpdater().setCurrentSlot(currentSlot);
+
+    final Attestation attestation =
+        attestationGenerator.validAttestation(head, head.getSlot().plus(SLOTS_PER_EPOCH * 3));
+    assertThat(validate(attestation)).isEqualTo(ACCEPT);
+  }
+
+  @Test
   public void shouldRejectAttestationWithIncorrectAggregateBitsSize() {
     final Attestation attestation =
         attestationGenerator.validAttestation(recentChainData.getHeadBlockAndState().orElseThrow());

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/SignedAggregateAndProofValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/SignedAggregateAndProofValidatorTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.gossip.topics.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -126,6 +127,13 @@ class SignedAggregateAndProofValidatorTest {
   public void setUp() {
     chainUpdater.initializeGenesis(false);
     bestBlock = chainUpdater.addNewBestBlock();
+
+    final AttestationValidator realAttestationValidator = new AttestationValidator(recentChainData);
+    when(attestationValidator.resolveStateForAttestation(any(), any()))
+        .thenAnswer(
+            i ->
+                realAttestationValidator.resolveStateForAttestation(
+                    i.getArgument(0), i.getArgument(1)));
   }
 
   @Test

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -451,6 +451,17 @@ class Store implements UpdatableStore {
                     }));
   }
 
+  @Override
+  public BeaconState getCheckpointState(
+      final Checkpoint checkpoint, final BeaconState latestStateAtEpoch) {
+    if (latestStateAtEpoch.getSlot().isGreaterThan(checkpoint.getEpochStartSlot())) {
+      throw new IllegalArgumentException("Latest state must be at or prior to checkpoint slot");
+    }
+    final BeaconState checkpointState = regenerateCheckpointState(checkpoint, latestStateAtEpoch);
+    putCheckpointState(checkpoint, checkpointState);
+    return checkpointState;
+  }
+
   private Optional<BeaconState> getCheckpointStateIfAvailable(final Checkpoint checkpoint) {
     readLock.lock();
     try {
@@ -837,6 +848,12 @@ class Store implements UpdatableStore {
             Optional.of(regenerateCheckpointState(checkpoint, inMemoryCheckpointBlockState)));
       }
       return Store.this.retrieveCheckpointState(checkpoint);
+    }
+
+    @Override
+    public BeaconState getCheckpointState(
+        final Checkpoint checkpoint, final BeaconState latestStateAtEpoch) {
+      return Store.this.getCheckpointState(checkpoint, latestStateAtEpoch);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
When receiving gossiped attestations that point to old blocks, roll the associated state forward before querying for committee information.

## Fixed Issue(s)
Fixes #2573 
Relates to #2334 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.