### PR TITLE
Remove obsolete TODOs

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/snappy/SnappyFrameDecoder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/snappy/SnappyFrameDecoder.java
@@ -126,7 +126,6 @@ public class SnappyFrameDecoder extends AbstractByteBufDecoder<ByteBuf, Compress
           }
 
           if (inSize < 4 + chunkLength) {
-            // TODO (#2404): Don't keep skippable bytes
             return Optional.empty();
           }
 

--- a/util/src/main/java/tech/pegasys/teku/util/hashtree/HashTreeUtil.java
+++ b/util/src/main/java/tech/pegasys/teku/util/hashtree/HashTreeUtil.java
@@ -276,9 +276,6 @@ public final class HashTreeUtil {
    *     Spec v0.5.1</a>
    */
   public static Bytes32 hash_tree_root_bitlist(Bitlist bitlist) {
-    // TODO (#2396): The following lines are a hack and can be fixed once we shift from Bytes to a
-    // real
-    // bitlist type.
     return mix_in_length(
         merkleize(
             bitfield_bytes(bitlist.serialize()),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Remove obsolete TODO in `SnappyFrameDecoder`. This comment probably means (this is the borrowed code) some minor optimization when you can skip bytes without waiting all of them to be available. But this is anyways the chunk type reserved for future use and this code path most likely wouldn't be touched.
- Remove obsolete TODO in `HashTreeUtil` : it was resolved earlier via commit 557e1ad 

## Fixed Issue(s)
- Fixes #2404 
- Fixes #2396

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.