### PR TITLE
Store generated p2p private key in a database dir and reuse it if none user key is supplied

### DIFF
--- a/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
@@ -155,4 +155,14 @@ public class StatusLogger {
   public void eth1AtHead() {
     log.info("Eth1 tracker successfully caught up to chain head");
   }
+
+  public void usingGeneratedP2pPrivateKey(final String keyFile, final boolean justGenerated) {
+    if (justGenerated) {
+      log.info(
+          "Generated new p2p private key. It was stored and will be reused on next run if no private key option is supplied: "
+              + keyFile);
+    } else {
+      log.info("Loading generated p2p private key from file: " + keyFile);
+    }
+  }
 }

--- a/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
@@ -158,9 +158,7 @@ public class StatusLogger {
 
   public void usingGeneratedP2pPrivateKey(final String keyFile, final boolean justGenerated) {
     if (justGenerated) {
-      log.info(
-          "Generated new p2p private key and storing in: "
-              + keyFile);
+      log.info("Generated new p2p private key and storing in: " + keyFile);
     } else {
       log.info("Loading generated p2p private key from file: " + keyFile);
     }

--- a/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
+++ b/logging/src/main/java/tech/pegasys/teku/logging/StatusLogger.java
@@ -159,7 +159,7 @@ public class StatusLogger {
   public void usingGeneratedP2pPrivateKey(final String keyFile, final boolean justGenerated) {
     if (justGenerated) {
       log.info(
-          "Generated new p2p private key. It was stored and will be reused on next run if no private key option is supplied: "
+          "Generated new p2p private key and storing in: "
               + keyFile);
     } else {
       log.info("Loading generated p2p private key from file: " + keyFile);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -473,15 +473,13 @@ public class BeaconChainController extends Service implements TimeTickChannel {
           final PrivKey privKey = KeyKt.generateKeyPair(KEY_TYPE.SECP256K1).component1();
           final Bytes privKeyBytes = Bytes.wrap(KeyKt.marshalPrivateKey(privKey));
           Files.writeString(p2pKeyFile, privKeyBytes.toHexString(), StandardOpenOption.CREATE_NEW);
-          LOG.info(
-              "Generated new p2p private key. It was stored and will be reused on next run if no private key option is supplied: "
-                  + p2pKeyFile);
+          STATUS_LOG.usingGeneratedP2pPrivateKey(p2pKeyFile.toString(), true);
         } catch (IOException e) {
           throw new RuntimeException(
               "Couldn't write generated p2p private key file: " + p2pKeyFile, e);
         }
       } else {
-        LOG.info("Loading generated p2p private key from file: " + p2pKeyFile);
+        STATUS_LOG.usingGeneratedP2pPrivateKey(p2pKeyFile.toString(), false);
       }
     }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.logging.StatusLogger.STATUS_LOG;
 import static tech.pegasys.teku.util.config.Constants.SECONDS_PER_SLOT;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.eventbus.EventBus;
 import io.libp2p.core.crypto.KEY_TYPE;
@@ -458,7 +459,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             eventBus);
   }
 
-  private Bytes getP2pPrivateKeyBytes() {
+  @VisibleForTesting
+  Bytes getP2pPrivateKeyBytes() {
     final String p2pConfigKeyFile = config.getP2pPrivateKeyFile();
     final Path p2pKeyFile;
     if (p2pConfigKeyFile != null) {

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainControllerTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainControllerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.services.beaconchain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import tech.pegasys.teku.events.EventChannels;
+import tech.pegasys.teku.service.serviceutils.ServiceConfig;
+import tech.pegasys.teku.util.config.TekuConfiguration;
+import tech.pegasys.teku.util.time.channels.SlotEventsChannel;
+
+public class BeaconChainControllerTest {
+
+  @TempDir public File dataDir;
+
+  private ServiceConfig mockServiceConfig(TekuConfiguration tekuConfiguration) {
+    ServiceConfig serviceConfig = mock(ServiceConfig.class);
+    when(serviceConfig.getConfig()).thenReturn(tekuConfiguration);
+    EventChannels eventChannels = mock(EventChannels.class);
+    when(eventChannels.getPublisher(any())).thenReturn(mock(SlotEventsChannel.class));
+    when(serviceConfig.getEventChannels()).thenReturn(eventChannels);
+    return serviceConfig;
+  }
+
+  @Test
+  void getP2pPrivateKeyBytes_generatedKeyTest() throws IOException {
+    TekuConfiguration tekuConfiguration =
+        TekuConfiguration.builder().setDataPath(dataDir.getCanonicalPath()).build();
+    BeaconChainController controller =
+        new BeaconChainController(mockServiceConfig(tekuConfiguration));
+
+    // check that new key is generated
+    Bytes generatedPK = controller.getP2pPrivateKeyBytes();
+    assertThat(generatedPK).isNotNull();
+    assertThat(generatedPK.size()).isGreaterThanOrEqualTo(32);
+
+    // check the same key loaded next time
+    Bytes loadedPK = controller.getP2pPrivateKeyBytes();
+    assertThat(loadedPK).isEqualTo(generatedPK);
+
+    for (File file : dataDir.listFiles()) {
+      file.delete();
+    }
+
+    // check that another key is generated after old key is deleted
+    Bytes generatedAnotherPK = controller.getP2pPrivateKeyBytes();
+    assertThat(generatedAnotherPK).isNotNull();
+    assertThat(generatedAnotherPK.size()).isGreaterThanOrEqualTo(32);
+    assertThat(generatedAnotherPK).isNotEqualTo(generatedPK);
+
+    // check that user supplied private key file has precedence over generated file
+    Path customPKFile = dataDir.toPath().resolve("customPK.hex");
+    Files.writeString(customPKFile, generatedPK.toHexString());
+
+    TekuConfiguration tekuConfiguration1 =
+        TekuConfiguration.builder()
+            .setDataPath(dataDir.getCanonicalPath())
+            .setP2pPrivateKeyFile(customPKFile.toString())
+            .build();
+    BeaconChainController controller1 =
+        new BeaconChainController(mockServiceConfig(tekuConfiguration1));
+    Bytes customPK = controller1.getP2pPrivateKeyBytes();
+    assertThat(customPK).isEqualTo(generatedPK);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Store generated p2p private key in a database dir and reuse it if none user key is supplied

TODO: 
- [x] add unit tests

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Fixes #2209 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.