### PR TITLE
Add independent timer event adapter for validator client

### DIFF
--- a/infrastructure/async/build.gradle
+++ b/infrastructure/async/build.gradle
@@ -8,6 +8,8 @@ dependencies {
   testImplementation 'org.apache.logging.log4j:log4j-core'
 
   testFixturesApi 'com.google.guava:guava'
+  testFixturesImplementation project(":infrastructure:unsigned")
+  testFixturesImplementation project(":infrastructure:time")
   testFixturesImplementation 'org.apache.logging.log4j:log4j-core'
   testFixturesImplementation 'org.awaitility:awaitility'
 }

--- a/infrastructure/async/build.gradle
+++ b/infrastructure/async/build.gradle
@@ -1,8 +1,10 @@
 dependencies {
   implementation project(":infrastructure:metrics")
+  implementation project(":infrastructure:time")
   implementation 'com.google.guava:guava'
 
   testImplementation testFixtures(project(":infrastructure:metrics"))
+  testImplementation testFixtures(project(":infrastructure:time"))
   testImplementation 'org.apache.logging.log4j:log4j-core'
 
   testFixturesApi 'com.google.guava:guava'

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/timed/RepeatingTaskScheduler.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/timed/RepeatingTaskScheduler.java
@@ -1,0 +1,118 @@
+package tech.pegasys.teku.infrastructure.async.timed;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Comparator;
+import java.util.Queue;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class RepeatingTaskScheduler {
+  private final Queue<TimedEvent> eventQueue =
+      new PriorityBlockingQueue<>(11, Comparator.comparing(TimedEvent::getNextDueSeconds));
+
+  private final AsyncRunner asyncRunner;
+  private final TimeProvider timeProvider;
+
+  public RepeatingTaskScheduler(final AsyncRunner asyncRunner, final TimeProvider timeProvider) {
+    this.asyncRunner = asyncRunner;
+    this.timeProvider = timeProvider;
+  }
+
+  public void scheduleRepeatingEvent(
+      final UInt64 initialInvocationTimeInSeconds,
+      final UInt64 repeatingPeriodSeconds,
+      final RepeatingTask action) {
+    scheduleEvent(new TimedEvent(initialInvocationTimeInSeconds, repeatingPeriodSeconds, action));
+  }
+
+  private void scheduleEvent(final TimedEvent event) {
+    eventQueue.add(event);
+    scheduleNextEvent();
+  }
+
+  private synchronized void scheduleNextEvent() {
+    // Remove and execute any tasks that are due or overdue
+    TimedEvent nextEvent = eventQueue.poll();
+    while (nextEvent != null
+        && timeProvider.getTimeInSeconds().isGreaterThanOrEqualTo(nextEvent.getNextDueSeconds())) {
+      executeEvent(nextEvent);
+      nextEvent = eventQueue.poll();
+    }
+    if (nextEvent == null) {
+      return;
+    }
+    // Otherwise schedule the next task for when it becomes due
+    final UInt64 nowMs = timeProvider.getTimeInMillis();
+    final UInt64 timeDueMs = nextEvent.getNextDueSeconds().times(TimeProvider.MILLIS_PER_SECOND);
+    if (nowMs.isGreaterThanOrEqualTo(timeDueMs)) {
+      // Became due during the calculations, execute immediately
+      onNextEventDue(nextEvent);
+    } else {
+      final TimedEvent event = nextEvent;
+      asyncRunner
+          .runAfterDelay(
+              () -> onNextEventDue(event),
+              timeDueMs.minus(nowMs).longValue(),
+              TimeUnit.MILLISECONDS)
+          .reportExceptions(); // TODO: Probably should keep retrying if rejected?
+    }
+  }
+
+  private void onNextEventDue(final TimedEvent dueEvent) {
+    executeEvent(dueEvent);
+    scheduleNextEvent();
+  }
+
+  private void executeEvent(final TimedEvent nextEvent) {
+    asyncRunner
+        .runAsync(
+            () -> {
+              try {
+                nextEvent.execute(timeProvider.getTimeInSeconds());
+              } finally {
+                // Schedule the next invocation
+                scheduleEvent(nextEvent);
+              }
+            })
+        .reportExceptions();
+  }
+
+  private static class TimedEvent {
+    private UInt64 nextDueSeconds;
+    private final UInt64 repeatPeriodSeconds;
+    private final RepeatingTask action;
+
+    private TimedEvent(
+        final UInt64 nextDueSeconds, final UInt64 repeatPeriodSeconds, final RepeatingTask action) {
+      this.nextDueSeconds = nextDueSeconds;
+      this.repeatPeriodSeconds = repeatPeriodSeconds;
+      this.action = action;
+    }
+
+    public UInt64 getNextDueSeconds() {
+      return nextDueSeconds;
+    }
+
+    public void execute(final UInt64 actualTime) {
+      checkArgument(
+          actualTime.isGreaterThanOrEqualTo(nextDueSeconds),
+          "Executing task before it is due. Scheduled "
+              + nextDueSeconds
+              + " currently "
+              + actualTime);
+      try {
+        action.execute(nextDueSeconds, actualTime);
+      } finally {
+        nextDueSeconds = nextDueSeconds.plus(repeatPeriodSeconds);
+      }
+    }
+  }
+
+  public interface RepeatingTask {
+    void execute(UInt64 scheduledTime, UInt64 actualTime);
+  }
+}

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/timed/RepeatingTaskSchedulerTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/timed/RepeatingTaskSchedulerTest.java
@@ -1,0 +1,97 @@
+package tech.pegasys.teku.infrastructure.async.timed;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.async.timed.RepeatingTaskScheduler.RepeatingTask;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+class RepeatingTaskSchedulerTest {
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(500);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
+  private final RepeatingTask action = mock(RepeatingTask.class);
+
+  private final RepeatingTaskScheduler eventQueue =
+      new RepeatingTaskScheduler(asyncRunner, timeProvider);
+
+  @Test
+  void shouldExecuteEventImmediatelyOnSeparateThreadWhenAlreadyDue() {
+    eventQueue.scheduleRepeatingEvent(timeProvider.getTimeInSeconds(), UInt64.valueOf(12), action);
+    verifyNoInteractions(action);
+
+    asyncRunner.executeDueActionsRepeatedly();
+    verify(action).execute(timeProvider.getTimeInSeconds(), timeProvider.getTimeInSeconds());
+  }
+
+  @Test
+  void shouldDelayExecutionUntilEventIsDue() {
+    eventQueue.scheduleRepeatingEvent(
+        timeProvider.getTimeInSeconds().plus(100), UInt64.valueOf(12), action);
+
+    asyncRunner.executeDueActionsRepeatedly();
+    verifyNoInteractions(action);
+
+    // Task executes when time becomes due
+    timeProvider.advanceTimeBySeconds(100);
+    // Delayed action fires
+    asyncRunner.executeDueActionsRepeatedly();
+    // Action is executed async
+    asyncRunner.executeDueActionsRepeatedly();
+    verify(action).execute(timeProvider.getTimeInSeconds(), timeProvider.getTimeInSeconds());
+    verifyNoMoreInteractions(action);
+  }
+
+  @Test
+  void shouldExecuteEventAgainAfterRepeatPeriod() {
+    final UInt64 repeatPeriod = UInt64.valueOf(12);
+    // Action executes immediately
+    eventQueue.scheduleRepeatingEvent(timeProvider.getTimeInSeconds(), repeatPeriod, action);
+    verifyNoInteractions(action);
+
+    asyncRunner.executeDueActionsRepeatedly();
+    verify(action).execute(timeProvider.getTimeInSeconds(), timeProvider.getTimeInSeconds());
+
+    timeProvider.advanceTimeBySeconds(repeatPeriod.longValue());
+    asyncRunner.executeDueActionsRepeatedly();
+    verify(action).execute(timeProvider.getTimeInSeconds(), timeProvider.getTimeInSeconds());
+  }
+
+  @Test
+  void shouldInterleaveMultipleRepeatingEvents() {
+    final RepeatingTask secondAction = mock(RepeatingTask.class);
+    eventQueue.scheduleRepeatingEvent(timeProvider.getTimeInSeconds(), UInt64.valueOf(6), action);
+    eventQueue.scheduleRepeatingEvent(
+        timeProvider.getTimeInSeconds(), UInt64.valueOf(5), secondAction);
+
+    // Both execute initially
+    asyncRunner.executeQueuedActions();
+    verify(action).execute(timeProvider.getTimeInSeconds(), timeProvider.getTimeInSeconds());
+    verify(secondAction).execute(timeProvider.getTimeInSeconds(), timeProvider.getTimeInSeconds());
+
+    // Then second action is scheduled 5 seconds later
+    timeProvider.advanceTimeBySeconds(5);
+    asyncRunner.executeDueActionsRepeatedly();
+    verify(secondAction).execute(timeProvider.getTimeInSeconds(), timeProvider.getTimeInSeconds());
+    verifyNoMoreInteractions(action);
+
+    // And action one second after that
+    timeProvider.advanceTimeBySeconds(1);
+    asyncRunner.executeDueActionsRepeatedly();
+    verify(action).execute(timeProvider.getTimeInSeconds(), timeProvider.getTimeInSeconds());
+    verifyNoMoreInteractions(secondAction);
+  }
+
+  @Test
+  void shouldReportScheduledAndActualExecutionTimeWhenTaskIsDelayed() {
+    final UInt64 scheduledTime = timeProvider.getTimeInSeconds().minus(5);
+    eventQueue.scheduleRepeatingEvent(scheduledTime, UInt64.valueOf(10), action);
+
+    asyncRunner.executeQueuedActions();
+    verify(action).execute(scheduledTime, timeProvider.getTimeInSeconds());
+  }
+}

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/timed/RepeatingTaskSchedulerTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/timed/RepeatingTaskSchedulerTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.infrastructure.async.timed;
 
 import static org.mockito.Mockito.mock;

--- a/infrastructure/time/build.gradle
+++ b/infrastructure/time/build.gradle
@@ -1,5 +1,3 @@
 dependencies {
-  api project(':infrastructure:events')
-
   testFixturesImplementation project(':infrastructure:unsigned')
 }

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -149,6 +149,7 @@ public class Constants {
   // Teku Validator Client Specific
   public static final long FORK_RETRY_DELAY_SECONDS = 10; // in sec
   public static final long FORK_REFRESH_TIME_SECONDS = TimeUnit.MINUTES.toSeconds(5); // in sec
+  public static final long GENESIS_TIME_RETRY_DELAY_SECONDS = 10; // in sec
 
   // Networking
   public static final int GOSSIP_MAX_SIZE = 1048576; // bytes

--- a/validator/client/build.gradle
+++ b/validator/client/build.gradle
@@ -27,5 +27,6 @@ dependencies {
   testImplementation testFixtures(project(':infrastructure:metrics'))
   testImplementation testFixtures(project(':ethereum:datastructures'))
   testImplementation testFixtures(project(':infrastructure:async'))
+  testImplementation testFixtures(project(':infrastructure:time'))
   testImplementation testFixtures(project(':util'))
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/time/GenesisTimeProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/time/GenesisTimeProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.time;
+
+import static tech.pegasys.teku.util.config.Constants.GENESIS_TIME_RETRY_DELAY_SECONDS;
+
+import com.google.common.base.Suppliers;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+
+public class GenesisTimeProvider {
+  private static final Logger LOG = LogManager.getLogger();
+  private final ValidatorApiChannel validatorApiChannel;
+  private final AsyncRunner asyncRunner;
+  private final Supplier<SafeFuture<UInt64>> genesisTime =
+      Suppliers.memoize(this::fetchGenesisTime);
+
+  public GenesisTimeProvider(
+      final AsyncRunner asyncRunner, final ValidatorApiChannel validatorApiChannel) {
+    this.validatorApiChannel = validatorApiChannel;
+    this.asyncRunner = asyncRunner;
+  }
+
+  public SafeFuture<UInt64> getGenesisTime() {
+    return genesisTime.get();
+  }
+
+  private SafeFuture<UInt64> fetchGenesisTime() {
+    return requestGenesisTime()
+        .exceptionallyCompose(
+            error -> {
+              LOG.error("Failed to retrieve genesis time. Retrying after delay", error);
+              return asyncRunner.runAfterDelay(
+                  this::fetchGenesisTime, GENESIS_TIME_RETRY_DELAY_SECONDS, TimeUnit.SECONDS);
+            });
+  }
+
+  public SafeFuture<UInt64> requestGenesisTime() {
+    return validatorApiChannel
+        .getGenesisTime()
+        .thenCompose(
+            maybeGenesisTime ->
+                maybeGenesisTime
+                    .map(SafeFuture::completedFuture)
+                    .orElseGet(
+                        () -> {
+                          LOG.info("Waiting for genesis time to be known");
+                          return asyncRunner.runAfterDelay(
+                              this::requestGenesisTime,
+                              GENESIS_TIME_RETRY_DELAY_SECONDS,
+                              TimeUnit.SECONDS);
+                        }));
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/time/TimeBasedEventAdapter.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/time/TimeBasedEventAdapter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.time;
+
+import static tech.pegasys.teku.core.ForkChoiceUtil.getCurrentSlot;
+import static tech.pegasys.teku.core.ForkChoiceUtil.getSlotStartTime;
+import static tech.pegasys.teku.util.config.Constants.SECONDS_PER_SLOT;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.timed.RepeatingTaskScheduler;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
+import tech.pegasys.teku.validator.eventadapter.BeaconChainEventAdapter;
+
+public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
+  private static final Logger LOG = LogManager.getLogger();
+  private final long oneThirdSlotSeconds = SECONDS_PER_SLOT / 3;
+  private final long twoThirdSlotSeconds = oneThirdSlotSeconds * 2;
+
+  private final GenesisTimeProvider genesisTimeProvider;
+  private final RepeatingTaskScheduler taskScheduler;
+  private final TimeProvider timeProvider;
+  private final ValidatorTimingChannel validatorTimingChannel;
+  private UInt64 genesisTime;
+
+  public TimeBasedEventAdapter(
+      final GenesisTimeProvider genesisTimeProvider,
+      final RepeatingTaskScheduler taskScheduler,
+      final TimeProvider timeProvider,
+      final ValidatorTimingChannel validatorTimingChannel) {
+    this.genesisTimeProvider = genesisTimeProvider;
+    this.taskScheduler = taskScheduler;
+    this.timeProvider = timeProvider;
+    this.validatorTimingChannel = validatorTimingChannel;
+  }
+
+  void start(final UInt64 genesisTime) {
+    this.genesisTime = genesisTime;
+    final UInt64 currentSlot = getCurrentSlot(timeProvider.getTimeInSeconds(), genesisTime);
+    final UInt64 nextSlotStartTime = getSlotStartTime(currentSlot.plus(1), genesisTime);
+    taskScheduler.scheduleRepeatingEvent(
+        nextSlotStartTime, UInt64.valueOf(SECONDS_PER_SLOT), this::onStartSlot);
+    taskScheduler.scheduleRepeatingEvent(
+        nextSlotStartTime.plus(twoThirdSlotSeconds),
+        UInt64.valueOf(SECONDS_PER_SLOT),
+        this::onAggregationDue);
+  }
+
+  private void onStartSlot(final UInt64 scheduledTime, final UInt64 actualTime) {
+    final UInt64 slot = getCurrentSlot(scheduledTime, genesisTime);
+    if (isTooLate(scheduledTime, actualTime)) {
+      LOG.warn(
+          "Skipping block creation for slot {} due to unexpected delay in slot processing", slot);
+      return;
+    }
+    validatorTimingChannel.onSlot(slot);
+    validatorTimingChannel.onBlockProductionDue(slot);
+  }
+
+  private void onAggregationDue(final UInt64 scheduledTime, final UInt64 actualTime) {
+    final UInt64 slot = getCurrentSlot(scheduledTime, genesisTime);
+    if (isTooLate(scheduledTime, actualTime)) {
+      LOG.warn("Skipping aggregation for slot {} due to unexpected delay in slot processing", slot);
+      return;
+    }
+    validatorTimingChannel.onAttestationAggregationDue(slot);
+  }
+
+  private boolean isTooLate(final UInt64 scheduledTime, final UInt64 actualTime) {
+    return scheduledTime.plus(SECONDS_PER_SLOT).isLessThan(actualTime);
+  }
+
+  @Override
+  public SafeFuture<Void> start() {
+    return genesisTimeProvider.getGenesisTime().thenAccept(this::start);
+  }
+
+  @Override
+  public SafeFuture<Void> stop() {
+    return SafeFuture.COMPLETE;
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/time/GenesisTimeProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/time/GenesisTimeProviderTest.java
@@ -24,7 +24,6 @@ import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -33,7 +32,6 @@ import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 class GenesisTimeProviderTest {
 
   private static final UInt64 GENESIS_TIME = UInt64.valueOf(12341234);
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/time/GenesisTimeProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/time/GenesisTimeProviderTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.time;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+
+class GenesisTimeProviderTest {
+
+  private static final UInt64 GENESIS_TIME = UInt64.valueOf(12341234);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+  private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
+
+  private final GenesisTimeProvider genesisTimeProvider =
+      new GenesisTimeProvider(asyncRunner, validatorApiChannel);
+
+  @Test
+  void shouldRequestGenesisTimeWhenNotPreviouslyLoaded() {
+    final SafeFuture<Optional<UInt64>> request = new SafeFuture<>();
+    when(validatorApiChannel.getGenesisTime()).thenReturn(request);
+
+    final SafeFuture<UInt64> result = genesisTimeProvider.getGenesisTime();
+    assertThat(result).isNotDone();
+
+    request.complete(Optional.of(GENESIS_TIME));
+    assertThat(result).isCompletedWithValue(GENESIS_TIME);
+  }
+
+  @Test
+  void shouldReturnCachedGenesisTimeWhenPreviouslyLoaded() {
+    when(validatorApiChannel.getGenesisTime())
+        .thenReturn(SafeFuture.completedFuture(Optional.of(GENESIS_TIME)));
+    assertThat(genesisTimeProvider.getGenesisTime()).isCompletedWithValue(GENESIS_TIME);
+    verify(validatorApiChannel).getGenesisTime();
+
+    // Subsequent requests just return the cached version
+    assertThat(genesisTimeProvider.getGenesisTime()).isCompletedWithValue(GENESIS_TIME);
+    verifyNoMoreInteractions(validatorApiChannel);
+  }
+
+  @Test
+  void shouldRetryWhenGenesisTimeFailsToLoad() {
+    when(validatorApiChannel.getGenesisTime())
+        .thenReturn(failedFuture(new RuntimeException("Nope")))
+        .thenReturn(completedFuture(Optional.of(GENESIS_TIME)));
+
+    // First request fails
+    final SafeFuture<UInt64> result = genesisTimeProvider.getGenesisTime();
+    verify(validatorApiChannel).getGenesisTime();
+    assertThat(result).isNotDone();
+    assertThat(asyncRunner.hasDelayedActions()).isTrue();
+
+    // Retry is scheduled.
+    asyncRunner.executeQueuedActions();
+    verify(validatorApiChannel, times(2)).getGenesisTime();
+    assertThat(result).isCompletedWithValue(GENESIS_TIME);
+  }
+
+  @Test
+  void shouldRetryWhenGenesisTimeIsNotYetKnown() {
+    when(validatorApiChannel.getGenesisTime())
+        .thenReturn(completedFuture(Optional.empty()))
+        .thenReturn(completedFuture(Optional.of(GENESIS_TIME)));
+
+    // First request fails
+    final SafeFuture<UInt64> result = genesisTimeProvider.getGenesisTime();
+    verify(validatorApiChannel).getGenesisTime();
+    assertThat(result).isNotDone();
+    assertThat(asyncRunner.hasDelayedActions()).isTrue();
+
+    // Retry is scheduled.
+    asyncRunner.executeQueuedActions();
+    verify(validatorApiChannel, times(2)).getGenesisTime();
+    assertThat(result).isCompletedWithValue(GENESIS_TIME);
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/time/TimeBasedEventAdapterTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/time/TimeBasedEventAdapterTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.time;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.async.timed.RepeatingTaskScheduler;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
+
+class TimeBasedEventAdapterTest {
+
+  private final GenesisTimeProvider genesisTimeProvider = mock(GenesisTimeProvider.class);
+  private final ValidatorTimingChannel validatorTimingChannel = mock(ValidatorTimingChannel.class);
+
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(100);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
+  private final RepeatingTaskScheduler repeatingTaskScheduler =
+      new RepeatingTaskScheduler(asyncRunner, timeProvider);
+
+  private final TimeBasedEventAdapter eventAdapter =
+      new TimeBasedEventAdapter(
+          genesisTimeProvider, repeatingTaskScheduler, timeProvider, validatorTimingChannel);
+
+  @Test
+  void shouldScheduleEventsOnceGenesisIsKnown() {
+    final SafeFuture<UInt64> genesisTimeFuture = new SafeFuture<>();
+    when(genesisTimeProvider.getGenesisTime()).thenReturn(genesisTimeFuture);
+
+    final SafeFuture<Void> startResult = eventAdapter.start();
+    assertThat(startResult).isNotDone();
+    assertThat(asyncRunner.hasDelayedActions()).isFalse();
+
+    genesisTimeFuture.complete(UInt64.ONE);
+    assertThat(startResult).isCompleted();
+    assertThat(asyncRunner.hasDelayedActions()).isTrue();
+  }
+
+  @Test
+  void shouldScheduleSlotStartEventsStartingFromNextSlot() {
+    final UInt64 genesisTime = timeProvider.getTimeInSeconds();
+    when(genesisTimeProvider.getGenesisTime()).thenReturn(SafeFuture.completedFuture(genesisTime));
+    final int nextSlot = 26;
+    final UInt64 firstSlotToFire = UInt64.valueOf(nextSlot);
+    final int timeUntilNextSlot = Constants.SECONDS_PER_SLOT / 2;
+    timeProvider.advanceTimeBySeconds(Constants.SECONDS_PER_SLOT * nextSlot - timeUntilNextSlot);
+
+    assertThat(eventAdapter.start()).isCompleted();
+
+    // Should not fire any events immediately
+    asyncRunner.executeDueActionsRepeatedly();
+    verifyNoMoreInteractions(validatorTimingChannel);
+
+    // Fire slot start events when the next slot is due to start
+    timeProvider.advanceTimeBySeconds(timeUntilNextSlot);
+    asyncRunner.executeDueActionsRepeatedly();
+    verify(validatorTimingChannel).onSlot(firstSlotToFire);
+    verify(validatorTimingChannel).onBlockProductionDue(firstSlotToFire);
+    verifyNoMoreInteractions(validatorTimingChannel);
+  }
+
+  @Test
+  void shouldScheduleAggregateEventsStartingFromNextSlot() {
+    final UInt64 genesisTime = timeProvider.getTimeInSeconds();
+    when(genesisTimeProvider.getGenesisTime()).thenReturn(SafeFuture.completedFuture(genesisTime));
+    final int nextSlot = 25;
+    // Starting time is before the aggregation for the current slot should happen, but should still
+    // wait until the next slot to start
+    final int timeUntilNextSlot = Constants.SECONDS_PER_SLOT - 1;
+    timeProvider.advanceTimeBySeconds(Constants.SECONDS_PER_SLOT * nextSlot - timeUntilNextSlot);
+
+    assertThat(eventAdapter.start()).isCompleted();
+
+    // Should not fire any events immediately
+    asyncRunner.executeDueActionsRepeatedly();
+    verifyNoMoreInteractions(validatorTimingChannel);
+
+    // Aggregation should not fire at the start of the slot
+    timeProvider.advanceTimeBySeconds(timeUntilNextSlot);
+    asyncRunner.executeDueActionsRepeatedly();
+    verify(validatorTimingChannel, never()).onAttestationAggregationDue(UInt64.valueOf(nextSlot));
+
+    // But does fire 2/3rds through the slot
+    timeProvider.advanceTimeBySeconds(Constants.SECONDS_PER_SLOT / 3 * 2);
+    asyncRunner.executeDueActionsRepeatedly();
+    verify(validatorTimingChannel, times(1)).onAttestationAggregationDue(UInt64.valueOf(nextSlot));
+  }
+}

--- a/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/IndependentTimerEventChannelEventAdapter.java
+++ b/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/IndependentTimerEventChannelEventAdapter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.eventadapter;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.events.EventChannels;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.service.serviceutils.ServiceConfig;
+import tech.pegasys.teku.storage.api.ChainHeadChannel;
+import tech.pegasys.teku.storage.api.ReorgContext;
+import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
+
+public class IndependentTimerEventChannelEventAdapter
+    implements ChainHeadChannel, BeaconChainEventAdapter {
+
+  private final BeaconChainEventAdapter timeBasedEventAdapter;
+  private final ValidatorTimingChannel validatorTimingChannel;
+  private final EventChannels eventChannels;
+
+  public IndependentTimerEventChannelEventAdapter(
+      final EventChannels eventChannels,
+      final BeaconChainEventAdapter timeBasedEventAdapter,
+      final ValidatorTimingChannel validatorTimingChannel) {
+    this.eventChannels = eventChannels;
+    this.timeBasedEventAdapter = timeBasedEventAdapter;
+    this.validatorTimingChannel = validatorTimingChannel;
+  }
+
+  public static BeaconChainEventAdapter create(
+      final ServiceConfig serviceConfig, final BeaconChainEventAdapter timeBasedEventAdapter) {
+    final ValidatorTimingChannel validatorTimingChannel =
+        serviceConfig.getEventChannels().getPublisher(ValidatorTimingChannel.class);
+    return new IndependentTimerEventChannelEventAdapter(
+        serviceConfig.getEventChannels(), timeBasedEventAdapter, validatorTimingChannel);
+  }
+
+  @Override
+  public SafeFuture<Void> start() {
+    return timeBasedEventAdapter
+        .start()
+        .thenRun(() -> eventChannels.subscribe(ChainHeadChannel.class, this));
+  }
+
+  @Override
+  public SafeFuture<Void> stop() {
+    return timeBasedEventAdapter.stop();
+  }
+
+  @Override
+  public void chainHeadUpdated(
+      final UInt64 slot,
+      final Bytes32 stateRoot,
+      final Bytes32 bestBlockRoot,
+      final boolean epochTransition,
+      final Optional<ReorgContext> optionalReorgContext) {
+    optionalReorgContext.ifPresent(
+        reorgContext ->
+            validatorTimingChannel.onChainReorg(slot, reorgContext.getCommonAncestorSlot()));
+    validatorTimingChannel.onAttestationCreationDue(slot);
+  }
+}


### PR DESCRIPTION
## PR Description
Adds an event adapter to trigger validator timing events based on an independent timer and the head update events from the EventChannel.  This matches the model required when using the events from the standard events stream.

Also updates `StubAsyncRunner` so that its possible to only execute tasks that are currently due based on a `TimeProvider`, rather than ignoring the specified delay.

## Fixed Issue(s)
#1918 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.