### PR TITLE
Replace todos with explanation for wait

### DIFF
--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GossipMessageHandlerIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GossipMessageHandlerIntegrationTest.java
@@ -81,7 +81,7 @@ public class GossipMessageHandlerIntegrationTest {
           assertThat(node2.network().getPeerCount()).isEqualTo(2);
           assertThat(node3.network().getPeerCount()).isEqualTo(1);
         });
-    // TODO (#1855): debug this - we shouldn't have to wait here
+    // Wait for subscriptions to complete (jvm-libp2p does this asynchronously)
     Thread.sleep(2000);
 
     // Propagate block from network 1
@@ -131,7 +131,7 @@ public class GossipMessageHandlerIntegrationTest {
           assertThat(node3.network().getPeerCount()).isEqualTo(1);
         });
 
-    // TODO (#1855): debug this - we shouldn't have to wait here
+    // Wait for subscriptions to complete (jvm-libp2p does this asynchronously)
     Thread.sleep(2000);
 
     // Propagate invalid block from network 1

--- a/sync/src/integration-test/java/tech/pegasys/teku/sync/BlockPropagationIntegrationTest.java
+++ b/sync/src/integration-test/java/tech/pegasys/teku/sync/BlockPropagationIntegrationTest.java
@@ -93,7 +93,7 @@ public class BlockPropagationIntegrationTest {
           assertThat(node1.network().getPeerCount()).isEqualTo(1);
           assertThat(node2.network().getPeerCount()).isEqualTo(1);
         });
-    // TODO (#1855): debug this - we shouldn't have to wait here
+    // Wait for subscriptions to complete (jvm-libp2p does this asynchronously)
     Thread.sleep(2000);
 
     // Update slot so that blocks can be imported


### PR DESCRIPTION
## PR Description
The waits in tests are required because jvm-libp2p performs a number of operations asynchronously, including sending messages to subscribe. The jvm-libp2p API doesn't currently provide a way to track when the operation is actually complete.

Given the amount of work involved in making such tracking possible, and the limited number of tests that have been affected by this, it's not worth fixing.

## Fixed Issue(s)
fixes #1855 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.