### PR TITLE
QSP-31: Remove Store equals() and hashCode() methods as obsolete

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -546,34 +546,4 @@ class Store implements UpdatableStore {
       writeLock.unlock();
     }
   }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (o == this) {
-      return true;
-    }
-    if (!(o instanceof Store)) {
-      return false;
-    }
-    final Store store = (Store) o;
-    return Objects.equals(time, store.time)
-        && Objects.equals(genesis_time, store.genesis_time)
-        && Objects.equals(justified_checkpoint, store.justified_checkpoint)
-        && Objects.equals(finalized_checkpoint, store.finalized_checkpoint)
-        && Objects.equals(best_justified_checkpoint, store.best_justified_checkpoint)
-        && Objects.equals(blocks, store.blocks)
-        && Objects.equals(
-            hotStatePersistenceFrequencyInEpochs, store.hotStatePersistenceFrequencyInEpochs);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        time,
-        genesis_time,
-        justified_checkpoint,
-        finalized_checkpoint,
-        best_justified_checkpoint,
-        blocks);
-  }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

`equals()` and `hashCode()` seems obsolete for the `Store` class as it is intended to be either a singleton or several unrelated instances per application.

## Fixed Issue(s)
https://github.com/quantstamp/teku/issues/31

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.