### PR TITLE
Upgrade RocksDB, sync WAL at shutdown

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -122,7 +122,7 @@ dependencyManagement {
     dependency 'org.openjdk.jmh:jmh-generator-annprocess:1.23'
     dependency 'org.miracl.milagro.amcl:milagro-crypto-java:0.4.0'
     dependency 'org.quartz-scheduler:quartz:2.3.2'
-    dependency 'org.rocksdb:rocksdbjni:6.10.2'
+    dependency 'org.rocksdb:rocksdbjni:6.11.4'
 
     dependencySet(group: "org.web3j", version: "4.6.2") {
       entry 'core'

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstance.java
@@ -160,6 +160,7 @@ public class RocksDbInstance implements RocksDbAccessor {
       for (Transaction openTransaction : openTransactions) {
         openTransaction.closeViaDatabase();
       }
+      db.syncWal();
       for (final AutoCloseable resource : resources) {
         resource.close();
       }


### PR DESCRIPTION
## PR Description
Upgrade to the latest RocksDB version and during a clean shutdown, async the RocksDB WAL to disk.  This is a trade off between the performance impact of using fsync on every database write and the risk that WAL writes will be lost, potentially leading to a "SST file is ahead of WALs" error on next startup.

## Fixed Issue(s)
fixes #2633 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.