### PR TITLE
Add a --X CLI option to enable new sync

### DIFF
--- a/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
+++ b/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
@@ -74,4 +74,8 @@ public class ServiceConfig {
   public AsyncRunner createAsyncRunner(final String name, final int maxThreads) {
     return asyncRunnerFactory.create(name, maxThreads);
   }
+
+  public AsyncRunnerFactory getAsyncRunnerFactory() {
+    return asyncRunnerFactory;
+  }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -337,6 +337,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setTargetSubnetSubscriberCount(p2POptions.getP2pTargetSubnetSubscriberCount())
         .setP2pStaticPeers(p2POptions.getP2pStaticPeers())
         .setP2pSnappyEnabled(p2POptions.isP2pSnappyEnabled())
+        .setMultiPeerSyncEnabled(p2POptions.isMultiPeerSyncEnabled())
         .setInteropGenesisTime(interopOptions.getInteropGenesisTime())
         .setInteropOwnedValidatorStartIndex(interopOptions.getInteropOwnerValidatorStartIndex())
         .setInteropOwnedValidatorCount(interopOptions.getInteropOwnerValidatorCount())

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -119,6 +119,14 @@ public class P2POptions {
       arity = "1")
   private Boolean p2pSnappyEnabled = null;
 
+  @Option(
+      names = {"--Xp2p-multipeer-sync-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Enables experimental multipeer sync",
+      hidden = true,
+      arity = "1")
+  private boolean multiPeerSyncEnabled = false;
+
   public boolean isP2pEnabled() {
     return p2pEnabled;
   }
@@ -179,5 +187,9 @@ public class P2POptions {
 
   public Boolean isP2pSnappyEnabled() {
     return p2pSnappyEnabled;
+  }
+
+  public boolean isMultiPeerSyncEnabled() {
+    return multiPeerSyncEnabled;
   }
 }

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfiguration.java
@@ -55,6 +55,7 @@ public class TekuConfiguration implements MetricsConfig {
   private final int targetSubnetSubscriberCount;
   private final List<String> p2pStaticPeers;
   private final boolean p2pSnappyEnabled;
+  private final boolean multiPeerSyncEnabled;
 
   // Interop
   private final Integer interopGenesisTime;
@@ -152,6 +153,7 @@ public class TekuConfiguration implements MetricsConfig {
       final int targetSubnetSubscriberCount,
       final List<String> p2pStaticPeers,
       final boolean p2pSnappyEnabled,
+      final boolean multiPeerSyncEnabled,
       final Integer interopGenesisTime,
       final int interopOwnedValidatorStartIndex,
       final int interopOwnedValidatorCount,
@@ -222,6 +224,7 @@ public class TekuConfiguration implements MetricsConfig {
     this.targetSubnetSubscriberCount = targetSubnetSubscriberCount;
     this.p2pStaticPeers = p2pStaticPeers;
     this.p2pSnappyEnabled = p2pSnappyEnabled;
+    this.multiPeerSyncEnabled = multiPeerSyncEnabled;
     this.interopGenesisTime = interopGenesisTime;
     this.interopOwnedValidatorStartIndex = interopOwnedValidatorStartIndex;
     this.interopOwnedValidatorCount = interopOwnedValidatorCount;
@@ -350,6 +353,10 @@ public class TekuConfiguration implements MetricsConfig {
 
   public boolean isP2pSnappyEnabled() {
     return p2pSnappyEnabled;
+  }
+
+  public boolean isMultiPeerSyncEnabled() {
+    return multiPeerSyncEnabled;
   }
 
   public Integer getInteropGenesisTime() {

--- a/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/TekuConfigurationBuilder.java
@@ -43,6 +43,7 @@ public class TekuConfigurationBuilder {
   private int targetSubnetSubscriberCount;
   private List<String> p2pStaticPeers;
   private Boolean p2pSnappyEnabled;
+  private boolean multiPeerSyncEnabled = false;
   private Integer interopGenesisTime;
   private int interopOwnedValidatorStartIndex;
   private int interopOwnedValidatorCount;
@@ -186,6 +187,11 @@ public class TekuConfigurationBuilder {
 
   public TekuConfigurationBuilder setP2pSnappyEnabled(final Boolean p2pSnappyEnabled) {
     this.p2pSnappyEnabled = p2pSnappyEnabled;
+    return this;
+  }
+
+  public TekuConfigurationBuilder setMultiPeerSyncEnabled(final boolean multiPeerSyncEnabled) {
+    this.multiPeerSyncEnabled = multiPeerSyncEnabled;
     return this;
   }
 
@@ -513,6 +519,7 @@ public class TekuConfigurationBuilder {
         targetSubnetSubscriberCount,
         p2pStaticPeers,
         p2pSnappyEnabled,
+        multiPeerSyncEnabled,
         interopGenesisTime,
         interopOwnedValidatorStartIndex,
         interopOwnedValidatorCount,


### PR DESCRIPTION
## PR Description
Adds a hidden `--X` option to switch from the current sync to the experimental multipeer sync.  Currently activating it effectively disables sync as only tracking the available chains is implemented, but having the toggle will make it easier to test as the new sync is developed.

## Fixed Issue(s)
#1844 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.