### PR TITLE
Revert "Mark all test sources as 'Test' in Idea (#2744)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -428,22 +428,6 @@ subprojects {
     return result
   }
 
-  apply plugin: 'idea'
-  idea {
-    module {
-      testSourceDirs += project.sourceSets.testFixtures.java.srcDirs
-      testSourceDirs += project.sourceSets.testFixtures.resources.srcDirs
-      testSourceDirs += project.sourceSets.integrationTest.java.srcDirs
-      testSourceDirs += project.sourceSets.integrationTest.resources.srcDirs
-      testSourceDirs += project.sourceSets.acceptanceTest.java.srcDirs
-      testSourceDirs += project.sourceSets.acceptanceTest.resources.srcDirs
-      testSourceDirs += project.sourceSets.compatibilityTest.java.srcDirs
-      testSourceDirs += project.sourceSets.compatibilityTest.resources.srcDirs
-      testSourceDirs += project.sourceSets.referenceTest.java.srcDirs
-      testSourceDirs += project.sourceSets.referenceTest.resources.srcDirs
-    }
-  }
-
   if (sourceSetIsPopulated("main") || sourceSetIsPopulated("testFixtures")) {
     apply plugin: 'com.jfrog.bintray'
     apply plugin: 'maven-publish'

--- a/eth-benchmark-tests/build.gradle
+++ b/eth-benchmark-tests/build.gradle
@@ -2,12 +2,6 @@ plugins {
   id 'me.champeau.gradle.jmh'
 }
 
-idea {
-  module {
-    testSourceDirs += sourceSets.main.java.srcDirs
-  }
-}
-
 dependencies {
   implementation project(':bls')
   implementation project(':ethereum:core')


### PR DESCRIPTION
## PR Description
Revert change to mark test sources as 'Test' in Idea.  IntelliJ works initially but regularly gets confused and can't compile because the output path for testFixtures modules aren't specified. :(

![image](https://user-images.githubusercontent.com/72675/92418713-3be8c180-f1ac-11ea-8753-67cc4a46b61f.png)


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.