### PR TITLE
[Issue-2566] Exit teku if eth1 service fails to start up

### DIFF
--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/TrackingDefaultUncaughtExceptionHandler.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/TrackingDefaultUncaughtExceptionHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.async;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TrackingDefaultUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+  private final List<Throwable> uncaughtExceptions = new ArrayList<>();
+
+  @Override
+  public void uncaughtException(final Thread t, final Throwable e) {
+    uncaughtExceptions.add(e);
+  }
+
+  public List<Throwable> getUncaughtExceptions() {
+    return uncaughtExceptions;
+  }
+}

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/TrackingUncaughtExceptionHandler.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/TrackingUncaughtExceptionHandler.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.infrastructure.async;
 import java.util.ArrayList;
 import java.util.List;
 
-public class TrackingDefaultUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+public class TrackingUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
   private final List<Throwable> uncaughtExceptions = new ArrayList<>();
 
   @Override

--- a/pow/build.gradle
+++ b/pow/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   implementation project(':ssz')
   implementation project(':util')
   implementation project(':events')
+  implementation project(':services:serviceutils')
   implementation project(':storage:api')
   implementation project(':logging')
 

--- a/pow/src/test/java/tech/pegasys/teku/pow/Eth1DepositManagerTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/Eth1DepositManagerTest.java
@@ -30,7 +30,7 @@ import org.mockito.InOrder;
 import org.web3j.protocol.core.methods.response.EthBlock.Block;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
-import tech.pegasys.teku.infrastructure.async.TrackingDefaultUncaughtExceptionHandler;
+import tech.pegasys.teku.infrastructure.async.TrackingUncaughtExceptionHandler;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.api.Eth1EventsChannel;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
@@ -54,8 +54,8 @@ class Eth1DepositManagerTest {
       mock(DepositProcessingController.class);
   private final MinimumGenesisTimeBlockFinder minimumGenesisTimeBlockFinder =
       mock(MinimumGenesisTimeBlockFinder.class);
-  private final TrackingDefaultUncaughtExceptionHandler exceptionHandler =
-      new TrackingDefaultUncaughtExceptionHandler();
+  private final TrackingUncaughtExceptionHandler exceptionHandler =
+      new TrackingUncaughtExceptionHandler();
 
   private final InOrder inOrder =
       inOrder(

--- a/services/serviceutils/build.gradle
+++ b/services/serviceutils/build.gradle
@@ -3,7 +3,6 @@ dependencies {
   implementation project(':events')
   implementation project(':infrastructure:async')
   implementation project(':logging')
-  implementation project(':storage')
   implementation project(':util')
 
   implementation 'io.vertx:vertx-core'

--- a/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/FatalServiceFailureException.java
+++ b/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/FatalServiceFailureException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.service.serviceutils;
+
+public class FatalServiceFailureException extends RuntimeException {
+
+  private final Class<?> service;
+
+  public FatalServiceFailureException(final Class<?> service, final Throwable cause) {
+    super(cause);
+    this.service = service;
+  }
+
+  public Class<?> getService() {
+    return service;
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
+++ b/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
@@ -20,12 +20,15 @@ import com.google.common.eventbus.SubscriberExceptionHandler;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.lang.reflect.Method;
 import java.nio.channels.ClosedChannelException;
+import java.util.Optional;
 import java.util.concurrent.RejectedExecutionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.events.ChannelExceptionHandler;
 import tech.pegasys.teku.logging.StatusLogger;
+import tech.pegasys.teku.service.serviceutils.FatalServiceFailureException;
 import tech.pegasys.teku.storage.server.ShuttingDownException;
+import tech.pegasys.teku.util.exceptions.ExceptionUtil;
 
 public final class TekuDefaultExceptionHandler
     implements SubscriberExceptionHandler, ChannelExceptionHandler, UncaughtExceptionHandler {
@@ -80,7 +83,14 @@ public final class TekuDefaultExceptionHandler
   }
 
   private void handleException(final Throwable exception, final String subscriberDescription) {
-    if (exception instanceof OutOfMemoryError) {
+    final Optional<FatalServiceFailureException> fatalServiceError =
+        ExceptionUtil.getCause(exception, FatalServiceFailureException.class);
+
+    if (fatalServiceError.isPresent()) {
+      final String failedService = fatalServiceError.get().getService().getSimpleName();
+      statusLog.fatalError(failedService, exception);
+      System.exit(2);
+    } else if (exception instanceof OutOfMemoryError) {
       statusLog.fatalError(subscriberDescription, exception);
       System.exit(2);
     } else if (exception instanceof ShuttingDownException) {

--- a/util/src/main/java/tech/pegasys/teku/util/exceptions/ExceptionUtil.java
+++ b/util/src/main/java/tech/pegasys/teku/util/exceptions/ExceptionUtil.java
@@ -14,19 +14,16 @@
 package tech.pegasys.teku.util.exceptions;
 
 import java.util.Optional;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public class ExceptionUtil {
 
   @SuppressWarnings("unchecked")
   public static <T extends Throwable> Optional<T> getCause(
       final Throwable err, Class<T> targetType) {
-    Throwable current = err;
-    while (current != null) {
-      if (targetType.isInstance(current)) {
-        return Optional.of((T) current);
-      }
-      current = current.getCause();
-    }
-    return Optional.empty();
+    return ExceptionUtils.getThrowableList(err).stream()
+        .filter(targetType::isInstance)
+        .map(e -> (T) e)
+        .findFirst();
   }
 }

--- a/util/src/main/java/tech/pegasys/teku/util/exceptions/ExceptionUtil.java
+++ b/util/src/main/java/tech/pegasys/teku/util/exceptions/ExceptionUtil.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.util.exceptions;
+
+import java.util.Optional;
+
+public class ExceptionUtil {
+
+  @SuppressWarnings("unchecked")
+  public static <T extends Throwable> Optional<T> getCause(
+      final Throwable err, Class<T> targetType) {
+    Throwable current = err;
+    while (current != null) {
+      if (targetType.isInstance(current)) {
+        return Optional.of((T) current);
+      }
+      current = current.getCause();
+    }
+    return Optional.empty();
+  }
+}

--- a/util/src/test/java/tech/pegasys/teku/util/exceptions/ExceptionUtilTest.java
+++ b/util/src/test/java/tech/pegasys/teku/util/exceptions/ExceptionUtilTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.util.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class ExceptionUtilTest {
+
+  @Test
+  public void getCause_noChainOfCauses() {
+    final RuntimeException err = new RuntimeException();
+
+    // Exact match
+    assertThat(ExceptionUtil.getCause(err, RuntimeException.class)).contains(err);
+    // Superclass match
+    assertThat(ExceptionUtil.getCause(err, Exception.class)).contains(err);
+
+    // Subclass does not match
+    assertThat(ExceptionUtil.getCause(err, CustomRuntimeException.class)).isEmpty();
+    // Other error does not match
+    assertThat(ExceptionUtil.getCause(err, IllegalStateException.class)).isEmpty();
+  }
+
+  @Test
+  public void getCause_withChainOfCauses() {
+    final IllegalArgumentException rootCause = new IllegalArgumentException("Wrong argument");
+    final IllegalStateException intermediateCause = new IllegalStateException(rootCause);
+    final RuntimeException err = new RuntimeException(intermediateCause);
+
+    // Match error
+    assertThat(ExceptionUtil.getCause(err, RuntimeException.class)).contains(err);
+    // Superclass match
+    assertThat(ExceptionUtil.getCause(err, Exception.class)).contains(err);
+
+    // Match intermediate cause
+    assertThat(ExceptionUtil.getCause(err, IllegalStateException.class))
+        .contains(intermediateCause);
+
+    // Match root cause
+    assertThat(ExceptionUtil.getCause(err, IllegalArgumentException.class)).contains(rootCause);
+  }
+
+  @Test
+  public void getCause_withChainOfSameType() {
+    final RuntimeException rootCause = new RuntimeException("Oops");
+    final RuntimeException err = new RuntimeException(rootCause);
+
+    // Match error
+    assertThat(ExceptionUtil.getCause(err, RuntimeException.class)).contains(err);
+  }
+
+  private static class CustomRuntimeException extends RuntimeException {}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
The eth1 service is critical for validators.  If the eth1 service fails to start up, throw a fatal exception and exit.

## Fixed Issue(s)
Part of #2566 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.