### PR TITLE
Reveal the validator command CLI options

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
@@ -19,12 +19,14 @@ import picocli.CommandLine.Option;
 
 public class BeaconRestApiOptions {
 
+  public static final int DEFAULT_REST_API_PORT = 5051;
+
   @Option(
       names = {"--rest-api-port"},
       paramLabel = "<INTEGER>",
       description = "Port number of Beacon Rest API",
       arity = "1")
-  private int restApiPort = 5051;
+  private int restApiPort = DEFAULT_REST_API_PORT;
 
   @Option(
       names = {"--rest-api-docs-enabled"},

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
@@ -23,8 +23,9 @@ import tech.pegasys.teku.util.cli.VersionProvider;
 public class LoggingOptions {
 
   private static final String SEP = System.getProperty("file.separator");
-  public static final String DEFAULT_LOG_FILE =
-      StringUtils.joinWith(SEP, VersionProvider.defaultStoragePath(), "logs", "teku.log");
+  private static final String DEFAULT_LOG_DIR = VersionProvider.defaultStoragePath() + SEP + "logs";
+  public static final String DEFAULT_LOG_FILE = DEFAULT_LOG_DIR + SEP + "teku.log";
+  public static final String DEFAULT_VC_LOG_FILE = DEFAULT_LOG_DIR + SEP + "teku-validator.log";
   public static final String DEFAULT_LOG_FILE_NAME_PATTERN =
       StringUtils.joinWith(
           SEP, VersionProvider.defaultStoragePath(), "logs", "teku_%d{yyyy-MM-dd}.log");
@@ -110,6 +111,14 @@ public class LoggingOptions {
       fallbackValue = "true",
       arity = "0..1")
   private boolean logWireGossipEnabled = false;
+
+  public LoggingOptions() {
+    this(DEFAULT_LOG_FILE);
+  }
+
+  public LoggingOptions(final String defaultLogFile) {
+    this.logFile = defaultLogFile;
+  }
 
   public boolean isLogColorEnabled() {
     return logColorEnabled;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -13,17 +13,18 @@
 
 package tech.pegasys.teku.cli.options;
 
+import static tech.pegasys.teku.cli.options.BeaconRestApiOptions.DEFAULT_REST_API_PORT;
+
 import picocli.CommandLine.Option;
 
 public class ValidatorClientOptions {
 
   @Option(
-      names = {"--Xbeacon-node-api-endpoint"},
+      names = {"--beacon-node-api-endpoint"},
       paramLabel = "<ENDPOINT>",
-      description = "Endpoint of the Beacon Node API",
-      arity = "1",
-      hidden = true)
-  private String beaconNodeApiEndpoint = "http://127.0.0.1:5051";
+      description = "Endpoint of the Beacon Node REST API",
+      arity = "1")
+  private String beaconNodeApiEndpoint = "http://127.0.0.1:" + DEFAULT_REST_API_PORT;
 
   public String getBeaconNodeApiEndpoint() {
     return beaconNodeApiEndpoint;

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
@@ -46,8 +46,7 @@ import tech.pegasys.teku.util.config.NetworkDefinition;
     descriptionHeading = "%nDescription:%n%n",
     optionListHeading = "%nOptions:%n",
     footerHeading = "%n",
-    footer = "Teku is licensed under the Apache License 2.0",
-    hidden = true)
+    footer = "Teku is licensed under the Apache License 2.0")
 public class ValidatorClientCommand implements Callable<Integer> {
 
   @Mixin(name = "Validator")

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
@@ -65,7 +65,8 @@ public class ValidatorClientCommand implements Callable<Integer> {
   private InteropOptions interopOptions;
 
   @Mixin(name = "Logging")
-  private LoggingOptions loggingOptions;
+  @SuppressWarnings("FieldMayBeFinal")
+  private LoggingOptions loggingOptions = new LoggingOptions(LoggingOptions.DEFAULT_VC_LOG_FILE);
 
   @Mixin(name = "Metrics")
   private MetricsOptions metricsOptions;


### PR DESCRIPTION
## PR Description
Unhides and removes the `--X` prefix from the external Validator Client options.

## Fixed Issue(s)
fixes #2741 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

To run the Validator Client as a separate process:
1. Be very, very certain that you've removed the validator keys from the beacon node and restarted it so that it is not still running them.  Never, specify the same validator keys on both the beacon node and Validator Client - only the validator client needs them.
2. Run the beacon node as usual (minus any validator key options) and ensure the REST API is enabled e.g. `teku --network medalla --rest-api-enabled`
3. Run the validator client and pass the URL to the beacon node REST API e.g. `teku validator-client --network medalla --beacon-rest-api-endpoint "http://localhost:5051" --validator-keys keys:passwords`.  The default rest api endpoint is `http://127.0.0.1:5051` so the option can be omitted if running the two processes on one machine.   It is important to specify the `--network` option (though we may be able to load the network from the beacon node in future).

The default log file for the Validator Client is same directory as the beacon node but called `teku-validator.log` so on Mac it defaults to `~/Library/teku/logs/teku-validator.log`.
