### PR TITLE
Switch validator over to load attestation and block duties separately

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttesterDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttesterDuties.java
@@ -117,11 +117,9 @@ public class GetAttesterDuties extends AbstractHandler implements Handler {
       final UInt64 currentEpoch = chainDataProvider.getCurrentEpoch();
       if (currentEpoch.plus(Constants.MIN_SEED_LOOKAHEAD).isLessThan(epoch)) {
         ctx.result(
-            jsonProvider.objectToJSON(
-                new BadRequest(
-                    "Cannot get attester duties for "
-                        + epoch.minus(currentEpoch)
-                        + " epochs ahead")));
+            BadRequest.badRequest(
+                jsonProvider,
+                "Cannot get attester duties for " + epoch.minus(currentEpoch) + " epochs ahead"));
         ctx.status(SC_BAD_REQUEST);
         return;
       }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/AttesterDuties.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/AttesterDuties.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.api;
 
+import com.google.common.base.MoreObjects;
 import java.util.Objects;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -84,5 +85,17 @@ public class AttesterDuties {
 
   public UInt64 getSlot() {
     return slot;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("publicKey", publicKey)
+        .add("validatorIndex", validatorIndex)
+        .add("committeeLength", committeeLength)
+        .add("committeeIndex", committeeIndex)
+        .add("validatorCommitteeIndex", validatorCommitteeIndex)
+        .add("slot", slot)
+        .toString();
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyLoader.java
@@ -39,7 +39,6 @@ public abstract class AbstractDutyLoader<D> implements DutyLoader {
     this.scheduledDutiesFactory = scheduledDutiesFactory;
     this.validators = validators;
     this.validatorIndexProvider = validatorIndexProvider;
-    // TODO: Find a new place to set the local_validator_count metric
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyLoader.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.validator.client.duties.ScheduledDuties;
+
+public abstract class AbstractDutyLoader<D> implements DutyLoader {
+
+  private static final Logger LOG = LogManager.getLogger();
+  private final Supplier<ScheduledDuties> scheduledDutiesFactory;
+  protected final Map<BLSPublicKey, Validator> validators;
+  private final ValidatorIndexProvider validatorIndexProvider;
+
+  protected AbstractDutyLoader(
+      final Supplier<ScheduledDuties> scheduledDutiesFactory,
+      final Map<BLSPublicKey, Validator> validators,
+      final ValidatorIndexProvider validatorIndexProvider) {
+    this.scheduledDutiesFactory = scheduledDutiesFactory;
+    this.validators = validators;
+    this.validatorIndexProvider = validatorIndexProvider;
+    // TODO: Find a new place to set the local_validator_count metric
+  }
+
+  @Override
+  public SafeFuture<ScheduledDuties> loadDutiesForEpoch(final UInt64 epoch) {
+    LOG.trace("Requesting attestation duties for epoch {}", epoch);
+    final ScheduledDuties scheduledDuties = scheduledDutiesFactory.get();
+    return requestDuties(epoch, validatorIndexProvider.getValidatorIndices(validators.keySet()))
+        .thenApply(
+            maybeDuties ->
+                maybeDuties.orElseThrow(
+                    () ->
+                        new NodeDataUnavailableException(
+                            "Duties could not be calculated because chain data was not yet available")))
+        .thenCompose(duties -> scheduleAllDuties(scheduledDuties, duties))
+        .thenApply(__ -> scheduledDuties);
+  }
+
+  protected abstract SafeFuture<Optional<List<D>>> requestDuties(
+      final UInt64 epoch, final Collection<Integer> validatorIndices);
+
+  private SafeFuture<Void> scheduleAllDuties(
+      final ScheduledDuties scheduledDuties, final List<D> duties) {
+    return SafeFuture.allOf(
+        duties.stream()
+            .map(duty -> scheduleDuties(scheduledDuties, duty))
+            .toArray(SafeFuture[]::new));
+  }
+
+  protected abstract SafeFuture<Void> scheduleDuties(
+      final ScheduledDuties scheduledDuties, final D duty);
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -44,7 +44,6 @@ public class AttestationDutyLoader extends AbstractDutyLoader<AttesterDuties> {
     super(scheduledDutiesFactory, validators, validatorIndexProvider);
     this.validatorApiChannel = validatorApiChannel;
     this.forkProvider = forkProvider;
-    // TODO: Find a new place to set the local_validator_count metric
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -13,111 +13,56 @@
 
 package tech.pegasys.teku.validator.client;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.util.CommitteeUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.validator.api.AttesterDuties;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
-import tech.pegasys.teku.validator.api.ValidatorDuties;
 import tech.pegasys.teku.validator.client.duties.ScheduledDuties;
 
-class ValidatorApiDutyLoader implements DutyLoader {
+public class AttestationDutyLoader extends AbstractDutyLoader<AttesterDuties> {
+
   private static final Logger LOG = LogManager.getLogger();
   private final ValidatorApiChannel validatorApiChannel;
   private final ForkProvider forkProvider;
-  private final Supplier<ScheduledDuties> scheduledDutiesFactory;
-  private final Map<BLSPublicKey, Validator> validators;
 
-  ValidatorApiDutyLoader(
-      final MetricsSystem metricsSystem,
+  public AttestationDutyLoader(
       final ValidatorApiChannel validatorApiChannel,
       final ForkProvider forkProvider,
       final Supplier<ScheduledDuties> scheduledDutiesFactory,
-      final Map<BLSPublicKey, Validator> validators) {
+      final Map<BLSPublicKey, Validator> validators,
+      final ValidatorIndexProvider validatorIndexProvider) {
+    super(scheduledDutiesFactory, validators, validatorIndexProvider);
     this.validatorApiChannel = validatorApiChannel;
     this.forkProvider = forkProvider;
-    this.scheduledDutiesFactory = scheduledDutiesFactory;
-    this.validators = validators;
-    metricsSystem.createIntegerGauge(
-        TekuMetricCategory.VALIDATOR,
-        "local_validator_count",
-        "Current number of validators running in this validator client",
-        this.validators::size);
+    // TODO: Find a new place to set the local_validator_count metric
   }
 
   @Override
-  public SafeFuture<ScheduledDuties> loadDutiesForEpoch(final UInt64 epoch) {
-    return requestAndScheduleDutiesForEpoch(epoch);
+  protected SafeFuture<Optional<List<AttesterDuties>>> requestDuties(
+      final UInt64 epoch, final Collection<Integer> validatorIndices) {
+    return validatorApiChannel.getAttestationDuties(epoch, validatorIndices);
   }
 
-  private SafeFuture<ScheduledDuties> requestAndScheduleDutiesForEpoch(final UInt64 epoch) {
-    LOG.trace("Requesting duties for epoch {}", epoch);
-    final ScheduledDuties scheduledDuties = scheduledDutiesFactory.get();
-    return validatorApiChannel
-        .getDuties(epoch, validators.keySet())
-        .thenApply(
-            maybeDuties ->
-                maybeDuties.orElseThrow(
-                    () ->
-                        new NodeDataUnavailableException(
-                            "Duties could not be calculated because chain data was not yet available")))
-        .thenCompose(duties -> scheduleAllDuties(scheduledDuties, duties))
-        .thenApply(__ -> scheduledDuties);
-  }
+  @Override
+  protected SafeFuture<Void> scheduleDuties(
+      final ScheduledDuties scheduledDuties, final AttesterDuties duty) {
+    final int attestationCommitteeIndex = duty.getCommitteeIndex();
+    final int attestationCommitteePosition = duty.getValidatorCommitteeIndex();
+    final int validatorIndex = duty.getValidatorIndex();
+    final Validator validator = validators.get(duty.getPublicKey());
+    final UInt64 slot = duty.getSlot();
+    final int aggregatorModulo = CommitteeUtil.getAggregatorModulo(duty.getCommitteeLength());
 
-  private SafeFuture<Void> scheduleAllDuties(
-      final ScheduledDuties scheduledDuties, final List<ValidatorDuties> duties) {
-    return SafeFuture.allOf(
-        duties.stream()
-            .map(validatorDuties -> scheduleDuties(scheduledDuties, validatorDuties))
-            .toArray(SafeFuture[]::new));
-  }
-
-  private SafeFuture<Void> scheduleDuties(
-      final ScheduledDuties scheduledDuties, final ValidatorDuties validatorDuties) {
-    LOG.trace("Got validator duties: {}", validatorDuties);
-    final Validator validator = validators.get(validatorDuties.getPublicKey());
-    return validatorDuties
-        .getDuties()
-        .map(
-            duties -> {
-              duties
-                  .getBlockProposalSlots()
-                  .forEach(slot -> scheduleBlockProduction(scheduledDuties, validator, slot));
-              return scheduleAttestationDuties(
-                  scheduledDuties,
-                  duties.getAttestationCommitteeIndex(),
-                  duties.getAttestationCommitteePosition(),
-                  duties.getValidatorIndex(),
-                  validator,
-                  duties.getAttestationSlot(),
-                  duties.getAggregatorModulo());
-            })
-        .orElse(SafeFuture.COMPLETE);
-  }
-
-  private void scheduleBlockProduction(
-      final ScheduledDuties scheduledDuties, final Validator validator, final UInt64 slot) {
-    scheduledDuties.scheduleBlockProduction(slot, validator);
-  }
-
-  private SafeFuture<Void> scheduleAttestationDuties(
-      final ScheduledDuties scheduledDuties,
-      final int attestationCommitteeIndex,
-      final int attestationCommitteePosition,
-      final int validatorIndex,
-      final Validator validator,
-      final UInt64 slot,
-      final int aggregatorModulo) {
     final SafeFuture<Optional<Attestation>> unsignedAttestationFuture =
         scheduleAttestationProduction(
             scheduledDuties,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.validator.api.ProposerDuties;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.duties.ScheduledDuties;
+
+public class BlockProductionDutyLoader extends AbstractDutyLoader<ProposerDuties> {
+
+  private final ValidatorApiChannel validatorApiChannel;
+
+  protected BlockProductionDutyLoader(
+      final ValidatorApiChannel validatorApiChannel,
+      final Supplier<ScheduledDuties> scheduledDutiesFactory,
+      final Map<BLSPublicKey, Validator> validators,
+      final ValidatorIndexProvider validatorIndexProvider) {
+    super(scheduledDutiesFactory, validators, validatorIndexProvider);
+    this.validatorApiChannel = validatorApiChannel;
+  }
+
+  @Override
+  protected SafeFuture<Optional<List<ProposerDuties>>> requestDuties(
+      final UInt64 epoch, final Collection<Integer> validatorIndices) {
+    return validatorApiChannel.getProposerDuties(epoch);
+  }
+
+  @Override
+  protected SafeFuture<Void> scheduleDuties(
+      final ScheduledDuties scheduledDuties, final ProposerDuties duty) {
+    final Validator validator = validators.get(duty.getPublicKey());
+    if (validator != null) {
+      scheduledDuties.scheduleBlockProduction(duty.getSlot(), validator);
+    }
+    return SafeFuture.COMPLETE;
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/RetryingDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/RetryingDutyLoader.java
@@ -43,6 +43,7 @@ public class RetryingDutyLoader implements DutyLoader {
 
   private SafeFuture<ScheduledDuties> requestDuties(
       final UInt64 epoch, final SafeFuture<ScheduledDuties> cancellable) {
+    LOG.trace("Request duties for epoch {}", epoch);
     return delegate
         .loadDutiesForEpoch(epoch)
         .exceptionallyCompose(
@@ -67,8 +68,9 @@ public class RetryingDutyLoader implements DutyLoader {
                         + ". Retrying after delay.",
                     error);
               }
+              // Short delay before retrying as loading duties is very time sensitive
               return asyncRunner.runAfterDelay(
-                  () -> requestDuties(epoch, cancellable), 5, TimeUnit.SECONDS);
+                  () -> requestDuties(epoch, cancellable), 1, TimeUnit.SECONDS);
             });
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.io.SyncDataAccessor;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
@@ -103,12 +104,24 @@ public class ValidatorClientService extends Service {
         new AttestationDutyScheduler(metricsSystem, attestationDutyLoader, stableSubnetSubscriber);
     final BlockDutyScheduler blockDutyScheduler =
         new BlockDutyScheduler(metricsSystem, blockDutyLoader);
+
+    addValidatorCountMetric(metricsSystem, validators.size());
+
     return new ValidatorClientService(
         eventChannels,
         attestationDutyScheduler,
         blockDutyScheduler,
         validatorIndexProvider,
         beaconNodeApi);
+  }
+
+  private static void addValidatorCountMetric(
+      final MetricsSystem metricsSystem, final int validatorCount) {
+    metricsSystem.createIntegerGauge(
+        TekuMetricCategory.VALIDATOR,
+        "local_validator_count",
+        "Current number of validators running in this validator client",
+        () -> validatorCount);
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIndexProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIndexProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+
+public class ValidatorIndexProvider {
+  private static final Logger LOG = LogManager.getLogger();
+  private final List<BLSPublicKey> unknownValidators;
+  private final ValidatorApiChannel validatorApiChannel;
+  private final Map<BLSPublicKey, Integer> validatorIndexesByPublicKey = new ConcurrentHashMap<>();
+
+  private final AtomicBoolean requestInProgress = new AtomicBoolean(false);
+
+  public ValidatorIndexProvider(
+      final Collection<BLSPublicKey> validators, final ValidatorApiChannel validatorApiChannel) {
+    this.unknownValidators = new CopyOnWriteArrayList<>(validators);
+    this.validatorApiChannel = validatorApiChannel;
+  }
+
+  public void lookupValidators() {
+    if (!requestInProgress.compareAndSet(false, true)) {
+      return;
+    }
+    validatorApiChannel
+        .getValidatorIndices(unknownValidators)
+        .thenAccept(
+            knownValidators -> {
+              validatorIndexesByPublicKey.putAll(knownValidators);
+              unknownValidators.removeAll(knownValidators.keySet());
+            })
+        .orTimeout(30, TimeUnit.SECONDS)
+        .whenComplete((result, error) -> requestInProgress.set(false))
+        .finish(error -> LOG.error("Failed to load validator indexes.", error));
+  }
+
+  public Optional<Integer> getValidatorIndex(final BLSPublicKey publicKey) {
+    return Optional.ofNullable(validatorIndexesByPublicKey.get(publicKey));
+  }
+
+  public Collection<Integer> getValidatorIndices(final Collection<BLSPublicKey> publicKeys) {
+    return publicKeys.stream().flatMap(key -> getValidatorIndex(key).stream()).collect(toList());
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
+
+public class ValidatorTimingActions implements ValidatorTimingChannel {
+  private final ValidatorIndexProvider validatorIndexProvider;
+  private final ValidatorTimingChannel blockDuties;
+  private final ValidatorTimingChannel attestationDuties;
+
+  public ValidatorTimingActions(
+      final ValidatorIndexProvider validatorIndexProvider,
+      final ValidatorTimingChannel blockDuties,
+      final ValidatorTimingChannel attestationDuties) {
+    this.validatorIndexProvider = validatorIndexProvider;
+    this.blockDuties = blockDuties;
+    this.attestationDuties = attestationDuties;
+  }
+
+  @Override
+  public void onSlot(final UInt64 slot) {
+    validatorIndexProvider.lookupValidators();
+    blockDuties.onSlot(slot);
+    attestationDuties.onSlot(slot);
+  }
+
+  @Override
+  public void onChainReorg(final UInt64 newSlot, final UInt64 commonAncestorSlot) {
+    blockDuties.onChainReorg(newSlot, commonAncestorSlot);
+    attestationDuties.onChainReorg(newSlot, commonAncestorSlot);
+  }
+
+  @Override
+  public void onPossibleMissedEvents() {
+    blockDuties.onPossibleMissedEvents();
+    attestationDuties.onPossibleMissedEvents();
+  }
+
+  @Override
+  public void onBlockProductionDue(final UInt64 slot) {
+    blockDuties.onBlockProductionDue(slot);
+    attestationDuties.onBlockProductionDue(slot);
+  }
+
+  @Override
+  public void onAttestationCreationDue(final UInt64 slot) {
+    attestationDuties.onAttestationCreationDue(slot);
+    blockDuties.onAttestationCreationDue(slot);
+  }
+
+  @Override
+  public void onAttestationAggregationDue(final UInt64 slot) {
+    attestationDuties.onAttestationAggregationDue(slot);
+    blockDuties.onAttestationAggregationDue(slot);
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AbstractDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AbstractDutySchedulerTest.java
@@ -13,13 +13,13 @@
 
 package tech.pegasys.teku.validator.client;
 
-import static java.util.Collections.emptyList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +40,8 @@ public abstract class AbstractDutySchedulerTest {
   static final BLSPublicKey VALIDATOR1_KEY = BLSPublicKey.random(100);
   static final BLSPublicKey VALIDATOR2_KEY = BLSPublicKey.random(200);
   static final Collection<BLSPublicKey> VALIDATOR_KEYS = Set.of(VALIDATOR1_KEY, VALIDATOR2_KEY);
+  static final List<Integer> VALIDATOR_INDICES = List.of(123, 559);
+  final ValidatorIndexProvider validatorIndexProvider = mock(ValidatorIndexProvider.class);
   final Signer validator1Signer = mock(Signer.class);
   final Signer validator2Signer = mock(Signer.class);
   final Validator validator1 = new Validator(VALIDATOR1_KEY, validator1Signer, Optional.empty());
@@ -57,8 +59,7 @@ public abstract class AbstractDutySchedulerTest {
 
   @BeforeEach
   public void setUp() {
-    when(validatorApiChannel.getDuties(any(), any()))
-        .thenReturn(completedFuture(Optional.of(emptyList())));
+    when(validatorIndexProvider.getValidatorIndices(VALIDATOR_KEYS)).thenReturn(VALIDATOR_INDICES);
     when(dutyFactory.createAttestationProductionDuty(any()))
         .thenReturn(mock(AttestationProductionDuty.class));
     final SafeFuture<BLSSignature> rejectAggregationSignature =

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorIndexProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorIndexProviderTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+
+class ValidatorIndexProviderTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+
+  private final BLSPublicKey key1 = dataStructureUtil.randomPublicKey();
+
+  private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
+
+  @Test
+  void shouldReturnEmptyWhenValidatorIsUnknown() {
+    final ValidatorIndexProvider provider =
+        new ValidatorIndexProvider(List.of(key1), validatorApiChannel);
+    assertThat(provider.getValidatorIndex(key1)).isEmpty();
+  }
+
+  @Test
+  void shouldLoadValidatorKeys() {
+    final BLSPublicKey key2 = dataStructureUtil.randomPublicKey();
+    final BLSPublicKey key3 = dataStructureUtil.randomPublicKey();
+    final List<BLSPublicKey> keys = List.of(key1, key2, key3);
+    final ValidatorIndexProvider provider = new ValidatorIndexProvider(keys, validatorApiChannel);
+
+    when(validatorApiChannel.getValidatorIndices(keys))
+        .thenReturn(SafeFuture.completedFuture(Map.of(key1, 1, key2, 20, key3, 300)));
+    provider.lookupValidators();
+
+    assertThat(provider.getValidatorIndex(key1)).contains(1);
+    assertThat(provider.getValidatorIndex(key2)).contains(20);
+    assertThat(provider.getValidatorIndex(key3)).contains(300);
+  }
+
+  @Test
+  void shouldLookupValidatorKeysThatWerePreviouslyUnknown() {
+    final BLSPublicKey key2 = dataStructureUtil.randomPublicKey();
+    final BLSPublicKey key3 = dataStructureUtil.randomPublicKey();
+    final List<BLSPublicKey> keys = List.of(key1, key2, key3);
+    final ValidatorIndexProvider provider = new ValidatorIndexProvider(keys, validatorApiChannel);
+
+    when(validatorApiChannel.getValidatorIndices(keys))
+        .thenReturn(SafeFuture.completedFuture(Map.of(key2, 20)));
+    provider.lookupValidators();
+
+    assertThat(provider.getValidatorIndex(key1)).isEmpty();
+    assertThat(provider.getValidatorIndex(key2)).contains(20);
+    assertThat(provider.getValidatorIndex(key3)).isEmpty();
+
+    when(validatorApiChannel.getValidatorIndices(List.of(key1, key3)))
+        .thenReturn(SafeFuture.completedFuture(Map.of(key1, 1, key3, 300)));
+    provider.lookupValidators();
+
+    assertThat(provider.getValidatorIndex(key1)).contains(1);
+    assertThat(provider.getValidatorIndex(key2)).contains(20);
+    assertThat(provider.getValidatorIndex(key3)).contains(300);
+  }
+
+  @Test
+  void shouldNotMakeConcurrentRequests() {
+    final SafeFuture<Map<BLSPublicKey, Integer>> result = new SafeFuture<>();
+    when(validatorApiChannel.getValidatorIndices(List.of(key1))).thenReturn(result);
+
+    final ValidatorIndexProvider provider =
+        new ValidatorIndexProvider(List.of(key1), validatorApiChannel);
+
+    provider.lookupValidators();
+    verify(validatorApiChannel).getValidatorIndices(List.of(key1));
+
+    provider.lookupValidators();
+    verifyNoMoreInteractions(validatorApiChannel);
+
+    // Can request again once the request completes.
+    result.complete(Collections.emptyMap());
+    provider.lookupValidators();
+    verify(validatorApiChannel, times(2)).getValidatorIndices(List.of(key1));
+  }
+}

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/EventSourceBeaconChainEventAdapter.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.validator.remote;
 
+import static java.util.Collections.emptyMap;
+
 import com.launchdarkly.eventsource.EventSource;
 import java.util.concurrent.CountDownLatch;
 import okhttp3.HttpUrl;
@@ -39,7 +41,7 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
     this.timeBasedEventAdapter = timeBasedEventAdapter;
     final HttpUrl eventSourceUrl =
         baseEndpoint.resolve(
-            ValidatorApiMethod.EVENTS.getPath()
+            ValidatorApiMethod.EVENTS.getPath(emptyMap())
                 + "?topics="
                 + EventType.head
                 + ","

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -180,7 +180,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
         attesterDuty.pubkey.asBLSPublicKey(),
         attesterDuty.validatorIndex.intValue(),
         attesterDuty.committeeLength.intValue(),
-        attesterDuty.committeeLength.intValue(),
+        attesterDuty.committeeIndex.intValue(),
         attesterDuty.validatorCommitteeIndex.intValue(),
         attesterDuty.slot);
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.remote.apiclient;
 
+import static java.util.Collections.emptyMap;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_AGGREGATE;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_DUTIES;
@@ -38,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -74,7 +76,7 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
 
   private static final MediaType APPLICATION_JSON =
       MediaType.parse("application/json; charset=utf-8");
-  private static final Map<String, String> EMPTY_QUERY_PARAMS = Collections.emptyMap();
+  private static final Map<String, String> EMPTY_QUERY_PARAMS = emptyMap();
 
   private final JsonProvider jsonProvider = new JsonProvider();
   private final OkHttpClient httpClient;
@@ -116,7 +118,10 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
       final UInt64 epoch, final Collection<Integer> validatorIndexes) {
     return get(
             GET_ATTESTATION_DUTIES,
-            Map.of("index", validatorIndexes.toString()),
+            Map.of("epoch", epoch.toString()),
+            Map.of(
+                "index",
+                validatorIndexes.stream().map(Object::toString).collect(Collectors.joining(","))),
             GetAttesterDutiesResponse.class)
         .map(response -> response.data)
         .orElse(Collections.emptyList());
@@ -124,7 +129,11 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
 
   @Override
   public List<ProposerDuty> getProposerDuties(final UInt64 epoch) {
-    return get(GET_PROPOSER_DUTIES, Collections.emptyMap(), GetProposerDutiesResponse.class)
+    return get(
+            GET_PROPOSER_DUTIES,
+            Map.of("epoch", epoch.toString()),
+            emptyMap(),
+            GetProposerDutiesResponse.class)
         .map(response -> response.data)
         .orElse(Collections.emptyList());
   }
@@ -194,7 +203,15 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
       final ValidatorApiMethod apiMethod,
       final Map<String, String> queryParams,
       final Class<T> responseClass) {
-    final HttpUrl.Builder httpUrlBuilder = urlBuilder(apiMethod);
+    return get(apiMethod, emptyMap(), queryParams, responseClass);
+  }
+
+  public <T> Optional<T> get(
+      final ValidatorApiMethod apiMethod,
+      final Map<String, String> urlParams,
+      final Map<String, String> queryParams,
+      final Class<T> responseClass) {
+    final HttpUrl.Builder httpUrlBuilder = urlBuilder(apiMethod, urlParams);
     if (queryParams != null && !queryParams.isEmpty()) {
       queryParams.forEach(httpUrlBuilder::addQueryParameter);
     }
@@ -216,15 +233,16 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
 
     final Request request =
         new Request.Builder()
-            .url(urlBuilder(apiMethod).build())
+            .url(urlBuilder(apiMethod, emptyMap()).build())
             .post(RequestBody.create(requestBody, APPLICATION_JSON))
             .build();
 
     return executeCall(request, responseClass);
   }
 
-  private HttpUrl.Builder urlBuilder(final ValidatorApiMethod apiMethod) {
-    return baseEndpoint.resolve(apiMethod.getPath()).newBuilder();
+  private HttpUrl.Builder urlBuilder(
+      final ValidatorApiMethod apiMethod, final Map<String, String> urlParams) {
+    return baseEndpoint.resolve(apiMethod.getPath(urlParams)).newBuilder();
   }
 
   private <T> Optional<T> executeCall(final Request request, final Class<T> responseClass) {
@@ -252,14 +270,17 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
         case 400:
           {
             LOG.error(
-                "Invalid params response from Beacon Node API - {}", response.body().string());
+                "Invalid params response from Beacon Node API (url = {}, response = {})",
+                request.url(),
+                response.body().string());
             return Optional.empty();
           }
         default:
           {
             final String responseBody = response.body().string();
             LOG.error(
-                "Unexpected error calling Beacon Node API (status = {}, response = {})",
+                "Unexpected error calling Beacon Node API (url = {}, status = {}, response = {})",
+                request.url(),
                 response.code(),
                 responseBody);
             throw new RuntimeException(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -269,11 +269,12 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
           }
         case 400:
           {
-            LOG.error(
-                "Invalid params response from Beacon Node API (url = {}, response = {})",
-                request.url(),
-                response.body().string());
-            return Optional.empty();
+            throw new IllegalArgumentException(
+                "Invalid params response from Beacon Node API (url = "
+                    + request.url()
+                    + ", response = "
+                    + response.body().string()
+                    + ")");
           }
         default:
           {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.validator.remote.apiclient;
 
 import java.util.Map;
-import java.util.Map.Entry;
 
 public enum ValidatorApiMethod {
   GET_FORK("node/fork"),
@@ -41,7 +40,7 @@ public enum ValidatorApiMethod {
 
   public String getPath(final Map<String, String> urlParams) {
     String result = path;
-    for (Entry<String, String> param : urlParams.entrySet()) {
+    for (final Map.Entry<String, String> param : urlParams.entrySet()) {
       result = result.replace(":" + param.getKey(), param.getValue());
     }
     return result;

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -13,6 +13,9 @@
 
 package tech.pegasys.teku.validator.remote.apiclient;
 
+import java.util.Map;
+import java.util.Map.Entry;
+
 public enum ValidatorApiMethod {
   GET_FORK("node/fork"),
   GET_GENESIS("eth/v1/beacon/genesis"),
@@ -36,7 +39,11 @@ public enum ValidatorApiMethod {
     this.path = path;
   }
 
-  public String getPath() {
-    return path;
+  public String getPath(final Map<String, String> urlParams) {
+    String result = path;
+    for (Entry<String, String> param : urlParams.entrySet()) {
+      result = result.replace(":" + param.getKey(), param.getValue());
+    }
+    return result;
   }
 }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -261,7 +261,8 @@ class OkHttpValidatorRestApiClientTest {
     RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getMethod()).isEqualTo("GET");
-    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_UNSIGNED_BLOCK.getPath(emptyMap()));
+    assertThat(request.getPath())
+        .contains(ValidatorApiMethod.GET_UNSIGNED_BLOCK.getPath(emptyMap()));
     assertThat(request.getRequestUrl().queryParameter("slot")).isEqualTo(slot.toString());
     assertThat(request.getRequestUrl().queryParameter("randao_reveal"))
         .isEqualTo(blsSignature.toHexString());
@@ -281,14 +282,15 @@ class OkHttpValidatorRestApiClientTest {
   }
 
   @Test
-  public void createUnsignedBlock_WhenBadRequest_ReturnsEmpty() {
+  public void createUnsignedBlock_WhenBadRequest_ThrowsIllegalArgumentException() {
     final UInt64 slot = UInt64.ONE;
     final BLSSignature blsSignature = schemaObjects.BLSSignature();
     final Optional<Bytes32> graffiti = Optional.of(Bytes32.random());
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(400));
 
-    assertThat(apiClient.createUnsignedBlock(slot, blsSignature, graffiti)).isEmpty();
+    assertThatThrownBy(() -> apiClient.createUnsignedBlock(slot, blsSignature, graffiti))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -320,7 +322,8 @@ class OkHttpValidatorRestApiClientTest {
     RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getMethod()).isEqualTo("POST");
-    assertThat(request.getPath()).contains(ValidatorApiMethod.SEND_SIGNED_BLOCK.getPath(emptyMap()));
+    assertThat(request.getPath())
+        .contains(ValidatorApiMethod.SEND_SIGNED_BLOCK.getPath(emptyMap()));
     assertThat(request.getBody().readString(StandardCharsets.UTF_8))
         .isEqualTo(asJson(signedBeaconBlock));
   }
@@ -336,12 +339,13 @@ class OkHttpValidatorRestApiClientTest {
   }
 
   @Test
-  public void sendSignedBlock_WhenBadParameters_DoesNotFailHandlingResponse() {
+  public void sendSignedBlock_WhenBadParameters_ThrowsIllegalArgumentException() {
     final SignedBeaconBlock signedBeaconBlock = schemaObjects.signedBeaconBlock();
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(400));
 
-    apiClient.sendSignedBlock(signedBeaconBlock);
+    assertThatThrownBy(() -> apiClient.sendSignedBlock(signedBeaconBlock))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -377,20 +381,22 @@ class OkHttpValidatorRestApiClientTest {
     RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getMethod()).isEqualTo("GET");
-    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_UNSIGNED_ATTESTATION.getPath(emptyMap()));
+    assertThat(request.getPath())
+        .contains(ValidatorApiMethod.GET_UNSIGNED_ATTESTATION.getPath(emptyMap()));
     assertThat(request.getRequestUrl().queryParameter("slot")).isEqualTo(slot.toString());
     assertThat(request.getRequestUrl().queryParameter("committee_index"))
         .isEqualTo(String.valueOf(committeeIndex));
   }
 
   @Test
-  public void createUnsignedAttestation_WhenBadRequest_ReturnsEmpty() {
+  public void createUnsignedAttestation_WhenBadRequest_ThrowsIllegalArgumentException() {
     final UInt64 slot = UInt64.ONE;
     final int committeeIndex = 1;
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(400));
 
-    assertThat(apiClient.createUnsignedAttestation(slot, committeeIndex)).isEmpty();
+    assertThatThrownBy(() -> apiClient.createUnsignedAttestation(slot, committeeIndex))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -430,17 +436,19 @@ class OkHttpValidatorRestApiClientTest {
     RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getMethod()).isEqualTo("POST");
-    assertThat(request.getPath()).contains(ValidatorApiMethod.SEND_SIGNED_ATTESTATION.getPath(emptyMap()));
+    assertThat(request.getPath())
+        .contains(ValidatorApiMethod.SEND_SIGNED_ATTESTATION.getPath(emptyMap()));
     assertThat(request.getBody().readString(StandardCharsets.UTF_8)).isEqualTo(asJson(attestation));
   }
 
   @Test
-  public void sendSignedAttestation_WhenBadParameters_DoesNotFailHandlingResponse() {
+  public void sendSignedAttestation_WhenBadParameters_ThrowsIllegalArgumentException() {
     final Attestation attestation = schemaObjects.attestation();
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(400));
 
-    apiClient.sendSignedAttestation(attestation);
+    assertThatThrownBy(() -> apiClient.sendSignedAttestation(attestation))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -473,12 +481,13 @@ class OkHttpValidatorRestApiClientTest {
   }
 
   @Test
-  public void createAggregate_WhenBadParameters_ReturnsEmpty() {
+  public void createAggregate_WhenBadParameters_ThrowsIllegalArgumentException() {
     final Bytes32 attestationHashTreeRoot = Bytes32.random();
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(400));
 
-    assertThat(apiClient.createAggregate(attestationHashTreeRoot)).isEmpty();
+    assertThatThrownBy(() -> apiClient.createAggregate(attestationHashTreeRoot))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -524,12 +533,13 @@ class OkHttpValidatorRestApiClientTest {
   }
 
   @Test
-  public void sendAggregateAndProof_WhenBadParameters_DoesNotFailHandlingResponse() {
+  public void sendAggregateAndProof_WhenBadParameters_ThrowsIllegalArgumentException() {
     final SignedAggregateAndProof signedAggregateAndProof = schemaObjects.signedAggregateAndProof();
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(400));
 
-    apiClient.sendAggregateAndProof(signedAggregateAndProof);
+    assertThatThrownBy(() -> apiClient.sendAggregateAndProof(signedAggregateAndProof))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -566,13 +576,16 @@ class OkHttpValidatorRestApiClientTest {
 
   @Test
   public void
-      subscribeToBeaconCommitteeForAggregation_WhenBadRequest_DoesNotFailHandlingResponse() {
+      subscribeToBeaconCommitteeForAggregation_WhenBadRequest_ThrowsIllegalArgumentException() {
     final int committeeIndex = 1;
     final UInt64 aggregationSlot = UInt64.ONE;
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(400));
 
-    apiClient.subscribeToBeaconCommitteeForAggregation(committeeIndex, aggregationSlot);
+    assertThatThrownBy(
+            () ->
+                apiClient.subscribeToBeaconCommitteeForAggregation(committeeIndex, aggregationSlot))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -607,12 +620,12 @@ class OkHttpValidatorRestApiClientTest {
   }
 
   @Test
-  public void subscribeToPersistentSubnets_WhenBadRequest_DoesNotFailHandlingResponse() {
+  public void subscribeToPersistentSubnets_WhenBadRequest_ThrowsIllegalArgumentException() {
     final Set<SubnetSubscription> subnetSubscriptions = Set.of(schemaObjects.subnetSubscription());
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(400));
-
-    apiClient.subscribeToPersistentSubnets(subnetSubscriptions);
+    assertThatThrownBy(() -> apiClient.subscribeToPersistentSubnets(subnetSubscriptions))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.remote.apiclient;
 
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -73,7 +74,7 @@ class OkHttpValidatorRestApiClientTest {
     RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getMethod()).isEqualTo("GET");
-    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_FORK.getPath());
+    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_FORK.getPath(emptyMap()));
   }
 
   @Test
@@ -113,7 +114,7 @@ class OkHttpValidatorRestApiClientTest {
     RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getMethod()).isEqualTo("GET");
-    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_GENESIS.getPath());
+    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_GENESIS.getPath(emptyMap()));
   }
 
   @Test
@@ -153,7 +154,7 @@ class OkHttpValidatorRestApiClientTest {
 
     final RecordedRequest request = mockWebServer.takeRequest();
     assertThat(request.getMethod()).isEqualTo("GET");
-    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_VALIDATORS.getPath());
+    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_VALIDATORS.getPath(emptyMap()));
     // %2C is ,
     assertThat(request.getPath()).contains("?validator_id=1%2C0x1234");
   }
@@ -199,7 +200,7 @@ class OkHttpValidatorRestApiClientTest {
     RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getMethod()).isEqualTo("POST");
-    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_DUTIES.getPath());
+    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_DUTIES.getPath(emptyMap()));
     assertThat(request.getBody().readString(StandardCharsets.UTF_8))
         .isEqualTo(asJson(validatorDutiesRequest));
   }
@@ -260,7 +261,7 @@ class OkHttpValidatorRestApiClientTest {
     RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getMethod()).isEqualTo("GET");
-    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_UNSIGNED_BLOCK.getPath());
+    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_UNSIGNED_BLOCK.getPath(emptyMap()));
     assertThat(request.getRequestUrl().queryParameter("slot")).isEqualTo(slot.toString());
     assertThat(request.getRequestUrl().queryParameter("randao_reveal"))
         .isEqualTo(blsSignature.toHexString());
@@ -319,7 +320,7 @@ class OkHttpValidatorRestApiClientTest {
     RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getMethod()).isEqualTo("POST");
-    assertThat(request.getPath()).contains(ValidatorApiMethod.SEND_SIGNED_BLOCK.getPath());
+    assertThat(request.getPath()).contains(ValidatorApiMethod.SEND_SIGNED_BLOCK.getPath(emptyMap()));
     assertThat(request.getBody().readString(StandardCharsets.UTF_8))
         .isEqualTo(asJson(signedBeaconBlock));
   }
@@ -376,7 +377,7 @@ class OkHttpValidatorRestApiClientTest {
     RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getMethod()).isEqualTo("GET");
-    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_UNSIGNED_ATTESTATION.getPath());
+    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_UNSIGNED_ATTESTATION.getPath(emptyMap()));
     assertThat(request.getRequestUrl().queryParameter("slot")).isEqualTo(slot.toString());
     assertThat(request.getRequestUrl().queryParameter("committee_index"))
         .isEqualTo(String.valueOf(committeeIndex));
@@ -429,7 +430,7 @@ class OkHttpValidatorRestApiClientTest {
     RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getMethod()).isEqualTo("POST");
-    assertThat(request.getPath()).contains(ValidatorApiMethod.SEND_SIGNED_ATTESTATION.getPath());
+    assertThat(request.getPath()).contains(ValidatorApiMethod.SEND_SIGNED_ATTESTATION.getPath(emptyMap()));
     assertThat(request.getBody().readString(StandardCharsets.UTF_8)).isEqualTo(asJson(attestation));
   }
 
@@ -465,7 +466,7 @@ class OkHttpValidatorRestApiClientTest {
     RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getMethod()).isEqualTo("GET");
-    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_AGGREGATE.getPath());
+    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_AGGREGATE.getPath(emptyMap()));
     assertThat(request.getRequestUrl().queryParameter("slot")).isEqualTo(slot.toString());
     assertThat(request.getRequestUrl().queryParameter("attestation_data_root"))
         .isEqualTo(attestationHashTreeRoot.toHexString());
@@ -517,7 +518,7 @@ class OkHttpValidatorRestApiClientTest {
 
     assertThat(request.getMethod()).isEqualTo("POST");
     assertThat(request.getPath())
-        .contains(ValidatorApiMethod.SEND_SIGNED_AGGREGATE_AND_PROOF.getPath());
+        .contains(ValidatorApiMethod.SEND_SIGNED_AGGREGATE_AND_PROOF.getPath(emptyMap()));
     assertThat(request.getBody().readString(StandardCharsets.UTF_8))
         .isEqualTo(asJson(signedAggregateAndProof));
   }
@@ -558,7 +559,7 @@ class OkHttpValidatorRestApiClientTest {
 
     assertThat(request.getMethod()).isEqualTo("POST");
     assertThat(request.getPath())
-        .contains(ValidatorApiMethod.SUBSCRIBE_TO_COMMITTEE_FOR_AGGREGATION.getPath());
+        .contains(ValidatorApiMethod.SUBSCRIBE_TO_COMMITTEE_FOR_AGGREGATION.getPath(emptyMap()));
     assertThat(request.getBody().readString(StandardCharsets.UTF_8))
         .isEqualTo(asJson(expectedRequest));
   }
@@ -600,7 +601,7 @@ class OkHttpValidatorRestApiClientTest {
 
     assertThat(request.getMethod()).isEqualTo("POST");
     assertThat(request.getPath())
-        .contains(ValidatorApiMethod.SUBSCRIBE_TO_PERSISTENT_SUBNETS.getPath());
+        .contains(ValidatorApiMethod.SUBSCRIBE_TO_PERSISTENT_SUBNETS.getPath(emptyMap()));
     assertThat(request.getBody().readString(StandardCharsets.UTF_8))
         .isEqualTo(asJson(subnetSubscriptions));
   }


### PR DESCRIPTION
## PR Description
Use the separate APIs to load attestation and block duties rather than the older combined one.

## Fixed Issue(s)
#1918 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.