### PR TITLE
Ensure votes map is only accessed within the read/write lock

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.core.lookup.BlockProvider.fromMap;
 
 import com.google.common.collect.Sets;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -140,7 +141,7 @@ class Store implements UpdatableStore {
     this.blocks = blocks;
     this.block_states = block_states;
     this.checkpoint_states = checkpoint_states;
-    this.votes = new ConcurrentHashMap<>(votes);
+    this.votes = new HashMap<>(votes);
     this.blockTree = blockTree;
 
     // Track latest finalized block
@@ -509,7 +510,16 @@ class Store implements UpdatableStore {
   public Set<UInt64> getVotedValidatorIndices() {
     readLock.lock();
     try {
-      return votes.keySet();
+      return new HashSet<>(votes.keySet());
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  private VoteTracker getVote(UInt64 validatorIndex) {
+    readLock.lock();
+    try {
+      return votes.get(validatorIndex);
     } finally {
       readLock.unlock();
     }
@@ -706,7 +716,7 @@ class Store implements UpdatableStore {
     public VoteTracker getVote(UInt64 validatorIndex) {
       VoteTracker vote = votes.get(validatorIndex);
       if (vote == null) {
-        vote = Store.this.votes.get(validatorIndex);
+        vote = Store.this.getVote(validatorIndex);
         if (vote == null) {
           vote = VoteTracker.Default();
         } else {


### PR DESCRIPTION
## PR Description
The Store.votes map was setup as a `ConcurrentHashMap` and then accessed without using the read/write lock.  However this doesn't ensure there's a consistent view of the data, especially when iterating the voted validator indices.

Make it a normal `HashMap` and ensure all access is within a read lock.

## Fixed Issue(s)
Part of #2562

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.