### PR TITLE
Include committee index in log message when aggregation is skipped

### DIFF
--- a/logging/src/main/java/tech/pegasys/teku/logging/ValidatorLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/ValidatorLogger.java
@@ -78,11 +78,13 @@ public class ValidatorLogger {
     return blockRoots.stream().map(LogFormatter::formatHashRoot).collect(Collectors.joining(", "));
   }
 
-  public void aggregationSkipped(final UInt64 slot) {
+  public void aggregationSkipped(final UInt64 slot, final int committeeIndex) {
     log.warn(
         print(
             PREFIX
-                + "Skipped aggregation for slot "
+                + "Skipped aggregation for committee "
+                + committeeIndex
+                + " at slot "
                 + slot
                 + " because there was nothing to aggregate",
             Color.YELLOW));

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.client.duties;
 import static java.util.stream.Collectors.toList;
 import static tech.pegasys.teku.validator.client.duties.DutyResult.combine;
 
+import com.google.common.base.MoreObjects;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
@@ -77,7 +78,11 @@ public class AggregationDuty implements Duty {
         committeeIndex -> {
           validatorApiChannel.subscribeToBeaconCommitteeForAggregation(committeeIndex, slot);
           return new CommitteeAggregator(
-              validator, UInt64.valueOf(validatorIndex), proof, unsignedAttestationFuture);
+              validator,
+              UInt64.valueOf(validatorIndex),
+              attestationCommitteeIndex,
+              proof,
+              unsignedAttestationFuture);
         });
   }
 
@@ -112,7 +117,7 @@ public class AggregationDuty implements Duty {
   private SafeFuture<DutyResult> sendAggregate(
       final CommitteeAggregator aggregator, final Optional<Attestation> maybeAggregate) {
     if (maybeAggregate.isEmpty()) {
-      validatorLogger.aggregationSkipped(slot);
+      validatorLogger.aggregationSkipped(slot, aggregator.attestationCommitteeIndex);
       return SafeFuture.completedFuture(DutyResult.NO_OP);
     }
     final Attestation aggregate = maybeAggregate.get();
@@ -141,30 +146,32 @@ public class AggregationDuty implements Duty {
 
     private final Validator validator;
     private final UInt64 validatorIndex;
+    private final int attestationCommitteeIndex;
     private final BLSSignature proof;
     private final SafeFuture<Optional<Attestation>> unsignedAttestationFuture;
 
     private CommitteeAggregator(
         final Validator validator,
         final UInt64 validatorIndex,
+        final int attestationCommitteeIndex,
         final BLSSignature proof,
         final SafeFuture<Optional<Attestation>> unsignedAttestationFuture) {
       this.validator = validator;
       this.validatorIndex = validatorIndex;
+      this.attestationCommitteeIndex = attestationCommitteeIndex;
       this.proof = proof;
       this.unsignedAttestationFuture = unsignedAttestationFuture;
     }
 
     @Override
     public String toString() {
-      return "CommitteeAggregator{"
-          + "validator="
-          + validator
-          + ", validatorIndex="
-          + validatorIndex
-          + ", proof="
-          + proof
-          + '}';
+      return MoreObjects.toStringHelper(this)
+          .add("validator", validator)
+          .add("validatorIndex", validatorIndex)
+          .add("attestationCommitteeIndex", attestationCommitteeIndex)
+          .add("proof", proof)
+          .add("unsignedAttestationFuture", unsignedAttestationFuture)
+          .toString();
     }
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
@@ -272,7 +272,7 @@ class AggregationDutyTest {
 
     assertThat(duty.performDuty()).isCompleted();
     verify(validatorApiChannel, never()).sendAggregateAndProof(any());
-    verify(validatorLogger).aggregationSkipped(SLOT);
+    verify(validatorLogger).aggregationSkipped(SLOT, 2);
     verifyNoMoreInteractions(validatorLogger);
   }
 


### PR DESCRIPTION
## PR Description
Include the committee index being aggregated when logging a warning that there was nothing to aggregate.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.