### PR TITLE
Add overrides to a few useful then*Async methods

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.infrastructure.async;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -356,8 +357,19 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   }
 
   @Override
+  public SafeFuture<Void> thenRunAsync(final Runnable action, final Executor executor) {
+    return (SafeFuture<Void>) super.thenRunAsync(action, executor);
+  }
+
+  @Override
   public SafeFuture<Void> thenAccept(final Consumer<? super T> action) {
     return (SafeFuture<Void>) super.thenAccept(action);
+  }
+
+  @Override
+  public SafeFuture<Void> thenAcceptAsync(
+      final Consumer<? super T> action, final Executor executor) {
+    return (SafeFuture<Void>) super.thenAcceptAsync(action, executor);
   }
 
   @SuppressWarnings("unchecked")
@@ -371,6 +383,12 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   @Override
   public <U> SafeFuture<U> thenCompose(final Function<? super T, ? extends CompletionStage<U>> fn) {
     return (SafeFuture<U>) super.thenCompose(fn);
+  }
+
+  @Override
+  public <U> SafeFuture<U> thenComposeAsync(
+      final Function<? super T, ? extends CompletionStage<U>> fn, final Executor executor) {
+    return (SafeFuture<U>) super.thenComposeAsync(fn, executor);
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Add a few `then*Async` method overrides to `SafeFuture` to declare the return type as `SafeFuture`.  These are very useful to use with `EventThread` because it implements the `Executor` interface so can be passed as the executor to these async functions to automatically have the task execute on the event thread.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.