### PR TITLE
[Issue-2273] Add weak subjectivity checks to BlockImporter

### DIFF
--- a/data/beaconrestapi/build.gradle
+++ b/data/beaconrestapi/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
     integrationTestImplementation testFixtures(project(':bls'))
     integrationTestImplementation testFixtures(project(':ethereum:datastructures'))
+    integrationTestImplementation project(':ethereum:weaksubjectivity')
     integrationTestImplementation testFixtures(project(':ethereum:core'))
 
     integrationTestImplementation project(':networking:p2p')

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -59,6 +59,7 @@ import tech.pegasys.teku.sync.SyncService;
 import tech.pegasys.teku.util.config.StateStorageMode;
 import tech.pegasys.teku.util.config.TekuConfiguration;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
 
 public abstract class AbstractDataBackedRestAPIIntegrationTest {
   protected static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(16);
@@ -125,7 +126,12 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
   }
 
   private void setupAndStartRestAPI(TekuConfiguration config) {
-    blockImporter = new BlockImporter(recentChainData, forkChoice, storageSystem.eventBus());
+    blockImporter =
+        new BlockImporter(
+            recentChainData,
+            forkChoice,
+            WeakSubjectivityValidator.lenient(),
+            storageSystem.eventBus());
     combinedChainDataClient = storageSystem.combinedChainDataClient();
     dataProvider =
         new DataProvider(

--- a/eth-benchmark-tests/build.gradle
+++ b/eth-benchmark-tests/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   implementation project(':ethereum:core')
   implementation project(':ethereum:datastructures')
   implementation project(':ethereum:statetransition')
+  implementation project(':ethereum:weaksubjectivity')
   implementation project(':eth-tests')
   implementation project(':infrastructure:async')
   implementation project(':storage')

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
@@ -43,6 +43,7 @@ import tech.pegasys.teku.statetransition.forkchoice.SyncForkChoiceExecutor;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
 
 /** The test to be run manually for profiling block imports */
 public class ProfilingRun {
@@ -83,7 +84,9 @@ public class ProfilingRun {
       recentChainData.initializeFromGenesis(initialState).join();
       ForkChoice forkChoice =
           new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, new StateTransition());
-      BlockImporter blockImporter = new BlockImporter(recentChainData, forkChoice, localEventBus);
+      BlockImporter blockImporter =
+          new BlockImporter(
+              recentChainData, forkChoice, WeakSubjectivityValidator.lenient(), localEventBus);
 
       System.out.println("Start blocks import from " + blocksFile);
       int blockCount = 0;
@@ -152,7 +155,9 @@ public class ProfilingRun {
       initialState = null;
       ForkChoice forkChoice =
           new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, new StateTransition());
-      BlockImporter blockImporter = new BlockImporter(recentChainData, forkChoice, localEventBus);
+      BlockImporter blockImporter =
+          new BlockImporter(
+              recentChainData, forkChoice, WeakSubjectivityValidator.lenient(), localEventBus);
 
       System.out.println("Start blocks import from " + blocksFile);
       int counter = 1;

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.statetransition.forkchoice.SyncForkChoiceExecutor;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
 
 /** JMH base class for measuring state transitions performance */
 @BenchmarkMode(Mode.SingleShotTime)
@@ -85,7 +86,9 @@ public abstract class TransitionBenchmark {
 
     ForkChoice forkChoice =
         new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, new StateTransition());
-    blockImporter = new BlockImporter(recentChainData, forkChoice, localEventBus);
+    blockImporter =
+        new BlockImporter(
+            recentChainData, forkChoice, WeakSubjectivityValidator.lenient(), localEventBus);
     blockIterator = BlockIO.createResourceReader(blocksFile).iterator();
     System.out.println("Importing blocks from " + blocksFile);
   }

--- a/ethereum/statetransition/build.gradle
+++ b/ethereum/statetransition/build.gradle
@@ -3,6 +3,7 @@ dependencies {
   implementation project(':data')
   implementation project(':ethereum:core')
   implementation project(':ethereum:datastructures')
+  implementation project(':ethereum:weaksubjectivity')
   implementation project(':infrastructure:async')
   implementation project(':infrastructure:collections')
   implementation project(':infrastructure:logging')

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
@@ -174,7 +174,6 @@ public class BlockImporterTest {
                   currentSlotFinal, aggregatedAttestations);
             })
         .hasMessageContaining("signature");
-    assertWeakSubjectivityWasChecked();
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blockimport/BlockImporterTest.java
@@ -15,7 +15,10 @@ package tech.pegasys.teku.statetransition.blockimport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 
 import com.google.common.eventbus.EventBus;
@@ -40,7 +43,9 @@ import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
+import tech.pegasys.teku.datastructures.state.CheckpointState;
 import tech.pegasys.teku.datastructures.util.BeaconStateUtil;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -49,11 +54,14 @@ import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
 
 public class BlockImporterTest {
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(8);
   private final EventBus localEventBus = mock(EventBus.class);
   private final RecentChainData recentChainData = MemoryOnlyRecentChainData.create(localEventBus);
+  private final WeakSubjectivityValidator weakSubjectivityValidator =
+      mock(WeakSubjectivityValidator.class);
   private final ForkChoice forkChoice =
       new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, new StateTransition());
   private final BeaconChainUtil localChain =
@@ -65,7 +73,7 @@ public class BlockImporterTest {
       BeaconChainUtil.create(otherStorage, validatorKeys, false);
 
   private final BlockImporter blockImporter =
-      new BlockImporter(recentChainData, forkChoice, localEventBus);
+      new BlockImporter(recentChainData, forkChoice, weakSubjectivityValidator, localEventBus);
 
   @BeforeAll
   public static void init() {
@@ -91,7 +99,21 @@ public class BlockImporterTest {
     localChain.setSlot(block.getSlot());
 
     final BlockImportResult result = blockImporter.importBlock(block).get();
+    assertWeakSubjectivityWasChecked();
     assertSuccessfulResult(result);
+  }
+
+  @Test
+  public void importBlock_errorDuringWeakSubjectivityCheck() throws Exception {
+    final SignedBeaconBlock block = otherChain.createBlockAtSlot(UInt64.ONE);
+    localChain.setSlot(block.getSlot());
+    doThrow(new RuntimeException("oops"))
+        .when(weakSubjectivityValidator)
+        .validateLatestFinalizedCheckpoint(any(), any());
+
+    final BlockImportResult result = blockImporter.importBlock(block).get();
+    assertWeakSubjectivityWasChecked();
+    assertImportFailed(result, FailureReason.INTERNAL_ERROR);
   }
 
   @Test
@@ -152,6 +174,7 @@ public class BlockImporterTest {
                   currentSlotFinal, aggregatedAttestations);
             })
         .hasMessageContaining("signature");
+    assertWeakSubjectivityWasChecked();
   }
 
   @Test
@@ -301,5 +324,14 @@ public class BlockImporterTest {
       final BlockImportResult result, final BlockImportResult.FailureReason expectedReason) {
     assertThat(result.isSuccessful()).isFalse();
     assertThat(result.getFailureReason()).isEqualTo(expectedReason);
+  }
+
+  private void assertWeakSubjectivityWasChecked() {
+    SafeFuture<CheckpointState> finalizedCheckpoint =
+        recentChainData.getStore().retrieveFinalizedCheckpointAndState();
+    assertThat(finalizedCheckpoint).isCompleted();
+    UInt64 currentSlot = recentChainData.getCurrentSlot().orElseThrow();
+    verify(weakSubjectivityValidator)
+        .validateLatestFinalizedCheckpoint(finalizedCheckpoint.join(), currentSlot);
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -532,7 +532,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   public void initBlockImporter() {
     LOG.debug("BeaconChainController.initBlockImporter()");
-    blockImporter = new BlockImporter(recentChainData, forkChoice, eventBus);
+    blockImporter =
+        new BlockImporter(recentChainData, forkChoice, weakSubjectivityValidator, eventBus);
   }
 
   public void initSyncManager() {

--- a/sync/build.gradle
+++ b/sync/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 
     testImplementation testFixtures(project(':ethereum:datastructures'))
     testImplementation testFixtures(project(':ethereum:statetransition'))
+    testImplementation project(':ethereum:weaksubjectivity')
     testImplementation testFixtures(project(':infrastructure:async'))
     testImplementation testFixtures(project('::networking:eth2'))
     testImplementation testFixtures(project('::networking:p2p'))
@@ -35,6 +36,7 @@ dependencies {
 
     testFixturesImplementation project(':services:serviceutils')
     testFixturesImplementation project(':ethereum:statetransition')
+    testFixturesImplementation project(':ethereum:weaksubjectivity')
     testFixturesImplementation project(':util')
 
     testFixturesImplementation testFixtures(project(':ethereum:core'))

--- a/sync/src/test/java/tech/pegasys/teku/sync/gossip/BlockManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/gossip/BlockManagerTest.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
 
 public class BlockManagerTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
@@ -73,7 +74,8 @@ public class BlockManagerTest {
   private final ImportedBlocks importedBlocks = new ImportedBlocks(localEventBus);
 
   private final BlockImporter blockImporter =
-      new BlockImporter(localRecentChainData, forkChoice, localEventBus);
+      new BlockImporter(
+          localRecentChainData, forkChoice, WeakSubjectivityValidator.lenient(), localEventBus);
   private final BlockManager blockManager =
       new BlockManager(
           localEventBus,

--- a/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
+++ b/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.sync.gossip.FetchRecentBlocksService;
 import tech.pegasys.teku.sync.singlepeer.SinglePeerSyncService;
 import tech.pegasys.teku.sync.singlepeer.SyncManager;
 import tech.pegasys.teku.util.time.channels.SlotEventsChannel;
+import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
 
 public class SyncingNodeManager {
   private final EventBus eventBus;
@@ -92,7 +93,9 @@ public class SyncingNodeManager {
 
     ForkChoice forkChoice =
         new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, new StateTransition());
-    BlockImporter blockImporter = new BlockImporter(recentChainData, forkChoice, eventBus);
+    BlockImporter blockImporter =
+        new BlockImporter(
+            recentChainData, forkChoice, WeakSubjectivityValidator.lenient(), eventBus);
     final PendingPool<SignedBeaconBlock> pendingBlocks = PendingPool.createForBlocks();
     final FutureItems<SignedBeaconBlock> futureBlocks =
         new FutureItems<>(SignedBeaconBlock::getSlot);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add weak-subjectivity validation to `BlockImporter`.  Before importing a block, check that the latest finalized checkpoint is still within the weak-subjectivity period. 

## Fixed Issue(s)
Part of #2273 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.