### PR TITLE
Enable Gossip 1.1 'Flood Publish' option

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -167,6 +167,7 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
             .gossipSize(config.getGossipConfig().getAdvertise())
             .gossipHistoryLength(config.getGossipConfig().getHistory())
             .heartbeatInterval(config.getGossipConfig().getHeartbeatInterval())
+            .floodPublish(true)
             .build();
 
     GossipRouter router = new GossipRouter(gossipParams);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Enable Gossip 1.1 [Flood Publish](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#flood-publishing) option. This may help with own validator attestations/blocks dissemination. 

@ajsutton 
> The idea being that for locally produced attestations, aggregates and blocks we publish them to all peers, not just a subset. For things received from other peers we still just send them on to a random subset of peers.  Would be good to know if other clients are doing this already or not.

I think this is exactly what you are suggesting. Here is the extract from the spec link above: 
>With flood publishing enabled, the mesh is used when propagating messages from other peers, but a peer's own messages will always be published to all known peers in the topic.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Related issue (with wrong assumption) #2697

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.