### PR TITLE
Implement POST `/eth/v1/validator/duties/attester/:epoch`

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -70,6 +70,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetIdentity;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeerById;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttesterDuties;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetProposerDuties;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostAttesterDuties;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAggregate;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAttestation;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetNewBlock;
@@ -264,6 +265,7 @@ public class BeaconRestApi {
 
   private void addV1ValidatorHandlers(final DataProvider dataProvider) {
     app.get(GetAttesterDuties.ROUTE, new GetAttesterDuties(dataProvider, jsonProvider));
+    app.post(PostAttesterDuties.ROUTE, new PostAttesterDuties(dataProvider, jsonProvider));
     app.get(GetProposerDuties.ROUTE, new GetProposerDuties(dataProvider, jsonProvider));
     app.get(
         tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetNewBlock.ROUTE,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.EPOCH;
-import static tech.pegasys.teku.beaconrestapi.RestApiConstants.INDEX;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
@@ -31,21 +30,21 @@ import io.javalin.http.Handler;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
-import io.javalin.plugin.openapi.annotations.OpenApiParam;
+import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
 import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
 import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
-import tech.pegasys.teku.beaconrestapi.ListQueryParameterUtils;
 import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -53,21 +52,21 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.util.config.Constants;
 
-public class GetAttesterDuties extends AbstractHandler implements Handler {
+public class PostAttesterDuties extends AbstractHandler implements Handler {
   private static final Logger LOG = LogManager.getLogger();
   public static final String ROUTE = "/eth/v1/validator/duties/attester/:epoch";
   private final ValidatorDataProvider validatorDataProvider;
   private final SyncDataProvider syncDataProvider;
   private final ChainDataProvider chainDataProvider;
 
-  public GetAttesterDuties(final DataProvider dataProvider, final JsonProvider jsonProvider) {
+  public PostAttesterDuties(final DataProvider dataProvider, final JsonProvider jsonProvider) {
     super(jsonProvider);
     this.validatorDataProvider = dataProvider.getValidatorDataProvider();
     this.syncDataProvider = dataProvider.getSyncDataProvider();
     this.chainDataProvider = dataProvider.getChainDataProvider();
   }
 
-  GetAttesterDuties(
+  PostAttesterDuties(
       final ChainDataProvider chainDataProvider,
       final SyncDataProvider syncDataProvider,
       final ValidatorDataProvider validatorDataProvider,
@@ -80,8 +79,7 @@ public class GetAttesterDuties extends AbstractHandler implements Handler {
 
   @OpenApi(
       path = ROUTE,
-      method = HttpMethod.GET,
-      deprecated = true,
+      method = HttpMethod.POST,
       summary = "Get attester duties",
       tags = {TAG_V1_VALIDATOR, TAG_VALIDATOR_REQUIRED},
       description =
@@ -90,14 +88,13 @@ public class GetAttesterDuties extends AbstractHandler implements Handler {
               + "Duties should only need to be checked once per epoch, however a "
               + "chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur, "
               + "resulting in a change of duties. For full safety, "
-              + "you should monitor chain reorganizations events.\n\n"
-              + "DEPRECATED, use POST endpoint, as it is able to cater for larger request sizes.",
-      queryParams = {
-        @OpenApiParam(
-            name = INDEX,
-            required = true,
-            description = "Validator indexes. Allows comma separated values per field."),
-      },
+              + "you should monitor chain reorganizations events.",
+      requestBody =
+          @OpenApiRequestBody(
+              content = @OpenApiContent(from = String[].class),
+              description =
+                  "An array of the validator indices for which to obtain the duties.\n\n"
+                      + "```\n[\n  \"(uint64)\",\n  ...\n]\n```\n\n"),
       responses = {
         @OpenApiResponse(
             status = RES_OK,
@@ -107,44 +104,39 @@ public class GetAttesterDuties extends AbstractHandler implements Handler {
         @OpenApiResponse(status = RES_SERVICE_UNAVAILABLE, description = SERVICE_UNAVAILABLE)
       })
   @Override
-  public void handle(@NotNull final Context ctx) throws Exception {
+  public void handle(Context ctx) throws Exception {
     if (!validatorDataProvider.isStoreAvailable() || syncDataProvider.isSyncing()) {
       ctx.status(SC_SERVICE_UNAVAILABLE);
       return;
     }
-
     final Map<String, String> parameters = ctx.pathParamMap();
     try {
       final UInt64 epoch = UInt64.valueOf(parameters.get(EPOCH));
       final UInt64 currentEpoch = chainDataProvider.getCurrentEpoch();
       if (currentEpoch.plus(Constants.MIN_SEED_LOOKAHEAD).isLessThan(epoch)) {
-        ctx.result(
-            jsonProvider.objectToJSON(
-                new BadRequest(
-                    "Cannot get attester duties for "
-                        + epoch.minus(currentEpoch)
-                        + " epochs ahead")));
         ctx.status(SC_BAD_REQUEST);
+        final String message =
+            "Cannot get attester duties for " + epoch.minus(currentEpoch) + " epochs ahead";
+        ctx.result(BadRequest.badRequest(jsonProvider, message));
         return;
       }
-      final List<Integer> indexes =
-          ListQueryParameterUtils.getParameterAsIntegerList(ctx.queryParamMap(), INDEX);
+      final UInt64[] indexes = jsonProvider.jsonToObject(ctx.body(), UInt64[].class);
 
       SafeFuture<Optional<List<AttesterDuty>>> future =
-          validatorDataProvider.getAttesterDuties(epoch, indexes);
+          validatorDataProvider.getAttesterDuties(
+              epoch, Arrays.stream(indexes).map(UInt64::intValue).collect(Collectors.toList()));
 
       handleOptionalResult(ctx, future, this::handleResult, List.of());
 
     } catch (NumberFormatException ex) {
       LOG.trace("Error parsing", ex);
       ctx.status(SC_BAD_REQUEST);
-      ctx.result(
-          jsonProvider.objectToJSON(
-              new BadRequest("Invalid epoch " + parameters.get(EPOCH) + " or index specified")));
+      final String message = "Invalid epoch " + parameters.get(EPOCH) + " or index specified";
+      ctx.result(BadRequest.badRequest(jsonProvider, message));
     } catch (IllegalArgumentException ex) {
-      LOG.trace("Illegal argument in GetAttesterDuties", ex);
+      LOG.trace("Illegal argument in PostAttesterDuties", ex);
       ctx.status(SC_BAD_REQUEST);
-      ctx.result(jsonProvider.objectToJSON(new BadRequest(ex.getMessage())));
+      ctx.result(BadRequest.badRequest(jsonProvider, ex.getMessage()));
     }
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetVersion;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttesterDuties;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetNewBlock;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetProposerDuties;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostAttesterDuties;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
@@ -106,6 +107,11 @@ public class BeaconRestApiV1Test {
   @Test
   public void shouldHaveGetAttesterDutiesEndpoint() {
     verify(app).get(eq(GetAttesterDuties.ROUTE), any(GetAttesterDuties.class));
+  }
+
+  @Test
+  public void shouldHavePostAttesterDutiesEndpoint() {
+    verify(app).post(eq(PostAttesterDuties.ROUTE), any(PostAttesterDuties.class));
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDutiesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDutiesTest.java
@@ -31,12 +31,12 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class GetAttesterDutiesTest extends AbstractValidatorApiTest {
+public class PostAttesterDutiesTest extends AbstractValidatorApiTest {
 
   @BeforeEach
   public void setup() {
     handler =
-        new GetAttesterDuties(
+        new PostAttesterDuties(
             chainDataProvider, syncDataProvider, validatorDataProvider, jsonProvider);
   }
 
@@ -46,7 +46,7 @@ public class GetAttesterDutiesTest extends AbstractValidatorApiTest {
     when(syncService.isSyncActive()).thenReturn(false);
     when(chainDataProvider.getCurrentEpoch()).thenReturn(UInt64.valueOf(99));
     when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
-    when(context.queryParamMap()).thenReturn(Map.of("index", List.of("2")));
+    when(context.body()).thenReturn("[\"2\"]");
     when(validatorDataProvider.getAttesterDuties(eq(UInt64.valueOf(100)), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
 
@@ -61,7 +61,7 @@ public class GetAttesterDutiesTest extends AbstractValidatorApiTest {
     when(syncService.isSyncActive()).thenReturn(false);
     when(chainDataProvider.getCurrentEpoch()).thenReturn(UInt64.valueOf(99));
     when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
-    when(context.queryParamMap()).thenReturn(Map.of("index", List.of("2")));
+    when(context.body()).thenReturn("[\"2\"]");
     List<AttesterDuty> duties =
         List.of(getDuty(2, 1, 2, 3, compute_start_slot_at_epoch(UInt64.valueOf(100))));
     when(validatorDataProvider.getAttesterDuties(eq(UInt64.valueOf(100)), any()))


### PR DESCRIPTION
 - deprecated the GET on `/eth/v1/validator/duties/attester/:epoch`, it doesn't support large enough queries.

 fixes #2838

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.