### PR TITLE
Use default log level for node1 in the docker testnet setup

### DIFF
--- a/test-network/docker-compose.yml
+++ b/test-network/docker-compose.yml
@@ -54,7 +54,6 @@ services:
       - '--Xinterop-enabled'
       - '--p2p-private-key-file=/etc/teku/p2p-key.txt'
       - '--p2p-static-peers=/dns4/teku2/tcp/9000/p2p/16Uiu2HAm7WCLoc7KqP5jKQuQM3CNfR9tiamadxmEmNYUviXKoYmm,/dns4/teku3/tcp/9000/p2p/16Uiu2HAm3NZUwzzNHfnnB8ADfnuP5MTDuqjRb3nTRBxPTQ4g7Wjj,/dns4/teku4/tcp/9000/p2p/16Uiu2HAmPF4kvruyovDo7Pg8ZSAYefGdQvTiqQUWC1oUGFfUGm32'
-      - '--logging=TRACE'
       - '--Xlog-wire-cipher-enabled'
       - '--Xlog-wire-mux-enabled'
       - '--Xlog-wire-gossip-enabled'


### PR DESCRIPTION
## PR Description
Node 1 in the docker testnet was configured with TRACE logging as a hang-over from initial development.  Restore it to default level like the other nodes.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.