### PR TITLE
add teku bootnode for Spadina.

### DIFF
--- a/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
@@ -95,6 +95,10 @@ public class NetworkDefinition {
                   .snappyCompressionEnabled(true)
                   .startupTimeoutSeconds(120)
                   .eth1DepositContractAddress("0x48B597F4b53C21B48AD95c7256B49D1779Bd5890")
+                  .discoveryBootnodes(
+                      // PegaSys Teku
+                      "enr:-KG4QAxcrhmEz0t86EcxDpNcPpvNim8m9iG4zEkFxXWUm293cJ9HE_45DgXOcQyImsTt_6EYxpwCKMlGGF1aM037VoIChGV0aDKQ9aX9QgAAAAD__________4JpZIJ2NIJpcIQDFt-UiXNlY3AyNTZrMaECkR4C5DVO_9rB48eHTY4kdyOHsguTEDlvb7Ce0_mvghSDdGNwgiMog3VkcIIjKA"
+                  )
                   .build())
           .build();
 

--- a/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
@@ -97,8 +97,7 @@ public class NetworkDefinition {
                   .eth1DepositContractAddress("0x48B597F4b53C21B48AD95c7256B49D1779Bd5890")
                   .discoveryBootnodes(
                       // PegaSys Teku
-                      "enr:-KG4QAxcrhmEz0t86EcxDpNcPpvNim8m9iG4zEkFxXWUm293cJ9HE_45DgXOcQyImsTt_6EYxpwCKMlGGF1aM037VoIChGV0aDKQ9aX9QgAAAAD__________4JpZIJ2NIJpcIQDFt-UiXNlY3AyNTZrMaECkR4C5DVO_9rB48eHTY4kdyOHsguTEDlvb7Ce0_mvghSDdGNwgiMog3VkcIIjKA"
-                  )
+                      "enr:-KG4QAxcrhmEz0t86EcxDpNcPpvNim8m9iG4zEkFxXWUm293cJ9HE_45DgXOcQyImsTt_6EYxpwCKMlGGF1aM037VoIChGV0aDKQ9aX9QgAAAAD__________4JpZIJ2NIJpcIQDFt-UiXNlY3AyNTZrMaECkR4C5DVO_9rB48eHTY4kdyOHsguTEDlvb7Ce0_mvghSDdGNwgiMog3VkcIIjKA")
                   .build())
           .build();
 


### PR DESCRIPTION
Signed-off-by: Paul Harris <paul.harris@consensys.net>

Adding the documentation label. The instructions should basically be the same as Madella, but with Spadina as network name. If we're trying to make sure genesis works, we should go through all the right hoops.

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.