### PR TITLE
Mark all test sources as 'Test' in Idea

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -428,6 +428,22 @@ subprojects {
     return result
   }
 
+  apply plugin: 'idea'
+  idea {
+    module {
+      testSourceDirs += project.sourceSets.testFixtures.java.srcDirs
+      testSourceDirs += project.sourceSets.testFixtures.resources.srcDirs
+      testSourceDirs += project.sourceSets.integrationTest.java.srcDirs
+      testSourceDirs += project.sourceSets.integrationTest.resources.srcDirs
+      testSourceDirs += project.sourceSets.acceptanceTest.java.srcDirs
+      testSourceDirs += project.sourceSets.acceptanceTest.resources.srcDirs
+      testSourceDirs += project.sourceSets.compatibilityTest.java.srcDirs
+      testSourceDirs += project.sourceSets.compatibilityTest.resources.srcDirs
+      testSourceDirs += project.sourceSets.referenceTest.java.srcDirs
+      testSourceDirs += project.sourceSets.referenceTest.resources.srcDirs
+    }
+  }
+
   if (sourceSetIsPopulated("main") || sourceSetIsPopulated("testFixtures")) {
     apply plugin: 'com.jfrog.bintray'
     apply plugin: 'maven-publish'

--- a/eth-benchmark-tests/build.gradle
+++ b/eth-benchmark-tests/build.gradle
@@ -2,6 +2,12 @@ plugins {
   id 'me.champeau.gradle.jmh'
 }
 
+idea {
+  module {
+    testSourceDirs += sourceSets.main.java.srcDirs
+  }
+}
+
 dependencies {
   implementation project(':bls')
   implementation project(':ethereum:core')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Currently only unit test sources are marked as `Test` in Idea. That often inconvenient when navigating through code: e.g. I'm often interested in usages/callers/hierarchies just in production code but Idea currently treats `integrationTests, acceptanceTests, referenceTests, testFixtures, benchmarks` as production code and it takes me a while to sort them out every time I'm navigating. 

The fix was merely copy-pasted from here https://youtrack.jetbrains.com/issue/IDEA-151925#comment=27-2355076 and I'm honestly has no ideas if can have any side effects (I'm a gradle junior).

Here are some samples on how it looks in Idea: 

| Before | After | 
|--------|------|
| ![изображение](https://user-images.githubusercontent.com/8173857/92386555-ad792f00-f11c-11ea-92ba-db01cda3e795.png) | ![изображение](https://user-images.githubusercontent.com/8173857/92386567-b36f1000-f11c-11ea-8b80-9aa1cefe133a.png) |
| ![изображение](https://user-images.githubusercontent.com/8173857/92386703-f6c97e80-f11c-11ea-869d-00dc8ccf6c90.png) | ![изображение](https://user-images.githubusercontent.com/8173857/92386717-fd57f600-f11c-11ea-8a26-dde6f0b14380.png) | 
| ![изображение](https://user-images.githubusercontent.com/8173857/92386806-2f695800-f11d-11ea-9e29-a17a4cc17a0b.png) | ![изображение](https://user-images.githubusercontent.com/8173857/92386829-36906600-f11d-11ea-9e1c-29703c5a3dd6.png) | 



## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.