### PR TITLE
Add get attestation data endpoint

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -70,6 +70,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.events.GetEvents;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetHealth;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetIdentity;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeerById;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttestationData;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttesterDuties;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetProposerDuties;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostAttesterDuties;
@@ -289,6 +290,7 @@ public class BeaconRestApi {
         tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetNewBlock.ROUTE,
         new tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetNewBlock(
             dataProvider, jsonProvider));
+    app.get(GetAttestationData.ROUTE, new GetAttestationData(dataProvider, jsonProvider));
   }
 
   private void addV1BeaconHandlers(final DataProvider dataProvider) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
@@ -63,7 +63,7 @@ public class GetAttestationData extends AbstractHandler {
   @OpenApi(
       path = ROUTE,
       method = HttpMethod.GET,
-      summary = "Produce an AttestationData.",
+      summary = "Produce an AttestationData",
       tags = {TAG_V1_VALIDATOR, TAG_VALIDATOR_REQUIRED},
       queryParams = {
         @OpenApiParam(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
@@ -11,22 +11,22 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beaconrestapi.handlers.validator;
+package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.COMMITTEE_INDEX;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
-import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_NOT_FOUND;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.SLOT;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR;
 import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsInt;
 import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsUInt64;
 
-import com.google.common.base.Throwables;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.Context;
-import io.javalin.http.Handler;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
@@ -35,60 +35,60 @@ import io.javalin.plugin.openapi.annotations.OpenApiResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletionStage;
+import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
+import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
 import tech.pegasys.teku.api.schema.Attestation;
+import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 
-public class GetAttestation implements Handler {
-  public static final String ROUTE = "/validator/attestation";
+public class GetAttestationData extends AbstractHandler {
+  public static final String ROUTE = "/eth/v1/validator/attestation_data";
 
   private final ValidatorDataProvider provider;
-  private final JsonProvider jsonProvider;
 
-  public GetAttestation(final ValidatorDataProvider provider, final JsonProvider jsonProvider) {
-    this.jsonProvider = jsonProvider;
+  public GetAttestationData(final DataProvider provider, final JsonProvider jsonProvider) {
+    this(provider.getValidatorDataProvider(), jsonProvider);
+  }
+
+  public GetAttestationData(final ValidatorDataProvider provider, final JsonProvider jsonProvider) {
+    super(jsonProvider);
     this.provider = provider;
   }
 
   @OpenApi(
-      deprecated = true,
       path = ROUTE,
       method = HttpMethod.GET,
-      summary = "Get an unsigned attestation for a slot from the current state.",
+      summary = "Requests that the beacon node produce an AttestationData.",
       tags = {TAG_VALIDATOR},
       queryParams = {
         @OpenApiParam(
             name = SLOT,
-            description = "`uint64` Non-finalized slot for which to create the attestation.",
+            description = "`uint64` The slot for which an attestation data should be created.",
             required = true),
         @OpenApiParam(
             name = COMMITTEE_INDEX,
             type = Integer.class,
-            description = "`Integer` Index of the committee making the attestation.",
+            description =
+                "`Integer` The committee index for which an attestation data should be created.",
             required = true)
       },
       description =
-          "Returns an unsigned attestation for the block at the specified non-finalized slot.\n\n"
-              + "This endpoint is not protected against slashing. Signing the returned attestation can result in a slashable offence.\n"
-              + "Deprecated - use `/eth/v1/validator/attestation_data` instead.",
+          "Returns attestation data for the block at the specified non-finalized slot.\n\n"
+              + "This endpoint is not protected against slashing. Signing the returned attestation data can result in a slashable offence.",
       responses = {
         @OpenApiResponse(
             status = RES_OK,
-            content = @OpenApiContent(from = Attestation.class),
-            description =
-                "Returns an attestation object with a blank signature. The `signature` field should be replaced by a valid signature."),
+            content = @OpenApiContent(from = GetAttestationDataResponse.class)),
         @OpenApiResponse(status = RES_BAD_REQUEST, description = "Invalid parameter supplied"),
-        @OpenApiResponse(
-            status = RES_NOT_FOUND,
-            description = "An attestation could not be created for the specified slot.")
+        @OpenApiResponse(status = RES_INTERNAL_ERROR),
+        @OpenApiResponse(status = RES_SERVICE_UNAVAILABLE, description = SERVICE_UNAVAILABLE)
       })
   @Override
   public void handle(Context ctx) throws Exception {
-
     try {
       final Map<String, List<String>> parameters = ctx.queryParamMap();
       if (parameters.size() < 2) {
@@ -102,32 +102,17 @@ public class GetAttestation implements Handler {
             String.format("'%s' needs to be greater than or equal to 0.", COMMITTEE_INDEX));
       }
 
-      ctx.result(
-          provider
-              .createUnsignedAttestationAtSlot(slot, committeeIndex)
-              .thenApplyChecked(optionalAttestation -> serializeResult(ctx, optionalAttestation))
-              .exceptionallyCompose(error -> handleError(ctx, error)));
+      final SafeFuture<Optional<Attestation>> future =
+          provider.createUnsignedAttestationAtSlot(slot, committeeIndex);
+      handleOptionalResult(ctx, future, this::processResult, SC_BAD_REQUEST);
     } catch (final IllegalArgumentException e) {
       ctx.result(jsonProvider.objectToJSON(new BadRequest(e.getMessage())));
       ctx.status(SC_BAD_REQUEST);
     }
   }
 
-  private String serializeResult(final Context ctx, final Optional<Attestation> optionalAttestation)
-      throws com.fasterxml.jackson.core.JsonProcessingException {
-    if (optionalAttestation.isPresent()) {
-      return jsonProvider.objectToJSON(optionalAttestation.get());
-    } else {
-      ctx.status(SC_NOT_FOUND);
-      return "";
-    }
-  }
-
-  private CompletionStage<String> handleError(final Context ctx, final Throwable error) {
-    if (Throwables.getRootCause(error) instanceof IllegalArgumentException) {
-      ctx.status(SC_BAD_REQUEST);
-      return SafeFuture.of(() -> jsonProvider.objectToJSON(new BadRequest(error.getMessage())));
-    }
-    return SafeFuture.failedFuture(error);
+  private Optional<String> processResult(final Context ctx, final Attestation attestation)
+      throws JsonProcessingException {
+    return Optional.of(jsonProvider.objectToJSON(attestation.data));
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
@@ -21,7 +21,8 @@ import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.SLOT;
-import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_V1_VALIDATOR;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR_REQUIRED;
 import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsInt;
 import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsUInt64;
 
@@ -62,8 +63,8 @@ public class GetAttestationData extends AbstractHandler {
   @OpenApi(
       path = ROUTE,
       method = HttpMethod.GET,
-      summary = "Requests that the beacon node produce an AttestationData.",
-      tags = {TAG_VALIDATOR},
+      summary = "Produce an AttestationData.",
+      tags = {TAG_V1_VALIDATOR, TAG_VALIDATOR_REQUIRED},
       queryParams = {
         @OpenApiParam(
             name = SLOT,

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.node.GetFork;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetGenesisTime;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetSyncing;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetVersion;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttestationData;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAggregate;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.PostAggregateAndProof;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.PostBlock;
@@ -207,6 +208,11 @@ class BeaconRestApiTest {
         .post(
             eq(PostSubscribeToPersistentSubnets.ROUTE),
             any(PostSubscribeToPersistentSubnets.class));
+  }
+
+  @Test
+  public void shouldHaveGetAttestationDataEndpoint() {
+    verify(app).get(eq(GetAttestationData.ROUTE), any(GetAttestationData.class));
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
@@ -44,7 +44,6 @@ import tech.pegasys.teku.beaconrestapi.handlers.node.GetFork;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetGenesisTime;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetSyncing;
 import tech.pegasys.teku.beaconrestapi.handlers.node.GetVersion;
-import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttestationData;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAggregate;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.PostAggregateAndProof;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.PostBlock;
@@ -208,11 +207,6 @@ class BeaconRestApiTest {
         .post(
             eq(PostSubscribeToPersistentSubnets.ROUTE),
             any(PostSubscribeToPersistentSubnets.class));
-  }
-
-  @Test
-  public void shouldHaveGetAttestationDataEndpoint() {
-    verify(app).get(eq(GetAttestationData.ROUTE), any(GetAttestationData.class));
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeerById;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeers;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetSyncing;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetVersion;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttestationData;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttesterDuties;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetNewBlock;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetProposerDuties;
@@ -147,5 +148,10 @@ public class BeaconRestApiV1Test {
   @Test
   public void shouldHaveGetNewBlockEndpoint() {
     verify(app).get(eq(GetNewBlock.ROUTE), any(GetNewBlock.class));
+  }
+
+  @Test
+  public void shouldHaveGetAttestationDataEndpoint() {
+    verify(app).get(eq(GetAttestationData.ROUTE), any(GetAttestationData.class));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationDataTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationDataTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
+
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.COMMITTEE_INDEX;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.SLOT;
+
+import io.javalin.http.Context;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import tech.pegasys.teku.api.ValidatorDataProvider;
+import tech.pegasys.teku.api.schema.Attestation;
+import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
+
+class GetAttestationDataTest {
+
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private Context context = mock(Context.class);
+  private ValidatorDataProvider provider = mock(ValidatorDataProvider.class);
+  private final JsonProvider jsonProvider = new JsonProvider();
+  private GetAttestationData handler;
+  private Attestation attestation = new Attestation(dataStructureUtil.randomAttestation());
+
+  @SuppressWarnings("unchecked")
+  final ArgumentCaptor<SafeFuture<String>> resultCaptor = ArgumentCaptor.forClass(SafeFuture.class);
+
+  @BeforeEach
+  public void setup() {
+    handler = new GetAttestationData(provider, jsonProvider);
+  }
+
+  @Test
+  void shouldRejectTooFewArguments() throws Exception {
+    badRequestParamsTest(Map.of(), "Please specify both slot and committee_index");
+  }
+
+  @Test
+  void shouldRejectWithoutSlot() throws Exception {
+    badRequestParamsTest(
+        Map.of("foo", List.of(), "Foo2", List.of()), "'slot' cannot be null or empty.");
+  }
+
+  @Test
+  void shouldRejectWithoutCommitteeIndex() throws Exception {
+    badRequestParamsTest(
+        Map.of(SLOT, List.of("1"), "Foo2", List.of()),
+        "'committee_index' cannot be null or empty.");
+  }
+
+  @Test
+  void shouldRejectNegativeCommitteeIndex() throws Exception {
+    badRequestParamsTest(
+        Map.of(SLOT, List.of("1"), COMMITTEE_INDEX, List.of("-1")),
+        "'committee_index' needs to be greater than or equal to 0.");
+  }
+
+  @Test
+  void shouldReturnNoContentIfNotReady() throws Exception {
+    Map<String, List<String>> params = Map.of(SLOT, List.of("1"), COMMITTEE_INDEX, List.of("1"));
+
+    when(context.queryParamMap()).thenReturn(params);
+    when(provider.createUnsignedAttestationAtSlot(UInt64.ONE, 1))
+        .thenReturn(SafeFuture.failedFuture(new ChainDataUnavailableException()));
+    handler.handle(context);
+
+    verify(context).result(resultCaptor.capture());
+    final SafeFuture<String> result = resultCaptor.getValue();
+    assertThat(result).isCompletedExceptionally();
+    assertThatThrownBy(result::join).hasRootCauseInstanceOf(ChainDataUnavailableException.class);
+  }
+
+  @Test
+  void shouldReturnAttestationData() throws Exception {
+    Map<String, List<String>> params = Map.of(SLOT, List.of("1"), COMMITTEE_INDEX, List.of("1"));
+
+    when(context.queryParamMap()).thenReturn(params);
+    when(provider.isStoreAvailable()).thenReturn(true);
+    when(provider.createUnsignedAttestationAtSlot(UInt64.ONE, 1))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(attestation)));
+    handler.handle(context);
+
+    verify(context).result(resultCaptor.capture());
+    final SafeFuture<String> result = resultCaptor.getValue();
+    assertThat(result).isCompletedWithValue(jsonProvider.objectToJSON(attestation.data));
+  }
+
+  private void badRequestParamsTest(final Map<String, List<String>> params, String message)
+      throws Exception {
+    when(context.queryParamMap()).thenReturn(params);
+
+    handler.handle(context);
+    verify(context).status(SC_BAD_REQUEST);
+
+    if (StringUtils.isNotEmpty(message)) {
+      BadRequest badRequest = new BadRequest(message);
+      verify(context).result(jsonProvider.objectToJSON(badRequest));
+    }
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/GetAttestationDataResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/GetAttestationDataResponse.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.response.v1.validator;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import tech.pegasys.teku.api.schema.AttestationData;
+
+public class GetAttestationDataResponse {
+
+  public final AttestationData data;
+
+  @JsonCreator
+  public GetAttestationDataResponse(@JsonProperty("data") final AttestationData data) {
+    this.data = data;
+  }
+}


### PR DESCRIPTION
## PR Description
Add the Standard API endpoint to get attestation data (/eth/v1/validator/attestation_data).

Deprecates the old `/validator/attestation` endpoint.

## Fixed Issue(s)
#2756 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.