### PR TITLE
[Issue 2273] Validate peers against weakSubjectivity checkpoint

### DIFF
--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
@@ -74,6 +74,10 @@ public class WeakSubjectivityValidator {
         calculator, policies, config.getWeakSubjectivityCheckpoint());
   }
 
+  public Optional<Checkpoint> getWSCheckpoint() {
+    return maybeWsCheckpoint;
+  }
+
   /** Check whether the chain matches any configured weak subjectivity checkpoint or state */
   public SafeFuture<Void> validateChainIsConsistentWithWSCheckpoint(
       CombinedChainDataClient chainData) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2Config.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2Config.java
@@ -13,14 +13,24 @@
 
 package tech.pegasys.teku.networking.eth2;
 
+import java.util.Optional;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
+
 public class Eth2Config {
   private final boolean enableSnappyCompression;
+  private final Optional<Checkpoint> requiredCheckpoint;
 
-  public Eth2Config(final boolean enableSnappyCompression) {
+  public Eth2Config(
+      final boolean enableSnappyCompression, Optional<Checkpoint> requiredCheckpoint) {
     this.enableSnappyCompression = enableSnappyCompression;
+    this.requiredCheckpoint = requiredCheckpoint;
   }
 
   public boolean isSnappyCompressionEnabled() {
     return enableSnappyCompression;
+  }
+
+  public Optional<Checkpoint> getRequiredCheckpoint() {
+    return requiredCheckpoint;
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2NetworkBuilder.java
@@ -101,6 +101,7 @@ public class Eth2NetworkBuilder {
             metricsSystem,
             attestationSubnetService,
             rpcEncoding,
+            eth2Config.getRequiredCheckpoint(),
             eth2RpcPingInterval,
             eth2RpcOutstandingPingThreshold,
             eth2StatusUpdateInterval,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
@@ -13,7 +13,9 @@
 
 package tech.pegasys.teku.networking.eth2.peers;
 
+import java.util.Optional;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.MetadataMessagesFactory;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
@@ -28,6 +30,7 @@ public class Eth2PeerFactory {
   private final MetricsSystem metricsSystem;
   private final CombinedChainDataClient chainDataClient;
   private final TimeProvider timeProvider;
+  private final Optional<Checkpoint> requiredCheckpoint;
   private final int peerRateLimit;
   private final int peerRequestLimit;
 
@@ -37,6 +40,7 @@ public class Eth2PeerFactory {
       final StatusMessageFactory statusMessageFactory,
       final MetadataMessagesFactory metadataMessagesFactory,
       final TimeProvider timeProvider,
+      final Optional<Checkpoint> requiredCheckpoint,
       final int peerRateLimit,
       final int peerRequestLimit) {
     this.metricsSystem = metricsSystem;
@@ -44,6 +48,7 @@ public class Eth2PeerFactory {
     this.timeProvider = timeProvider;
     this.statusMessageFactory = statusMessageFactory;
     this.metadataMessagesFactory = metadataMessagesFactory;
+    this.requiredCheckpoint = requiredCheckpoint;
     this.peerRateLimit = peerRateLimit;
     this.peerRequestLimit = peerRequestLimit;
   }
@@ -54,7 +59,7 @@ public class Eth2PeerFactory {
         rpcMethods,
         statusMessageFactory,
         metadataMessagesFactory,
-        PeerChainValidator.create(metricsSystem, chainDataClient),
+        PeerChainValidator.create(metricsSystem, chainDataClient, requiredCheckpoint),
         new RateTracker(peerRateLimit, 60, timeProvider),
         new RateTracker(peerRequestLimit, 60, timeProvider));
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.MetadataMessage;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.Cancellable;
 import tech.pegasys.teku.infrastructure.async.RootCauseExceptionHandler;
@@ -101,6 +102,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
       final MetricsSystem metricsSystem,
       final AttestationSubnetService attestationSubnetService,
       final RpcEncoding rpcEncoding,
+      final Optional<Checkpoint> requiredCheckpoint,
       final Duration eth2RpcPingInterval,
       final int eth2RpcOutstandingPingThreshold,
       final Duration eth2StatusUpdateInterval,
@@ -124,6 +126,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
             statusMessageFactory,
             metadataMessagesFactory,
             timeProvider,
+            requiredCheckpoint,
             peerRateLimit,
             peerRequestLimit),
         statusMessageFactory,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
@@ -97,7 +97,7 @@ public class PeerChainValidator {
   }
 
   private SafeFuture<Boolean> isRemoteChainValid(final Eth2Peer peer, final PeerStatus status) {
-    if (!validateFork(peer, status)) {
+    if (!isForkValid(peer, status)) {
       return SafeFuture.completedFuture(false);
     }
 
@@ -106,7 +106,7 @@ public class PeerChainValidator {
       return SafeFuture.completedFuture(true);
     }
 
-    return validateRequiredCheckpoint(peer, status)
+    return isConsistentWithRequiredCheckpoint(peer, status)
         .thenCompose(
             isValid -> {
               if (!isValid) {
@@ -116,11 +116,11 @@ public class PeerChainValidator {
                 return SafeFuture.completedFuture(isValid);
               }
 
-              return validateFinalizedCheckpoint(peer, status);
+              return isFinalizedCheckpointValid(peer, status);
             });
   }
 
-  private boolean validateFork(final Eth2Peer peer, final PeerStatus status) {
+  private boolean isForkValid(final Eth2Peer peer, final PeerStatus status) {
     Bytes4 expectedForkDigest = chainDataClient.getHeadForkInfo().orElseThrow().getForkDigest();
     if (!Objects.equals(expectedForkDigest, status.getForkDigest())) {
       LOG.trace(
@@ -134,7 +134,7 @@ public class PeerChainValidator {
     return true;
   }
 
-  private SafeFuture<Boolean> validateRequiredCheckpoint(
+  private SafeFuture<Boolean> isConsistentWithRequiredCheckpoint(
       final Eth2Peer peer, final PeerStatus status) {
     if (requiredCheckpointVerified.get()) {
       return SafeFuture.completedFuture(true);
@@ -172,7 +172,7 @@ public class PeerChainValidator {
     }
   }
 
-  private SafeFuture<Boolean> validateFinalizedCheckpoint(
+  private SafeFuture<Boolean> isFinalizedCheckpointValid(
       final Eth2Peer peer, final PeerStatus status) {
     final UInt64 remoteFinalizedEpoch = status.getFinalizedEpoch();
     final Checkpoint finalizedCheckpoint =

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.peers;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -35,11 +36,13 @@ public class PeerChainValidator {
   private static final Logger LOG = LogManager.getLogger();
 
   private final CombinedChainDataClient chainDataClient;
-  private final Optional<Checkpoint> requiredCheckpoint;
   private final Counter validationStartedCounter;
   private final Counter chainValidCounter;
   private final Counter chainInvalidCounter;
   private final Counter validationErrorCounter;
+
+  private final Optional<Checkpoint> requiredCheckpoint;
+  private final AtomicBoolean requiredCheckpointVerified = new AtomicBoolean(false);
 
   private PeerChainValidator(
       final MetricsSystem metricsSystem,
@@ -70,7 +73,7 @@ public class PeerChainValidator {
   public SafeFuture<Boolean> validate(final Eth2Peer peer, final PeerStatus newStatus) {
     LOG.trace("Validate chain of peer: {}", peer.getId());
     validationStartedCounter.inc();
-    return checkRemoteChain(peer, newStatus)
+    return isRemoteChainValid(peer, newStatus)
         .thenApply(
             isValid -> {
               if (!isValid) {
@@ -93,8 +96,31 @@ public class PeerChainValidator {
             });
   }
 
-  private SafeFuture<Boolean> checkRemoteChain(final Eth2Peer peer, final PeerStatus status) {
-    // Check fork compatibility
+  private SafeFuture<Boolean> isRemoteChainValid(final Eth2Peer peer, final PeerStatus status) {
+    if (!validateFork(peer, status)) {
+      return SafeFuture.completedFuture(false);
+    }
+
+    // Skip remaining checks if only genesis is finalized
+    if (status.getFinalizedEpoch().equals(UInt64.ZERO)) {
+      return SafeFuture.completedFuture(true);
+    }
+
+    return validateRequiredCheckpoint(peer, status)
+        .thenCompose(
+            isValid -> {
+              if (!isValid) {
+                // Short-circuit if we know the chain is invalid
+                LOG.trace(
+                    "Failed to validate peer against required checkpoint {}", requiredCheckpoint);
+                return SafeFuture.completedFuture(isValid);
+              }
+
+              return validateFinalizedCheckpoint(peer, status);
+            });
+  }
+
+  private boolean validateFork(final Eth2Peer peer, final PeerStatus status) {
     Bytes4 expectedForkDigest = chainDataClient.getHeadForkInfo().orElseThrow().getForkDigest();
     if (!Objects.equals(expectedForkDigest, status.getForkDigest())) {
       LOG.trace(
@@ -102,15 +128,53 @@ public class PeerChainValidator {
           status.getForkDigest(),
           expectedForkDigest,
           peer.getId());
-      return SafeFuture.completedFuture(false);
+      return false;
     }
-    final UInt64 remoteFinalizedEpoch = status.getFinalizedEpoch();
-    // Only require fork digest to match if only genesis is finalized
-    if (remoteFinalizedEpoch.equals(UInt64.ZERO)) {
+
+    return true;
+  }
+
+  private SafeFuture<Boolean> validateRequiredCheckpoint(
+      final Eth2Peer peer, final PeerStatus status) {
+    if (requiredCheckpointVerified.get()) {
+      return SafeFuture.completedFuture(true);
+    }
+    if (requiredCheckpoint.isEmpty()) {
+      requiredCheckpointVerified.set(true);
       return SafeFuture.completedFuture(true);
     }
 
-    // Check finalized checkpoint compatibility
+    final Checkpoint checkpointToVerify = requiredCheckpoint.get();
+    if (status.getFinalizedCheckpoint().getEpoch().isLessThan(checkpointToVerify.getEpoch())) {
+      // Peer hasn't finalized the required checkpoint, so defer check
+      return SafeFuture.completedFuture(true);
+    } else if (status.getFinalizedCheckpoint().getEpoch().equals(checkpointToVerify.getEpoch())) {
+      // Peer is at the required checkpoint, check for consistency
+      final boolean blockMatches = status.getFinalizedCheckpoint().equals(checkpointToVerify);
+      requiredCheckpointVerified.set(blockMatches);
+      return SafeFuture.completedFuture(blockMatches);
+    } else {
+      // Peer has finalized the required checkpoint in the past, request this block to check
+      // consistency
+      return peer.requestBlockByRoot(checkpointToVerify.getRoot())
+          // When requesting block by root, there is no explicit guarantee that the block is
+          // canonical.
+          // So, double-check by requesting the block by slot to make sure the peer considers this
+          // block canonical.
+          .thenCompose(block -> peer.requestBlockBySlot(block.getSlot()))
+          .thenApply(
+              blockBySlot -> {
+                final boolean blockMatches =
+                    blockBySlot.getRoot().equals(checkpointToVerify.getRoot());
+                requiredCheckpointVerified.set(blockMatches);
+                return blockMatches;
+              });
+    }
+  }
+
+  private SafeFuture<Boolean> validateFinalizedCheckpoint(
+      final Eth2Peer peer, final PeerStatus status) {
+    final UInt64 remoteFinalizedEpoch = status.getFinalizedEpoch();
     final Checkpoint finalizedCheckpoint =
         chainDataClient.getBestState().orElseThrow().getFinalized_checkpoint();
     final UInt64 finalizedEpoch = finalizedCheckpoint.getEpoch();

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
@@ -35,14 +35,18 @@ public class PeerChainValidator {
   private static final Logger LOG = LogManager.getLogger();
 
   private final CombinedChainDataClient chainDataClient;
+  private final Optional<Checkpoint> requiredCheckpoint;
   private final Counter validationStartedCounter;
   private final Counter chainValidCounter;
   private final Counter chainInvalidCounter;
   private final Counter validationErrorCounter;
 
   private PeerChainValidator(
-      final MetricsSystem metricsSystem, final CombinedChainDataClient chainDataClient) {
+      final MetricsSystem metricsSystem,
+      final CombinedChainDataClient chainDataClient,
+      final Optional<Checkpoint> requiredCheckpoint) {
     this.chainDataClient = chainDataClient;
+    this.requiredCheckpoint = requiredCheckpoint;
 
     final LabelledMetric<Counter> validationCounter =
         metricsSystem.createLabelledCounter(
@@ -57,8 +61,10 @@ public class PeerChainValidator {
   }
 
   public static PeerChainValidator create(
-      final MetricsSystem metricsSystem, final CombinedChainDataClient chainDataClient) {
-    return new PeerChainValidator(metricsSystem, chainDataClient);
+      final MetricsSystem metricsSystem,
+      final CombinedChainDataClient chainDataClient,
+      final Optional<Checkpoint> requiredCheckpoint) {
+    return new PeerChainValidator(metricsSystem, chainDataClient, requiredCheckpoint);
   }
 
   public SafeFuture<Boolean> validate(final Eth2Peer peer, final PeerStatus newStatus) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
@@ -112,7 +112,9 @@ public class PeerChainValidator {
               if (!isValid) {
                 // Short-circuit if we know the chain is invalid
                 LOG.trace(
-                    "Failed to validate peer against required checkpoint {}", requiredCheckpoint);
+                    "Failed to validate peer {} against required checkpoint {}",
+                    peer.getId(),
+                    requiredCheckpoint);
                 return SafeFuture.completedFuture(isValid);
               }
 
@@ -149,6 +151,11 @@ public class PeerChainValidator {
       // Peer hasn't finalized the required checkpoint, so defer check
       return SafeFuture.completedFuture(true);
     } else if (status.getFinalizedCheckpoint().getEpoch().equals(checkpointToVerify.getEpoch())) {
+      LOG.trace(
+          "Validate peer's ({}) finalized checkpoint {} matches required checkpoint {}",
+          peer.getId(),
+          status.getFinalizedCheckpoint(),
+          checkpointToVerify);
       // Peer is at the required checkpoint, check for consistency
       final boolean blockMatches = status.getFinalizedCheckpoint().equals(checkpointToVerify);
       requiredCheckpointVerified.set(blockMatches);
@@ -156,6 +163,8 @@ public class PeerChainValidator {
     } else {
       // Peer has finalized the required checkpoint in the past, request this block to check
       // consistency
+      LOG.trace(
+          "Request required checkpoint block from peer {}: {}", peer.getId(), checkpointToVerify);
       return peer.requestBlockByRoot(checkpointToVerify.getRoot())
           // When requesting block by root, there is no explicit guarantee that the block is
           // canonical.

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
@@ -347,6 +347,7 @@ public class PeerChainValidatorTest {
     when(peer.getStatus()).thenReturn(status);
 
     remoteStatus = status;
-    peerChainValidator = PeerChainValidator.create(new NoOpMetricsSystem(), combinedChainData);
+    peerChainValidator =
+        PeerChainValidator.create(new NoOpMetricsSystem(), combinedChainData, Optional.empty());
   }
 }

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -115,6 +116,7 @@ public class Eth2NetworkFactory {
     protected List<PeerHandler> peerHandlers = new ArrayList<>();
     protected RpcEncoding rpcEncoding = RpcEncoding.SSZ_SNAPPY;
     protected GossipEncoding gossipEncoding = GossipEncoding.SSZ_SNAPPY;
+    private Optional<Checkpoint> requiredCheckpoint = Optional.empty();
     protected Duration eth2RpcPingInterval;
     protected Integer eth2RpcOutstandingPingThreshold;
     protected Duration eth2StatusUpdateInterval;
@@ -166,6 +168,7 @@ public class Eth2NetworkFactory {
                 METRICS_SYSTEM,
                 attestationSubnetService,
                 rpcEncoding,
+                requiredCheckpoint,
                 eth2RpcPingInterval,
                 eth2RpcOutstandingPingThreshold,
                 eth2StatusUpdateInterval,
@@ -305,6 +308,12 @@ public class Eth2NetworkFactory {
     public Eth2P2PNetworkBuilder gossipEncoding(final GossipEncoding gossipEncoding) {
       checkNotNull(gossipEncoding);
       this.gossipEncoding = gossipEncoding;
+      return this;
+    }
+
+    public Eth2P2PNetworkBuilder setRequiredCheckpoint(
+        final Optional<Checkpoint> requiredCheckpoint) {
+      this.requiredCheckpoint = requiredCheckpoint;
       return this;
     }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -432,7 +432,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
                   config.isLogWireGossip()));
 
       p2pConfig.validateListenPortAvailable();
-      final Eth2Config eth2Config = new Eth2Config(config.isP2pSnappyEnabled());
+      final Eth2Config eth2Config =
+          new Eth2Config(config.isP2pSnappyEnabled(), weakSubjectivityValidator.getWSCheckpoint());
 
       this.p2pNetwork =
           Eth2NetworkBuilder.create()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Pass weak subjectivity checkpoint into `PeerChainValidator` and check that peers' chains are consistent with this checkpoint.

## Fixed Issue(s)
Part of #2273

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.