### PR TITLE
[issue #2747] fix slashing data export

### DIFF
--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/SyncDataAccessor.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/SyncDataAccessor.java
@@ -52,8 +52,9 @@ public class SyncDataAccessor {
    * @exception IOException if an IO error occurs while writing
    */
   public void syncedWrite(final Path path, final Bytes data) throws IOException {
-    if (path.getParent() != null) {
-      final File parentDirectory = path.getParent().toFile();
+    final Path absolutePath = path.toAbsolutePath();
+    if (absolutePath.getParent() != null) {
+      final File parentDirectory = absolutePath.getParent().toFile();
       if (!parentDirectory.mkdirs() && !parentDirectory.isDirectory()) {
         throw new IOException("Unable to create directory " + parentDirectory);
       }

--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/SyncDataAccessor.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/SyncDataAccessor.java
@@ -60,7 +60,7 @@ public class SyncDataAccessor {
       }
     }
     Files.write(
-        path,
+        absolutePath,
         data.toArrayUnsafe(),
         StandardOpenOption.SYNC,
         StandardOpenOption.CREATE,

--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/SyncDataAccessor.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/SyncDataAccessor.java
@@ -52,9 +52,11 @@ public class SyncDataAccessor {
    * @exception IOException if an IO error occurs while writing
    */
   public void syncedWrite(final Path path, final Bytes data) throws IOException {
-    final File parentDirectory = path.getParent().toFile();
-    if (!parentDirectory.mkdirs() && !parentDirectory.isDirectory()) {
-      throw new IOException("Unable to create directory " + parentDirectory);
+    if (path.getParent() != null) {
+      final File parentDirectory = path.getParent().toFile();
+      if (!parentDirectory.mkdirs() && !parentDirectory.isDirectory()) {
+        throw new IOException("Unable to create directory " + parentDirectory);
+      }
     }
     Files.write(
         path,

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
@@ -364,7 +364,7 @@ public class TekuConfigurationBuilder {
 
   public TekuConfigurationBuilder setDataPath(final String dataPath) {
     this.dataPath = dataPath;
-    this.setValidatorsSlashingProtectionPath(Path.of(dataPath, "validators", "slashingprotection"));
+    this.setValidatorsSlashingProtectionPath(Path.of(dataPath, "validators", "slashprotection"));
     return this;
   }
 


### PR DESCRIPTION
After recent changes to use SyncDataAccessor, the slashing protection exporter requires a path to be passed, or an NPE occurs.

Also found that the path in use by the export command wasn't correct.

Fixes #2747

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.