### PR TITLE
Rearrange packages to make room for multiple sync implementations

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -91,13 +91,13 @@ import tech.pegasys.teku.storage.store.FileKeyValueStore;
 import tech.pegasys.teku.storage.store.KeyValueStore;
 import tech.pegasys.teku.storage.store.StoreConfig;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
-import tech.pegasys.teku.sync.BlockManager;
-import tech.pegasys.teku.sync.DefaultSyncService;
-import tech.pegasys.teku.sync.FetchRecentBlocksService;
-import tech.pegasys.teku.sync.SyncManager;
 import tech.pegasys.teku.sync.SyncService;
 import tech.pegasys.teku.sync.SyncStateTracker;
-import tech.pegasys.teku.sync.util.NoopSyncService;
+import tech.pegasys.teku.sync.gossip.BlockManager;
+import tech.pegasys.teku.sync.gossip.FetchRecentBlocksService;
+import tech.pegasys.teku.sync.noop.NoopSyncService;
+import tech.pegasys.teku.sync.singlepeer.SinglePeerSyncService;
+import tech.pegasys.teku.sync.singlepeer.SyncManager;
 import tech.pegasys.teku.util.cli.VersionProvider;
 import tech.pegasys.teku.util.config.InvalidConfigurationException;
 import tech.pegasys.teku.util.config.TekuConfiguration;
@@ -552,7 +552,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
       SyncManager syncManager =
           SyncManager.create(
               asyncRunner, p2pNetwork, recentChainData, blockImporter, metricsSystem);
-      syncService = new DefaultSyncService(blockManager, syncManager, recentChainData);
+      syncService = new SinglePeerSyncService(blockManager, syncManager, recentChainData);
       eventChannels
           .subscribe(SlotEventsChannel.class, blockManager)
           .subscribe(FinalizedCheckpointChannel.class, pendingBlocks);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -45,7 +45,6 @@ import tech.pegasys.teku.core.operationvalidators.AttesterSlashingStateTransitio
 import tech.pegasys.teku.core.operationvalidators.ProposerSlashingStateTransitionValidator;
 import tech.pegasys.teku.core.operationvalidators.VoluntaryExitStateTransitionValidator;
 import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
-import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.interop.InteropStartupUtil;
 import tech.pegasys.teku.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.datastructures.operations.ProposerSlashing;
@@ -93,11 +92,8 @@ import tech.pegasys.teku.storage.store.StoreConfig;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 import tech.pegasys.teku.sync.SyncService;
 import tech.pegasys.teku.sync.SyncStateTracker;
-import tech.pegasys.teku.sync.gossip.BlockManager;
-import tech.pegasys.teku.sync.gossip.FetchRecentBlocksService;
 import tech.pegasys.teku.sync.noop.NoopSyncService;
-import tech.pegasys.teku.sync.singlepeer.SinglePeerSyncService;
-import tech.pegasys.teku.sync.singlepeer.SyncManager;
+import tech.pegasys.teku.sync.singlepeer.SinglePeerSyncServiceFactory;
 import tech.pegasys.teku.util.cli.VersionProvider;
 import tech.pegasys.teku.util.config.InvalidConfigurationException;
 import tech.pegasys.teku.util.config.TekuConfiguration;
@@ -536,26 +532,15 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     if (!config.isP2pEnabled()) {
       syncService = new NoopSyncService();
     } else {
-      final PendingPool<SignedBeaconBlock> pendingBlocks = PendingPool.createForBlocks();
-      final FutureItems<SignedBeaconBlock> futureBlocks =
-          new FutureItems<>(SignedBeaconBlock::getSlot);
-      final FetchRecentBlocksService recentBlockFetcher =
-          FetchRecentBlocksService.create(asyncRunner, p2pNetwork, pendingBlocks);
-      BlockManager blockManager =
-          BlockManager.create(
+      syncService =
+          SinglePeerSyncServiceFactory.create(
+              metricsSystem,
+              asyncRunner,
+              eventChannels,
               eventBus,
-              pendingBlocks,
-              futureBlocks,
-              recentBlockFetcher,
+              p2pNetwork,
               recentChainData,
               blockImporter);
-      SyncManager syncManager =
-          SyncManager.create(
-              asyncRunner, p2pNetwork, recentChainData, blockImporter, metricsSystem);
-      syncService = new SinglePeerSyncService(blockManager, syncManager, recentChainData);
-      eventChannels
-          .subscribe(SlotEventsChannel.class, blockManager)
-          .subscribe(FinalizedCheckpointChannel.class, pendingBlocks);
     }
   }
 

--- a/sync/src/main/java/tech/pegasys/teku/sync/gossip/BlockManager.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/gossip/BlockManager.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.gossip;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;

--- a/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchBlockTask.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchBlockTask.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.gossip;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -29,7 +29,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
-import tech.pegasys.teku.sync.FetchBlockTask.FetchBlockResult.Status;
+import tech.pegasys.teku.sync.gossip.FetchBlockTask.FetchBlockResult.Status;
 
 class FetchBlockTask {
   private static final Logger LOG = LogManager.getLogger();

--- a/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchRecentBlocksService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchRecentBlocksService.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.gossip;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
@@ -32,7 +32,8 @@ import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.statetransition.util.PendingPool;
-import tech.pegasys.teku.sync.FetchBlockTask.FetchBlockResult;
+import tech.pegasys.teku.sync.gossip.FetchBlockTask.FetchBlockResult;
+import tech.pegasys.teku.sync.singlepeer.RetryDelayFunction;
 
 public class FetchRecentBlocksService extends Service {
   private static final Logger LOG = LogManager.getLogger();

--- a/sync/src/main/java/tech/pegasys/teku/sync/noop/NoopSyncService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/noop/NoopSyncService.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync.util;
+package tech.pegasys.teku.sync.noop;
 
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 

--- a/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/CommonAncestor.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/CommonAncestor.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.singlepeer;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/FailedBlockImportException.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/FailedBlockImportException.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.singlepeer;
 
 import tech.pegasys.teku.core.results.BlockImportResult;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;

--- a/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/PeerSync.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/PeerSync.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.singlepeer;
 
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 import static tech.pegasys.teku.util.config.Constants.MAX_BLOCK_BY_RANGE_REQUEST_SIZE;

--- a/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/PeerSyncBlockRequest.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/PeerSyncBlockRequest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.singlepeer;
 
 import java.util.Optional;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;

--- a/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/PeerSyncResult.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/PeerSyncResult.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.singlepeer;
 
 enum PeerSyncResult {
   SUCCESSFUL_SYNC,

--- a/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/RetryDelayFunction.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/RetryDelayFunction.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.singlepeer;
 
 import java.time.Duration;
 

--- a/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/SinglePeerSyncService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/SinglePeerSyncService.java
@@ -11,19 +11,22 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.singlepeer;
 
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.sync.SyncService;
+import tech.pegasys.teku.sync.SyncingStatus;
+import tech.pegasys.teku.sync.gossip.BlockManager;
 
-public class DefaultSyncService extends Service implements SyncService {
+public class SinglePeerSyncService extends Service implements SyncService {
 
   private final SyncManager syncManager;
   private final BlockManager blockManager;
   private final RecentChainData storageClient;
 
-  public DefaultSyncService(
+  public SinglePeerSyncService(
       final BlockManager blockManager,
       final SyncManager syncManager,
       final RecentChainData storageClient) {

--- a/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/SinglePeerSyncServiceFactory.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/SinglePeerSyncServiceFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.sync.singlepeer;
+
+import com.google.common.eventbus.EventBus;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.events.EventChannels;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
+import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
+import tech.pegasys.teku.statetransition.util.FutureItems;
+import tech.pegasys.teku.statetransition.util.PendingPool;
+import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.sync.SyncService;
+import tech.pegasys.teku.sync.gossip.BlockManager;
+import tech.pegasys.teku.sync.gossip.FetchRecentBlocksService;
+import tech.pegasys.teku.util.time.channels.SlotEventsChannel;
+
+public class SinglePeerSyncServiceFactory {
+  public static SyncService create(
+      final MetricsSystem metricsSystem,
+      final AsyncRunner asyncRunner,
+      final EventChannels eventChannels,
+      final EventBus eventBus,
+      final P2PNetwork<Eth2Peer> p2pNetwork,
+      final RecentChainData recentChainData,
+      final BlockImporter blockImporter) {
+    final PendingPool<SignedBeaconBlock> pendingBlocks = PendingPool.createForBlocks();
+    final FutureItems<SignedBeaconBlock> futureBlocks =
+        new FutureItems<>(SignedBeaconBlock::getSlot);
+    final FetchRecentBlocksService recentBlockFetcher =
+        FetchRecentBlocksService.create(asyncRunner, p2pNetwork, pendingBlocks);
+    BlockManager blockManager =
+        BlockManager.create(
+            eventBus,
+            pendingBlocks,
+            futureBlocks,
+            recentBlockFetcher,
+            recentChainData,
+            blockImporter);
+    SyncManager syncManager =
+        SyncManager.create(asyncRunner, p2pNetwork, recentChainData, blockImporter, metricsSystem);
+    final SinglePeerSyncService syncService =
+        new SinglePeerSyncService(blockManager, syncManager, recentChainData);
+    eventChannels
+        .subscribe(SlotEventsChannel.class, blockManager)
+        .subscribe(FinalizedCheckpointChannel.class, pendingBlocks);
+    return syncService;
+  }
+}

--- a/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/SyncManager.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/SyncManager.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.singlepeer;
 
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
@@ -41,6 +41,8 @@ import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.sync.SyncService.SyncSubscriber;
+import tech.pegasys.teku.sync.SyncStatus;
+import tech.pegasys.teku.sync.SyncingStatus;
 
 public class SyncManager extends Service {
   private static final Duration SHORT_DELAY = Duration.ofSeconds(5);

--- a/sync/src/test/java/tech/pegasys/teku/sync/gossip/BlockManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/gossip/BlockManagerTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.gossip;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/sync/src/test/java/tech/pegasys/teku/sync/gossip/FetchBlockTaskTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/gossip/FetchBlockTaskTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.gossip;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -28,8 +28,8 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.Eth2Network;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
-import tech.pegasys.teku.sync.FetchBlockTask.FetchBlockResult;
-import tech.pegasys.teku.sync.FetchBlockTask.FetchBlockResult.Status;
+import tech.pegasys.teku.sync.gossip.FetchBlockTask.FetchBlockResult;
+import tech.pegasys.teku.sync.gossip.FetchBlockTask.FetchBlockResult.Status;
 
 public class FetchBlockTaskTest {
 

--- a/sync/src/test/java/tech/pegasys/teku/sync/gossip/FetchRecentBlocksServiceTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/gossip/FetchRecentBlocksServiceTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.gossip;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -33,9 +33,9 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.networking.eth2.Eth2Network;
 import tech.pegasys.teku.statetransition.util.PendingPool;
-import tech.pegasys.teku.sync.FetchBlockTask.FetchBlockResult;
-import tech.pegasys.teku.sync.FetchBlockTask.FetchBlockResult.Status;
-import tech.pegasys.teku.sync.FetchRecentBlocksService.FetchBlockTaskFactory;
+import tech.pegasys.teku.sync.gossip.FetchBlockTask.FetchBlockResult;
+import tech.pegasys.teku.sync.gossip.FetchBlockTask.FetchBlockResult.Status;
+import tech.pegasys.teku.sync.gossip.FetchRecentBlocksService.FetchBlockTaskFactory;
 
 public class FetchRecentBlocksServiceTest {
 

--- a/sync/src/test/java/tech/pegasys/teku/sync/singlepeer/AbstractSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/singlepeer/AbstractSyncTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.singlepeer;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;

--- a/sync/src/test/java/tech/pegasys/teku/sync/singlepeer/CommonAncestorTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/singlepeer/CommonAncestorTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.singlepeer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;

--- a/sync/src/test/java/tech/pegasys/teku/sync/singlepeer/PeerSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/singlepeer/PeerSyncTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.singlepeer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;

--- a/sync/src/test/java/tech/pegasys/teku/sync/singlepeer/RetryDelayFunctionTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/singlepeer/RetryDelayFunctionTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.singlepeer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sync/src/test/java/tech/pegasys/teku/sync/singlepeer/SyncManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/singlepeer/SyncManagerTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.sync;
+package tech.pegasys.teku.sync.singlepeer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -39,6 +39,7 @@ import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
 import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.sync.SyncService.SyncSubscriber;
+import tech.pegasys.teku.sync.SyncStatus;
 import tech.pegasys.teku.util.config.Constants;
 
 public class SyncManagerTest {

--- a/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
+++ b/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
@@ -40,6 +40,10 @@ import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.sync.gossip.BlockManager;
+import tech.pegasys.teku.sync.gossip.FetchRecentBlocksService;
+import tech.pegasys.teku.sync.singlepeer.SinglePeerSyncService;
+import tech.pegasys.teku.sync.singlepeer.SyncManager;
 import tech.pegasys.teku.util.time.channels.SlotEventsChannel;
 
 public class SyncingNodeManager {
@@ -106,7 +110,7 @@ public class SyncingNodeManager {
     SyncManager syncManager =
         SyncManager.create(
             asyncRunner, eth2Network, recentChainData, blockImporter, new NoOpMetricsSystem());
-    SyncService syncService = new DefaultSyncService(blockManager, syncManager, recentChainData);
+    SyncService syncService = new SinglePeerSyncService(blockManager, syncManager, recentChainData);
 
     eventChannels
         .subscribe(SlotEventsChannel.class, blockManager)


### PR DESCRIPTION
## PR Description
Create a package structure in the sync module to separate out the different sync implementations. Currently have noop and single peer but will add a more sophisticated sync also soon.

## Fixed Issue(s)
Part of #1844

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.