### PR TITLE
Reset Constants after PerformanceTrackerTest unit tests

### DIFF
--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/PerformanceTrackerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/PerformanceTrackerTest.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_star
 import static tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker.BLOCK_PERFORMANCE_EVALUATION_INTERVAL;
 
 import java.util.List;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,6 +64,11 @@ public class PerformanceTrackerTest {
   void beforeEach() {
     chainUpdater.initializeGenesis();
     performanceTracker.start(UInt64.ZERO);
+  }
+
+  @AfterAll
+  static void restoreConstants() {
+    Constants.setConstants("minimal");
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Reset Constants back to "minimal" after the PerformanceTrackerTest.java unit tests finish, as other unit tests in this task depend on the Constants to use the "minimal" configuration. 

## Fixed Issue(s)
fixes #2878 

## Documentation
- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.