### PR TITLE
Use a single threaded executor instead of locks for fork choice

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -49,6 +49,7 @@ import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.SyncForkChoiceExecutor;
 import tech.pegasys.teku.storage.client.ChainUpdater;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -118,7 +119,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
     forkChoice =
         useMockForkChoice
             ? mock(ForkChoice.class)
-            : new ForkChoice(recentChainData, stateTransition);
+            : new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, stateTransition);
     beaconChainUtil =
         BeaconChainUtil.create(recentChainData, chainBuilder.getValidatorKeys(), forkChoice, true);
   }
@@ -274,7 +275,6 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
   }
 
   protected Response post(final String route, final String postData) throws IOException {
-    System.out.println(postData);
     final RequestBody body = RequestBody.create(JSON, postData);
     final Request request = new Request.Builder().url(getUrl() + route).post(body).build();
     return client.newCall(request).execute();

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.ssz.backing.ViewRead;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.SyncForkChoiceExecutor;
 import tech.pegasys.teku.statetransition.util.StartupUtil;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -80,7 +81,8 @@ public class ProfilingRun {
       RecentChainData recentChainData = MemoryOnlyRecentChainData.create(localEventBus);
       BeaconChainUtil localChain = BeaconChainUtil.create(recentChainData, validatorKeys, false);
       recentChainData.initializeFromGenesis(initialState).join();
-      ForkChoice forkChoice = new ForkChoice(recentChainData, new StateTransition());
+      ForkChoice forkChoice =
+          new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, new StateTransition());
       BlockImporter blockImporter = new BlockImporter(recentChainData, forkChoice, localEventBus);
 
       System.out.println("Start blocks import from " + blocksFile);
@@ -148,7 +150,8 @@ public class ProfilingRun {
       BeaconChainUtil localChain = BeaconChainUtil.create(recentChainData, validatorKeys, false);
       recentChainData.initializeFromGenesis(initialState).join();
       initialState = null;
-      ForkChoice forkChoice = new ForkChoice(recentChainData, new StateTransition());
+      ForkChoice forkChoice =
+          new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, new StateTransition());
       BlockImporter blockImporter = new BlockImporter(recentChainData, forkChoice, localEventBus);
 
       System.out.println("Start blocks import from " + blocksFile);

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.datastructures.util.BeaconStateUtil;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.SyncForkChoiceExecutor;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.util.config.Constants;
@@ -82,7 +83,8 @@ public abstract class TransitionBenchmark {
     localChain = BeaconChainUtil.create(recentChainData, validatorKeys, false);
     localChain.initializeStorage();
 
-    ForkChoice forkChoice = new ForkChoice(recentChainData, new StateTransition());
+    ForkChoice forkChoice =
+        new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, new StateTransition());
     blockImporter = new BlockImporter(recentChainData, forkChoice, localEventBus);
     blockIterator = BlockIO.createResourceReader(blocksFile).iterator();
     System.out.println("Importing blocks from " + blocksFile);

--- a/ethereum/statetransition/build.gradle
+++ b/ethereum/statetransition/build.gradle
@@ -23,6 +23,7 @@ dependencies {
   testImplementation testFixtures(project(':bls'))
   testImplementation testFixtures(project(':ethereum:core'))
   testImplementation testFixtures(project(':ethereum:datastructures'))
+  testImplementation testFixtures(project(':infrastructure:async'))
   testImplementation testFixtures(project(':util'))
   testImplementation testFixtures(project(':storage'))
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -18,8 +18,6 @@ import static tech.pegasys.teku.core.ForkChoiceUtil.on_block;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.Semaphore;
-import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -34,17 +32,21 @@ import tech.pegasys.teku.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceExecutor.ForkChoiceTask;
 import tech.pegasys.teku.storage.client.RecentChainData;
-import tech.pegasys.teku.storage.server.ShuttingDownException;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
 public class ForkChoice {
   private static final Logger LOG = LogManager.getLogger();
-  private final Semaphore lock = new Semaphore(1);
+  private final ForkChoiceExecutor forkChoiceExecutor;
   private final RecentChainData recentChainData;
   private final StateTransition stateTransition;
 
-  public ForkChoice(final RecentChainData recentChainData, final StateTransition stateTransition) {
+  public ForkChoice(
+      final ForkChoiceExecutor forkChoiceExecutor,
+      final RecentChainData recentChainData,
+      final StateTransition stateTransition) {
+    this.forkChoiceExecutor = forkChoiceExecutor;
     this.recentChainData = recentChainData;
     this.stateTransition = stateTransition;
     recentChainData.subscribeStoreInitialized(this::initializeProtoArrayForkChoice);
@@ -69,7 +71,7 @@ public class ForkChoice {
         .retrieveCheckpointState(retrievedJustifiedCheckpoint)
         .thenCompose(
             justifiedCheckpointState ->
-                withLock(
+                onForkChoiceThread(
                     () -> {
                       final Checkpoint finalizedCheckpoint =
                           recentChainData.getStore().getFinalizedCheckpoint();
@@ -109,7 +111,7 @@ public class ForkChoice {
 
   public SafeFuture<BlockImportResult> onBlock(
       final SignedBeaconBlock block, Optional<BeaconState> preState) {
-    return withLock(
+    return onForkChoiceThread(
         () -> {
           final ForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();
           final StoreTransaction transaction = recentChainData.startStoreTransaction();
@@ -167,7 +169,7 @@ public class ForkChoice {
         .retrieveCheckpointState(attestation.getData().getTarget())
         .thenCompose(
             targetState ->
-                withLock(
+                onForkChoiceThread(
                     () -> {
                       final StoreTransaction transaction = recentChainData.startStoreTransaction();
                       final AttestationProcessingResult result =
@@ -184,7 +186,7 @@ public class ForkChoice {
   }
 
   public void applyIndexedAttestations(final List<ValidateableAttestation> attestations) {
-    withLock(
+    onForkChoiceThread(
             () -> {
               final StoreTransaction transaction = recentChainData.startStoreTransaction();
               final ForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();
@@ -206,12 +208,7 @@ public class ForkChoice {
                     "Attempting to perform fork choice operations before store has been initialized"));
   }
 
-  private <T> SafeFuture<T> withLock(final Supplier<SafeFuture<T>> action) {
-    try {
-      lock.acquire();
-    } catch (InterruptedException e) {
-      throw new ShuttingDownException();
-    }
-    return SafeFuture.ofComposed(action::get).alwaysRun(lock::release);
+  private <T> SafeFuture<T> onForkChoiceThread(final ForkChoiceTask<T> task) {
+    return forkChoiceExecutor.performTask(task);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceExecutor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceExecutor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+public interface ForkChoiceExecutor {
+
+  <T> SafeFuture<T> performTask(ForkChoiceTask<T> task);
+
+  void stop();
+
+  @FunctionalInterface
+  interface ForkChoiceTask<T> {
+    SafeFuture<T> performTask();
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/SingleThreadedForkChoiceExecutor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/SingleThreadedForkChoiceExecutor.java
@@ -42,7 +42,7 @@ public class SingleThreadedForkChoiceExecutor implements ForkChoiceExecutor {
   public <T> SafeFuture<T> performTask(final ForkChoiceTask<T> task) {
     final SafeFuture<T> result = new SafeFuture<>();
     try {
-      executor.submit(() -> syncPerformTask(task).propagateTo(result));
+      executor.execute(() -> syncPerformTask(task).propagateTo(result));
     } catch (final RejectedExecutionException e) {
       if (stopped.get()) {
         LOG.debug("Ignoring fork choice task because shutdown is in progress");

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/SingleThreadedForkChoiceExecutor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/SingleThreadedForkChoiceExecutor.java
@@ -22,6 +22,19 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
+/**
+ * Executes fork choice tasks using a single thread. This ensures that only one task is in progress
+ * at a time while ensuring that only a single thread is ever blocked waiting for tasks to complete.
+ *
+ * <p>Tasks may perform their operation using multiple threads (e.g. when committing transactions)
+ * but this executor will block until the returned future completes, ensure the task is fully
+ * completed before beginning the next one.
+ *
+ * <p>The net result is equivalent to having an exclusive lock to perform tasks, but the single
+ * executor thread blocks, rather than potentially blocking calling threads waiting to acquire the
+ * lock. This avoids the risk of all threads in a thread pool blocking on the lock and deadlocking
+ * if the task being performed needs a task to execute in that thread pool.
+ */
 public class SingleThreadedForkChoiceExecutor implements ForkChoiceExecutor {
   private static final Logger LOG = LogManager.getLogger();
   private final AtomicBoolean stopped = new AtomicBoolean(false);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/SingleThreadedForkChoiceExecutor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/SingleThreadedForkChoiceExecutor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+public class SingleThreadedForkChoiceExecutor implements ForkChoiceExecutor {
+  private static final Logger LOG = LogManager.getLogger();
+  private final AtomicBoolean stopped = new AtomicBoolean(false);
+  private final ExecutorService executor;
+
+  private SingleThreadedForkChoiceExecutor(final ExecutorService executor) {
+    this.executor = executor;
+  }
+
+  public static ForkChoiceExecutor create() {
+    final ExecutorService executor =
+        Executors.newSingleThreadExecutor(
+            new ThreadFactoryBuilder().setNameFormat("forkchoice-%d").build());
+    return new SingleThreadedForkChoiceExecutor(executor);
+  }
+
+  @Override
+  public <T> SafeFuture<T> performTask(final ForkChoiceTask<T> task) {
+    final SafeFuture<T> result = new SafeFuture<>();
+    try {
+      executor.submit(() -> syncPerformTask(task).propagateTo(result));
+    } catch (final RejectedExecutionException e) {
+      if (stopped.get()) {
+        LOG.debug("Ignoring fork choice task because shutdown is in progress");
+      } else {
+        result.completeExceptionally(e);
+      }
+    } catch (final Throwable t) {
+      result.completeExceptionally(t);
+    }
+    return result;
+  }
+
+  /**
+   * Perform the task, blocking the current thread until it completes. When executed on a single
+   * threaded executor, this ensures that only one task can be completed at a time, without blocking
+   * many threads while queuing to acquire a lock.
+   */
+  private <T> SafeFuture<T> syncPerformTask(final ForkChoiceTask<T> task) {
+    return SafeFuture.of(() -> task.performTask().join());
+  }
+
+  @Override
+  public void stop() {
+    if (stopped.compareAndSet(false, true)) {
+      executor.shutdownNow();
+    }
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.datastructures.util.BeaconStateUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.SyncForkChoiceExecutor;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
@@ -54,7 +55,8 @@ public class BlockImporterTest {
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(8);
   private final EventBus localEventBus = mock(EventBus.class);
   private final RecentChainData recentChainData = MemoryOnlyRecentChainData.create(localEventBus);
-  private final ForkChoice forkChoice = new ForkChoice(recentChainData, new StateTransition());
+  private final ForkChoice forkChoice =
+      new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, new StateTransition());
   private final BeaconChainUtil localChain =
       BeaconChainUtil.create(recentChainData, validatorKeys, forkChoice, false);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -41,7 +41,8 @@ class ForkChoiceTest {
   private final SignedBlockAndState genesis = chainBuilder.generateGenesis();
   private final RecentChainData recentChainData = storageSystem.recentChainData();
 
-  private final ForkChoice forkChoice = new ForkChoice(recentChainData, stateTransition);
+  private final ForkChoice forkChoice =
+      new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, stateTransition);
 
   @BeforeEach
   public void setup() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/SingleThreadedForkChoiceExecutorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/SingleThreadedForkChoiceExecutorTest.java
@@ -1,8 +1,28 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.statetransition.forkchoice;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.Waiter;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceExecutor.ForkChoiceTask;
 
 class SingleThreadedForkChoiceExecutorTest {
 
@@ -19,7 +39,58 @@ class SingleThreadedForkChoiceExecutorTest {
   }
 
   @Test
-  void shouldPerformTasks() {
+  void shouldPerformTasks() throws Exception {
+    final StubTask task = new StubTask();
+    final SafeFuture<String> result = executor.performTask(task);
+    task.assertStarted();
+    assertThat(result).isNotDone();
 
+    task.result.complete("Done");
+    Waiter.waitFor(result);
+    assertThat(result).isCompletedWithValue("Done");
+  }
+
+  @Test
+  void shouldNotExecuteNextTaskUntilFirstIsComplete() throws Exception {
+    final StubTask task1 = new StubTask();
+    final StubTask task2 = new StubTask();
+    final SafeFuture<String> result1 = executor.performTask(task1);
+    final SafeFuture<String> result2 = executor.performTask(task2);
+
+    task1.assertStarted();
+    assertThat(task2.started).isFalse();
+
+    task1.result.complete("Foo");
+    Waiter.waitFor(result1);
+    task2.assertStarted();
+    task2.result.complete("Bar");
+    Waiter.waitFor(result2);
+    assertThat(result1).isCompletedWithValue("Foo");
+    assertThat(result2).isCompletedWithValue("Bar");
+  }
+
+  @Test
+  void shouldReportExceptionWhenTaskFails() {
+    final StubTask task = new StubTask();
+    final SafeFuture<String> result = executor.performTask(task);
+    final RuntimeException error = new RuntimeException("Failed");
+    task.result.completeExceptionally(error);
+    Waiter.waitFor(result::isCompletedExceptionally);
+    assertThatSafeFuture(result).isCompletedExceptionallyWith(error);
+  }
+
+  private static class StubTask implements ForkChoiceTask<String> {
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final SafeFuture<String> result = new SafeFuture<>();
+
+    @Override
+    public SafeFuture<String> performTask() {
+      started.set(true);
+      return result;
+    }
+
+    void assertStarted() {
+      Waiter.waitFor(started::get);
+    }
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/SingleThreadedForkChoiceExecutorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/SingleThreadedForkChoiceExecutorTest.java
@@ -1,0 +1,25 @@
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SingleThreadedForkChoiceExecutorTest {
+
+  private ForkChoiceExecutor executor;
+
+  @BeforeEach
+  void setUp() {
+    executor = SingleThreadedForkChoiceExecutor.create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    executor.stop();
+  }
+
+  @Test
+  void shouldPerformTasks() {
+
+  }
+}

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.datastructures.util.MockStartValidatorKeyPairFactory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.SyncForkChoiceExecutor;
 import tech.pegasys.teku.statetransition.util.StartupUtil;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
@@ -74,7 +75,10 @@ public class BeaconChainUtil {
   public static BeaconChainUtil create(
       final RecentChainData storageClient, final List<BLSKeyPair> validatorKeys) {
     return create(
-        storageClient, validatorKeys, new ForkChoice(storageClient, new StateTransition()), true);
+        storageClient,
+        validatorKeys,
+        new ForkChoice(new SyncForkChoiceExecutor(), storageClient, new StateTransition()),
+        true);
   }
 
   public static BeaconChainUtil create(
@@ -84,7 +88,7 @@ public class BeaconChainUtil {
     return new BeaconChainUtil(
         validatorKeys,
         storageClient,
-        new ForkChoice(storageClient, new StateTransition()),
+        new ForkChoice(new SyncForkChoiceExecutor(), storageClient, new StateTransition()),
         signDeposits);
   }
 

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/SyncForkChoiceExecutor.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/SyncForkChoiceExecutor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+public class SyncForkChoiceExecutor implements ForkChoiceExecutor {
+
+  @Override
+  public <T> SafeFuture<T> performTask(final ForkChoiceTask<T> task) {
+    return task.performTask();
+  }
+
+  @Override
+  public void stop() {}
+}

--- a/sync/src/test/java/tech/pegasys/teku/sync/BlockManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/BlockManagerTest.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.ImportedBlocks;
 import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.SyncForkChoiceExecutor;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
@@ -63,7 +64,8 @@ public class BlockManagerTest {
       BeaconChainUtil.create(localRecentChainData, validatorKeys);
   private final BeaconChainUtil remoteChain =
       BeaconChainUtil.create(remoteRecentChainData, validatorKeys);
-  private final ForkChoice forkChoice = new ForkChoice(localRecentChainData, new StateTransition());
+  private final ForkChoice forkChoice =
+      new ForkChoice(new SyncForkChoiceExecutor(), localRecentChainData, new StateTransition());
   private final ImportedBlocks importedBlocks = new ImportedBlocks(localEventBus);
 
   private final BlockImporter blockImporter =

--- a/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
+++ b/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.SyncForkChoiceExecutor;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
@@ -85,7 +86,8 @@ public class SyncingNodeManager {
 
     final Eth2Network eth2Network = networkBuilder.startNetwork();
 
-    ForkChoice forkChoice = new ForkChoice(recentChainData, new StateTransition());
+    ForkChoice forkChoice =
+        new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, new StateTransition());
     BlockImporter blockImporter = new BlockImporter(recentChainData, forkChoice, eventBus);
     final PendingPool<SignedBeaconBlock> pendingBlocks = PendingPool.createForBlocks();
     final FutureItems<SignedBeaconBlock> futureBlocks =


### PR DESCRIPTION
## PR Description
There can be a lot of tasks submitted to fork choice so use a single threaded executor to ensure they are only performed one at a time instead of locks.  Using locks prevented concurrent access but also blocked the thread while it waited to acquire the lock.  Due to the number of incoming tasks and unfair queuing leaving a potential for starvation, it was possible for all threads in the thread pool to be blocked waiting to acquire the fork choice lock.  This could lead to a deadlock as the result of committing the transaction in fork choice was sent on the same thread pool but could never get executed as all threads were already busy.

In the new model, once any prerequisite data is retrieved, the task is executed by `ForkChoiceExecutor` - which in production is implemented by `SingleThreadedForkChoiceExecutor`.  No locks are used, but the task is submitted to a single threaded executor and `.join()` used to ensure the single fork choice thread is blocked until the task completes.  Thus it is guaranteed that only one task can be in progress at a time but the only thread that ever blocks is the fork choice thread.

Re-entrancy is not supported (ie fork choice operations cannot call to other fork choice operations without causing a deadlock) but that was true with the previous `Semaphore` based lock as well.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.