### PR TITLE
Start the BlockManager independently of sync service

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.core.operationvalidators.AttesterSlashingStateTransitio
 import tech.pegasys.teku.core.operationvalidators.ProposerSlashingStateTransitionValidator;
 import tech.pegasys.teku.core.operationvalidators.VoluntaryExitStateTransitionValidator;
 import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.interop.InteropStartupUtil;
 import tech.pegasys.teku.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.datastructures.operations.ProposerSlashing;
@@ -97,6 +98,10 @@ import tech.pegasys.teku.storage.store.StoreConfig;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 import tech.pegasys.teku.sync.SyncService;
 import tech.pegasys.teku.sync.SyncStateTracker;
+import tech.pegasys.teku.sync.gossip.BlockManager;
+import tech.pegasys.teku.sync.gossip.FetchRecentBlocksService;
+import tech.pegasys.teku.sync.gossip.NoopRecentBlockFetcher;
+import tech.pegasys.teku.sync.gossip.RecentBlockFetcher;
 import tech.pegasys.teku.sync.multipeer.MultipeerSyncService;
 import tech.pegasys.teku.sync.noop.NoopSyncService;
 import tech.pegasys.teku.sync.singlepeer.SinglePeerSyncServiceFactory;
@@ -160,6 +165,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   private SyncStateTracker syncStateTracker;
   private UInt64 genesisTimeTracker = ZERO;
   private ForkChoiceExecutor forkChoiceExecutor;
+  private BlockManager blockManager;
 
   public BeaconChainController(
       final ServiceConfig serviceConfig, final BeaconChainConfiguration beaconConfig) {
@@ -189,6 +195,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     SafeFuture.allOfFailFast(
             attestationManager.start(),
             p2pNetwork.start(),
+            blockManager.start(),
             syncService.start(),
             syncStateTracker.start())
         .finish(
@@ -216,6 +223,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
         SafeFuture.fromRunnable(() -> forkChoiceExecutor.stop()),
         syncStateTracker.stop(),
         syncService.stop(),
+        blockManager.stop(),
         attestationManager.stop(),
         p2pNetwork.stop());
   }
@@ -277,6 +285,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     initGenesisHandler();
     initAttestationManager();
     initP2PNetwork();
+    initBlockManager();
     initSyncManager();
     initSlotProcessor();
     initMetrics();
@@ -618,6 +627,30 @@ public class BeaconChainController extends Service implements TimeTickChannel {
         new BlockImporter(recentChainData, forkChoice, weakSubjectivityValidator, eventBus);
   }
 
+  public void initBlockManager() {
+    LOG.debug("BeaconChainController.initBlockManager()");
+    final PendingPool<SignedBeaconBlock> pendingBlocks = PendingPool.createForBlocks();
+    final FutureItems<SignedBeaconBlock> futureBlocks =
+        new FutureItems<>(SignedBeaconBlock::getSlot);
+    final RecentBlockFetcher recentBlockFetcher;
+    if (!config.isP2pEnabled()) {
+      recentBlockFetcher = new NoopRecentBlockFetcher();
+    } else {
+      recentBlockFetcher = FetchRecentBlocksService.create(asyncRunner, p2pNetwork, pendingBlocks);
+    }
+    blockManager =
+        BlockManager.create(
+            eventBus,
+            pendingBlocks,
+            futureBlocks,
+            recentBlockFetcher,
+            recentChainData,
+            blockImporter);
+    eventChannels
+        .subscribe(SlotEventsChannel.class, blockManager)
+        .subscribe(FinalizedCheckpointChannel.class, pendingBlocks);
+  }
+
   public void initSyncManager() {
     LOG.debug("BeaconChainController.initSyncManager()");
     if (!config.isP2pEnabled()) {
@@ -628,21 +661,14 @@ public class BeaconChainController extends Service implements TimeTickChannel {
               asyncRunnerFactory,
               asyncRunner,
               timeProvider,
-              eventBus,
-              eventChannels,
               recentChainData,
               p2pNetwork,
-              blockImporter);
+              blockImporter,
+              blockManager);
     } else {
       syncService =
           SinglePeerSyncServiceFactory.create(
-              metricsSystem,
-              asyncRunner,
-              eventChannels,
-              eventBus,
-              p2pNetwork,
-              recentChainData,
-              blockImporter);
+              metricsSystem, asyncRunner, p2pNetwork, recentChainData, blockImporter, blockManager);
     }
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -663,12 +663,11 @@ public class BeaconChainController extends Service implements TimeTickChannel {
               timeProvider,
               recentChainData,
               p2pNetwork,
-              blockImporter,
-              blockManager);
+              blockImporter);
     } else {
       syncService =
           SinglePeerSyncServiceFactory.create(
-              metricsSystem, asyncRunner, p2pNetwork, recentChainData, blockImporter, blockManager);
+              metricsSystem, asyncRunner, p2pNetwork, recentChainData, blockImporter);
     }
   }
 

--- a/sync/src/main/java/tech/pegasys/teku/sync/gossip/BlockManager.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/gossip/BlockManager.java
@@ -48,7 +48,7 @@ public class BlockManager extends Service implements SlotEventsChannel {
   private final PendingPool<SignedBeaconBlock> pendingBlocks;
 
   private final FutureItems<SignedBeaconBlock> futureBlocks;
-  private final FetchRecentBlocksService recentBlockFetcher;
+  private final RecentBlockFetcher recentBlockFetcher;
   private final Set<Bytes32> invalidBlockRoots = LimitedSet.create(500);
 
   BlockManager(
@@ -57,7 +57,7 @@ public class BlockManager extends Service implements SlotEventsChannel {
       final BlockImporter blockImporter,
       final PendingPool<SignedBeaconBlock> pendingBlocks,
       final FutureItems<SignedBeaconBlock> futureBlocks,
-      final FetchRecentBlocksService recentBlockFetcher) {
+      final RecentBlockFetcher recentBlockFetcher) {
     this.eventBus = eventBus;
     this.recentChainData = recentChainData;
     this.blockImporter = blockImporter;
@@ -70,7 +70,7 @@ public class BlockManager extends Service implements SlotEventsChannel {
       final EventBus eventBus,
       final PendingPool<SignedBeaconBlock> pendingBlocks,
       final FutureItems<SignedBeaconBlock> futureBlocks,
-      final FetchRecentBlocksService recentBlockFetcher,
+      final RecentBlockFetcher recentBlockFetcher,
       final RecentChainData recentChainData,
       final BlockImporter blockImporter) {
     return new BlockManager(

--- a/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchRecentBlocksService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchRecentBlocksService.java
@@ -81,13 +81,13 @@ public class FetchRecentBlocksService extends Service implements RecentBlockFetc
   }
 
   @Override
-  public SafeFuture<?> doStart() {
+  protected SafeFuture<?> doStart() {
     setupSubscribers();
     return SafeFuture.completedFuture(null);
   }
 
   @Override
-  public SafeFuture<?> doStop() {
+  protected SafeFuture<?> doStop() {
     return SafeFuture.completedFuture(null);
   }
 

--- a/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchRecentBlocksService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchRecentBlocksService.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.sync.gossip.FetchBlockTask.FetchBlockResult;
 import tech.pegasys.teku.sync.singlepeer.RetryDelayFunction;
 
-public class FetchRecentBlocksService extends Service {
+public class FetchRecentBlocksService extends Service implements RecentBlockFetcher {
   private static final Logger LOG = LogManager.getLogger();
 
   private static final int MAX_CONCURRENT_REQUESTS = 3;
@@ -81,16 +81,17 @@ public class FetchRecentBlocksService extends Service {
   }
 
   @Override
-  protected SafeFuture<?> doStart() {
+  public SafeFuture<?> doStart() {
     setupSubscribers();
     return SafeFuture.completedFuture(null);
   }
 
   @Override
-  protected SafeFuture<?> doStop() {
+  public SafeFuture<?> doStop() {
     return SafeFuture.completedFuture(null);
   }
 
+  @Override
   public long subscribeBlockFetched(final BlockSubscriber subscriber) {
     return blockSubscribers.subscribe(subscriber);
   }
@@ -104,6 +105,7 @@ public class FetchRecentBlocksService extends Service {
     this.pendingBlocksPool.subscribeRequiredBlockRootDropped(this::cancelRecentBlockRequest);
   }
 
+  @Override
   public void requestRecentBlock(final Bytes32 blockRoot) {
     if (pendingBlocksPool.contains(blockRoot)) {
       // We've already got this block
@@ -119,6 +121,7 @@ public class FetchRecentBlocksService extends Service {
     queueTask(task);
   }
 
+  @Override
   public void cancelRecentBlockRequest(final Bytes32 blockRoot) {
     final FetchBlockTask task = allTasks.get(blockRoot);
     if (task != null) {

--- a/sync/src/main/java/tech/pegasys/teku/sync/gossip/NoopRecentBlockFetcher.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/gossip/NoopRecentBlockFetcher.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.sync.gossip;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.sync.gossip.FetchRecentBlocksService.BlockSubscriber;
+
+public class NoopRecentBlockFetcher implements RecentBlockFetcher {
+
+  @Override
+  public SafeFuture<?> start() {
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
+  public SafeFuture<?> stop() {
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
+  public long subscribeBlockFetched(final BlockSubscriber subscriber) {
+    return 0;
+  }
+
+  @Override
+  public void requestRecentBlock(final Bytes32 blockRoot) {}
+
+  @Override
+  public void cancelRecentBlockRequest(final Bytes32 blockRoot) {}
+}

--- a/sync/src/main/java/tech/pegasys/teku/sync/gossip/RecentBlockFetcher.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/gossip/RecentBlockFetcher.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.sync.gossip;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.sync.gossip.FetchRecentBlocksService.BlockSubscriber;
+
+public interface RecentBlockFetcher {
+
+  SafeFuture<?> start();
+
+  SafeFuture<?> stop();
+
+  long subscribeBlockFetched(BlockSubscriber subscriber);
+
+  void requestRecentBlock(Bytes32 blockRoot);
+
+  void cancelRecentBlockRequest(Bytes32 blockRoot);
+}

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/MultipeerSyncService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/MultipeerSyncService.java
@@ -13,36 +13,28 @@
 
 package tech.pegasys.teku.sync.multipeer;
 
-import com.google.common.eventbus.EventBus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
 import tech.pegasys.teku.infrastructure.async.OrderedAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.AsyncRunnerEventThread;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
-import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
-import tech.pegasys.teku.statetransition.util.FutureItems;
-import tech.pegasys.teku.statetransition.util.PendingPool;
-import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.sync.SyncService;
 import tech.pegasys.teku.sync.SyncingStatus;
 import tech.pegasys.teku.sync.gossip.BlockManager;
-import tech.pegasys.teku.sync.gossip.FetchRecentBlocksService;
 import tech.pegasys.teku.sync.multipeer.batches.BatchFactory;
 import tech.pegasys.teku.sync.multipeer.chains.PeerChainTracker;
 import tech.pegasys.teku.sync.multipeer.chains.SyncSourceFactory;
 import tech.pegasys.teku.sync.multipeer.chains.TargetChains;
 import tech.pegasys.teku.util.config.Constants;
-import tech.pegasys.teku.util.time.channels.SlotEventsChannel;
 
 public class MultipeerSyncService extends Service implements SyncService {
   private static final Logger LOG = LogManager.getLogger();
@@ -69,27 +61,12 @@ public class MultipeerSyncService extends Service implements SyncService {
       final AsyncRunnerFactory asyncRunnerFactory,
       final AsyncRunner asyncRunner,
       final TimeProvider timeProvider,
-      final EventBus eventBus,
-      final EventChannels eventChannels,
       final RecentChainData recentChainData,
       final P2PNetwork<Eth2Peer> p2pNetwork,
-      final BlockImporter blockImporter) {
+      final BlockImporter blockImporter,
+      final BlockManager blockManager) {
     LOG.info("Using multipeer sync");
     final EventThread eventThread = new AsyncRunnerEventThread("sync", asyncRunnerFactory);
-
-    final PendingPool<SignedBeaconBlock> pendingBlocks = PendingPool.createForBlocks();
-    final FutureItems<SignedBeaconBlock> futureBlocks =
-        new FutureItems<>(SignedBeaconBlock::getSlot);
-    final FetchRecentBlocksService recentBlockFetcher =
-        FetchRecentBlocksService.create(asyncRunner, p2pNetwork, pendingBlocks);
-    BlockManager blockManager =
-        BlockManager.create(
-            eventBus,
-            pendingBlocks,
-            futureBlocks,
-            recentBlockFetcher,
-            recentChainData,
-            blockImporter);
 
     final TargetChains finalizedTargetChains = new TargetChains();
     final TargetChains nonfinalizedTargetChains = new TargetChains();
@@ -117,9 +94,6 @@ public class MultipeerSyncService extends Service implements SyncService {
             finalizedTargetChains,
             nonfinalizedTargetChains);
     peerChainTracker.subscribeToTargetChainUpdates(syncController::onTargetChainsUpdated);
-    eventChannels
-        .subscribe(SlotEventsChannel.class, blockManager)
-        .subscribe(FinalizedCheckpointChannel.class, pendingBlocks);
     return new MultipeerSyncService(
         eventThread, blockManager, recentChainData, peerChainTracker, syncController);
   }

--- a/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/SinglePeerSyncService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/SinglePeerSyncService.java
@@ -18,21 +18,15 @@ import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.sync.SyncService;
 import tech.pegasys.teku.sync.SyncingStatus;
-import tech.pegasys.teku.sync.gossip.BlockManager;
 
 public class SinglePeerSyncService extends Service implements SyncService {
 
   private final SyncManager syncManager;
-  private final BlockManager blockManager;
   private final RecentChainData storageClient;
 
-  public SinglePeerSyncService(
-      final BlockManager blockManager,
-      final SyncManager syncManager,
-      final RecentChainData storageClient) {
+  public SinglePeerSyncService(final SyncManager syncManager, final RecentChainData storageClient) {
     this.storageClient = storageClient;
     this.syncManager = syncManager;
-    this.blockManager = blockManager;
   }
 
   @Override
@@ -40,17 +34,13 @@ public class SinglePeerSyncService extends Service implements SyncService {
     // We shouldn't start syncing until we have reached genesis.
     // There are also no valid blocks until we've reached genesis so no point in gossipping and
     // queuing them
-    storageClient.subscribeStoreInitialized(
-        () -> {
-          syncManager.start().reportExceptions();
-          blockManager.start().reportExceptions();
-        });
+    storageClient.subscribeStoreInitialized(() -> syncManager.start().reportExceptions());
     return SafeFuture.COMPLETE;
   }
 
   @Override
   protected SafeFuture<?> doStop() {
-    return SafeFuture.allOf(syncManager.stop(), blockManager.stop());
+    return syncManager.stop();
   }
 
   @Override

--- a/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/SinglePeerSyncServiceFactory.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/SinglePeerSyncServiceFactory.java
@@ -20,7 +20,6 @@ import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.sync.SyncService;
-import tech.pegasys.teku.sync.gossip.BlockManager;
 
 public class SinglePeerSyncServiceFactory {
   public static SyncService create(
@@ -28,10 +27,9 @@ public class SinglePeerSyncServiceFactory {
       final AsyncRunner asyncRunner,
       final P2PNetwork<Eth2Peer> p2pNetwork,
       final RecentChainData recentChainData,
-      final BlockImporter blockImporter,
-      final BlockManager blockManager) {
+      final BlockImporter blockImporter) {
     final SyncManager syncManager =
         SyncManager.create(asyncRunner, p2pNetwork, recentChainData, blockImporter, metricsSystem);
-    return new SinglePeerSyncService(blockManager, syncManager, recentChainData);
+    return new SinglePeerSyncService(syncManager, recentChainData);
   }
 }

--- a/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/SinglePeerSyncServiceFactory.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/SinglePeerSyncServiceFactory.java
@@ -13,52 +13,25 @@
 
 package tech.pegasys.teku.sync.singlepeer;
 
-import com.google.common.eventbus.EventBus;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
-import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.statetransition.blockimport.BlockImporter;
-import tech.pegasys.teku.statetransition.util.FutureItems;
-import tech.pegasys.teku.statetransition.util.PendingPool;
-import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.sync.SyncService;
 import tech.pegasys.teku.sync.gossip.BlockManager;
-import tech.pegasys.teku.sync.gossip.FetchRecentBlocksService;
-import tech.pegasys.teku.util.time.channels.SlotEventsChannel;
 
 public class SinglePeerSyncServiceFactory {
   public static SyncService create(
       final MetricsSystem metricsSystem,
       final AsyncRunner asyncRunner,
-      final EventChannels eventChannels,
-      final EventBus eventBus,
       final P2PNetwork<Eth2Peer> p2pNetwork,
       final RecentChainData recentChainData,
-      final BlockImporter blockImporter) {
-    final PendingPool<SignedBeaconBlock> pendingBlocks = PendingPool.createForBlocks();
-    final FutureItems<SignedBeaconBlock> futureBlocks =
-        new FutureItems<>(SignedBeaconBlock::getSlot);
-    final FetchRecentBlocksService recentBlockFetcher =
-        FetchRecentBlocksService.create(asyncRunner, p2pNetwork, pendingBlocks);
-    BlockManager blockManager =
-        BlockManager.create(
-            eventBus,
-            pendingBlocks,
-            futureBlocks,
-            recentBlockFetcher,
-            recentChainData,
-            blockImporter);
-    SyncManager syncManager =
+      final BlockImporter blockImporter,
+      final BlockManager blockManager) {
+    final SyncManager syncManager =
         SyncManager.create(asyncRunner, p2pNetwork, recentChainData, blockImporter, metricsSystem);
-    final SinglePeerSyncService syncService =
-        new SinglePeerSyncService(blockManager, syncManager, recentChainData);
-    eventChannels
-        .subscribe(SlotEventsChannel.class, blockManager)
-        .subscribe(FinalizedCheckpointChannel.class, pendingBlocks);
-    return syncService;
+    return new SinglePeerSyncService(blockManager, syncManager, recentChainData);
   }
 }

--- a/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
+++ b/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
@@ -113,7 +113,7 @@ public class SyncingNodeManager {
     SyncManager syncManager =
         SyncManager.create(
             asyncRunner, eth2Network, recentChainData, blockImporter, new NoOpMetricsSystem());
-    SyncService syncService = new SinglePeerSyncService(blockManager, syncManager, recentChainData);
+    SyncService syncService = new SinglePeerSyncService(syncManager, recentChainData);
 
     eventChannels
         .subscribe(SlotEventsChannel.class, blockManager)

--- a/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
+++ b/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
@@ -119,6 +119,7 @@ public class SyncingNodeManager {
         .subscribe(SlotEventsChannel.class, blockManager)
         .subscribe(FinalizedCheckpointChannel.class, pendingBlocks);
 
+    blockManager.start().join();
     syncService.start().join();
 
     return new SyncingNodeManager(


### PR DESCRIPTION
## PR Description
When p2p is disabled, the sync service isn't started but we still need the `BlockManager` created and started since it is now responsible for importing locally produced blocks.

`BlockManager` is now created and managed by `BeaconChainController` instead of as part of the sync service so it is created even when p2p network doesn't exist.  A `NoopRecentBlockFetcher` is introduced and used when there is no network.

## Fixed Issue(s)
fixes #2912 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.