### PR TITLE
Upgrade testcontainers to fix compatibility with latest docker on Mac

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuNode.java
@@ -24,7 +24,7 @@ public class BesuNode extends Node {
   private static final int JSON_RPC_PORT = 8545;
 
   public BesuNode(final Network network) {
-    super(network, "hyperledger/besu:1.3.6", LOG);
+    super(network, "hyperledger/besu:1.5.5", LOG);
     container
         .withExposedPorts(JSON_RPC_PORT)
         .withLogConsumer(frame -> LOG.debug(frame.getUtf8String().trim()))
@@ -36,7 +36,7 @@ public class BesuNode extends Node {
             "--rpc-http-port",
             Integer.toString(JSON_RPC_PORT),
             "--rpc-http-cors-origins=*",
-            "--host-whitelist=*",
+            "--host-allowlist=*",
             "--miner-enabled",
             "--miner-coinbase",
             "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73",

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -143,8 +143,8 @@ dependencyManagement {
     dependency 'org.hyperledger.besu.internal:metrics-core:1.5.4'
     dependency 'org.hyperledger.besu:plugin-api:1.5.4'
 
-    dependency "org.testcontainers:testcontainers:1.14.3"
-    dependency "org.testcontainers:junit-jupiter:1.14.3"
+    dependency "org.testcontainers:testcontainers:1.15.0-rc2"
+    dependency "org.testcontainers:junit-jupiter:1.15.0-rc2"
 
     dependency 'tech.pegasys.discovery:discovery:0.3.8-dev-5bb7c5a0'
 


### PR DESCRIPTION
## PR Description
Docker on Mac changed the way it's socket worked so upgrade testcontainers to fix compatibility.

Upgrade besu used in ATs to latest release.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.