### PR TITLE
Avoid performing duplicate tasks when they are rebased

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/stategenerator/CachingTaskQueue.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/stategenerator/CachingTaskQueue.java
@@ -141,7 +141,7 @@ public class CachingTaskQueue<K, V> {
       newBase
           .get()
           .thenAccept(ancestorResult -> queueTask(task.rebase(ancestorResult)))
-          .propagateExceptionTo(generationResult);
+          .finish(error -> completePendingTask(task, Optional.empty(), error));
       return generationResult;
     }
 

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/stategenerator/CachingTaskQueue.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/stategenerator/CachingTaskQueue.java
@@ -123,6 +123,9 @@ public class CachingTaskQueue<K, V> {
       return currentPendingTask;
     }
 
+    final SafeFuture<Optional<V>> generationResult = new SafeFuture<>();
+    pendingTasks.put(task.getKey(), generationResult);
+
     // Check if there's a better starting point (in cache or in progress)
     final Optional<SafeFuture<Optional<V>>> newBase =
         task.streamIntermediateSteps()
@@ -135,24 +138,26 @@ public class CachingTaskQueue<K, V> {
             .findFirst();
     if (newBase.isPresent()) {
       rebasedTaskCounter.inc();
-      return newBase.get().thenCompose(ancestorResult -> queueTask(task.rebase(ancestorResult)));
+      newBase
+          .get()
+          .thenAccept(ancestorResult -> queueTask(task.rebase(ancestorResult)))
+          .propagateExceptionTo(generationResult);
+      return generationResult;
     }
 
     // Schedule the task for execution
     newTaskCounter.inc();
-    return queueTask(task);
+    queueTask(task);
+    return generationResult;
   }
 
   public Optional<V> getIfAvailable(final K key) {
     return Optional.ofNullable(cache.get(key));
   }
 
-  private SafeFuture<Optional<V>> queueTask(final CacheableTask<K, V> task) {
-    final SafeFuture<Optional<V>> generationResult = new SafeFuture<>();
-    pendingTasks.put(task.getKey(), generationResult);
+  private void queueTask(final CacheableTask<K, V> task) {
     queuedTasks.add(task);
     tryProcessNext();
-    return generationResult;
   }
 
   private synchronized void tryProcessNext() {


### PR DESCRIPTION
## PR Description
Previously when a task was rebased, it was only added to the pending tasks list once the task it was being rebased onto completed. If duplicate tasks were requested before the dependent task completed, they would all be scheduled to execute after it.  This resulted in duplicate work being performed and a `NullPointerException` when later tasks completed and found the result future had already been removed.

Now the result future is added to pending tasks immediately regardless of whether the task is rebased or immediately added to the queue. Duplicates then simply return the existing pending result and are not executed themselves.

## Fixed Issue(s)
fixes #2685 
fixes #2686 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.