### PR TITLE
Remove support for unencrypted keystore generation

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/GenesisStateAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/GenesisStateAcceptanceTest.java
@@ -25,7 +25,7 @@ public class GenesisStateAcceptanceTest extends AcceptanceTestBase {
     final BesuNode eth1Node = createBesuNode();
     eth1Node.start();
 
-    createTekuDepositSender().sendValidatorDeposits(eth1Node, 64);
+    createTekuDepositSender().sendValidatorDeposits(eth1Node, 4);
 
     final TekuNode firstTeku = createTekuNode(config -> config.withDepositsFrom(eth1Node));
     firstTeku.start();

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/StartupAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/StartupAcceptanceTest.java
@@ -61,7 +61,7 @@ public class StartupAcceptanceTest extends AcceptanceTestBase {
     final TekuNode tekuNode = createTekuNode(config -> config.withDepositsFrom(eth1Node));
     tekuNode.start();
 
-    createTekuDepositSender().sendValidatorDeposits(eth1Node, 64);
+    createTekuDepositSender().sendValidatorDeposits(eth1Node, 4);
     tekuNode.waitForGenesis();
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/deposit/GenerateAction.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/deposit/GenerateAction.java
@@ -38,7 +38,6 @@ public class GenerateAction {
   private static final String WITHDRAWAL_PASSWORD_PROMPT = "Withdrawal Keystore";
   private final int validatorCount;
   private final String outputPath;
-  private final boolean encryptKeys;
   private final ValidatorPasswordOptions validatorPasswordOptions;
   private final WithdrawalPasswordOptions withdrawalPasswordOptions;
   private final SecureRandom srng;
@@ -50,7 +49,6 @@ public class GenerateAction {
   public GenerateAction(
       final int validatorCount,
       final String outputPath,
-      final boolean encryptKeys,
       final ValidatorPasswordOptions validatorPasswordOptions,
       final WithdrawalPasswordOptions withdrawalPasswordOptions,
       final ConsoleAdapter consoleAdapter,
@@ -59,7 +57,6 @@ public class GenerateAction {
       final Consumer<String> commandOutput) {
     this.validatorCount = validatorCount;
     this.outputPath = outputPath;
-    this.encryptKeys = encryptKeys;
     this.validatorPasswordOptions = validatorPasswordOptions;
     this.withdrawalPasswordOptions = withdrawalPasswordOptions;
     this.consoleAdapter = consoleAdapter;
@@ -87,27 +84,19 @@ public class GenerateAction {
 
   private KeysWriter getKeysWriter(final SecureRandom secureRandom) {
     final KeysWriter keysWriter;
-    if (encryptKeys) {
-      final String validatorKeystorePassword =
-          readKeystorePassword(validatorPasswordOptions, VALIDATOR_PASSWORD_PROMPT);
-      final String withdrawalKeystorePassword =
-          readKeystorePassword(withdrawalPasswordOptions, WITHDRAWAL_PASSWORD_PROMPT);
+    final String validatorKeystorePassword =
+        readKeystorePassword(validatorPasswordOptions, VALIDATOR_PASSWORD_PROMPT);
+    final String withdrawalKeystorePassword =
+        readKeystorePassword(withdrawalPasswordOptions, WITHDRAWAL_PASSWORD_PROMPT);
 
-      final Path keystoreDir = getKeystoreOutputDir();
-      keysWriter =
-          new EncryptedKeystoreWriter(
-              secureRandom,
-              validatorKeystorePassword,
-              withdrawalKeystorePassword,
-              keystoreDir,
-              commandOutput);
-    } else {
-      keysWriter = new YamlKeysWriter(isBlank(outputPath) ? null : Path.of(outputPath));
-      if (consoleAdapter.isConsoleAvailable() && isBlank(outputPath)) {
-        commandOutput.accept(
-            "NOTE: This is the only time your keys will be displayed. Save these before they are gone!");
-      }
-    }
+    final Path keystoreDir = getKeystoreOutputDir();
+    keysWriter =
+        new EncryptedKeystoreWriter(
+            secureRandom,
+            validatorKeystorePassword,
+            withdrawalKeystorePassword,
+            keystoreDir,
+            commandOutput);
     return keysWriter;
   }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/deposit/GenerateParams.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/deposit/GenerateParams.java
@@ -41,16 +41,8 @@ public class GenerateParams {
       names = {"--keys-output-path"},
       paramLabel = "<FILE|DIR>",
       description =
-          "Path to output file for unencrypted keys or output directory for encrypted keystore files. If not set, unencrypted keys will be written on standard out and encrypted keystores will be created in current directory")
+          "Path to output directory for encrypted keystore files. If not set keystores will be created in current directory")
   private String outputPath;
-
-  @Option(
-      names = {"--encrypted-keystore-enabled"},
-      defaultValue = "true",
-      paramLabel = "<true|false>",
-      description = "Create encrypted keystores for validator and withdrawal keys. (Default: true)",
-      arity = "1")
-  private boolean encryptKeys = true;
 
   @ArgGroup(heading = "Non-interactive password options for validator keystores:%n")
   private ValidatorPasswordOptions validatorPasswordOptions;
@@ -79,7 +71,6 @@ public class GenerateParams {
     return new GenerateAction(
         validatorCount,
         outputPath,
-        encryptKeys,
         validatorPasswordOptions,
         withdrawalPasswordOptions,
         consoleAdapter,

--- a/teku/src/test/java/tech/pegasys/teku/cli/deposit/GenerateActionTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/deposit/GenerateActionTest.java
@@ -46,7 +46,6 @@ class GenerateActionTest {
   private static final String EXPECTED_ENV_VARIABLE = "TEST_ENV";
   private static final Function<String, String> envSupplier =
       s -> EXPECTED_ENV_VARIABLE.equals(s) ? EXPECTED_PASSWORD : null;
-  private static final boolean ENCRYPTED_KEYSTORE_ENABLED = true;
   private ConsoleAdapter consoleAdapter;
   private CommandSpec commandSpec;
 
@@ -179,7 +178,6 @@ class GenerateActionTest {
         new GenerateAction(
             VALIDATORS_COUNT,
             outputPath.toString(),
-            ENCRYPTED_KEYSTORE_ENABLED,
             validatorPasswordOptions,
             withdrawalPasswordOptions,
             consoleAdapter,
@@ -195,18 +193,7 @@ class GenerateActionTest {
     assertKeyStoreFilesExistAndAreEncryptedWithPassword(outputPath);
 
     // select only withdrawal files
-    FilenameFilter withdrawalFilter =
-        new FilenameFilter() {
-          @Override
-          public boolean accept(File dir, String name) {
-            String lowercaseName = name.toLowerCase();
-            if (lowercaseName.contains("withdrawal")) {
-              return true;
-            } else {
-              return false;
-            }
-          }
-        };
+    FilenameFilter withdrawalFilter = (dir, name) -> name.toLowerCase().contains("withdrawal");
 
     // assert that files exist: 1 withdrawal file per validator
     final File[] withdrawalFiles = outputPath.toFile().listFiles(withdrawalFilter);
@@ -214,18 +201,7 @@ class GenerateActionTest {
     Arrays.stream(withdrawalFiles).forEach(file -> assertThat(file).isFile());
 
     // select only validator files
-    FilenameFilter validatorFilter =
-        new FilenameFilter() {
-          @Override
-          public boolean accept(File dir, String name) {
-            String lowercaseName = name.toLowerCase();
-            if (lowercaseName.contains("validator")) {
-              return true;
-            } else {
-              return false;
-            }
-          }
-        };
+    FilenameFilter validatorFilter = (dir, name) -> name.toLowerCase().contains("validator");
 
     // assert that files exist: 1 validator file per validator
     final File[] validatorFiles = outputPath.toFile().listFiles(validatorFilter);

--- a/util/src/main/resources/tech/pegasys/teku/util/config/swift.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/swift.yaml
@@ -3,6 +3,7 @@
 # Copy of the minimal preset but
 # SECONDS_PER_SLOT is 1 instead of 6 and
 # SLOTS_PER_EPOCH is 4 instead of 8
+# MIN_GENESIS_ACTIVE_VALIDATOR_COUNT is 4 instead of 64
 
 
 # Misc
@@ -21,7 +22,7 @@ CHURN_LIMIT_QUOTIENT: 65536
 # [customized] Faster, but unsecure.
 SHUFFLE_ROUND_COUNT: 10
 # [customized]
-MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 64
+MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 4
 # Jan 3, 2020
 MIN_GENESIS_TIME: 1578009600
 # 4


### PR DESCRIPTION
## PR Description
Remove the ability to generate unencrypted keystores.  Reduced the minimum number of validators required for genesis in swift config because generating encrypted keystores is pretty slow.

## Fixed Issue(s)
fixes #2708 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.