### PR TITLE
Avoid accessing store each time metrics are retrieved

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
@@ -24,9 +24,9 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.datastructures.blocks.NodeSlot;
 import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.metrics.SettableGauge;
@@ -46,6 +46,12 @@ public class BeaconChainMetrics implements SlotEventsChannel {
   private final SettableGauge currentActiveValidators;
   private final SettableGauge previousActiveValidators;
   private final SettableGauge currentLiveValidators;
+  private final SettableGauge finalizedEpoch;
+  private final SettableGauge finalizedRoot;
+  private final SettableGauge currentJustifiedEpoch;
+  private final SettableGauge currentJustifiedRoot;
+  private final SettableGauge previousJustifiedEpoch;
+  private final SettableGauge previousJustifiedRoot;
 
   public BeaconChainMetrics(
       final RecentChainData recentChainData,
@@ -75,44 +81,44 @@ public class BeaconChainMetrics implements SlotEventsChannel {
         "head_root",
         "Root of the head block of the beacon chain",
         this::getHeadRootValue);
-
-    metricsSystem.createGauge(
-        TekuMetricCategory.BEACON,
-        "finalized_epoch",
-        "Current finalized epoch",
-        this::getFinalizedEpochValue);
-    metricsSystem.createGauge(
-        TekuMetricCategory.BEACON,
-        "finalized_root",
-        "Current finalized root",
-        this::getFinalizedRootValue);
-
-    metricsSystem.createGauge(
-        TekuMetricCategory.BEACON,
-        "current_justified_epoch",
-        "Current justified epoch",
-        this::getJustifiedEpochValue);
-    metricsSystem.createGauge(
-        TekuMetricCategory.BEACON,
-        "current_justified_root",
-        "Current justified root",
-        this::getJustifiedRootValue);
-
-    metricsSystem.createGauge(
-        TekuMetricCategory.BEACON,
-        "previous_justified_epoch",
-        "Current previously justified epoch",
-        this::getPreviousJustifiedEpochValue);
-    metricsSystem.createGauge(
-        TekuMetricCategory.BEACON,
-        "previous_justified_root",
-        "Current previously justified root",
-        this::getPreviousJustifiedRootValue);
     metricsSystem.createGauge(
         TekuMetricCategory.BEACON,
         "peer_count",
         "Tracks number of connected peers, verified to be on the same chain",
         p2pNetwork::getPeerCount);
+
+    finalizedEpoch =
+        SettableGauge.create(
+            metricsSystem, TekuMetricCategory.BEACON, "finalized_epoch", "Current finalized epoch");
+    finalizedRoot =
+        SettableGauge.create(
+            metricsSystem, TekuMetricCategory.BEACON, "finalized_root", "Current finalized root");
+
+    currentJustifiedEpoch =
+        SettableGauge.create(
+            metricsSystem,
+            TekuMetricCategory.BEACON,
+            "current_justified_epoch",
+            "Current justified epoch");
+    currentJustifiedRoot =
+        SettableGauge.create(
+            metricsSystem,
+            TekuMetricCategory.BEACON,
+            "current_justified_root",
+            "Current justified root");
+
+    previousJustifiedEpoch =
+        SettableGauge.create(
+            metricsSystem,
+            TekuMetricCategory.BEACON,
+            "previous_justified_epoch",
+            "Current previously justified epoch");
+    previousJustifiedRoot =
+        SettableGauge.create(
+            metricsSystem,
+            TekuMetricCategory.BEACON,
+            "previous_justified_root",
+            "Current previously justified root");
 
     previousLiveValidators =
         SettableGauge.create(
@@ -152,6 +158,18 @@ public class BeaconChainMetrics implements SlotEventsChannel {
     previousLiveValidators.set(getLiveValidators(state.getPrevious_epoch_attestations()));
     previousActiveValidators.set(
         get_active_validator_indices(state, get_previous_epoch(state)).size());
+
+    final Checkpoint finalizedCheckpoint = state.getFinalized_checkpoint();
+    finalizedEpoch.set(finalizedCheckpoint.getEpoch().longValue());
+    finalizedRoot.set(getLongFromRoot(finalizedCheckpoint.getRoot()));
+
+    final Checkpoint currentJustifiedCheckpoint = state.getCurrent_justified_checkpoint();
+    currentJustifiedEpoch.set(currentJustifiedCheckpoint.getEpoch().longValue());
+    currentJustifiedRoot.set(getLongFromRoot(currentJustifiedCheckpoint.getRoot()));
+
+    final Checkpoint previousJustifiedCheckpoint = state.getPrevious_justified_checkpoint();
+    previousJustifiedEpoch.set(previousJustifiedCheckpoint.getEpoch().longValue());
+    previousJustifiedRoot.set(getLongFromRoot(previousJustifiedCheckpoint.getRoot()));
   }
 
   private int getLiveValidators(final SSZList<PendingAttestation> attestations) {
@@ -186,68 +204,12 @@ public class BeaconChainMetrics implements SlotEventsChannel {
     return recentChainData.getHeadSlot().longValue();
   }
 
-  private long getFinalizedRootValue() {
-    Optional<BeaconBlockAndState> maybeBlockAndState = recentChainData.getHeadBlockAndState();
-    if (maybeBlockAndState.isPresent()) {
-      Bytes32 root = maybeBlockAndState.get().getState().getFinalized_checkpoint().getRoot();
-      return getLongFromRoot(root);
-    }
-    return 0L;
-  }
-
-  private long getPreviousJustifiedRootValue() {
-    Optional<BeaconBlockAndState> maybeBlockAndState = recentChainData.getHeadBlockAndState();
-    if (maybeBlockAndState.isPresent()) {
-      Bytes32 root =
-          maybeBlockAndState.get().getState().getPrevious_justified_checkpoint().getRoot();
-      return getLongFromRoot(root);
-    }
-    return 0L;
-  }
-
-  private long getJustifiedRootValue() {
-    Optional<BeaconBlockAndState> maybeBlockAndState = recentChainData.getHeadBlockAndState();
-    if (maybeBlockAndState.isPresent()) {
-      Bytes32 root =
-          maybeBlockAndState.get().getState().getCurrent_justified_checkpoint().getRoot();
-      return getLongFromRoot(root);
-    }
-    return 0L;
-  }
-
   private long getHeadRootValue() {
     if (recentChainData.isPreGenesis()) {
       return NOT_SET;
     }
     Optional<Bytes32> maybeBlockRoot = recentChainData.getBestBlockRoot();
     return maybeBlockRoot.map(BeaconChainMetrics::getLongFromRoot).orElse(0L);
-  }
-
-  private long getFinalizedEpochValue() {
-    if (recentChainData.isPreGenesis()) {
-      return NOT_SET;
-    }
-    return recentChainData.getFinalizedEpoch().longValue();
-  }
-
-  private long getJustifiedEpochValue() {
-    if (recentChainData.isPreGenesis()) {
-      return NOT_SET;
-    }
-    return recentChainData.getBestJustifiedEpoch().longValue();
-  }
-
-  private long getPreviousJustifiedEpochValue() {
-    Optional<BeaconBlockAndState> maybeBlockAndState = recentChainData.getHeadBlockAndState();
-    return maybeBlockAndState
-        .map(
-            beaconBlockAndState ->
-                beaconBlockAndState
-                    .getState()
-                    .getPrevious_justified_checkpoint()
-                    .getEpoch()
-                    .longValue())
-        .orElse(0L);
   }
 
   private long getCurrentEpochValue() {

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -29,7 +29,6 @@ import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.datastructures.blocks.NodeSlot;
 import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.datastructures.state.BeaconState;
@@ -55,9 +54,6 @@ class BeaconChainMetricsTest {
       Bytes32.fromHexString("0x760aa80a2c5cc1452a5301ecb176b366372d5f2218e0c24eFFFFFFFFFFFFFF7F");
   private final Bytes32 root3 =
       Bytes32.fromHexString("0x760aa80a2c5cc1452a5301ecb176b366372d5f2218e0c24e0000000000000080");
-  private final Checkpoint checkpoint = new Checkpoint(NODE_SLOT_VALUE, root);
-
-  private static final BeaconBlockAndState blockAndState = mock(BeaconBlockAndState.class);
   private final BeaconState randomState = dataStructureUtil.randomBeaconState();
   private final BeaconState state = mock(BeaconState.class);
 

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -81,11 +81,6 @@ class BeaconChainMetricsTest {
     when(state.getFinalized_checkpoint()).thenReturn(finalizedCheckpoint);
     when(state.getCurrent_justified_checkpoint()).thenReturn(currentJustifiedCheckpoint);
     when(state.getPrevious_justified_checkpoint()).thenReturn(previousJustifiedCheckpoint);
-    //
-    // when(state.getCurrent_epoch_attestations()).thenReturn(SSZList.empty(PendingAttestation.class));
-    //    when(state.getPrevious_epoch_attestations())
-    //        .thenReturn(SSZList.empty(PendingAttestation.class));
-    //    when(state.getSlot()).thenReturn(NODE_SLOT_VALUE);
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Avoid needing to take out a lock on the store, use `SettableGauge` and update the checkpoint metrics only at each slot boundary.  The other metrics all read from `chainHead` in `RecentChainData` which doesn't require a read lock.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.