### PR TITLE
Process attestations received in blocks while syncing

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/operations/OperationsTestExecutor.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.reference.phase0.TestDataUtils.loadStateFromSsz;
 import com.google.common.collect.ImmutableMap;
 import tech.pegasys.teku.core.BlockProcessorUtil;
 import tech.pegasys.teku.core.exceptions.BlockProcessingException;
+import tech.pegasys.teku.core.lookup.IndexedAttestationProvider;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.operations.AttesterSlashing;
@@ -78,7 +79,10 @@ public class OperationsTestExecutor<T> implements TestExecutor {
                   "attestation.ssz",
                   Attestation.class,
                   (state, data) ->
-                      BlockProcessorUtil.process_attestations(state, SSZList.singleton(data))))
+                      BlockProcessorUtil.process_attestations(
+                          state,
+                          SSZList.singleton(data),
+                          IndexedAttestationProvider.DIRECT_PROVIDER)))
           .build();
 
   private final String dataFileName;

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -230,7 +230,9 @@ public class ForkChoiceUtil {
 
     // Check the block is valid and compute the post-state
     try {
-      state = st.initiate(preState, signed_block, true, beaconStateConsumer, indexedAttestationProvider);
+      state =
+          st.initiate(
+              preState, signed_block, true, beaconStateConsumer, indexedAttestationProvider);
     } catch (StateTransitionException e) {
       return BlockImportResult.failedStateTransition(e);
     }

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -32,6 +32,7 @@ import javax.annotation.CheckReturnValue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.core.lookup.IndexedAttestationProvider;
 import tech.pegasys.teku.core.results.BlockImportResult;
 import tech.pegasys.teku.data.BlockProcessingRecord;
 import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
@@ -212,7 +213,8 @@ public class ForkChoiceUtil {
       Optional<BeaconState> maybePreState,
       final StateTransition st,
       final ForkChoiceStrategy forkChoiceStrategy,
-      final Consumer<BeaconState> beaconStateConsumer) {
+      final Consumer<BeaconState> beaconStateConsumer,
+      final IndexedAttestationProvider indexedAttestationProvider) {
     final BeaconBlock block = signed_block.getMessage();
 
     // Return early if precondition checks fail;
@@ -228,7 +230,7 @@ public class ForkChoiceUtil {
 
     // Check the block is valid and compute the post-state
     try {
-      state = st.initiate(preState, signed_block, true, beaconStateConsumer);
+      state = st.initiate(preState, signed_block, true, beaconStateConsumer, indexedAttestationProvider);
     } catch (StateTransitionException e) {
       return BlockImportResult.failedStateTransition(e);
     }

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/blockvalidator/BlockValidator.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/blockvalidator/BlockValidator.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.core.blockvalidator;
 
+import tech.pegasys.teku.core.lookup.IndexedAttestationProvider;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -62,9 +63,13 @@ public interface BlockValidator {
    *     information (randao history) to recover committees for the block slot, attestations slots,
    *     etc
    * @param block Block to be validated
+   * @param indexedAttestationProvider the provider to use to calculate indexed attestations
    * @return Result promise
    */
-  SafeFuture<BlockValidationResult> validatePreState(BeaconState preState, SignedBeaconBlock block);
+  SafeFuture<BlockValidationResult> validatePreState(
+      BeaconState preState,
+      SignedBeaconBlock block,
+      IndexedAttestationProvider indexedAttestationProvider);
 
   /**
    * Validates the block against the state after block processing
@@ -80,12 +85,16 @@ public interface BlockValidator {
       BeaconState postState, SignedBeaconBlock block);
 
   /**
-   * Combines {@link #validatePreState(BeaconState, SignedBeaconBlock)} and {@link
-   * #validatePostState(BeaconState, SignedBeaconBlock)}
+   * Combines {@link #validatePreState(BeaconState, SignedBeaconBlock, IndexedAttestationProvider)}
+   * and {@link #validatePostState(BeaconState, SignedBeaconBlock)}
    */
   default SafeFuture<BlockValidationResult> validate(
-      BeaconState preState, SignedBeaconBlock block, BeaconState postState) {
-    SafeFuture<BlockValidationResult> preFut = validatePreState(preState, block);
+      BeaconState preState,
+      SignedBeaconBlock block,
+      BeaconState postState,
+      IndexedAttestationProvider indexedAttestationProvider) {
+    SafeFuture<BlockValidationResult> preFut =
+        validatePreState(preState, block, indexedAttestationProvider);
     SafeFuture<BlockValidationResult> postFut = validatePostState(postState, block);
     return preFut.thenCombine(postFut, (pre, post) -> !pre.isValid() ? pre : post);
   }

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/blockvalidator/NoOpBlockValidator.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/blockvalidator/NoOpBlockValidator.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.core.blockvalidator;
 
+import tech.pegasys.teku.core.lookup.IndexedAttestationProvider;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -21,7 +22,9 @@ public class NoOpBlockValidator implements BlockValidator {
 
   @Override
   public SafeFuture<BlockValidationResult> validatePreState(
-      BeaconState preState, SignedBeaconBlock block) {
+      BeaconState preState,
+      SignedBeaconBlock block,
+      IndexedAttestationProvider indexedAttestationProvider) {
     return SafeFuture.completedFuture(new BlockValidationResult(true));
   }
 

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/blockvalidator/SimpleBlockValidator.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/blockvalidator/SimpleBlockValidator.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.bls.BLSSignatureVerifier.InvalidSignatureException;
 import tech.pegasys.teku.core.BlockProcessorUtil;
 import tech.pegasys.teku.core.StateTransitionException;
 import tech.pegasys.teku.core.exceptions.BlockProcessingException;
+import tech.pegasys.teku.core.lookup.IndexedAttestationProvider;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlockBody;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
@@ -66,7 +67,9 @@ public class SimpleBlockValidator implements BlockValidator {
 
   @Override
   public SafeFuture<BlockValidationResult> validatePreState(
-      BeaconState preState, SignedBeaconBlock block) {
+      BeaconState preState,
+      SignedBeaconBlock block,
+      IndexedAttestationProvider indexedAttestationProvider) {
     try {
       if (verifyBlockSignature) {
         verify_block_signature(preState, block);
@@ -76,7 +79,7 @@ public class SimpleBlockValidator implements BlockValidator {
         BeaconBlock blockMessage = block.getMessage();
         BeaconBlockBody blockBody = blockMessage.getBody();
         BlockProcessorUtil.verify_attestations(
-            preState, blockBody.getAttestations(), signatureVerifier);
+            preState, blockBody.getAttestations(), signatureVerifier, indexedAttestationProvider);
         BlockProcessorUtil.verify_randao(preState, blockMessage, signatureVerifier);
 
         if (!BlockProcessorUtil.verify_proposer_slashings(

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/lookup/CachingIndexedAttestationProvider.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/lookup/CachingIndexedAttestationProvider.java
@@ -1,0 +1,23 @@
+package tech.pegasys.teku.core.lookup;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+
+public class CachingIndexedAttestationProvider implements IndexedAttestationProvider {
+  private final Map<Attestation, IndexedAttestation> indexedAttestations = new HashMap<>();
+
+  @Override
+  public IndexedAttestation getIndexedAttestation(
+      final BeaconState state, final Attestation attestation) {
+    return indexedAttestations.computeIfAbsent(
+        attestation, key -> DIRECT_PROVIDER.getIndexedAttestation(state, attestation));
+  }
+
+  public Collection<IndexedAttestation> getIndexedAttestations() {
+    return indexedAttestations.values();
+  }
+}

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/lookup/CachingIndexedAttestationProvider.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/lookup/CachingIndexedAttestationProvider.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.core.lookup;
 
 import java.util.Collection;

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/lookup/CapturingIndexedAttestationProvider.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/lookup/CapturingIndexedAttestationProvider.java
@@ -20,7 +20,7 @@ import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.operations.IndexedAttestation;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 
-public class CachingIndexedAttestationProvider implements IndexedAttestationProvider {
+public class CapturingIndexedAttestationProvider implements IndexedAttestationProvider {
   private final Map<Attestation, IndexedAttestation> indexedAttestations = new HashMap<>();
 
   @Override

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/lookup/IndexedAttestationProvider.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/lookup/IndexedAttestationProvider.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.core.lookup;
 
 import tech.pegasys.teku.datastructures.operations.Attestation;

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/lookup/IndexedAttestationProvider.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/lookup/IndexedAttestationProvider.java
@@ -1,0 +1,13 @@
+package tech.pegasys.teku.core.lookup;
+
+import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.util.AttestationUtil;
+
+@FunctionalInterface
+public interface IndexedAttestationProvider {
+  IndexedAttestationProvider DIRECT_PROVIDER = AttestationUtil::get_indexed_attestation;
+
+  IndexedAttestation getIndexedAttestation(BeaconState state, Attestation attestation);
+}

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/lookup/CapturingIndexedAttestationProviderTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/lookup/CapturingIndexedAttestationProviderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.core.lookup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.core.ChainBuilder;
+import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.util.AttestationUtil;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+class CapturingIndexedAttestationProviderTest {
+
+  private final ChainBuilder chainBuilder = ChainBuilder.createDefault();
+
+  @BeforeEach
+  void setUp() {
+    chainBuilder.generateGenesis();
+  }
+
+  @Test
+  void shouldStoreCreatedIndexedAttestations() {
+    final CapturingIndexedAttestationProvider provider = new CapturingIndexedAttestationProvider();
+    final BeaconState state = chainBuilder.getStateAtSlot(0);
+    final List<Attestation> attestations =
+        chainBuilder
+            .streamValidAttestationsForBlockAtSlot(UInt64.ONE)
+            .limit(5)
+            .collect(Collectors.toList());
+
+    final Set<IndexedAttestation> expectedIndexedAttestations =
+        attestations.stream()
+            .map(attestation -> AttestationUtil.get_indexed_attestation(state, attestation))
+            .collect(Collectors.toSet());
+
+    // Should get the attestations we expect
+    final Set<IndexedAttestation> calculatedIndexedAttestations =
+        attestations.stream()
+            .map(attestation -> provider.getIndexedAttestation(state, attestation))
+            .collect(Collectors.toSet());
+    assertThat(calculatedIndexedAttestations)
+        .containsExactlyInAnyOrderElementsOf(expectedIndexedAttestations);
+
+    // And they should have all be captured.
+    assertThat(provider.getIndexedAttestations())
+        .containsExactlyInAnyOrderElementsOf(expectedIndexedAttestations);
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.core.StateTransition;
-import tech.pegasys.teku.core.lookup.CachingIndexedAttestationProvider;
+import tech.pegasys.teku.core.lookup.CapturingIndexedAttestationProvider;
 import tech.pegasys.teku.core.results.BlockImportResult;
 import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
@@ -114,8 +114,8 @@ public class ForkChoice {
         () -> {
           final ForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();
           final StoreTransaction transaction = recentChainData.startStoreTransaction();
-          final CachingIndexedAttestationProvider indexedAttestationProvider =
-              new CachingIndexedAttestationProvider();
+          final CapturingIndexedAttestationProvider indexedAttestationProvider =
+              new CapturingIndexedAttestationProvider();
           final BlockImportResult result =
               on_block(
                   transaction,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -18,11 +18,14 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
 import java.util.List;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.core.ChainBuilder;
+import tech.pegasys.teku.core.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.results.BlockImportResult;
+import tech.pegasys.teku.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -71,8 +74,7 @@ class ForkChoiceTest {
     final SignedBlockAndState blockAndState = chainBuilder.generateBlockAtSlot(ONE);
     final SafeFuture<BlockImportResult> importResult =
         forkChoice.onBlock(blockAndState.getBlock(), Optional.of(genesis.getState()));
-    assertThat(importResult).isCompleted();
-    assertThat(importResult.join().isSuccessful()).isTrue();
+    assertBlockImportedSuccessfully(importResult);
 
     assertThat(recentChainData.getHeadBlock()).contains(blockAndState.getBlock());
     assertThat(recentChainData.getHeadSlot()).isEqualTo(blockAndState.getSlot());
@@ -87,12 +89,55 @@ class ForkChoiceTest {
     final SignedBlockAndState blockAndState = chainBuilder.generateBlockAtSlot(ONE);
     final SafeFuture<BlockImportResult> importResult =
         forkChoice.onBlock(blockAndState.getBlock(), Optional.of(genesis.getState()));
-    assertThat(importResult).isCompleted();
-    assertThat(importResult.join().isSuccessful()).isTrue();
+    assertBlockImportedSuccessfully(importResult);
 
     assertThat(recentChainData.getHeadBlock()).contains(blockAndState.getBlock());
     assertThat(recentChainData.getHeadSlot()).isEqualTo(blockAndState.getSlot());
     assertThat(storageSystem.reorgEventChannel().getReorgEvents())
         .contains(new ReorgEvent(blockAndState.getRoot(), blockAndState.getSlot()));
+  }
+
+  @Test
+  void onBlock_shouldUpdateVotesBasedOnAttestationsInBlocks() {
+    final ChainBuilder forkChain = chainBuilder.fork();
+    final SignedBlockAndState forkBlock =
+        forkChain.generateBlockAtSlot(
+            ONE,
+            BlockOptions.create()
+                .setEth1Data(new Eth1Data(Bytes32.ZERO, UInt64.valueOf(6), Bytes32.ZERO)));
+    final List<SignedBlockAndState> betterChain = chainBuilder.generateBlocksUpToSlot(3);
+
+    importBlock(forkChain, forkBlock);
+    // Should automatically follow the fork
+    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock.getRoot());
+
+    betterChain.forEach(blockAndState -> importBlock(chainBuilder, blockAndState));
+    final BlockOptions options = BlockOptions.create();
+    chainBuilder
+        .streamValidAttestationsForBlockAtSlot(UInt64.valueOf(4))
+        .limit(3)
+        .forEach(options::addAttestation);
+    final SignedBlockAndState blockWithAttestations =
+        chainBuilder.generateBlockAtSlot(UInt64.valueOf(4), options);
+    importBlock(chainBuilder, blockWithAttestations);
+    // Haven't run fork choice so won't have re-orged yet
+    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock.getRoot());
+
+    // Should have processed the attestations and switched to this fork
+    forkChoice.processHead(blockWithAttestations.getSlot());
+    assertThat(recentChainData.getBestBlockRoot()).contains(blockWithAttestations.getRoot());
+  }
+
+  private void assertBlockImportedSuccessfully(final SafeFuture<BlockImportResult> importResult) {
+    assertThat(importResult).isCompleted();
+    final BlockImportResult result = importResult.join();
+    assertThat(result.isSuccessful()).describedAs(result.toString()).isTrue();
+  }
+
+  private void importBlock(final ChainBuilder chainBuilder, final SignedBlockAndState block) {
+    final SafeFuture<BlockImportResult> result =
+        forkChoice.onBlock(
+            block.getBlock(), Optional.of(chainBuilder.getStateAtSlot(block.getSlot().minus(ONE))));
+    assertBlockImportedSuccessfully(result);
   }
 }

--- a/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
+++ b/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.core.BlockProcessorUtil;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.StateTransitionException;
 import tech.pegasys.teku.core.exceptions.BlockProcessingException;
+import tech.pegasys.teku.core.lookup.IndexedAttestationProvider;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.util.BeaconStateUtil;
 import tech.pegasys.teku.datastructures.util.CommitteeUtil;
@@ -93,10 +94,11 @@ public class FuzzUtil {
           structuredInput
               .getState()
               .updated(
-                  state -> {
-                    BlockProcessorUtil.process_attestations(
-                        state, SSZList.singleton(structuredInput.getAttestation()));
-                  });
+                  state ->
+                      BlockProcessorUtil.process_attestations(
+                          state,
+                          SSZList.singleton(structuredInput.getAttestation()),
+                          IndexedAttestationProvider.DIRECT_PROVIDER));
       Bytes output = SimpleOffsetSerializer.serialize(postState);
       return Optional.of(output.toArrayUnsafe());
     } catch (BlockProcessingException e) {


### PR DESCRIPTION
## PR Description
When importing a block, capture the indexed attestations created during import and use them to update the votes for fork choice.  This allows fork choice to correctly update the chain head while syncing and ensures we consider attestations that were included in blocks but weren't received via gossip.

## Fixed Issue(s)
fixes #2642 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.