### PR TITLE
Include committees_at_slot in attester duties response

### DIFF
--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDutiesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDutiesTest.java
@@ -63,7 +63,7 @@ public class PostAttesterDutiesTest extends AbstractValidatorApiTest {
     when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
     when(context.body()).thenReturn("[\"2\"]");
     List<AttesterDuty> duties =
-        List.of(getDuty(2, 1, 2, 3, compute_start_slot_at_epoch(UInt64.valueOf(100))));
+        List.of(getDuty(2, 1, 2, 10, 3, compute_start_slot_at_epoch(UInt64.valueOf(100))));
     when(validatorDataProvider.getAttesterDuties(eq(UInt64.valueOf(100)), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(duties)));
 
@@ -91,6 +91,7 @@ public class PostAttesterDutiesTest extends AbstractValidatorApiTest {
       final long validatorIndex,
       final long committeeIndex,
       final long committeeLength,
+      final int committeesAtSlot,
       final long validatorCommitteeIndex,
       final UInt64 slot) {
     return new AttesterDuty(
@@ -98,6 +99,7 @@ public class PostAttesterDutiesTest extends AbstractValidatorApiTest {
         UInt64.valueOf(validatorIndex),
         UInt64.valueOf(committeeIndex),
         UInt64.valueOf(committeeLength),
+        UInt64.valueOf(committeesAtSlot),
         UInt64.valueOf(validatorCommitteeIndex),
         slot);
   }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -256,6 +256,7 @@ public class ValidatorDataProvider {
         UInt64.valueOf(duties.getValidatorIndex()),
         UInt64.valueOf(duties.getCommitteeIndex()),
         UInt64.valueOf(duties.getCommitteeLength()),
+        UInt64.valueOf(duties.getCommiteesAtSlot()),
         UInt64.valueOf(duties.getValidatorCommitteeIndex()),
         duties.getSlot());
   }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -372,8 +372,8 @@ public class ValidatorDataProviderTest {
 
   @Test
   public void getAttesterDuties_shouldReturnDutiesForKnownValidator() {
-    AttesterDuties v1 = new AttesterDuties(BLSPublicKey.random(0), 1, 2, 3, 4, ONE);
-    AttesterDuties v2 = new AttesterDuties(BLSPublicKey.random(1), 11, 12, 13, 14, ZERO);
+    AttesterDuties v1 = new AttesterDuties(BLSPublicKey.random(0), 1, 2, 3, 15, 4, ONE);
+    AttesterDuties v2 = new AttesterDuties(BLSPublicKey.random(1), 11, 12, 13, 15, 14, ZERO);
     when(validatorApiChannel.getAttestationDuties(eq(ONE), any()))
         .thenReturn(completedFuture(Optional.of(List.of(v1, v2))));
 
@@ -392,6 +392,7 @@ public class ValidatorDataProviderTest {
         UInt64.valueOf(duties.getValidatorIndex()),
         UInt64.valueOf(duties.getCommitteeIndex()),
         UInt64.valueOf(duties.getCommitteeLength()),
+        UInt64.valueOf(duties.getCommiteesAtSlot()),
         UInt64.valueOf(duties.getValidatorCommitteeIndex()),
         duties.getSlot());
   }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/AttesterDuty.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/AttesterDuty.java
@@ -53,6 +53,13 @@ public class AttesterDuty {
       description = "Number of validators in committee")
   public final UInt64 committeeLength;
 
+  @JsonProperty("committees_at_slot")
+  @Schema(
+      type = "string",
+      example = EXAMPLE_UINT64,
+      description = "Number of committees at the provided slot")
+  public final UInt64 committeesAtSlot;
+
   @JsonProperty("validator_committee_index")
   @Schema(
       type = "string",
@@ -73,25 +80,32 @@ public class AttesterDuty {
       @JsonProperty("validator_index") final UInt64 validatorIndex,
       @JsonProperty("committee_index") final UInt64 committeeIndex,
       @JsonProperty("committee_length") final UInt64 committeeLength,
+      @JsonProperty("committees_at_slot") final UInt64 committeesAtSlot,
       @JsonProperty("validator_committee_index") final UInt64 validatorCommitteeIndex,
       @JsonProperty("slot") final UInt64 slot) {
     this.pubkey = pubkey;
     this.validatorIndex = validatorIndex;
     this.committeeIndex = committeeIndex;
     this.committeeLength = committeeLength;
+    this.committeesAtSlot = committeesAtSlot;
     this.validatorCommitteeIndex = validatorCommitteeIndex;
     this.slot = slot;
   }
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     final AttesterDuty that = (AttesterDuty) o;
     return Objects.equals(pubkey, that.pubkey)
         && Objects.equals(validatorIndex, that.validatorIndex)
         && Objects.equals(committeeIndex, that.committeeIndex)
         && Objects.equals(committeeLength, that.committeeLength)
+        && Objects.equals(committeesAtSlot, that.committeesAtSlot)
         && Objects.equals(validatorCommitteeIndex, that.validatorCommitteeIndex)
         && Objects.equals(slot, that.slot);
   }
@@ -99,6 +113,12 @@ public class AttesterDuty {
   @Override
   public int hashCode() {
     return Objects.hash(
-        pubkey, validatorIndex, committeeIndex, committeeLength, validatorCommitteeIndex, slot);
+        pubkey,
+        validatorIndex,
+        committeeIndex,
+        committeeLength,
+        committeesAtSlot,
+        validatorCommitteeIndex,
+        slot);
   }
 }

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/CommitteeAssignmentUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/CommitteeAssignmentUtil.java
@@ -41,12 +41,29 @@ public class CommitteeAssignmentUtil {
    */
   public static Optional<CommitteeAssignment> get_committee_assignment(
       BeaconState state, UInt64 epoch, int validator_index) {
+    return get_committee_assignment(
+        state, epoch, validator_index, get_committee_count_per_slot(state, epoch));
+  }
+
+  /**
+   * Return the committee assignment in the ``epoch`` for ``validator_index``. ``assignment``
+   * returned is a tuple of the following form: ``assignment[0]`` is the list of validators in the
+   * committee ``assignment[1]`` is the index to which the committee is assigned ``assignment[2]``
+   * is the slot at which the committee is assigned Return None if no assignment.
+   *
+   * @param state the BeaconState.
+   * @param epoch either on or between previous or current epoch.
+   * @param validator_index the validator that is calling this function.
+   * @param committeeCountPerSlot the number of committees for the target epoch
+   * @return Optional.of(CommitteeAssignment).
+   */
+  public static Optional<CommitteeAssignment> get_committee_assignment(
+      BeaconState state, UInt64 epoch, int validator_index, final UInt64 committeeCountPerSlot) {
     UInt64 next_epoch = get_current_epoch(state).plus(UInt64.ONE);
     checkArgument(
         epoch.compareTo(next_epoch) <= 0, "get_committee_assignment: Epoch number too high");
 
     UInt64 start_slot = compute_start_slot_at_epoch(epoch);
-    final UInt64 committeeCountPerSlot = get_committee_count_per_slot(state, epoch);
     for (UInt64 slot = start_slot;
         slot.isLessThan(start_slot.plus(SLOTS_PER_EPOCH));
         slot = slot.plus(UInt64.ONE)) {

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/AttesterDuties.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/AttesterDuties.java
@@ -25,6 +25,8 @@ public class AttesterDuties {
   private final int committeeLength;
   /** the committee index of the committee that includes the specified validator */
   private final int committeeIndex;
+
+  private final int commiteesAtSlot;
   // index of the validator in the committee
   private final int validatorCommitteeIndex;
   private final UInt64 slot;
@@ -34,33 +36,16 @@ public class AttesterDuties {
       final int validatorIndex,
       final int committeeLength,
       final int committeeIndex,
+      final int commiteesAtSlot,
       final int validatorCommitteeIndex,
       final UInt64 slot) {
     this.publicKey = publicKey;
     this.validatorIndex = validatorIndex;
     this.committeeLength = committeeLength;
     this.committeeIndex = committeeIndex;
+    this.commiteesAtSlot = commiteesAtSlot;
     this.validatorCommitteeIndex = validatorCommitteeIndex;
     this.slot = slot;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    final AttesterDuties that = (AttesterDuties) o;
-    return validatorIndex == that.validatorIndex
-        && committeeLength == that.committeeLength
-        && committeeIndex == that.committeeIndex
-        && validatorCommitteeIndex == that.validatorCommitteeIndex
-        && Objects.equals(publicKey, that.publicKey)
-        && Objects.equals(slot, that.slot);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        publicKey, validatorIndex, committeeLength, committeeIndex, validatorCommitteeIndex, slot);
   }
 
   public BLSPublicKey getPublicKey() {
@@ -79,6 +64,10 @@ public class AttesterDuties {
     return committeeIndex;
   }
 
+  public int getCommiteesAtSlot() {
+    return commiteesAtSlot;
+  }
+
   public int getValidatorCommitteeIndex() {
     return validatorCommitteeIndex;
   }
@@ -88,12 +77,43 @@ public class AttesterDuties {
   }
 
   @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AttesterDuties that = (AttesterDuties) o;
+    return validatorIndex == that.validatorIndex
+        && committeeLength == that.committeeLength
+        && committeeIndex == that.committeeIndex
+        && commiteesAtSlot == that.commiteesAtSlot
+        && validatorCommitteeIndex == that.validatorCommitteeIndex
+        && Objects.equals(publicKey, that.publicKey)
+        && Objects.equals(slot, that.slot);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        publicKey,
+        validatorIndex,
+        committeeLength,
+        committeeIndex,
+        commiteesAtSlot,
+        validatorCommitteeIndex,
+        slot);
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("publicKey", publicKey)
         .add("validatorIndex", validatorIndex)
         .add("committeeLength", committeeLength)
         .add("committeeIndex", committeeIndex)
+        .add("commiteesAtSlot", commiteesAtSlot)
         .add("validatorCommitteeIndex", validatorCommitteeIndex)
         .add("slot", slot)
         .toString();

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -264,7 +264,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   public void shouldNotPerformDutiesForSameSlotTwice() {
     final UInt64 attestationProductionSlot = UInt64.valueOf(5);
     final AttesterDuties validator1Duties =
-        new AttesterDuties(VALIDATOR1_KEY, 5, 10, 3, 6, attestationProductionSlot);
+        new AttesterDuties(VALIDATOR1_KEY, 5, 10, 3, 15, 6, attestationProductionSlot);
     when(validatorApiChannel.getAttestationDuties(eq(ZERO), any()))
         .thenReturn(completedFuture(Optional.of(List.of(validator1Duties))));
 
@@ -298,12 +298,14 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     final int validator2Committee = 4;
     final int validator2CommitteePosition = 8;
     final int validator2CommitteeSize = 11;
+    final int committeesAtSlot = 15;
     final AttesterDuties validator1Duties =
         new AttesterDuties(
             VALIDATOR1_KEY,
             validator1Index,
             validator1CommitteeSize,
             validator1Committee,
+            committeesAtSlot,
             validator1CommitteePosition,
             attestationSlot);
     final AttesterDuties validator2Duties =
@@ -312,6 +314,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validator2Index,
             validator2CommitteeSize,
             validator2Committee,
+            committeesAtSlot,
             validator2CommitteePosition,
             attestationSlot);
     when(validatorApiChannel.getAttestationDuties(eq(ZERO), any()))
@@ -356,12 +359,14 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     final int validator2Committee = 4;
     final int validator2CommitteePosition = 8;
     final int validator2CommitteeSize = 11;
+    final int committeesAtSlot = 15;
     final AttesterDuties validator1Duties =
         new AttesterDuties(
             VALIDATOR1_KEY,
             validator1Index,
             validator1CommitteeSize,
             validator1Committee,
+            committeesAtSlot,
             validator1CommitteePosition,
             attestationSlot);
     final AttesterDuties validator2Duties =
@@ -370,6 +375,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validator2Index,
             validator2CommitteeSize,
             validator2Committee,
+            committeesAtSlot,
             validator2CommitteePosition,
             attestationSlot);
     when(validatorApiChannel.getAttestationDuties(eq(ZERO), any()))
@@ -414,12 +420,14 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     final int validator2Committee = 4;
     final int validator2CommitteePosition = 8;
     final int validator2CommitteeSize = 11;
+    final int committeesAtSlot = 15;
     final AttesterDuties validator1Duties =
         new AttesterDuties(
             VALIDATOR1_KEY,
             validator1Index,
             validator1CommitteeSize,
             validator1Committee,
+            committeesAtSlot,
             validator1CommitteePosition,
             attestationSlot);
     final AttesterDuties validator2Duties =
@@ -428,6 +436,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validator2Index,
             validator2CommitteeSize,
             validator2Committee,
+            committeesAtSlot,
             validator2CommitteePosition,
             attestationSlot);
     when(validatorApiChannel.getAttestationDuties(eq(ZERO), any()))
@@ -475,6 +484,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     final int validator2Committee = 4;
     final int validator2CommitteePosition = 8;
     final int validator2CommitteeSize = 1000000000; // Won't be an aggregator
+    final int committeesAtSlot = 15;
 
     final AttesterDuties validator1Duties =
         new AttesterDuties(
@@ -482,6 +492,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validator1Index,
             validator1CommitteeSize,
             validator1Committee,
+            committeesAtSlot,
             validator1CommitteePosition,
             attestationSlot);
     final AttesterDuties validator2Duties =
@@ -490,6 +501,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validator2Index,
             validator2CommitteeSize,
             validator2Committee,
+            committeesAtSlot,
             validator2CommitteePosition,
             attestationSlot);
     when(validatorApiChannel.getAttestationDuties(eq(ONE), any()))

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -524,6 +524,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final BeaconState state, final UInt64 epoch, final Integer validatorIndex) {
     try {
       final BLSPublicKey pkey = state.getValidators().get(validatorIndex).getPubkey();
+      final UInt64 committeeCountPerSlot = get_committee_count_per_slot(state, epoch);
       return CommitteeAssignmentUtil.get_committee_assignment(state, epoch, validatorIndex)
           .map(
               committeeAssignment ->
@@ -532,6 +533,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                       validatorIndex,
                       committeeAssignment.getCommittee().size(),
                       committeeAssignment.getCommitteeIndex().intValue(),
+                      committeeCountPerSlot.intValue(),
                       committeeAssignment.getCommittee().indexOf(validatorIndex),
                       committeeAssignment.getSlot()));
     } catch (IndexOutOfBoundsException ex) {

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -346,7 +346,7 @@ class ValidatorApiHandlerTest {
         validatorApiHandler.getAttestationDuties(EPOCH, List.of(1, 32));
     final Optional<List<AttesterDuties>> duties = assertCompletedSuccessfully(result);
     assertThat(duties.get())
-        .containsExactly(new AttesterDuties(validator1Key, 1, 4, 0, 1, UInt64.valueOf(108)));
+        .containsExactly(new AttesterDuties(validator1Key, 1, 4, 0, 1, 1, UInt64.valueOf(108)));
   }
 
   @Test
@@ -361,7 +361,7 @@ class ValidatorApiHandlerTest {
         validatorApiHandler.getAttestationDuties(EPOCH, List.of(1, 32));
     final Optional<List<AttesterDuties>> duties = assertCompletedSuccessfully(result);
     assertThat(duties.get())
-        .containsExactly(new AttesterDuties(validator1Key, 1, 4, 0, 1, UInt64.valueOf(108)));
+        .containsExactly(new AttesterDuties(validator1Key, 1, 4, 0, 1, 1, UInt64.valueOf(108)));
   }
 
   @Test

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -189,6 +189,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
         attesterDuty.validatorIndex.intValue(),
         attesterDuty.committeeLength.intValue(),
         attesterDuty.committeeIndex.intValue(),
+        attesterDuty.committeesAtSlot.intValue(),
         attesterDuty.validatorCommitteeIndex.intValue(),
         attesterDuty.slot);
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -303,12 +303,14 @@ class RemoteValidatorApiHandlerTest {
     final int committeeLength = 2;
     final int committeeIndex = 1;
     final int validatorCommitteeIndex = 3;
+    final int committeesAtSlot = 15;
     final AttesterDuty schemaValidatorDuties =
         new AttesterDuty(
             new BLSPubKey(blsPublicKey),
             UInt64.valueOf(validatorIndex),
             UInt64.valueOf(committeeIndex),
             UInt64.valueOf(committeeLength),
+            UInt64.valueOf(committeesAtSlot),
             UInt64.valueOf(validatorCommitteeIndex),
             UInt64.ZERO);
     final AttesterDuties expectedValidatorDuties =
@@ -317,6 +319,7 @@ class RemoteValidatorApiHandlerTest {
             validatorIndex,
             committeeLength,
             committeeIndex,
+            committeesAtSlot,
             validatorCommitteeIndex,
             UInt64.ZERO);
 
@@ -581,7 +584,7 @@ class RemoteValidatorApiHandlerTest {
 
     final Set<tech.pegasys.teku.api.schema.SubnetSubscription> request = argumentCaptor.getValue();
     assertThat(request).hasSize(1);
-    assertThat(request.stream().findFirst().get())
+    assertThat(request.stream().findFirst().orElseThrow())
         .usingRecursiveComparison()
         .isEqualTo(schemaSubnetSubscription);
   }


### PR DESCRIPTION
## PR Description
https://github.com/ethereum/eth2.0-APIs/pull/81 added `committees_at_slot` to the attester duty response. Update our response to include it.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.