### PR TITLE
Exclude stack trace for most common places RejectedExecutionException is reported

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2TopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2TopicHandler.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.gossip.topics;
 
 import com.google.common.base.Throwables;
 import io.libp2p.core.pubsub.ValidationResult;
+import java.util.concurrent.RejectedExecutionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -63,6 +64,9 @@ public abstract class Eth2TopicHandler<T extends SimpleOffsetSerializable, TWrap
   protected ValidationResult handleMessageProcessingError(Throwable err) {
     if (Throwables.getRootCause(err) instanceof DecodingException) {
       LOG.trace("Received malformed gossip message on {}", getTopic());
+    } else if (Throwables.getRootCause(err) instanceof RejectedExecutionException) {
+      LOG.warn(
+          "Discarding gossip message for topic {} because the executor queue is full", getTopic());
     } else {
       LOG.warn("Encountered exception while processing message for topic {}", getTopic(), err);
     }

--- a/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
+++ b/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
@@ -14,11 +14,13 @@
 package tech.pegasys.teku;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
 import com.google.common.eventbus.SubscriberExceptionContext;
 import com.google.common.eventbus.SubscriberExceptionHandler;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.lang.reflect.Method;
 import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.RejectedExecutionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.events.ChannelExceptionHandler;
@@ -87,6 +89,9 @@ public final class TekuDefaultExceptionHandler
       LOG.debug("Channel unexpectedly closed", exception);
     } else if (isSpecFailure(exception)) {
       statusLog.specificationFailure(subscriberDescription, exception);
+    } else if (Throwables.getRootCause(exception) instanceof RejectedExecutionException) {
+      LOG.error(
+          "Unexpected rejected execution due to full task queue in {}", subscriberDescription);
     } else {
       statusLog.unexpectedFailure(subscriberDescription, exception);
     }


### PR DESCRIPTION
## PR Description
Reduce noise in logs and risk of running out of disk space as a result, but excluding the stack trace for `RejectedExecutionException` in the two most common places.  The stack trace generally just shows the `AsyncRunner` methods.

For gossip messages, a warn level log is issued as the gossip message is just skipped.
For default exception handler and error level log is issued as the type of task rejected is unknown and may have been more important.

## Fixed Issue(s)
fixes #2622

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.