### PR TITLE
Fix slot calculation underflow

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -59,6 +59,9 @@ public class ForkChoiceUtil {
   }
 
   public static UInt64 getCurrentSlot(UInt64 currentTime, UInt64 genesisTime) {
+    if (currentTime.isLessThan(genesisTime)) {
+      return UInt64.ZERO;
+    }
     return currentTime.minus(genesisTime).dividedBy(SECONDS_PER_SLOT);
   }
 

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
@@ -139,6 +139,12 @@ class ForkChoiceUtilTest {
   }
 
   @Test
+  public void getCurrentSlot_shouldGetZeroPriorToGenesis() {
+    assertThat(ForkChoiceUtil.getCurrentSlot(GENESIS_TIME.minus(1), GENESIS_TIME))
+        .isEqualTo(UInt64.ZERO);
+  }
+
+  @Test
   public void getSlotStartTime_shouldGetGenesisTimeForBlockZero() {
     assertThat(ForkChoiceUtil.getSlotStartTime(UInt64.ZERO, GENESIS_TIME)).isEqualTo(GENESIS_TIME);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fix slot calculation underflow. 

Bug presents with errors such as: 
```
2020-09-28 22:33:45.876+00:00 | nioEventLoopGroup-3-4 | ERROR | Subscribers | Error in callback:
java.lang.ArithmeticException: uint64 underflow
        at tech.pegasys.teku.infrastructure.unsigned.UInt64.minus(UInt64.java:160) ~[teku-infrastructure-unsigned-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.infrastructure.unsigned.UInt64.minus(UInt64.java:155) ~[teku-infrastructure-unsigned-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.core.ForkChoiceUtil.getCurrentSlot(ForkChoiceUtil.java:62) ~[teku-ethereum-core-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.core.ForkChoiceUtil.get_slots_since_genesis(ForkChoiceUtil.java:58) ~[teku-ethereum-core-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.core.ForkChoiceUtil.get_current_slot(ForkChoiceUtil.java:70) ~[teku-ethereum-core-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.core.ForkChoiceUtil.get_current_slot(ForkChoiceUtil.java:74) ~[teku-ethereum-core-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.storage.client.RecentChainData.getCurrentSlot(RecentChainData.java:296) ~[teku-storage-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.sync.singlepeer.SyncManager.peerStatusIsConsistentWithOurNode(SyncManager.java:272) ~[teku-sync-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.sync.singlepeer.SyncManager.isPeerSyncSuitable(SyncManager.java:266) ~[teku-sync-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.sync.singlepeer.SyncManager.onNewPeer(SyncManager.java:251) ~[teku-sync-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.networking.eth2.peers.Eth2PeerManager.lambda$onConnect$11(Eth2PeerManager.java:208) ~[teku-networking-eth2-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.infrastructure.subscribers.Subscribers.lambda$forEach$0(Subscribers.java:98) ~[teku-infrastructure-subscribers-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at java.util.concurrent.ConcurrentHashMap$ValuesView.forEach(ConcurrentHashMap.java:4780) ~[?:?]
        at tech.pegasys.teku.infrastructure.subscribers.Subscribers.forEach(Subscribers.java:95) ~[teku-infrastructure-subscribers-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.networking.eth2.peers.Eth2PeerManager.lambda$onConnect$12(Eth2PeerManager.java:208) ~[teku-networking-eth2-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$finish$18(SafeFuture.java:258) ~[teku-infrastructure-async-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:930) ~[?:?]
        at java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:907) ~[?:?]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
        at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2137) ~[?:?]
        at tech.pegasys.teku.networking.eth2.peers.Eth2Peer.lambda$updateStatus$0(Eth2Peer.java:97) ~[teku-networking-eth2-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$finish$18(SafeFuture.java:258) ~[teku-infrastructure-async-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:930) ~[?:?]
        at java.util.concurrent.CompletableFuture.uniHandleStage(CompletableFuture.java:946) ~[?:?]
        at java.util.concurrent.CompletableFuture.handle(CompletableFuture.java:2330) ~[?:?]
        at tech.pegasys.teku.infrastructure.async.SafeFuture.handle(SafeFuture.java:426) ~[teku-infrastructure-async-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.infrastructure.async.SafeFuture.finish(SafeFuture.java:253) ~[teku-infrastructure-async-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.networking.eth2.peers.Eth2Peer.updateStatus(Eth2Peer.java:93) ~[teku-networking-eth2-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageHandler.onIncomingMessage(StatusMessageHandler.java:50) ~[teku-networking-eth2-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageHandler.onIncomingMessage(StatusMessageHandler.java:27) ~[teku-networking-eth2-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler.lambda$onIncomingMessage$0(PeerRequiredLocalMessageHandler.java:29) ~[teku-networking-eth2-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at java.util.Optional.ifPresentOrElse(Optional.java:194) ~[?:?]
        at tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler.onIncomingMessage(PeerRequiredLocalMessageHandler.java:28) ~[teku-networking-eth2-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.networking.eth2.rpc.core.Eth2IncomingRequestHandler.handleRequest(Eth2IncomingRequestHandler.java:101) ~[teku-networking-eth2-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.networking.eth2.rpc.core.Eth2IncomingRequestHandler.lambda$processData$0(Eth2IncomingRequestHandler.java:74) ~[teku-networking-eth2-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at java.util.Optional.ifPresent(Optional.java:176) [?:?]
        at tech.pegasys.teku.networking.eth2.rpc.core.Eth2IncomingRequestHandler.processData(Eth2IncomingRequestHandler.java:72) [teku-networking-eth2-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.networking.p2p.libp2p.rpc.RpcHandler$Controller.channelRead0(RpcHandler.java:143) [teku-networking-p2p-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at tech.pegasys.teku.networking.p2p.libp2p.rpc.RpcHandler$Controller.channelRead0(RpcHandler.java:118) [teku-networking-p2p-0.12.9-SNAPSHOT.jar:0.12.9-dev-17c220f9]
        at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.libp2p.etc.util.netty.mux.AbstractMuxHandler.childRead(AbstractMuxHandler.kt:55) [jvm-libp2p-minimal-0.5.7-RELEASE.jar:?]
        at io.libp2p.mux.MuxHandler.channelRead(MuxHandler.kt:39) [jvm-libp2p-minimal-0.5.7-RELEASE.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.handler.codec.ByteToMessageCodec.channelRead(ByteToMessageCodec.java:103) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:111) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:163) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:714) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:650) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:576) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-all-4.1.51.Final.jar:4.1.51.Final]
        at java.lang.Thread.run(Thread.java:832) [?:?]
```

## Fixed Issue(s)


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.