### PR TITLE
Check gossip message size by ByteBuf.readableBytes() instead of ByteBuf.capacity()

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandler.java
@@ -54,7 +54,7 @@ public class GossipHandler implements Function<MessageApi, CompletableFuture<Val
 
   @Override
   public SafeFuture<ValidationResult> apply(final MessageApi message) {
-    final int messageSize = message.getData().capacity();
+    final int messageSize = message.getData().readableBytes();
     if (messageSize > GOSSIP_MAX_SIZE) {
       LOG.trace(
           "Rejecting gossip message of length {} which exceeds maximum size of {}",

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandlerTest.java
@@ -77,6 +77,15 @@ public class GossipHandlerTest {
   }
 
   @Test
+  public void apply_bufferCapacityExceedsMaxSize() {
+    ByteBuf data = Unpooled.buffer(GOSSIP_MAX_SIZE + 1).writeBytes(new byte[GOSSIP_MAX_SIZE]);
+    final MockMessageApi message = new MockMessageApi(data, topic);
+    final SafeFuture<ValidationResult> result = gossipHandler.apply(message);
+
+    assertThat(result).isCompletedWithValue(ValidationResult.Valid);
+  }
+
+  @Test
   @SuppressWarnings("FutureReturnValueIgnored")
   public void apply_duplicate() {
     final Bytes data = Bytes.fromHexString("0x01");

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/jvmlibp2p/MockMessageApi.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/jvmlibp2p/MockMessageApi.java
@@ -30,6 +30,7 @@ public class MockMessageApi implements MessageApi {
     this.data = data;
     topics = List.of(topic);
   }
+
   public MockMessageApi(final Bytes data, final Topic topic) {
     this(Unpooled.wrappedBuffer(data.toArrayUnsafe()), topic);
   }

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/jvmlibp2p/MockMessageApi.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/jvmlibp2p/MockMessageApi.java
@@ -26,9 +26,12 @@ public class MockMessageApi implements MessageApi {
   private final byte[] from = new byte[] {0x1, 0x2};
   private final List<Topic> topics;
 
-  public MockMessageApi(final Bytes data, final Topic topic) {
-    this.data = Unpooled.wrappedBuffer(data.toArrayUnsafe());
+  public MockMessageApi(final ByteBuf data, final Topic topic) {
+    this.data = data;
     topics = List.of(topic);
+  }
+  public MockMessageApi(final Bytes data, final Topic topic) {
+    this(Unpooled.wrappedBuffer(data.toArrayUnsafe()), topic);
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
`ByteBuf` capacity can potentially be pretty large if reusing pooled buffers, so it's correctly to check `ByteBuf.readableBytes()` else gossip messages can be unreasonably dropped.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.