### PR TITLE
Add getGenesisTime to ValidatorApiChannel

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -338,6 +338,10 @@ public class CombinedChainDataClient {
     return result;
   }
 
+  public Optional<UInt64> getGenesisTime() {
+    return Optional.ofNullable(recentChainData.getGenesisTime());
+  }
+
   /** @return The slot at which the chain head block was proposed */
   public UInt64 getHeadSlot() {
     return this.recentChainData.getHeadSlot();

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -33,6 +33,8 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 public interface ValidatorApiChannel extends ChannelInterface {
   SafeFuture<Optional<ForkInfo>> getForkInfo();
 
+  SafeFuture<Optional<UInt64>> getGenesisTime();
+
   SafeFuture<Optional<List<ValidatorDuties>>> getDuties(
       UInt64 epoch, Collection<BLSPublicKey> publicKeys);
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/metrics/MetricRecordingValidatorApiChannel.java
@@ -39,6 +39,8 @@ import tech.pegasys.teku.validator.api.ValidatorDuties;
 public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
 
   public static final String FORK_REQUESTS_COUNTER_NAME = "beacon_node_fork_info_requests_total";
+  public static final String GENESIS_TIME_REQUESTS_COUNTER_NAME =
+      "beacon_node_genesis_time_requests_total";
   public static final String DUTIES_REQUESTS_COUNTER_NAME = "beacon_node_duties_requests_total";
   public static final String ATTESTATION_DUTIES_REQUESTS_COUNTER_NAME =
       "beacon_node_attestation_duties_requests_total";
@@ -61,6 +63,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   public static final String PUBLISHED_BLOCK_COUNTER_NAME = "beacon_node_published_block_total";
   private final ValidatorApiChannel delegate;
   private final BeaconChainRequestCounter forkInfoRequestCounter;
+  private final BeaconChainRequestCounter genesisTimeRequestCounter;
   private final BeaconChainRequestCounter dutiesRequestCounter;
   private final BeaconChainRequestCounter attestationDutiesRequestCounter;
   private final BeaconChainRequestCounter proposerDutiesRequestCounter;
@@ -82,6 +85,12 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
             metricsSystem,
             FORK_REQUESTS_COUNTER_NAME,
             "Counter recording the number of requests for fork info");
+
+    genesisTimeRequestCounter =
+        BeaconChainRequestCounter.create(
+            metricsSystem,
+            GENESIS_TIME_REQUESTS_COUNTER_NAME,
+            "Counter recording the number of requests for genesis time");
     dutiesRequestCounter =
         BeaconChainRequestCounter.create(
             metricsSystem,
@@ -142,6 +151,11 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<ForkInfo>> getForkInfo() {
     return countRequest(delegate.getForkInfo(), forkInfoRequestCounter);
+  }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getGenesisTime() {
+    return countRequest(delegate.getGenesisTime(), genesisTimeRequestCounter);
   }
 
   @Override

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -152,6 +152,11 @@ class MetricRecordingValidatorApiChannelTest {
             MetricRecordingValidatorApiChannel.FORK_REQUESTS_COUNTER_NAME,
             dataStructureUtil.randomForkInfo()),
         requestDataTest(
+            "getGenesisTime",
+            ValidatorApiChannel::getGenesisTime,
+            MetricRecordingValidatorApiChannel.GENESIS_TIME_REQUESTS_COUNTER_NAME,
+            dataStructureUtil.randomUInt64()),
+        requestDataTest(
             "getDuties",
             channel -> channel.getDuties(slot, Collections.emptyList()),
             MetricRecordingValidatorApiChannel.DUTIES_REQUESTS_COUNTER_NAME,

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -119,6 +119,11 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
+  public SafeFuture<Optional<UInt64>> getGenesisTime() {
+    return SafeFuture.completedFuture(combinedChainDataClient.getGenesisTime());
+  }
+
+  @Override
   public SafeFuture<Optional<List<ValidatorDuties>>> getDuties(
       final UInt64 epoch, final Collection<BLSPublicKey> publicKeys) {
     if (isSyncActive()) {
@@ -489,7 +494,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     final UInt64 endSlot = epochStartSlot.plus(Constants.SLOTS_PER_EPOCH);
     final Map<UInt64, BLSPublicKey> proposerSlots = new HashMap<>();
     for (UInt64 slot = startSlot; slot.compareTo(endSlot) < 0; slot = slot.plus(UInt64.ONE)) {
-      final Integer proposerIndex = get_beacon_proposer_index(state, slot);
+      final int proposerIndex = get_beacon_proposer_index(state, slot);
       final BLSPublicKey publicKey = state.getValidators().get(proposerIndex).getPubkey();
       proposerSlots.put(slot, publicKey);
     }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -78,6 +78,12 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
+  public SafeFuture<Optional<UInt64>> getGenesisTime() {
+    return asyncRunner.runAsync(
+        () -> apiClient.getGenesis().map(response -> response.data.genesisTime));
+  }
+
+  @Override
   public SafeFuture<Optional<List<ValidatorDuties>>> getDuties(
       final UInt64 epoch, final Collection<BLSPublicKey> publicKeys) {
     if (publicKeys.isEmpty()) {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GE
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_FORK;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_GENESIS;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_PROPOSER_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_ATTESTATION;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK;
@@ -48,6 +49,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.request.SubscribeToBeaconCommitteeRequest;
 import tech.pegasys.teku.api.response.GetForkResponse;
+import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
 import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
@@ -88,6 +90,11 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   @Override
   public Optional<GetForkResponse> getFork() {
     return get(GET_FORK, EMPTY_QUERY_PARAMS, GetForkResponse.class);
+  }
+
+  @Override
+  public Optional<GetGenesisResponse> getGenesis() {
+    return get(GET_GENESIS, EMPTY_QUERY_PARAMS, GetGenesisResponse.class);
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.remote.apiclient;
 
 public enum ValidatorApiMethod {
   GET_FORK("node/fork"),
+  GET_GENESIS("eth/v1/beacon/genesis"),
   GET_DUTIES("validator/duties"),
   GET_UNSIGNED_BLOCK("validator/block"),
   SEND_SIGNED_BLOCK("validator/block"),

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.GetForkResponse;
+import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
 import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.api.schema.Attestation;
@@ -34,6 +35,8 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 public interface ValidatorRestApiClient {
 
   Optional<GetForkResponse> getFork();
+
+  Optional<GetGenesisResponse> getGenesis();
 
   List<ValidatorDuties> getDuties(ValidatorDutiesRequest request);
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.api.response.GetForkResponse;
+import tech.pegasys.teku.api.response.v1.beacon.GenesisData;
+import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.api.schema.ValidatorDutiesRequest;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -81,6 +83,32 @@ class RemoteValidatorApiHandlerTest {
     when(apiClient.getFork()).thenReturn(Optional.empty());
 
     SafeFuture<Optional<ForkInfo>> future = apiHandler.getForkInfo();
+
+    assertThat(unwrapToOptional(future)).isNotPresent();
+  }
+
+  @Test
+  public void getGenesisTime_WhenPresent_ReturnsValue() {
+    final UInt64 genesisTime = dataStructureUtil.randomUInt64();
+    when(apiClient.getGenesis())
+        .thenReturn(
+            Optional.of(
+                new GetGenesisResponse(
+                    new GenesisData(
+                        genesisTime,
+                        dataStructureUtil.randomBytes32(),
+                        dataStructureUtil.randomBytes4()))));
+
+    SafeFuture<Optional<UInt64>> future = apiHandler.getGenesisTime();
+
+    assertThat(unwrapToValue(future)).isEqualTo(genesisTime);
+  }
+
+  @Test
+  public void getGenesisTime_WhenNotPresent_ReturnsEmpty() {
+    when(apiClient.getGenesis()).thenReturn(Optional.empty());
+
+    SafeFuture<Optional<UInt64>> future = apiHandler.getGenesisTime();
 
     assertThat(unwrapToOptional(future)).isNotPresent();
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/SchemaObjectsTestFixture.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/SchemaObjectsTestFixture.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.validator.remote.apiclient;
 
 import java.util.List;
 import tech.pegasys.teku.api.response.GetForkResponse;
+import tech.pegasys.teku.api.response.v1.beacon.GenesisData;
+import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.api.schema.BLSSignature;
@@ -33,6 +35,14 @@ public class SchemaObjectsTestFixture {
 
   public GetForkResponse getForkResponse() {
     return new GetForkResponse(dataStructureUtil.randomForkInfo());
+  }
+
+  public GetGenesisResponse getGenesisResponse() {
+    return new GetGenesisResponse(
+        new GenesisData(
+            dataStructureUtil.randomUInt64(),
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomBytes4()));
   }
 
   public BLSPubKey BLSPubKey() {


### PR DESCRIPTION
## PR Description
To perform independent timing, the validator client will need to know genesis time so add that to `ValidatorApiChannel`.

## Fixed Issue(s)
#1918 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.