### PR TITLE
Added remote validator service to ServiceController

### DIFF
--- a/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/BeaconChainEvent.java
+++ b/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/BeaconChainEvent.java
@@ -16,13 +16,13 @@ package tech.pegasys.teku.services.remotevalidator;
 import java.util.Objects;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class BeaconChainEvent {
+class BeaconChainEvent {
 
-  public static final String ATTESTATION = "BroadcastAttestationEvent";
-  public static final String AGGREGATION = "BroadcastAggregatesEvent";
-  public static final String IMPORTED_BLOCK = "ImportedBlockEvent";
-  public static final String ON_SLOT = "OnSlotEvent";
-  public static final String REORG_OCCURRED = "ReorgOccurredEvent";
+  static final String ATTESTATION = "BroadcastAttestationEvent";
+  static final String AGGREGATION = "BroadcastAggregatesEvent";
+  static final String IMPORTED_BLOCK = "ImportedBlockEvent";
+  static final String ON_SLOT = "OnSlotEvent";
+  static final String REORG_OCCURRED = "ReorgOccurredEvent";
 
   private String name;
   private UInt64 data;

--- a/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/BeaconChainEventsListener.java
+++ b/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/BeaconChainEventsListener.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.services.remotevalidator;
 
 @FunctionalInterface
-public interface BeaconChainEventsListener {
+interface BeaconChainEventsListener {
 
   void onEvent(BeaconChainEvent event);
 }

--- a/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorApi.java
+++ b/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorApi.java
@@ -28,7 +28,7 @@ import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.services.remotevalidator.RemoteValidatorSubscriptions.SubscriptionStatus;
 import tech.pegasys.teku.util.config.TekuConfiguration;
 
-public class RemoteValidatorApi {
+class RemoteValidatorApi {
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -36,7 +36,7 @@ public class RemoteValidatorApi {
   private final Javalin app;
   private final JsonProvider jsonProvider = new JsonProvider();
 
-  public RemoteValidatorApi(
+  RemoteValidatorApi(
       final TekuConfiguration configuration,
       final RemoteValidatorSubscriptions subscriptionManager) {
     checkNotNull(configuration, "TekuConfiguration can't be null");
@@ -102,11 +102,11 @@ public class RemoteValidatorApi {
     subscriptionManager.unsubscribe(handler.getSessionId());
   }
 
-  public void start() {
+  void start() {
     app.start();
   }
 
-  public void stop() {
+  void stop() {
     app.stop();
   }
 }

--- a/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorBeaconChainEventsAdapter.java
+++ b/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorBeaconChainEventsAdapter.java
@@ -25,13 +25,12 @@ import tech.pegasys.teku.statetransition.events.block.ImportedBlockEvent;
 import tech.pegasys.teku.storage.api.ReorgEventChannel;
 import tech.pegasys.teku.util.time.channels.SlotEventsChannel;
 
-public class RemoteValidatorBeaconChainEventsAdapter
-    implements SlotEventsChannel, ReorgEventChannel {
+class RemoteValidatorBeaconChainEventsAdapter implements SlotEventsChannel, ReorgEventChannel {
 
   private final ServiceConfig config;
   private final BeaconChainEventsListener listener;
 
-  public RemoteValidatorBeaconChainEventsAdapter(
+  RemoteValidatorBeaconChainEventsAdapter(
       final ServiceConfig config, final BeaconChainEventsListener listener) {
     checkNotNull(config, "ServiceConfig can't be null");
     checkNotNull(listener, "BeaconChainEventsListener can't be null");

--- a/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorMetrics.java
+++ b/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorMetrics.java
@@ -17,7 +17,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.metrics.SettableGauge;
 import tech.pegasys.teku.metrics.TekuMetricCategory;
 
-public class RemoteValidatorMetrics {
+class RemoteValidatorMetrics {
 
   private final SettableGauge connectedValidatorsGauge;
 
@@ -30,7 +30,7 @@ public class RemoteValidatorMetrics {
             "Number of validator nodes connected to the Remote Validator Service");
   }
 
-  public void updateConnectedValidators(final int value) {
+  void updateConnectedValidators(final int value) {
     connectedValidatorsGauge.set(value);
   }
 }

--- a/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorSubscriptions.java
+++ b/services/remote-validator/src/main/java/tech/pegasys/teku/services/remotevalidator/RemoteValidatorSubscriptions.java
@@ -20,14 +20,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import tech.pegasys.teku.util.config.TekuConfiguration;
 
-public class RemoteValidatorSubscriptions implements BeaconChainEventsListener {
+class RemoteValidatorSubscriptions implements BeaconChainEventsListener {
 
   private final int maxSubscribers;
   private final RemoteValidatorMetrics metrics;
 
   private final Map<String, Consumer<BeaconChainEvent>> subscriptions = new ConcurrentHashMap<>();
 
-  public RemoteValidatorSubscriptions(
+  RemoteValidatorSubscriptions(
       final TekuConfiguration configuration, final RemoteValidatorMetrics metrics) {
     checkNotNull(configuration, "TekuConfiguration can't be null");
     checkNotNull(metrics, "RemoteValidatorMetrics can't be null");
@@ -85,11 +85,11 @@ public class RemoteValidatorSubscriptions implements BeaconChainEventsListener {
       this.info = info;
     }
 
-    public boolean hasSubscribed() {
+    boolean hasSubscribed() {
       return hasSubscribed;
     }
 
-    public String getInfo() {
+    String getInfo() {
       return info;
     }
   }

--- a/teku/build.gradle
+++ b/teku/build.gradle
@@ -15,6 +15,7 @@ dependencies {
   implementation project(':services:beaconchain')
   implementation project(':services:chainstorage')
   implementation project(':services:powchain')
+  implementation project(':services:remote-validator')
   implementation project(':services:serviceutils')
   implementation project(':services:timer')
   implementation project(':storage')

--- a/teku/src/main/java/tech/pegasys/teku/services/ServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/ServiceController.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.services.beaconchain.BeaconChainService;
 import tech.pegasys.teku.services.chainstorage.StorageService;
 import tech.pegasys.teku.services.powchain.PowchainService;
+import tech.pegasys.teku.services.remotevalidator.RemoteValidatorService;
 import tech.pegasys.teku.services.timer.TimerService;
 import tech.pegasys.teku.validator.client.ValidatorClientService;
 
@@ -33,7 +34,11 @@ public class ServiceController extends Service {
     // Note services will be started in the order they are added here.
     services.add(new StorageService(config));
     services.add(new BeaconChainService(config));
-    services.add(ValidatorClientService.create(config));
+    if (config.getConfig().isRemoteValidatorApiEnabled()) {
+      services.add(new RemoteValidatorService(config));
+    } else {
+      services.add(ValidatorClientService.create(config));
+    }
     services.add(new TimerService(config));
     if (!config.getConfig().isInteropEnabled() && config.getConfig().isEth1Enabled()) {
       services.add(new PowchainService(config));


### PR DESCRIPTION
## PR Description
- Added Remote Validator service to `ServiceController`.
- If BeaconNode is started with option `--Xremote-validator-api-enabled`, we start a `RemoteValidatorService` and not a `ValidatorClientService` instance.
- Reduced visibility in some internal remove validator classes

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.