### PR TITLE
Ignore env var for --version and --help args

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/util/EnvironmentVariableDefaultProvider.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/util/EnvironmentVariableDefaultProvider.java
@@ -44,10 +44,12 @@ public class EnvironmentVariableDefaultProvider implements IDefaultValueProvider
   }
 
   private Stream<String> envVarNames(final OptionSpec spec) {
-    return Arrays.stream(spec.names())
-        .filter(name -> name.startsWith("--")) // Only long options are allowed
-        .flatMap(
-            name -> Stream.of(ENV_VAR_PREFIX).map(prefix -> prefix + nameToEnvVarSuffix(name)));
+    return spec.versionHelp() || spec.usageHelp()
+        ? Stream.empty()
+        : Arrays.stream(spec.names())
+            .filter(name -> name.startsWith("--")) // Only long options are allowed
+            .flatMap(
+                name -> Stream.of(ENV_VAR_PREFIX).map(prefix -> prefix + nameToEnvVarSuffix(name)));
   }
 
   private String nameToEnvVarSuffix(final String name) {

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -92,6 +92,19 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  void ignoreVersionAndHelpEnvVars() {
+    beaconNodeCommand =
+        new BeaconNodeCommand(
+            outputWriter,
+            errorWriter,
+            Map.of("TEKU_VERSION", "1.2.3", "TEKU_HELP", "what?"),
+            startAction);
+
+    // No error from invalid --version or --help arg.
+    assertThat(beaconNodeCommand.parse(new String[0])).isZero();
+  }
+
+  @Test
   public void overrideEnvironmentValuesIfKeyIsPresentInCLIOptions() {
     final String[] args = createCliArgs();
     args[5] = "1.2.3.5";


### PR DESCRIPTION
## PR Description
The environment variable fallback for `--version` and `--help` is not helpful so ignore those env vars.  In particular, it's very common for the `TEKU_VERSION` env var to be set to the teku version but that causes a PicoCLI error because the value is not a boolean.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.