### PR TITLE
Make optional Gossip message fields empty for outbound messages 

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -31,7 +31,7 @@ dependencyManagement {
     dependency 'io.protostuff:protostuff-core:1.6.2'
     dependency 'io.protostuff:protostuff-runtime:1.6.2'
 
-    dependency 'io.libp2p:jvm-libp2p-minimal:0.5.6-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p-minimal:0.5.7-RELEASE'
     dependency 'tech.pegasys:jblst:0.1.0-RELEASE'
 
     dependency 'org.hdrhistogram:HdrHistogram:2.1.12'

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -48,10 +48,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
+import kotlin.jvm.functions.Function0;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -79,6 +79,7 @@ import tech.pegasys.teku.util.cli.VersionProvider;
 public class LibP2PNetwork implements P2PNetwork<Peer> {
 
   private static final Logger LOG = LogManager.getLogger();
+  private static Function0<Long> NULL_SEQNO_GENERATOR = () -> null;
 
   private final PrivKey privKey;
   private final NodeId nodeId;
@@ -112,7 +113,7 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
 
     // Setup gossip
     gossip = createGossip();
-    final PubsubPublisherApi publisher = gossip.createPublisher(privKey, new Random().nextLong());
+    final PubsubPublisherApi publisher = gossip.createPublisher(null, NULL_SEQNO_GENERATOR);
     gossipNetwork = new LibP2PGossipNetwork(gossip, publisher);
 
     // Setup rpc methods

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandler.java
@@ -82,8 +82,7 @@ public class GossipHandler implements Function<MessageApi, CompletableFuture<Val
     }
 
     LOG.trace("Gossiping {}: {} bytes", topic, bytes.size());
-    SafeFuture.of(
-            publisher.publishExt(Unpooled.wrappedBuffer(bytes.toArrayUnsafe()), null, null, topic))
+    SafeFuture.of(publisher.publish(Unpooled.wrappedBuffer(bytes.toArrayUnsafe()), topic))
         .finish(
             () -> LOG.trace("Successfully gossiped message on {}", topic),
             err -> LOG.debug("Failed to gossip message on " + topic, err));

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandler.java
@@ -82,7 +82,8 @@ public class GossipHandler implements Function<MessageApi, CompletableFuture<Val
     }
 
     LOG.trace("Gossiping {}: {} bytes", topic, bytes.size());
-    SafeFuture.of(publisher.publish(Unpooled.wrappedBuffer(bytes.toArrayUnsafe()), topic))
+    SafeFuture.of(
+            publisher.publishExt(Unpooled.wrappedBuffer(bytes.toArrayUnsafe()), null, null, topic))
         .finish(
             () -> LOG.trace("Successfully gossiped message on {}", topic),
             err -> LOG.debug("Failed to gossip message on " + topic, err));

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/jvmlibp2p/MockMessageApi.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/jvmlibp2p/MockMessageApi.java
@@ -46,8 +46,8 @@ public class MockMessageApi implements MessageApi {
   }
 
   @Override
-  public long getSeqId() {
-    return 1;
+  public Long getSeqId() {
+    return 1L;
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Upgrade libp2p version to 0.5.7
- Nullify Gossip from/signature/seqNo fields for outbound messages

## Fixed Issue(s)
Fixes Teku side issue https://github.com/ethereum/eth2.0-specs/issues/1981

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.