### PR TITLE
[Issue-2974] Explicitly pull finalized block when checking weak subjectivity

### DIFF
--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
@@ -99,7 +99,7 @@ public class WeakSubjectivityValidator {
     }
 
     return chainData
-        .getBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot())
+        .getFinalizedBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot())
         .thenAccept(
             maybeBlock -> {
               // We must have a block at this slot because we know this epoch is finalized

--- a/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidatorTest.java
+++ b/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidatorTest.java
@@ -384,7 +384,7 @@ public class WeakSubjectivityValidatorTest {
     assertThat(result).isCompleted();
     verifyNoMoreInteractions(policy);
     verify(chainData).isFinalizedEpoch(wsCheckpoint.getEpoch());
-    verify(chainData).getBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot());
+    verify(chainData).getFinalizedBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot());
   }
 
   @Test
@@ -406,7 +406,7 @@ public class WeakSubjectivityValidatorTest {
 
     assertThat(result).isCompleted();
     verify(chainData).isFinalizedEpoch(wsCheckpoint.getEpoch());
-    verify(chainData).getBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot());
+    verify(chainData).getFinalizedBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot());
 
     verify(policy).onChainInconsistentWithWeakSubjectivityCheckpoint(wsCheckpoint, otherBlock);
     verifyNoMoreInteractions(policy);
@@ -430,7 +430,7 @@ public class WeakSubjectivityValidatorTest {
 
     assertThat(result).isCompletedExceptionally();
     verify(chainData).isFinalizedEpoch(wsCheckpoint.getEpoch());
-    verify(chainData).getBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot());
+    verify(chainData).getFinalizedBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot());
     verifyNoMoreInteractions(policy);
   }
 
@@ -593,7 +593,7 @@ public class WeakSubjectivityValidatorTest {
       final Checkpoint wsCheckpoint, final Optional<SignedBeaconBlock> block) {
     final CombinedChainDataClient client = mock(CombinedChainDataClient.class);
     when(client.isFinalizedEpoch(any())).thenReturn(true);
-    when(client.getBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot()))
+    when(client.getFinalizedBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot()))
         .thenReturn(SafeFuture.completedFuture(block));
 
     return client;

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -136,6 +136,11 @@ public class CombinedChainDataClient {
     return historicalChainData.getLatestFinalizedBlockAtSlot(slot);
   }
 
+  public SafeFuture<Optional<SignedBeaconBlock>> getFinalizedBlockInEffectAtSlot(
+      final UInt64 slot) {
+    return historicalChainData.getLatestFinalizedBlockAtSlot(slot);
+  }
+
   public SafeFuture<Optional<BeaconBlockAndState>> getBlockAndStateInEffectAtSlot(
       final UInt64 slot) {
     return getSignedBlockAndStateInEffectAtSlot(slot)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fix bug where the `WeakSubjectivityValidator` may try to pull a finalized block before the `Store`'s `ChainHead` is set.  This causes `CombinedChainDataClient.getBlockInEffectAtSlot` to return an empty value.  To fix, explicitly pull finalized block when checking weak subjectivity - bypassing the check on the `Store`'s status.

## Fixed Issue(s)
Fixes #2974

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.