### PR TITLE
Bump Libp2p version to 0.5.6

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -31,7 +31,7 @@ dependencyManagement {
     dependency 'io.protostuff:protostuff-core:1.6.2'
     dependency 'io.protostuff:protostuff-runtime:1.6.2'
 
-    dependency 'io.libp2p:jvm-libp2p-minimal:0.5.5-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p-minimal:0.5.6-RELEASE'
     dependency 'tech.pegasys:jblst:0.1.0-RELEASE'
 
     dependency 'org.hdrhistogram:HdrHistogram:2.1.12'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

See Release 0.5.6: https://github.com/libp2p/jvm-libp2p/pull/137

## Fixed Issue(s)

fix #2620

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.