### PR TITLE
Reduce reorg noise during sync

### DIFF
--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -202,7 +202,7 @@ public class BeaconChainUtil {
               + ": "
               + block);
     }
-    forkChoice.processHead(slot);
+    forkChoice.processHead(slot, false);
     return importResult.getBlock();
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
@@ -127,7 +127,7 @@ public class SlotProcessor {
 
   private void processSlotWhileSyncing() {
     UInt64 slot = nodeSlot.getValue();
-    this.forkChoice.processHead(slot);
+    this.forkChoice.processHead(slot, true);
     eventLog.syncEvent(slot, recentChainData.getHeadSlot(), p2pNetwork.getPeerCount());
     slotEventsChannelPublisher.onSlot(slot);
   }
@@ -185,7 +185,7 @@ public class SlotProcessor {
 
   private void processSlotAttestation(final UInt64 nodeEpoch) {
     onTickSlotAttestation = nodeSlot.getValue();
-    this.forkChoice.processHead(onTickSlotAttestation);
+    this.forkChoice.processHead(onTickSlotAttestation, false);
     recentChainData
         .getHeadBlock()
         .ifPresent(


### PR DESCRIPTION
## PR Description
This is a "quick fix" approach to avoid logging a reorg message for every block we import during sync. When we're more than 2 epochs behind, we skip updating the chain head for every block imported and only do it once per slot, and when we're syncing (ie printing "Sync Event") we suppress the reorg log message (but the event is still fired to be completely safe).  Notably for the last 2 epochs of the sync there'll still be a heap of reorg events printed so would be nice to do better.

 It's still worth investigating better changes as this feels overly specific but it significantly improves the user experience while syncing so we can take the time required to design a better solution.

## Fixed Issue(s)
#2773

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.