### PR TITLE
Add method to get validator indicies to ValidatorApiChannel

### DIFF
--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.api;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
@@ -34,6 +35,8 @@ public interface ValidatorApiChannel extends ChannelInterface {
   SafeFuture<Optional<ForkInfo>> getForkInfo();
 
   SafeFuture<Optional<UInt64>> getGenesisTime();
+
+  SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(final List<BLSPublicKey> publicKeys);
 
   SafeFuture<Optional<List<ValidatorDuties>>> getDuties(
       UInt64 epoch, Collection<BLSPublicKey> publicKeys);

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.beaconnode.metrics;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
@@ -42,6 +43,8 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   public static final String FORK_REQUESTS_COUNTER_NAME = "beacon_node_fork_info_requests_total";
   public static final String GENESIS_TIME_REQUESTS_COUNTER_NAME =
       "beacon_node_genesis_time_requests_total";
+  public static final String GET_VALIDATOR_INDICES_REQUESTS_COUNTER_NAME =
+      "beacon_node_get_validator_indices_requests_total";
   public static final String DUTIES_REQUESTS_COUNTER_NAME = "beacon_node_duties_requests_total";
   public static final String ATTESTATION_DUTIES_REQUESTS_COUNTER_NAME =
       "beacon_node_attestation_duties_requests_total";
@@ -71,6 +74,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   private final BeaconChainRequestCounter unsignedBlockRequestsCounter;
   private final BeaconChainRequestCounter unsignedAttestationRequestsCounter;
   private final BeaconChainRequestCounter aggregateRequestsCounter;
+  private final Counter getValidatorIndicesRequestCounter;
   private final Counter subscribeAggregationRequestCounter;
   private final Counter subscribePersistentRequestCounter;
   private final Counter sendAttestationRequestCounter;
@@ -122,6 +126,11 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
             metricsSystem,
             AGGREGATE_REQUESTS_COUNTER_NAME,
             "Counter recording the number of requests for aggregate attestations");
+    getValidatorIndicesRequestCounter =
+        metricsSystem.createCounter(
+            TekuMetricCategory.VALIDATOR,
+            GET_VALIDATOR_INDICES_REQUESTS_COUNTER_NAME,
+            "Counter recording the number of requests for validator indices");
     subscribeAggregationRequestCounter =
         metricsSystem.createCounter(
             TekuMetricCategory.VALIDATOR,
@@ -157,6 +166,13 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<UInt64>> getGenesisTime() {
     return countRequest(delegate.getGenesisTime(), genesisTimeRequestCounter);
+  }
+
+  @Override
+  public SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(
+      final List<BLSPublicKey> publicKeys) {
+    getValidatorIndicesRequestCounter.inc();
+    return delegate.getValidatorIndices(publicKeys);
   }
 
   @Override

--- a/validator/coordinator/build.gradle
+++ b/validator/coordinator/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   testImplementation testFixtures(project(':ethereum:core'))
   testImplementation testFixtures(project(':util'))
   testImplementation testFixtures(project(':storage'))
+  testImplementation testFixtures(project(':infrastructure:async'))
   testImplementation testFixtures(project(':infrastructure:metrics'))
   testImplementation testFixtures(project(':infrastructure:time'))
 

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.coordinator;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
@@ -128,6 +129,24 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<UInt64>> getGenesisTime() {
     return SafeFuture.completedFuture(combinedChainDataClient.getGenesisTime());
+  }
+
+  @Override
+  public SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(
+      final List<BLSPublicKey> publicKeys) {
+    return SafeFuture.completedFuture(
+        combinedChainDataClient
+            .getBestState()
+            .map(
+                state -> {
+                  final Map<BLSPublicKey, Integer> results = new HashMap<>();
+                  publicKeys.forEach(
+                      publicKey ->
+                          ValidatorsUtil.getValidatorIndex(state, publicKey)
+                              .ifPresent(index -> results.put(publicKey, index)));
+                  return results;
+                })
+            .orElse(emptyMap()));
   }
 
   @Override

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.coordinator;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -577,12 +578,12 @@ class ValidatorApiHandlerTest {
   }
 
   @Test
-  void getValidatorIndices_shouldReturnEmptyOptionalWhenBestStateNotAvailable() {
+  void getValidatorIndices_shouldReturnEmptyMapWhenBestStateNotAvailable() {
     when(chainDataClient.getBestState()).thenReturn(Optional.empty());
 
     assertThatSafeFuture(
             validatorApiHandler.getValidatorIndices(List.of(dataStructureUtil.randomPublicKey())))
-        .isCompletedWithEmptyOptional();
+        .isCompletedWithValue(emptyMap());
   }
 
   @Test

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -93,16 +93,20 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
           for (int i = 0; i < publicKeys.size(); i += MAX_PUBLIC_KEY_BATCH_SIZE) {
             final List<BLSPublicKey> batch =
                 publicKeys.subList(i, Math.min(publicKeys.size(), i + MAX_PUBLIC_KEY_BATCH_SIZE));
-            apiClient
-                .getValidators(
-                    batch.stream()
-                        .map(key -> key.toBytesCompressed().toHexString())
-                        .collect(Collectors.toList()))
-                .map(this::convertToValidatorIndexMap)
-                .ifPresent(indices::putAll);
+            requestValidatorIndices(batch).ifPresent(indices::putAll);
           }
           return indices;
         });
+  }
+
+  private Optional<Map<BLSPublicKey, Integer>> requestValidatorIndices(
+      final List<BLSPublicKey> batch) {
+    return apiClient
+        .getValidators(
+            batch.stream()
+                .map(key -> key.toBytesCompressed().toHexString())
+                .collect(Collectors.toList()))
+        .map(this::convertToValidatorIndexMap);
   }
 
   private Map<BLSPublicKey, Integer> convertToValidatorIndexMap(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -13,9 +13,13 @@
 
 package tech.pegasys.teku.validator.remote;
 
+import static java.util.Collections.emptyMap;
+
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -23,6 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.GetForkResponse;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
 import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.api.schema.BLSPubKey;
@@ -49,6 +54,7 @@ import tech.pegasys.teku.validator.remote.apiclient.ValidatorRestApiClient;
 public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 
   private static final Logger LOG = LogManager.getLogger();
+  static final int MAX_PUBLIC_KEY_BATCH_SIZE = 10;
 
   private final ValidatorRestApiClient apiClient;
   private final AsyncRunner asyncRunner;
@@ -73,6 +79,39 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   public SafeFuture<Optional<UInt64>> getGenesisTime() {
     return asyncRunner.runAsync(
         () -> apiClient.getGenesis().map(response -> response.data.genesisTime));
+  }
+
+  @Override
+  public SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(
+      final List<BLSPublicKey> publicKeys) {
+    if (publicKeys.isEmpty()) {
+      return SafeFuture.completedFuture(emptyMap());
+    }
+    return asyncRunner.runAsync(
+        () -> {
+          final Map<BLSPublicKey, Integer> indices = new HashMap<>();
+          for (int i = 0; i < publicKeys.size(); i += MAX_PUBLIC_KEY_BATCH_SIZE) {
+            final List<BLSPublicKey> batch =
+                publicKeys.subList(i, Math.min(publicKeys.size(), i + MAX_PUBLIC_KEY_BATCH_SIZE));
+            apiClient
+                .getValidators(
+                    batch.stream()
+                        .map(key -> key.toBytesCompressed().toHexString())
+                        .collect(Collectors.toList()))
+                .map(this::convertToValidatorIndexMap)
+                .ifPresent(indices::putAll);
+          }
+          return indices;
+        });
+  }
+
+  private Map<BLSPublicKey, Integer> convertToValidatorIndexMap(
+      final List<ValidatorResponse> validatorResponses) {
+    return validatorResponses.stream()
+        .collect(
+            Collectors.<ValidatorResponse, BLSPublicKey, Integer>toMap(
+                response -> response.validator.pubkey.asBLSPublicKey(),
+                response -> response.index.intValue()));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GE
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_PROPOSER_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_ATTESTATION;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_VALIDATORS;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_AGGREGATE_AND_PROOF;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_ATTESTATION;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_BLOCK;
@@ -49,6 +50,8 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.request.SubscribeToBeaconCommitteeRequest;
 import tech.pegasys.teku.api.response.GetForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
+import tech.pegasys.teku.api.response.v1.beacon.GetStateValidatorsResponse;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
 import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
@@ -90,6 +93,14 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   @Override
   public Optional<GetGenesisResponse> getGenesis() {
     return get(GET_GENESIS, EMPTY_QUERY_PARAMS, GetGenesisResponse.class);
+  }
+
+  @Override
+  public Optional<List<ValidatorResponse>> getValidators(final List<String> validatorIds) {
+    final Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("validator_id", String.join(",", validatorIds));
+    return get(GET_VALIDATORS, queryParams, GetStateValidatorsResponse.class)
+        .map(response -> response.data);
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.remote.apiclient;
 public enum ValidatorApiMethod {
   GET_FORK("node/fork"),
   GET_GENESIS("eth/v1/beacon/genesis"),
+  GET_VALIDATORS("eth/v1/beacon/states/head/validators"),
   GET_DUTIES("validator/duties"),
   GET_UNSIGNED_BLOCK("validator/block"),
   SEND_SIGNED_BLOCK("validator/block"),

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.GetForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
 import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.api.schema.Attestation;
@@ -38,6 +39,8 @@ public interface ValidatorRestApiClient {
   Optional<GetForkResponse> getFork();
 
   Optional<GetGenesisResponse> getGenesis();
+
+  Optional<List<ValidatorResponse>> getValidators(List<String> validatorIds);
 
   List<ValidatorDuties> getDuties(ValidatorDutiesRequest request);
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -14,7 +14,9 @@
 package tech.pegasys.teku.validator.remote;
 
 import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -23,11 +25,14 @@ import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.validator.remote.RemoteValidatorApiHandler.MAX_PUBLIC_KEY_BATCH_SIZE;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +40,7 @@ import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.api.response.GetForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GenesisData;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.api.schema.ValidatorDutiesRequest;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -53,11 +59,13 @@ import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorDuties;
+import tech.pegasys.teku.validator.remote.apiclient.SchemaObjectsTestFixture;
 import tech.pegasys.teku.validator.remote.apiclient.ValidatorRestApiClient;
 
 class RemoteValidatorApiHandlerTest {
 
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final SchemaObjectsTestFixture schemaObjects = new SchemaObjectsTestFixture();
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
 
   private final ValidatorRestApiClient apiClient = mock(ValidatorRestApiClient.class);
@@ -112,6 +120,93 @@ class RemoteValidatorApiHandlerTest {
     SafeFuture<Optional<UInt64>> future = apiHandler.getGenesisTime();
 
     assertThat(unwrapToOptional(future)).isNotPresent();
+  }
+
+  @Test
+  void getValidatorIndices_WithEmptyPublicKeys_ReturnsEmptyMap() {
+    final SafeFuture<Map<BLSPublicKey, Integer>> future =
+        apiHandler.getValidatorIndices(emptyList());
+
+    asyncRunner.executeQueuedActions();
+    assertThat(future).isCompleted();
+    assertThat(future.join()).isEmpty();
+  }
+
+  @Test
+  void getValidatorIndices_WithSmallNumberOfPublicKeys_RequestsSingleBatch() {
+    final BLSPublicKey key1 = dataStructureUtil.randomPublicKey();
+    final BLSPublicKey key2 = dataStructureUtil.randomPublicKey();
+    final BLSPublicKey key3 = dataStructureUtil.randomPublicKey();
+    final List<String> expectedValidatorIds =
+        List.of(
+            key1.toBytesCompressed().toHexString(),
+            key2.toBytesCompressed().toHexString(),
+            key3.toBytesCompressed().toHexString());
+    when(apiClient.getValidators(expectedValidatorIds))
+        .thenReturn(
+            Optional.of(
+                List.of(
+                    schemaObjects.validatorResponse(1, key1),
+                    schemaObjects.validatorResponse(2, key2))));
+
+    final SafeFuture<Map<BLSPublicKey, Integer>> future =
+        apiHandler.getValidatorIndices(List.of(key1, key2, key3));
+
+    asyncRunner.executeQueuedActions();
+    assertThat(future).isCompleted();
+    assertThat(future.join()).containsOnly(entry(key1, 1), entry(key2, 2));
+    verify(apiClient).getValidators(expectedValidatorIds);
+  }
+
+  @Test
+  void getValidatorIndices_WithLargeNumberOfPublicKeys_CombinesMultipleBatches() {
+    // Need to ensure the URL length limit isn't exceeded, so send requests in batches
+    final List<BLSPublicKey> allKeys =
+        IntStream.range(0, MAX_PUBLIC_KEY_BATCH_SIZE * 3 - 2)
+            .mapToObj(index -> dataStructureUtil.randomPublicKey())
+            .collect(toList());
+
+    final List<String> allSerializedKeys =
+        allKeys.stream().map(key -> key.toBytesCompressed().toHexString()).collect(toList());
+
+    final List<String> expectedBatch1 = allSerializedKeys.subList(0, MAX_PUBLIC_KEY_BATCH_SIZE);
+    final List<String> expectedBatch2 =
+        allSerializedKeys.subList(MAX_PUBLIC_KEY_BATCH_SIZE, MAX_PUBLIC_KEY_BATCH_SIZE * 2);
+    final List<String> expectedBatch3 =
+        allSerializedKeys.subList(MAX_PUBLIC_KEY_BATCH_SIZE * 2, allKeys.size());
+
+    final List<ValidatorResponse> batch1Responses =
+        List.of(
+            schemaObjects.validatorResponse(10, allKeys.get(0)),
+            schemaObjects.validatorResponse(11, allKeys.get(3)));
+    final List<ValidatorResponse> batch2Responses =
+        List.of(
+            schemaObjects.validatorResponse(20, allKeys.get(MAX_PUBLIC_KEY_BATCH_SIZE)),
+            schemaObjects.validatorResponse(21, allKeys.get(MAX_PUBLIC_KEY_BATCH_SIZE + 3)));
+    final List<ValidatorResponse> batch3Responses =
+        List.of(
+            schemaObjects.validatorResponse(30, allKeys.get(MAX_PUBLIC_KEY_BATCH_SIZE * 2)),
+            schemaObjects.validatorResponse(31, allKeys.get(MAX_PUBLIC_KEY_BATCH_SIZE * 2 + 3)));
+
+    when(apiClient.getValidators(expectedBatch1)).thenReturn(Optional.of(batch1Responses));
+    when(apiClient.getValidators(expectedBatch2)).thenReturn(Optional.of(batch2Responses));
+    when(apiClient.getValidators(expectedBatch3)).thenReturn(Optional.of(batch3Responses));
+
+    final SafeFuture<Map<BLSPublicKey, Integer>> future = apiHandler.getValidatorIndices(allKeys);
+
+    asyncRunner.executeQueuedActions();
+    assertThat(future).isCompleted();
+    assertThat(future.join())
+        .containsOnly(
+            entry(allKeys.get(0), 10),
+            entry(allKeys.get(3), 11),
+            entry(allKeys.get(MAX_PUBLIC_KEY_BATCH_SIZE), 20),
+            entry(allKeys.get(MAX_PUBLIC_KEY_BATCH_SIZE + 3), 21),
+            entry(allKeys.get(MAX_PUBLIC_KEY_BATCH_SIZE * 2), 30),
+            entry(allKeys.get(MAX_PUBLIC_KEY_BATCH_SIZE * 2 + 3), 31));
+    verify(apiClient).getValidators(expectedBatch1);
+    verify(apiClient).getValidators(expectedBatch2);
+    verify(apiClient).getValidators(expectedBatch3);
   }
 
   @Test

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/SchemaObjectsTestFixture.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/SchemaObjectsTestFixture.java
@@ -17,6 +17,8 @@ import java.util.List;
 import tech.pegasys.teku.api.response.GetForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GenesisData;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.api.schema.BLSSignature;
@@ -24,10 +26,13 @@ import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SubnetSubscription;
+import tech.pegasys.teku.api.schema.Validator;
 import tech.pegasys.teku.api.schema.ValidatorDuties;
 import tech.pegasys.teku.api.schema.ValidatorDutiesRequest;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.util.config.Constants;
 
 public class SchemaObjectsTestFixture {
 
@@ -51,6 +56,26 @@ public class SchemaObjectsTestFixture {
 
   public BLSSignature BLSSignature() {
     return new BLSSignature(dataStructureUtil.randomSignature());
+  }
+
+  public ValidatorResponse validatorResponse() {
+    return validatorResponse(dataStructureUtil.randomLong(), dataStructureUtil.randomPublicKey());
+  }
+
+  public ValidatorResponse validatorResponse(final long index, final BLSPublicKey publicKey) {
+    return new ValidatorResponse(
+        UInt64.valueOf(index),
+        dataStructureUtil.randomUInt64(),
+        ValidatorStatus.active_ongoing,
+        new Validator(
+            new BLSPubKey(publicKey),
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomUInt64(),
+            false,
+            UInt64.ZERO,
+            UInt64.ZERO,
+            Constants.FAR_FUTURE_EPOCH,
+            Constants.FAR_FUTURE_EPOCH));
   }
 
   public ValidatorDutiesRequest validatorDutiesRequest() {


### PR DESCRIPTION
## PR Description
So that the validator client can lookup the index for validators based on their public key, add `getValidatorIndices` to `ValidatorApiChannel`.  The remote implementation uses `/eth/v1/beacon/states/head/validators` to retrieve the validator information and requests are made in batches to avoid exceeding the URL length limit.

## Fixed Issue(s)
#1918 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.