### PR TITLE
[Issue 2273] Use the wsCheckpoint during finalized checkpoint validation

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/CheckpointState.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/CheckpointState.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
@@ -52,6 +53,10 @@ public class CheckpointState {
 
   public UInt64 getEpoch() {
     return getCheckpoint().getEpoch();
+  }
+
+  public Bytes32 getRoot() {
+    return getBlock().getRoot();
   }
 
   /** @return The checkpoint state which is advanced to the checkpoint epoch boundary */

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
@@ -16,6 +16,9 @@ package tech.pegasys.teku.weaksubjectivity;
 import java.util.List;
 import java.util.Optional;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.state.CheckpointState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -25,11 +28,12 @@ import tech.pegasys.teku.weaksubjectivity.policies.StrictWeakSubjectivityViolati
 import tech.pegasys.teku.weaksubjectivity.policies.WeakSubjectivityViolationPolicy;
 
 public class WeakSubjectivityValidator {
+  private static final Logger LOG = LogManager.getLogger();
+
   private final WeakSubjectivityCalculator calculator;
   private final List<WeakSubjectivityViolationPolicy> violationPolicies;
 
-  @SuppressWarnings("unused")
-  private final Optional<Checkpoint> wsCheckpoint;
+  private final Optional<Checkpoint> maybeWsCheckpoint;
 
   WeakSubjectivityValidator(
       WeakSubjectivityCalculator calculator,
@@ -37,7 +41,7 @@ public class WeakSubjectivityValidator {
       Optional<Checkpoint> wsCheckpoint) {
     this.calculator = calculator;
     this.violationPolicies = violationPolicies;
-    this.wsCheckpoint = wsCheckpoint;
+    this.maybeWsCheckpoint = wsCheckpoint;
   }
 
   public static WeakSubjectivityValidator strict(final WeakSubjectivityConfig config) {
@@ -72,16 +76,25 @@ public class WeakSubjectivityValidator {
    */
   public void validateLatestFinalizedCheckpoint(
       final CheckpointState latestFinalizedCheckpoint, final UInt64 currentSlot) {
-    if (isPriorToWeakSubjectivityCheckpoint(latestFinalizedCheckpoint)) {
+    if (isPriorToWSCheckpoint(latestFinalizedCheckpoint)) {
       // Defer validation until we reach the weakSubjectivity checkpoint
       LOG.debug(
           "Latest finalized checkpoint at epoch {} is prior to weak subjectivity checkpoint at epoch {}. Defer validation.",
           latestFinalizedCheckpoint.getEpoch(),
-          wsCheckpoint.orElseThrow().getEpoch());
+          maybeWsCheckpoint.orElseThrow().getEpoch());
       return;
     }
 
-    if (!calculator.isWithinWeakSubjectivityPeriod(latestFinalizedCheckpoint, currentSlot)) {
+    // Determine validity
+    boolean isValid = true;
+    if (isAtWSCheckpoint(latestFinalizedCheckpoint)) {
+      // Roots must match
+      isValid = isWSCheckpointRoot(latestFinalizedCheckpoint.getRoot());
+    }
+    isValid = isValid && isWithinWSPeriod(latestFinalizedCheckpoint, currentSlot);
+
+    // Handle invalid checkpoint
+    if (!isValid) {
       final int activeValidators =
           calculator.getActiveValidators(latestFinalizedCheckpoint.getState());
       for (WeakSubjectivityViolationPolicy policy : violationPolicies) {
@@ -89,10 +102,6 @@ public class WeakSubjectivityValidator {
             latestFinalizedCheckpoint, activeValidators, currentSlot);
       }
     }
-  }
-
-  private boolean isPriorToWeakSubjectivityCheckpoint(final CheckpointState checkpoint) {
-    return wsCheckpoint.map(c -> checkpoint.getEpoch().isLessThan(c.getEpoch())).orElse(false);
   }
 
   /**
@@ -116,5 +125,21 @@ public class WeakSubjectivityValidator {
     for (WeakSubjectivityViolationPolicy policy : violationPolicies) {
       policy.onFailedToPerformValidation(message, error);
     }
+  }
+
+  private boolean isWithinWSPeriod(CheckpointState checkpointState, UInt64 currentSlot) {
+    return calculator.isWithinWeakSubjectivityPeriod(checkpointState, currentSlot);
+  }
+
+  private boolean isWSCheckpointRoot(final Bytes32 blockRoot) {
+    return maybeWsCheckpoint.map(c -> c.getRoot().equals(blockRoot)).orElse(false);
+  }
+
+  private boolean isPriorToWSCheckpoint(final CheckpointState checkpoint) {
+    return maybeWsCheckpoint.map(c -> checkpoint.getEpoch().isLessThan(c.getEpoch())).orElse(false);
+  }
+
+  private boolean isAtWSCheckpoint(final CheckpointState checkpoint) {
+    return maybeWsCheckpoint.map(c -> checkpoint.getEpoch().equals(c.getEpoch())).orElse(false);
   }
 }

--- a/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidatorTest.java
+++ b/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidatorTest.java
@@ -178,7 +178,7 @@ public class WeakSubjectivityValidatorTest {
         new Checkpoint(UInt64.valueOf(100), Bytes32.fromHexStringLenient("0x01"));
     final WeakSubjectivityValidator validator =
         new WeakSubjectivityValidator(calculator, policies, Optional.of(wsCheckpoint));
-    // Checkpoint is at the ws epoch, with the same root different root
+    // Checkpoint is at the ws epoch, with the same root
     when(checkpointState.getEpoch()).thenReturn(wsCheckpoint.getEpoch());
     when(checkpointState.getRoot()).thenReturn(wsCheckpoint.getRoot());
     when(calculator.isWithinWeakSubjectivityPeriod(checkpointState, currentSlot)).thenReturn(true);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Use `weakSubjectivityCheckpoint` when validating the latest finalized checkpoint:
* If the latest finalized checkpoint is prior to the ws checkpoint, defer validation
* If the latest finalized checkpoint is at the ws checkpoint, make sure that the roots match

## Fixed Issue(s)
Part of #2273

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.