### PR TITLE
Update metrics library from Besu to ignore Accept header

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -81,7 +81,7 @@ dependencyManagement {
     dependencySet(group: 'org.apache.tuweni', version: '1.0.0') {
       entry 'tuweni-bytes'
       entry 'tuweni-config'
-      entry 'tuweni-crypto' 
+      entry 'tuweni-crypto'
       entry 'tuweni-junit'
       entry 'tuweni-kv'
       entry 'tuweni-plumtree'
@@ -134,8 +134,8 @@ dependencyManagement {
 
     dependency 'io.prometheus:simpleclient:0.9.0'
 
-    dependency 'org.hyperledger.besu.internal:metrics-core:1.4.6'
-    dependency 'org.hyperledger.besu:plugin-api:1.4.6'
+    dependency 'org.hyperledger.besu.internal:metrics-core:1.5.4'
+    dependency 'org.hyperledger.besu:plugin-api:1.5.4'
 
     dependency "org.testcontainers:testcontainers:1.14.3"
     dependency "org.testcontainers:junit-jupiter:1.14.3"


### PR DESCRIPTION
## PR Description
Pull in the latest version of Besu' metrics which no longer requires the `Accept` header to exactly match the prometheus format.

## Fixed Issue(s)
fixes #2678 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.