### PR TITLE
Move beaconApiEndpoint to ValidatorConfig

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/Teku.java
+++ b/teku/src/main/java/tech/pegasys/teku/Teku.java
@@ -35,9 +35,9 @@ public final class Teku {
     }
   }
 
-  private static void start(final TekuConfiguration config) {
+  private static void start(final TekuConfiguration config, final boolean validatorOnly) {
     final Node node;
-    if (config.global().isValidatorClient()) {
+    if (validatorOnly) {
       node = new ValidatorNode(config);
     } else {
       node = new BeaconNode(config);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -15,7 +15,11 @@ package tech.pegasys.teku.cli.options;
 
 import static tech.pegasys.teku.cli.options.BeaconRestApiOptions.DEFAULT_REST_API_PORT;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import picocli.CommandLine.Option;
+import tech.pegasys.teku.config.TekuConfiguration;
+import tech.pegasys.teku.util.config.InvalidConfigurationException;
 
 public class ValidatorClientOptions {
 
@@ -26,7 +30,16 @@ public class ValidatorClientOptions {
       arity = "1")
   private String beaconNodeApiEndpoint = "http://127.0.0.1:" + DEFAULT_REST_API_PORT;
 
-  public String getBeaconNodeApiEndpoint() {
-    return beaconNodeApiEndpoint;
+  public void configure(TekuConfiguration.Builder builder) {
+    builder.validator(config -> config.beaconNodeApiEndpoint(parseApiEndpoint()));
+  }
+
+  private URI parseApiEndpoint() {
+    try {
+      return new URI(beaconNodeApiEndpoint);
+    } catch (URISyntaxException e) {
+      throw new InvalidConfigurationException(
+          "Invalid configuration. Beacon node API endpoint has invalid syntax", e);
+    }
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -39,7 +39,9 @@ public class ValidatorClientOptions {
       return new URI(beaconNodeApiEndpoint);
     } catch (URISyntaxException e) {
       throw new InvalidConfigurationException(
-          "Invalid configuration. Beacon node API endpoint has invalid syntax", e);
+          "Invalid configuration. Beacon node API endpoint is not a valid URL: "
+              + beaconNodeApiEndpoint,
+          e);
     }
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
@@ -78,7 +78,7 @@ public class ValidatorClientCommand implements Callable<Integer> {
     try {
       parentCommand.setLogLevels();
       final TekuConfiguration globalConfiguration = tekuConfiguration();
-      parentCommand.getStartAction().accept(globalConfiguration);
+      parentCommand.getStartAction().start(globalConfiguration, true);
       return 0;
     } catch (InvalidConfigurationException | DatabaseStorageException ex) {
       parentCommand.reportUserError(ex);
@@ -98,6 +98,7 @@ public class ValidatorClientCommand implements Callable<Integer> {
     final TekuConfiguration.Builder builder = TekuConfiguration.builder();
     builder.globalConfig(this::buildGlobalConfiguration);
     validatorOptions.configure(builder);
+    validatorClientOptions.configure(builder);
     return builder.build();
   }
 
@@ -124,8 +125,6 @@ public class ValidatorClientCommand implements Callable<Integer> {
         .setMetricsInterface(metricsOptions.getMetricsInterface())
         .setMetricsCategories(metricsOptions.getMetricsCategories())
         .setMetricsHostAllowlist(metricsOptions.getMetricsHostAllowlist())
-        .setDataPath(dataOptions.getDataPath())
-        .setValidatorClient(true)
-        .setBeaconNodeApiEndpoint(validatorClientOptions.getBeaconNodeApiEndpoint());
+        .setDataPath(dataOptions.getDataPath());
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/AbstractBeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/AbstractBeaconNodeCommandTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.cli;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -52,7 +53,7 @@ public abstract class AbstractBeaconNodeCommandTest {
     try {
       final ArgumentCaptor<TekuConfiguration> configCaptor =
           ArgumentCaptor.forClass(TekuConfiguration.class);
-      verify(startAction).start(configCaptor.capture(), false);
+      verify(startAction).start(configCaptor.capture(), eq(false));
       assertThat(stringWriter.toString()).isEmpty();
 
       return configCaptor.getValue();

--- a/teku/src/test/java/tech/pegasys/teku/cli/AbstractBeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/AbstractBeaconNodeCommandTest.java
@@ -23,11 +23,11 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
+import tech.pegasys.teku.cli.BeaconNodeCommand.StartAction;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.util.config.GlobalConfiguration;
 
@@ -37,8 +37,7 @@ public abstract class AbstractBeaconNodeCommandTest {
   protected final PrintWriter outputWriter = new PrintWriter(stringWriter, true);
   protected final PrintWriter errorWriter = new PrintWriter(stringWriter, true);
 
-  @SuppressWarnings("unchecked")
-  final Consumer<TekuConfiguration> startAction = mock(Consumer.class);
+  final StartAction startAction = mock(StartAction.class);
 
   protected BeaconNodeCommand beaconNodeCommand =
       new BeaconNodeCommand(outputWriter, errorWriter, Collections.emptyMap(), startAction);
@@ -53,7 +52,7 @@ public abstract class AbstractBeaconNodeCommandTest {
     try {
       final ArgumentCaptor<TekuConfiguration> configCaptor =
           ArgumentCaptor.forClass(TekuConfiguration.class);
-      verify(startAction).accept(configCaptor.capture());
+      verify(startAction).start(configCaptor.capture(), false);
       assertThat(stringWriter.toString()).isEmpty();
 
       return configCaptor.getValue();

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -372,8 +372,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setRestApiDocsEnabled(false)
         .setRestApiEnabled(false)
         .setRestApiInterface("127.0.0.1")
-        .setRestApiHostAllowlist(List.of("127.0.0.1", "localhost"))
-        .setBeaconNodeApiEndpoint("http://127.0.0.1:5051");
+        .setRestApiHostAllowlist(List.of("127.0.0.1", "localhost"));
   }
 
   private void assertTekuConfiguration(final TekuConfiguration expected) {

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
@@ -101,10 +101,6 @@ public class GlobalConfiguration implements MetricsConfig {
   private final String restApiInterface;
   private final List<String> restApiHostAllowlist;
 
-  // Validator Client
-  private final boolean isValidatorClient;
-  private final String beaconNodeApiEndpoint;
-
   public static GlobalConfigurationBuilder builder() {
     return new GlobalConfigurationBuilder();
   }
@@ -164,9 +160,7 @@ public class GlobalConfiguration implements MetricsConfig {
       final boolean restApiEnabled,
       final String restApiInterface,
       final List<String> restApiHostAllowlist,
-      final Path validatorsSlashingProtectionPath,
-      final boolean isValidatorClient,
-      final String beaconNodeApiEndpoint) {
+      final Path validatorsSlashingProtectionPath) {
     this.constants = constants;
     this.startupTargetPeerCount = startupTargetPeerCount;
     this.startupTimeoutSeconds = startupTimeoutSeconds;
@@ -222,8 +216,6 @@ public class GlobalConfiguration implements MetricsConfig {
     this.restApiInterface = restApiInterface;
     this.restApiHostAllowlist = restApiHostAllowlist;
     this.validatorsSlashingProtectionPath = validatorsSlashingProtectionPath;
-    this.isValidatorClient = isValidatorClient;
-    this.beaconNodeApiEndpoint = beaconNodeApiEndpoint;
   }
 
   public String getConstants() {
@@ -457,14 +449,6 @@ public class GlobalConfiguration implements MetricsConfig {
 
   public List<String> getRestApiHostAllowlist() {
     return restApiHostAllowlist;
-  }
-
-  public boolean isValidatorClient() {
-    return isValidatorClient;
-  }
-
-  public String getBeaconNodeApiEndpoint() {
-    return beaconNodeApiEndpoint;
   }
 
   public void validate() throws IllegalArgumentException {

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
@@ -83,8 +83,6 @@ public class GlobalConfigurationBuilder {
   private List<String> restApiHostAllowlist;
   private NetworkDefinition network;
   private Path validatorsSlashingProtectionPath;
-  private boolean isValidatorClient;
-  private String beaconNodeApiEndpoint;
 
   public GlobalConfigurationBuilder setConstants(final String constants) {
     this.constants = constants;
@@ -384,16 +382,6 @@ public class GlobalConfigurationBuilder {
     return this;
   }
 
-  public GlobalConfigurationBuilder setValidatorClient(final boolean isValidatorOnly) {
-    this.isValidatorClient = isValidatorOnly;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setBeaconNodeApiEndpoint(final String beaconNodeApiEndpoint) {
-    this.beaconNodeApiEndpoint = beaconNodeApiEndpoint;
-    return this;
-  }
-
   public GlobalConfiguration build() {
     if (network != null) {
       constants = getOrDefault(constants, network::getConstants);
@@ -468,9 +456,7 @@ public class GlobalConfigurationBuilder {
         restApiEnabled,
         restApiInterface,
         restApiHostAllowlist,
-        validatorsSlashingProtectionPath,
-        isValidatorClient,
-        beaconNodeApiEndpoint);
+        validatorsSlashingProtectionPath);
   }
 
   private <T> T getOrDefault(final T explicitValue, final Supplier<T> predefinedNetworkValue) {

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -14,10 +14,12 @@
 package tech.pegasys.teku.validator.api;
 
 import java.io.File;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -36,6 +38,7 @@ public class ValidatorConfig {
   private final Bytes32 graffiti;
   private final boolean validatorPerformanceTrackingEnabled;
   private final boolean validatorKeystoreLockingEnabled;
+  private final Optional<URI> beaconNodeApiEndpoint;
 
   private ValidatorConfig(
       final List<String> validatorKeys,
@@ -44,6 +47,7 @@ public class ValidatorConfig {
       final List<BLSPublicKey> validatorExternalSignerPublicKeys,
       final URL validatorExternalSignerUrl,
       final int validatorExternalSignerTimeout,
+      final Optional<URI> beaconNodeApiEndpoint,
       final Bytes32 graffiti,
       final boolean validatorPerformanceTrackingEnabled,
       final boolean validatorKeystoreLockingEnabled) {
@@ -56,6 +60,7 @@ public class ValidatorConfig {
     this.graffiti = graffiti;
     this.validatorPerformanceTrackingEnabled = validatorPerformanceTrackingEnabled;
     this.validatorKeystoreLockingEnabled = validatorKeystoreLockingEnabled;
+    this.beaconNodeApiEndpoint = beaconNodeApiEndpoint;
   }
 
   public static Builder builder() {
@@ -90,6 +95,10 @@ public class ValidatorConfig {
     return validatorExternalSignerTimeout;
   }
 
+  public Optional<URI> getBeaconNodeApiEndpoint() {
+    return beaconNodeApiEndpoint;
+  }
+
   public Bytes32 getGraffiti() {
     return graffiti;
   }
@@ -121,6 +130,7 @@ public class ValidatorConfig {
     private Bytes32 graffiti;
     private boolean validatorPerformanceTrackingEnabled;
     private boolean validatorKeystoreLockingEnabled;
+    private Optional<URI> beaconNodeApiEndpoint = Optional.empty();
 
     private Builder() {}
 
@@ -155,6 +165,11 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder beaconNodeApiEndpoint(final URI beaconNodeApiEndpoint) {
+      this.beaconNodeApiEndpoint = Optional.of(beaconNodeApiEndpoint);
+      return this;
+    }
+
     public Builder graffiti(Bytes32 graffiti) {
       this.graffiti = graffiti;
       return this;
@@ -180,6 +195,7 @@ public class ValidatorConfig {
           validatorExternalSignerPublicKeys,
           validatorExternalSignerUrl,
           validatorExternalSignerTimeout,
+          beaconNodeApiEndpoint,
           graffiti,
           validatorPerformanceTrackingEnabled,
           validatorKeystoreLockingEnabled);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -68,12 +68,12 @@ public class ValidatorClientService extends Service {
         validatorLoader.initializeValidators(
             config.getValidatorConfig(), config.getGlobalConfiguration());
 
-    final BeaconNodeApi beaconNodeApi;
-    if (services.getConfig().isValidatorClient()) {
-      beaconNodeApi = RemoteBeaconNodeApi.create(services, asyncRunner);
-    } else {
-      beaconNodeApi = InProcessBeaconNodeApi.create(services, asyncRunner);
-    }
+    final BeaconNodeApi beaconNodeApi =
+        config
+            .getValidatorConfig()
+            .getBeaconNodeApiEndpoint()
+            .map(endpoint -> RemoteBeaconNodeApi.create(services, asyncRunner, endpoint))
+            .orElseGet(() -> InProcessBeaconNodeApi.create(services, asyncRunner));
 
     final ValidatorApiChannel validatorApiChannel = beaconNodeApi.getValidatorApi();
     final ForkProvider forkProvider = new ForkProvider(asyncRunner, validatorApiChannel);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.remote;
 
+import java.net.URI;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -41,10 +42,12 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
   }
 
   public static BeaconNodeApi create(
-      final ServiceConfig serviceConfig, final AsyncRunner asyncRunner) {
+      final ServiceConfig serviceConfig,
+      final AsyncRunner asyncRunner,
+      final URI beaconNodeApiEndpoint) {
 
     final OkHttpClient okHttpClient = new OkHttpClient();
-    final HttpUrl apiEndpoint = HttpUrl.parse(serviceConfig.getConfig().getBeaconNodeApiEndpoint());
+    final HttpUrl apiEndpoint = HttpUrl.get(beaconNodeApiEndpoint);
     final OkHttpValidatorRestApiClient apiClient =
         new OkHttpValidatorRestApiClient(apiEndpoint, okHttpClient);
 


### PR DESCRIPTION
## PR Description
Move beaconApiEndpoint from GlobalConfig to ValidatorConfig and tidy up the startup logic a little.  Startup logic still needs a design overhaul to handle the split better but one step at a time...

## Fixed Issue(s)
#1918 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.