### PR TITLE
Use standard attestation data endpoint

### DIFF
--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.datastructures.validator.SubnetSubscription;
@@ -50,6 +51,8 @@ public interface ValidatorApiChannel extends ChannelInterface {
       UInt64 slot, BLSSignature randaoReveal, Optional<Bytes32> graffiti);
 
   SafeFuture<Optional<Attestation>> createUnsignedAttestation(UInt64 slot, int committeeIndex);
+
+  SafeFuture<Optional<AttestationData>> createAttestationData(UInt64 slot, int committeeIndex);
 
   SafeFuture<Optional<Attestation>> createAggregate(Bytes32 attestationHashTreeRoot);
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.datastructures.validator.SubnetSubscription;
@@ -54,6 +55,8 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       "beacon_node_unsigned_block_requests_total";
   public static final String UNSIGNED_ATTESTATION_REQUEST_COUNTER_NAME =
       "beacon_node_unsigned_attestation_requests_total";
+  public static final String ATTESTATION_DATA_REQUEST_COUNTER_NAME =
+      "beacon_node_attestation_data_requests_total";
   public static final String AGGREGATE_REQUESTS_COUNTER_NAME =
       "beacon_node_aggregate_requests_total";
   public static final String AGGREGATION_SUBSCRIPTION_COUNTER_NAME =
@@ -73,6 +76,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   private final BeaconChainRequestCounter proposerDutiesRequestCounter;
   private final BeaconChainRequestCounter unsignedBlockRequestsCounter;
   private final BeaconChainRequestCounter unsignedAttestationRequestsCounter;
+  private final BeaconChainRequestCounter attestationDataRequestsCounter;
   private final BeaconChainRequestCounter aggregateRequestsCounter;
   private final Counter getValidatorIndicesRequestCounter;
   private final Counter subscribeAggregationRequestCounter;
@@ -121,6 +125,11 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
             metricsSystem,
             UNSIGNED_ATTESTATION_REQUEST_COUNTER_NAME,
             "Counter recording the number of requests for unsigned attestations");
+    attestationDataRequestsCounter =
+        BeaconChainRequestCounter.create(
+            metricsSystem,
+            ATTESTATION_DATA_REQUEST_COUNTER_NAME,
+            "Counter recording the number of requests for attestation data");
     aggregateRequestsCounter =
         BeaconChainRequestCounter.create(
             metricsSystem,
@@ -206,6 +215,13 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
     return countRequest(
         delegate.createUnsignedAttestation(slot, committeeIndex),
         unsignedAttestationRequestsCounter);
+  }
+
+  @Override
+  public SafeFuture<Optional<AttestationData>> createAttestationData(
+      final UInt64 slot, final int committeeIndex) {
+    return countRequest(
+        delegate.createAttestationData(slot, committeeIndex), attestationDataRequestsCounter);
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.bls.BLSPublicKey;
-import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.datastructures.util.CommitteeUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -62,11 +62,12 @@ public class AttestationDutyLoader extends AbstractDutyLoader<AttesterDuties> {
     final UInt64 slot = duty.getSlot();
     final int aggregatorModulo = CommitteeUtil.getAggregatorModulo(duty.getCommitteeLength());
 
-    final SafeFuture<Optional<Attestation>> unsignedAttestationFuture =
+    final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture =
         scheduleAttestationProduction(
             scheduledDuties,
             attestationCommitteeIndex,
             attestationCommitteePosition,
+            duty.getCommitteeLength(),
             validatorIndex,
             validator,
             slot);
@@ -81,15 +82,21 @@ public class AttestationDutyLoader extends AbstractDutyLoader<AttesterDuties> {
         unsignedAttestationFuture);
   }
 
-  private SafeFuture<Optional<Attestation>> scheduleAttestationProduction(
+  private SafeFuture<Optional<AttestationData>> scheduleAttestationProduction(
       final ScheduledDuties scheduledDuties,
       final int attestationCommitteeIndex,
       final int attestationCommitteePosition,
+      final int attestationCommitteeSize,
       final int validatorIndex,
       final Validator validator,
       final UInt64 slot) {
     return scheduledDuties.scheduleAttestationProduction(
-        slot, validator, attestationCommitteeIndex, attestationCommitteePosition, validatorIndex);
+        slot,
+        validator,
+        attestationCommitteeIndex,
+        attestationCommitteePosition,
+        attestationCommitteeSize,
+        validatorIndex);
   }
 
   private SafeFuture<Void> scheduleAggregation(
@@ -99,7 +106,7 @@ public class AttestationDutyLoader extends AbstractDutyLoader<AttesterDuties> {
       final Validator validator,
       final UInt64 slot,
       final int aggregatorModulo,
-      final SafeFuture<Optional<Attestation>> unsignedAttestationFuture) {
+      final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture) {
     return forkProvider
         .getForkInfo()
         .thenCompose(forkInfo -> validator.getSigner().signAggregationSlot(slot, forkInfo))

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
@@ -64,15 +64,15 @@ public class AggregationDuty implements Duty {
    * @param proof the validator's slot signature proving it is the aggregator
    * @param attestationCommitteeIndex the committee index to aggregate
    * @param unsignedAttestationFuture the future returned by {@link
-   *     AttestationProductionDuty#addValidator(Validator, int, int, int)} which completes with the
-   *     unsigned attestation for this committee and slot.
+   *     AttestationProductionDuty#addValidator(Validator, int, int, int, int)} which completes with
+   *     the unsigned attestation for this committee and slot.
    */
   public void addValidator(
       final Validator validator,
       final int validatorIndex,
       final BLSSignature proof,
       final int attestationCommitteeIndex,
-      final SafeFuture<Optional<Attestation>> unsignedAttestationFuture) {
+      final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture) {
     aggregatorsByCommitteeIndex.computeIfAbsent(
         attestationCommitteeIndex,
         committeeIndex -> {
@@ -103,14 +103,12 @@ public class AggregationDuty implements Duty {
   }
 
   public CompletionStage<Optional<Attestation>> createAggregate(
-      final Optional<Attestation> maybeAttestation) {
+      final Optional<AttestationData> maybeAttestation) {
     final AttestationData attestationData =
-        maybeAttestation
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "Unable to perform aggregation for committee because no attestation was produced"))
-            .getData();
+        maybeAttestation.orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Unable to perform aggregation for committee because no attestation was produced"));
     return validatorApiChannel.createAggregate(attestationData.hashTreeRoot());
   }
 
@@ -148,14 +146,14 @@ public class AggregationDuty implements Duty {
     private final UInt64 validatorIndex;
     private final int attestationCommitteeIndex;
     private final BLSSignature proof;
-    private final SafeFuture<Optional<Attestation>> unsignedAttestationFuture;
+    private final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture;
 
     private CommitteeAggregator(
         final Validator validator,
         final UInt64 validatorIndex,
         final int attestationCommitteeIndex,
         final BLSSignature proof,
-        final SafeFuture<Optional<Attestation>> unsignedAttestationFuture) {
+        final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture) {
       this.validator = validator;
       this.validatorIndex = validatorIndex;
       this.attestationCommitteeIndex = attestationCommitteeIndex;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ScheduledDuties.java
@@ -19,7 +19,7 @@ import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.client.Validator;
@@ -40,16 +40,21 @@ public class ScheduledDuties {
     blockProductionDuties.put(slot, dutyFactory.createBlockProductionDuty(slot, validator));
   }
 
-  public synchronized SafeFuture<Optional<Attestation>> scheduleAttestationProduction(
+  public synchronized SafeFuture<Optional<AttestationData>> scheduleAttestationProduction(
       final UInt64 slot,
       final Validator validator,
       final int attestationCommitteeIndex,
       final int attestationCommitteePosition,
+      final int attestationCommitteeSize,
       final int validatorIndex) {
     return attestationProductionDuties
         .computeIfAbsent(slot, dutyFactory::createAttestationProductionDuty)
         .addValidator(
-            validator, attestationCommitteeIndex, attestationCommitteePosition, validatorIndex);
+            validator,
+            attestationCommitteeIndex,
+            attestationCommitteePosition,
+            validatorIndex,
+            attestationCommitteeSize);
   }
 
   public synchronized void scheduleAggregationDuties(
@@ -58,7 +63,7 @@ public class ScheduledDuties {
       final int validatorIndex,
       final BLSSignature slotSignature,
       final int attestationCommitteeIndex,
-      final SafeFuture<Optional<Attestation>> unsignedAttestationFuture) {
+      final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture) {
     aggregationDuties
         .computeIfAbsent(slot, dutyFactory::createAggregationDuty)
         .addValidator(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -275,7 +275,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
 
     // Load duties
     dutyScheduler.onSlot(compute_start_slot_at_epoch(ZERO));
-    verify(attestationDuty).addValidator(validator1, 3, 6, 5);
+    verify(attestationDuty).addValidator(validator1, 3, 6, 5, 10);
 
     // Execute
     dutyScheduler.onAttestationCreationDue(attestationProductionSlot);
@@ -293,14 +293,16 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     final int validator1Index = 5;
     final int validator1Committee = 3;
     final int validator1CommitteePosition = 9;
+    final int validator1CommitteeSize = 10;
     final int validator2Index = 6;
     final int validator2Committee = 4;
     final int validator2CommitteePosition = 8;
+    final int validator2CommitteeSize = 11;
     final AttesterDuties validator1Duties =
         new AttesterDuties(
             VALIDATOR1_KEY,
             validator1Index,
-            10,
+            validator1CommitteeSize,
             validator1Committee,
             validator1CommitteePosition,
             attestationSlot);
@@ -308,7 +310,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
         new AttesterDuties(
             VALIDATOR2_KEY,
             validator2Index,
-            10,
+            validator2CommitteeSize,
             validator2Committee,
             validator2CommitteePosition,
             attestationSlot);
@@ -325,10 +327,18 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     // Both validators should be scheduled to create an attestation in the same slot
     verify(attestationDuty)
         .addValidator(
-            validator1, validator1Committee, validator1CommitteePosition, validator1Index);
+            validator1,
+            validator1Committee,
+            validator1CommitteePosition,
+            validator1Index,
+            validator1CommitteeSize);
     verify(attestationDuty)
         .addValidator(
-            validator2, validator2Committee, validator2CommitteePosition, validator2Index);
+            validator2,
+            validator2Committee,
+            validator2CommitteePosition,
+            validator2Index,
+            validator2CommitteeSize);
 
     // Execute
     dutyScheduler.onAttestationCreationDue(attestationSlot);
@@ -341,14 +351,16 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     final int validator1Index = 5;
     final int validator1Committee = 3;
     final int validator1CommitteePosition = 9;
+    final int validator1CommitteeSize = 10;
     final int validator2Index = 6;
     final int validator2Committee = 4;
     final int validator2CommitteePosition = 8;
+    final int validator2CommitteeSize = 11;
     final AttesterDuties validator1Duties =
         new AttesterDuties(
             VALIDATOR1_KEY,
             validator1Index,
-            10,
+            validator1CommitteeSize,
             validator1Committee,
             validator1CommitteePosition,
             attestationSlot);
@@ -356,7 +368,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
         new AttesterDuties(
             VALIDATOR2_KEY,
             validator2Index,
-            10,
+            validator2CommitteeSize,
             validator2Committee,
             validator2CommitteePosition,
             attestationSlot);
@@ -373,10 +385,18 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     // Both validators should be scheduled to create an attestation in the same slot
     verify(attestationDuty)
         .addValidator(
-            validator1, validator1Committee, validator1CommitteePosition, validator1Index);
+            validator1,
+            validator1Committee,
+            validator1CommitteePosition,
+            validator1Index,
+            validator1CommitteeSize);
     verify(attestationDuty)
         .addValidator(
-            validator2, validator2Committee, validator2CommitteePosition, validator2Index);
+            validator2,
+            validator2Committee,
+            validator2CommitteePosition,
+            validator2Index,
+            validator2CommitteeSize);
 
     // Execute
     dutyScheduler.onAttestationCreationDue(attestationSlot);
@@ -389,14 +409,16 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     final int validator1Index = 5;
     final int validator1Committee = 3;
     final int validator1CommitteePosition = 9;
+    final int validator1CommitteeSize = 10;
     final int validator2Index = 6;
     final int validator2Committee = 4;
     final int validator2CommitteePosition = 8;
+    final int validator2CommitteeSize = 11;
     final AttesterDuties validator1Duties =
         new AttesterDuties(
             VALIDATOR1_KEY,
             validator1Index,
-            10,
+            validator1CommitteeSize,
             validator1Committee,
             validator1CommitteePosition,
             attestationSlot);
@@ -404,7 +426,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
         new AttesterDuties(
             VALIDATOR2_KEY,
             validator2Index,
-            10,
+            validator2CommitteeSize,
             validator2Committee,
             validator2CommitteePosition,
             attestationSlot);
@@ -421,10 +443,18 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     // Both validators should be scheduled to create an attestation in the same slot
     verify(attestationDuty)
         .addValidator(
-            validator1, validator1Committee, validator1CommitteePosition, validator1Index);
+            validator1,
+            validator1Committee,
+            validator1CommitteePosition,
+            validator1Index,
+            validator1CommitteeSize);
     verify(attestationDuty)
         .addValidator(
-            validator2, validator2Committee, validator2CommitteePosition, validator2Index);
+            validator2,
+            validator2Committee,
+            validator2CommitteePosition,
+            validator2Index,
+            validator2CommitteeSize);
 
     // Execute
     dutyScheduler.onAttestationCreationDue(attestationSlot);
@@ -440,15 +470,17 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     final int validator1Index = 5;
     final int validator1Committee = 3;
     final int validator1CommitteePosition = 9;
+    final int validator1CommitteeSize = 1; // Guaranteed to be an aggregator
     final int validator2Index = 6;
     final int validator2Committee = 4;
     final int validator2CommitteePosition = 8;
+    final int validator2CommitteeSize = 1000000000; // Won't be an aggregator
 
     final AttesterDuties validator1Duties =
         new AttesterDuties(
             VALIDATOR1_KEY,
             validator1Index,
-            1, // Guaranteed to be an aggregator
+            validator1CommitteeSize,
             validator1Committee,
             validator1CommitteePosition,
             attestationSlot);
@@ -456,7 +488,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
         new AttesterDuties(
             VALIDATOR2_KEY,
             validator2Index,
-            1000000000, // Won't be an aggregator
+            validator2CommitteeSize,
             validator2Committee,
             validator2CommitteePosition,
             attestationSlot);
@@ -469,14 +501,18 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     when(validator2.getSigner().signAggregationSlot(attestationSlot, fork))
         .thenReturn(completedFuture(dataStructureUtil.randomSignature()));
 
-    final SafeFuture<Optional<Attestation>> unsignedAttestationFuture = new SafeFuture<>();
+    final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture = new SafeFuture<>();
     final AggregationDuty aggregationDuty = mock(AggregationDuty.class);
     final AttestationProductionDuty attestationDuty = mock(AttestationProductionDuty.class);
     when(dutyFactory.createAttestationProductionDuty(attestationSlot)).thenReturn(attestationDuty);
     when(dutyFactory.createAggregationDuty(attestationSlot)).thenReturn(aggregationDuty);
     when(aggregationDuty.performDuty()).thenReturn(new SafeFuture<>());
     when(attestationDuty.addValidator(
-            validator1, validator1Committee, validator1CommitteePosition, validator1Index))
+            validator1,
+            validator1Committee,
+            validator1CommitteePosition,
+            validator1Index,
+            validator1CommitteeSize))
         .thenReturn(unsignedAttestationFuture);
 
     // Load duties

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.core.signatures.Signer;
 import tech.pegasys.teku.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
@@ -104,16 +105,16 @@ class AggregationDutyTest {
     final int validatorIndex = 1;
     final int attestationCommitteeIndex = 2;
     final BLSSignature proof = dataStructureUtil.randomSignature();
-    final Attestation unsignedAttestation = dataStructureUtil.randomAttestation();
+    final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     final Attestation aggregate = dataStructureUtil.randomAttestation();
     duty.addValidator(
         validator1,
         validatorIndex,
         proof,
         attestationCommitteeIndex,
-        completedFuture(Optional.of(unsignedAttestation)));
+        completedFuture(Optional.of(attestationData)));
 
-    when(validatorApiChannel.createAggregate(unsignedAttestation.getData().hashTreeRoot()))
+    when(validatorApiChannel.createAggregate(attestationData.hashTreeRoot()))
         .thenReturn(completedFuture(Optional.of(aggregate)));
 
     final AggregateAndProof expectedAggregateAndProof =
@@ -139,8 +140,8 @@ class AggregationDutyTest {
     final int validator2CommitteeIndex = 0;
     final BLSSignature validator2Proof = dataStructureUtil.randomSignature();
 
-    final Attestation committee1UnsignedAttestation = dataStructureUtil.randomAttestation();
-    final Attestation committee2UnsignedAttestation = dataStructureUtil.randomAttestation();
+    final AttestationData committee1AttestationData = dataStructureUtil.randomAttestationData();
+    final AttestationData committee2AttestationData = dataStructureUtil.randomAttestationData();
     final Attestation committee1Aggregate = dataStructureUtil.randomAttestation();
     final Attestation committee2Aggregate = dataStructureUtil.randomAttestation();
     duty.addValidator(
@@ -148,19 +149,17 @@ class AggregationDutyTest {
         validator1Index,
         validator1Proof,
         validator1CommitteeIndex,
-        completedFuture(Optional.of(committee1UnsignedAttestation)));
+        completedFuture(Optional.of(committee1AttestationData)));
     duty.addValidator(
         validator2,
         validator2Index,
         validator2Proof,
         validator2CommitteeIndex,
-        completedFuture(Optional.of(committee2UnsignedAttestation)));
+        completedFuture(Optional.of(committee2AttestationData)));
 
-    when(validatorApiChannel.createAggregate(
-            committee1UnsignedAttestation.getData().hashTreeRoot()))
+    when(validatorApiChannel.createAggregate(committee1AttestationData.hashTreeRoot()))
         .thenReturn(completedFuture(Optional.of(committee1Aggregate)));
-    when(validatorApiChannel.createAggregate(
-            committee2UnsignedAttestation.getData().hashTreeRoot()))
+    when(validatorApiChannel.createAggregate(committee2AttestationData.hashTreeRoot()))
         .thenReturn(completedFuture(Optional.of(committee2Aggregate)));
 
     final AggregateAndProof aggregateAndProof1 =
@@ -197,22 +196,22 @@ class AggregationDutyTest {
     final int validator2Index = 6;
     final BLSSignature validator2Proof = dataStructureUtil.randomSignature();
 
-    final Attestation unsignedAttestation = dataStructureUtil.randomAttestation();
+    final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     final Attestation aggregate = dataStructureUtil.randomAttestation();
     duty.addValidator(
         validator1,
         validator1Index,
         validator1Proof,
         committeeIndex,
-        completedFuture(Optional.of(unsignedAttestation)));
+        completedFuture(Optional.of(attestationData)));
     duty.addValidator(
         validator2,
         validator2Index,
         validator2Proof,
         committeeIndex,
-        completedFuture(Optional.of(unsignedAttestation)));
+        completedFuture(Optional.of(attestationData)));
 
-    when(validatorApiChannel.createAggregate(unsignedAttestation.getData().hashTreeRoot()))
+    when(validatorApiChannel.createAggregate(attestationData.hashTreeRoot()))
         .thenReturn(completedFuture(Optional.of(aggregate)));
 
     final AggregateAndProof aggregateAndProof =
@@ -234,7 +233,7 @@ class AggregationDutyTest {
   }
 
   @Test
-  public void shouldFailWhenUnsignedAttestationNotCreated() {
+  public void shouldFailWhenAttestationDataNotCreated() {
     duty.addValidator(
         validator1, 1, dataStructureUtil.randomSignature(), 2, completedFuture(Optional.empty()));
     verify(validatorApiChannel).subscribeToBeaconCommitteeForAggregation(anyInt(), any());
@@ -247,7 +246,7 @@ class AggregationDutyTest {
   }
 
   @Test
-  public void shouldFailWhenUnsignedAttestationCompletesExceptionally() {
+  public void shouldFailWhenAttestationDataCompletesExceptionally() {
     final RuntimeException exception = new RuntimeException("Doh!");
     duty.addValidator(
         validator1, 1, dataStructureUtil.randomSignature(), 2, failedFuture(exception));
@@ -260,14 +259,14 @@ class AggregationDutyTest {
 
   @Test
   public void shouldReportWhenAggregateNotCreated() {
-    final Attestation unsignedAttestation = dataStructureUtil.randomAttestation();
+    final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     duty.addValidator(
         validator1,
         1,
         dataStructureUtil.randomSignature(),
         2,
-        completedFuture(Optional.of(unsignedAttestation)));
-    when(validatorApiChannel.createAggregate(unsignedAttestation.getData().hashTreeRoot()))
+        completedFuture(Optional.of(attestationData)));
+    when(validatorApiChannel.createAggregate(attestationData.hashTreeRoot()))
         .thenReturn(completedFuture(Optional.empty()));
 
     assertThat(duty.performDuty()).isCompleted();
@@ -279,14 +278,14 @@ class AggregationDutyTest {
   @Test
   public void shouldFailWhenAggregateFails() {
     final Exception exception = new RuntimeException("Whoops");
-    final Attestation unsignedAttestation = dataStructureUtil.randomAttestation();
+    final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     duty.addValidator(
         validator1,
         1,
         dataStructureUtil.randomSignature(),
         2,
-        completedFuture(Optional.of(unsignedAttestation)));
-    when(validatorApiChannel.createAggregate(unsignedAttestation.getData().hashTreeRoot()))
+        completedFuture(Optional.of(attestationData)));
+    when(validatorApiChannel.createAggregate(attestationData.hashTreeRoot()))
         .thenReturn(failedFuture(exception));
 
     performAndReportDuty();

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
@@ -79,7 +79,7 @@ class AttestationProductionDutyTest {
   @Test
   public void shouldFailWhenUnsignedAttestationCanNotBeCreated() {
     final Validator validator = createValidator();
-    when(validatorApiChannel.createUnsignedAttestation(SLOT, 0))
+    when(validatorApiChannel.createAttestationData(SLOT, 0))
         .thenReturn(completedFuture(Optional.empty()));
 
     final SafeFuture<Optional<AttestationData>> attestationFuture =
@@ -113,7 +113,11 @@ class AttestationProductionDutyTest {
             validator1, validator1CommitteeIndex, validator1CommitteePosition, 10, 11);
     final SafeFuture<Optional<AttestationData>> attestationResult2 =
         duty.addValidator(
-            validator2, validator2CommitteeIndex, validator2CommitteePosition, 10, 11);
+            validator2,
+            validator2CommitteeIndex,
+            validator2CommitteePosition,
+            10,
+            validator2CommitteeSize);
 
     performAndReportDuty();
 
@@ -139,7 +143,7 @@ class AttestationProductionDutyTest {
     final int validator2CommitteePosition = 3;
     final int validator2CommitteeSize = 12;
     final RuntimeException failure = new RuntimeException("Golly gee");
-    when(validatorApiChannel.createUnsignedAttestation(SLOT, validator1CommitteeIndex))
+    when(validatorApiChannel.createAttestationData(SLOT, validator1CommitteeIndex))
         .thenReturn(failedFuture(failure));
     final AttestationData attestationData = expectCreateAttestationData(validator2CommitteeIndex);
     final Attestation expectedAttestation =
@@ -151,7 +155,11 @@ class AttestationProductionDutyTest {
             validator1, validator1CommitteeIndex, validator1CommitteePosition, 10, 11);
     final SafeFuture<Optional<AttestationData>> attestationResult2 =
         duty.addValidator(
-            validator2, validator2CommitteeIndex, validator2CommitteePosition, 10, 11);
+            validator2,
+            validator2CommitteeIndex,
+            validator2CommitteePosition,
+            10,
+            validator2CommitteeSize);
 
     performAndReportDuty();
 
@@ -231,7 +239,7 @@ class AttestationProductionDutyTest {
   @Test
   public void shouldCreateAttestationForMultipleValidatorsInSameCommittee() {
     final int committeeIndex = 3;
-    final int committeeSize = 3;
+    final int committeeSize = 33;
     final int validator1CommitteePosition = 6;
     final int validator2CommitteePosition = 2;
     final int validator3CommitteePosition = 5;
@@ -269,7 +277,7 @@ class AttestationProductionDutyTest {
     verify(validatorApiChannel).sendSignedAttestation(expectedAttestation3, Optional.of(10));
 
     // Should have only needed to create one unsigned attestation and reused it for each validator
-    verify(validatorApiChannel, times(1)).createUnsignedAttestation(any(), anyInt());
+    verify(validatorApiChannel, times(1)).createAttestationData(any(), anyInt());
     verify(validatorLogger)
         .dutyCompleted(
             duty.getProducedType(), SLOT, 3, Set.of(attestationData.getBeacon_block_root()));
@@ -321,7 +329,7 @@ class AttestationProductionDutyTest {
     verify(validatorApiChannel).sendSignedAttestation(expectedAttestation3, Optional.of(10));
 
     // Need to create an unsigned attestation for each committee
-    verify(validatorApiChannel, times(2)).createUnsignedAttestation(any(), anyInt());
+    verify(validatorApiChannel, times(2)).createAttestationData(any(), anyInt());
     verify(validatorLogger)
         .dutyCompleted(
             duty.getProducedType(),

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
+import static tech.pegasys.teku.util.config.Constants.MAX_VALIDATORS_PER_COMMITTEE;
 
 import java.util.Optional;
 import java.util.Set;
@@ -34,13 +35,13 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.core.signatures.Signer;
 import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.SSZTypes.Bitlist;
-import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.ForkProvider;
 import tech.pegasys.teku.validator.client.Validator;
@@ -81,8 +82,8 @@ class AttestationProductionDutyTest {
     when(validatorApiChannel.createUnsignedAttestation(SLOT, 0))
         .thenReturn(completedFuture(Optional.empty()));
 
-    final SafeFuture<Optional<Attestation>> attestationFuture =
-        duty.addValidator(validator, 0, 5, 10);
+    final SafeFuture<Optional<AttestationData>> attestationFuture =
+        duty.addValidator(validator, 0, 5, 10, 11);
     performAndReportDuty();
 
     assertThat(attestationFuture).isCompletedWithValue(Optional.empty());
@@ -99,30 +100,30 @@ class AttestationProductionDutyTest {
     final int validator1CommitteePosition = 5;
     final int validator2CommitteeIndex = 1;
     final int validator2CommitteePosition = 3;
-    when(validatorApiChannel.createUnsignedAttestation(SLOT, validator1CommitteeIndex))
+    final int validator2CommitteeSize = 8;
+    when(validatorApiChannel.createAttestationData(SLOT, validator1CommitteeIndex))
         .thenReturn(completedFuture(Optional.empty()));
-    final Attestation unsignedAttestation =
-        expectCreateUnsignedAttestation(validator2CommitteeIndex);
+    final AttestationData attestationData = expectCreateAttestationData(validator2CommitteeIndex);
     final Attestation expectedAttestation =
-        expectSignAttestation(validator2, validator2CommitteePosition, unsignedAttestation);
+        expectSignAttestation(
+            validator2, validator2CommitteePosition, validator2CommitteeSize, attestationData);
 
-    final SafeFuture<Optional<Attestation>> attestationResult1 =
-        duty.addValidator(validator1, validator1CommitteeIndex, validator1CommitteePosition, 10);
-    final SafeFuture<Optional<Attestation>> attestationResult2 =
-        duty.addValidator(validator2, validator2CommitteeIndex, validator2CommitteePosition, 10);
+    final SafeFuture<Optional<AttestationData>> attestationResult1 =
+        duty.addValidator(
+            validator1, validator1CommitteeIndex, validator1CommitteePosition, 10, 11);
+    final SafeFuture<Optional<AttestationData>> attestationResult2 =
+        duty.addValidator(
+            validator2, validator2CommitteeIndex, validator2CommitteePosition, 10, 11);
 
     performAndReportDuty();
 
     assertThat(attestationResult1).isCompletedWithValue(Optional.empty());
-    assertThat(attestationResult2).isCompletedWithValue(Optional.of(unsignedAttestation));
+    assertThat(attestationResult2).isCompletedWithValue(Optional.of(attestationData));
 
     verify(validatorApiChannel).sendSignedAttestation(expectedAttestation, Optional.of(10));
     verify(validatorLogger)
         .dutyCompleted(
-            duty.getProducedType(),
-            SLOT,
-            1,
-            Set.of(unsignedAttestation.getData().getBeacon_block_root()));
+            duty.getProducedType(), SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
     verify(validatorLogger)
         .dutyFailed(eq(duty.getProducedType()), eq(SLOT), any(IllegalStateException.class));
     verifyNoMoreInteractions(validatorLogger);
@@ -136,33 +137,33 @@ class AttestationProductionDutyTest {
     final int validator1CommitteePosition = 5;
     final int validator2CommitteeIndex = 1;
     final int validator2CommitteePosition = 3;
+    final int validator2CommitteeSize = 12;
     final RuntimeException failure = new RuntimeException("Golly gee");
     when(validatorApiChannel.createUnsignedAttestation(SLOT, validator1CommitteeIndex))
         .thenReturn(failedFuture(failure));
-    final Attestation unsignedAttestation =
-        expectCreateUnsignedAttestation(validator2CommitteeIndex);
+    final AttestationData attestationData = expectCreateAttestationData(validator2CommitteeIndex);
     final Attestation expectedAttestation =
-        expectSignAttestation(validator2, validator2CommitteePosition, unsignedAttestation);
+        expectSignAttestation(
+            validator2, validator2CommitteePosition, validator2CommitteeSize, attestationData);
 
-    final SafeFuture<Optional<Attestation>> attestationResult1 =
-        duty.addValidator(validator1, validator1CommitteeIndex, validator1CommitteePosition, 10);
-    final SafeFuture<Optional<Attestation>> attestationResult2 =
-        duty.addValidator(validator2, validator2CommitteeIndex, validator2CommitteePosition, 10);
+    final SafeFuture<Optional<AttestationData>> attestationResult1 =
+        duty.addValidator(
+            validator1, validator1CommitteeIndex, validator1CommitteePosition, 10, 11);
+    final SafeFuture<Optional<AttestationData>> attestationResult2 =
+        duty.addValidator(
+            validator2, validator2CommitteeIndex, validator2CommitteePosition, 10, 11);
 
     performAndReportDuty();
 
     assertThat(attestationResult1).isCompletedExceptionally();
     assertThatThrownBy(attestationResult1::join).hasRootCause(failure);
-    assertThat(attestationResult2).isCompletedWithValue(Optional.of(unsignedAttestation));
+    assertThat(attestationResult2).isCompletedWithValue(Optional.of(attestationData));
 
     verify(validatorApiChannel).sendSignedAttestation(expectedAttestation, Optional.of(10));
 
     verify(validatorLogger)
         .dutyCompleted(
-            duty.getProducedType(),
-            SLOT,
-            1,
-            Set.of(unsignedAttestation.getData().getBeacon_block_root()));
+            duty.getProducedType(), SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
     verify(validatorLogger).dutyFailed(duty.getProducedType(), SLOT, failure);
     verifyNoMoreInteractions(validatorLogger);
   }
@@ -174,30 +175,32 @@ class AttestationProductionDutyTest {
     final int committeeIndex = 0;
     final int validator1CommitteePosition = 5;
     final int validator2CommitteePosition = 3;
-    final Attestation unsignedAttestation = expectCreateUnsignedAttestation(committeeIndex);
+    final int validator1CommitteeSize = 23;
+    final int validator2CommitteeSize = 39;
+    final AttestationData attestationData = expectCreateAttestationData(committeeIndex);
     final RuntimeException signingFailure = new RuntimeException("Gosh darn");
-    when(validator1.getSigner().signAttestationData(unsignedAttestation.getData(), fork))
+    when(validator1.getSigner().signAttestationData(attestationData, fork))
         .thenReturn(failedFuture(signingFailure));
     final Attestation expectedAttestation =
-        expectSignAttestation(validator2, validator2CommitteePosition, unsignedAttestation);
+        expectSignAttestation(
+            validator2, validator2CommitteePosition, validator2CommitteeSize, attestationData);
 
-    final SafeFuture<Optional<Attestation>> attestationResult1 =
-        duty.addValidator(validator1, committeeIndex, validator1CommitteePosition, 10);
-    final SafeFuture<Optional<Attestation>> attestationResult2 =
-        duty.addValidator(validator2, committeeIndex, validator2CommitteePosition, 10);
+    final SafeFuture<Optional<AttestationData>> attestationResult1 =
+        duty.addValidator(
+            validator1, committeeIndex, validator1CommitteePosition, 10, validator1CommitteeSize);
+    final SafeFuture<Optional<AttestationData>> attestationResult2 =
+        duty.addValidator(
+            validator2, committeeIndex, validator2CommitteePosition, 10, validator2CommitteeSize);
 
     performAndReportDuty();
-    assertThat(attestationResult1).isCompletedWithValue(Optional.of(unsignedAttestation));
-    assertThat(attestationResult2).isCompletedWithValue(Optional.of(unsignedAttestation));
+    assertThat(attestationResult1).isCompletedWithValue(Optional.of(attestationData));
+    assertThat(attestationResult2).isCompletedWithValue(Optional.of(attestationData));
 
     verify(validatorApiChannel).sendSignedAttestation(expectedAttestation, Optional.of(10));
 
     verify(validatorLogger)
         .dutyCompleted(
-            duty.getProducedType(),
-            SLOT,
-            1,
-            Set.of(unsignedAttestation.getData().getBeacon_block_root()));
+            duty.getProducedType(), SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
     verify(validatorLogger).dutyFailed(duty.getProducedType(), SLOT, signingFailure);
     verifyNoMoreInteractions(validatorLogger);
   }
@@ -206,30 +209,29 @@ class AttestationProductionDutyTest {
   public void shouldCreateAttestationForSingleValidator() {
     final int committeeIndex = 3;
     final int committeePosition = 6;
+    final int committeeSize = 22;
     final Validator validator = createValidator();
 
-    final Attestation unsignedAttestation = expectCreateUnsignedAttestation(committeeIndex);
+    final AttestationData attestationData = expectCreateAttestationData(committeeIndex);
     final Attestation expectedAttestation =
-        expectSignAttestation(validator, committeePosition, unsignedAttestation);
+        expectSignAttestation(validator, committeePosition, committeeSize, attestationData);
 
-    final SafeFuture<Optional<Attestation>> attestationResult =
-        duty.addValidator(validator, committeeIndex, committeePosition, 10);
+    final SafeFuture<Optional<AttestationData>> attestationResult =
+        duty.addValidator(validator, committeeIndex, committeePosition, 10, committeeSize);
     performAndReportDuty();
-    assertThat(attestationResult).isCompletedWithValue(Optional.of(unsignedAttestation));
+    assertThat(attestationResult).isCompletedWithValue(Optional.of(attestationData));
 
     verify(validatorApiChannel).sendSignedAttestation(expectedAttestation, Optional.of(10));
     verify(validatorLogger)
         .dutyCompleted(
-            duty.getProducedType(),
-            SLOT,
-            1,
-            Set.of(unsignedAttestation.getData().getBeacon_block_root()));
+            duty.getProducedType(), SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
     verifyNoMoreInteractions(validatorLogger);
   }
 
   @Test
   public void shouldCreateAttestationForMultipleValidatorsInSameCommittee() {
     final int committeeIndex = 3;
+    final int committeeSize = 3;
     final int validator1CommitteePosition = 6;
     final int validator2CommitteePosition = 2;
     final int validator3CommitteePosition = 5;
@@ -237,24 +239,30 @@ class AttestationProductionDutyTest {
     final Validator validator2 = createValidator();
     final Validator validator3 = createValidator();
 
-    final Attestation unsignedAttestation = expectCreateUnsignedAttestation(committeeIndex);
+    final AttestationData attestationData = expectCreateAttestationData(committeeIndex);
     final Attestation expectedAttestation1 =
-        expectSignAttestation(validator1, validator1CommitteePosition, unsignedAttestation);
+        expectSignAttestation(
+            validator1, validator1CommitteePosition, committeeSize, attestationData);
     final Attestation expectedAttestation2 =
-        expectSignAttestation(validator2, validator2CommitteePosition, unsignedAttestation);
+        expectSignAttestation(
+            validator2, validator2CommitteePosition, committeeSize, attestationData);
     final Attestation expectedAttestation3 =
-        expectSignAttestation(validator3, validator3CommitteePosition, unsignedAttestation);
+        expectSignAttestation(
+            validator3, validator3CommitteePosition, committeeSize, attestationData);
 
-    final SafeFuture<Optional<Attestation>> attestationResult1 =
-        duty.addValidator(validator1, committeeIndex, validator1CommitteePosition, 10);
-    final SafeFuture<Optional<Attestation>> attestationResult2 =
-        duty.addValidator(validator2, committeeIndex, validator2CommitteePosition, 10);
-    final SafeFuture<Optional<Attestation>> attestationResult3 =
-        duty.addValidator(validator3, committeeIndex, validator3CommitteePosition, 10);
+    final SafeFuture<Optional<AttestationData>> attestationResult1 =
+        duty.addValidator(
+            validator1, committeeIndex, validator1CommitteePosition, 10, committeeSize);
+    final SafeFuture<Optional<AttestationData>> attestationResult2 =
+        duty.addValidator(
+            validator2, committeeIndex, validator2CommitteePosition, 10, committeeSize);
+    final SafeFuture<Optional<AttestationData>> attestationResult3 =
+        duty.addValidator(
+            validator3, committeeIndex, validator3CommitteePosition, 10, committeeSize);
     performAndReportDuty();
-    assertThat(attestationResult1).isCompletedWithValue(Optional.of(unsignedAttestation));
-    assertThat(attestationResult2).isCompletedWithValue(Optional.of(unsignedAttestation));
-    assertThat(attestationResult3).isCompletedWithValue(Optional.of(unsignedAttestation));
+    assertThat(attestationResult1).isCompletedWithValue(Optional.of(attestationData));
+    assertThat(attestationResult2).isCompletedWithValue(Optional.of(attestationData));
+    assertThat(attestationResult3).isCompletedWithValue(Optional.of(attestationData));
 
     verify(validatorApiChannel).sendSignedAttestation(expectedAttestation1, Optional.of(10));
     verify(validatorApiChannel).sendSignedAttestation(expectedAttestation2, Optional.of(10));
@@ -264,10 +272,7 @@ class AttestationProductionDutyTest {
     verify(validatorApiChannel, times(1)).createUnsignedAttestation(any(), anyInt());
     verify(validatorLogger)
         .dutyCompleted(
-            duty.getProducedType(),
-            SLOT,
-            3,
-            Set.of(unsignedAttestation.getData().getBeacon_block_root()));
+            duty.getProducedType(), SLOT, 3, Set.of(attestationData.getBeacon_block_root()));
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -275,6 +280,8 @@ class AttestationProductionDutyTest {
   public void shouldCreateAttestationForMultipleValidatorsInDifferentCommittees() {
     final int committeeIndex1 = 3;
     final int committeeIndex2 = 5;
+    final int committeeSize1 = 15;
+    final int committeeSize2 = 20;
     final int validator1CommitteePosition = 6;
     final int validator2CommitteePosition = 2;
     final int validator3CommitteePosition = 5;
@@ -282,21 +289,27 @@ class AttestationProductionDutyTest {
     final Validator validator2 = createValidator();
     final Validator validator3 = createValidator();
 
-    final Attestation unsignedAttestation1 = expectCreateUnsignedAttestation(committeeIndex1);
-    final Attestation unsignedAttestation2 = expectCreateUnsignedAttestation(committeeIndex2);
+    final AttestationData unsignedAttestation1 = expectCreateAttestationData(committeeIndex1);
+    final AttestationData unsignedAttestation2 = expectCreateAttestationData(committeeIndex2);
     final Attestation expectedAttestation1 =
-        expectSignAttestation(validator1, validator1CommitteePosition, unsignedAttestation1);
+        expectSignAttestation(
+            validator1, validator1CommitteePosition, committeeSize1, unsignedAttestation1);
     final Attestation expectedAttestation2 =
-        expectSignAttestation(validator2, validator2CommitteePosition, unsignedAttestation2);
+        expectSignAttestation(
+            validator2, validator2CommitteePosition, committeeSize2, unsignedAttestation2);
     final Attestation expectedAttestation3 =
-        expectSignAttestation(validator3, validator3CommitteePosition, unsignedAttestation1);
+        expectSignAttestation(
+            validator3, validator3CommitteePosition, committeeSize1, unsignedAttestation1);
 
-    final SafeFuture<Optional<Attestation>> attestationResult1 =
-        duty.addValidator(validator1, committeeIndex1, validator1CommitteePosition, 10);
-    final SafeFuture<Optional<Attestation>> attestationResult2 =
-        duty.addValidator(validator2, committeeIndex2, validator2CommitteePosition, 10);
-    final SafeFuture<Optional<Attestation>> attestationResult3 =
-        duty.addValidator(validator3, committeeIndex1, validator3CommitteePosition, 10);
+    final SafeFuture<Optional<AttestationData>> attestationResult1 =
+        duty.addValidator(
+            validator1, committeeIndex1, validator1CommitteePosition, 10, committeeSize1);
+    final SafeFuture<Optional<AttestationData>> attestationResult2 =
+        duty.addValidator(
+            validator2, committeeIndex2, validator2CommitteePosition, 10, committeeSize2);
+    final SafeFuture<Optional<AttestationData>> attestationResult3 =
+        duty.addValidator(
+            validator3, committeeIndex1, validator3CommitteePosition, 10, committeeSize1);
 
     performAndReportDuty();
     assertThat(attestationResult1).isCompletedWithValue(Optional.of(unsignedAttestation1));
@@ -315,8 +328,8 @@ class AttestationProductionDutyTest {
             SLOT,
             3,
             Set.of(
-                unsignedAttestation1.getData().getBeacon_block_root(),
-                unsignedAttestation2.getData().getBeacon_block_root()));
+                unsignedAttestation1.getBeacon_block_root(),
+                unsignedAttestation2.getBeacon_block_root()));
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -328,32 +341,29 @@ class AttestationProductionDutyTest {
   public Attestation expectSignAttestation(
       final Validator validator,
       final int committeePosition,
-      final Attestation unsignedAttestation) {
+      final int committeeSize,
+      final AttestationData attestationData) {
     final BLSSignature signature = dataStructureUtil.randomSignature();
-    when(validator.getSigner().signAttestationData(unsignedAttestation.getData(), fork))
+    when(validator.getSigner().signAttestationData(attestationData, fork))
         .thenReturn(completedFuture(signature));
-    return createExpectedAttestation(unsignedAttestation, committeePosition, signature);
+    return createExpectedAttestation(attestationData, committeePosition, committeeSize, signature);
   }
 
-  public Attestation expectCreateUnsignedAttestation(final int committeeIndex) {
-    final Attestation unsignedAttestation =
-        new Attestation(
-            new Bitlist(10, Constants.MAX_VALIDATORS_PER_COMMITTEE),
-            dataStructureUtil.randomAttestationData(SLOT),
-            BLSSignature.empty());
-
-    when(validatorApiChannel.createUnsignedAttestation(SLOT, committeeIndex))
-        .thenReturn(completedFuture(Optional.of(unsignedAttestation)));
-    return unsignedAttestation;
+  public AttestationData expectCreateAttestationData(final int committeeIndex) {
+    final AttestationData attestationData = dataStructureUtil.randomAttestationData(SLOT);
+    when(validatorApiChannel.createAttestationData(SLOT, committeeIndex))
+        .thenReturn(completedFuture(Optional.of(attestationData)));
+    return attestationData;
   }
 
   public Attestation createExpectedAttestation(
-      final Attestation unsignedAttestation,
+      final AttestationData attestationData,
       final int committeePosition,
+      final int commiteeSize,
       final BLSSignature signature) {
-    final Bitlist expectedAggregationBits = new Bitlist(unsignedAttestation.getAggregation_bits());
+    final Bitlist expectedAggregationBits = new Bitlist(commiteeSize, MAX_VALIDATORS_PER_COMMITTEE);
     expectedAggregationBits.setBit(committeePosition);
-    return new Attestation(expectedAggregationBits, unsignedAttestation.getData(), signature);
+    return new Attestation(expectedAggregationBits, attestationData, signature);
   }
 
   private void performAndReportDuty() {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ScheduledDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ScheduledDutiesTest.java
@@ -68,9 +68,9 @@ class ScheduledDutiesTest {
     when(dutyFactory.createAttestationProductionDuty(ONE)).thenReturn(duty1);
     when(dutyFactory.createAttestationProductionDuty(TWO)).thenReturn(duty2);
 
-    ignoreFuture(duties.scheduleAttestationProduction(ZERO, validator, 0, 0, 10));
-    ignoreFuture(duties.scheduleAttestationProduction(ONE, validator, 0, 0, 10));
-    ignoreFuture(duties.scheduleAttestationProduction(TWO, validator, 0, 0, 10));
+    ignoreFuture(duties.scheduleAttestationProduction(ZERO, validator, 0, 0, 10, 5));
+    ignoreFuture(duties.scheduleAttestationProduction(ONE, validator, 0, 0, 10, 5));
+    ignoreFuture(duties.scheduleAttestationProduction(TWO, validator, 0, 0, 10, 5));
 
     duties.produceAttestations(ONE);
     verify(duty1).performDuty();

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -306,6 +306,13 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
             });
   }
 
+  @Override
+  public SafeFuture<Optional<AttestationData>> createAttestationData(
+      final UInt64 slot, final int committeeIndex) {
+    return createUnsignedAttestation(slot, committeeIndex)
+        .thenApply(maybeAttestation -> maybeAttestation.map(Attestation::getData));
+  }
+
   private Attestation createAttestation(
       final BeaconBlock block,
       final BeaconState state,

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.datastructures.state.Fork;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
@@ -205,6 +206,16 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
             apiClient
                 .createUnsignedAttestation(slot, committeeIndex)
                 .map(tech.pegasys.teku.api.schema.Attestation::asInternalAttestation));
+  }
+
+  @Override
+  public SafeFuture<Optional<AttestationData>> createAttestationData(
+      final UInt64 slot, final int committeeIndex) {
+    return asyncRunner.runAsync(
+        () ->
+            apiClient
+                .createAttestationData(slot, committeeIndex)
+                .map(tech.pegasys.teku.api.schema.AttestationData::asInternalAttestationData));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.remote.apiclient;
 
 import static java.util.Collections.emptyMap;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_AGGREGATE;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DATA;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_FORK;
@@ -59,6 +60,7 @@ import tech.pegasys.teku.api.response.v1.validator.GetNewBlockResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.api.schema.Attestation;
+import tech.pegasys.teku.api.schema.AttestationData;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
@@ -167,6 +169,16 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
     queryParams.put("committee_index", String.valueOf(committeeIndex));
 
     return get(GET_UNSIGNED_ATTESTATION, queryParams, Attestation.class);
+  }
+
+  @Override
+  public Optional<AttestationData> createAttestationData(
+      final UInt64 slot, final int committeeIndex) {
+    final Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("slot", encodeQueryParam(slot));
+    queryParams.put("committee_index", String.valueOf(committeeIndex));
+
+    return get(GET_ATTESTATION_DATA, queryParams, AttestationData.class);
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -26,6 +26,7 @@ public enum ValidatorApiMethod {
   GET_UNSIGNED_BLOCK("eth/v1/validator/blocks/:slot"),
   SEND_SIGNED_BLOCK("eth/v1/beacon/blocks"),
   GET_UNSIGNED_ATTESTATION("validator/attestation"),
+  GET_ATTESTATION_DATA("/eth/v1/validator/attestation_data"),
   SEND_SIGNED_ATTESTATION("validator/attestation"),
   GET_AGGREGATE("validator/aggregate_attestation"),
   SEND_SIGNED_AGGREGATE_AND_PROOF("validator/aggregate_and_proofs"),

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
 import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.api.schema.Attestation;
+import tech.pegasys.teku.api.schema.AttestationData;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
@@ -55,6 +56,8 @@ public interface ValidatorRestApiClient {
   SendSignedBlockResult sendSignedBlock(SignedBeaconBlock beaconBlock);
 
   Optional<Attestation> createUnsignedAttestation(UInt64 slot, int committeeIndex);
+
+  Optional<AttestationData> createAttestationData(UInt64 slot, int committeeIndex);
 
   void sendSignedAttestation(Attestation attestation);
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -51,6 +51,7 @@ import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
@@ -387,6 +388,29 @@ class RemoteValidatorApiHandlerTest {
     SafeFuture<Optional<Attestation>> future = apiHandler.createUnsignedAttestation(UInt64.ONE, 0);
 
     assertThat(unwrapToValue(future)).usingRecursiveComparison().isEqualTo(attestation);
+  }
+
+  @Test
+  public void createAttestationData_WhenNone_ReturnsEmpty() {
+    when(apiClient.createAttestationData(any(), anyInt())).thenReturn(Optional.empty());
+
+    SafeFuture<Optional<AttestationData>> future = apiHandler.createAttestationData(UInt64.ONE, 0);
+
+    assertThat(unwrapToOptional(future)).isEmpty();
+  }
+
+  @Test
+  public void createAttestationData_WhenFound_ReturnsAttestation() {
+    final Attestation attestation = dataStructureUtil.randomAttestation();
+    final tech.pegasys.teku.api.schema.AttestationData schemaAttestationData =
+        new tech.pegasys.teku.api.schema.AttestationData(attestation.getData());
+
+    when(apiClient.createAttestationData(eq(UInt64.ONE), eq(0)))
+        .thenReturn(Optional.of(schemaAttestationData));
+
+    SafeFuture<Optional<AttestationData>> future = apiHandler.createAttestationData(UInt64.ONE, 0);
+
+    assertThat(unwrapToValue(future)).usingRecursiveComparison().isEqualTo(attestation.getData());
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Use the standard `/eth/v1/validator/attestation_data` endpoint to create attestation data. Since this only creates the `AttestationData` and not an unsigned `Attestation`, we need to pass the committee size through so the Validator Client can create the right length aggregation bits.

## Fixed Issue(s)
#1918 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.