### PR TITLE
implement rest /eth/v1/validator/duties/proposer/:epoch endpoint

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -63,6 +63,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetHealth;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetIdentity;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeerById;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttesterDuties;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetProposerDuties;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAggregate;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAttestation;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetNewBlock;
@@ -232,6 +233,7 @@ public class BeaconRestApi {
 
   private void addV1ValidatorHandlers(final DataProvider dataProvider) {
     app.get(GetAttesterDuties.ROUTE, new GetAttesterDuties(dataProvider, jsonProvider));
+    app.get(GetProposerDuties.ROUTE, new GetProposerDuties(dataProvider, jsonProvider));
   }
 
   private void addNodeHandlers(final DataProvider provider) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDuties.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.EPOCH;
-import static tech.pegasys.teku.beaconrestapi.RestApiConstants.INDEX;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
@@ -29,7 +28,6 @@ import io.javalin.http.Handler;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
-import io.javalin.plugin.openapi.annotations.OpenApiParam;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
 import java.util.List;
 import java.util.Map;
@@ -41,31 +39,29 @@ import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
-import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
-import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
-import tech.pegasys.teku.beaconrestapi.ListQueryParameterUtils;
+import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
+import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
-import tech.pegasys.teku.util.config.Constants;
 
-public class GetAttesterDuties extends AbstractHandler implements Handler {
+public class GetProposerDuties extends AbstractHandler implements Handler {
   private static final Logger LOG = LogManager.getLogger();
-  public static final String ROUTE = "/eth/v1/validator/duties/attester/:epoch";
+  public static final String ROUTE = "/eth/v1/validator/duties/proposer/:epoch";
   private final ValidatorDataProvider validatorDataProvider;
   private final SyncDataProvider syncDataProvider;
   private final ChainDataProvider chainDataProvider;
 
-  public GetAttesterDuties(final DataProvider dataProvider, final JsonProvider jsonProvider) {
+  public GetProposerDuties(final DataProvider dataProvider, final JsonProvider jsonProvider) {
     super(jsonProvider);
     this.validatorDataProvider = dataProvider.getValidatorDataProvider();
     this.syncDataProvider = dataProvider.getSyncDataProvider();
     this.chainDataProvider = dataProvider.getChainDataProvider();
   }
 
-  GetAttesterDuties(
+  GetProposerDuties(
       final ChainDataProvider chainDataProvider,
       final SyncDataProvider syncDataProvider,
       final ValidatorDataProvider validatorDataProvider,
@@ -79,25 +75,14 @@ public class GetAttesterDuties extends AbstractHandler implements Handler {
   @OpenApi(
       path = ROUTE,
       method = HttpMethod.GET,
-      summary = "Get attester duties",
+      summary = "Get proposer duties",
       tags = {TG_V1_VALIDATOR},
       description =
-          "Requests the beacon node to provide a set of attestation duties, "
-              + "which should be performed by validators, for a particular epoch. "
-              + "Duties should only need to be checked once per epoch, however a "
-              + "chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur, "
-              + "resulting in a change of duties. For full safety, "
-              + "you should monitor chain reorganizations events.",
-      queryParams = {
-        @OpenApiParam(
-            name = INDEX,
-            required = true,
-            description = "Validator indexes. Allows comma separated values per field."),
-      },
+          "Request beacon node to provide all validators that are supposed to propose a block in the given epoch.",
       responses = {
         @OpenApiResponse(
             status = RES_OK,
-            content = @OpenApiContent(from = GetAttesterDutiesResponse.class)),
+            content = @OpenApiContent(from = GetProposerDutiesResponse.class)),
         @OpenApiResponse(status = RES_BAD_REQUEST),
         @OpenApiResponse(status = RES_INTERNAL_ERROR),
         @OpenApiResponse(
@@ -116,39 +101,30 @@ public class GetAttesterDuties extends AbstractHandler implements Handler {
     try {
       final UInt64 epoch = UInt64.valueOf(parameters.get(EPOCH));
       final UInt64 currentEpoch = chainDataProvider.getCurrentEpoch();
-      if (currentEpoch.plus(Constants.MIN_SEED_LOOKAHEAD).isLessThan(epoch)) {
+      if (currentEpoch.isLessThan(epoch)) {
         ctx.result(
             jsonProvider.objectToJSON(
                 new BadRequest(
-                    "Cannot get attester duties for "
+                    "Cannot get proposer duties for "
                         + epoch.minus(currentEpoch)
                         + " epochs ahead")));
         ctx.status(SC_BAD_REQUEST);
         return;
       }
-      final List<Integer> indexes =
-          ListQueryParameterUtils.getParameterAsIntegerList(ctx.queryParamMap(), INDEX);
-
-      SafeFuture<Optional<List<AttesterDuty>>> future =
-          validatorDataProvider.getAttesterDuties(epoch, indexes);
-
+      SafeFuture<Optional<List<ProposerDuty>>> future =
+          validatorDataProvider.getProposerDuties(epoch);
       handleOptionalResult(ctx, future, this::handleResult, List.of());
-
     } catch (NumberFormatException ex) {
       LOG.trace("Error parsing", ex);
       ctx.status(SC_BAD_REQUEST);
       ctx.result(
           jsonProvider.objectToJSON(
               new BadRequest("Invalid epoch " + parameters.get(EPOCH) + " or index specified")));
-    } catch (IllegalArgumentException ex) {
-      LOG.trace("Illegal argument in GetAttesterDuties", ex);
-      ctx.status(SC_BAD_REQUEST);
-      ctx.result(jsonProvider.objectToJSON(new BadRequest(ex.getMessage())));
     }
   }
 
-  private Optional<String> handleResult(Context ctx, final List<AttesterDuty> response)
+  private Optional<String> handleResult(Context ctx, final List<ProposerDuty> response)
       throws JsonProcessingException {
-    return Optional.of(jsonProvider.objectToJSON(new GetAttesterDutiesResponse(response)));
+    return Optional.of(jsonProvider.objectToJSON(new GetProposerDutiesResponse(response)));
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDuties.java
@@ -78,7 +78,7 @@ public class GetProposerDuties extends AbstractHandler implements Handler {
       summary = "Get proposer duties",
       tags = {TG_V1_VALIDATOR},
       description =
-          "Request beacon node to provide all validators that are supposed to propose a block in the given epoch.",
+          "Request beacon node to provide all validators that are scheduled to propose a block in the given epoch.",
       responses = {
         @OpenApiResponse(
             status = RES_OK,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/validator/PostDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/validator/PostDuties.java
@@ -54,6 +54,7 @@ public class PostDuties extends AbstractHandler implements Handler {
   }
 
   @OpenApi(
+      deprecated = true,
       path = ROUTE,
       method = HttpMethod.POST,
       summary = "Get the validator duties for the specified epoch.",

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/validator/PostDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/validator/PostDuties.java
@@ -61,7 +61,9 @@ public class PostDuties extends AbstractHandler implements Handler {
       tags = {TAG_VALIDATOR},
       description =
           "Returns the validator duties for validators that match the specified public keys and epoch.\n\n"
-              + "Public keys that do not match a validator are returned without validator information.",
+              + "Public keys that do not match a validator are returned without validator information.\n"
+              + "Deprecated - use`/eth/v1/validator/duties/attester/{epoch}` and "
+              + "`/eth/v1/validator/duties/proposer/{epoch}` instead.",
       requestBody =
           @OpenApiRequestBody(
               content = @OpenApiContent(from = ValidatorsRequest.class),

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeers;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetSyncing;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetVersion;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttesterDuties;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetProposerDuties;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -102,5 +103,10 @@ public class BeaconRestApiV1Test {
   @Test
   public void shouldHaveGetAttesterDutiesEndpoint() {
     verify(app).get(eq(GetAttesterDuties.ROUTE), any(GetAttesterDuties.class));
+  }
+
+  @Test
+  public void shouldHaveGetProposerDutiesEndpoint() {
+    verify(app).get(eq(GetProposerDuties.ROUTE), any(GetProposerDuties.class));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/AbstractValidatorApiTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/AbstractValidatorApiTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
+
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.javalin.http.Handler;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public abstract class AbstractValidatorApiTest extends AbstractBeaconHandlerTest {
+  protected Handler handler;
+
+  @Test
+  public void shouldReturnBadRequestIfEpochDoesNotParse() throws Exception {
+    when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.isSyncActive()).thenReturn(false);
+    when(context.pathParamMap()).thenReturn(Map.of("epoch", "epoch"));
+    handler.handle(context);
+    verifyStatusCode(SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void shouldReturnNotReadyWhenSyncing() throws Exception {
+    when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.isSyncActive()).thenReturn(true);
+
+    handler.handle(context);
+    verifyStatusCode(SC_SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  public void shouldReturnNotReadyWhenStoreNotReady() throws Exception {
+    when(validatorDataProvider.isStoreAvailable()).thenReturn(false);
+
+    handler.handle(context);
+    verify(syncService, never()).isSyncActive();
+    verifyStatusCode(SC_SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  public void shouldReturnBadRequestIfEpochTooFarAhead() throws Exception {
+    when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.isSyncActive()).thenReturn(false);
+    when(chainDataProvider.getCurrentEpoch()).thenReturn(UInt64.valueOf(98));
+    when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
+
+    handler.handle(context);
+    verifyStatusCode(SC_BAD_REQUEST);
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttesterDutiesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttesterDutiesTest.java
@@ -13,60 +13,31 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
-import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
 import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
 import tech.pegasys.teku.api.schema.BLSPubKey;
-import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class GetAttesterDutiesTest extends AbstractBeaconHandlerTest {
-  final GetAttesterDuties handler =
-      new GetAttesterDuties(
-          chainDataProvider, syncDataProvider, validatorDataProvider, jsonProvider);
+public class GetAttesterDutiesTest extends AbstractValidatorApiTest {
 
-  @Test
-  public void shouldReturnNotReadyWhenSyncing() throws Exception {
-    when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
-    when(syncService.isSyncActive()).thenReturn(true);
-
-    handler.handle(context);
-    verifyStatusCode(SC_SERVICE_UNAVAILABLE);
-  }
-
-  @Test
-  public void shouldReturnNotReadyWhenStoreNotReady() throws Exception {
-    when(validatorDataProvider.isStoreAvailable()).thenReturn(false);
-
-    handler.handle(context);
-    verify(syncService, never()).isSyncActive();
-    verifyStatusCode(SC_SERVICE_UNAVAILABLE);
-  }
-
-  @Test
-  public void shouldReturnBadRequestIfEpochTooFarAhead() throws Exception {
-    when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
-    when(syncService.isSyncActive()).thenReturn(false);
-    when(chainDataProvider.getCurrentEpoch()).thenReturn(UInt64.valueOf(98));
-    when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
-
-    handler.handle(context);
-    verifyStatusCode(SC_BAD_REQUEST);
+  @BeforeEach
+  public void setup() {
+    handler =
+        new GetAttesterDuties(
+            chainDataProvider, syncDataProvider, validatorDataProvider, jsonProvider);
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDutiesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDutiesTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
+import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
+import tech.pegasys.teku.api.schema.BLSPubKey;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class GetProposerDutiesTest extends AbstractValidatorApiTest {
+  @BeforeEach
+  public void setup() {
+    handler =
+        new GetProposerDuties(
+            chainDataProvider, syncDataProvider, validatorDataProvider, jsonProvider);
+  }
+
+  @Test
+  public void shouldGetProposerDuties() throws Exception {
+    when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.isSyncActive()).thenReturn(false);
+    when(chainDataProvider.getCurrentEpoch()).thenReturn(UInt64.valueOf(100));
+    when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
+
+    List<ProposerDuty> duties =
+        List.of(getProposerDuty(2, compute_start_slot_at_epoch(UInt64.valueOf(100))));
+    when(validatorDataProvider.getProposerDuties(eq(UInt64.valueOf(100))))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(duties)));
+
+    handler.handle(context);
+    GetProposerDutiesResponse response = getResponseFromFuture(GetProposerDutiesResponse.class);
+    assertThat(response.data).isEqualTo(duties);
+  }
+
+  private ProposerDuty getProposerDuty(final int validatorIndex, final UInt64 slot) {
+    return new ProposerDuty(new BLSPubKey(BLSPublicKey.random(1)), validatorIndex, slot);
+  }
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.request.SubscribeToBeaconCommitteeRequest;
 import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
+import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.AttestationData;
 import tech.pegasys.teku.api.schema.BLSPubKey;
@@ -45,6 +46,7 @@ import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
 import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.validator.api.AttesterDuties;
+import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.api.ValidatorDuties.Duties;
 
@@ -232,6 +234,23 @@ public class ValidatorDataProvider {
                             .filter(duty -> duty.getPublicKey() != null)
                             .map(this::mapToAttesterDuties)
                             .collect(toList())));
+  }
+
+  public SafeFuture<Optional<List<ProposerDuty>>> getProposerDuties(final UInt64 epoch) {
+    return SafeFuture.of(() -> validatorApiChannel.getProposerDuties(epoch))
+        .thenApply(
+            res ->
+                res.map(
+                    duties ->
+                        duties.stream()
+                            .filter(duty -> duty.getPublicKey() != null)
+                            .map(this::mapToProposerDuties)
+                            .collect(toList())));
+  }
+
+  private ProposerDuty mapToProposerDuties(final ProposerDuties duties) {
+    return new ProposerDuty(
+        new BLSPubKey(duties.getPublicKey()), duties.getValidatorIndex(), duties.getSlot());
   }
 
   private AttesterDuty mapToAttesterDuties(final AttesterDuties duties) {


### PR DESCRIPTION
 - deprecated POST /validator/duties, as the new standard endpoints are now implemented.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.