### PR TITLE
Prevent the fork choice head from going backwards when updating chain head

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -208,12 +208,16 @@ public abstract class RecentChainData implements StoreUpdateHandler {
    */
   public void updateHead(Bytes32 root, UInt64 currentSlot) {
     final Optional<ChainHead> originalChainHead = chainHead;
+
+    // Never let the fork choice slot go backwards.
+    final UInt64 newForkChoiceSlot =
+        currentSlot.max(originalChainHead.map(ChainHead::getForkChoiceSlot).orElse(UInt64.ZERO));
     store
         .retrieveBlockAndState(root)
         .thenApply(
             headBlockAndState ->
                 headBlockAndState
-                    .map(head -> ChainHead.create(head, currentSlot))
+                    .map(head -> ChainHead.create(head, newForkChoiceSlot))
                     .orElseThrow(
                         () ->
                             new IllegalStateException(

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -247,9 +247,10 @@ public abstract class RecentChainData implements StoreUpdateHandler {
         final UInt64 commonAncestorSlot = previousChainHead.findCommonAncestor(newChainHead);
 
         LOG.info(
-            "Chain reorg from {} to {}",
+            "Chain reorg from {} to {}. Common ancestor at slot {}",
             formatBlock(previousChainHead.getForkChoiceSlot(), previousChainHead.getRoot()),
-            formatBlock(newChainHead.getForkChoiceSlot(), newChainHead.getRoot()));
+            formatBlock(newChainHead.getForkChoiceSlot(), newChainHead.getRoot()),
+            commonAncestorSlot);
 
         reorgCounter.inc();
         reorgEventChannel.reorgOccurred(


### PR DESCRIPTION
## PR Description
When chain head is updated as a result of importing a block, it doesn't have the node slot to provide as the `currentSlot` to `updateHead` which can result in "forgetting" empty slots which had previously been considered the head and so missing reorgs when those empty slots are filled in.  In turn that can lead to validator duties being scheduled incorrectly.

To prevent this from happening under any circumstances, never allow the fork choice head to move backwards.

Also added the common ancestor slot to reorg logs to make these issues easier to debug in future.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.