### PR TITLE
Test improvements

### DIFF
--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AggregateGenerator.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AggregateGenerator.java
@@ -62,8 +62,7 @@ public class AggregateGenerator {
 
   private Signer getSignerForValidatorIndex(final int validatorIndex) {
     return new UnprotectedSigner(
-        new LocalMessageSignerService(
-            validatorKeys.get(validatorIndex), SYNC_RUNNER));
+        new LocalMessageSignerService(validatorKeys.get(validatorIndex), SYNC_RUNNER));
   }
 
   public class Generator {

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AggregateGenerator.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AggregateGenerator.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.core;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static tech.pegasys.teku.infrastructure.async.SyncAsyncRunner.SYNC_RUNNER;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -31,7 +32,6 @@ import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.util.CommitteeUtil;
-import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class AggregateGenerator {
@@ -63,7 +63,7 @@ public class AggregateGenerator {
   private Signer getSignerForValidatorIndex(final int validatorIndex) {
     return new UnprotectedSigner(
         new LocalMessageSignerService(
-            validatorKeys.get(validatorIndex), DelayedExecutorAsyncRunner.create()));
+            validatorKeys.get(validatorIndex), SYNC_RUNNER));
   }
 
   public class Generator {

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AttestationGenerator.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AttestationGenerator.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.core;
 
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
+import static tech.pegasys.teku.infrastructure.async.SyncAsyncRunner.SYNC_RUNNER;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
@@ -44,7 +45,6 @@ import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Committee;
 import tech.pegasys.teku.datastructures.state.CommitteeAssignment;
 import tech.pegasys.teku.datastructures.util.AttestationUtil;
-import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.SSZTypes.Bitlist;
 import tech.pegasys.teku.util.config.Constants;
@@ -338,9 +338,7 @@ public class AttestationGenerator {
           AttestationUtil.getAggregationBits(committeSize, indexIntoCommittee);
 
       BLSSignature signature =
-          new UnprotectedSigner(
-                  new LocalMessageSignerService(
-                      attesterKeyPair, DelayedExecutorAsyncRunner.create()))
+          new UnprotectedSigner(new LocalMessageSignerService(attesterKeyPair, SYNC_RUNNER))
               .signAttestationData(attestationData, state.getForkInfo())
               .join();
       return new Attestation(aggregationBitfield, attestationData, signature);

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -59,7 +59,7 @@ import tech.pegasys.teku.util.config.Constants;
 /** A utility for building small, valid chains of blocks with states for testing */
 public class ChainBuilder {
   private static final List<BLSKeyPair> DEFAULT_VALIDATOR_KEYS =
-      new MockStartValidatorKeyPairFactory().generateKeyPairs(0, 3);
+      Collections.unmodifiableList(new MockStartValidatorKeyPairFactory().generateKeyPairs(0, 3));
 
   private final List<BLSKeyPair> validatorKeys;
   private final AttestationGenerator attestationGenerator;

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/VoluntaryExitGenerator.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/VoluntaryExitGenerator.java
@@ -41,8 +41,7 @@ public class VoluntaryExitGenerator {
 
     BLSSignature exitSignature =
         new UnprotectedSigner(
-                new LocalMessageSignerService(
-                    getKeypair(validatorIndex, valid), SYNC_RUNNER))
+                new LocalMessageSignerService(getKeypair(validatorIndex, valid), SYNC_RUNNER))
             .signVoluntaryExit(exit, forkInfo)
             .join();
 

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/VoluntaryExitGenerator.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/VoluntaryExitGenerator.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.core;
 
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
+import static tech.pegasys.teku.infrastructure.async.SyncAsyncRunner.SYNC_RUNNER;
 
 import java.util.List;
 import tech.pegasys.teku.bls.BLSKeyPair;
@@ -24,7 +25,6 @@ import tech.pegasys.teku.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
-import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.util.config.Constants;
 
@@ -42,7 +42,7 @@ public class VoluntaryExitGenerator {
     BLSSignature exitSignature =
         new UnprotectedSigner(
                 new LocalMessageSignerService(
-                    getKeypair(validatorIndex, valid), DelayedExecutorAsyncRunner.create()))
+                    getKeypair(validatorIndex, valid), SYNC_RUNNER))
             .signVoluntaryExit(exit, forkInfo)
             .join();
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -19,9 +19,12 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.core.ChainBuilder;
 import tech.pegasys.teku.core.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.core.StateTransition;
@@ -159,9 +162,21 @@ class ForkChoiceTest {
     final Attestation attestation =
         chainBuilder
             .streamValidAttestationsWithTargetBlock(forkBlock)
-            .limit(3)
             .findFirst()
-            .orElseThrow();
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Failed to create attestation for block "
+                            + forkBlock.getRoot()
+                            + " genesis root: "
+                            + genesis.getRoot()
+                            + " chain head: "
+                            + chainBuilder.getLatestBlockAndState().getRoot()
+                            + " validators: "
+                            + chainBuilder.getValidatorKeys().stream()
+                                .map(BLSKeyPair::getPublicKey)
+                                .map(BLSPublicKey::toString)
+                                .collect(Collectors.joining(", "))));
     options.addAttestation(attestation);
     final SignedBlockAndState blockWithAttestations =
         chainBuilder.generateBlockAtSlot(UInt64.valueOf(4), options);


### PR DESCRIPTION
## PR Description
A few minor tweaks to tests:

* Use sync runner for test signers
* Add more information when ForkChoiceTest fails
* Make ChainBuilder.DEFAULT_VALIDATOR_KEYS immutable

Trying to track down why ForkChoiceTest is intermittent in CI and cleaning things up as I see them.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.