### PR TITLE
Allow state to wind forward to head slot if head has no block

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -186,6 +186,10 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
     return createBlocksAtSlots(unsignedSlots);
   }
 
+  public void setCurrentSlot(long slot) {
+    chainUpdater.setCurrentSlot(UInt64.valueOf(slot));
+  }
+
   public ArrayList<SignedBlockAndState> createBlocksAtSlots(UInt64... slots) {
     final ArrayList<SignedBlockAndState> results = new ArrayList<>();
     for (UInt64 slot : slots) {

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetForkIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetForkIntegrationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.v1.beacon;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import okhttp3.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetStateFork;
+
+public class GetForkIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
+
+  @BeforeEach
+  public void setup() {
+    startRestAPIAtGenesis();
+  }
+
+  @Test
+  public void shouldGetForkChoiceAtEmptyHeadSlot() throws IOException {
+    createBlocksAtSlots(10, 11, 12);
+    setCurrentSlot(13);
+    final Response response = get("head");
+    assertThat(response.code()).isEqualTo(SC_OK);
+  }
+
+  @Test
+  public void shouldGetForkChoiceAtHeadSlot() throws IOException {
+    createBlocksAtSlots(10, 11, 12);
+    final Response response = get("head");
+    assertThat(response.code()).isEqualTo(SC_OK);
+  }
+
+  public Response get(final String stateIdString) throws IOException {
+    return getResponse(GetStateFork.ROUTE.replace(":state_id", stateIdString));
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -291,7 +291,7 @@ public class CombinedChainDataClient {
       final BeaconState preState, final UInt64 slot) {
     if (preState.getSlot().equals(slot)) {
       return Optional.of(preState);
-    } else if (slot.compareTo(getHeadSlot()) > 0) {
+    } else if (slot.compareTo(getCurrentSlot()) > 0) {
       LOG.debug("Attempted to wind forward to a future state: {}", slot.toString());
       return Optional.empty();
     }


### PR DESCRIPTION
 - Get fork endpoint can now get fork when no block has been produced at the head slot.

fixes #2945

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.