### PR TITLE
[Issue-2273] Add logic to persist weak subjectivity checkpoints

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/events/WeakSubjectivityUpdate.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/events/WeakSubjectivityUpdate.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.events;
+
+import java.util.Optional;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
+
+public class WeakSubjectivityUpdate {
+  private final Optional<Checkpoint> weakSubjectivityCheckpoint;
+
+  private WeakSubjectivityUpdate(Optional<Checkpoint> weakSubjectivityCheckpoint) {
+    this.weakSubjectivityCheckpoint = weakSubjectivityCheckpoint;
+  }
+
+  public static WeakSubjectivityUpdate clearWeakSubjectivityCheckpoint() {
+    return new WeakSubjectivityUpdate(Optional.empty());
+  }
+
+  public static WeakSubjectivityUpdate setWeakSubjectivityCheckpoint(
+      final Checkpoint newCheckpoint) {
+    return new WeakSubjectivityUpdate(Optional.of(newCheckpoint));
+  }
+
+  public Optional<Checkpoint> getWeakSubjectivityCheckpoint() {
+    return weakSubjectivityCheckpoint;
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -24,12 +24,14 @@ import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.protoarray.ProtoArraySnapshot;
 import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.events.StorageUpdate;
+import tech.pegasys.teku.storage.events.WeakSubjectivityUpdate;
 import tech.pegasys.teku.storage.store.StoreBuilder;
 
 public interface Database extends AutoCloseable {
@@ -38,7 +40,11 @@ public interface Database extends AutoCloseable {
 
   void update(StorageUpdate event);
 
+  void updateWeakSubjectivityState(WeakSubjectivityUpdate weakSubjectivityUpdate);
+
   Optional<StoreBuilder> createMemoryStore();
+
+  Optional<Checkpoint> getWeakSubjectivityCheckpoint();
 
   Map<UInt64, VoteTracker> getVotes();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -24,12 +24,14 @@ import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.protoarray.ProtoArraySnapshot;
 import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.events.StorageUpdate;
+import tech.pegasys.teku.storage.events.WeakSubjectivityUpdate;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.store.StoreBuilder;
 
@@ -42,7 +44,15 @@ public class NoOpDatabase implements Database {
   public void update(final StorageUpdate event) {}
 
   @Override
+  public void updateWeakSubjectivityState(WeakSubjectivityUpdate weakSubjectivityUpdate) {}
+
+  @Override
   public Optional<StoreBuilder> createMemoryStore() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Checkpoint> getWeakSubjectivityCheckpoint() {
     return Optional.empty();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -47,6 +47,7 @@ import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.protoarray.ProtoArraySnapshot;
 import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.events.StorageUpdate;
+import tech.pegasys.teku.storage.events.WeakSubjectivityUpdate;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.server.rocksdb.core.RocksDbAccessor;
 import tech.pegasys.teku.storage.server.rocksdb.core.RocksDbInstanceFactory;
@@ -174,6 +175,20 @@ public class RocksDbDatabase implements Database {
   }
 
   @Override
+  public void updateWeakSubjectivityState(WeakSubjectivityUpdate weakSubjectivityUpdate) {
+    try (final HotUpdater updater = hotDao.hotUpdater()) {
+      Optional<Checkpoint> checkpoint = weakSubjectivityUpdate.getWeakSubjectivityCheckpoint();
+      if (checkpoint.isPresent()) {
+        updater.setWeakSubjectivityCheckpoint(checkpoint.get());
+      } else {
+        updater.clearWeakSubjectivityCheckpoint();
+      }
+
+      updater.commit();
+    }
+  }
+
+  @Override
   public Optional<StoreBuilder> createMemoryStore() {
     Optional<UInt64> maybeGenesisTime = hotDao.getGenesisTime();
     if (maybeGenesisTime.isEmpty()) {
@@ -221,6 +236,11 @@ public class RocksDbDatabase implements Database {
             .rootToSlotMap(rootToSlot)
             .latestFinalized(latestFinalized)
             .votes(votes));
+  }
+
+  @Override
+  public Optional<Checkpoint> getWeakSubjectivityCheckpoint() {
+    return hotDao.getWeakSubjectivityCheckpoint();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -178,12 +178,8 @@ public class RocksDbDatabase implements Database {
   public void updateWeakSubjectivityState(WeakSubjectivityUpdate weakSubjectivityUpdate) {
     try (final HotUpdater updater = hotDao.hotUpdater()) {
       Optional<Checkpoint> checkpoint = weakSubjectivityUpdate.getWeakSubjectivityCheckpoint();
-      if (checkpoint.isPresent()) {
-        updater.setWeakSubjectivityCheckpoint(checkpoint.get());
-      } else {
-        updater.clearWeakSubjectivityCheckpoint();
-      }
-
+      checkpoint.ifPresentOrElse(
+          updater::setWeakSubjectivityCheckpoint, updater::clearWeakSubjectivityCheckpoint);
       updater.commit();
     }
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbAccessor.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbAccessor.java
@@ -78,6 +78,8 @@ public interface RocksDbAccessor extends AutoCloseable {
 
     <K, V> void delete(RocksDbColumn<K, V> column, K key);
 
+    <T> void delete(RocksDbVariable<T> variable);
+
     void commit();
 
     void rollback();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstance.java
@@ -261,7 +261,7 @@ public class RocksDbInstance implements RocksDbAccessor {
             try {
               rocksDbTx.delete(defaultHandle, variable.getId().toArrayUnsafe());
             } catch (RocksDBException e) {
-              throw new DatabaseStorageException("Failed to put variable", e);
+              throw new DatabaseStorageException("Failed to delete variable", e);
             }
           });
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstance.java
@@ -255,6 +255,18 @@ public class RocksDbInstance implements RocksDbAccessor {
     }
 
     @Override
+    public <T> void delete(RocksDbVariable<T> variable) {
+      applyUpdate(
+          () -> {
+            try {
+              rocksDbTx.delete(defaultHandle, variable.getId().toArrayUnsafe());
+            } catch (RocksDBException e) {
+              throw new DatabaseStorageException("Failed to put variable", e);
+            }
+          });
+    }
+
+    @Override
     public void commit() {
       applyUpdate(
           () -> {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbHotDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbHotDao.java
@@ -74,6 +74,8 @@ public interface RocksDbHotDao extends AutoCloseable {
 
     void setWeakSubjectivityCheckpoint(final Checkpoint checkpoint);
 
+    void clearWeakSubjectivityCheckpoint();
+
     void setLatestFinalizedState(final BeaconState state);
 
     void addHotBlock(final SignedBeaconBlock block);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbHotDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbHotDao.java
@@ -43,6 +43,8 @@ public interface RocksDbHotDao extends AutoCloseable {
   // In hot dao because it must be in sync with the finalized checkpoint
   Optional<BeaconState> getLatestFinalizedState();
 
+  Optional<Checkpoint> getWeakSubjectivityCheckpoint();
+
   Optional<SignedBeaconBlock> getHotBlock(final Bytes32 root);
 
   Optional<BeaconState> getHotState(final Bytes32 root);
@@ -69,6 +71,8 @@ public interface RocksDbHotDao extends AutoCloseable {
     void setBestJustifiedCheckpoint(final Checkpoint checkpoint);
 
     void setFinalizedCheckpoint(final Checkpoint checkpoint);
+
+    void setWeakSubjectivityCheckpoint(final Checkpoint checkpoint);
 
     void setLatestFinalizedState(final BeaconState state);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V3RocksDbDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V3RocksDbDao.java
@@ -133,6 +133,11 @@ public class V3RocksDbDao
   }
 
   @Override
+  public Optional<Checkpoint> getWeakSubjectivityCheckpoint() {
+    return db.get(V3Schema.WEAK_SUBJECTIVITY_CHECKPOINT);
+  }
+
+  @Override
   public Map<Bytes32, SignedBeaconBlock> getHotBlocks() {
     return db.getAll(V3Schema.HOT_BLOCKS_BY_ROOT);
   }
@@ -236,6 +241,11 @@ public class V3RocksDbDao
     @Override
     public void setFinalizedCheckpoint(final Checkpoint checkpoint) {
       transaction.put(V3Schema.FINALIZED_CHECKPOINT, checkpoint);
+    }
+
+    @Override
+    public void setWeakSubjectivityCheckpoint(Checkpoint checkpoint) {
+      transaction.put(V3Schema.WEAK_SUBJECTIVITY_CHECKPOINT, checkpoint);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V3RocksDbDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V3RocksDbDao.java
@@ -249,6 +249,11 @@ public class V3RocksDbDao
     }
 
     @Override
+    public void clearWeakSubjectivityCheckpoint() {
+      transaction.delete(V3Schema.WEAK_SUBJECTIVITY_CHECKPOINT);
+    }
+
+    @Override
     public void setLatestFinalizedState(final BeaconState state) {
       transaction.put(V3Schema.LATEST_FINALIZED_STATE, state);
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V4HotRocksDbDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V4HotRocksDbDao.java
@@ -187,6 +187,11 @@ public class V4HotRocksDbDao implements RocksDbHotDao, RocksDbEth1Dao, RocksDbPr
     }
 
     @Override
+    public void clearWeakSubjectivityCheckpoint() {
+      transaction.delete(V4SchemaHot.WEAK_SUBJECTIVITY_CHECKPOINT);
+    }
+
+    @Override
     public void setLatestFinalizedState(final BeaconState state) {
       transaction.put(V4SchemaHot.LATEST_FINALIZED_STATE, state);
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V4HotRocksDbDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V4HotRocksDbDao.java
@@ -84,6 +84,11 @@ public class V4HotRocksDbDao implements RocksDbHotDao, RocksDbEth1Dao, RocksDbPr
   }
 
   @Override
+  public Optional<Checkpoint> getWeakSubjectivityCheckpoint() {
+    return db.get(V4SchemaHot.WEAK_SUBJECTIVITY_CHECKPOINT);
+  }
+
+  @Override
   public Map<Bytes32, SignedBeaconBlock> getHotBlocks() {
     return db.getAll(V4SchemaHot.HOT_BLOCKS_BY_ROOT);
   }
@@ -174,6 +179,11 @@ public class V4HotRocksDbDao implements RocksDbHotDao, RocksDbEth1Dao, RocksDbPr
     @Override
     public void setFinalizedCheckpoint(final Checkpoint checkpoint) {
       transaction.put(V4SchemaHot.FINALIZED_CHECKPOINT, checkpoint);
+    }
+
+    @Override
+    public void setWeakSubjectivityCheckpoint(Checkpoint checkpoint) {
+      transaction.put(V4SchemaHot.WEAK_SUBJECTIVITY_CHECKPOINT, checkpoint);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/V3Schema.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/V3Schema.java
@@ -71,4 +71,6 @@ public interface V3Schema extends Schema {
       RocksDbVariable.create(6, MIN_GENESIS_TIME_BLOCK_EVENT_SERIALIZER);
   RocksDbVariable<ProtoArraySnapshot> PROTO_ARRAY_SNAPSHOT =
       RocksDbVariable.create(7, PROTO_ARRAY_SNAPSHOT_SERIALIZER);
+  RocksDbVariable<Checkpoint> WEAK_SUBJECTIVITY_CHECKPOINT =
+      RocksDbVariable.create(8, CHECKPOINT_SERIALIZER);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/V4SchemaHot.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/V4SchemaHot.java
@@ -63,4 +63,6 @@ public interface V4SchemaHot extends Schema {
       RocksDbVariable.create(6, MIN_GENESIS_TIME_BLOCK_EVENT_SERIALIZER);
   RocksDbVariable<ProtoArraySnapshot> PROTO_ARRAY_SNAPSHOT =
       RocksDbVariable.create(7, PROTO_ARRAY_SNAPSHOT_SERIALIZER);
+  RocksDbVariable<Checkpoint> WEAK_SUBJECTIVITY_CHECKPOINT =
+      RocksDbVariable.create(8, CHECKPOINT_SERIALIZER);
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
@@ -53,6 +53,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.events.AnchorPoint;
+import tech.pegasys.teku.storage.events.WeakSubjectivityUpdate;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.storage.store.StoreConfig;
 import tech.pegasys.teku.storage.store.UpdatableStore;
@@ -146,6 +147,37 @@ public abstract class AbstractDatabaseTest {
   public void shouldRecreateOriginalGenesisStore() {
     final UpdatableStore memoryStore = recreateStore();
     assertStoresMatch(memoryStore, store);
+  }
+
+  @Test
+  public void updateWeakSubjectivityState_setValue() {
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+    final Checkpoint checkpoint = dataStructureUtil.randomCheckpoint();
+    assertThat(database.getWeakSubjectivityCheckpoint()).isEmpty();
+
+    final WeakSubjectivityUpdate update =
+        WeakSubjectivityUpdate.setWeakSubjectivityCheckpoint(checkpoint);
+    database.updateWeakSubjectivityState(update);
+
+    assertThat(database.getWeakSubjectivityCheckpoint()).contains(checkpoint);
+  }
+
+  @Test
+  public void updateWeakSubjectivityState_clearValue() {
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+    final Checkpoint checkpoint = dataStructureUtil.randomCheckpoint();
+
+    // Set an initial value
+    final WeakSubjectivityUpdate initUpdate =
+        WeakSubjectivityUpdate.setWeakSubjectivityCheckpoint(checkpoint);
+    database.updateWeakSubjectivityState(initUpdate);
+    assertThat(database.getWeakSubjectivityCheckpoint()).contains(checkpoint);
+
+    // Clear the checkpoint
+    final WeakSubjectivityUpdate update = WeakSubjectivityUpdate.clearWeakSubjectivityCheckpoint();
+    database.updateWeakSubjectivityState(update);
+
+    assertThat(database.getWeakSubjectivityCheckpoint()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Implement `Database` API for persisting / clearing weak subjectivity checkpoints.

## Fixed Issue(s)
Part of #2273

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.