### PR TITLE
Remove todo about reporting external IP.

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -193,9 +193,7 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
             .setAgentVersion(VersionProvider.CLIENT_IDENTITY + "/" + VersionProvider.VERSION)
             .setPublicKey(ByteArrayExtKt.toProtobuf(privKey.publicKey().bytes()))
             .addListenAddrs(ByteArrayExtKt.toProtobuf(advertisedAddr.getBytes()))
-            .setObservedAddr(
-                ByteArrayExtKt.toProtobuf( // TODO (#1854): Report external IP?
-                    advertisedAddr.getBytes()))
+            .setObservedAddr(ByteArrayExtKt.toProtobuf(advertisedAddr.getBytes()))
             .addAllProtocols(ping.getProtocolDescriptor().getAnnounceProtocols())
             .addAllProtocols(gossip.getProtocolDescriptor().getAnnounceProtocols())
             .build();


### PR DESCRIPTION
## PR Description
Remove todo about reporting external IP. We are already reporting the IP the user told us to use as the advertised IP.

Automatically detecting the right external IP and configuring firewalls is part of UPNP support (#2301)

## Fixed Issue(s)
fixes 1854

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.