### PR TITLE
Don't process attestations in blocks if the target block is unknown

### DIFF
--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -317,8 +317,19 @@ public class ChainBuilder {
         .map(this::getLatestBlockAndStateAtSlot)
         .filter(Objects::nonNull)
         .filter(b -> b.getSlot().compareTo(minBlockSlot) >= 0)
-        .map(SignedBlockAndState::toUnsigned)
-        .flatMap(head -> attestationGenerator.streamAttestations(head, head.getSlot()));
+        .flatMap(this::streamValidAttestationsWithTargetBlock);
+  }
+
+  /**
+   * Utility for streaming valid attestations with a specific target block.
+   *
+   * @param attestedHead the block to use as the attestation target
+   * @return a stream of valid attestations voting for the specified block
+   */
+  public Stream<Attestation> streamValidAttestationsWithTargetBlock(
+      final SignedBlockAndState attestedHead) {
+    return attestationGenerator.streamAttestations(
+        attestedHead.toUnsigned(), attestedHead.getSlot());
   }
 
   private void assertChainIsNotEmpty() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -85,6 +85,7 @@ public class ForkChoice {
                             retrievedJustifiedCheckpoint.getRoot(),
                             justifiedCheckpoint.getEpoch(),
                             justifiedCheckpoint.getRoot());
+                        return SafeFuture.COMPLETE;
                       }
                       final StoreTransaction transaction = recentChainData.startStoreTransaction();
                       final ForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();
@@ -136,8 +137,10 @@ public class ForkChoice {
           if (!result.isSuccessful()) {
             return SafeFuture.completedFuture(result);
           }
-          indexedAttestationProvider
-              .getIndexedAttestations()
+          indexedAttestationProvider.getIndexedAttestations().stream()
+              .filter(
+                  attestation ->
+                      forkChoiceStrategy.contains(attestation.getData().getBeacon_block_root()))
               .forEach(
                   indexedAttestation ->
                       forkChoiceStrategy.onAttestation(transaction, indexedAttestation));

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.statetransition.forkchoice;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
 import java.util.List;
@@ -25,10 +26,19 @@ import tech.pegasys.teku.core.ChainBuilder;
 import tech.pegasys.teku.core.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.results.BlockImportResult;
+import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.operations.AttestationData;
+import tech.pegasys.teku.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
+import tech.pegasys.teku.datastructures.util.BeaconStateUtil;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.ssz.SSZTypes.Bitlist;
+import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 import tech.pegasys.teku.storage.api.TrackingReorgEventChannel.ReorgEvent;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -37,6 +47,7 @@ import tech.pegasys.teku.util.config.StateStorageMode;
 
 class ForkChoiceTest {
 
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final StateTransition stateTransition = new StateTransition();
   private final StorageSystem storageSystem =
       InMemoryStorageSystemBuilder.buildDefault(StateStorageMode.PRUNE);
@@ -129,6 +140,77 @@ class ForkChoiceTest {
     assertThat(recentChainData.getBestBlockRoot()).contains(blockWithAttestations.getRoot());
   }
 
+  @Test
+  void onBlock_shouldNotProcessAttestationsForBlocksThatDoNotYetExist() {
+    final ChainBuilder forkChain = chainBuilder.fork();
+    // Create a fork block, but don't import it.
+    final SignedBlockAndState forkBlock =
+        forkChain.generateBlockAtSlot(
+            UInt64.valueOf(2),
+            BlockOptions.create()
+                .setEth1Data(new Eth1Data(Bytes32.ZERO, UInt64.valueOf(6), Bytes32.ZERO)));
+
+    // Now create the canonical chain and import.
+    final List<SignedBlockAndState> betterChain = chainBuilder.generateBlocksUpToSlot(3);
+    betterChain.forEach(blockAndState -> importBlock(chainBuilder, blockAndState));
+
+    // And create a block containing an attestation for forkBlock
+    final BlockOptions options = BlockOptions.create();
+    final Attestation attestation =
+        chainBuilder
+            .streamValidAttestationsWithTargetBlock(forkBlock)
+            .limit(3)
+            .findFirst()
+            .orElseThrow();
+    options.addAttestation(attestation);
+    final SignedBlockAndState blockWithAttestations =
+        chainBuilder.generateBlockAtSlot(UInt64.valueOf(4), options);
+    importBlock(chainBuilder, blockWithAttestations);
+
+    // Apply these votes
+    forkChoice.processHead(blockWithAttestations.getSlot());
+    assertThat(recentChainData.getBestBlockRoot()).contains(blockWithAttestations.getRoot());
+
+    // Now we import the fork block
+    importBlock(forkChain, forkBlock);
+
+    // Then we get a later attestation from the same validator pointing to a different chain
+    final UInt64 updatedAttestationSlot =
+        applyAttestationFromValidator(UInt64.ZERO, blockWithAttestations);
+
+    // And we should be able to apply the new weightings without making the fork block's weight
+    // negative
+    assertDoesNotThrow(() -> forkChoice.processHead(updatedAttestationSlot));
+  }
+
+  private UInt64 applyAttestationFromValidator(
+      final UInt64 validatorIndex, final SignedBlockAndState targetBlock) {
+    // Note this attestation is wildly invalid but we're going to shove it straight into fork choice
+    // as pre-validated.
+    final UInt64 updatedAttestationSlot = UInt64.valueOf(20);
+    final ValidateableAttestation updatedVote =
+        ValidateableAttestation.fromAttestation(
+            new Attestation(
+                new Bitlist(16, 16),
+                new AttestationData(
+                    updatedAttestationSlot,
+                    UInt64.ONE,
+                    targetBlock.getRoot(),
+                    recentChainData.getStore().getJustifiedCheckpoint(),
+                    new Checkpoint(
+                        BeaconStateUtil.compute_epoch_at_slot(updatedAttestationSlot),
+                        targetBlock.getRoot())),
+                dataStructureUtil.randomSignature()));
+    updatedVote.setIndexedAttestation(
+        new IndexedAttestation(
+            SSZList.singleton(validatorIndex),
+            updatedVote.getData(),
+            updatedVote.getAttestation().getAggregate_signature()));
+
+    forkChoice.applyIndexedAttestations(List.of(updatedVote));
+    return updatedAttestationSlot;
+  }
+
   private void assertBlockImportedSuccessfully(final SafeFuture<BlockImportResult> importResult) {
     assertThat(importResult).isCompleted();
     final BlockImportResult result = importResult.join();
@@ -138,7 +220,9 @@ class ForkChoiceTest {
   private void importBlock(final ChainBuilder chainBuilder, final SignedBlockAndState block) {
     final SafeFuture<BlockImportResult> result =
         forkChoice.onBlock(
-            block.getBlock(), Optional.of(chainBuilder.getStateAtSlot(block.getSlot().minus(ONE))));
+            block.getBlock(),
+            Optional.of(
+                chainBuilder.getLatestBlockAndStateAtSlot(block.getSlot().minus(ONE)).getState()));
     assertBlockImportedSuccessfully(result);
   }
 }

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoNode.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoNode.java
@@ -64,7 +64,11 @@ public class ProtoNode {
       UInt64 deltaAbsoluteValue = UInt64.valueOf(Math.abs(delta));
       if (deltaAbsoluteValue.isGreaterThan(weight)) {
         throw new RuntimeException(
-            "ProtoNode: Delta to be subtracted is greater than node weight. Attempting to subtract "
+            "ProtoNode: Delta to be subtracted is greater than node weight for block "
+                + blockRoot
+                + " ("
+                + blockSlot
+                + "). Attempting to subtract "
                 + deltaAbsoluteValue
                 + " from "
                 + weight);


### PR DESCRIPTION
## PR Description
When processing attestations received in blocks, skip any attestations that target a block not currently contained in the protoarray.  Otherwise, the votes and protoarray get out of sync resulting in errors like "ProtoNode: Delta to be subtracted is greater than node weight. Attempting to subtract 310426637961 from 0"

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.