### PR TITLE
Revert "Use multiple threads to service ValidatorApiChannel"

### DIFF
--- a/events/src/main/java/tech/pegasys/teku/events/DirectEventDeliverer.java
+++ b/events/src/main/java/tech/pegasys/teku/events/DirectEventDeliverer.java
@@ -24,7 +24,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
 class DirectEventDeliverer<T> extends EventDeliverer<T> {
-  protected final ChannelExceptionHandler exceptionHandler;
+  private final ChannelExceptionHandler exceptionHandler;
   private final LabelledMetric<Counter> consumedEventCounter;
   private final LabelledMetric<Counter> failedEventCounter;
 

--- a/events/src/main/java/tech/pegasys/teku/events/EventChannels.java
+++ b/events/src/main/java/tech/pegasys/teku/events/EventChannels.java
@@ -67,8 +67,8 @@ public class EventChannels {
    *
    * <p>Any methods which return a future, will complete that future via {@code responseRunner}. As
    * a result, any handlers chained to the returned future via methods like {@link
-   * tech.pegasys.teku.infrastructure.async.SafeFuture#thenApply(Function)} will be executed on one
-   * of {@code responseRunner}'s threads.
+   * tech.pegasys.teku.util.async.SafeFuture#thenApply(Function)} will be executed on one of {@code
+   * responseRunner}'s threads.
    *
    * @param channelInterface the interface defining the channel
    * @param responseRunner the {@link AsyncRunner} to use when completing any returned futures
@@ -82,8 +82,7 @@ public class EventChannels {
 
   public <T extends ChannelInterface> EventChannels subscribe(
       final Class<T> channelInterface, final T subscriber) {
-    getChannel(channelInterface).subscribe(subscriber);
-    return this;
+    return subscribeMultithreaded(channelInterface, subscriber, 1);
   }
 
   /**
@@ -93,15 +92,15 @@ public class EventChannels {
    * always use the publisher thread to process events.
    *
    * <p>Events are still placed into an ordered queue and started in order, but as multiple threads
-   * are used for execution, the execution order can no longer be guaranteed.
+   * pull from the queue, the execution order can no longer be guaranteed.
    *
    * @param channelInterface the channel to subscribe to
    * @param subscriber the subscriber to notify of events
-   * @param asyncRunner the runner to use to execute tasks
+   * @param requestedParallelism the number of threads to use to process events
    */
   public <T extends ChannelInterface> EventChannels subscribeMultithreaded(
-      final Class<T> channelInterface, final T subscriber, final AsyncRunner asyncRunner) {
-    getChannel(channelInterface).subscribeMultithreaded(subscriber, asyncRunner);
+      final Class<T> channelInterface, final T subscriber, final int requestedParallelism) {
+    getChannel(channelInterface).subscribeMultithreaded(subscriber, requestedParallelism);
     return this;
   }
 

--- a/events/src/main/java/tech/pegasys/teku/events/EventDeliverer.java
+++ b/events/src/main/java/tech/pegasys/teku/events/EventDeliverer.java
@@ -37,11 +37,7 @@ abstract class EventDeliverer<T> {
             "channel");
   }
 
-  void subscribe(final T subscriber, final AsyncRunner asyncRunner) {
-    subscribe(subscriber);
-  }
-
-  void subscribe(final T subscriber) {
+  void subscribe(final T subscriber, final int numberOfThreads) {
     subscribers.subscribe(subscriber);
   }
 

--- a/events/src/test/java/tech/pegasys/teku/events/EventChannelTest.java
+++ b/events/src/test/java/tech/pegasys/teku/events/EventChannelTest.java
@@ -36,10 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import tech.pegasys.teku.events.AsyncEventDeliverer.QueueReader;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
-import tech.pegasys.teku.infrastructure.async.MetricTrackingExecutorFactory;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.async.ScheduledExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 
 class EventChannelTest {
@@ -47,15 +44,11 @@ class EventChannelTest {
   private final ChannelExceptionHandler exceptionHandler = mock(ChannelExceptionHandler.class);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private ExecutorService executor;
-  private AsyncRunner realAsyncRunner;
 
   @AfterEach
   public void tearDown() {
     if (executor != null) {
       executor.shutdownNow();
-    }
-    if (realAsyncRunner != null) {
-      realAsyncRunner.shutdown();
     }
   }
 
@@ -230,12 +223,7 @@ class EventChannelTest {
             throw new RuntimeException(e);
           }
         };
-
-    // Two subscribing threads
-    realAsyncRunner =
-        ScheduledExecutorAsyncRunner.create(
-            EventChannelTest.class.getName(), 2, new MetricTrackingExecutorFactory(metricsSystem));
-    channel.subscribeMultithreaded(subscriber, realAsyncRunner);
+    channel.subscribeMultithreaded(subscriber, 2); // Two subscribing threads
 
     final CountDownLatch started1 = new CountDownLatch(1);
     final CountDownLatch await1 = new CountDownLatch(1);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -335,7 +335,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             DutyMetrics.create(metricsSystem, timeProvider, recentChainData));
     eventChannels
         .subscribe(SlotEventsChannel.class, attestationTopicSubscriber)
-        .subscribeMultithreaded(ValidatorApiChannel.class, validatorApiHandler, asyncRunner);
+        .subscribe(ValidatorApiChannel.class, validatorApiHandler);
   }
 
   private void initGenesisHandler() {

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.services.chainstorage;
 
 import static tech.pegasys.teku.util.config.Constants.STORAGE_QUERY_CHANNEL_PARALLELISM;
 
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.pow.api.Eth1EventsChannel;
 import tech.pegasys.teku.protoarray.ProtoArrayStorageChannel;
@@ -62,8 +61,6 @@ public class StorageService extends Service {
                   serviceConfig.getConfig().isEth1DepositsFromStorageEnabled());
           protoArrayStorage = new ProtoArrayStorage(database);
 
-          final AsyncRunner storageQueryAsyncRunner =
-              serviceConfig.createAsyncRunner("storageQuery", STORAGE_QUERY_CHANNEL_PARALLELISM);
           serviceConfig
               .getEventChannels()
               .subscribe(Eth1DepositStorageChannel.class, depositStorage)
@@ -71,7 +68,7 @@ public class StorageService extends Service {
               .subscribe(StorageUpdateChannel.class, chainStorage)
               .subscribe(ProtoArrayStorageChannel.class, protoArrayStorage)
               .subscribeMultithreaded(
-                  StorageQueryChannel.class, chainStorage, storageQueryAsyncRunner);
+                  StorageQueryChannel.class, chainStorage, STORAGE_QUERY_CHANNEL_PARALLELISM);
 
           chainStorage.start();
         });


### PR DESCRIPTION
Reverts PegaSysEng/teku#2572

Looks like our medalla nodes running many validators are struggling with this change.