### PR TITLE
Fix debug-tools db subcommands to support writing UInt64 as YAML

### DIFF
--- a/data/yaml/src/main/java/tech/pegasys/teku/data/yaml/YamlProvider.java
+++ b/data/yaml/src/main/java/tech/pegasys/teku/data/yaml/YamlProvider.java
@@ -80,6 +80,10 @@ public class YamlProvider {
     }
   }
 
+  public ObjectMapper getObjectMapper() {
+    return objectMapper;
+  }
+
   public static class UInt64Deserializer extends JsonDeserializer<UInt64> {
 
     @Override

--- a/data/yaml/src/main/java/tech/pegasys/teku/data/yaml/YamlProvider.java
+++ b/data/yaml/src/main/java/tech/pegasys/teku/data/yaml/YamlProvider.java
@@ -31,6 +31,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
@@ -73,6 +74,17 @@ public class YamlProvider {
     try (final ByteArrayOutputStream out = new ByteArrayOutputStream()) {
       objectMapper.writerWithDefaultPrettyPrinter().writeValue(out, object);
       return Bytes.wrap(out.toByteArray());
+    } catch (JsonGenerationException | JsonMappingException e) {
+      throw new IllegalStateException("Failed to serialize object", e);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public <T> String writeString(T object) {
+    try (final StringWriter out = new StringWriter()) {
+      objectMapper.writerWithDefaultPrettyPrinter().writeValue(out, object);
+      return out.toString();
     } catch (JsonGenerationException | JsonMappingException e) {
       throw new IllegalStateException("Failed to serialize object", e);
     } catch (IOException e) {

--- a/teku/build.gradle
+++ b/teku/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   implementation project(':infrastructure:metrics')
   implementation project(':data:recorder')
   implementation project(':data:dataexchange')
+  implementation project(':data:yaml')
   implementation project(':ethereum:core')
   implementation project(':ethereum:datastructures')
   implementation project(':ethereum:statetransition')

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/ForkChoiceDataWriter.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/ForkChoiceDataWriter.java
@@ -15,13 +15,11 @@ package tech.pegasys.teku.cli.subcommand.debug;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Map;
+import tech.pegasys.teku.data.yaml.YamlProvider;
 import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.protoarray.BlockInformation;
@@ -31,15 +29,12 @@ public class ForkChoiceDataWriter {
 
   public static String writeForkChoiceData(
       final ProtoArraySnapshot snapshot, final Map<UInt64, VoteTracker> votes) throws IOException {
-    final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-    mapper.registerModule(
+    final SimpleModule forkChoiceModule =
         new SimpleModule()
             .addSerializer(ProtoArraySnapshot.class, new ProtoArraySnapshotSerializer())
-            .addSerializer(VoteTracker.class, new VoteSerializer()));
-    try (final StringWriter out = new StringWriter()) {
-      mapper.writeValue(out, Map.of("snapshot", snapshot, "votes", votes));
-      return out.toString();
-    }
+            .addSerializer(VoteTracker.class, new VoteSerializer());
+    final YamlProvider mapper = new YamlProvider(forkChoiceModule);
+    return mapper.writeString(Map.of("snapshot", snapshot, "votes", votes));
   }
 
   private static class VoteSerializer extends JsonSerializer<VoteTracker> {

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/YamlEth1EventsChannel.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/YamlEth1EventsChannel.java
@@ -15,9 +15,7 @@ package tech.pegasys.teku.cli.subcommand.debug;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SequenceWriter;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
@@ -27,6 +25,7 @@ import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.data.yaml.YamlProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.api.Eth1EventsChannel;
 import tech.pegasys.teku.pow.event.Deposit;
@@ -41,8 +40,9 @@ class YamlEth1EventsChannel implements Eth1EventsChannel, AutoCloseable {
   private final SequenceWriter writer;
 
   public YamlEth1EventsChannel(final PrintStream out) throws IOException {
-    final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-    writer = mapper.writerWithDefaultPrettyPrinter().writeValuesAsArray(out);
+    final YamlProvider yamlProvider = new YamlProvider();
+    writer =
+        yamlProvider.getObjectMapper().writerWithDefaultPrettyPrinter().writeValuesAsArray(out);
   }
 
   @Override


### PR DESCRIPTION
## PR Description
The `debug-tools db get-deposits` and `get-forkchoice-snapshot` commands were broken  because they didn't have a YAML serialiser set for `UInt64`.  Convert them over to the new `YamlProvider` so they get our default set of formatters for these kinds of basic types.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.