### PR TITLE
Remove toString from BLSSecretKey and MikuliSecretKey

### DIFF
--- a/bls/src/main/java/tech/pegasys/teku/bls/BLSSecretKey.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/BLSSecretKey.java
@@ -93,9 +93,4 @@ public final class BLSSecretKey {
   public int hashCode() {
     return Objects.hash(secretKey);
   }
-
-  @Override
-  public String toString() {
-    return "BLSSecretKey{" + toBytes() + '}';
-  }
 }

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/MikuliSecretKey.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/MikuliSecretKey.java
@@ -84,11 +84,6 @@ public class MikuliSecretKey implements SecretKey {
   }
 
   @Override
-  public String toString() {
-    return toBytes().toHexString();
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;


### PR DESCRIPTION
## PR Description
Reduce the risk of logging a secret key by removing the `toString()` methods.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.