### PR TITLE
Migrate directory layout to clearly separate beacon node and validator client

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -159,8 +159,18 @@ public class StatusLogger {
     log.info("ETH1 block satisfying minimum genesis time found");
   }
 
-  public void dataPathSet(final String dataPath) {
-    log.info("Using data path: {}", dataPath);
+  public void migratingDataDirectory(final Path dataPath) {
+    log.info(
+        "Migrating data directory layout under {} to separate beacon node and validator data",
+        dataPath.toAbsolutePath());
+  }
+
+  public void beaconDataPathSet(final Path dataPath) {
+    log.info("Storing beacon chain data in: {}", dataPath.toAbsolutePath());
+  }
+
+  public void validatorDataPathSet(final Path dataPath) {
+    log.info("Storing validator data in: {}", dataPath.toAbsolutePath());
   }
 
   public void eth1ServiceDown(final long interval) {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -142,6 +142,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   private final AsyncRunner networkAsyncRunner;
   private final AsyncRunnerFactory asyncRunnerFactory;
   private final AsyncRunner eventAsyncRunner;
+  private final Path beaconDataDirectory;
 
   private volatile ForkChoice forkChoice;
   private volatile StateTransition stateTransition;
@@ -172,7 +173,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
       final ServiceConfig serviceConfig, final BeaconChainConfiguration beaconConfig) {
     this.beaconConfig = beaconConfig;
     this.config = serviceConfig.getConfig();
-    asyncRunnerFactory = serviceConfig.getAsyncRunnerFactory();
+    this.beaconDataDirectory = serviceConfig.getDataDirLayout().getBeaconDataDirectory();
+    this.asyncRunnerFactory = serviceConfig.getAsyncRunnerFactory();
     this.asyncRunner = serviceConfig.createAsyncRunner("beaconchain");
     this.eventAsyncRunner = serviceConfig.createAsyncRunner("events", 10);
     this.networkAsyncRunner = serviceConfig.createAsyncRunner("p2p", 10);
@@ -493,7 +495,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
       this.p2pNetwork = new NoOpEth2Network();
     } else {
       final KeyValueStore<String, Bytes> keyValueStore =
-          new FileKeyValueStore(Path.of(config.getDataPath(), KEY_VALUE_STORE_SUBDIRECTORY));
+          new FileKeyValueStore(beaconDataDirectory.resolve(KEY_VALUE_STORE_SUBDIRECTORY));
       final PrivKey pk =
           KeyKt.unmarshalPrivateKey(getP2pPrivateKeyBytes(keyValueStore).toArrayUnsafe());
       final NetworkConfig p2pConfig =

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainControllerTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainControllerTest.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
+import tech.pegasys.teku.service.serviceutils.layout.DataConfig;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
@@ -62,7 +63,9 @@ public class BeaconChainControllerTest {
     when(eventChannels.getPublisher(any())).thenReturn(mock(SlotEventsChannel.class));
     when(serviceConfig.getEventChannels()).thenReturn(eventChannels);
     when(serviceConfig.getDataDirLayout())
-        .thenReturn(DataDirLayout.createFrom(dataDir, Optional.of(dataDir), Optional.empty()));
+        .thenReturn(
+            DataDirLayout.createFrom(
+                DataConfig.builder().dataBasePath(dataDir).beaconDataPath(dataDir).build()));
   }
 
   private BeaconChainConfiguration beaconChainConfiguration() {

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -46,7 +46,7 @@ public class StorageService extends Service {
           final VersionedDatabaseFactory dbFactory =
               new VersionedDatabaseFactory(
                   serviceConfig.getMetricsSystem(),
-                  serviceConfig.getConfig().getDataPath(),
+                  serviceConfig.getDataDirLayout().getBeaconDataDirectory(),
                   serviceConfig.getConfig().getDataStorageMode(),
                   serviceConfig.getConfig().getDataStorageCreateDbVersion(),
                   serviceConfig.getConfig().getDataStorageFrequency(),

--- a/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
+++ b/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
@@ -14,11 +14,14 @@
 package tech.pegasys.teku.service.serviceutils;
 
 import com.google.common.eventbus.EventBus;
+import java.nio.file.Path;
+import java.util.Optional;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.util.config.GlobalConfiguration;
 
 public class ServiceConfig {
@@ -29,6 +32,7 @@ public class ServiceConfig {
   private final EventChannels eventChannels;
   private final MetricsSystem metricsSystem;
   private final GlobalConfiguration config;
+  private final DataDirLayout dataDirLayout;
 
   public ServiceConfig(
       final AsyncRunnerFactory asyncRunnerFactory,
@@ -43,6 +47,9 @@ public class ServiceConfig {
     this.eventChannels = eventChannels;
     this.metricsSystem = metricsSystem;
     this.config = config;
+    this.dataDirLayout =
+        DataDirLayout.createFrom(
+            Path.of(config.getBaseDataPath()), Optional.empty(), Optional.empty());
   }
 
   public TimeProvider getTimeProvider() {
@@ -64,6 +71,10 @@ public class ServiceConfig {
 
   public MetricsSystem getMetricsSystem() {
     return metricsSystem;
+  }
+
+  public DataDirLayout getDataDirLayout() {
+    return dataDirLayout;
   }
 
   public AsyncRunner createAsyncRunner(final String name) {

--- a/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
+++ b/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
@@ -14,8 +14,6 @@
 package tech.pegasys.teku.service.serviceutils;
 
 import com.google.common.eventbus.EventBus;
-import java.nio.file.Path;
-import java.util.Optional;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
@@ -40,16 +38,15 @@ public class ServiceConfig {
       final EventBus eventBus,
       final EventChannels eventChannels,
       final MetricsSystem metricsSystem,
-      final GlobalConfiguration config) {
+      final GlobalConfiguration config,
+      final DataDirLayout dataDirLayout) {
     this.asyncRunnerFactory = asyncRunnerFactory;
     this.timeProvider = timeProvider;
     this.eventBus = eventBus;
     this.eventChannels = eventChannels;
     this.metricsSystem = metricsSystem;
     this.config = config;
-    this.dataDirLayout =
-        DataDirLayout.createFrom(
-            Path.of(config.getBaseDataPath()), Optional.empty(), Optional.empty());
+    this.dataDirLayout = dataDirLayout;
   }
 
   public TimeProvider getTimeProvider() {

--- a/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/DataConfig.java
+++ b/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/DataConfig.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.service.serviceutils.layout;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import tech.pegasys.teku.util.config.InvalidConfigurationException;
+
+public class DataConfig {
+  private final Path dataBasePath;
+  private final Optional<Path> beaconDataPath;
+  private final Optional<Path> validatorDataPath;
+
+  private DataConfig(
+      final Path dataBasePath,
+      final Optional<Path> beaconDataPath,
+      final Optional<Path> validatorDataPath) {
+    this.dataBasePath = dataBasePath;
+    this.beaconDataPath = beaconDataPath;
+    this.validatorDataPath = validatorDataPath;
+  }
+
+  public static DataConfig.Builder builder() {
+    return new Builder();
+  }
+
+  public Path getDataBasePath() {
+    return dataBasePath;
+  }
+
+  public Optional<Path> getBeaconDataPath() {
+    return beaconDataPath;
+  }
+
+  public Optional<Path> getValidatorDataPath() {
+    return validatorDataPath;
+  }
+
+  public static final class Builder {
+
+    private Path dataBasePath;
+    private Optional<Path> beaconDataPath = Optional.empty();
+    private Optional<Path> validatorDataPath = Optional.empty();
+
+    private Builder() {}
+
+    public Builder dataBasePath(Path dataBasePath) {
+      this.dataBasePath = dataBasePath;
+      return this;
+    }
+
+    public Builder beaconDataPath(Path beaconDataPath) {
+      this.beaconDataPath = Optional.ofNullable(beaconDataPath);
+      return this;
+    }
+
+    public Builder validatorDataPath(Path validatorDataPath) {
+      this.validatorDataPath = Optional.ofNullable(validatorDataPath);
+      return this;
+    }
+
+    public DataConfig build() {
+      if (dataBasePath == null) {
+        throw new InvalidConfigurationException("data-base-path must be specified");
+      }
+      return new DataConfig(dataBasePath, beaconDataPath, validatorDataPath);
+    }
+  }
+}

--- a/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/DataDirLayout.java
+++ b/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/DataDirLayout.java
@@ -16,16 +16,14 @@ package tech.pegasys.teku.service.serviceutils.layout;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
-import java.util.Optional;
 
 public interface DataDirLayout {
-  static DataDirLayout createFrom(
-      final Path dataDirectory,
-      final Optional<Path> beaconDataDirectory,
-      final Optional<Path> validatorDataDirectory) {
+  static DataDirLayout createFrom(final DataConfig dataConfig) {
     final SeparateServiceDataDirLayout layout =
         new SeparateServiceDataDirLayout(
-            dataDirectory, beaconDataDirectory, validatorDataDirectory);
+            dataConfig.getDataBasePath(),
+            dataConfig.getBeaconDataPath(),
+            dataConfig.getValidatorDataPath());
     try {
       layout.migrateIfNecessary();
     } catch (final IOException e) {

--- a/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/DataDirLayout.java
+++ b/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/DataDirLayout.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.service.serviceutils.layout;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+public interface DataDirLayout {
+  static DataDirLayout createFrom(
+      final Path dataDirectory,
+      final Optional<Path> beaconDataDirectory,
+      final Optional<Path> validatorDataDirectory) {
+    final SeparateServiceDataDirLayout layout =
+        new SeparateServiceDataDirLayout(
+            dataDirectory, beaconDataDirectory, validatorDataDirectory);
+    try {
+      layout.migrateIfNecessary();
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    return layout;
+  }
+
+  Path getBeaconDataDirectory();
+
+  Path getValidatorDataDirectory();
+}

--- a/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/SeparateServiceDataDirLayout.java
+++ b/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/SeparateServiceDataDirLayout.java
@@ -26,6 +26,8 @@ public class SeparateServiceDataDirLayout implements DataDirLayout {
 
   private static final List<String> BEACON_FILES_TO_MIGRATE =
       List.of("archive", "db", "db.version", "kvstore", "metadata.yml", "network.yml");
+  static final String BEACON_DATA_DIR_NAME = "beacon";
+  static final String VALIDATOR_DATA_DIR_NAME = "validator";
   private final Path baseDir;
   private final Path beaconNodeDataDir;
   private final Path validatorDataDir;
@@ -35,8 +37,9 @@ public class SeparateServiceDataDirLayout implements DataDirLayout {
       final Optional<Path> beaconDataDirectory,
       final Optional<Path> validatorDataDirectory) {
     this.baseDir = baseDir;
-    beaconNodeDataDir = beaconDataDirectory.orElseGet(() -> baseDir.resolve("beacon"));
-    validatorDataDir = validatorDataDirectory.orElseGet(() -> baseDir.resolve("validator"));
+    beaconNodeDataDir = beaconDataDirectory.orElseGet(() -> baseDir.resolve(BEACON_DATA_DIR_NAME));
+    validatorDataDir =
+        validatorDataDirectory.orElseGet(() -> baseDir.resolve(VALIDATOR_DATA_DIR_NAME));
   }
 
   public void migrateIfNecessary() throws IOException {
@@ -67,7 +70,7 @@ public class SeparateServiceDataDirLayout implements DataDirLayout {
     }
 
     if (baseDir.resolve("validators").toFile().exists()) {
-      Files.move(baseDir.resolve("validators"), baseDir.resolve("validator"));
+      Files.move(baseDir.resolve("validators"), baseDir.resolve(VALIDATOR_DATA_DIR_NAME));
     }
   }
 

--- a/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/SeparateServiceDataDirLayout.java
+++ b/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/layout/SeparateServiceDataDirLayout.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.service.serviceutils.layout;
+
+import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+public class SeparateServiceDataDirLayout implements DataDirLayout {
+
+  private static final List<String> BEACON_FILES_TO_MIGRATE =
+      List.of("archive", "db", "db.version", "kvstore", "metadata.yml", "network.yml");
+  private final Path baseDir;
+  private final Path beaconNodeDataDir;
+  private final Path validatorDataDir;
+
+  public SeparateServiceDataDirLayout(
+      final Path baseDir,
+      final Optional<Path> beaconDataDirectory,
+      final Optional<Path> validatorDataDirectory) {
+    this.baseDir = baseDir;
+    beaconNodeDataDir = beaconDataDirectory.orElseGet(() -> baseDir.resolve("beacon"));
+    validatorDataDir = validatorDataDirectory.orElseGet(() -> baseDir.resolve("validator"));
+  }
+
+  public void migrateIfNecessary() throws IOException {
+    if (baseDir.resolve("db.version").toFile().exists()
+        || baseDir.resolve("data").resolve("db.version").toFile().exists()) {
+      performMigration();
+    }
+  }
+
+  private void performMigration() throws IOException {
+    STATUS_LOG.migratingDataDirectory(baseDir);
+    final File dataSubdir = baseDir.resolve("data").toFile();
+    if (dataSubdir.isDirectory()) {
+      for (final File file : dataSubdir.listFiles()) {
+        Files.move(file.toPath(), baseDir.resolve(file.getName()));
+      }
+    }
+    if (!dataSubdir.delete() && dataSubdir.isDirectory()) {
+      throw new IOException(
+          "Unable to delete " + dataSubdir.getAbsolutePath() + " during migration");
+    }
+    mkdir(beaconNodeDataDir);
+    for (final String beaconFileName : BEACON_FILES_TO_MIGRATE) {
+      final Path source = baseDir.resolve(beaconFileName);
+      if (source.toFile().exists()) {
+        Files.move(source, beaconNodeDataDir.resolve(beaconFileName));
+      }
+    }
+
+    if (baseDir.resolve("validators").toFile().exists()) {
+      Files.move(baseDir.resolve("validators"), baseDir.resolve("validator"));
+    }
+  }
+
+  private void mkdir(final Path path) throws IOException {
+    final File file = path.toFile();
+    if (!file.mkdir() && !file.isDirectory()) {
+      throw new IOException("Unable to create directory " + path.toAbsolutePath());
+    }
+  }
+
+  @Override
+  public Path getBeaconDataDirectory() {
+    return beaconNodeDataDir;
+  }
+
+  @Override
+  public Path getValidatorDataDirectory() {
+    return validatorDataDir;
+  }
+}

--- a/services/serviceutils/src/test/java/tech/pegasys/teku/service/serviceutils/layout/SeparateServiceDataDirLayoutTest.java
+++ b/services/serviceutils/src/test/java/tech/pegasys/teku/service/serviceutils/layout/SeparateServiceDataDirLayoutTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.service.serviceutils.layout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static tech.pegasys.teku.service.serviceutils.layout.SeparateServiceDataDirLayout.BEACON_DATA_DIR_NAME;
+import static tech.pegasys.teku.service.serviceutils.layout.SeparateServiceDataDirLayout.VALIDATOR_DATA_DIR_NAME;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SeparateServiceDataDirLayoutTest {
+  @TempDir Path tempDir;
+
+  private SeparateServiceDataDirLayout layout;
+
+  @BeforeEach
+  void setUp() {
+    layout = new SeparateServiceDataDirLayout(tempDir, Optional.empty(), Optional.empty());
+  }
+
+  @Test
+  void shouldUseDefaultBeaconDataDirectory() {
+    assertThat(layout.getBeaconDataDirectory()).isEqualTo(tempDir.resolve(BEACON_DATA_DIR_NAME));
+  }
+
+  @Test
+  void shouldUseDefaultValidatorDataDirectory() {
+    assertThat(layout.getValidatorDataDirectory())
+        .isEqualTo(tempDir.resolve(VALIDATOR_DATA_DIR_NAME));
+  }
+
+  @Test
+  void shouldMigrateFromOldLayoutWithCustomDataPath() throws IOException {
+    createOldDataDirLayout(tempDir);
+
+    layout.migrateIfNecessary();
+
+    final Path beaconDataDirectory = layout.getBeaconDataDirectory();
+    assertThat(beaconDataDirectory).isEqualTo(tempDir.resolve(BEACON_DATA_DIR_NAME));
+    assertBeaconDataDirectoryContent(beaconDataDirectory);
+
+    final Path validatorDataDirectory = layout.getValidatorDataDirectory();
+    assertThat(validatorDataDirectory).isEqualTo(tempDir.resolve(VALIDATOR_DATA_DIR_NAME));
+    assertValidatorDataDirectoryContent(validatorDataDirectory);
+  }
+
+  @Test
+  void shouldMigrateFromOldLayoutWithDefaultDataPath() throws IOException {
+    // Should move content out of the data subdirectory to adapt to changed default path
+    createOldTekuDirLayout(tempDir);
+
+    layout.migrateIfNecessary();
+
+    final Path beaconDataDirectory = layout.getBeaconDataDirectory();
+    assertThat(beaconDataDirectory).isEqualTo(tempDir.resolve(BEACON_DATA_DIR_NAME));
+    assertBeaconDataDirectoryContent(beaconDataDirectory);
+
+    final Path validatorDataDirectory = layout.getValidatorDataDirectory();
+    assertThat(validatorDataDirectory).isEqualTo(tempDir.resolve(VALIDATOR_DATA_DIR_NAME));
+    assertValidatorDataDirectoryContent(validatorDataDirectory);
+
+    assertLogDirectoryContent(tempDir.resolve("logs"));
+  }
+
+  @Test
+  void shouldNotMakeChangesIfDataDirIsEmpty() throws IOException {
+    layout.migrateIfNecessary();
+
+    assertThat(tempDir).isEmptyDirectory();
+  }
+
+  /*
+  Manually create the old layout so we know it has the same layout even if the prod code changes
+
+  ~/Library/teku
+  ├── data
+  │   ├── archive
+  │   │   ├── <rocksdb stuff>
+  │   ├── db
+  │   │   ├── <rocksdb stuff>
+  │   ├── db.version
+  │   ├── kvstore
+  │   │   ├── generated-node-key.dat
+  │   │   └── local-enr-seqno.dat
+  │   ├── metadata.yml
+  │   ├── network.yml
+  │   └── validators
+  │       └── slashprotection
+  │           └── b89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b.yml
+  └── logs
+      └── teku.log
+   */
+  private void createOldTekuDirLayout(final Path tekuDir) throws IOException {
+    final Path dataDir = tekuDir.resolve("data");
+    createOldDataDirLayout(dataDir);
+    newFile(tekuDir.resolve(Path.of("logs", "teku.log")), "log content");
+  }
+
+  private void createOldDataDirLayout(final Path dataDir) throws IOException {
+    newFile(dataDir.resolve(Path.of("db", "rocksdb")), "db-content");
+    newFile(dataDir.resolve(Path.of("archive", "rocksdb")), "archive-content");
+    newFile(dataDir.resolve(Path.of("kvstore", "kvvalue.yml")), "kvstore-content");
+    newFile(dataDir.resolve("db.version"), "1");
+    newFile(dataDir.resolve("metadata.yml"), "metadata: true");
+    newFile(dataDir.resolve("network.yml"), "network: true");
+    newFile(
+        dataDir.resolve(
+            Path.of(
+                "validators",
+                "slashprotection",
+                "b89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b.yml")),
+        "slashing-record");
+  }
+
+  private void assertBeaconDataDirectoryContent(final Path beaconDataDirectory) {
+    assertThat(beaconDataDirectory).isDirectory();
+    assertThat(beaconDataDirectory.resolve("db")).isDirectory();
+    assertThat(beaconDataDirectory.resolve("archive")).isDirectory();
+    assertThat(beaconDataDirectory.resolve("kvstore")).isDirectory();
+    assertThat(beaconDataDirectory.resolve(Path.of("db", "rocksdb"))).hasContent("db-content");
+    assertThat(beaconDataDirectory.resolve(Path.of("archive", "rocksdb")))
+        .hasContent("archive-content");
+    assertThat(beaconDataDirectory.resolve(Path.of("kvstore", "kvvalue.yml")))
+        .hasContent("kvstore-content");
+    assertThat(beaconDataDirectory.resolve("db.version")).hasContent("1");
+    assertThat(beaconDataDirectory.resolve("metadata.yml")).hasContent("metadata: true");
+    assertThat(beaconDataDirectory.resolve("network.yml")).hasContent("network: true");
+  }
+
+  private void assertValidatorDataDirectoryContent(final Path validatorDataDirectory) {
+    assertThat(
+            validatorDataDirectory.resolve(
+                Path.of(
+                    "slashprotection",
+                    "b89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b.yml")))
+        .hasContent("slashing-record");
+  }
+
+  private void assertLogDirectoryContent(final Path logDir) {
+    assertThat(logDir.resolve("teku.log")).hasContent("log content");
+  }
+
+  private void mkdirs(final Path path) {
+    final File file = path.toFile();
+    if (!file.mkdirs() && !file.isDirectory()) {
+      fail("Unable to create directory " + path.toAbsolutePath());
+    }
+  }
+
+  private void newFile(final Path path, final String content) throws IOException {
+    mkdirs(path.getParent());
+    Files.writeString(path, content, StandardOpenOption.CREATE_NEW);
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -17,7 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -53,7 +53,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
 
   public VersionedDatabaseFactory(
       final MetricsSystem metricsSystem,
-      final String dataPath,
+      final Path dataPath,
       final StateStorageMode dataStorageMode,
       final Eth1Address depositContractAddress) {
     this(
@@ -67,13 +67,13 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
 
   public VersionedDatabaseFactory(
       final MetricsSystem metricsSystem,
-      final String dataPath,
+      final Path dataPath,
       final StateStorageMode dataStorageMode,
       final String createDatabaseVersion,
       final long stateStorageFrequency,
       final Eth1Address eth1Address) {
     this.metricsSystem = metricsSystem;
-    this.dataDirectory = Paths.get(dataPath).toFile();
+    this.dataDirectory = dataPath.toFile();
     this.dbDirectory = this.dataDirectory.toPath().resolve(DB_PATH).toFile();
     this.archiveDirectory = this.dataDirectory.toPath().resolve(ARCHIVE_PATH).toFile();
     this.dbVersionFile = this.dataDirectory.toPath().resolve(DB_VERSION_PATH).toFile();
@@ -87,7 +87,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
 
   @Override
   public Database createDatabase() {
-    LOG.info("Data directory set to: {}", dataDirectory.getAbsolutePath());
+    LOG.info("Beacon data directory set to: {}", dataDirectory.getAbsolutePath());
     validateDataPaths();
     final DatabaseVersion dbVersion = getDatabaseVersion();
     createDirectories();

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
@@ -39,7 +39,7 @@ public class VersionedDatabaseFactoryTest {
   public void createDatabase_fromEmptyDataDir() throws Exception {
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, eth1Address);
+            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, eth1Address);
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
 
@@ -54,7 +54,7 @@ public class VersionedDatabaseFactoryTest {
 
     final VersionedDatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, eth1Address);
+            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, eth1Address);
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
     }
@@ -65,7 +65,7 @@ public class VersionedDatabaseFactoryTest {
   public void createDatabase_asV4Database() throws Exception {
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, "4", 1L, eth1Address);
+            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, "4", 1L, eth1Address);
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
       assertDbVersionSaved(dataDir, DatabaseVersion.V4);
@@ -80,7 +80,7 @@ public class VersionedDatabaseFactoryTest {
   public void createDatabase_asV5Database() throws Exception {
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, "5", 1L, eth1Address);
+            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, "5", 1L, eth1Address);
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
       assertDbVersionSaved(dataDir, DatabaseVersion.V5);
@@ -101,7 +101,7 @@ public class VersionedDatabaseFactoryTest {
 
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, eth1Address);
+            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, eth1Address);
     assertThatThrownBy(dbFactory::createDatabase)
         .isInstanceOf(DatabaseStorageException.class)
         .hasMessageContaining("Unrecognized database version: bla");
@@ -113,7 +113,7 @@ public class VersionedDatabaseFactoryTest {
 
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, eth1Address);
+            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, eth1Address);
     assertThatThrownBy(dbFactory::createDatabase)
         .isInstanceOf(DatabaseStorageException.class)
         .hasMessageContaining("No database version file was found");
@@ -124,7 +124,7 @@ public class VersionedDatabaseFactoryTest {
     createDbDirectory(dataDir);
     final VersionedDatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, "4", 1L, eth1Address);
+            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, "4", 1L, eth1Address);
     assertThat(dbFactory.getDatabaseVersion()).isEqualTo(DatabaseVersion.V4);
   }
 
@@ -133,7 +133,7 @@ public class VersionedDatabaseFactoryTest {
     createDbDirectory(dataDir);
     final VersionedDatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir.toString(), DATA_STORAGE_MODE, "3.0", 1L, eth1Address);
+            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, "3.0", 1L, eth1Address);
     assertThat(dbFactory.getDatabaseVersion()).isEqualTo(DatabaseVersion.V3);
   }
 

--- a/teku/src/main/java/tech/pegasys/teku/BeaconNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/BeaconNode.java
@@ -92,7 +92,7 @@ public class BeaconNode implements Node {
     }
 
     this.serviceController = new BeaconNodeServiceController(tekuConfig, serviceConfig);
-    STATUS_LOG.dataPathSet(serviceConfig.getConfig().getDataPath());
+    STATUS_LOG.beaconDataPathSet(serviceConfig.getDataDirLayout().getBeaconDataDirectory());
   }
 
   @Override

--- a/teku/src/main/java/tech/pegasys/teku/BeaconNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/BeaconNode.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.infrastructure.logging.LoggingConfigurator;
 import tech.pegasys.teku.infrastructure.metrics.MetricsEndpoint;
 import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
+import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.services.BeaconNodeServiceController;
 import tech.pegasys.teku.util.cli.VersionProvider;
 import tech.pegasys.teku.util.config.Constants;
@@ -80,7 +81,8 @@ public class BeaconNode implements Node {
             eventBus,
             eventChannels,
             metricsSystem,
-            globalConfig);
+            globalConfig,
+            DataDirLayout.createFrom(tekuConfig.dataConfig()));
     tekuConfig.validate();
     Constants.setConstants(globalConfig.getConstants());
 

--- a/teku/src/main/java/tech/pegasys/teku/ValidatorNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/ValidatorNode.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.infrastructure.logging.LoggingConfigurator;
 import tech.pegasys.teku.infrastructure.metrics.MetricsEndpoint;
 import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
+import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.services.ValidatorNodeServiceController;
 import tech.pegasys.teku.util.cli.VersionProvider;
 import tech.pegasys.teku.util.config.Constants;
@@ -78,7 +79,8 @@ public class ValidatorNode implements Node {
             eventBus,
             eventChannels,
             metricsSystem,
-            globalConfig);
+            globalConfig,
+            DataDirLayout.createFrom(tekuConfig.dataConfig()));
     tekuConfig.validate();
     Constants.setConstants(globalConfig.getConstants());
 

--- a/teku/src/main/java/tech/pegasys/teku/ValidatorNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/ValidatorNode.java
@@ -83,7 +83,7 @@ public class ValidatorNode implements Node {
     Constants.setConstants(globalConfig.getConstants());
 
     this.serviceController = new ValidatorNodeServiceController(tekuConfig, serviceConfig);
-    STATUS_LOG.dataPathSet(serviceConfig.getConfig().getDataPath());
+    STATUS_LOG.validatorDataPathSet(serviceConfig.getDataDirLayout().getValidatorDataDirectory());
   }
 
   @Override

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -33,8 +33,8 @@ import picocli.CommandLine.Unmatched;
 import tech.pegasys.teku.cli.converter.LogTypeConverter;
 import tech.pegasys.teku.cli.converter.MetricCategoryConverter;
 import tech.pegasys.teku.cli.converter.PicoCliVersionProvider;
+import tech.pegasys.teku.cli.options.BeaconNodeDataOptions;
 import tech.pegasys.teku.cli.options.BeaconRestApiOptions;
-import tech.pegasys.teku.cli.options.DataOptions;
 import tech.pegasys.teku.cli.options.DataStorageOptions;
 import tech.pegasys.teku.cli.options.DepositOptions;
 import tech.pegasys.teku.cli.options.InteropOptions;
@@ -159,7 +159,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
   private MetricsOptions metricsOptions;
 
   @Mixin(name = "Data")
-  private DataOptions dataOptions;
+  private BeaconNodeDataOptions dataOptions;
 
   @Mixin(name = "Data Storage")
   private DataStorageOptions dataStorageOptions;
@@ -326,6 +326,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
       builder.globalConfig(this::buildGlobalConfiguration);
       weakSubjectivityOptions.configure(builder);
       validatorOptions.configure(builder);
+      dataOptions.configure(builder);
 
       return builder.build();
     } catch (IllegalArgumentException e) {
@@ -378,7 +379,6 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setMetricsInterface(metricsOptions.getMetricsInterface())
         .setMetricsCategories(metricsOptions.getMetricsCategories())
         .setMetricsHostAllowlist(metricsOptions.getMetricsHostAllowlist())
-        .setDataPath(dataOptions.getDataPath())
         .setDataStorageMode(dataStorageOptions.getDataStorageMode())
         .setDataStorageFrequency(dataStorageOptions.getDataStorageFrequency())
         .setDataStorageCreateDbVersion(dataStorageOptions.getCreateDbVersion())

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
@@ -15,32 +15,19 @@ package tech.pegasys.teku.cli.options;
 
 import java.nio.file.Path;
 import picocli.CommandLine.Option;
-import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.service.serviceutils.layout.DataConfig;
-import tech.pegasys.teku.util.cli.VersionProvider;
 
-public abstract class DataOptions {
+public class BeaconNodeDataOptions extends ValidatorClientDataOptions {
 
   @Option(
-      names = {"--data-base-path", "--data-path"},
+      names = {"--data-beacon-path"},
       paramLabel = "<FILENAME>",
-      description = "Path to the base directory to store output files",
+      description = "Path to the directory to store beacon node data",
       arity = "1")
-  private Path dataBasePath = defaultDataPath();
+  private Path dataBeaconPath;
 
-  public DataConfig getDataConfig() {
-    return configure(DataConfig.builder()).build();
-  }
-
-  public void configure(TekuConfiguration.Builder builder) {
-    builder.data(this::configure);
-  }
-
+  @Override
   protected DataConfig.Builder configure(final DataConfig.Builder config) {
-    return config.dataBasePath(dataBasePath);
-  }
-
-  private static Path defaultDataPath() {
-    return Path.of(VersionProvider.defaultStoragePath());
+    return super.configure(config).beaconDataPath(dataBeaconPath);
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
@@ -22,7 +22,8 @@ public class BeaconNodeDataOptions extends ValidatorClientDataOptions {
   @Option(
       names = {"--data-beacon-path"},
       paramLabel = "<FILENAME>",
-      description = "Path to the directory to store beacon node data",
+      description =
+          "Path to beacon node data\n  Default: <data-base-path>/beacon",
       arity = "1")
   private Path dataBeaconPath;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
@@ -22,8 +22,7 @@ public class BeaconNodeDataOptions extends ValidatorClientDataOptions {
   @Option(
       names = {"--data-beacon-path"},
       paramLabel = "<FILENAME>",
-      description =
-          "Path to beacon node data\n  Default: <data-base-path>/beacon",
+      description = "Path to beacon node data\n  Default: <data-base-path>/beacon",
       arity = "1")
   private Path dataBeaconPath;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DataOptions.java
@@ -21,7 +21,7 @@ public class DataOptions {
   @Option(
       names = {"--data-path"},
       paramLabel = "<FILENAME>",
-      description = "Path to output data files",
+      description = "Path to the base directory to store output files",
       arity = "1")
   private String dataPath = defaultDataPath();
 
@@ -30,6 +30,6 @@ public class DataOptions {
   }
 
   private static String defaultDataPath() {
-    return VersionProvider.defaultStoragePath() + System.getProperty("file.separator") + "data";
+    return VersionProvider.defaultStoragePath();
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DataOptions.java
@@ -24,7 +24,7 @@ public abstract class DataOptions {
   @Option(
       names = {"--data-base-path", "--data-path"},
       paramLabel = "<FILENAME>",
-      description = "Path to the base directory to store output files",
+      description = "Path to the base directory for storage",
       arity = "1")
   private Path dataBasePath = defaultDataPath();
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientDataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientDataOptions.java
@@ -14,33 +14,22 @@
 package tech.pegasys.teku.cli.options;
 
 import java.nio.file.Path;
+import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Option;
-import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.service.serviceutils.layout.DataConfig;
-import tech.pegasys.teku.util.cli.VersionProvider;
 
-public abstract class DataOptions {
+public class ValidatorClientDataOptions extends DataOptions {
 
   @Option(
-      names = {"--data-base-path", "--data-path"},
+      names = {"--data-validator-path"},
       paramLabel = "<FILENAME>",
-      description = "Path to the base directory to store output files",
+      description = "Path to the directory to store validator client data. Defaults to ",
+      showDefaultValue = Visibility.NEVER,
       arity = "1")
-  private Path dataBasePath = defaultDataPath();
+  private Path dataValidatorPath;
 
-  public DataConfig getDataConfig() {
-    return configure(DataConfig.builder()).build();
-  }
-
-  public void configure(TekuConfiguration.Builder builder) {
-    builder.data(this::configure);
-  }
-
+  @Override
   protected DataConfig.Builder configure(final DataConfig.Builder config) {
-    return config.dataBasePath(dataBasePath);
-  }
-
-  private static Path defaultDataPath() {
-    return Path.of(VersionProvider.defaultStoragePath());
+    return super.configure(config).validatorDataPath(dataValidatorPath);
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientDataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientDataOptions.java
@@ -23,7 +23,8 @@ public class ValidatorClientDataOptions extends DataOptions {
   @Option(
       names = {"--data-validator-path"},
       paramLabel = "<FILENAME>",
-      description = "Path to the directory to store validator client data. Defaults to ",
+      description =
+          "Path to validator client data\n  Default: <data-base-path>/validator",
       showDefaultValue = Visibility.NEVER,
       arity = "1")
   private Path dataValidatorPath;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientDataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientDataOptions.java
@@ -23,8 +23,7 @@ public class ValidatorClientDataOptions extends DataOptions {
   @Option(
       names = {"--data-validator-path"},
       paramLabel = "<FILENAME>",
-      description =
-          "Path to validator client data\n  Default: <data-base-path>/validator",
+      description = "Path to validator client data\n  Default: <data-base-path>/validator",
       showDefaultValue = Visibility.NEVER,
       arity = "1")
   private Path dataValidatorPath;

--- a/teku/src/main/java/tech/pegasys/teku/cli/slashingprotection/ExportCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/slashingprotection/ExportCommand.java
@@ -18,10 +18,11 @@ import java.nio.file.Path;
 import org.apache.logging.log4j.util.Strings;
 import picocli.CommandLine;
 import tech.pegasys.teku.cli.converter.PicoCliVersionProvider;
-import tech.pegasys.teku.cli.options.DataOptions;
+import tech.pegasys.teku.cli.options.ValidatorClientDataOptions;
 import tech.pegasys.teku.data.SlashingProtectionExporter;
 import tech.pegasys.teku.infrastructure.logging.SubCommandLogger;
-import tech.pegasys.teku.util.config.GlobalConfiguration;
+import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
+import tech.pegasys.teku.validator.client.ValidatorClientService;
 
 @CommandLine.Command(
     name = "export",
@@ -38,7 +39,7 @@ public class ExportCommand implements Runnable {
   public static final SubCommandLogger SUB_COMMAND_LOG = new SubCommandLogger();
 
   @CommandLine.Mixin(name = "Data")
-  private DataOptions dataOptions;
+  private ValidatorClientDataOptions dataOptions;
 
   @CommandLine.Option(
       names = {"--to"},
@@ -51,7 +52,7 @@ public class ExportCommand implements Runnable {
   @Override
   public void run() {
 
-    final Path slashProtectionPath = tekuConfiguration().getValidatorsSlashingProtectionPath();
+    final Path slashProtectionPath = getSlashingProtectionPath(dataOptions);
     verifySlashingProtectionPathExists(slashProtectionPath);
 
     SlashingProtectionExporter slashingProtectionExporter =
@@ -78,7 +79,8 @@ public class ExportCommand implements Runnable {
     }
   }
 
-  private GlobalConfiguration tekuConfiguration() {
-    return GlobalConfiguration.builder().setDataPath(dataOptions.getDataPath()).build();
+  private Path getSlashingProtectionPath(final ValidatorClientDataOptions dataOptions) {
+    final DataDirLayout dataDirLayout = DataDirLayout.createFrom(dataOptions.getDataConfig());
+    return ValidatorClientService.getSlashingProtectionPath(dataDirLayout);
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/slashingprotection/ImportCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/slashingprotection/ImportCommand.java
@@ -19,10 +19,11 @@ import java.nio.file.Path;
 import org.apache.logging.log4j.util.Strings;
 import picocli.CommandLine;
 import tech.pegasys.teku.cli.converter.PicoCliVersionProvider;
-import tech.pegasys.teku.cli.options.DataOptions;
+import tech.pegasys.teku.cli.options.ValidatorClientDataOptions;
 import tech.pegasys.teku.data.SlashingProtectionImporter;
 import tech.pegasys.teku.infrastructure.logging.SubCommandLogger;
-import tech.pegasys.teku.util.config.GlobalConfiguration;
+import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
+import tech.pegasys.teku.validator.client.ValidatorClientService;
 
 @CommandLine.Command(
     name = "import",
@@ -40,7 +41,7 @@ public class ImportCommand implements Runnable {
   public static final SubCommandLogger SUB_COMMAND_LOG = new SubCommandLogger();
 
   @CommandLine.Mixin(name = "Data")
-  private DataOptions dataOptions;
+  private ValidatorClientDataOptions dataOptions;
 
   @CommandLine.Option(
       names = {"--from"},
@@ -52,7 +53,7 @@ public class ImportCommand implements Runnable {
 
   @Override
   public void run() {
-    final Path slashProtectionPath = tekuConfiguration().getValidatorsSlashingProtectionPath();
+    final Path slashProtectionPath = getSlashingProtectionPath(dataOptions);
     File importFile = new File(fromFileName);
     verifyImportFileExists(importFile);
     prepareOutputPath(slashProtectionPath.toFile());
@@ -88,7 +89,8 @@ public class ImportCommand implements Runnable {
     }
   }
 
-  private GlobalConfiguration tekuConfiguration() {
-    return GlobalConfiguration.builder().setDataPath(dataOptions.getDataPath()).build();
+  private Path getSlashingProtectionPath(final ValidatorClientDataOptions dataOptions) {
+    final DataDirLayout dataDirLayout = DataDirLayout.createFrom(dataOptions.getDataConfig());
+    return ValidatorClientService.getSlashingProtectionPath(dataDirLayout);
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
@@ -21,11 +21,11 @@ import picocli.CommandLine.Mixin;
 import picocli.CommandLine.ParentCommand;
 import tech.pegasys.teku.cli.BeaconNodeCommand;
 import tech.pegasys.teku.cli.converter.PicoCliVersionProvider;
-import tech.pegasys.teku.cli.options.DataOptions;
 import tech.pegasys.teku.cli.options.InteropOptions;
 import tech.pegasys.teku.cli.options.LoggingOptions;
 import tech.pegasys.teku.cli.options.MetricsOptions;
 import tech.pegasys.teku.cli.options.NetworkOptions;
+import tech.pegasys.teku.cli.options.ValidatorClientDataOptions;
 import tech.pegasys.teku.cli.options.ValidatorClientOptions;
 import tech.pegasys.teku.cli.options.ValidatorOptions;
 import tech.pegasys.teku.config.TekuConfiguration;
@@ -59,7 +59,7 @@ public class ValidatorClientCommand implements Callable<Integer> {
   private NetworkOptions networkOptions;
 
   @Mixin(name = "Data")
-  private DataOptions dataOptions;
+  private ValidatorClientDataOptions dataOptions;
 
   @Mixin(name = "Interop")
   private InteropOptions interopOptions;
@@ -99,6 +99,7 @@ public class ValidatorClientCommand implements Callable<Integer> {
     builder.globalConfig(this::buildGlobalConfiguration);
     validatorOptions.configure(builder);
     validatorClientOptions.configure(builder);
+    dataOptions.configure(builder);
     return builder.build();
   }
 
@@ -124,7 +125,6 @@ public class ValidatorClientCommand implements Callable<Integer> {
         .setMetricsPort(metricsOptions.getMetricsPort())
         .setMetricsInterface(metricsOptions.getMetricsInterface())
         .setMetricsCategories(metricsOptions.getMetricsCategories())
-        .setMetricsHostAllowlist(metricsOptions.getMetricsHostAllowlist())
-        .setDataPath(dataOptions.getDataPath());
+        .setMetricsHostAllowlist(metricsOptions.getMetricsHostAllowlist());
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/admin/WeakSubjectivityCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/admin/WeakSubjectivityCommand.java
@@ -15,12 +15,10 @@ package tech.pegasys.teku.cli.subcommand.admin;
 
 import static tech.pegasys.teku.infrastructure.logging.SubCommandLogger.SUB_COMMAND_LOG;
 
-import java.nio.file.Path;
-import java.util.Optional;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import picocli.CommandLine;
 import tech.pegasys.teku.cli.converter.PicoCliVersionProvider;
-import tech.pegasys.teku.cli.options.DataOptions;
+import tech.pegasys.teku.cli.options.BeaconNodeDataOptions;
 import tech.pegasys.teku.cli.options.DataStorageOptions;
 import tech.pegasys.teku.cli.options.NetworkOptions;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
@@ -62,7 +60,7 @@ public class WeakSubjectivityCommand implements Runnable {
       footerHeading = "%n",
       footer = "Teku is licensed under the Apache License 2.0")
   public int clearWeakSubjectivityState(
-      @CommandLine.Mixin final DataOptions dataOptions,
+      @CommandLine.Mixin final BeaconNodeDataOptions dataOptions,
       @CommandLine.Mixin final DataStorageOptions dataStorageOptions,
       @CommandLine.Mixin final NetworkOptions networkOptions)
       throws Exception {
@@ -93,7 +91,7 @@ public class WeakSubjectivityCommand implements Runnable {
       footerHeading = "%n",
       footer = "Teku is licensed under the Apache License 2.0")
   public int displayWeakSubjectivityState(
-      @CommandLine.Mixin final DataOptions dataOptions,
+      @CommandLine.Mixin final BeaconNodeDataOptions dataOptions,
       @CommandLine.Mixin final DataStorageOptions dataStorageOptions,
       @CommandLine.Mixin final NetworkOptions networkOptions)
       throws Exception {
@@ -105,15 +103,13 @@ public class WeakSubjectivityCommand implements Runnable {
   }
 
   private Database createDatabase(
-      final DataOptions dataOptions,
+      final BeaconNodeDataOptions dataOptions,
       final DataStorageOptions dataStorageOptions,
       final NetworkOptions networkOptions) {
     final VersionedDatabaseFactory databaseFactory =
         new VersionedDatabaseFactory(
             new NoOpMetricsSystem(),
-            DataDirLayout.createFrom(
-                    Path.of(dataOptions.getDataPath()), Optional.empty(), Optional.empty())
-                .getBeaconDataDirectory(),
+            DataDirLayout.createFrom(dataOptions.getDataConfig()).getBeaconDataDirectory(),
             dataStorageOptions.getDataStorageMode(),
             NetworkDefinition.fromCliArg(networkOptions.getNetwork())
                 .getEth1DepositContractAddress()

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/admin/WeakSubjectivityCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/admin/WeakSubjectivityCommand.java
@@ -15,12 +15,15 @@ package tech.pegasys.teku.cli.subcommand.admin;
 
 import static tech.pegasys.teku.infrastructure.logging.SubCommandLogger.SUB_COMMAND_LOG;
 
+import java.nio.file.Path;
+import java.util.Optional;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import picocli.CommandLine;
 import tech.pegasys.teku.cli.converter.PicoCliVersionProvider;
 import tech.pegasys.teku.cli.options.DataOptions;
 import tech.pegasys.teku.cli.options.DataStorageOptions;
 import tech.pegasys.teku.cli.options.NetworkOptions;
+import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.storage.events.WeakSubjectivityState;
 import tech.pegasys.teku.storage.events.WeakSubjectivityUpdate;
 import tech.pegasys.teku.storage.server.Database;
@@ -108,7 +111,9 @@ public class WeakSubjectivityCommand implements Runnable {
     final VersionedDatabaseFactory databaseFactory =
         new VersionedDatabaseFactory(
             new NoOpMetricsSystem(),
-            dataOptions.getDataPath(),
+            DataDirLayout.createFrom(
+                    Path.of(dataOptions.getDataPath()), Optional.empty(), Optional.empty())
+                .getBeaconDataDirectory(),
             dataStorageOptions.getDataStorageMode(),
             NetworkDefinition.fromCliArg(networkOptions.getNetwork())
                 .getEth1DepositContractAddress()

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -25,7 +25,7 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import tech.pegasys.teku.cli.converter.PicoCliVersionProvider;
-import tech.pegasys.teku.cli.options.DataOptions;
+import tech.pegasys.teku.cli.options.BeaconNodeDataOptions;
 import tech.pegasys.teku.cli.options.DataStorageOptions;
 import tech.pegasys.teku.cli.options.NetworkOptions;
 import tech.pegasys.teku.core.lookup.BlockProvider;
@@ -75,7 +75,7 @@ public class DebugDbCommand implements Runnable {
       footerHeading = "%n",
       footer = "Teku is licensed under the Apache License 2.0")
   public int getDeposits(
-      @Mixin final DataOptions dataOptions,
+      @Mixin final BeaconNodeDataOptions dataOptions,
       @Mixin final DataStorageOptions dataStorageOptions,
       @Mixin final NetworkOptions networkOptions)
       throws Exception {
@@ -101,7 +101,7 @@ public class DebugDbCommand implements Runnable {
       footerHeading = "%n",
       footer = "Teku is licensed under the Apache License 2.0")
   public int getFinalizedState(
-      @Mixin final DataOptions dataOptions,
+      @Mixin final BeaconNodeDataOptions dataOptions,
       @Mixin final DataStorageOptions dataStorageOptions,
       @Mixin final NetworkOptions networkOptions,
       @Option(
@@ -137,7 +137,7 @@ public class DebugDbCommand implements Runnable {
       footerHeading = "%n",
       footer = "Teku is licensed under the Apache License 2.0")
   public int getLatestFinalizedState(
-      @Mixin final DataOptions dataOptions,
+      @Mixin final BeaconNodeDataOptions dataOptions,
       @Mixin final DataStorageOptions dataStorageOptions,
       @Mixin final NetworkOptions networkOptions,
       @Option(
@@ -182,7 +182,7 @@ public class DebugDbCommand implements Runnable {
       footerHeading = "%n",
       footer = "Teku is licensed under the Apache License 2.0")
   public int getForkChoiceSnapshot(
-      @Mixin final DataOptions dataOptions,
+      @Mixin final BeaconNodeDataOptions dataOptions,
       @Mixin final DataStorageOptions dataStorageOptions,
       @Mixin final NetworkOptions networkOptions,
       @Option(
@@ -215,15 +215,13 @@ public class DebugDbCommand implements Runnable {
   }
 
   private Database createDatabase(
-      final DataOptions dataOptions,
+      final BeaconNodeDataOptions dataOptions,
       final DataStorageOptions dataStorageOptions,
       final NetworkOptions networkOptions) {
     final VersionedDatabaseFactory databaseFactory =
         new VersionedDatabaseFactory(
             new NoOpMetricsSystem(),
-            DataDirLayout.createFrom(
-                    Path.of(dataOptions.getDataPath()), Optional.empty(), Optional.empty())
-                .getBeaconDataDirectory(),
+            DataDirLayout.createFrom(dataOptions.getDataConfig()).getBeaconDataDirectory(),
             dataStorageOptions.getDataStorageMode(),
             NetworkDefinition.fromCliArg(networkOptions.getNetwork())
                 .getEth1DepositContractAddress()

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.infrastructure.async.MetricTrackingExecutorFactory;
 import tech.pegasys.teku.infrastructure.async.ScheduledExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.protoarray.ProtoArraySnapshot;
+import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.server.DepositStorage;
 import tech.pegasys.teku.storage.server.VersionedDatabaseFactory;
@@ -220,7 +221,9 @@ public class DebugDbCommand implements Runnable {
     final VersionedDatabaseFactory databaseFactory =
         new VersionedDatabaseFactory(
             new NoOpMetricsSystem(),
-            dataOptions.getDataPath(),
+            DataDirLayout.createFrom(
+                    Path.of(dataOptions.getDataPath()), Optional.empty(), Optional.empty())
+                .getBeaconDataDirectory(),
             dataStorageOptions.getDataStorageMode(),
             NetworkDefinition.fromCliArg(networkOptions.getNetwork())
                 .getEth1DepositContractAddress()

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.config;
 
 import java.util.function.Consumer;
+import tech.pegasys.teku.service.serviceutils.layout.DataConfig;
 import tech.pegasys.teku.services.beaconchain.BeaconChainConfiguration;
 import tech.pegasys.teku.util.config.GlobalConfiguration;
 import tech.pegasys.teku.util.config.GlobalConfigurationBuilder;
@@ -24,18 +25,21 @@ import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 public class TekuConfiguration {
   private final GlobalConfiguration globalConfiguration;
   private final WeakSubjectivityConfig weakSubjectivityConfig;
+  private final DataConfig dataConfig;
   private final BeaconChainConfiguration beaconChainConfig;
   private final ValidatorClientConfiguration validatorClientConfig;
 
   private TekuConfiguration(
       GlobalConfiguration globalConfiguration,
       WeakSubjectivityConfig weakSubjectivityConfig,
-      final ValidatorConfig validatorConfig) {
+      final ValidatorConfig validatorConfig,
+      final DataConfig dataConfig) {
     this.globalConfiguration = globalConfiguration;
     this.weakSubjectivityConfig = weakSubjectivityConfig;
+    this.dataConfig = dataConfig;
     this.beaconChainConfig = new BeaconChainConfiguration(weakSubjectivityConfig, validatorConfig);
     this.validatorClientConfig =
-        new ValidatorClientConfiguration(globalConfiguration, validatorConfig);
+        new ValidatorClientConfiguration(globalConfiguration, validatorConfig, dataConfig);
   }
 
   public static Builder builder() {
@@ -58,16 +62,21 @@ public class TekuConfiguration {
     return validatorClientConfig;
   }
 
+  public DataConfig dataConfig() {
+    return dataConfig;
+  }
+
   public void validate() {
     globalConfiguration.validate();
   }
 
   public static class Builder {
-    private GlobalConfigurationBuilder globalConfigurationBuilder =
+    private final GlobalConfigurationBuilder globalConfigurationBuilder =
         new GlobalConfigurationBuilder();
-    private WeakSubjectivityConfig.Builder weakSubjectivityBuilder =
+    private final WeakSubjectivityConfig.Builder weakSubjectivityBuilder =
         WeakSubjectivityConfig.builder();
-    private ValidatorConfig.Builder validatorConfigBuilder = ValidatorConfig.builder();
+    private final ValidatorConfig.Builder validatorConfigBuilder = ValidatorConfig.builder();
+    private final DataConfig.Builder dataConfigBuilder = DataConfig.builder();
 
     private Builder() {}
 
@@ -75,7 +84,8 @@ public class TekuConfiguration {
       return new TekuConfiguration(
           globalConfigurationBuilder.build(),
           weakSubjectivityBuilder.build(),
-          validatorConfigBuilder.build());
+          validatorConfigBuilder.build(),
+          dataConfigBuilder.build());
     }
 
     public Builder globalConfig(final Consumer<GlobalConfigurationBuilder> globalConfigConsumer) {
@@ -91,6 +101,11 @@ public class TekuConfiguration {
 
     public Builder validator(final Consumer<ValidatorConfig.Builder> validatorConfigConsumer) {
       validatorConfigConsumer.accept(validatorConfigBuilder);
+      return this;
+    }
+
+    public Builder data(final Consumer<DataConfig.Builder> dataConfigConsumer) {
+      dataConfigConsumer.accept(dataConfigBuilder);
       return this;
     }
   }

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -321,6 +321,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   private TekuConfiguration.Builder expectedConfigurationBuilder() {
     return TekuConfiguration.builder()
         .globalConfig(this::buildExpectedGlobalConfiguration)
+        .data(b -> b.dataBasePath(dataPath))
         .validator(
             b -> b.validatorExternalSignerTimeout(1000).validatorKeystoreLockingEnabled(true));
   }
@@ -362,7 +363,6 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setLogFileNamePattern(DEFAULT_LOG_FILE_NAME_PATTERN)
         .setLogIncludeEventsEnabled(true)
         .setLogIncludeValidatorDutiesEnabled(true)
-        .setDataPath(dataPath.toString())
         .setDataStorageMode(PRUNE)
         .setDataStorageFrequency(VersionedDatabaseFactory.DEFAULT_STORAGE_FREQUENCY)
         .setDataStorageCreateDbVersion(DatabaseVersion.DEFAULT_VERSION.getValue())

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DataOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DataOptionsTest.java
@@ -17,18 +17,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.util.config.StateStorageMode.ARCHIVE;
 import static tech.pegasys.teku.util.config.StateStorageMode.PRUNE;
 
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
+import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.util.config.GlobalConfiguration;
 
 public class DataOptionsTest extends AbstractBeaconNodeCommandTest {
-  private static final String TEST_PATH = "/tmp/teku";
+  private static final Path TEST_PATH = Path.of("/tmp/teku");
 
   @Test
   public void dataPath_shouldReadFromConfigurationFile() {
-    final GlobalConfiguration globalConfiguration =
-        getGlobalConfigurationFromFile("dataOptions_config.yaml");
-    assertThat(globalConfiguration.getBaseDataPath()).isEqualTo(TEST_PATH);
+    final TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromFile("dataOptions_config.yaml");
+    final GlobalConfiguration globalConfiguration = tekuConfiguration.global();
+    assertThat(tekuConfiguration.dataConfig().getDataBasePath()).isEqualTo(TEST_PATH);
     assertThat(globalConfiguration.getDataStorageMode()).isEqualTo(ARCHIVE);
     assertThat(globalConfiguration.getDataStorageCreateDbVersion()).isEqualTo("4");
     assertThat(globalConfiguration.getDataStorageFrequency()).isEqualTo(128L);
@@ -50,9 +53,9 @@ public class DataOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
   public void dataPath_shouldAcceptNonDefaultValues() {
-    final GlobalConfiguration globalConfiguration =
-        getGlobalConfigurationFromArguments("--data-path", TEST_PATH);
-    assertThat(globalConfiguration.getBaseDataPath()).isEqualTo(TEST_PATH);
+    final TekuConfiguration config =
+        getTekuConfigurationFromArguments("--data-path", TEST_PATH.toString());
+    assertThat(config.dataConfig().getDataBasePath()).isEqualTo(TEST_PATH);
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DataOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DataOptionsTest.java
@@ -28,7 +28,7 @@ public class DataOptionsTest extends AbstractBeaconNodeCommandTest {
   public void dataPath_shouldReadFromConfigurationFile() {
     final GlobalConfiguration globalConfiguration =
         getGlobalConfigurationFromFile("dataOptions_config.yaml");
-    assertThat(globalConfiguration.getDataPath()).isEqualTo(TEST_PATH);
+    assertThat(globalConfiguration.getBaseDataPath()).isEqualTo(TEST_PATH);
     assertThat(globalConfiguration.getDataStorageMode()).isEqualTo(ARCHIVE);
     assertThat(globalConfiguration.getDataStorageCreateDbVersion()).isEqualTo("4");
     assertThat(globalConfiguration.getDataStorageFrequency()).isEqualTo(128L);
@@ -52,7 +52,7 @@ public class DataOptionsTest extends AbstractBeaconNodeCommandTest {
   public void dataPath_shouldAcceptNonDefaultValues() {
     final GlobalConfiguration globalConfiguration =
         getGlobalConfigurationFromArguments("--data-path", TEST_PATH);
-    assertThat(globalConfiguration.getDataPath()).isEqualTo(TEST_PATH);
+    assertThat(globalConfiguration.getBaseDataPath()).isEqualTo(TEST_PATH);
   }
 
   @Test

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
@@ -407,7 +407,7 @@ public class GlobalConfiguration implements MetricsConfig {
     return metricsHostAllowlist;
   }
 
-  public String getDataPath() {
+  public String getBaseDataPath() {
     return dataPath;
   }
 

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.util.config;
 
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -54,9 +53,6 @@ public class GlobalConfiguration implements MetricsConfig {
   private final int interopNumberOfValidators;
   private final boolean interopEnabled;
 
-  // Validator
-  private final Path validatorsSlashingProtectionPath;
-
   // Deposit
   private final Eth1Address eth1DepositContractAddress;
   private final String eth1Endpoint;
@@ -85,7 +81,6 @@ public class GlobalConfiguration implements MetricsConfig {
   private final List<String> metricsHostAllowlist;
 
   // Database
-  private final String dataPath;
   private final StateStorageMode dataStorageMode;
   private final long dataStorageFrequency;
   private final String dataStorageCreateDbVersion;
@@ -149,7 +144,6 @@ public class GlobalConfiguration implements MetricsConfig {
       final String metricsInterface,
       final List<String> metricsCategories,
       final List<String> metricsHostAllowlist,
-      final String dataPath,
       final StateStorageMode dataStorageMode,
       final long dataStorageFrequency,
       final String dataStorageCreateDbVersion,
@@ -159,8 +153,7 @@ public class GlobalConfiguration implements MetricsConfig {
       final boolean restApiDocsEnabled,
       final boolean restApiEnabled,
       final String restApiInterface,
-      final List<String> restApiHostAllowlist,
-      final Path validatorsSlashingProtectionPath) {
+      final List<String> restApiHostAllowlist) {
     this.constants = constants;
     this.startupTargetPeerCount = startupTargetPeerCount;
     this.startupTimeoutSeconds = startupTimeoutSeconds;
@@ -204,7 +197,6 @@ public class GlobalConfiguration implements MetricsConfig {
     this.metricsInterface = metricsInterface;
     this.metricsCategories = metricsCategories;
     this.metricsHostAllowlist = metricsHostAllowlist;
-    this.dataPath = dataPath;
     this.dataStorageMode = dataStorageMode;
     this.dataStorageFrequency = dataStorageFrequency;
     this.dataStorageCreateDbVersion = dataStorageCreateDbVersion;
@@ -215,7 +207,6 @@ public class GlobalConfiguration implements MetricsConfig {
     this.restApiEnabled = restApiEnabled;
     this.restApiInterface = restApiInterface;
     this.restApiHostAllowlist = restApiHostAllowlist;
-    this.validatorsSlashingProtectionPath = validatorsSlashingProtectionPath;
   }
 
   public String getConstants() {
@@ -407,10 +398,6 @@ public class GlobalConfiguration implements MetricsConfig {
     return metricsHostAllowlist;
   }
 
-  public String getBaseDataPath() {
-    return dataPath;
-  }
-
   public StateStorageMode getDataStorageMode() {
     return dataStorageMode;
   }
@@ -459,9 +446,5 @@ public class GlobalConfiguration implements MetricsConfig {
               "Invalid configuration. Interop number of validators [%d] must be greater than or equal to [%d]",
               interopNumberOfValidators, Constants.SLOTS_PER_EPOCH));
     }
-  }
-
-  public Path getValidatorsSlashingProtectionPath() {
-    return validatorsSlashingProtectionPath;
   }
 }

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.util.config;
 
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -70,7 +69,6 @@ public class GlobalConfigurationBuilder {
   private String metricsInterface;
   private List<String> metricsCategories;
   private List<String> metricsHostAllowlist;
-  private String dataPath;
   private StateStorageMode dataStorageMode;
   private String dataStorageCreateDbVersion;
   private int hotStatePersistenceFrequencyInEpochs;
@@ -82,7 +80,6 @@ public class GlobalConfigurationBuilder {
   private String restApiInterface;
   private List<String> restApiHostAllowlist;
   private NetworkDefinition network;
-  private Path validatorsSlashingProtectionPath;
 
   public GlobalConfigurationBuilder setConstants(final String constants) {
     this.constants = constants;
@@ -311,12 +308,6 @@ public class GlobalConfigurationBuilder {
     return this;
   }
 
-  public GlobalConfigurationBuilder setDataPath(final String dataPath) {
-    this.dataPath = dataPath;
-    this.setValidatorsSlashingProtectionPath(Path.of(dataPath, "validators", "slashprotection"));
-    return this;
-  }
-
   public GlobalConfigurationBuilder setDataStorageMode(final StateStorageMode dataStorageMode) {
     this.dataStorageMode = dataStorageMode;
     return this;
@@ -373,12 +364,6 @@ public class GlobalConfigurationBuilder {
 
   public GlobalConfigurationBuilder setNetwork(final NetworkDefinition network) {
     this.network = network;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setValidatorsSlashingProtectionPath(
-      final Path validatorsSlashingProtectionPath) {
-    this.validatorsSlashingProtectionPath = validatorsSlashingProtectionPath;
     return this;
   }
 
@@ -445,7 +430,6 @@ public class GlobalConfigurationBuilder {
         metricsInterface,
         metricsCategories,
         metricsHostAllowlist,
-        dataPath,
         dataStorageMode,
         dataStorageFrequency,
         dataStorageCreateDbVersion,
@@ -455,8 +439,7 @@ public class GlobalConfigurationBuilder {
         restApiDocsEnabled,
         restApiEnabled,
         restApiInterface,
-        restApiHostAllowlist,
-        validatorsSlashingProtectionPath);
+        restApiHostAllowlist);
   }
 
   private <T> T getOrDefault(final T explicitValue, final Supplier<T> predefinedNetworkValue) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientConfiguration.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientConfiguration.java
@@ -13,17 +13,22 @@
 
 package tech.pegasys.teku.validator.client;
 
+import tech.pegasys.teku.service.serviceutils.layout.DataConfig;
 import tech.pegasys.teku.util.config.GlobalConfiguration;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
 
 public class ValidatorClientConfiguration {
   private final GlobalConfiguration globalConfiguration;
   private final ValidatorConfig validatorConfig;
+  private final DataConfig dataConfig;
 
   public ValidatorClientConfiguration(
-      final GlobalConfiguration globalConfiguration, final ValidatorConfig validatorConfig) {
+      final GlobalConfiguration globalConfiguration,
+      final ValidatorConfig validatorConfig,
+      final DataConfig dataConfig) {
     this.globalConfiguration = globalConfiguration;
     this.validatorConfig = validatorConfig;
+    this.dataConfig = dataConfig;
   }
 
   public GlobalConfiguration getGlobalConfiguration() {
@@ -32,5 +37,9 @@ public class ValidatorClientConfiguration {
 
   public ValidatorConfig getValidatorConfig() {
     return validatorConfig;
+  }
+
+  public DataConfig getDataConfig() {
+    return dataConfig;
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -61,8 +61,7 @@ public class ValidatorClientService extends Service {
     final EventChannels eventChannels = services.getEventChannels();
     final MetricsSystem metricsSystem = services.getMetricsSystem();
     final AsyncRunner asyncRunner = services.createAsyncRunner("validator");
-    final DataDirLayout dataDirLayout = DataDirLayout.createFrom(config.getDataConfig());
-    final Path slashingProtectionPath = getSlashingProtectionPath(dataDirLayout);
+    final Path slashingProtectionPath = getSlashingProtectionPath(services.getDataDirLayout());
     final SlashingProtector slashingProtector =
         new SlashingProtector(new SyncDataAccessor(), slashingProtectionPath);
     final ValidatorLoader validatorLoader = new ValidatorLoader(slashingProtector, asyncRunner);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.infrastructure.io.SyncDataAccessor;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
+import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.beaconnode.BeaconNodeApi;
@@ -60,7 +61,8 @@ public class ValidatorClientService extends Service {
     final EventChannels eventChannels = services.getEventChannels();
     final MetricsSystem metricsSystem = services.getMetricsSystem();
     final AsyncRunner asyncRunner = services.createAsyncRunner("validator");
-    final Path slashingProtectionPath = services.getConfig().getValidatorsSlashingProtectionPath();
+    final DataDirLayout dataDirLayout = DataDirLayout.createFrom(config.getDataConfig());
+    final Path slashingProtectionPath = getSlashingProtectionPath(dataDirLayout);
     final SlashingProtector slashingProtector =
         new SlashingProtector(new SyncDataAccessor(), slashingProtectionPath);
     final ValidatorLoader validatorLoader = new ValidatorLoader(slashingProtector, asyncRunner);
@@ -113,6 +115,10 @@ public class ValidatorClientService extends Service {
         blockDutyScheduler,
         validatorIndexProvider,
         beaconNodeApi);
+  }
+
+  public static Path getSlashingProtectionPath(final DataDirLayout dataDirLayout) {
+    return dataDirLayout.getValidatorDataDirectory().resolve("slashprotection");
   }
 
   private static void addValidatorCountMetric(


### PR DESCRIPTION
## PR Description
Introduces a clearer directory layout under `--data-path` to clearly separate the beacon node data from the validator data. This is a draft to get feedback on the changes - more testing will be required and potentially include logs in the default layout as described below.

Up until now the default layout was:

```
~/Library/teku
├── data
│   ├── archive
│   │   ├── <rocksdb stuff>
│   ├── db
│   │   ├── <rocksdb stuff>
│   ├── db.version
│   ├── kvstore
│   │   ├── generated-node-key.dat
│   │   └── local-enr-seqno.dat
│   ├── metadata.yml
│   ├── network.yml
│   └── validators
│       └── slashprotection
│           └── b89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b.yml
└── logs
    └── teku.log
```

When you set `--data-path` the files under `data` move, but `logs` are left in the default location.  The validator's slashing protection storage is intermingled with the various parts of beacon chain storage. This has a few problems:

 * When users want to resync the chain, they are likely to delete the entire `data` directory, deleting the validator slashing protection records which should be kept
 * When users move to using an external Validator Client, to reuse the slashing protection database they wound need to set `data-path` to the same directory as the beacon chain uses, but intuition is that this would cause conflicts.
 * Docker users are likely to use `--data-path` to change the location of data to be on a volume, but forget to move the log file and thus lose access to their logs.

If we just added a separate option to specify the slashing protection location, it's highly likely that docker users would fail to set it and lose their slashing protection records after every restart.

With this PR the `data-path` moves to being explicitly the base directory that each service then has its own subdirectory to store things in.  The resulting layout becomes:

```
~/Library/teku
├── beacon
│   ├── archive
│   │   ├── <rocksdb stuff>
│   ├── db
│   │   ├── <rocksdb stuff>
│   ├── db.version
│   ├── kvstore
│   │   ├── generated-node-key.dat
│   │   └── local-enr-seqno.dat
│   ├── metadata.yml
│   └── network.yml
├── logs
│   └── teku.log
└── validator
    └── slashprotection
        └── b89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b.yml
```

The default value for `--data-path` has changed from (on MacOS) `~/Library/teku/data` to `~/Library/teku`. Most of the files that were under the `data-path` directly are now under a `beacon` subdirectory which is the root of storage for the beacon node.  The slashing protection has moved from being under `validators/slashprotection` to `validator/slashprotection` so the top level of `data-path` is now just `beacon`, `validator`, `logs`, giving a clear separation of storage between services.

Not implemented yet in this PR, but I think is worth doing, is to also have the default `--log-file` location be under `--data-path` so when a user specifies a custom `--data-path` the whole directory structure above moves under it.  `--data-path` is then the one-stop-shop for moving all data, and we can provide more specific CLI options to move override the location of other items. i.e. the existing `--log-file` would take precedence and we'd add (hopefully better named) `--data-beacon-path` and `--data-validator-path` options to move the beacon and validator directories respectively to a custom location.

We could potentially rename `--data-path` to `--data-base-path` (keeping an alias for `--data-path` for backwards compatibility) to make this structure clearer.


Note: more testing is required on this PR, plus updates to CLI descriptions and adding the new options to specify a different beacon or validator storage dir. The aim of the code at this point is really just to prove the concept can work and the migration is sane.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.