### PR TITLE
Process gossip off of the netty thread

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2Network.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.AggregateGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.AttestationGossipManager;
@@ -62,6 +63,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements Eth2Network {
 
+  private final AsyncRunner asyncRunner;
   private final MetricsSystem metricsSystem;
   private final DiscoveryNetwork<?> discoveryNetwork;
   private final Eth2PeerManager peerManager;
@@ -92,6 +94,7 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
   private final GossipedOperationConsumer<SignedVoluntaryExit> gossipedVoluntaryExitConsumer;
 
   public ActiveEth2Network(
+      final AsyncRunner asyncRunner,
       final MetricsSystem metricsSystem,
       final DiscoveryNetwork<?> discoveryNetwork,
       final Eth2PeerManager peerManager,
@@ -107,6 +110,7 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
       final VerifiedBlockAttestationsSubscriptionProvider
           verifiedBlockAttestationsSubscriptionProvider) {
     super(discoveryNetwork);
+    this.asyncRunner = asyncRunner;
     this.metricsSystem = metricsSystem;
     this.discoveryNetwork = discoveryNetwork;
     this.peerManager = peerManager;
@@ -161,6 +165,7 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
 
     AttestationSubnetSubscriptions attestationSubnetSubscriptions =
         new AttestationSubnetSubscriptions(
+            asyncRunner,
             discoveryNetwork,
             gossipEncoding,
             attestationValidator,
@@ -169,13 +174,14 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
 
     blockGossipManager =
         new BlockGossipManager(
-            discoveryNetwork, gossipEncoding, forkInfo, blockValidator, eventBus);
+            asyncRunner, discoveryNetwork, gossipEncoding, forkInfo, blockValidator, eventBus);
 
     attestationGossipManager =
         new AttestationGossipManager(metricsSystem, attestationSubnetSubscriptions);
 
     aggregateGossipManager =
         new AggregateGossipManager(
+            asyncRunner,
             discoveryNetwork,
             gossipEncoding,
             forkInfo,
@@ -184,6 +190,7 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
 
     voluntaryExitGossipManager =
         new VoluntaryExitGossipManager(
+            asyncRunner,
             discoveryNetwork,
             gossipEncoding,
             forkInfo,
@@ -192,6 +199,7 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
 
     proposerSlashingGossipManager =
         new ProposerSlashingGossipManager(
+            asyncRunner,
             discoveryNetwork,
             gossipEncoding,
             forkInfo,
@@ -200,6 +208,7 @@ public class ActiveEth2Network extends DelegatingP2PNetwork<Eth2Peer> implements
 
     attesterSlashingGossipManager =
         new AttesterSlashingGossipManager(
+            asyncRunner,
             discoveryNetwork,
             gossipEncoding,
             forkInfo,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
@@ -114,6 +114,7 @@ public class Eth2NetworkBuilder {
     final DiscoveryNetwork<?> network = buildNetwork(gossipEncoding);
 
     return new ActiveEth2Network(
+        asyncRunner,
         metricsSystem,
         network,
         eth2PeerManager,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManager.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.AggregateAttestationTopicHandler;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipedOperationConsumer;
@@ -32,6 +33,7 @@ public class AggregateGossipManager {
   private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
   public AggregateGossipManager(
+      final AsyncRunner asyncRunner,
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
@@ -41,7 +43,7 @@ public class AggregateGossipManager {
     this.gossipEncoding = gossipEncoding;
     final AggregateAttestationTopicHandler aggregateAttestationTopicHandler =
         new AggregateAttestationTopicHandler(
-            gossipEncoding, forkInfo, validator, gossipedAttestationConsumer);
+            asyncRunner, gossipEncoding, forkInfo, validator, gossipedAttestationConsumer);
     this.channel =
         gossipNetwork.subscribe(
             aggregateAttestationTopicHandler.getTopic(), aggregateAttestationTopicHandler);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2.gossip;
 import java.util.concurrent.atomic.AtomicBoolean;
 import tech.pegasys.teku.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.AttesterSlashingTopicHandler;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipedOperationConsumer;
@@ -29,6 +30,7 @@ public class AttesterSlashingGossipManager {
   private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
   public AttesterSlashingGossipManager(
+      final AsyncRunner asyncRunner,
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
@@ -36,7 +38,11 @@ public class AttesterSlashingGossipManager {
       final GossipedOperationConsumer<AttesterSlashing> gossipedAttesterSlashingConsumer) {
     final AttesterSlashingTopicHandler topicHandler =
         new AttesterSlashingTopicHandler(
-            gossipEncoding, forkInfo, attesterSlashingValidator, gossipedAttesterSlashingConsumer);
+            asyncRunner,
+            gossipEncoding,
+            forkInfo,
+            attesterSlashingValidator,
+            gossipedAttesterSlashingConsumer);
     this.channel = gossipNetwork.subscribe(topicHandler.getTopic(), topicHandler);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManager.java
@@ -18,6 +18,7 @@ import com.google.common.eventbus.Subscribe;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.BlockTopicHandler;
 import tech.pegasys.teku.networking.eth2.gossip.topics.validation.BlockValidator;
@@ -33,6 +34,7 @@ public class BlockGossipManager {
   private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
   public BlockGossipManager(
+      final AsyncRunner asyncRunner,
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
@@ -41,7 +43,7 @@ public class BlockGossipManager {
     this.gossipEncoding = gossipEncoding;
 
     final BlockTopicHandler topicHandler =
-        new BlockTopicHandler(gossipEncoding, forkInfo, blockValidator, eventBus);
+        new BlockTopicHandler(asyncRunner, gossipEncoding, forkInfo, blockValidator, eventBus);
     this.channel = gossipNetwork.subscribe(topicHandler.getTopic(), topicHandler);
 
     this.eventBus = eventBus;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2.gossip;
 import java.util.concurrent.atomic.AtomicBoolean;
 import tech.pegasys.teku.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipedOperationConsumer;
 import tech.pegasys.teku.networking.eth2.gossip.topics.ProposerSlashingTopicHandler;
@@ -29,6 +30,7 @@ public class ProposerSlashingGossipManager {
   private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
   public ProposerSlashingGossipManager(
+      final AsyncRunner asyncRunner,
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
@@ -36,7 +38,11 @@ public class ProposerSlashingGossipManager {
       final GossipedOperationConsumer<ProposerSlashing> gossipedProposerSlashingConsumer) {
     final ProposerSlashingTopicHandler topicHandler =
         new ProposerSlashingTopicHandler(
-            gossipEncoding, forkInfo, proposerSlashingValidator, gossipedProposerSlashingConsumer);
+            asyncRunner,
+            gossipEncoding,
+            forkInfo,
+            proposerSlashingValidator,
+            gossipedProposerSlashingConsumer);
     this.channel = gossipNetwork.subscribe(topicHandler.getTopic(), topicHandler);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2.gossip;
 import java.util.concurrent.atomic.AtomicBoolean;
 import tech.pegasys.teku.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipedOperationConsumer;
 import tech.pegasys.teku.networking.eth2.gossip.topics.VoluntaryExitTopicHandler;
@@ -29,6 +30,7 @@ public class VoluntaryExitGossipManager {
   private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
   public VoluntaryExitGossipManager(
+      final AsyncRunner asyncRunner,
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
@@ -36,7 +38,11 @@ public class VoluntaryExitGossipManager {
       final GossipedOperationConsumer<SignedVoluntaryExit> gossipedVoluntaryExitConsumer) {
     final VoluntaryExitTopicHandler topicHandler =
         new VoluntaryExitTopicHandler(
-            gossipEncoding, forkInfo, voluntaryExitValidator, gossipedVoluntaryExitConsumer);
+            asyncRunner,
+            gossipEncoding,
+            forkInfo,
+            voluntaryExitValidator,
+            gossipedVoluntaryExitConsumer);
     this.channel = gossipNetwork.subscribe(topicHandler.getTopic(), topicHandler);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/AggregateAttestationTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/AggregateAttestationTopicHandler.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.validation.InternalValidationResult;
@@ -35,10 +36,12 @@ public class AggregateAttestationTopicHandler
   private final GossipedOperationConsumer<ValidateableAttestation> gossipedAttestationConsumer;
 
   public AggregateAttestationTopicHandler(
+      final AsyncRunner asyncRunner,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
       final SignedAggregateAndProofValidator validator,
       final GossipedOperationConsumer<ValidateableAttestation> gossipedAttestationConsumer) {
+    super(asyncRunner);
     this.gossipEncoding = gossipEncoding;
     this.forkDigest = forkInfo.getForkDigest();
     this.validator = validator;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/AttesterSlashingTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/AttesterSlashingTopicHandler.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.validation.AttesterSlashingValidator;
@@ -34,10 +35,12 @@ public class AttesterSlashingTopicHandler
   private final GossipedOperationConsumer<AttesterSlashing> consumer;
 
   public AttesterSlashingTopicHandler(
+      final AsyncRunner asyncRunner,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
       final AttesterSlashingValidator validator,
       final GossipedOperationConsumer<AttesterSlashing> consumer) {
+    super(asyncRunner);
     this.gossipEncoding = gossipEncoding;
     this.forkDigest = forkInfo.getForkDigest();
     this.validator = validator;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/BlockTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/BlockTopicHandler.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.events.GossipedBlockEvent;
@@ -35,10 +36,12 @@ public class BlockTopicHandler extends Eth2TopicHandler.SimpleEth2TopicHandler<S
   private final EventBus eventBus;
 
   public BlockTopicHandler(
+      final AsyncRunner asyncRunner,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
       final BlockValidator blockValidator,
       final EventBus eventBus) {
+    super(asyncRunner);
     this.gossipEncoding = gossipEncoding;
     this.forkDigest = forkInfo.getForkDigest();
     this.blockValidator = blockValidator;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2TopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2TopicHandler.java
@@ -18,6 +18,7 @@ import io.libp2p.core.pubsub.ValidationResult;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.DecodingException;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
@@ -29,6 +30,11 @@ import tech.pegasys.teku.ssz.sos.SimpleOffsetSerializable;
 public abstract class Eth2TopicHandler<T extends SimpleOffsetSerializable, TWrapped>
     implements TopicHandler {
   private static final Logger LOG = LogManager.getLogger();
+  private final AsyncRunner asyncRunner;
+
+  protected Eth2TopicHandler(final AsyncRunner asyncRunner) {
+    this.asyncRunner = asyncRunner;
+  }
 
   @Override
   public SafeFuture<ValidationResult> handleMessage(final Bytes bytes) {
@@ -36,12 +42,14 @@ public abstract class Eth2TopicHandler<T extends SimpleOffsetSerializable, TWrap
         .thenApply(this::wrapMessage)
         .thenCompose(
             wrapped ->
-                validateData(wrapped)
-                    .thenApply(
-                        internalValidation -> {
-                          processMessage(wrapped, internalValidation);
-                          return internalValidation.getGossipSubValidationResult();
-                        }))
+                asyncRunner.runAsync(
+                    () ->
+                        validateData(wrapped)
+                            .thenApply(
+                                internalValidation -> {
+                                  processMessage(wrapped, internalValidation);
+                                  return internalValidation.getGossipSubValidationResult();
+                                })))
         .exceptionally(this::handleMessageProcessingError);
   }
 
@@ -79,6 +87,10 @@ public abstract class Eth2TopicHandler<T extends SimpleOffsetSerializable, TWrap
 
   public abstract static class SimpleEth2TopicHandler<T extends SimpleOffsetSerializable>
       extends Eth2TopicHandler<T, T> {
+
+    protected SimpleEth2TopicHandler(final AsyncRunner asyncRunner) {
+      super(asyncRunner);
+    }
 
     @Override
     public T deserialize(Bytes bytes) throws DecodingException {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/ProposerSlashingTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/ProposerSlashingTopicHandler.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.validation.InternalValidationResult;
@@ -34,10 +35,12 @@ public class ProposerSlashingTopicHandler
   private final GossipedOperationConsumer<ProposerSlashing> consumer;
 
   public ProposerSlashingTopicHandler(
+      final AsyncRunner asyncRunner,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
       final ProposerSlashingValidator validator,
       final GossipedOperationConsumer<ProposerSlashing> consumer) {
+    super(asyncRunner);
     this.gossipEncoding = gossipEncoding;
     this.forkDigest = forkInfo.getForkDigest();
     this.validator = validator;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandler.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.validation.AttestationValidator;
@@ -35,11 +36,13 @@ public class SingleAttestationTopicHandler
   private final Bytes4 forkDigest;
 
   public SingleAttestationTopicHandler(
+      final AsyncRunner asyncRunner,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
       final int subnetId,
       final AttestationValidator validator,
       final GossipedOperationConsumer<ValidateableAttestation> gossipedAttestationConsumer) {
+    super(asyncRunner);
     this.gossipEncoding = gossipEncoding;
     this.forkDigest = forkInfo.getForkDigest();
     this.validator = validator;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/VoluntaryExitTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/VoluntaryExitTopicHandler.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.validation.InternalValidationResult;
@@ -34,10 +35,12 @@ public class VoluntaryExitTopicHandler
   private final GossipedOperationConsumer<SignedVoluntaryExit> consumer;
 
   public VoluntaryExitTopicHandler(
+      final AsyncRunner asyncRunner,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
       final VoluntaryExitValidator validator,
       final GossipedOperationConsumer<SignedVoluntaryExit> consumer) {
+    super(asyncRunner);
     this.gossipEncoding = gossipEncoding;
     this.forkDigest = forkInfo.getForkDigest();
     this.validator = validator;

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManagerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.AggregateAttestationTopicHandler;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipedOperationConsumer;
@@ -37,6 +38,7 @@ public class AggregateGossipManagerTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final SignedAggregateAndProofValidator validator =
       mock(SignedAggregateAndProofValidator.class);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final GossipNetwork gossipNetwork = mock(GossipNetwork.class);
   private final GossipEncoding gossipEncoding = GossipEncoding.SSZ_SNAPPY;
   private final TopicChannel topicChannel = mock(TopicChannel.class);
@@ -54,6 +56,7 @@ public class AggregateGossipManagerTest {
         .subscribe(contains(AggregateAttestationTopicHandler.TOPIC_NAME), any());
     gossipManager =
         new AggregateGossipManager(
+            asyncRunner,
             gossipNetwork,
             gossipEncoding,
             dataStructureUtil.randomForkInfo(),

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.util.CommitteeUtil;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.metrics.StubCounter;
 import tech.pegasys.teku.metrics.StubMetricsSystem;
@@ -58,8 +59,10 @@ public class AttestationGossipManagerTest {
   private final GossipEncoding gossipEncoding = GossipEncoding.SSZ_SNAPPY;
   private AttestationGossipManager attestationGossipManager;
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final AttestationSubnetSubscriptions attestationSubnetSubscriptions =
       new AttestationSubnetSubscriptions(
+          asyncRunner,
           gossipNetwork,
           gossipEncoding,
           attestationValidator,

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlockGossipManagerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.BlockTopicHandler;
 import tech.pegasys.teku.networking.eth2.gossip.topics.validation.BlockValidator;
@@ -39,6 +40,7 @@ public class BlockGossipManagerTest {
 
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final EventBus eventBus = new EventBus();
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final RecentChainData recentChainData = MemoryOnlyRecentChainData.create(eventBus);
   private final BlockValidator blockValidator =
       new BlockValidator(recentChainData, new StateTransition());
@@ -52,6 +54,7 @@ public class BlockGossipManagerTest {
         .when(gossipNetwork)
         .subscribe(contains(BlockTopicHandler.TOPIC_NAME), any());
     new BlockGossipManager(
+        asyncRunner,
         gossipNetwork,
         gossipEncoding,
         dataStructureUtil.randomForkInfo(),

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetSubscriptionsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetSubscriptionsTest.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.util.CommitteeUtil;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipedOperationConsumer;
 import tech.pegasys.teku.networking.eth2.gossip.topics.validation.AttestationValidator;
@@ -42,6 +43,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class AttestationSubnetSubscriptionsTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final RecentChainData recentChainData =
       MemoryOnlyRecentChainData.create(mock(EventBus.class));
   private final GossipNetwork gossipNetwork = mock(GossipNetwork.class);
@@ -58,6 +60,7 @@ public class AttestationSubnetSubscriptionsTest {
     BeaconChainUtil.create(0, recentChainData).initializeStorage();
     subnetSubscriptions =
         new AttestationSubnetSubscriptions(
+            asyncRunner,
             gossipNetwork,
             gossipEncoding,
             mock(AttestationValidator.class),

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AttesterSlashingTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AttesterSlashingTopicHandlerTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.validation.AttesterSlashingValidator;
 import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
@@ -45,6 +47,7 @@ public class AttesterSlashingTopicHandlerTest {
   private final GossipedOperationConsumer<AttesterSlashing> consumer =
       mock(GossipedOperationConsumer.class);
 
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final GossipEncoding gossipEncoding = GossipEncoding.SSZ_SNAPPY;
   private final RecentChainData recentChainData = MemoryOnlyRecentChainData.create(eventBus);
   private final BeaconChainUtil beaconChainUtil = BeaconChainUtil.create(5, recentChainData);
@@ -53,7 +56,7 @@ public class AttesterSlashingTopicHandlerTest {
 
   private AttesterSlashingTopicHandler topicHandler =
       new AttesterSlashingTopicHandler(
-          gossipEncoding, dataStructureUtil.randomForkInfo(), validator, consumer);
+          asyncRunner, gossipEncoding, dataStructureUtil.randomForkInfo(), validator, consumer);
 
   @BeforeEach
   public void setup() {
@@ -65,8 +68,9 @@ public class AttesterSlashingTopicHandlerTest {
     final AttesterSlashing slashing = dataStructureUtil.randomAttesterSlashing();
     when(validator.validate(slashing)).thenReturn(ACCEPT);
     Bytes serialized = gossipEncoding.encode(slashing);
-    final ValidationResult result = topicHandler.handleMessage(serialized).join();
-    assertThat(result).isEqualTo(ValidationResult.Valid);
+    final SafeFuture<ValidationResult> result = topicHandler.handleMessage(serialized);
+    asyncRunner.executeQueuedActions();
+    assertThat(result).isCompletedWithValue(ValidationResult.Valid);
     verify(consumer).forward(slashing);
   }
 
@@ -75,8 +79,9 @@ public class AttesterSlashingTopicHandlerTest {
     final AttesterSlashing slashing = dataStructureUtil.randomAttesterSlashing();
     when(validator.validate(slashing)).thenReturn(IGNORE);
     Bytes serialized = gossipEncoding.encode(slashing);
-    final ValidationResult result = topicHandler.handleMessage(serialized).join();
-    assertThat(result).isEqualTo(ValidationResult.Ignore);
+    final SafeFuture<ValidationResult> result = topicHandler.handleMessage(serialized);
+    asyncRunner.executeQueuedActions();
+    assertThat(result).isCompletedWithValue(ValidationResult.Ignore);
     verifyNoInteractions(consumer);
   }
 
@@ -85,8 +90,9 @@ public class AttesterSlashingTopicHandlerTest {
     final AttesterSlashing slashing = dataStructureUtil.randomAttesterSlashing();
     when(validator.validate(slashing)).thenReturn(REJECT);
     Bytes serialized = gossipEncoding.encode(slashing);
-    final ValidationResult result = topicHandler.handleMessage(serialized).join();
-    assertThat(result).isEqualTo(ValidationResult.Invalid);
+    final SafeFuture<ValidationResult> result = topicHandler.handleMessage(serialized);
+    asyncRunner.executeQueuedActions();
+    assertThat(result).isCompletedWithValue(ValidationResult.Invalid);
     verifyNoInteractions(consumer);
   }
 
@@ -94,8 +100,9 @@ public class AttesterSlashingTopicHandlerTest {
   public void handleMessage_invalidSSZ() {
     Bytes serialized = Bytes.fromHexString("0x1234");
 
-    final ValidationResult result = topicHandler.handleMessage(serialized).join();
-    assertThat(result).isEqualTo(ValidationResult.Invalid);
+    final SafeFuture<ValidationResult> result = topicHandler.handleMessage(serialized);
+    asyncRunner.executeQueuedActions();
+    assertThat(result).isCompletedWithValue(ValidationResult.Invalid);
     verifyNoInteractions(consumer);
   }
 
@@ -105,7 +112,8 @@ public class AttesterSlashingTopicHandlerTest {
     final ForkInfo forkInfo = mock(ForkInfo.class);
     when(forkInfo.getForkDigest()).thenReturn(forkDigest);
     final AttesterSlashingTopicHandler topicHandler =
-        new AttesterSlashingTopicHandler(gossipEncoding, forkInfo, validator, consumer);
+        new AttesterSlashingTopicHandler(
+            asyncRunner, gossipEncoding, forkInfo, validator, consumer);
     assertThat(topicHandler.getTopic()).isEqualTo("/eth2/11223344/attester_slashing/ssz_snappy");
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.validation.AttestationValidator;
 import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
@@ -55,11 +56,13 @@ public class SingleAttestationTopicHandlerTest {
   private final GossipedOperationConsumer<ValidateableAttestation> gossipedAttestationConsumer =
       mock(GossipedOperationConsumer.class);
 
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final RecentChainData recentChainData =
       MemoryOnlyRecentChainData.create(mock(EventBus.class));
   private final AttestationValidator attestationValidator = mock(AttestationValidator.class);
   private final SingleAttestationTopicHandler topicHandler =
       new tech.pegasys.teku.networking.eth2.gossip.topics.SingleAttestationTopicHandler(
+          asyncRunner,
           gossipEncoding,
           dataStructureUtil.randomForkInfo(),
           SUBNET_ID,
@@ -82,8 +85,9 @@ public class SingleAttestationTopicHandlerTest {
         .thenReturn(SafeFuture.completedFuture(ACCEPT));
     final Bytes serialized = gossipEncoding.encode(attestation.getAttestation());
 
-    final ValidationResult result = topicHandler.handleMessage(serialized).join();
-    assertThat(result).isEqualTo(ValidationResult.Valid);
+    final SafeFuture<ValidationResult> result = topicHandler.handleMessage(serialized);
+    asyncRunner.executeQueuedActions();
+    assertThat(result).isCompletedWithValue(ValidationResult.Valid);
     verify(gossipedAttestationConsumer).forward(attestation);
   }
 
@@ -98,8 +102,9 @@ public class SingleAttestationTopicHandlerTest {
         .thenReturn(SafeFuture.completedFuture(IGNORE));
     final Bytes serialized = gossipEncoding.encode(attestation.getAttestation());
 
-    final ValidationResult result = topicHandler.handleMessage(serialized).join();
-    assertThat(result).isEqualTo(ValidationResult.Ignore);
+    final SafeFuture<ValidationResult> result = topicHandler.handleMessage(serialized);
+    asyncRunner.executeQueuedActions();
+    assertThat(result).isCompletedWithValue(ValidationResult.Ignore);
     verify(gossipedAttestationConsumer, never()).forward(attestation);
   }
 
@@ -114,8 +119,9 @@ public class SingleAttestationTopicHandlerTest {
         .thenReturn(SafeFuture.completedFuture(SAVE_FOR_FUTURE));
     final Bytes serialized = gossipEncoding.encode(attestation.getAttestation());
 
-    final ValidationResult result = topicHandler.handleMessage(serialized).join();
-    assertThat(result).isEqualTo(ValidationResult.Ignore);
+    final SafeFuture<ValidationResult> result = topicHandler.handleMessage(serialized);
+    asyncRunner.executeQueuedActions();
+    assertThat(result).isCompletedWithValue(ValidationResult.Ignore);
     verify(gossipedAttestationConsumer).forward(attestation);
   }
 
@@ -130,8 +136,9 @@ public class SingleAttestationTopicHandlerTest {
         .thenReturn(SafeFuture.completedFuture(REJECT));
     final Bytes serialized = gossipEncoding.encode(attestation.getAttestation());
 
-    final ValidationResult result = topicHandler.handleMessage(serialized).join();
-    assertThat(result).isEqualTo(ValidationResult.Invalid);
+    final SafeFuture<ValidationResult> result = topicHandler.handleMessage(serialized);
+    asyncRunner.executeQueuedActions();
+    assertThat(result).isCompletedWithValue(ValidationResult.Invalid);
     verify(gossipedAttestationConsumer, never()).forward(attestation);
   }
 
@@ -139,8 +146,9 @@ public class SingleAttestationTopicHandlerTest {
   public void handleMessage_invalidAttestation_invalidSSZ() {
     final Bytes serialized = Bytes.fromHexString("0x3456");
 
-    final ValidationResult result = topicHandler.handleMessage(serialized).join();
-    assertThat(result).isEqualTo(ValidationResult.Invalid);
+    final SafeFuture<ValidationResult> result = topicHandler.handleMessage(serialized);
+    asyncRunner.executeQueuedActions();
+    assertThat(result).isCompletedWithValue(ValidationResult.Invalid);
   }
 
   @Test
@@ -150,7 +158,12 @@ public class SingleAttestationTopicHandlerTest {
     when(forkInfo.getForkDigest()).thenReturn(forkDigest);
     final SingleAttestationTopicHandler topicHandler =
         new SingleAttestationTopicHandler(
-            gossipEncoding, forkInfo, 0, attestationValidator, gossipedAttestationConsumer);
+            asyncRunner,
+            gossipEncoding,
+            forkInfo,
+            0,
+            attestationValidator,
+            gossipedAttestationConsumer);
     assertThat(topicHandler.getTopic()).isEqualTo("/eth2/11223344/beacon_attestation_0/ssz_snappy");
   }
 }

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
@@ -205,6 +205,7 @@ public class Eth2NetworkFactory {
                 config);
 
         return new ActiveEth2Network(
+            asyncRunner,
             metricsSystem,
             network,
             eth2PeerManager,


### PR DESCRIPTION
## PR Description
Move validation of gossip messages to an `AsyncRunner` instead of processing on the netty thread.

## Fixed Issue(s)
Simplest possible approach to #1947 but suspect we should revisit and use smarter queuing and deduplication.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.