### PR TITLE
Fix typo in metric description

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorApiDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorApiDutyLoader.java
@@ -50,7 +50,7 @@ class ValidatorApiDutyLoader implements DutyLoader {
     metricsSystem.createIntegerGauge(
         TekuMetricCategory.VALIDATOR,
         "local_validator_count",
-        "Current number of valdiators running in this validator client",
+        "Current number of validators running in this validator client",
         this.validators::size);
   }
 


### PR DESCRIPTION
## PR Description
Completely unimportant but may as well get the spelling right...

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.