### PR TITLE
Add more constraints around Store.time

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -193,7 +193,9 @@ public class ForkChoiceUtil {
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.1/specs/core/0_fork-choice.md#on_tick</a>
    */
   public static void on_tick(MutableStore store, UInt64 time) {
-    if (store.getTime().isGreaterThan(time)) {
+    // To be extra safe check both time and genesisTime, although time should always be >=
+    // genesisTime
+    if (store.getTime().isGreaterThan(time) || store.getGenesisTime().isGreaterThan(time)) {
       return;
     }
     UInt64 previous_slot = get_current_slot(store);

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -193,7 +193,7 @@ public class ForkChoiceUtil {
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.1/specs/core/0_fork-choice.md#on_tick</a>
    */
   public static void on_tick(MutableStore store, UInt64 time) {
-    if (store.getGenesisTime().isGreaterThan(time)) {
+    if (store.getTime().isGreaterThan(time)) {
       return;
     }
     UInt64 previous_slot = get_current_slot(store);

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
@@ -159,8 +159,18 @@ class ForkChoiceUtilTest {
   void on_tick_shouldExitImmediatelyWhenCurrentTimeIsBeforeGenesisTime() {
     final MutableStore store = mock(MutableStore.class);
     when(store.getGenesisTime()).thenReturn(UInt64.valueOf(3000));
-    when(store.getTime()).thenReturn(UInt64.ZERO);
+    when(store.getTime()).thenReturn(UInt64.valueOf(3000));
     ForkChoiceUtil.on_tick(store, UInt64.valueOf(2000));
+
+    verify(store, never()).setTime(any());
+  }
+
+  @Test
+  void on_tick_shouldExitImmediatelyWhenCurrentTimeIsBeforeStoreTime() {
+    final MutableStore store = mock(MutableStore.class);
+    when(store.getGenesisTime()).thenReturn(UInt64.valueOf(3000));
+    when(store.getTime()).thenReturn(UInt64.valueOf(5000));
+    ForkChoiceUtil.on_tick(store, UInt64.valueOf(4000));
 
     verify(store, never()).setTime(any());
   }

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
@@ -159,7 +159,7 @@ class ForkChoiceUtilTest {
   void on_tick_shouldExitImmediatelyWhenCurrentTimeIsBeforeGenesisTime() {
     final MutableStore store = mock(MutableStore.class);
     when(store.getGenesisTime()).thenReturn(UInt64.valueOf(3000));
-    when(store.getTime()).thenReturn(UInt64.valueOf(3000));
+    when(store.getTime()).thenReturn(UInt64.ZERO);
     ForkChoiceUtil.on_tick(store, UInt64.valueOf(2000));
 
     verify(store, never()).setTime(any());

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -219,10 +219,10 @@ public class ChainBuilder {
   }
 
   public SignedBlockAndState generateGenesis() {
-    return generateGenesis(true);
+    return generateGenesis(UInt64.ZERO, true);
   }
 
-  public SignedBlockAndState generateGenesis(final boolean signDeposits) {
+  public SignedBlockAndState generateGenesis(final UInt64 genesisTime, final boolean signDeposits) {
     checkState(blocks.isEmpty(), "Genesis already created");
 
     // Generate genesis state
@@ -231,7 +231,7 @@ public class ChainBuilder {
             .createDeposits(validatorKeys);
     final BeaconState genesisState =
         new MockStartBeaconStateGenerator()
-            .createInitialBeaconState(UInt64.ZERO, initialDepositData);
+            .createInitialBeaconState(genesisTime, initialDepositData);
 
     // Generate genesis block
     BeaconBlock genesisBlock = new BeaconBlock(genesisState.hash_tree_root());

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.STORAGE_FINALIZED_DB;
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.STORAGE_HOT_DB;
+import static tech.pegasys.teku.util.config.Constants.SECONDS_PER_SLOT;
 import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_EPOCH;
 
 import com.google.errorprone.annotations.MustBeClosed;
@@ -220,10 +221,16 @@ public class RocksDbDatabase implements Database {
     final SignedBlockAndState latestFinalized =
         new SignedBlockAndState(finalizedBlock, finalizedState);
 
+    // Make sure time is set to a reasonable value in the case where we start up before genesis when
+    // the clock time would be prior to genesis
+    final long clockTime = Instant.now().getEpochSecond();
+    final UInt64 slotTime = genesisTime.plus(finalizedState.getSlot().times(SECONDS_PER_SLOT));
+    final UInt64 time = slotTime.max(clockTime);
+
     return Optional.of(
         StoreBuilder.create()
             .metricsSystem(metricsSystem)
-            .time(UInt64.valueOf(Instant.now().getEpochSecond()))
+            .time(time)
             .genesisTime(genesisTime)
             .finalizedCheckpoint(finalizedCheckpoint)
             .justifiedCheckpoint(justifiedCheckpoint)

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.store;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.core.lookup.BlockProvider.fromDynamicMap;
 import static tech.pegasys.teku.core.lookup.BlockProvider.fromMap;
 import static tech.pegasys.teku.core.stategenerator.CheckpointStateTask.AsyncStateProvider.fromBlockAndState;
@@ -94,6 +95,9 @@ class Store implements UpdatableStore {
       final Map<UInt64, VoteTracker> votes,
       final Map<Bytes32, SignedBeaconBlock> blocks,
       final CachingTaskQueue<Checkpoint, BeaconState> checkpointStates) {
+    checkArgument(
+        time.isGreaterThanOrEqualTo(genesis_time),
+        "Time must be greater than or equal to genesisTime");
     this.stateAndBlockProvider = stateAndBlockProvider;
     LOG.trace(
         "Create store with hot state persistence configured to {}",

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.store;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.core.stategenerator.CheckpointStateTask.AsyncStateProvider.fromBlockAndState;
 
 import com.google.common.collect.Sets;
@@ -90,6 +91,12 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
 
   @Override
   public void setTime(UInt64 time) {
+    final UInt64 storeTime = store.getTime();
+    checkArgument(
+        time.isGreaterThanOrEqualTo(storeTime),
+        "Cannot revert time from %s to %s",
+        storeTime,
+        time);
     this.time = Optional.of(time);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -81,7 +81,7 @@ class StoreTransactionUpdates {
 
   public void applyToStore(final Store store) {
     // Add new data
-    tx.time.ifPresent(value -> store.time = value);
+    tx.time.filter(t -> t.isGreaterThan(store.getTime())).ifPresent(value -> store.time = value);
     tx.genesis_time.ifPresent(value -> store.genesis_time = value);
     tx.justified_checkpoint.ifPresent(value -> store.justified_checkpoint = value);
     tx.best_justified_checkpoint.ifPresent(value -> store.best_justified_checkpoint = value);

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
@@ -67,6 +67,7 @@ public abstract class AbstractDatabaseTest {
 
   protected final ChainBuilder chainBuilder = ChainBuilder.create(VALIDATOR_KEYS);
 
+  protected UInt64 genesisTime = UInt64.valueOf(100);
   protected AnchorPoint genesisAnchor;
   protected SignedBlockAndState genesisBlockAndState;
   protected SignedBlockAndState checkpoint1BlockAndState;
@@ -92,7 +93,7 @@ public abstract class AbstractDatabaseTest {
     Constants.SLOTS_PER_EPOCH = 3;
     createStorage(StateStorageMode.ARCHIVE);
 
-    genesisBlockAndState = chainBuilder.generateGenesis();
+    genesisBlockAndState = chainBuilder.generateGenesis(genesisTime, true);
     genesisCheckpoint = getCheckpointForBlock(genesisBlockAndState.getBlock());
     genesisAnchor = AnchorPoint.fromGenesisState(genesisBlockAndState.getState());
 
@@ -574,7 +575,7 @@ public abstract class AbstractDatabaseTest {
     // Setup chains
     // Both chains share block up to slot 3
     final ChainBuilder primaryChain = ChainBuilder.create(VALIDATOR_KEYS);
-    primaryChain.generateGenesis();
+    primaryChain.generateGenesis(genesisTime, true);
     primaryChain.generateBlocksUpToSlot(3);
     final ChainBuilder forkChain = primaryChain.fork();
     // Fork chain's next block is at 6

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/V3RocksDbDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/V3RocksDbDatabaseTest.java
@@ -78,7 +78,7 @@ public class V3RocksDbDatabaseTest extends AbstractRocksDbDatabaseTest {
     // Setup chains
     // Both chains share block up to slot 3
     final ChainBuilder primaryChain = ChainBuilder.create(VALIDATOR_KEYS);
-    primaryChain.generateGenesis();
+    primaryChain.generateGenesis(genesisTime, true);
     primaryChain.generateBlocksUpToSlot(3);
     final ChainBuilder forkChain = primaryChain.fork();
     // Primary chain's next block is at 7

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -17,12 +17,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.async.SyncAsyncRunner.SYNC_RUNNER;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.core.lookup.StateAndBlockProvider;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
@@ -31,6 +35,7 @@ import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.state.CheckpointState;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.storage.api.StubStorageUpdateChannel;
 import tech.pegasys.teku.storage.api.StubStorageUpdateChannelWithDelays;
@@ -38,6 +43,33 @@ import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 import tech.pegasys.teku.util.config.Constants;
 
 class StoreTest extends AbstractStoreTest {
+
+  @Test
+  public void create_timeLessThanGenesisTime() {
+    final UInt64 genesisTime = UInt64.valueOf(100);
+    final SignedBlockAndState genesis = chainBuilder.generateGenesis(genesisTime, false);
+    final Checkpoint genesisCheckpoint = chainBuilder.getCurrentCheckpointForEpoch(0);
+
+    assertThatThrownBy(
+            () ->
+                Store.create(
+                    SYNC_RUNNER,
+                    new StubMetricsSystem(),
+                    blockProviderFromChainBuilder(),
+                    StateAndBlockProvider.NOOP,
+                    genesisTime.minus(1),
+                    genesisTime,
+                    genesisCheckpoint,
+                    genesisCheckpoint,
+                    genesisCheckpoint,
+                    Map.of(genesis.getRoot(), genesis.getParentRoot()),
+                    Map.of(genesis.getRoot(), genesis.getSlot()),
+                    genesis,
+                    Collections.emptyMap(),
+                    StoreConfig.createDefault()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Time must be greater than or equal to genesisTime");
+  }
 
   @Test
   public void retrieveSignedBlock_withLimitedCache() {

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -61,7 +61,7 @@ public class ChainUpdater {
   }
 
   public SignedBlockAndState initializeGenesis(final boolean signDeposits) {
-    final SignedBlockAndState genesis = chainBuilder.generateGenesis(signDeposits);
+    final SignedBlockAndState genesis = chainBuilder.generateGenesis(UInt64.ZERO, signDeposits);
     assertThat(recentChainData.initializeFromGenesis(genesis.getState())).isCompleted();
     return genesis;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add more constraints around initializing and setting `Store.time`:
* When recreating the `Store` from the `Database` set a lower bound on time based on the latest finalized state
* Enforce constraint that time >= genesisTime in `Store` constructor
* Check argument when calling `StoreTransaction.setTime`
* Only apply `Store.time` update if time is increasing
* Exit `on_tick` early if clock time is prior to `Store.time`

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.