### PR TITLE
Add endpoint for `/eth/v1/beacon/genesis`

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -59,6 +59,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.node.GetFork;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetGenesisTime;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetSyncing;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetVersion;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetGenesis;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetHealth;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetIdentity;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeerById;
@@ -104,6 +105,7 @@ public class BeaconRestApi {
     // standard api endpoint inclusion
     addV1NodeHandlers(dataProvider);
     addV1ValidatorHandlers(dataProvider);
+    addV1BeaconHandlers(dataProvider);
   }
 
   private void addHostAllowlistHandler(final GlobalConfiguration configuration) {
@@ -234,6 +236,10 @@ public class BeaconRestApi {
   private void addV1ValidatorHandlers(final DataProvider dataProvider) {
     app.get(GetAttesterDuties.ROUTE, new GetAttesterDuties(dataProvider, jsonProvider));
     app.get(GetProposerDuties.ROUTE, new GetProposerDuties(dataProvider, jsonProvider));
+  }
+
+  private void addV1BeaconHandlers(final DataProvider dataProvider) {
+    app.get(GetGenesis.ROUTE, new GetGenesis(dataProvider, jsonProvider));
   }
 
   private void addNodeHandlers(final DataProvider provider) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/RestApiConstants.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/RestApiConstants.java
@@ -34,7 +34,9 @@ public class RestApiConstants {
   public static final String TAG_VALIDATOR = "Validator";
 
   public static final String TAG_V1_NODE = "Node V1";
-  public static final String TG_V1_VALIDATOR = "Validator V1";
+  public static final String TAG_V1_VALIDATOR = "Validator V1";
+  public static final String TAG_V1_BEACON = "Beacon V1";
+  public static final String TAG_VALIDATOR_REQUIRED = "Validator Required Api";
 
   public static final String RES_OK = "200"; // SC_OK
   public static final String RES_ACCEPTED = "202"; // SC_ACCEPTED

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/node/GetGenesisTime.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/node/GetGenesisTime.java
@@ -42,11 +42,14 @@ public class GetGenesisTime implements Handler {
   }
 
   @OpenApi(
+      deprecated = true,
       path = GetGenesisTime.ROUTE,
       method = HttpMethod.GET,
       summary = "Get genesis time.",
       tags = {TAG_NODE},
-      description = "Returns the genesis time from the beacon node.",
+      description =
+          "Returns the genesis time from the beacon node. "
+              + "Replaced by standard api endpoint /eth/v1/beacon/genesis",
       responses = {
         @OpenApiResponse(status = RES_OK, content = @OpenApiContent(from = String.class)),
         @OpenApiResponse(status = RES_NO_CONTENT, description = NO_CONTENT_PRE_GENESIS),

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetGenesis.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetGenesis.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
+
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_NOT_FOUND;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_V1_BEACON;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR_REQUIRED;
+
+import io.javalin.http.Context;
+import io.javalin.http.Handler;
+import io.javalin.plugin.openapi.annotations.HttpMethod;
+import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiContent;
+import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import java.util.Optional;
+import org.jetbrains.annotations.NotNull;
+import tech.pegasys.teku.api.ChainDataProvider;
+import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.response.v1.beacon.GenesisData;
+import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
+import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
+import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.util.config.Constants;
+
+public class GetGenesis extends AbstractHandler implements Handler {
+  public static final String ROUTE = "/eth/v1/beacon/genesis";
+  private final ChainDataProvider chainDataProvider;
+
+  public GetGenesis(final DataProvider dataProvider, final JsonProvider jsonProvider) {
+    super(jsonProvider);
+    this.chainDataProvider = dataProvider.getChainDataProvider();
+  }
+
+  GetGenesis(final ChainDataProvider chainDataProvider, final JsonProvider jsonProvider) {
+    super(jsonProvider);
+    this.chainDataProvider = chainDataProvider;
+  }
+
+  @OpenApi(
+      path = ROUTE,
+      method = HttpMethod.GET,
+      summary = "Get chain genesis details",
+      tags = {TAG_V1_BEACON, TAG_VALIDATOR_REQUIRED},
+      description = "Retrieve details of the chain's genesis which can be used to identify chain.",
+      responses = {
+        @OpenApiResponse(
+            status = RES_OK,
+            content = @OpenApiContent(from = GetGenesisResponse.class)),
+        @OpenApiResponse(
+            status = RES_NOT_FOUND,
+            description = "Chain genesis info is not yet known"),
+        @OpenApiResponse(status = RES_INTERNAL_ERROR),
+      })
+  @Override
+  public void handle(@NotNull final Context ctx) throws Exception {
+    final Optional<GenesisData> maybeData = getGenesisData();
+    if (maybeData.isEmpty()) {
+      ctx.status(SC_NOT_FOUND);
+      return;
+    }
+    ctx.result(jsonProvider.objectToJSON(new GetGenesisResponse(maybeData.get())));
+  }
+
+  private Optional<GenesisData> getGenesisData() {
+    if (!chainDataProvider.isStoreAvailable()) {
+      return Optional.empty();
+    }
+    final ForkInfo forkInfo = chainDataProvider.getForkInfo().asInternalForkInfo();
+    return Optional.of(
+        new GenesisData(
+            chainDataProvider.getGenesisTime(),
+            forkInfo.getGenesisValidatorsRoot(),
+            Constants.GENESIS_FORK_VERSION));
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncing.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncing.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.beaconrestapi.CacheControlUtils.CACHE_NONE;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_V1_NODE;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR_REQUIRED;
 
 import io.javalin.core.util.Header;
 import io.javalin.http.Context;
@@ -53,7 +54,7 @@ public class GetSyncing implements Handler {
       description =
           "Requests the beacon node to describe if it's currently syncing or not, "
               + "and if it is, what block it is up to.",
-      tags = {TAG_V1_NODE},
+      tags = {TAG_V1_NODE, TAG_VALIDATOR_REQUIRED},
       responses = {
         @OpenApiResponse(status = RES_OK, content = @OpenApiContent(from = SyncingResponse.class)),
         @OpenApiResponse(status = RES_INTERNAL_ERROR)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttesterDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttesterDuties.java
@@ -21,7 +21,7 @@ import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_SERVICE_UNAVAILABLE;
-import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TG_V1_VALIDATOR;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_V1_VALIDATOR;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.Context;
@@ -80,7 +80,7 @@ public class GetAttesterDuties extends AbstractHandler implements Handler {
       path = ROUTE,
       method = HttpMethod.GET,
       summary = "Get attester duties",
-      tags = {TG_V1_VALIDATOR},
+      tags = {TAG_V1_VALIDATOR},
       description =
           "Requests the beacon node to provide a set of attestation duties, "
               + "which should be performed by validators, for a particular epoch. "

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDuties.java
@@ -20,7 +20,7 @@ import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_SERVICE_UNAVAILABLE;
-import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TG_V1_VALIDATOR;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_V1_VALIDATOR;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.Context;
@@ -76,7 +76,7 @@ public class GetProposerDuties extends AbstractHandler implements Handler {
       path = ROUTE,
       method = HttpMethod.GET,
       summary = "Get proposer duties",
-      tags = {TG_V1_VALIDATOR},
+      tags = {TAG_V1_VALIDATOR},
       description =
           "Request beacon node to provide all validators that are scheduled to propose a block in the given epoch.",
       responses = {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -25,6 +25,7 @@ import io.javalin.core.JavalinServer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetGenesis;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetHealth;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetIdentity;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeerById;
@@ -108,5 +109,10 @@ public class BeaconRestApiV1Test {
   @Test
   public void shouldHaveGetProposerDutiesEndpoint() {
     verify(app).get(eq(GetProposerDuties.ROUTE), any(GetProposerDuties.class));
+  }
+
+  @Test
+  public void shouldHaveGetGenesisEndpoint() {
+    verify(app).get(eq(GetGenesis.ROUTE), any(GetGenesis.class));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetGenesisTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetGenesisTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
+
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.response.GetForkResponse;
+import tech.pegasys.teku.api.response.v1.beacon.GenesisData;
+import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
+import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
+import tech.pegasys.teku.datastructures.state.ForkInfo;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.util.config.Constants;
+
+public class GetGenesisTest extends AbstractBeaconHandlerTest {
+  final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+
+  @Test
+  public void shouldReturnUnavailableWhenStoreNotAvailable() throws Exception {
+    final GetGenesis handler = new GetGenesis(chainDataProvider, jsonProvider);
+    when(chainDataProvider.isStoreAvailable()).thenReturn(false);
+
+    handler.handle(context);
+    verifyStatusCode(SC_NOT_FOUND);
+  }
+
+  @Test
+  public void shouldReturnGenesisInformation() throws Exception {
+    final GetGenesis handler = new GetGenesis(chainDataProvider, jsonProvider);
+    final UInt64 genesisTime = dataStructureUtil.randomUInt64();
+    final ForkInfo forkInfo = dataStructureUtil.randomForkInfo();
+    when(chainDataProvider.isStoreAvailable()).thenReturn(true);
+    when(chainDataProvider.getGenesisTime()).thenReturn(genesisTime);
+    when(chainDataProvider.getForkInfo()).thenReturn(new GetForkResponse(forkInfo));
+
+    handler.handle(context);
+    final GetGenesisResponse response = getResponseObject(GetGenesisResponse.class);
+    assertThat(response.data)
+        .isEqualTo(
+            new GenesisData(
+                genesisTime, forkInfo.getGenesisValidatorsRoot(), Constants.GENESIS_FORK_VERSION));
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/GenesisData.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/GenesisData.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.response.v1.beacon;
+
+import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_BYTES32;
+import static tech.pegasys.teku.api.schema.SchemaConstants.PATTERN_BYTES32;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
+
+public class GenesisData {
+  @JsonProperty("genesis_time")
+  @Schema(
+      type = "string",
+      example = "1590832934",
+      description =
+          "The genesis_time configured for the beacon node, which is the unix time in seconds at which the Eth2.0 chain began.")
+  public final UInt64 genesisTime;
+
+  @JsonProperty("genesis_validators_root")
+  @Schema(type = "string", example = EXAMPLE_BYTES32, pattern = PATTERN_BYTES32)
+  public final Bytes32 genesisValidatorsRoot;
+
+  @JsonProperty("genesis_fork_version")
+  @Schema(type = "string", example = "0x00000000", pattern = "^0x[a-fA-F0-9]{8}$")
+  public final Bytes4 genesisForkVersion;
+
+  @JsonCreator
+  public GenesisData(
+      @JsonProperty("genesis_time") final UInt64 genesisTime,
+      @JsonProperty("genesis_validators_root") final Bytes32 genesisValidatorsRoot,
+      @JsonProperty("genesis_fork_version") final Bytes4 genesisForkVersion) {
+    this.genesisTime = genesisTime;
+    this.genesisValidatorsRoot = genesisValidatorsRoot;
+    this.genesisForkVersion = genesisForkVersion;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final GenesisData that = (GenesisData) o;
+    return Objects.equals(genesisTime, that.genesisTime)
+        && Objects.equals(genesisValidatorsRoot, that.genesisValidatorsRoot)
+        && Objects.equals(genesisForkVersion, that.genesisForkVersion);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(genesisTime, genesisValidatorsRoot, genesisForkVersion);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("genesisTime", genesisTime)
+        .add("genesisValidatorsRoot", genesisValidatorsRoot)
+        .add("genesisForkVersion", genesisForkVersion)
+        .toString();
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/GetGenesisResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/GetGenesisResponse.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.response.v1.beacon;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GetGenesisResponse {
+  @JsonProperty("data")
+  public final GenesisData data;
+
+  @JsonCreator
+  public GetGenesisResponse(@JsonProperty("data") final GenesisData data) {
+    this.data = data;
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SchemaConstants.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SchemaConstants.java
@@ -22,8 +22,11 @@ public class SchemaConstants {
 
   public static final String PATTERN_UINT64 = "^0-9+$";
   public static final String PATTERN_PUBKEY = "^0x[a-fA-F0-9]{96}$";
+  public static final String PATTERN_BYTES32 = "^0x[a-fA-F0-9]{64}$";
 
   public static final String EXAMPLE_PUBKEY =
       "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a";
+  public static final String EXAMPLE_BYTES32 =
+      "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2";
   public static final String EXAMPLE_UINT64 = "1";
 }


### PR DESCRIPTION
- deprecated the previous genesis endpoint `/node/genesis_time`.

 partially addresses #2757

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.