### PR TITLE
Remove separate event method for block imported

### DIFF
--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
@@ -26,6 +26,4 @@ public interface ValidatorTimingChannel extends VoidReturningChannelInterface {
   void onAttestationCreationDue(UInt64 slot);
 
   void onAttestationAggregationDue(UInt64 slot);
-
-  void onBlockImportedForSlot(UInt64 slot);
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -89,9 +89,6 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   public void onBlockProductionDue(final UInt64 slot) {}
 
   @Override
-  public void onBlockImportedForSlot(final UInt64 slot) {}
-
-  @Override
   public void onAttestationCreationDue(final UInt64 slot) {}
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
@@ -52,12 +52,6 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
   }
 
   @Override
-  public void onBlockImportedForSlot(final UInt64 slot) {
-    // Create attestations for the current slot as soon as the block is imported.
-    onAttestationCreationDue(slot);
-  }
-
-  @Override
   public void onAttestationAggregationDue(final UInt64 slot) {
     notifyDutyQueue(DutyQueue::onAttestationAggregationDue, slot);
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -347,7 +347,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validator2, validator2Committee, validator2CommitteePosition, validator2Index);
 
     // Execute
-    dutyScheduler.onBlockImportedForSlot(attestationSlot);
+    dutyScheduler.onAttestationCreationDue(attestationSlot);
     verify(attestationDuty).performDuty();
   }
 
@@ -397,7 +397,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validator2, validator2Committee, validator2CommitteePosition, validator2Index);
 
     // Execute
-    dutyScheduler.onBlockImportedForSlot(attestationSlot);
+    dutyScheduler.onAttestationCreationDue(attestationSlot);
     verify(attestationDuty).performDuty();
 
     dutyScheduler.onAttestationCreationDue(attestationSlot);

--- a/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/EventChannelBeaconChainEventAdapter.java
+++ b/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/EventChannelBeaconChainEventAdapter.java
@@ -72,7 +72,7 @@ public class EventChannelBeaconChainEventAdapter
 
   @Subscribe
   public void onImportedBlockEvent(ImportedBlockEvent event) {
-    validatorTimingChannel.onBlockImportedForSlot(event.getBlock().getSlot());
+    validatorTimingChannel.onAttestationCreationDue(event.getBlock().getSlot());
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconChainEventMapper.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconChainEventMapper.java
@@ -46,6 +46,7 @@ public class BeaconChainEventMapper {
     final String name = event.get(NAME_FIELD).toString();
     switch (name) {
       case ATTESTATION:
+      case IMPORTED_BLOCK:
         {
           validatorTimingChannel.onAttestationCreationDue(slot);
           break;
@@ -53,11 +54,6 @@ public class BeaconChainEventMapper {
       case AGGREGATION:
         {
           validatorTimingChannel.onAttestationAggregationDue(slot);
-          break;
-        }
-      case IMPORTED_BLOCK:
-        {
-          validatorTimingChannel.onBlockImportedForSlot(slot);
           break;
         }
       case ON_SLOT:

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/WebSocketBeaconChainEventAdapterTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/WebSocketBeaconChainEventAdapterTest.java
@@ -61,7 +61,7 @@ class WebSocketBeaconChainEventAdapterTest {
 
     mapEvent(event);
 
-    verify(validatorTimingChannel).onBlockImportedForSlot(eq(UInt64.ONE));
+    verify(validatorTimingChannel).onAttestationCreationDue(eq(UInt64.ONE));
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Remove the separate `onBlockImportedForSlot` method from `ValidatorTimingChannel` that's just a signal that attestation creation is due, so use that method directly.

## Fixed Issue(s)
#1918 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.