### PR TITLE
Check latest peer status while syncing

### DIFF
--- a/sync/src/main/java/tech/pegasys/teku/sync/PeerSync.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/PeerSync.java
@@ -90,7 +90,7 @@ public class PeerSync {
 
     this.startingSlot = firstNonFinalSlot;
 
-    return executeSync(peer, peer.getStatus(), firstNonFinalSlot, SafeFuture.COMPLETE)
+    return executeSync(peer, firstNonFinalSlot, SafeFuture.COMPLETE)
         .whenComplete(
             (res, err) -> {
               if (err != null) {
@@ -107,14 +107,12 @@ public class PeerSync {
 
   @SuppressWarnings("FutureReturnValueIgnored")
   private SafeFuture<PeerSyncResult> executeSync(
-      final Eth2Peer peer,
-      final PeerStatus status,
-      final UInt64 startSlot,
-      final SafeFuture<Void> readyForRequest) {
+      final Eth2Peer peer, final UInt64 startSlot, final SafeFuture<Void> readyForRequest) {
     if (stopped.get()) {
       return SafeFuture.completedFuture(PeerSyncResult.CANCELLED);
     }
 
+    final PeerStatus status = peer.getStatus();
     final UInt64 count = calculateNumberOfBlocksToRequest(startSlot, status);
     if (count.longValue() == 0) {
       return completeSyncWithPeer(peer, status);
@@ -150,7 +148,7 @@ public class PeerSync {
                     peer.getId());
                 return SafeFuture.completedFuture(PeerSyncResult.EXCESSIVE_THROTTLING);
               }
-              return executeSync(peer, status, nextSlot, blockRequest.getReadyForNextRequest());
+              return executeSync(peer, nextSlot, blockRequest.getReadyForNextRequest());
             })
         .exceptionally(err -> handleFailedRequestToPeer(peer, err));
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
When syncing, pull the peer's latest status when determining whether to request more blocks.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.