### PR TITLE
Be more lenient before deciding a peer is excessively throttling requests

### DIFF
--- a/sync/src/main/java/tech/pegasys/teku/sync/PeerSync.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/PeerSync.java
@@ -49,10 +49,11 @@ public class PeerSync {
    * may be empty we check that we're progressing through slots, even if not many blocks are being
    * returned.
    */
-  private static final UInt64 MIN_SLOTS_TO_PROGRESS_PER_REQUEST = UInt64.valueOf(50);
+  static final UInt64 MIN_SLOTS_TO_PROGRESS_PER_REQUEST = UInt64.valueOf(50);
 
   private static final Logger LOG = LogManager.getLogger();
   private static final UInt64 STEP = UInt64.ONE;
+  static final int MAX_THROTTLED_REQUESTS = 10;
 
   private final AtomicBoolean stopped = new AtomicBoolean(false);
   private final RecentChainData storageClient;
@@ -150,7 +151,7 @@ public class PeerSync {
                     "Received {} consecutive excessively throttled response from {}",
                     throttledRequests,
                     peer.getId());
-                if (throttledRequests > 10) {
+                if (throttledRequests > MAX_THROTTLED_REQUESTS) {
                   LOG.debug(
                       "Rejecting peer {} as sync target because it excessively throttled returned blocks",
                       peer.getId());
@@ -224,8 +225,7 @@ public class PeerSync {
         .importBlock(block)
         .thenAccept(
             (result) -> {
-              LOG.trace(
-                  "Block import result for block at {}: {}", block.getMessage().getSlot(), result);
+              LOG.trace("Block import result for block at {}: {}", block.getSlot(), result);
               if (!result.isSuccessful()) {
                 this.blockImportFailureResult.inc();
                 throw new FailedBlockImportException(block, result);

--- a/sync/src/main/java/tech/pegasys/teku/sync/PeerSync.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/PeerSync.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -61,6 +62,7 @@ public class PeerSync {
   private final Counter blockImportSuccessResult;
   private final Counter blockImportFailureResult;
 
+  private final AtomicInteger throttledRequestCount = new AtomicInteger(0);
   private volatile UInt64 startingSlot = UInt64.valueOf(0);
 
   public PeerSync(
@@ -143,10 +145,19 @@ public class PeerSync {
                   nextSlot);
               if (count.compareTo(MIN_SLOTS_TO_PROGRESS_PER_REQUEST) > 0
                   && startSlot.plus(MIN_SLOTS_TO_PROGRESS_PER_REQUEST).compareTo(nextSlot) > 0) {
+                final int throttledRequests = throttledRequestCount.incrementAndGet();
                 LOG.debug(
-                    "Rejecting peer {} as sync target because it excessively throttled returned blocks",
+                    "Received {} consecutive excessively throttled response from {}",
+                    throttledRequests,
                     peer.getId());
-                return SafeFuture.completedFuture(PeerSyncResult.EXCESSIVE_THROTTLING);
+                if (throttledRequests > 10) {
+                  LOG.debug(
+                      "Rejecting peer {} as sync target because it excessively throttled returned blocks",
+                      peer.getId());
+                  return SafeFuture.completedFuture(PeerSyncResult.EXCESSIVE_THROTTLING);
+                }
+              } else {
+                throttledRequestCount.set(0);
               }
               return executeSync(peer, nextSlot, blockRequest.getReadyForNextRequest());
             })

--- a/sync/src/test/java/tech/pegasys/teku/sync/PeerSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/PeerSyncTest.java
@@ -17,11 +17,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,9 +33,9 @@ import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.OngoingStubbing;
 import tech.pegasys.teku.core.StateTransitionException;
 import tech.pegasys.teku.core.results.BlockImportResult;
 import tech.pegasys.teku.data.BlockProcessingRecord;
@@ -45,6 +48,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseStreamListener;
+import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -83,6 +87,7 @@ public class PeerSyncTest {
   public void setUp() {
     when(storageClient.getFinalizedEpoch()).thenReturn(UInt64.ZERO);
     when(peer.getStatus()).thenReturn(PEER_STATUS);
+    when(peer.getId()).thenReturn(new MockNodeId());
     // By default set up block import to succeed
     final BlockProcessingRecord processingRecord = mock(BlockProcessingRecord.class);
     final SignedBeaconBlock block = mock(SignedBeaconBlock.class);
@@ -406,18 +411,19 @@ public class PeerSyncTest {
   }
 
   @Test
-  @Disabled("Needs to be updated to throttle multiple requests")
   void sync_failSyncIfPeerThrottlesTooAggressively() {
     final UInt64 startSlot = UInt64.ONE;
-    UInt64 peerHeadSlot = Constants.MAX_BLOCK_BY_RANGE_REQUEST_SIZE.plus(startSlot);
+    UInt64 minPeerSlot = Constants.MAX_BLOCK_BY_RANGE_REQUEST_SIZE.plus(startSlot);
+    withPeerFinalizedEpoch(compute_epoch_at_slot(minPeerSlot));
 
-    withPeerHeadSlot(peerHeadSlot);
-
-    final SafeFuture<Void> requestFuture1 = new SafeFuture<>();
-    final SafeFuture<Void> requestFuture2 = new SafeFuture<>();
-    when(peer.requestBlocksByRange(any(), any(), any(), any()))
-        .thenReturn(requestFuture1)
-        .thenReturn(requestFuture2);
+    final List<SafeFuture<Void>> requestFutures = new ArrayList<>();
+    OngoingStubbing<SafeFuture<Void>> requestStub =
+        when(peer.requestBlocksByRange(any(), any(), any(), any()));
+    for (int i = 0; i < PeerSync.MAX_THROTTLED_REQUESTS + 1; i++) {
+      final SafeFuture<Void> future = new SafeFuture<>();
+      requestStub = requestStub.thenReturn(future);
+      requestFutures.add(future);
+    }
 
     final SafeFuture<PeerSyncResult> syncFuture = peerSync.sync(peer);
     assertThat(syncFuture).isNotDone();
@@ -429,10 +435,21 @@ public class PeerSyncTest {
             eq(UInt64.ONE),
             responseListenerArgumentCaptor.capture());
 
-    // Peer only returns a couple of blocks
-    final int lastReceivedBlockSlot = 3;
-    completeRequestWithBlockAtSlot(requestFuture1, lastReceivedBlockSlot);
+    // Peer only returns a couple of blocks for each request
+    int nextBlock = startSlot.intValue();
+    for (int i = 0; i < PeerSync.MAX_THROTTLED_REQUESTS; i++) {
+      completeRequestWithBlockAtSlot(requestFutures.get(i), nextBlock);
+      nextBlock += 1;
+    }
 
+    // We haven't hit our limit yet
+    assertThat(syncFuture).isNotDone();
+
+    // Next request hits our limit
+    final int lastRequestIndex = PeerSync.MAX_THROTTLED_REQUESTS;
+    completeRequestWithBlockAtSlot(requestFutures.get(lastRequestIndex), nextBlock + 2);
+
+    // We hit our limit
     assertThat(syncFuture).isCompletedWithValue(PeerSyncResult.EXCESSIVE_THROTTLING);
     // We don't disconnect the peer, the SyncManager just excludes the peer as a sync target for a
     // period
@@ -440,17 +457,22 @@ public class PeerSyncTest {
   }
 
   @Test
-  void sync_continueSyncIfPeerThrottlesAReasonableAmount() {
+  void sync_resetThrottlingLimit() {
     final UInt64 startSlot = UInt64.ONE;
-    UInt64 peerHeadSlot = UInt64.valueOf(1000000);
+    UInt64 minPeerSlot =
+        Constants.MAX_BLOCK_BY_RANGE_REQUEST_SIZE
+            .plus(startSlot)
+            .plus(PeerSync.MIN_SLOTS_TO_PROGRESS_PER_REQUEST);
+    withPeerFinalizedEpoch(compute_epoch_at_slot(minPeerSlot));
 
-    withPeerHeadSlot(peerHeadSlot);
-
-    final SafeFuture<Void> requestFuture1 = new SafeFuture<>();
-    final SafeFuture<Void> requestFuture2 = new SafeFuture<>();
-    when(peer.requestBlocksByRange(any(), any(), any(), any()))
-        .thenReturn(requestFuture1)
-        .thenReturn(requestFuture2);
+    final List<SafeFuture<Void>> requestFutures = new ArrayList<>();
+    OngoingStubbing<SafeFuture<Void>> requestStub =
+        when(peer.requestBlocksByRange(any(), any(), any(), any()));
+    for (int i = 0; i < PeerSync.MAX_THROTTLED_REQUESTS + 1; i++) {
+      final SafeFuture<Void> future = new SafeFuture<>();
+      requestStub = requestStub.thenReturn(future);
+      requestFutures.add(future);
+    }
 
     final SafeFuture<PeerSyncResult> syncFuture = peerSync.sync(peer);
     assertThat(syncFuture).isNotDone();
@@ -462,28 +484,41 @@ public class PeerSyncTest {
             eq(UInt64.ONE),
             responseListenerArgumentCaptor.capture());
 
-    // Peer only returns some blocks but not as many as were requested
-    final int lastReceivedBlockSlot = 70;
-    completeRequestWithBlockAtSlot(requestFuture1, lastReceivedBlockSlot);
+    // Peer only returns a couple of blocks for each request
+    int nextBlock = startSlot.intValue();
+    for (int i = 0; i < PeerSync.MAX_THROTTLED_REQUESTS; i++) {
+      completeRequestWithBlockAtSlot(requestFutures.get(i), nextBlock);
+      nextBlock += 1;
+    }
 
+    // We haven't hit our limit yet
     assertThat(syncFuture).isNotDone();
 
-    // Next request should start after the last received block
+    // Don't throttle the next request
+    final int lastRequestIndex = PeerSync.MAX_THROTTLED_REQUESTS;
+    nextBlock = nextBlock + PeerSync.MIN_SLOTS_TO_PROGRESS_PER_REQUEST.intValue();
+    completeRequestWithBlockAtSlot(requestFutures.get(lastRequestIndex), nextBlock);
+
+    // We should continue syncing
+    assertThat(syncFuture).isNotDone();
     verify(peer)
         .requestBlocksByRange(
-            eq(UInt64.valueOf(lastReceivedBlockSlot + 1)),
+            eq(UInt64.valueOf(nextBlock + 1)),
             eq(Constants.MAX_BLOCK_BY_RANGE_REQUEST_SIZE),
             eq(UInt64.ONE),
             any());
-
     verify(peer, never()).disconnectCleanly(any());
   }
 
   private void completeRequestWithBlockAtSlot(
       final SafeFuture<Void> requestFuture1, final int lastBlockSlot) {
-    final ResponseStreamListener<SignedBeaconBlock> responseListener1 =
+    // Capture latest response listener
+    verify(peer, atLeastOnce())
+        .requestBlocksByRange(any(), any(), any(), responseListenerArgumentCaptor.capture());
+    final ResponseStreamListener<SignedBeaconBlock> responseListener =
         responseListenerArgumentCaptor.getValue();
-    List<SignedBeaconBlock> blocks = respondWithBlocksAtSlots(responseListener1, 1, lastBlockSlot);
+
+    List<SignedBeaconBlock> blocks = respondWithBlocksAtSlots(responseListener, lastBlockSlot);
     for (SignedBeaconBlock block : blocks) {
       verify(blockImporter).importBlock(block);
     }
@@ -511,6 +546,21 @@ public class PeerSyncTest {
                 PEER_FINALIZED_EPOCH,
                 PEER_HEAD_BLOCK_ROOT,
                 peerHeadSlot));
+
+    when(peer.getStatus()).thenReturn(peer_status);
+  }
+
+  private void withPeerFinalizedEpoch(final UInt64 finalizedEpoch) {
+    final UInt64 headSlot =
+        compute_start_slot_at_epoch(finalizedEpoch).plus(2 * Constants.SLOTS_PER_EPOCH);
+    final PeerStatus peer_status =
+        PeerStatus.fromStatusMessage(
+            new StatusMessage(
+                Constants.GENESIS_FORK_VERSION,
+                Bytes32.ZERO,
+                finalizedEpoch,
+                PEER_HEAD_BLOCK_ROOT,
+                headSlot));
 
     when(peer.getStatus()).thenReturn(peer_status);
   }

--- a/sync/src/test/java/tech/pegasys/teku/sync/PeerSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/PeerSyncTest.java
@@ -30,6 +30,7 @@ import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.core.StateTransitionException;
@@ -405,6 +406,7 @@ public class PeerSyncTest {
   }
 
   @Test
+  @Disabled("Needs to be updated to throttle multiple requests")
   void sync_failSyncIfPeerThrottlesTooAggressively() {
     final UInt64 startSlot = UInt64.ONE;
     UInt64 peerHeadSlot = Constants.MAX_BLOCK_BY_RANGE_REQUEST_SIZE.plus(startSlot);


### PR DESCRIPTION
## PR Description
Previously a single request which didn't progress the chain by at least 50 blocks caused us to mark a peer as temporarily unsuitable as a sync target.  This could give false alarms during periods where a lot of validators were offline and leaving many sequential empty slots.  On Medalla this resulted in regularly restarting sync from the finalised slot and then abandoning the peer when we reached the gap in the chain.

Note, the test for detecting throttling has been disabled and will need to be updated to assert that disabling only happens after multiple responses.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.