### PR TITLE
Remove TODO comment: deposit count shouldn't overflow int

### DIFF
--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.validator.coordinator;
 
-import static java.lang.StrictMath.toIntExact;
 import static tech.pegasys.teku.core.BlockProcessorUtil.getVoteCount;
 import static tech.pegasys.teku.core.BlockProcessorUtil.isEnoughVotesToUpdateEth1Data;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
@@ -150,8 +149,6 @@ public class DepositProvider implements Eth1EventsChannel, FinalizedCheckpointCh
     return depositNavigableMap.size();
   }
 
-  // TODO (#2395): switch the MerkleTree to use UInt64s instead of using toIntExact() here,
-  //  it will result in an overflow at some point
   /**
    * @param fromDepositIndex inclusive
    * @param toDepositIndex exclusive
@@ -166,8 +163,7 @@ public class DepositProvider implements Eth1EventsChannel, FinalizedCheckpointCh
             deposit ->
                 new DepositWithIndex(
                     depositMerkleTree.getProofWithViewBoundary(
-                        toIntExact(deposit.getIndex().longValue()),
-                        toIntExact(eth1DepositCount.longValue())),
+                        deposit.getIndex().intValue(), eth1DepositCount.intValue()),
                     deposit.getData(),
                     deposit.getIndex()))
         .collect(Collectors.toList());


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Switch to using `UInt64.intValue()`

Remove TODO comment from `DepositProvider`: overflow is not possible under normal conditions: else more than 2^31 deposits should be processed. Even if overflow takes place (which may be considered as fatal error) it would be handled by UInt64.intValue()

I didn't find any reasons to switch the `MerkleTree` to use `UInt64` since it anyway can't handle more than 2^31 leafs and generating a proof for a zero leaf (which index can be larger than 2^31) doesn't make much sense 

## Fixed Issue(s)
Fixes #2395

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.