### PR TITLE
Use the actual balance instead of the effective balance

### DIFF
--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -95,8 +95,7 @@ public class ChainDataProviderTest {
   public void setup() {
     slot = UInt64.valueOf(SLOTS_PER_EPOCH * 3);
     actualBalance = UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE + 100000);
-    storageSystem.chainUpdater().initializeGenesis(true,
-        actualBalance);
+    storageSystem.chainUpdater().initializeGenesis(true, actualBalance);
     bestBlock = storageSystem.chainUpdater().advanceChain(slot);
     storageSystem.chainUpdater().updateBestBlock(bestBlock);
 

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -69,6 +69,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.storage.store.UpdatableStore;
+import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.util.config.StateStorageMode;
 
 public class ChainDataProviderTest {
@@ -88,11 +89,14 @@ public class ChainDataProviderTest {
   private final CombinedChainDataClient mockCombinedChainDataClient =
       mock(CombinedChainDataClient.class);
   private final RecentChainData mockRecentChainData = mock(RecentChainData.class);
+  private UInt64 actualBalance;
 
   @BeforeEach
   public void setup() {
     slot = UInt64.valueOf(SLOTS_PER_EPOCH * 3);
-    storageSystem.chainUpdater().initializeGenesis();
+    actualBalance = UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE + 100000);
+    storageSystem.chainUpdater().initializeGenesis(true,
+        actualBalance);
     bestBlock = storageSystem.chainUpdater().advanceChain(slot);
     storageSystem.chainUpdater().updateBestBlock(bestBlock);
 
@@ -701,7 +705,7 @@ public class ChainDataProviderTest {
         .isEqualTo(
             new ValidatorResponse(
                 ONE,
-                UInt64.valueOf("32000000000"),
+                actualBalance,
                 ValidatorStatus.active_ongoing,
                 new Validator(
                     validator.pubkey,
@@ -721,7 +725,7 @@ public class ChainDataProviderTest {
             .map(id -> ValidatorResponse.fromState(beaconStateInternal, id))
             .collect(toList());
     SafeFuture<Optional<List<ValidatorResponse>>> response =
-        provider.getValidatorsDetails(ZERO, validatorIds);
+        provider.getValidatorsDetails(slot, validatorIds);
     assertThatSafeFuture(response).isCompletedWithValue(Optional.of(expectedValidators));
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.util.config.Constants.FAR_FUTURE_EPOCH;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
 import tech.pegasys.teku.api.schema.Validator;
@@ -64,7 +65,7 @@ public class ValidatorResponse {
     final UInt64 current_epoch = compute_epoch_at_slot(state.getSlot());
     return new ValidatorResponse(
         UInt64.valueOf(index),
-        validatorInternal.getEffective_balance(),
+        state.getBalances().get(index),
         getValidatorStatus(current_epoch, validatorInternal),
         new Validator(validatorInternal));
   }
@@ -119,5 +120,15 @@ public class ValidatorResponse {
   @Override
   public int hashCode() {
     return Objects.hash(index, balance, status, validator);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("index", index)
+        .add("balance", balance)
+        .add("status", status)
+        .add("validator", validator)
+        .toString();
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/Validator.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/Validator.java
@@ -22,6 +22,7 @@ import static tech.pegasys.teku.api.schema.SchemaConstants.PATTERN_PUBKEY;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
@@ -141,5 +142,19 @@ public class Validator {
         activation_epoch,
         exit_epoch,
         withdrawable_epoch);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("pubkey", pubkey)
+        .add("withdrawal_credentials", withdrawal_credentials)
+        .add("effective_balance", effective_balance)
+        .add("slashed", slashed)
+        .add("activation_eligibility_epoch", activation_eligibility_epoch)
+        .add("activation_epoch", activation_epoch)
+        .add("exit_epoch", exit_epoch)
+        .add("withdrawable_epoch", withdrawable_epoch)
+        .toString();
   }
 }

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -223,12 +223,18 @@ public class ChainBuilder {
   }
 
   public SignedBlockAndState generateGenesis(final UInt64 genesisTime, final boolean signDeposits) {
+    return generateGenesis(
+        genesisTime, signDeposits, UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE));
+  }
+
+  public SignedBlockAndState generateGenesis(
+      final UInt64 genesisTime, final boolean signDeposits, final UInt64 depositAmount) {
     checkState(blocks.isEmpty(), "Genesis already created");
 
     // Generate genesis state
     final List<DepositData> initialDepositData =
         new MockStartDepositGenerator(new DepositGenerator(signDeposits))
-            .createDeposits(validatorKeys);
+            .createDeposits(validatorKeys, depositAmount);
     final BeaconState genesisState =
         new MockStartBeaconStateGenerator()
             .createInitialBeaconState(genesisTime, initialDepositData);

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/interop/MockStartDepositGenerator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/interop/MockStartDepositGenerator.java
@@ -50,7 +50,6 @@ public class MockStartDepositGenerator {
   }
 
   private DepositData createDepositData(final BLSKeyPair keyPair, final UInt64 depositBalance) {
-    return depositGenerator.createDepositData(
-        keyPair, depositBalance, keyPair.getPublicKey());
+    return depositGenerator.createDepositData(keyPair, depositBalance, keyPair.getPublicKey());
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/interop/MockStartDepositGenerator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/interop/MockStartDepositGenerator.java
@@ -38,7 +38,7 @@ public class MockStartDepositGenerator {
   }
 
   public List<DepositData> createDeposits(
-      final List<BLSKeyPair> validatorKeys, final long depositBalance) {
+      final List<BLSKeyPair> validatorKeys, final UInt64 depositBalance) {
     return validatorKeys.stream()
         .map(key -> createDepositData(key, depositBalance))
         .collect(toList());
@@ -49,8 +49,8 @@ public class MockStartDepositGenerator {
         keyPair, UInt64.valueOf(MAX_EFFECTIVE_BALANCE), keyPair.getPublicKey());
   }
 
-  private DepositData createDepositData(final BLSKeyPair keyPair, final long depositBalance) {
+  private DepositData createDepositData(final BLSKeyPair keyPair, final UInt64 depositBalance) {
     return depositGenerator.createDepositData(
-        keyPair, UInt64.valueOf(depositBalance), keyPair.getPublicKey());
+        keyPair, depositBalance, keyPair.getPublicKey());
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/GenesisGeneratorTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/GenesisGeneratorTest.java
@@ -96,10 +96,14 @@ class GenesisGeneratorTest {
     MockStartDepositGenerator mockStartDepositGenerator =
         new MockStartDepositGenerator(new DepositGenerator(true));
     DepositData PARTIAL_DEPOSIT_DATA =
-        mockStartDepositGenerator.createDeposits(VALIDATOR_KEYS.subList(0, 1), 1000000000L).get(0);
+        mockStartDepositGenerator
+            .createDeposits(VALIDATOR_KEYS.subList(0, 1), UInt64.valueOf(1000000000L))
+            .get(0);
 
     DepositData TOP_UP_DEPOSIT_DATA =
-        mockStartDepositGenerator.createDeposits(VALIDATOR_KEYS.subList(0, 1), 31000000000L).get(0);
+        mockStartDepositGenerator
+            .createDeposits(VALIDATOR_KEYS.subList(0, 1), UInt64.valueOf(31000000000L))
+            .get(0);
 
     List<DepositData> INITIAL_DEPOSIT_DATA = List.of(PARTIAL_DEPOSIT_DATA, TOP_UP_DEPOSIT_DATA);
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -61,7 +61,13 @@ public class ChainUpdater {
   }
 
   public SignedBlockAndState initializeGenesis(final boolean signDeposits) {
-    final SignedBlockAndState genesis = chainBuilder.generateGenesis(UInt64.ZERO, signDeposits);
+    return initializeGenesis(signDeposits, UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE));
+  }
+
+  public SignedBlockAndState initializeGenesis(
+      final boolean signDeposits, final UInt64 depositAmount) {
+    final SignedBlockAndState genesis =
+        chainBuilder.generateGenesis(UInt64.ZERO, signDeposits, depositAmount);
     assertThat(recentChainData.initializeFromGenesis(genesis.getState())).isCompleted();
     return genesis;
   }


### PR DESCRIPTION
## PR Description
When returning validator results from the REST API, ensure the `balance` field is the actual balance, not the effective balance.

## Fixed Issue(s)
fixes #2948 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.