### PR TITLE
[2722] add GetPeers and GetPeersById api endpoints

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/node/GetPeerByIdIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/node/GetPeerByIdIntegrationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.v1.node;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Optional;
+import okhttp3.Response;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.response.v1.node.Direction;
+import tech.pegasys.teku.api.response.v1.node.Peer;
+import tech.pegasys.teku.api.response.v1.node.PeerResponse;
+import tech.pegasys.teku.api.response.v1.node.State;
+import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeerById;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
+import tech.pegasys.teku.networking.p2p.network.PeerAddress;
+
+public class GetPeerByIdIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
+  final Eth2Peer peer = mock(Eth2Peer.class);
+  final MockNodeId node1 = new MockNodeId(0);
+  final PeerAddress peerAddress = mock(PeerAddress.class);
+
+  @Test
+  public void shouldGetPeerById() throws IOException {
+    startRestAPIAtGenesis();
+    when(eth2Network.getPeer(any())).thenReturn(Optional.of(peer));
+    when(peer.getId()).thenReturn(node1);
+    when(peer.getAddress()).thenReturn(peerAddress);
+    when(peerAddress.toExternalForm()).thenReturn("/ip/1.2.3.4/tcp/4242/p2p/aeiou");
+    when(peer.isConnected()).thenReturn(true);
+    when(peer.connectionInitiatedLocally()).thenReturn(true);
+
+    final Response response = get("QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N");
+    assertThat(response.code()).isEqualTo(SC_OK);
+
+    final PeerResponse peerResponse =
+        jsonProvider.jsonToObject(response.body().string(), PeerResponse.class);
+    assertThat(peerResponse.data)
+        .isEqualTo(
+            new Peer(
+                node1.toBase58(),
+                null,
+                "/ip/1.2.3.4/tcp/4242/p2p/aeiou",
+                State.connected,
+                Direction.outbound));
+  }
+
+  private Response get(final String peerId) throws IOException {
+    return getResponse(GetPeerById.ROUTE.replace(":peer_id", peerId));
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -61,6 +61,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.node.GetSyncing;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetVersion;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetHealth;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetIdentity;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeerById;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAggregate;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAttestation;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetNewBlock;
@@ -212,6 +213,10 @@ public class BeaconRestApi {
   private void addV1NodeHandlers(final DataProvider provider) {
     app.get(GetHealth.ROUTE, new GetHealth(provider));
     app.get(GetIdentity.ROUTE, new GetIdentity(provider, jsonProvider));
+    app.get(
+        tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeers.ROUTE,
+        new tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeers(provider, jsonProvider));
+    app.get(GetPeerById.ROUTE, new GetPeerById(provider, jsonProvider));
     app.get(
         tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetSyncing.ROUTE,
         new tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetSyncing(provider, jsonProvider));

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/network/GetEthereumNameRecord.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/network/GetEthereumNameRecord.java
@@ -38,11 +38,14 @@ public class GetEthereumNameRecord implements Handler {
   }
 
   @OpenApi(
+      deprecated = true,
       path = ROUTE,
       method = HttpMethod.GET,
       summary = "Get the listening ENR address of the node.",
       tags = {TAG_NETWORK},
-      description = "Returns the beacon node's listening Ethereum Node Record (ENR) address.",
+      description =
+          "Returns the beacon node's listening Ethereum Node Record (ENR) address."
+              + " Replaced by standard api endpoint `/eth/v1/node/identity`.",
       responses = {
         @OpenApiResponse(
             status = RES_OK,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/network/GetListenAddresses.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/network/GetListenAddresses.java
@@ -40,12 +40,14 @@ public class GetListenAddresses implements Handler {
   }
 
   @OpenApi(
+      deprecated = true,
       path = ROUTE,
       method = HttpMethod.GET,
       summary = "Get the addresses the client's libp2p service is listening on.",
       tags = {TAG_NETWORK},
       description =
-          "Returns the list of addresses that the client's libp2p service is listening on.",
+          "Returns the list of addresses that the client's libp2p service is listening on."
+              + " Replaced by standard api endpoint `/eth/v1/node/identity`.",
       responses = {
         @OpenApiResponse(
             status = RES_OK,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/network/GetPeerId.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/network/GetPeerId.java
@@ -41,11 +41,14 @@ public class GetPeerId implements Handler {
   }
 
   @OpenApi(
+      deprecated = true,
       path = ROUTE,
       method = HttpMethod.GET,
       summary = "Get the node PeerId.",
       tags = {TAG_NETWORK},
-      description = "Returns the beacon node's base58-encoded PeerId.",
+      description =
+          "Returns the beacon node's base58-encoded PeerId."
+              + " Replaced by standard api endpoint `/eth/v1/node/identity`.",
       responses = {
         @OpenApiResponse(status = RES_OK, content = @OpenApiContent(from = String.class)),
         @OpenApiResponse(status = RES_INTERNAL_ERROR)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/network/GetPeers.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/network/GetPeers.java
@@ -40,11 +40,14 @@ public class GetPeers implements Handler {
   }
 
   @OpenApi(
+      deprecated = true,
       path = ROUTE,
       method = HttpMethod.GET,
       summary = "Get the PeerIds of connected peers.",
       tags = {TAG_NETWORK},
-      description = "Returns the base58-encoded PeerId of each peer connected to the beacon node.",
+      description =
+          "Returns the base58-encoded PeerId of each peer connected to the beacon node."
+              + " Replaced by standard api endpoint `/eth/v1/node/peers`.",
       responses = {
         @OpenApiResponse(
             status = RES_OK,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerById.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerById.java
@@ -11,12 +11,14 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beaconrestapi.handlers.network;
+package tech.pegasys.teku.beaconrestapi.handlers.v1.node;
 
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static tech.pegasys.teku.beaconrestapi.CacheControlUtils.CACHE_NONE;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_NOT_FOUND;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
-import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_NETWORK;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_V1_NODE;
 
 import io.javalin.core.util.Header;
 import io.javalin.http.Context;
@@ -25,39 +27,50 @@ import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import java.util.Map;
+import java.util.Optional;
+import org.jetbrains.annotations.NotNull;
+import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.NetworkDataProvider;
+import tech.pegasys.teku.api.response.v1.node.Peer;
+import tech.pegasys.teku.api.response.v1.node.PeerResponse;
 import tech.pegasys.teku.provider.JsonProvider;
 
-public class GetPeerCount implements Handler {
-
-  public static final String ROUTE = "/network/peer_count";
+public class GetPeerById implements Handler {
+  public static final String ROUTE = "/eth/v1/node/peers/:peer_id";
   private final JsonProvider jsonProvider;
   private final NetworkDataProvider network;
 
-  public GetPeerCount(NetworkDataProvider network, JsonProvider jsonProvider) {
-    this.network = network;
+  public GetPeerById(final DataProvider provider, final JsonProvider jsonProvider) {
     this.jsonProvider = jsonProvider;
+    this.network = provider.getNetworkDataProvider();
+  }
+
+  GetPeerById(final NetworkDataProvider network, final JsonProvider jsonProvider) {
+    this.jsonProvider = jsonProvider;
+    this.network = network;
   }
 
   @OpenApi(
-      deprecated = true,
       path = ROUTE,
       method = HttpMethod.GET,
-      summary = "Get the number of connected peers.",
-      tags = {TAG_NETWORK},
-      description =
-          "Returns the number of peers connected to the beacon node."
-              + " Replaced by standard api endpoint `/eth/v1/node/peers`.",
+      summary = "Get peer",
+      tags = {TAG_V1_NODE},
+      description = "Retrieves data about the given peer.",
       responses = {
-        @OpenApiResponse(
-            status = RES_OK,
-            content = @OpenApiContent(from = long.class),
-            description = "Number of peers connected to the beacon node."),
+        @OpenApiResponse(status = RES_OK, content = @OpenApiContent(from = PeerResponse.class)),
+        @OpenApiResponse(status = RES_NOT_FOUND, description = "Peer not found"),
         @OpenApiResponse(status = RES_INTERNAL_ERROR)
       })
   @Override
-  public void handle(Context ctx) throws Exception {
+  public void handle(@NotNull final Context ctx) throws Exception {
+    final Map<String, String> parameters = ctx.pathParamMap();
     ctx.header(Header.CACHE_CONTROL, CACHE_NONE);
-    ctx.result(jsonProvider.objectToJSON(network.getPeerCount()));
+    Optional<Peer> peer = network.getPeerById(parameters.get("peer_id"));
+    if (peer.isEmpty()) {
+      ctx.status(SC_NOT_FOUND);
+    } else {
+      ctx.result(jsonProvider.objectToJSON(new PeerResponse(peer.get())));
+    }
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractBeaconHandlerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractBeaconHandlerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.javalin.core.util.Header;
+import io.javalin.http.Context;
+import org.mockito.ArgumentCaptor;
+import tech.pegasys.teku.api.ChainDataProvider;
+import tech.pegasys.teku.api.NetworkDataProvider;
+import tech.pegasys.teku.api.SyncDataProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networking.eth2.Eth2Network;
+import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.sync.SyncService;
+
+public abstract class AbstractBeaconHandlerTest {
+
+  @SuppressWarnings("unchecked")
+  protected final Eth2Network eth2Network = mock(Eth2Network.class);
+
+  protected final Context context = mock(Context.class);
+  protected final JsonProvider jsonProvider = new JsonProvider();
+  protected final NetworkDataProvider network = new NetworkDataProvider(eth2Network);
+
+  protected final SyncService syncService = mock(SyncService.class);
+  protected final SyncDataProvider syncDataProvider = new SyncDataProvider(syncService);
+
+  private final ArgumentCaptor<String> stringArgs = ArgumentCaptor.forClass(String.class);
+
+  protected final ChainDataProvider chainDataProvider = mock(ChainDataProvider.class);
+
+  protected void verifyCacheStatus(final String cacheControlString) {
+    verify(context).header(Header.CACHE_CONTROL, cacheControlString);
+  }
+
+  protected void verifyStatusCode(final int statusCode) {
+    verify(context).status(statusCode);
+  }
+
+  protected <T> T getResponseObject(Class<T> clazz) throws JsonProcessingException {
+    verify(context).result(stringArgs.capture());
+    String val = stringArgs.getValue();
+    return jsonProvider.jsonToObject(val, clazz);
+  }
+
+  protected tech.pegasys.teku.sync.SyncingStatus getSyncStatus(
+      final boolean isSyncing,
+      final long startSlot,
+      final long currentSlot,
+      final long highestSlot) {
+    return new tech.pegasys.teku.sync.SyncingStatus(
+        isSyncing,
+        new tech.pegasys.teku.sync.SyncStatus(
+            UInt64.valueOf(startSlot), UInt64.valueOf(currentSlot), UInt64.valueOf(highestSlot)));
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetHealth;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetIdentity;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeerById;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeers;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetSyncing;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetVersion;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
@@ -84,5 +86,15 @@ public class BeaconRestApiV1Test {
   @Test
   public void shouldHaveSyncingEndpoint() {
     verify(app).get(eq(GetSyncing.ROUTE), any(GetSyncing.class));
+  }
+
+  @Test
+  public void shouldHavePeersEndpoint() {
+    verify(app).get(eq(GetPeers.ROUTE), any(GetPeers.class));
+  }
+
+  @Test
+  public void shouldHavePeerByIdEndpoint() {
+    verify(app).get(eq(GetPeerById.ROUTE), any(GetPeerById.class));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetIdentityTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetIdentityTest.java
@@ -15,31 +15,16 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.node;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.beaconrestapi.CacheControlUtils.CACHE_NONE;
 
-import io.javalin.core.util.Header;
-import io.javalin.http.Context;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.api.response.v1.node.IdentityResponse;
+import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.MetadataMessage;
-import tech.pegasys.teku.networking.eth2.Eth2Network;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
-import tech.pegasys.teku.provider.JsonProvider;
 
-public class GetIdentityTest {
-  private final JsonProvider jsonProvider = new JsonProvider();
-  private final Context context = mock(Context.class);
-
-  @SuppressWarnings("unchecked")
-  private final Eth2Network eth2Network = mock(Eth2Network.class);
-
-  private final NetworkDataProvider network = new NetworkDataProvider(eth2Network);
-
-  private final ArgumentCaptor<String> stringArgs = ArgumentCaptor.forClass(String.class);
+public class GetIdentityTest extends AbstractBeaconHandlerTest {
 
   @Test
   public void shouldReturnExpectedObjectType() throws Exception {
@@ -52,11 +37,9 @@ public class GetIdentityTest {
     when(eth2Network.getNodeAddress()).thenReturn("address");
 
     handler.handle(context);
-    verify(context).result(stringArgs.capture());
-    verify(context).header(Header.CACHE_CONTROL, CACHE_NONE);
-    String val = stringArgs.getValue();
-    assertThat(val).isNotNull();
-    IdentityResponse response = jsonProvider.jsonToObject(val, IdentityResponse.class);
+    verifyCacheStatus(CACHE_NONE);
+
+    IdentityResponse response = getResponseObject(IdentityResponse.class);
     assertThat(response.data.peerId).isEqualTo("aeiou");
     assertThat(response.data.p2pAddresses.get(0)).isEqualTo("address");
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerByIdTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerByIdTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.node;
+
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.libp2p.core.PeerId;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.NetworkDataProvider;
+import tech.pegasys.teku.api.response.v1.node.Direction;
+import tech.pegasys.teku.api.response.v1.node.Peer;
+import tech.pegasys.teku.api.response.v1.node.PeerResponse;
+import tech.pegasys.teku.api.response.v1.node.State;
+import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
+
+public class GetPeerByIdTest extends AbstractBeaconHandlerTest {
+  final String peerId = PeerId.random().toBase58();
+  final Peer peer =
+      new Peer(
+          peerId, null, "/ip4/7.7.7.7/tcp/4242/p2p/" + peerId, State.connected, Direction.inbound);
+
+  @Test
+  public void shouldReturnNotFoundIfPeerNotFound() throws Exception {
+    final GetPeerById handler = new GetPeerById(network, jsonProvider);
+    when(network.getPeerById(peerId)).thenReturn(Optional.empty());
+    when(context.pathParamMap()).thenReturn(Map.of("peer_id", peerId));
+    handler.handle(context);
+
+    verifyStatusCode(SC_NOT_FOUND);
+  }
+
+  @Test
+  public void shouldReturnPeerIfFound() throws Exception {
+    final NetworkDataProvider networkDataProvider = mock(NetworkDataProvider.class);
+    GetPeerById handler = new GetPeerById(networkDataProvider, jsonProvider);
+    when(context.pathParamMap()).thenReturn(Map.of("peer_id", peerId));
+    when(networkDataProvider.getPeerById(eq(peerId))).thenReturn(Optional.of(peer));
+    handler.handle(context);
+
+    final PeerResponse response = getResponseObject(PeerResponse.class);
+
+    assertThat(response.data).isEqualTo(peer);
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeersTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeersTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.node;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.libp2p.core.PeerId;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.NetworkDataProvider;
+import tech.pegasys.teku.api.response.v1.node.Direction;
+import tech.pegasys.teku.api.response.v1.node.Peer;
+import tech.pegasys.teku.api.response.v1.node.PeersResponse;
+import tech.pegasys.teku.api.response.v1.node.State;
+import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
+
+public class GetPeersTest extends AbstractBeaconHandlerTest {
+  final String peerId1 = PeerId.random().toBase58();
+  final Peer peer1 =
+      new Peer(
+          peerId1,
+          null,
+          "/ip4/7.7.7.7/tcp/4242/p2p/" + peerId1,
+          State.connected,
+          Direction.inbound);
+  final String peerId2 = PeerId.random().toBase58();
+  final Peer peer2 =
+      new Peer(
+          peerId2,
+          null,
+          "/ip4/8.8.8.8/tcp/4243/p2p/" + peerId2,
+          State.connected,
+          Direction.outbound);
+
+  @Test
+  public void shouldReturnListOfPeers() throws Exception {
+    final NetworkDataProvider networkDataProvider = mock(NetworkDataProvider.class);
+    GetPeers handler = new GetPeers(networkDataProvider, jsonProvider);
+    when(networkDataProvider.getPeers()).thenReturn(List.of(peer1, peer2));
+    handler.handle(context);
+
+    PeersResponse response = getResponseObject(PeersResponse.class);
+    assertThat(response.data).containsExactlyInAnyOrder(peer1, peer2);
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncingTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncingTest.java
@@ -14,39 +14,23 @@
 package tech.pegasys.teku.beaconrestapi.handlers.v1.node;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.beaconrestapi.CacheControlUtils.CACHE_NONE;
 
-import io.javalin.core.util.Header;
-import io.javalin.http.Context;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.api.response.v1.node.SyncingResponse;
+import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.provider.JsonProvider;
-import tech.pegasys.teku.sync.SyncService;
 
-public class GetSyncingTest {
-  private final JsonProvider jsonProvider = new JsonProvider();
-  private final SyncService syncService = mock(SyncService.class);
-  private final SyncDataProvider syncDataProvider = new SyncDataProvider(syncService);
-  private final Context context = mock(Context.class);
-
-  private final ArgumentCaptor<String> stringArgs = ArgumentCaptor.forClass(String.class);
-
+public class GetSyncingTest extends AbstractBeaconHandlerTest {
   @Test
   public void shouldGetSyncingStatusSyncing() throws Exception {
     GetSyncing handler = new GetSyncing(syncDataProvider, jsonProvider);
     when(syncService.getSyncStatus()).thenReturn(getSyncStatus(true, 1, 7, 10));
     handler.handle(context);
-    verify(context).result(stringArgs.capture());
-    verify(context).header(Header.CACHE_CONTROL, CACHE_NONE);
-    String val = stringArgs.getValue();
-    assertThat(val).isNotNull();
-    SyncingResponse response = jsonProvider.jsonToObject(val, SyncingResponse.class);
+    verifyCacheStatus(CACHE_NONE);
+
+    SyncingResponse response = getResponseObject(SyncingResponse.class);
     assertThat(response.data.headSlot).isEqualTo(UInt64.valueOf(7));
     assertThat(response.data.syncingDistance).isEqualTo(UInt64.valueOf(3));
   }
@@ -56,23 +40,10 @@ public class GetSyncingTest {
     GetSyncing handler = new GetSyncing(syncDataProvider, jsonProvider);
     when(syncService.getSyncStatus()).thenReturn(getSyncStatus(false, 1, 10, 11));
     handler.handle(context);
+    verifyCacheStatus(CACHE_NONE);
 
-    verify(context).result(stringArgs.capture());
-    String val = stringArgs.getValue();
-    assertThat(val).isNotNull();
-    SyncingResponse response = jsonProvider.jsonToObject(val, SyncingResponse.class);
+    SyncingResponse response = getResponseObject(SyncingResponse.class);
     assertThat(response.data.headSlot).isEqualTo(UInt64.valueOf(10));
     assertThat(response.data.syncingDistance).isEqualTo(UInt64.valueOf(0));
-  }
-
-  private tech.pegasys.teku.sync.SyncingStatus getSyncStatus(
-      final boolean isSyncing,
-      final long startSlot,
-      final long currentSlot,
-      final long highestSlot) {
-    return new tech.pegasys.teku.sync.SyncingStatus(
-        isSyncing,
-        new tech.pegasys.teku.sync.SyncStatus(
-            UInt64.valueOf(startSlot), UInt64.valueOf(currentSlot), UInt64.valueOf(highestSlot)));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetVersionTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetVersionTest.java
@@ -13,21 +13,16 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v1.node;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.beaconrestapi.CacheControlUtils.CACHE_NONE;
 
-import io.javalin.core.util.Header;
-import io.javalin.http.Context;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.response.v1.node.Version;
 import tech.pegasys.teku.api.response.v1.node.VersionResponse;
-import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
 import tech.pegasys.teku.util.cli.VersionProvider;
 
-public class GetVersionTest {
-  private Context context = mock(Context.class);
-  private final JsonProvider jsonProvider = new JsonProvider();
+public class GetVersionTest extends AbstractBeaconHandlerTest {
   private final VersionResponse versionResponse =
       new VersionResponse(new Version(VersionProvider.VERSION));
 
@@ -35,7 +30,9 @@ public class GetVersionTest {
   public void shouldReturnVersionString() throws Exception {
     GetVersion handler = new GetVersion(jsonProvider);
     handler.handle(context);
-    verify(context).header(Header.CACHE_CONTROL, CACHE_NONE);
-    verify(context).result(jsonProvider.objectToJSON(versionResponse));
+    verifyCacheStatus(CACHE_NONE);
+
+    VersionResponse response = getResponseObject(VersionResponse.class);
+    assertThat(response).isEqualTo(versionResponse);
   }
 }

--- a/data/provider/build.gradle
+++ b/data/provider/build.gradle
@@ -17,7 +17,6 @@ dependencies {
 
     implementation 'com.google.code.gson:gson'
     implementation 'org.apache.tuweni:tuweni-units'
-    implementation 'io.libp2p:jvm-libp2p-minimal'
 
     testImplementation testFixtures(project(':ethereum:core'))
     testImplementation testFixtures(project(':ethereum:datastructures'))

--- a/data/provider/build.gradle
+++ b/data/provider/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 
     implementation 'com.google.code.gson:gson'
     implementation 'org.apache.tuweni:tuweni-units'
+    implementation 'io.libp2p:jvm-libp2p-minimal'
 
     testImplementation testFixtures(project(':ethereum:core'))
     testImplementation testFixtures(project(':ethereum:datastructures'))

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NetworkDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NetworkDataProvider.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.api;
 
-import io.libp2p.core.PeerId;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -22,7 +21,6 @@ import tech.pegasys.teku.api.response.v1.node.State;
 import tech.pegasys.teku.api.schema.Metadata;
 import tech.pegasys.teku.networking.eth2.Eth2Network;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNodeId;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 
@@ -100,7 +98,7 @@ public class NetworkDataProvider {
   }
 
   public Optional<tech.pegasys.teku.api.response.v1.node.Peer> getPeerById(final String peerId) {
-    final NodeId nodeId = new LibP2PNodeId(PeerId.fromBase58(peerId));
+    final NodeId nodeId = network.parseNodeId(peerId);
     return network.getPeer(nodeId).map(this::toPeer);
   }
 

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/node/Direction.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/node/Direction.java
@@ -13,28 +13,7 @@
 
 package tech.pegasys.teku.api.response.v1.node;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Objects;
-
-public class VersionResponse {
-  public final Version data;
-
-  @JsonCreator
-  public VersionResponse(@JsonProperty("data") final Version data) {
-    this.data = data;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    final VersionResponse that = (VersionResponse) o;
-    return Objects.equals(data, that.data);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(data);
-  }
+public enum Direction {
+  inbound,
+  outbound
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/node/Peer.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/node/Peer.java
@@ -34,6 +34,7 @@ public class Peer {
   @JsonProperty("enr")
   @Schema(
       type = "string",
+      nullable = true,
       description =
           "Ethereum node record. Not currently populated. "
               + "[Read more](https://eips.ethereum.org/EIPS/eip-778)",

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/node/Peer.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/node/Peer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.response.v1.node;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Peer {
+
+  @JsonProperty("peer_id")
+  @Schema(
+      type = "string",
+      description =
+          "Cryptographic hash of a peer’s public key. "
+              + "'[Read more](https://docs.libp2p.io/concepts/peer-id/)",
+      example = "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N")
+  public final String peerId;
+
+  @JsonProperty("enr")
+  @Schema(
+      type = "string",
+      description =
+          "Ethereum node record. Not currently populated. "
+              + "[Read more](https://eips.ethereum.org/EIPS/eip-778)",
+      example =
+          "example: enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrk"
+              + "Tfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYp"
+              + "Ma2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8")
+  public final String enr;
+
+  @JsonProperty("address")
+  @Schema(
+      type = "string",
+      example = "/ip4/7.7.7.7/tcp/4242/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N",
+      description = "[Read more](https://docs.libp2p.io/reference/glossary/#multiaddr)")
+  public final String address;
+
+  @JsonProperty("state")
+  public final State state;
+
+  @JsonProperty("direction")
+  public final Direction direction;
+
+  @JsonCreator
+  public Peer(
+      @JsonProperty("peer_id") final String peerId,
+      @JsonProperty("enr") final String enr,
+      @JsonProperty("address") final String address,
+      @JsonProperty("state") final State state,
+      @JsonProperty("direction") final Direction direction) {
+    this.peerId = peerId;
+    this.enr = enr;
+    this.address = address;
+    this.state = state;
+    this.direction = direction;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final Peer peer = (Peer) o;
+    return Objects.equals(peerId, peer.peerId)
+        && Objects.equals(enr, peer.enr)
+        && Objects.equals(address, peer.address)
+        && state == peer.state
+        && direction == peer.direction;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(peerId, enr, address, state, direction);
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/node/PeerResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/node/PeerResponse.java
@@ -15,33 +15,27 @@ package tech.pegasys.teku.api.response.v1.node;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
 
-public class Version {
-  @JsonProperty("version")
-  @Schema(
-      description =
-          "A string which uniquely identifies the client implementation and its version; "
-              + "similar to [HTTP User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3).",
-      example = "teku/v0.12.6-dev-994997f8/osx-x86_64/adoptopenjdk-java-11")
-  public final String version;
+public class PeerResponse {
+  @JsonProperty("data")
+  public final Peer data;
 
   @JsonCreator
-  public Version(@JsonProperty("version") final String version) {
-    this.version = version;
+  public PeerResponse(@JsonProperty("data") final Peer data) {
+    this.data = data;
   }
 
   @Override
   public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    final Version version1 = (Version) o;
-    return Objects.equals(version, version1.version);
+    final PeerResponse that = (PeerResponse) o;
+    return Objects.equals(data, that.data);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(version);
+    return Objects.hash(data);
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/node/PeersResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/node/PeersResponse.java
@@ -15,33 +15,27 @@ package tech.pegasys.teku.api.response.v1.node;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import java.util.Objects;
 
-public class Version {
-  @JsonProperty("version")
-  @Schema(
-      description =
-          "A string which uniquely identifies the client implementation and its version; "
-              + "similar to [HTTP User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3).",
-      example = "teku/v0.12.6-dev-994997f8/osx-x86_64/adoptopenjdk-java-11")
-  public final String version;
+public class PeersResponse {
+  public final List<Peer> data;
 
   @JsonCreator
-  public Version(@JsonProperty("version") final String version) {
-    this.version = version;
+  public PeersResponse(@JsonProperty("data") final List<Peer> data) {
+    this.data = data;
   }
 
   @Override
   public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    final Version version1 = (Version) o;
-    return Objects.equals(version, version1.version);
+    final PeersResponse that = (PeersResponse) o;
+    return Objects.equals(data, that.data);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(version);
+    return Objects.hash(data);
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/node/State.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/node/State.java
@@ -13,28 +13,9 @@
 
 package tech.pegasys.teku.api.response.v1.node;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Objects;
-
-public class VersionResponse {
-  public final Version data;
-
-  @JsonCreator
-  public VersionResponse(@JsonProperty("data") final Version data) {
-    this.data = data;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    final VersionResponse that = (VersionResponse) o;
-    return Objects.equals(data, that.data);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(data);
-  }
+public enum State {
+  disconnected,
+  connecting,
+  connected,
+  disconnecting
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -267,6 +267,11 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
   }
 
   @Override
+  public NodeId parseNodeId(final String nodeId) {
+    return new LibP2PNodeId(PeerId.fromBase58(nodeId));
+  }
+
+  @Override
   public int getPeerCount() {
     return peerManager.getPeerCount();
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrPeerAddress.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrPeerAddress.java
@@ -30,6 +30,11 @@ public class MultiaddrPeerAddress extends PeerAddress {
     this.multiaddr = multiaddr;
   }
 
+  @Override
+  public String toExternalForm() {
+    return multiaddr.toString();
+  }
+
   public static MultiaddrPeerAddress fromAddress(final String address) {
     final Multiaddr multiaddr = Multiaddr.fromString(address);
     return fromMultiaddr(multiaddr);

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/mock/MockP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/mock/MockP2PNetwork.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.p2p.mock;
 
+import io.libp2p.core.PeerId;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -71,6 +72,12 @@ public class MockP2PNetwork<P extends Peer> implements P2PNetwork<P> {
   @Override
   public Stream<P> streamPeers() {
     return Stream.empty();
+  }
+
+  @Override
+  public NodeId parseNodeId(final String nodeId) {
+    PeerId peerId = PeerId.fromBase58(nodeId);
+    return new MockNodeId(Bytes.wrap(peerId.getBytes()));
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/DelegatingP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/DelegatingP2PNetwork.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.p2p.network;
 
+import io.libp2p.core.PeerId;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -21,6 +22,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
 import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
 import tech.pegasys.teku.networking.p2p.gossip.TopicHandler;
+import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNodeId;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 
@@ -39,6 +41,11 @@ public abstract class DelegatingP2PNetwork<T extends Peer> implements P2PNetwork
   @Override
   public PeerAddress createPeerAddress(final DiscoveryPeer discoveryPeer) {
     return network.createPeerAddress(discoveryPeer);
+  }
+
+  @Override
+  public NodeId parseNodeId(final String nodeId) {
+    return new LibP2PNodeId(PeerId.fromBase58(nodeId));
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/DelegatingP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/DelegatingP2PNetwork.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.networking.p2p.network;
 
-import io.libp2p.core.PeerId;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -22,7 +21,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
 import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
 import tech.pegasys.teku.networking.p2p.gossip.TopicHandler;
-import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNodeId;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/DelegatingP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/DelegatingP2PNetwork.java
@@ -45,7 +45,7 @@ public abstract class DelegatingP2PNetwork<T extends Peer> implements P2PNetwork
 
   @Override
   public NodeId parseNodeId(final String nodeId) {
-    return new LibP2PNodeId(PeerId.fromBase58(nodeId));
+    return network.parseNodeId(nodeId);
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/P2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/P2PNetwork.java
@@ -73,6 +73,8 @@ public interface P2PNetwork<T extends Peer> extends GossipNetwork {
 
   Stream<T> streamPeers();
 
+  NodeId parseNodeId(final String nodeId);
+
   int getPeerCount();
 
   String getNodeAddress();

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/PeerAddress.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/PeerAddress.java
@@ -24,6 +24,10 @@ public class PeerAddress {
     this.id = id;
   }
 
+  public String toExternalForm() {
+    return toString();
+  }
+
   public NodeId getId() {
     return id;
   }


### PR DESCRIPTION
- deprecated a number of endpoints that are now served by standard endpoints
   - /network/enr -> /eth/v1/node/identity
   - /network/listen_addresses -> /eth/v1/node/identity
   - /network/listen_port -> /eth/v1/node/identity
   - /network/peer_count -> /eth/v1/node/peers
   - /network/peer_id -> /eth/v1/node/identity
   - /network/peers -> /eth/v1/node/peers

- provided `/eth/v1/node/peers`
   - never sets ENR currently, as its a non trivial exercise to retrieve.
- provided `/eth/v1/node/peers/:peer_id`

Only added an integration test for getPeerById, as getPeers is just a case of calling that multiple times.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.