### PR TITLE
Add standard api endpoint for node health.

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -59,6 +59,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.node.GetFork;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetGenesisTime;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetSyncing;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetVersion;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetHealth;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetIdentity;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAggregate;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAttestation;
@@ -209,6 +210,7 @@ public class BeaconRestApi {
   }
 
   private void addV1NodeHandlers(final DataProvider provider) {
+    app.get(GetHealth.ROUTE, new GetHealth(provider));
     app.get(GetIdentity.ROUTE, new GetIdentity(provider, jsonProvider));
     app.get(
         tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetVersion.ROUTE,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/RestApiConstants.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/RestApiConstants.java
@@ -37,6 +37,7 @@ public class RestApiConstants {
   public static final String RES_OK = "200"; // SC_OK
   public static final String RES_ACCEPTED = "202"; // SC_ACCEPTED
   public static final String RES_NO_CONTENT = "204"; // SC_NO_CONTENT
+  public static final String RES_PARTIAL_CONTENT = "206"; // SC_PARTIAL_CONTENT
   public static final String RES_BAD_REQUEST = "400"; // SC_BAD_REQUEST
   public static final String RES_FORBIDDEN = "403"; // SC_FORBIDDEN
   public static final String RES_NOT_FOUND = "404"; // SC_NOT_FOUND

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealth.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealth.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.node;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static javax.servlet.http.HttpServletResponse.SC_PARTIAL_CONTENT;
+import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.beaconrestapi.CacheControlUtils.CACHE_NONE;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_PARTIAL_CONTENT;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_V1_NODE;
+
+import io.javalin.core.util.Header;
+import io.javalin.http.Context;
+import io.javalin.http.Handler;
+import io.javalin.plugin.openapi.annotations.HttpMethod;
+import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import org.jetbrains.annotations.NotNull;
+import tech.pegasys.teku.api.ChainDataProvider;
+import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.SyncDataProvider;
+
+public class GetHealth implements Handler {
+  public static final String ROUTE = "/eth/v1/node/health";
+  private final SyncDataProvider syncProvider;
+  private final ChainDataProvider chainDataProvider;
+
+  public GetHealth(final DataProvider provider) {
+    this.syncProvider = provider.getSyncDataProvider();
+    this.chainDataProvider = provider.getChainDataProvider();
+  }
+
+  GetHealth(final SyncDataProvider syncProvider, final ChainDataProvider chainDataProvider) {
+    this.syncProvider = syncProvider;
+    this.chainDataProvider = chainDataProvider;
+  }
+
+  @OpenApi(
+      path = ROUTE,
+      method = HttpMethod.GET,
+      summary = "Returns node health status in http status codes. Useful for load balancers.",
+      tags = {TAG_V1_NODE},
+      responses = {
+        @OpenApiResponse(status = RES_OK, description = "Node is ready"),
+        @OpenApiResponse(
+            status = RES_PARTIAL_CONTENT,
+            description = "Node is syncing but can serve incomplete data"),
+        @OpenApiResponse(
+            status = RES_SERVICE_UNAVAILABLE,
+            description = "Node not initialized or having issues")
+      })
+  @Override
+  public void handle(@NotNull final Context ctx) throws Exception {
+    ctx.header(Header.CACHE_CONTROL, CACHE_NONE);
+    if (!chainDataProvider.isStoreAvailable()) {
+      ctx.status(SC_SERVICE_UNAVAILABLE);
+    } else if (syncProvider.getSyncStatus().is_syncing) {
+      ctx.status(SC_PARTIAL_CONTENT);
+    } else {
+      ctx.status(SC_OK);
+    }
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
@@ -44,7 +44,6 @@ import tech.pegasys.teku.beaconrestapi.handlers.node.GetFork;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetGenesisTime;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetSyncing;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetVersion;
-import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetIdentity;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAggregate;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.PostAggregateAndProof;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.PostBlock;
@@ -137,19 +136,6 @@ class BeaconRestApiTest {
   @Test
   public void shouldHaveBeaconValidatorsEndpoint() {
     verify(app).get(eq(GetValidators.ROUTE), any(GetValidators.class));
-  }
-
-  @Test
-  public void shouldHaveV1VersionEndpoint() {
-    verify(app)
-        .get(
-            eq(tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetVersion.ROUTE),
-            any(tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetVersion.class));
-  }
-
-  @Test
-  public void shouldHaveV1IdentityEndpoint() {
-    verify(app).get(eq(GetIdentity.ROUTE), any(GetIdentity.class));
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.eventbus.EventBus;
+import io.javalin.Javalin;
+import io.javalin.core.JavalinServer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetHealth;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetIdentity;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetVersion;
+import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
+import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.sync.SyncService;
+import tech.pegasys.teku.util.config.TekuConfiguration;
+
+public class BeaconRestApiV1Test {
+  private final RecentChainData storageClient = MemoryOnlyRecentChainData.create(new EventBus());
+  private final CombinedChainDataClient combinedChainDataClient =
+      mock(CombinedChainDataClient.class);
+  private final JavalinServer server = mock(JavalinServer.class);
+  private final Javalin app = mock(Javalin.class);
+  private final SyncService syncService = mock(SyncService.class);
+  private final BlockImporter blockImporter = mock(BlockImporter.class);
+  private static final Integer THE_PORT = 12345;
+  private AggregatingAttestationPool attestationPool = mock(AggregatingAttestationPool.class);
+
+  @BeforeEach
+  public void setup() {
+    TekuConfiguration config =
+        TekuConfiguration.builder().setRestApiPort(THE_PORT).setRestApiDocsEnabled(false).build();
+    when(app.server()).thenReturn(server);
+    new BeaconRestApi(
+        new DataProvider(
+            storageClient,
+            combinedChainDataClient,
+            null,
+            syncService,
+            null,
+            blockImporter,
+            attestationPool),
+        config,
+        app);
+  }
+
+  @Test
+  public void shouldHaveVersionEndpoint() {
+    verify(app).get(eq(GetVersion.ROUTE), any(GetVersion.class));
+  }
+
+  @Test
+  public void shouldHaveIdentityEndpoint() {
+    verify(app).get(eq(GetIdentity.ROUTE), any(GetIdentity.class));
+  }
+
+  @Test
+  public void shouldHaveHealthEndpoint() {
+    verify(app).get(eq(GetHealth.ROUTE), any(GetHealth.class));
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealthTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealthTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.node;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static javax.servlet.http.HttpServletResponse.SC_PARTIAL_CONTENT;
+import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.beaconrestapi.CacheControlUtils.CACHE_NONE;
+
+import io.javalin.core.util.Header;
+import io.javalin.http.Context;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.ChainDataProvider;
+import tech.pegasys.teku.api.SyncDataProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.sync.SyncService;
+
+public class GetHealthTest {
+  private Context context = mock(Context.class);
+  private final SyncService syncService = mock(SyncService.class);
+  private final SyncDataProvider syncDataProvider = new SyncDataProvider(syncService);
+  private final ChainDataProvider chainDataProvider = mock(ChainDataProvider.class);
+
+  @Test
+  public void shouldReturnSyncingStatusWhenSyncing() throws Exception {
+    final GetHealth handler = new GetHealth(syncDataProvider, chainDataProvider);
+
+    when(chainDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.getSyncStatus()).thenReturn(getSyncStatus(true, 1, 10, 10));
+
+    handler.handle(context);
+    verify(context).header(Header.CACHE_CONTROL, CACHE_NONE);
+    verify(context).status(SC_PARTIAL_CONTENT);
+  }
+
+  @Test
+  public void shouldReturnOkWhenInSyncAndReady() throws Exception {
+    final GetHealth handler = new GetHealth(syncDataProvider, chainDataProvider);
+
+    when(chainDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.getSyncStatus()).thenReturn(getSyncStatus(false, 1, 10, 10));
+
+    handler.handle(context);
+    verify(context).header(Header.CACHE_CONTROL, CACHE_NONE);
+    verify(context).status(SC_OK);
+  }
+
+  @Test
+  public void shouldReturnUnavailableWhenStoreNotAvailable() throws Exception {
+    final GetHealth handler = new GetHealth(syncDataProvider, chainDataProvider);
+
+    when(chainDataProvider.isStoreAvailable()).thenReturn(false);
+
+    handler.handle(context);
+    verify(context).header(Header.CACHE_CONTROL, CACHE_NONE);
+    verify(context).status(SC_SERVICE_UNAVAILABLE);
+  }
+
+  private tech.pegasys.teku.sync.SyncingStatus getSyncStatus(
+      final boolean isSyncing,
+      final long startSlot,
+      final long currentSlot,
+      final long highestSlot) {
+    return new tech.pegasys.teku.sync.SyncingStatus(
+        isSyncing,
+        new tech.pegasys.teku.sync.SyncStatus(
+            UInt64.valueOf(startSlot), UInt64.valueOf(currentSlot), UInt64.valueOf(highestSlot)));
+  }
+}


### PR DESCRIPTION
 - added unit test to show return codes, but no integration test specifically, because there is no content object to read and verify.

 partially addresses #2722

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.