### PR TITLE
Skip running fork choice if there is already a previous update still in progress

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -239,6 +239,15 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     finish(res -> onFinished.run(), err -> onFinished.run());
   }
 
+  public SafeFuture<T> alwaysRun(final Runnable action) {
+    return exceptionallyCompose(
+            error -> {
+              action.run();
+              return failedFuture(error);
+            })
+        .thenPeek(value -> action.run());
+  }
+
   public void finish(final Consumer<T> onSuccess, final Consumer<Throwable> onError) {
     handle(
             (result, error) -> {

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
@@ -95,11 +95,11 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
   public void shouldRespondWithBlocksFromCanonicalChain() throws Exception {
     final SignedBeaconBlock block1 = beaconChainUtil.createAndImportBlockAtSlot(1);
     final Bytes32 block1Root = block1.getMessage().hash_tree_root();
-    recentChainData1.updateHead(block1Root, block1.getSlot());
+    updateHead(block1, block1Root);
 
     final SignedBeaconBlock block2 = beaconChainUtil.createAndImportBlockAtSlot(2);
     final Bytes32 block2Root = block2.getMessage().hash_tree_root();
-    recentChainData1.updateHead(block2Root, block2.getSlot());
+    updateHead(block2, block2Root);
 
     final List<SignedBeaconBlock> response = requestBlocks();
     assertThat(response).containsExactly(block1, block2);
@@ -111,7 +111,7 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
     beaconChainUtil.createAndImportBlockAtSlot(1);
     final SignedBeaconBlock block2 = beaconChainUtil.createAndImportBlockAtSlot(2);
     final Bytes32 block2Root = block2.getMessage().hash_tree_root();
-    recentChainData1.updateHead(block2Root, block2.getSlot());
+    updateHead(block2, block2Root);
 
     peer1.disconnectImmediately(Optional.empty(), false);
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
@@ -131,7 +131,7 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
     beaconChainUtil.createAndImportBlockAtSlot(1);
     final SignedBeaconBlock block2 = beaconChainUtil.createAndImportBlockAtSlot(2);
     final Bytes32 block2Root = block2.getMessage().hash_tree_root();
-    recentChainData1.updateHead(block2Root, block2.getSlot());
+    updateHead(block2, block2Root);
 
     peer1.disconnectCleanly(DisconnectReason.TOO_MANY_PEERS);
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
@@ -151,7 +151,7 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
     beaconChainUtil.createAndImportBlockAtSlot(1);
     final SignedBeaconBlock block2 = beaconChainUtil.createAndImportBlockAtSlot(2);
     final Bytes32 block2Root = block2.getMessage().hash_tree_root();
-    recentChainData1.updateHead(block2Root, block2.getSlot());
+    updateHead(block2, block2Root);
 
     peer1.disconnectImmediately(Optional.empty(), false);
     final SafeFuture<SignedBeaconBlock> res = peer1.requestBlockBySlot(UInt64.ONE);
@@ -167,7 +167,7 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
     beaconChainUtil.createAndImportBlockAtSlot(1);
     final SignedBeaconBlock block2 = beaconChainUtil.createAndImportBlockAtSlot(2);
     final Bytes32 block2Root = block2.getMessage().hash_tree_root();
-    recentChainData1.updateHead(block2Root, block2.getSlot());
+    updateHead(block2, block2Root);
 
     peer1.disconnectCleanly(DisconnectReason.TOO_MANY_PEERS);
     final SafeFuture<SignedBeaconBlock> res = peer1.requestBlockBySlot(UInt64.ONE);
@@ -185,6 +185,10 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
         peer1.requestBlocksByRange(
             UInt64.ONE, UInt64.valueOf(10), UInt64.ONE, ResponseStreamListener.from(blocks::add)));
     return blocks;
+  }
+
+  private void updateHead(final SignedBeaconBlock block1, final Bytes32 block1Root) {
+    assertThat(recentChainData1.updateHead(block1Root, block1.getSlot())).isCompleted();
   }
 
   public static class BeaconBlocksByRangeIntegrationTest_ssz

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -86,7 +86,7 @@ public class ChainUpdater {
   public void updateBestBlock(final SignedBlockAndState bestBlock) {
     saveBlock(bestBlock);
 
-    recentChainData.updateHead(bestBlock.getRoot(), bestBlock.getSlot());
+    assertThat(recentChainData.updateHead(bestBlock.getRoot(), bestBlock.getSlot())).isCompleted();
   }
 
   public SignedBlockAndState advanceChain() {


### PR DESCRIPTION
## PR Description
Currently we run fork choice and then may fail to actually apply the new chain head because a new change comes in while we were regenerating the state.  Instead if we're still waiting for a previous result to apply, skip running fork choice entirely.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.