### PR TITLE
Check if a checkpoint state is available from cache before regenerating

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -465,9 +465,14 @@ class Store implements UpdatableStore {
     if (latestStateAtEpoch.getSlot().isGreaterThan(checkpoint.getEpochStartSlot())) {
       throw new IllegalArgumentException("Latest state must be at or prior to checkpoint slot");
     }
-    final BeaconState checkpointState = regenerateCheckpointState(checkpoint, latestStateAtEpoch);
-    putCheckpointState(checkpoint, checkpointState);
-    return checkpointState;
+    return getCheckpointStateIfAvailable(checkpoint)
+        .orElseGet(
+            () -> {
+              final BeaconState checkpointState =
+                  regenerateCheckpointState(checkpoint, latestStateAtEpoch);
+              putCheckpointState(checkpoint, checkpointState);
+              return checkpointState;
+            });
   }
 
   private Optional<BeaconState> getCheckpointStateIfAvailable(final Checkpoint checkpoint) {


### PR DESCRIPTION

## PR Description
`Store.getCheckpointState` wasn't checking if the state was already in cache before processing slots even though it then stored the result in the cache.

This is the simplest possible change to reduce CPU usage for gossiped attestation.  Will likely need to deduplicate requests as well but can do that in a follow up.

## Fixed Issue(s)
Part of #2598 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.