### PR TITLE
Use deterministic validator keys by default in ChainBuilder

### DIFF
--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -31,7 +31,6 @@ import java.util.TreeMap;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.core.lookup.BlockProvider;
@@ -50,6 +49,7 @@ import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.util.DepositGenerator;
 import tech.pegasys.teku.datastructures.util.MockStartBeaconStateGenerator;
 import tech.pegasys.teku.datastructures.util.MockStartDepositGenerator;
+import tech.pegasys.teku.datastructures.util.MockStartValidatorKeyPairFactory;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
@@ -59,7 +59,7 @@ import tech.pegasys.teku.util.config.Constants;
 /** A utility for building small, valid chains of blocks with states for testing */
 public class ChainBuilder {
   private static final List<BLSKeyPair> DEFAULT_VALIDATOR_KEYS =
-      BLSKeyGenerator.generateKeyPairs(3);
+      new MockStartValidatorKeyPairFactory().generateKeyPairs(0, 3);
 
   private final List<BLSKeyPair> validatorKeys;
   private final AttestationGenerator attestationGenerator;


### PR DESCRIPTION
## PR Description
To make tests more predictable, use deterministically generated validator keys by default in ChainBuilder instead of randomly generated ones.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.