### PR TITLE
[Issue-2273] Handle weakSubjectivity checkpoint persistence

### DIFF
--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoc
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_current_epoch;
 import static tech.pegasys.teku.datastructures.util.ValidatorsUtil.get_active_validator_indices;
 
+import java.util.Objects;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.CheckpointState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -111,5 +112,19 @@ public class WeakSubjectivityCalculator {
         (state) -> get_active_validator_indices(state, get_current_epoch(state)).size();
 
     int getActiveValidators(final BeaconState state);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    WeakSubjectivityCalculator that = (WeakSubjectivityCalculator) o;
+    return safetyDecay.equals(that.safetyDecay)
+        && activeValidatorCalculator.equals(that.activeValidatorCalculator);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(safetyDecay, activeValidatorCalculator);
   }
 }

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
@@ -115,12 +115,12 @@ public class WeakSubjectivityCalculator {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    WeakSubjectivityCalculator that = (WeakSubjectivityCalculator) o;
-    return safetyDecay.equals(that.safetyDecay)
-        && activeValidatorCalculator.equals(that.activeValidatorCalculator);
+    final WeakSubjectivityCalculator that = (WeakSubjectivityCalculator) o;
+    return Objects.equals(safetyDecay, that.safetyDecay)
+        && Objects.equals(activeValidatorCalculator, that.activeValidatorCalculator);
   }
 
   @Override

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoc
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -214,5 +215,20 @@ public class WeakSubjectivityValidator {
 
   private boolean isAtWSCheckpoint(final CheckpointState checkpoint) {
     return maybeWsCheckpoint.map(c -> checkpoint.getEpoch().equals(c.getEpoch())).orElse(false);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    WeakSubjectivityValidator that = (WeakSubjectivityValidator) o;
+    return calculator.equals(that.calculator)
+        && violationPolicies.equals(that.violationPolicies)
+        && maybeWsCheckpoint.equals(that.maybeWsCheckpoint);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(calculator, violationPolicies, maybeWsCheckpoint);
   }
 }

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
@@ -218,13 +218,13 @@ public class WeakSubjectivityValidator {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    WeakSubjectivityValidator that = (WeakSubjectivityValidator) o;
-    return calculator.equals(that.calculator)
-        && violationPolicies.equals(that.violationPolicies)
-        && maybeWsCheckpoint.equals(that.maybeWsCheckpoint);
+    final WeakSubjectivityValidator that = (WeakSubjectivityValidator) o;
+    return Objects.equals(calculator, that.calculator)
+        && Objects.equals(violationPolicies, that.violationPolicies)
+        && Objects.equals(maybeWsCheckpoint, that.maybeWsCheckpoint);
   }
 
   @Override

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/config/WeakSubjectivityConfig.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/config/WeakSubjectivityConfig.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.weaksubjectivity.config;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
@@ -69,17 +69,17 @@ public class WeakSubjectivityConfig {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    WeakSubjectivityConfig that = (WeakSubjectivityConfig) o;
-    return Objects.equal(safetyDecay, that.safetyDecay)
-        && Objects.equal(weakSubjectivityCheckpoint, that.weakSubjectivityCheckpoint);
+    final WeakSubjectivityConfig that = (WeakSubjectivityConfig) o;
+    return Objects.equals(safetyDecay, that.safetyDecay)
+        && Objects.equals(weakSubjectivityCheckpoint, that.weakSubjectivityCheckpoint);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(safetyDecay, weakSubjectivityCheckpoint);
+    return Objects.hash(safetyDecay, weakSubjectivityCheckpoint);
   }
 
   @Override

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/config/WeakSubjectivityConfig.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/config/WeakSubjectivityConfig.java
@@ -15,9 +15,12 @@ package tech.pegasys.teku.weaksubjectivity.config;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.events.WeakSubjectivityState;
 
 public class WeakSubjectivityConfig {
   public static UInt64 DEFAULT_SAFETY_DECAY = UInt64.valueOf(10);
@@ -37,8 +40,24 @@ public class WeakSubjectivityConfig {
     return builder().build();
   }
 
+  public static WeakSubjectivityConfig from(final WeakSubjectivityState state) {
+    return builder().weakSubjectivityCheckpoint(state.getCheckpoint()).build();
+  }
+
   public static Builder builder() {
     return new Builder();
+  }
+
+  public WeakSubjectivityConfig updated(final Consumer<Builder> updater) {
+    Builder builder = copy();
+    updater.accept(builder);
+    return builder.build();
+  }
+
+  private Builder copy() {
+    Builder builder = WeakSubjectivityConfig.builder().safetyDecay(safetyDecay);
+    weakSubjectivityCheckpoint.ifPresent(builder::weakSubjectivityCheckpoint);
+    return builder;
   }
 
   public Optional<Checkpoint> getWeakSubjectivityCheckpoint() {
@@ -47,6 +66,30 @@ public class WeakSubjectivityConfig {
 
   public UInt64 getSafetyDecay() {
     return safetyDecay;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    WeakSubjectivityConfig that = (WeakSubjectivityConfig) o;
+    return Objects.equal(safetyDecay, that.safetyDecay)
+        && Objects.equal(weakSubjectivityCheckpoint, that.weakSubjectivityCheckpoint);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(safetyDecay, weakSubjectivityCheckpoint);
+  }
+
+  @Override
+  public String toString() {
+    return "WeakSubjectivityConfig{"
+        + "safetyDecay="
+        + safetyDecay
+        + ", weakSubjectivityCheckpoint="
+        + weakSubjectivityCheckpoint
+        + '}';
   }
 
   public static class Builder {
@@ -62,15 +105,19 @@ public class WeakSubjectivityConfig {
     }
 
     public Builder weakSubjectivityCheckpoint(Checkpoint weakSubjectivityCheckpoint) {
-      checkNotNull(weakSubjectivityCheckpoint);
-      this.weakSubjectivityCheckpoint = Optional.of(weakSubjectivityCheckpoint);
-      return this;
+      return weakSubjectivityCheckpoint(Optional.of(weakSubjectivityCheckpoint));
     }
 
     public Builder weakSubjectivityCheckpoint(String weakSubjectivityCheckpoint) {
       checkNotNull(weakSubjectivityCheckpoint);
       final Checkpoint checkpoint = parser.parseCheckpoint(weakSubjectivityCheckpoint);
       return weakSubjectivityCheckpoint(checkpoint);
+    }
+
+    public Builder weakSubjectivityCheckpoint(Optional<Checkpoint> weakSubjectivityCheckpoint) {
+      checkNotNull(weakSubjectivityCheckpoint);
+      this.weakSubjectivityCheckpoint = weakSubjectivityCheckpoint;
+      return this;
     }
 
     public Builder safetyDecay(UInt64 safetyDecay) {

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/LoggingWeakSubjectivityViolationPolicy.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/LoggingWeakSubjectivityViolationPolicy.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.weaksubjectivity.policies;
 
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 
+import java.util.Objects;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -66,5 +67,18 @@ public class LoggingWeakSubjectivityViolationPolicy implements WeakSubjectivityV
   @Override
   public void onFailedToPerformValidation(final String message, final Throwable error) {
     LOG.log(level, "Failed to perform weak subjectivity validation: " + message, error);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LoggingWeakSubjectivityViolationPolicy that = (LoggingWeakSubjectivityViolationPolicy) o;
+    return level.equals(that.level);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(level);
   }
 }

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/LoggingWeakSubjectivityViolationPolicy.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/LoggingWeakSubjectivityViolationPolicy.java
@@ -70,11 +70,11 @@ public class LoggingWeakSubjectivityViolationPolicy implements WeakSubjectivityV
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    LoggingWeakSubjectivityViolationPolicy that = (LoggingWeakSubjectivityViolationPolicy) o;
-    return level.equals(that.level);
+    final LoggingWeakSubjectivityViolationPolicy that = (LoggingWeakSubjectivityViolationPolicy) o;
+    return Objects.equals(level, that.level);
   }
 
   @Override

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/StrictWeakSubjectivityViolationPolicy.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/StrictWeakSubjectivityViolationPolicy.java
@@ -45,4 +45,15 @@ public class StrictWeakSubjectivityViolationPolicy implements WeakSubjectivityVi
   private void exitClient() {
     System.exit(2);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    return o != null && getClass() == o.getClass();
+  }
+
+  @Override
+  public int hashCode() {
+    return getClass().hashCode();
+  }
 }

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/StrictWeakSubjectivityViolationPolicy.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/StrictWeakSubjectivityViolationPolicy.java
@@ -47,7 +47,7 @@ public class StrictWeakSubjectivityViolationPolicy implements WeakSubjectivityVi
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) return true;
     return o != null && getClass() == o.getClass();
   }

--- a/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/config/WeakSubjectivityConfigTest.java
+++ b/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/config/WeakSubjectivityConfigTest.java
@@ -15,16 +15,17 @@ package tech.pegasys.teku.weaksubjectivity.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 
 public class WeakSubjectivityConfigTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Checkpoint checkpoint = dataStructureUtil.randomCheckpoint();
 
   @Test
   public void build_withStringParameters() {
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil();
-    final Checkpoint checkpoint = dataStructureUtil.randomCheckpoint();
     final String checkpointString =
         checkpoint.getRoot().toHexString() + ":" + checkpoint.getEpoch();
 
@@ -36,9 +37,6 @@ public class WeakSubjectivityConfigTest {
 
   @Test
   public void build_withParsedParameters() {
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil();
-    final Checkpoint checkpoint = dataStructureUtil.randomCheckpoint();
-
     WeakSubjectivityConfig config =
         WeakSubjectivityConfig.builder().weakSubjectivityCheckpoint(checkpoint).build();
 
@@ -49,5 +47,41 @@ public class WeakSubjectivityConfigTest {
   public void build_withNoWeakSubjectivityCheckpoint() {
     WeakSubjectivityConfig config = WeakSubjectivityConfig.builder().build();
     assertThat(config.getWeakSubjectivityCheckpoint()).isEmpty();
+  }
+
+  @Test
+  public void updated_setNewCheckpoint() {
+    WeakSubjectivityConfig original = WeakSubjectivityConfig.defaultConfig();
+    assertThat(original.getWeakSubjectivityCheckpoint()).isEmpty();
+
+    WeakSubjectivityConfig updated =
+        original.updated(b -> b.weakSubjectivityCheckpoint(checkpoint));
+    assertThat(original.getWeakSubjectivityCheckpoint()).isEmpty();
+    assertThat(updated.getWeakSubjectivityCheckpoint()).contains(checkpoint);
+    assertThat(updated).isNotEqualTo(original);
+  }
+
+  @Test
+  public void updated_clearCheckpoint() {
+    WeakSubjectivityConfig original =
+        WeakSubjectivityConfig.builder().weakSubjectivityCheckpoint(checkpoint).build();
+    assertThat(original.getWeakSubjectivityCheckpoint()).contains(checkpoint);
+
+    WeakSubjectivityConfig updated =
+        original.updated(b -> b.weakSubjectivityCheckpoint(Optional.empty()));
+    assertThat(original.getWeakSubjectivityCheckpoint()).contains(checkpoint);
+    assertThat(updated.getWeakSubjectivityCheckpoint()).isEmpty();
+    assertThat(updated).isNotEqualTo(original);
+  }
+
+  @Test
+  public void equals() {
+    WeakSubjectivityConfig configA = WeakSubjectivityConfig.defaultConfig();
+    WeakSubjectivityConfig configB =
+        WeakSubjectivityConfig.builder().weakSubjectivityCheckpoint(checkpoint).build();
+
+    assertThat(configA).isEqualTo(configA);
+    assertThat(configB).isEqualTo(configB);
+    assertThat(configA).isNotEqualTo(configB);
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -309,7 +309,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             stateTransition);
   }
 
-  private SafeFuture<Void> initWeakSubjectivityValidator() {
+  @VisibleForTesting
+  SafeFuture<Void> initWeakSubjectivityValidator() {
     StorageQueryChannel storageQueryChannel =
         eventChannels.getPublisher(StorageQueryChannel.class, asyncRunner);
     StorageUpdateChannel storageUpdateChannel =
@@ -552,6 +553,11 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     }
 
     return privateKey;
+  }
+
+  @VisibleForTesting
+  WeakSubjectivityValidator getWeakSubjectivityValidator() {
+    return weakSubjectivityValidator;
   }
 
   public void initAttestationPool() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,6 +51,7 @@ import tech.pegasys.teku.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.util.StartupUtil;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
@@ -87,6 +89,7 @@ import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.client.StorageBackedRecentChainData;
+import tech.pegasys.teku.storage.events.WeakSubjectivityUpdate;
 import tech.pegasys.teku.storage.store.FileKeyValueStore;
 import tech.pegasys.teku.storage.store.KeyValueStore;
 import tech.pegasys.teku.storage.store.StoreConfig;
@@ -110,6 +113,7 @@ import tech.pegasys.teku.validator.coordinator.Eth1DataCache;
 import tech.pegasys.teku.validator.coordinator.Eth1VotingPeriod;
 import tech.pegasys.teku.validator.coordinator.ValidatorApiHandler;
 import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
+import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 
 public class BeaconChainController extends Service implements TimeTickChannel {
   private static final Logger LOG = LogManager.getLogger();
@@ -117,16 +121,16 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   private static final String KEY_VALUE_STORE_SUBDIRECTORY = "kvstore";
   private static final String GENERATED_NODE_KEY_KEY = "generated-node-key";
 
+  private final BeaconChainConfiguration beaconConfig;
+  private final GlobalConfiguration config;
   private final EventChannels eventChannels;
   private final MetricsSystem metricsSystem;
-  private final GlobalConfiguration config;
   private final AsyncRunner asyncRunner;
   private final TimeProvider timeProvider;
   private final EventBus eventBus;
   private final SlotEventsChannel slotEventsChannelPublisher;
   private final AsyncRunner networkAsyncRunner;
   private final AsyncRunnerFactory asyncRunnerFactory;
-  private final WeakSubjectivityValidator weakSubjectivityValidator;
 
   private volatile ForkChoice forkChoice;
   private volatile StateTransition stateTransition;
@@ -145,6 +149,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   private volatile OperationPool<ProposerSlashing> proposerSlashingPool;
   private volatile OperationPool<SignedVoluntaryExit> voluntaryExitPool;
   private volatile OperationsReOrgManager operationsReOrgManager;
+  private volatile WeakSubjectivityValidator weakSubjectivityValidator;
 
   private SyncStateTracker syncStateTracker;
   private UInt64 genesisTimeTracker = ZERO;
@@ -152,17 +157,16 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   public BeaconChainController(
       BeaconChainConfiguration beaconConfig, final ServiceConfig serviceConfig) {
+    this.beaconConfig = beaconConfig;
+    this.config = serviceConfig.getConfig();
     asyncRunnerFactory = serviceConfig.getAsyncRunnerFactory();
     this.asyncRunner = serviceConfig.createAsyncRunner("beaconchain");
     this.networkAsyncRunner = serviceConfig.createAsyncRunner("p2p", 10);
     this.timeProvider = serviceConfig.getTimeProvider();
     this.eventBus = serviceConfig.getEventBus();
     this.eventChannels = serviceConfig.getEventChannels();
-    this.config = serviceConfig.getConfig();
     this.metricsSystem = serviceConfig.getMetricsSystem();
     this.slotEventsChannelPublisher = eventChannels.getPublisher(SlotEventsChannel.class);
-    // TODO(#2779) - make this validator strict when it is fully fleshed out
-    weakSubjectivityValidator = WeakSubjectivityValidator.lenient(beaconConfig.weakSubjectivity());
   }
 
   @Override
@@ -252,6 +256,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   }
 
   public void initAll() {
+    initWeakSubjectivityValidator().join();
     initStateTransition();
     initForkChoice();
     initBlockImporter();
@@ -302,6 +307,49 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             recentChainData,
             eventChannels.getPublisher(StorageQueryChannel.class, asyncRunner),
             stateTransition);
+  }
+
+  private SafeFuture<Void> initWeakSubjectivityValidator() {
+    StorageQueryChannel storageQueryChannel =
+        eventChannels.getPublisher(StorageQueryChannel.class, asyncRunner);
+    StorageUpdateChannel storageUpdateChannel =
+        eventChannels.getPublisher(StorageUpdateChannel.class, asyncRunner);
+    return storageQueryChannel
+        .getWeakSubjectivityState()
+        .thenApply(WeakSubjectivityConfig::from)
+        .thenApply(
+            storedConfig -> {
+              final WeakSubjectivityConfig updatedConfig =
+                  storedConfig.updated(
+                      b -> {
+                        beaconConfig
+                            .weakSubjectivity()
+                            .getWeakSubjectivityCheckpoint()
+                            .ifPresent(b::weakSubjectivityCheckpoint);
+                      });
+              Optional<WeakSubjectivityConfig> configToPersist = Optional.empty();
+              if (!Objects.equals(storedConfig, updatedConfig)) {
+                LOG.info(
+                    "Updated weak subjectivity config to {} from {}", updatedConfig, storedConfig);
+                configToPersist = Optional.of(updatedConfig);
+              }
+              // TODO(#2779) - make this validator strict when it is fully fleshed out
+              weakSubjectivityValidator = WeakSubjectivityValidator.lenient(updatedConfig);
+              return configToPersist;
+            })
+        .thenCompose(
+            maybeConfigToPersist -> {
+              // Persist weak subjectivity configuration
+              if (maybeConfigToPersist.isEmpty()) {
+                return SafeFuture.COMPLETE;
+              }
+              final WeakSubjectivityConfig config = maybeConfigToPersist.get();
+              final Checkpoint updatedCheckpoint =
+                  config.getWeakSubjectivityCheckpoint().orElseThrow();
+              WeakSubjectivityUpdate update =
+                  WeakSubjectivityUpdate.setWeakSubjectivityCheckpoint(updatedCheckpoint);
+              return storageUpdateChannel.onWeakSubjectivityUpdate(update);
+            });
   }
 
   private void initStateTransition() {

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainControllerTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainControllerTest.java
@@ -15,34 +15,50 @@ package tech.pegasys.teku.services.beaconchain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
+import tech.pegasys.teku.storage.api.StorageQueryChannel;
+import tech.pegasys.teku.storage.api.StorageUpdateChannel;
+import tech.pegasys.teku.storage.events.WeakSubjectivityState;
+import tech.pegasys.teku.storage.events.WeakSubjectivityUpdate;
 import tech.pegasys.teku.storage.store.MemKeyValueStore;
 import tech.pegasys.teku.util.config.GlobalConfiguration;
 import tech.pegasys.teku.util.time.channels.SlotEventsChannel;
+import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
 import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 
 public class BeaconChainControllerTest {
 
+  private final ServiceConfig serviceConfig = mock(ServiceConfig.class);
+  private final EventChannels eventChannels = mock(EventChannels.class);
+  private final AtomicReference<GlobalConfiguration> globalConfig =
+      new AtomicReference<>(GlobalConfiguration.builder().build());
   @TempDir public File dataDir;
 
-  private ServiceConfig mockServiceConfig(GlobalConfiguration globalConfiguration) {
-    ServiceConfig serviceConfig = mock(ServiceConfig.class);
-    when(serviceConfig.getConfig()).thenReturn(globalConfiguration);
-    EventChannels eventChannels = mock(EventChannels.class);
+  @BeforeEach
+  public void setup() {
+    when(serviceConfig.getConfig()).thenAnswer(__ -> globalConfig.get());
     when(eventChannels.getPublisher(any())).thenReturn(mock(SlotEventsChannel.class));
     when(serviceConfig.getEventChannels()).thenReturn(eventChannels);
-    return serviceConfig;
   }
 
   private BeaconChainConfiguration beaconChainConfiguration() {
@@ -53,9 +69,9 @@ public class BeaconChainControllerTest {
   void getP2pPrivateKeyBytes_generatedKeyTest() throws IOException {
     GlobalConfiguration globalConfiguration =
         GlobalConfiguration.builder().setDataPath(dataDir.getCanonicalPath()).build();
+    globalConfig.set(globalConfiguration);
     BeaconChainController controller =
-        new BeaconChainController(
-            beaconChainConfiguration(), mockServiceConfig(globalConfiguration));
+        new BeaconChainController(beaconChainConfiguration(), serviceConfig);
 
     MemKeyValueStore<String, Bytes> store = new MemKeyValueStore<>();
 
@@ -85,10 +101,167 @@ public class BeaconChainControllerTest {
             .setDataPath(dataDir.getCanonicalPath())
             .setP2pPrivateKeyFile(customPKFile.toString())
             .build();
+    globalConfig.set(globalConfiguration1);
     BeaconChainController controller1 =
-        new BeaconChainController(
-            beaconChainConfiguration(), mockServiceConfig(globalConfiguration1));
+        new BeaconChainController(beaconChainConfiguration(), serviceConfig);
     Bytes customPK = controller1.getP2pPrivateKeyBytes(store);
     assertThat(customPK).isEqualTo(generatedPK);
+  }
+
+  @Test
+  public void initWeakSubjectivityValidator_nothingStored_noNewArgs() {
+    final BeaconChainController controller =
+        new BeaconChainController(beaconChainConfiguration(), serviceConfig);
+
+    // Mock storage channels
+    final StorageQueryChannel queryChannel = mock(StorageQueryChannel.class);
+    final StorageUpdateChannel updateChannel = mock(StorageUpdateChannel.class);
+    when(eventChannels.getPublisher(eq(StorageQueryChannel.class), any())).thenReturn(queryChannel);
+    when(eventChannels.getPublisher(eq(StorageUpdateChannel.class), any()))
+        .thenReturn(updateChannel);
+
+    // Nothing is stored
+    when(queryChannel.getWeakSubjectivityState())
+        .thenReturn(SafeFuture.completedFuture(WeakSubjectivityState.empty()));
+
+    assertThat(controller.initWeakSubjectivityValidator()).isCompleted();
+    verify(queryChannel).getWeakSubjectivityState();
+    verify(updateChannel, never()).onWeakSubjectivityUpdate(any());
+
+    final WeakSubjectivityValidator expectedValidator = WeakSubjectivityValidator.lenient();
+    assertThat(controller.getWeakSubjectivityValidator()).isEqualTo(expectedValidator);
+  }
+
+  @Test
+  public void initWeakSubjectivityValidator_nothingStored_withNewArgs() {
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+    final Checkpoint cliCheckpoint = dataStructureUtil.randomCheckpoint();
+    final WeakSubjectivityConfig cliConfig =
+        WeakSubjectivityConfig.builder().weakSubjectivityCheckpoint(cliCheckpoint).build();
+    final BeaconChainConfiguration beaconChainConfiguration =
+        new BeaconChainConfiguration(cliConfig);
+    final BeaconChainController controller =
+        new BeaconChainController(beaconChainConfiguration, serviceConfig);
+
+    // Mock storage channels
+    final StorageQueryChannel queryChannel = mock(StorageQueryChannel.class);
+    final StorageUpdateChannel updateChannel = mock(StorageUpdateChannel.class);
+    when(eventChannels.getPublisher(eq(StorageQueryChannel.class), any())).thenReturn(queryChannel);
+    when(eventChannels.getPublisher(eq(StorageUpdateChannel.class), any()))
+        .thenReturn(updateChannel);
+    when(updateChannel.onWeakSubjectivityUpdate(any())).thenReturn(SafeFuture.COMPLETE);
+
+    // Nothing is stored
+    when(queryChannel.getWeakSubjectivityState())
+        .thenReturn(SafeFuture.completedFuture(WeakSubjectivityState.empty()));
+
+    assertThat(controller.initWeakSubjectivityValidator()).isCompleted();
+    verify(queryChannel).getWeakSubjectivityState();
+    verify(updateChannel)
+        .onWeakSubjectivityUpdate(
+            WeakSubjectivityUpdate.setWeakSubjectivityCheckpoint(cliCheckpoint));
+
+    final WeakSubjectivityValidator expectedValidator =
+        WeakSubjectivityValidator.lenient(cliConfig);
+    assertThat(controller.getWeakSubjectivityValidator()).isEqualTo(expectedValidator);
+  }
+
+  @Test
+  public void initWeakSubjectivityValidator_withStoredCheckpoint_noNewArgs() {
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+    final BeaconChainController controller =
+        new BeaconChainController(beaconChainConfiguration(), serviceConfig);
+
+    // Mock storage channels
+    final StorageQueryChannel queryChannel = mock(StorageQueryChannel.class);
+    final StorageUpdateChannel updateChannel = mock(StorageUpdateChannel.class);
+    when(eventChannels.getPublisher(eq(StorageQueryChannel.class), any())).thenReturn(queryChannel);
+    when(eventChannels.getPublisher(eq(StorageUpdateChannel.class), any()))
+        .thenReturn(updateChannel);
+
+    // Setup storage
+    final Checkpoint storedCheckpoint = dataStructureUtil.randomCheckpoint();
+    final WeakSubjectivityState storedState =
+        WeakSubjectivityState.create(Optional.of(storedCheckpoint));
+    when(queryChannel.getWeakSubjectivityState())
+        .thenReturn(SafeFuture.completedFuture(storedState));
+
+    assertThat(controller.initWeakSubjectivityValidator()).isCompleted();
+    verify(queryChannel).getWeakSubjectivityState();
+    verify(updateChannel, never()).onWeakSubjectivityUpdate(any());
+
+    final WeakSubjectivityValidator expectedValidator =
+        WeakSubjectivityValidator.lenient(WeakSubjectivityConfig.from(storedState));
+    assertThat(controller.getWeakSubjectivityValidator()).isEqualTo(expectedValidator);
+  }
+
+  @Test
+  public void initWeakSubjectivityValidator_withStoredCheckpoint_withNewDistinctArgs() {
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+    final Checkpoint cliCheckpoint = dataStructureUtil.randomCheckpoint();
+    final WeakSubjectivityConfig cliConfig =
+        WeakSubjectivityConfig.builder().weakSubjectivityCheckpoint(cliCheckpoint).build();
+    final BeaconChainConfiguration beaconChainConfiguration =
+        new BeaconChainConfiguration(cliConfig);
+    final BeaconChainController controller =
+        new BeaconChainController(beaconChainConfiguration, serviceConfig);
+
+    // Mock storage channels
+    final StorageQueryChannel queryChannel = mock(StorageQueryChannel.class);
+    final StorageUpdateChannel updateChannel = mock(StorageUpdateChannel.class);
+    when(eventChannels.getPublisher(eq(StorageQueryChannel.class), any())).thenReturn(queryChannel);
+    when(eventChannels.getPublisher(eq(StorageUpdateChannel.class), any()))
+        .thenReturn(updateChannel);
+    when(updateChannel.onWeakSubjectivityUpdate(any())).thenReturn(SafeFuture.COMPLETE);
+
+    // Setup storage
+    final Checkpoint storedCheckpoint = dataStructureUtil.randomCheckpoint();
+    final WeakSubjectivityState storedState =
+        WeakSubjectivityState.create(Optional.of(storedCheckpoint));
+    when(queryChannel.getWeakSubjectivityState())
+        .thenReturn(SafeFuture.completedFuture(storedState));
+
+    assertThat(controller.initWeakSubjectivityValidator()).isCompleted();
+    verify(queryChannel).getWeakSubjectivityState();
+    verify(updateChannel)
+        .onWeakSubjectivityUpdate(
+            WeakSubjectivityUpdate.setWeakSubjectivityCheckpoint(cliCheckpoint));
+
+    final WeakSubjectivityValidator expectedValidator =
+        WeakSubjectivityValidator.lenient(cliConfig);
+    assertThat(controller.getWeakSubjectivityValidator()).isEqualTo(expectedValidator);
+  }
+
+  @Test
+  public void initWeakSubjectivityValidator_withStoredCheckpoint_withConsistentCLIArgs() {
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+    final Checkpoint cliCheckpoint = dataStructureUtil.randomCheckpoint();
+    final WeakSubjectivityConfig cliConfig =
+        WeakSubjectivityConfig.builder().weakSubjectivityCheckpoint(cliCheckpoint).build();
+    final BeaconChainConfiguration beaconChainConfiguration =
+        new BeaconChainConfiguration(cliConfig);
+    final BeaconChainController controller =
+        new BeaconChainController(beaconChainConfiguration, serviceConfig);
+
+    // Mock storage channels
+    final StorageQueryChannel queryChannel = mock(StorageQueryChannel.class);
+    final StorageUpdateChannel updateChannel = mock(StorageUpdateChannel.class);
+    when(eventChannels.getPublisher(eq(StorageQueryChannel.class), any())).thenReturn(queryChannel);
+    when(eventChannels.getPublisher(eq(StorageUpdateChannel.class), any()))
+        .thenReturn(updateChannel);
+
+    // Setup storage
+    final WeakSubjectivityState storedState =
+        WeakSubjectivityState.create(Optional.of(cliCheckpoint));
+    when(queryChannel.getWeakSubjectivityState())
+        .thenReturn(SafeFuture.completedFuture(storedState));
+
+    assertThat(controller.initWeakSubjectivityValidator()).isCompleted();
+    verify(queryChannel).getWeakSubjectivityState();
+    verify(updateChannel, never()).onWeakSubjectivityUpdate(any());
+
+    final WeakSubjectivityValidator expectedValidator =
+        WeakSubjectivityValidator.lenient(cliConfig);
+    assertThat(controller.getWeakSubjectivityValidator()).isEqualTo(expectedValidator);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
@@ -24,11 +24,14 @@ import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.ChannelInterface;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.events.WeakSubjectivityState;
 import tech.pegasys.teku.storage.store.StoreBuilder;
 
 public interface StorageQueryChannel extends ChannelInterface {
 
   SafeFuture<Optional<StoreBuilder>> onStoreRequest();
+
+  SafeFuture<WeakSubjectivityState> getWeakSubjectivityState();
 
   SafeFuture<Optional<SignedBeaconBlock>> getFinalizedBlockAtSlot(final UInt64 slot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
@@ -17,10 +17,13 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.ChannelInterface;
 import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.events.StorageUpdate;
+import tech.pegasys.teku.storage.events.WeakSubjectivityUpdate;
 
 public interface StorageUpdateChannel extends ChannelInterface {
 
   SafeFuture<Void> onStorageUpdate(StorageUpdate event);
+
+  SafeFuture<Void> onWeakSubjectivityUpdate(WeakSubjectivityUpdate weakSubjectivityUpdate);
 
   void onGenesis(AnchorPoint genesis);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/events/WeakSubjectivityState.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/events/WeakSubjectivityState.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.events;
+
+import com.google.common.base.Objects;
+import java.util.Optional;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
+
+public class WeakSubjectivityState {
+  private final Optional<Checkpoint> checkpoint;
+
+  private WeakSubjectivityState(Optional<Checkpoint> checkpoint) {
+    this.checkpoint = checkpoint;
+  }
+
+  public static WeakSubjectivityState create(Optional<Checkpoint> checkpoint) {
+    return new WeakSubjectivityState(checkpoint);
+  }
+
+  public static WeakSubjectivityState empty() {
+    return new WeakSubjectivityState(Optional.empty());
+  }
+
+  public Optional<Checkpoint> getCheckpoint() {
+    return checkpoint;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    WeakSubjectivityState that = (WeakSubjectivityState) o;
+    return Objects.equal(checkpoint, that.checkpoint);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(checkpoint);
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/events/WeakSubjectivityState.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/events/WeakSubjectivityState.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.storage.events;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 import java.util.Optional;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 
@@ -37,15 +37,15 @@ public class WeakSubjectivityState {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    WeakSubjectivityState that = (WeakSubjectivityState) o;
-    return Objects.equal(checkpoint, that.checkpoint);
+    final WeakSubjectivityState that = (WeakSubjectivityState) o;
+    return Objects.equals(checkpoint, that.checkpoint);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(checkpoint);
+    return Objects.hash(checkpoint);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/events/WeakSubjectivityUpdate.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/events/WeakSubjectivityUpdate.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.events;
 
+import java.util.Objects;
 import java.util.Optional;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 
@@ -34,5 +35,18 @@ public class WeakSubjectivityUpdate {
 
   public Optional<Checkpoint> getWeakSubjectivityCheckpoint() {
     return weakSubjectivityCheckpoint;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    WeakSubjectivityUpdate that = (WeakSubjectivityUpdate) o;
+    return weakSubjectivityCheckpoint.equals(that.weakSubjectivityCheckpoint);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(weakSubjectivityCheckpoint);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/events/WeakSubjectivityUpdate.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/events/WeakSubjectivityUpdate.java
@@ -38,11 +38,11 @@ public class WeakSubjectivityUpdate {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    WeakSubjectivityUpdate that = (WeakSubjectivityUpdate) o;
-    return weakSubjectivityCheckpoint.equals(that.weakSubjectivityCheckpoint);
+    final WeakSubjectivityUpdate that = (WeakSubjectivityUpdate) o;
+    return Objects.equals(weakSubjectivityCheckpoint, that.weakSubjectivityCheckpoint);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -22,12 +22,14 @@ import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.events.StorageUpdate;
+import tech.pegasys.teku.storage.events.WeakSubjectivityState;
 import tech.pegasys.teku.storage.events.WeakSubjectivityUpdate;
 import tech.pegasys.teku.storage.server.state.FinalizedStateCache;
 import tech.pegasys.teku.storage.store.StoreBuilder;
@@ -85,6 +87,15 @@ public class ChainStorage implements StorageUpdateChannel, StorageQueryChannel {
     }
 
     return SafeFuture.completedFuture(getStore());
+  }
+
+  @Override
+  public SafeFuture<WeakSubjectivityState> getWeakSubjectivityState() {
+    return SafeFuture.of(
+        () -> {
+          Optional<Checkpoint> checkpoint = database.getWeakSubjectivityCheckpoint();
+          return WeakSubjectivityState.create(checkpoint);
+        });
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.events.StorageUpdate;
+import tech.pegasys.teku.storage.events.WeakSubjectivityUpdate;
 import tech.pegasys.teku.storage.server.state.FinalizedStateCache;
 import tech.pegasys.teku.storage.store.StoreBuilder;
 import tech.pegasys.teku.util.config.Constants;
@@ -98,6 +99,14 @@ public class ChainStorage implements StorageUpdateChannel, StorageQueryChannel {
   @Override
   public void onGenesis(final AnchorPoint genesis) {
     database.storeGenesis(genesis);
+  }
+
+  @Override
+  public SafeFuture<Void> onWeakSubjectivityUpdate(WeakSubjectivityUpdate weakSubjectivityUpdate) {
+    return SafeFuture.fromRunnable(
+        () -> {
+          database.updateWeakSubjectivityState(weakSubjectivityUpdate);
+        });
   }
 
   @Override

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.events.WeakSubjectivityState;
 import tech.pegasys.teku.storage.store.StoreBuilder;
 
 public class StubStorageQueryChannel implements StorageQueryChannel {
@@ -31,6 +32,11 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
   @Override
   public SafeFuture<Optional<StoreBuilder>> onStoreRequest() {
     return SafeFuture.completedFuture(Optional.empty());
+  }
+
+  @Override
+  public SafeFuture<WeakSubjectivityState> getWeakSubjectivityState() {
+    return SafeFuture.completedFuture(WeakSubjectivityState.empty());
   }
 
   @Override

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
@@ -16,11 +16,17 @@ package tech.pegasys.teku.storage.api;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.events.StorageUpdate;
+import tech.pegasys.teku.storage.events.WeakSubjectivityUpdate;
 
 public class StubStorageUpdateChannel implements StorageUpdateChannel {
 
   @Override
   public SafeFuture<Void> onStorageUpdate(StorageUpdate event) {
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
+  public SafeFuture<Void> onWeakSubjectivityUpdate(WeakSubjectivityUpdate weakSubjectivityUpdate) {
     return SafeFuture.COMPLETE;
   }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
@@ -17,6 +17,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.storage.events.AnchorPoint;
 import tech.pegasys.teku.storage.events.StorageUpdate;
+import tech.pegasys.teku.storage.events.WeakSubjectivityUpdate;
 
 public class StubStorageUpdateChannelWithDelays implements StorageUpdateChannel {
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
@@ -27,6 +28,11 @@ public class StubStorageUpdateChannelWithDelays implements StorageUpdateChannel 
 
   @Override
   public SafeFuture<Void> onStorageUpdate(StorageUpdate event) {
+    return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
+  }
+
+  @Override
+  public SafeFuture<Void> onWeakSubjectivityUpdate(WeakSubjectivityUpdate weakSubjectivityUpdate) {
     return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Handle weakSubjectivity checkpoint persistence.  At startup:
* Read weak subjectivity checkpoint from the database
* If a new checkpoint was provided via CLI args, overwrite stored WS checkpoint
* Set the WS checkpoint to that provided by the CLI or else whatever was pulled from storage

## Fixed Issue(s)
Part of #2273

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.