### PR TITLE
implement `/eth/v1/validator/blocks/{slot}` rest api

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -264,6 +264,10 @@ public class BeaconRestApi {
   private void addV1ValidatorHandlers(final DataProvider dataProvider) {
     app.get(GetAttesterDuties.ROUTE, new GetAttesterDuties(dataProvider, jsonProvider));
     app.get(GetProposerDuties.ROUTE, new GetProposerDuties(dataProvider, jsonProvider));
+    app.get(
+        tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetNewBlock.ROUTE,
+        new tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetNewBlock(
+            dataProvider, jsonProvider));
   }
 
   private void addV1BeaconHandlers(final DataProvider dataProvider) {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeers;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetSyncing;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetVersion;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttesterDuties;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetNewBlock;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetProposerDuties;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
@@ -123,5 +124,10 @@ public class BeaconRestApiV1Test {
   @Test
   public void shouldHaveGetGenesisEndpoint() {
     verify(app).get(eq(GetGenesis.ROUTE), any(GetGenesis.class));
+  }
+
+  @Test
+  public void shouldHaveGetNewBlockEndpoint() {
+    verify(app).get(eq(GetNewBlock.ROUTE), any(GetNewBlock.class));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlockTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
+
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RANDAO_REVEAL;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.SLOT;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
+
+import io.javalin.http.Context;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
+import tech.pegasys.teku.api.ValidatorDataProvider;
+import tech.pegasys.teku.api.response.v1.validator.GetNewBlockResponse;
+import tech.pegasys.teku.api.schema.BLSSignature;
+import tech.pegasys.teku.api.schema.BeaconBlock;
+import tech.pegasys.teku.beaconrestapi.RestApiConstants;
+import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.provider.JsonProvider;
+
+public class GetNewBlockTest {
+  private final tech.pegasys.teku.bls.BLSSignature signatureInternal =
+      tech.pegasys.teku.bls.BLSSignature.random(1234);
+  private BLSSignature signature = new BLSSignature(signatureInternal);
+  private Context context = mock(Context.class);
+  private final ValidatorDataProvider provider = mock(ValidatorDataProvider.class);
+  private final JsonProvider jsonProvider = new JsonProvider();
+  private GetNewBlock handler;
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Bytes32 graffiti = dataStructureUtil.randomBytes32();
+
+  @SuppressWarnings("unchecked")
+  final ArgumentCaptor<SafeFuture<String>> args = ArgumentCaptor.forClass(SafeFuture.class);
+
+  @BeforeEach
+  public void setup() {
+    handler = new GetNewBlock(provider, jsonProvider);
+  }
+
+  @Test
+  void shouldRequireThatRandaoRevealIsSet() throws Exception {
+    badRequestParamsTest(Map.of(), "'randao_reveal' cannot be null or empty.");
+  }
+
+  @Test
+  void shouldReturnBlockWithoutGraffiti() throws Exception {
+    final Map<String, String> pathParams = Map.of(SLOT, "1");
+    final Map<String, List<String>> queryParams =
+        Map.of(RANDAO_REVEAL, List.of(signature.toHexString()));
+    Optional<BeaconBlock> optionalBeaconBlock =
+        Optional.of(
+            new BeaconBlock(dataStructureUtil.randomBeaconBlock(dataStructureUtil.randomLong())));
+    when(context.queryParamMap()).thenReturn(queryParams);
+    when(context.pathParamMap()).thenReturn(pathParams);
+    when(provider.getUnsignedBeaconBlockAtSlot(ONE, signature, Optional.empty()))
+        .thenReturn(SafeFuture.completedFuture(optionalBeaconBlock));
+    handler.handle(context);
+
+    verify(context).result(args.capture());
+    SafeFuture<String> result = args.getValue();
+    assertThat(result)
+        .isCompletedWithValue(
+            jsonProvider.objectToJSON(new GetNewBlockResponse(optionalBeaconBlock.get())));
+  }
+
+  @Test
+  void shouldReturnBlockWithGraffiti() throws Exception {
+    final Map<String, List<String>> params =
+        Map.of(
+            RANDAO_REVEAL,
+            List.of(signature.toHexString()),
+            RestApiConstants.GRAFFITI,
+            List.of(graffiti.toHexString()));
+    Optional<BeaconBlock> optionalBeaconBlock =
+        Optional.of(
+            new BeaconBlock(dataStructureUtil.randomBeaconBlock(dataStructureUtil.randomLong())));
+    when(context.queryParamMap()).thenReturn(params);
+    when(context.pathParamMap()).thenReturn(Map.of(SLOT, "1"));
+    when(provider.getUnsignedBeaconBlockAtSlot(ONE, signature, Optional.of(graffiti)))
+        .thenReturn(SafeFuture.completedFuture(optionalBeaconBlock));
+    handler.handle(context);
+
+    verify(context).result(args.capture());
+    SafeFuture<String> result = args.getValue();
+
+    assertThat(result)
+        .isCompletedWithValue(
+            jsonProvider.objectToJSON(new GetNewBlockResponse(optionalBeaconBlock.get())));
+  }
+
+  @Test
+  void shouldReturnServerErrorWhenRuntimeExceptionReceived() throws Exception {
+    final Map<String, List<String>> params =
+        Map.of(RANDAO_REVEAL, List.of(signature.toHexString()));
+    when(context.queryParamMap()).thenReturn(params);
+    when(context.pathParamMap()).thenReturn(Map.of(SLOT, "1"));
+    when(provider.getUnsignedBeaconBlockAtSlot(ONE, signature, Optional.empty()))
+        .thenReturn(SafeFuture.failedFuture(new RuntimeException("TEST")));
+    handler.handle(context);
+
+    // Exception should just be propagated up via the future
+    verify(context, never()).status(anyInt());
+    verify(context)
+        .result(
+            argThat((ArgumentMatcher<SafeFuture<?>>) CompletableFuture::isCompletedExceptionally));
+  }
+
+  @Test
+  void shouldReturnBadRequestErrorWhenIllegalArgumentExceptionReceived() throws Exception {
+
+    final Map<String, List<String>> params =
+        Map.of(RANDAO_REVEAL, List.of(signature.toHexString()));
+    when(context.pathParamMap()).thenReturn(Map.of(SLOT, "1"));
+    when(context.queryParamMap()).thenReturn(params);
+    when(provider.getUnsignedBeaconBlockAtSlot(ONE, signature, Optional.empty()))
+        .thenReturn(SafeFuture.failedFuture(new IllegalArgumentException("TEST")));
+    handler.handle(context);
+
+    verify(context).status(SC_BAD_REQUEST);
+  }
+
+  private void badRequestParamsTest(final Map<String, List<String>> params, String message)
+      throws Exception {
+    when(context.queryParamMap()).thenReturn(params);
+    when(context.pathParamMap()).thenReturn(Map.of(SLOT, "1"));
+
+    handler.handle(context);
+    verify(context).status(SC_BAD_REQUEST);
+
+    if (StringUtils.isNotEmpty(message)) {
+      BadRequest badRequest = new BadRequest(message);
+      verify(context).result(jsonProvider.objectToJSON(badRequest));
+    }
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/GetNewBlockResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/GetNewBlockResponse.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.response.v1.validator;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import tech.pegasys.teku.api.schema.BeaconBlock;
+
+public class GetNewBlockResponse {
+  public final BeaconBlock data;
+
+  @JsonCreator
+  public GetNewBlockResponse(@JsonProperty("data") final BeaconBlock data) {
+    this.data = data;
+  }
+}


### PR DESCRIPTION
 - deprecated `/validator/block`

 partially addresses #2756

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.