### PR TITLE
follow symlinks in order to better support k8s secrets

### DIFF
--- a/util/src/main/java/tech/pegasys/teku/util/config/KeyStoreFilesLocator.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/KeyStoreFilesLocator.java
@@ -18,6 +18,7 @@ import static java.util.stream.Collectors.toList;
 import com.google.common.base.Splitter;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -93,7 +94,7 @@ public class KeyStoreFilesLocator {
   }
 
   void parseDirectory(final File keyDirectory, final File passwordDirectory) {
-    try (Stream<Path> walk = Files.walk(keyDirectory.toPath())) {
+    try (Stream<Path> walk = Files.walk(keyDirectory.toPath(), FileVisitOption.FOLLOW_LINKS)) {
       walk.filter(Files::isRegularFile)
           .filter(
               (path) ->

--- a/util/src/test/java/tech/pegasys/teku/util/config/KeyStoreFilesLocatorTest.java
+++ b/util/src/test/java/tech/pegasys/teku/util/config/KeyStoreFilesLocatorTest.java
@@ -13,20 +13,19 @@
 
 package tech.pegasys.teku.util.config;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.opentest4j.TestAbortedException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.opentest4j.TestAbortedException;
 
 public class KeyStoreFilesLocatorTest {
   private static final String PATH_SEP = ":";

--- a/util/src/test/java/tech/pegasys/teku/util/config/KeyStoreFilesLocatorTest.java
+++ b/util/src/test/java/tech/pegasys/teku/util/config/KeyStoreFilesLocatorTest.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.opentest4j.TestAbortedException;
 
 import java.io.File;
 import java.io.IOException;
@@ -198,8 +199,12 @@ public class KeyStoreFilesLocatorTest {
     createFolders(tempDir, realKeyDir, realPassDir);
     createFiles(tempDir, realKeyDir.resolve("a.json"), realPassDir.resolve("a.txt"));
 
-    Files.createSymbolicLink(tempDir.resolve("key"), realKeyDir);
-    Files.createSymbolicLink(tempDir.resolve("pass"), realPassDir);
+    try {
+      Files.createSymbolicLink(tempDir.resolve("key"), realKeyDir);
+      Files.createSymbolicLink(tempDir.resolve("pass"), realPassDir);
+    } catch (UnsupportedOperationException e) {
+      throw new TestAbortedException("Symbolic links not supported on this file system");
+    }
 
     final String p1 = generatePath(tempDir, PATH_SEP, "key", "pass");
     final KeyStoreFilesLocator locator = new KeyStoreFilesLocator(List.of(p1), PATH_SEP);


### PR DESCRIPTION
## PR Description

When k8s secrets are mounted as files into a pod the resulting directory structure contains symlinks to timestamped directories - presumably to better support the update lifecycle. 

When looking for keys using `--validator-keys` the code uses Files.walk() to find key files.

## Fixed Issue(s)
Files.walk wasn't following symlinks so was not finding key files mounted as secrets.

## Documentation

n/a