### PR TITLE
clean up recentChainData finalizedEpoch handling

### DIFF
--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.core.ForkChoiceUtil;
 import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -162,12 +163,13 @@ public class SlotProcessorTest {
     slotProcessor.onTick(beaconState.getGenesis_time());
     verify(slotEventsChannel).onSlot(captor.capture());
     assertThat(captor.getValue()).isEqualTo(ZERO);
+    final Checkpoint finalizedCheckpoint = recentChainData.getStore().getFinalizedCheckpoint();
     verify(eventLogger)
         .epochEvent(
             ZERO,
             recentChainData.getStore().getJustifiedCheckpoint().getEpoch(),
-            recentChainData.getStore().getFinalizedCheckpoint().getEpoch(),
-            recentChainData.getFinalizedRoot());
+            finalizedCheckpoint.getEpoch(),
+            finalizedCheckpoint.getRoot());
     assertThat(slotProcessor.getNodeSlot().getValue()).isEqualTo(ZERO);
   }
 
@@ -190,12 +192,13 @@ public class SlotProcessorTest {
     assertThat(captor.getValue()).isEqualTo(slot);
 
     // event logger reports slot 100
+    final Checkpoint finalizedCheckpoint = recentChainData.getStore().getFinalizedCheckpoint();
     verify(eventLogger)
         .epochEvent(
             compute_epoch_at_slot(slot),
             recentChainData.getStore().getJustifiedCheckpoint().getEpoch(),
-            recentChainData.getStore().getFinalizedCheckpoint().getEpoch(),
-            recentChainData.getFinalizedRoot());
+            finalizedCheckpoint.getEpoch(),
+            finalizedCheckpoint.getRoot());
 
     // node slots missed event to indicate that slots were missed to catch up
     verify(eventLogger).nodeSlotsMissed(ZERO, slot);
@@ -212,14 +215,15 @@ public class SlotProcessorTest {
     when(p2pNetwork.getPeerCount()).thenReturn(1);
 
     slotProcessor.onTick(beaconState.getGenesis_time().plus(SECONDS_PER_SLOT / 3));
+    final Checkpoint finalizedCheckpoint = recentChainData.getStore().getFinalizedCheckpoint();
     verify(eventLogger)
         .slotEvent(
             ZERO,
             recentChainData.getHeadSlot(),
             recentChainData.getBestBlockRoot().get(),
             ZERO,
-            recentChainData.getStore().getFinalizedCheckpoint().getEpoch(),
-            recentChainData.getFinalizedRoot(),
+            finalizedCheckpoint.getEpoch(),
+            finalizedCheckpoint.getRoot(),
             1);
     assertThat(events)
         .containsExactly(new BroadcastAttestationEvent(slotProcessor.getNodeSlot().getValue()));

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -387,17 +387,12 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     return forkChoiceStrategy.flatMap(strategy -> get_ancestor(strategy, headBlockRoot, slot));
   }
 
-  // TODO (#2398): These methods should not return zero if null. We should handle this better
   public UInt64 getFinalizedEpoch() {
-    return store == null ? UInt64.ZERO : store.getFinalizedCheckpoint().getEpoch();
+    return getFinalizedCheckpoint().map(Checkpoint::getEpoch).orElse(UInt64.ZERO);
   }
 
-  public UInt64 getBestJustifiedEpoch() {
-    return store == null ? UInt64.ZERO : store.getBestJustifiedCheckpoint().getEpoch();
-  }
-
-  public Bytes32 getFinalizedRoot() {
-    return store == null ? null : store.getFinalizedCheckpoint().getRoot();
+  public Optional<Checkpoint> getFinalizedCheckpoint() {
+    return store == null ? Optional.empty() : Optional.of(store.getFinalizedCheckpoint());
   }
 
   @Override


### PR DESCRIPTION
 - created getFinalizedCheckpoint returning an optional

 - removed getBestJustifiedEpoch as it wasn't used

 - removed getFinalizedRoot as it was used where the finalized checkpoint was already needed, so we now get the checkpoint and reference multiple attributes, rather than effectively fetching the finalizedCheckpoint multiple times.

 fixes #2398

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.