### PR TITLE
Handle a different closed exception to avoid noise in logs

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVAL
 import static tech.pegasys.teku.util.config.Constants.MAX_REQUEST_BLOCKS;
 
 import com.google.common.base.Throwables;
+import java.nio.channels.ClosedChannelException;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -87,7 +88,8 @@ public class BeaconBlocksByRangeMessageHandler
                 LOG.trace("Rejecting beacon blocks by range request", error); // Keep full context
                 callback.completeWithErrorResponse((RpcException) rootCause);
               } else {
-                if (rootCause instanceof StreamClosedException) {
+                if (rootCause instanceof StreamClosedException
+                    || rootCause instanceof ClosedChannelException) {
                   LOG.trace("Stream closed while sending requested blocks", error);
                 } else {
                   LOG.error("Failed to process blocks by range request", error);


### PR DESCRIPTION
## PR Description
Handle `ClosedChannelException` in the same way as `StreamClosedException` to avoid printing errors when the remote side closes the connection unexpectedly.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.