### PR TITLE
Move ValidatorApiChannel subscribeToBeaconCommittee towards the standard API

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/validator/PostSubscribeToBeaconCommitteeIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/validator/PostSubscribeToBeaconCommitteeIntegrationTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.beaconrestapi.validator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doThrow;
 
@@ -48,7 +49,7 @@ public class PostSubscribeToBeaconCommitteeIntegrationTest
 
     doThrow(new RuntimeException())
         .when(validatorApiChannel)
-        .subscribeToBeaconCommitteeForAggregation(anyInt(), any());
+        .subscribeToBeaconCommittee(anyInt(), anyInt(), any(), any(), anyBoolean());
 
     Response response =
         post(PostSubscribeToBeaconCommittee.ROUTE, jsonProvider.objectToJSON(request));

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/validator/PostSubscribeToBeaconCommitteeIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/validator/PostSubscribeToBeaconCommitteeIntegrationTest.java
@@ -15,8 +15,6 @@ package tech.pegasys.teku.beaconrestapi.validator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doThrow;
 
 import okhttp3.Response;
@@ -47,9 +45,7 @@ public class PostSubscribeToBeaconCommitteeIntegrationTest
     final SubscribeToBeaconCommitteeRequest request =
         new SubscribeToBeaconCommitteeRequest(1, UInt64.ONE);
 
-    doThrow(new RuntimeException())
-        .when(validatorApiChannel)
-        .subscribeToBeaconCommittee(anyInt(), anyInt(), any(), any(), anyBoolean());
+    doThrow(new RuntimeException()).when(validatorApiChannel).subscribeToBeaconCommittee(any());
 
     Response response =
         post(PostSubscribeToBeaconCommittee.ROUTE, jsonProvider.objectToJSON(request));

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/validator/PostSubscribeToPersistentSubnetsIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/validator/PostSubscribeToPersistentSubnetsIntegrationTest.java
@@ -15,8 +15,6 @@ package tech.pegasys.teku.beaconrestapi.validator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doThrow;
 
 import okhttp3.Response;
@@ -47,9 +45,7 @@ public class PostSubscribeToPersistentSubnetsIntegrationTest
     final SubscribeToBeaconCommitteeRequest request =
         new SubscribeToBeaconCommitteeRequest(1, UInt64.ONE);
 
-    doThrow(new RuntimeException())
-        .when(validatorApiChannel)
-        .subscribeToBeaconCommittee(anyInt(), anyInt(), any(), any(), anyBoolean());
+    doThrow(new RuntimeException()).when(validatorApiChannel).subscribeToBeaconCommittee(any());
 
     Response response =
         post(PostSubscribeToBeaconCommittee.ROUTE, jsonProvider.objectToJSON(request));

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/validator/PostSubscribeToPersistentSubnetsIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/validator/PostSubscribeToPersistentSubnetsIntegrationTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.beaconrestapi.validator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doThrow;
 
@@ -48,7 +49,7 @@ public class PostSubscribeToPersistentSubnetsIntegrationTest
 
     doThrow(new RuntimeException())
         .when(validatorApiChannel)
-        .subscribeToBeaconCommitteeForAggregation(anyInt(), any());
+        .subscribeToBeaconCommittee(anyInt(), anyInt(), any(), any(), anyBoolean());
 
     Response response =
         post(PostSubscribeToBeaconCommittee.ROUTE, jsonProvider.objectToJSON(request));

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -47,6 +47,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.validator.api.AttesterDuties;
+import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.api.ValidatorDuties.Duties;
@@ -216,7 +217,9 @@ public class ValidatorDataProvider {
               final UInt64 committeesAtSlot =
                   get_committee_count_per_slot(state, compute_epoch_at_slot(slot));
               validatorApiChannel.subscribeToBeaconCommittee(
-                  0, request.committee_index, committeesAtSlot, slot, true);
+                  List.of(
+                      new CommitteeSubscriptionRequest(
+                          0, request.committee_index, committeesAtSlot, slot, true)));
             });
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -16,6 +16,8 @@ package tech.pegasys.teku.api;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_committee_count_per_slot;
 import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_EPOCH;
 
 import java.util.Collections;
@@ -204,8 +206,18 @@ public class ValidatorDataProvider {
 
   public void subscribeToBeaconCommitteeForAggregation(
       final SubscribeToBeaconCommitteeRequest request) {
-    validatorApiChannel.subscribeToBeaconCommitteeForAggregation(
-        request.committee_index, request.aggregation_slot);
+    final UInt64 slot = request.aggregation_slot;
+    combinedChainDataClient
+        .getBestState()
+        // No point aggregating for historic slots and we can't calculate the subnet ID
+        .filter(state -> state.getSlot().compareTo(slot) <= 0)
+        .ifPresent(
+            state -> {
+              final UInt64 committeesAtSlot =
+                  get_committee_count_per_slot(state, compute_epoch_at_slot(slot));
+              validatorApiChannel.subscribeToBeaconCommittee(
+                  0, request.committee_index, committeesAtSlot, slot, true);
+            });
   }
 
   public void subscribeToPersistentSubnets(final List<SubnetSubscription> subnetSubscriptions) {

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
@@ -307,10 +307,16 @@ public class CommitteeUtil {
 
   public static int computeSubnetForCommittee(
       final BeaconState state, final UInt64 attestationSlot, final UInt64 committeeIndex) {
+    return computeSubnetForCommittee(
+        attestationSlot,
+        committeeIndex,
+        get_committee_count_per_slot(state, compute_epoch_at_slot(attestationSlot)));
+  }
+
+  public static int computeSubnetForCommittee(
+      final UInt64 attestationSlot, final UInt64 committeeIndex, final UInt64 committeesPerSlot) {
     final UInt64 slotsSinceEpochStart = attestationSlot.mod(SLOTS_PER_EPOCH);
-    final UInt64 committeesSinceEpochStart =
-        get_committee_count_per_slot(state, compute_epoch_at_slot(attestationSlot))
-            .times(slotsSinceEpochStart);
+    final UInt64 committeesSinceEpochStart = committeesPerSlot.times(slotsSinceEpochStart);
     return committeesSinceEpochStart.plus(committeeIndex).mod(ATTESTATION_SUBNET_COUNT).intValue();
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationTopicSubscriber.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationTopicSubscriber.java
@@ -20,7 +20,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.util.CommitteeUtil;
 import tech.pegasys.teku.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -40,21 +39,11 @@ public class AttestationTopicSubscriber implements SlotEventsChannel {
     this.recentChainData = recentChainData;
   }
 
-  public synchronized void subscribeToCommitteeForAggregation(
-      final int committeeIndex, final UInt64 aggregationSlot) {
-    recentChainData
-        .getBestState()
-        // No point aggregating for historic slots and we can't calculate the subnet ID
-        .filter(state -> state.getSlot().compareTo(aggregationSlot) <= 0)
-        .ifPresent(
-            state -> subscribeToCommitteeForAggregation(state, committeeIndex, aggregationSlot));
-  }
-
-  private void subscribeToCommitteeForAggregation(
-      final BeaconState state, final int committeeIndex, final UInt64 aggregationSlot) {
+  public void subscribeToCommitteeForAggregation(
+      final int committeeIndex, final UInt64 committeesAtSlot, final UInt64 aggregationSlot) {
     final int subnetId =
         CommitteeUtil.computeSubnetForCommittee(
-            state, aggregationSlot, UInt64.valueOf(committeeIndex));
+            aggregationSlot, UInt64.valueOf(committeeIndex), committeesAtSlot);
     final UInt64 currentUnsubscriptionSlot = subnetIdToUnsubscribeSlot.getOrDefault(subnetId, ZERO);
     if (currentUnsubscriptionSlot.equals(ZERO)) {
       eth2Network.subscribeToAttestationSubnetId(subnetId);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationTopicSubscriber.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationTopicSubscriber.java
@@ -24,19 +24,15 @@ import tech.pegasys.teku.datastructures.util.CommitteeUtil;
 import tech.pegasys.teku.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2Network;
-import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.util.time.channels.SlotEventsChannel;
 
 public class AttestationTopicSubscriber implements SlotEventsChannel {
   private final Map<Integer, UInt64> subnetIdToUnsubscribeSlot = new HashMap<>();
   private final Set<Integer> persistentSubnetIdSet = new HashSet<>();
   private final Eth2Network eth2Network;
-  private final RecentChainData recentChainData;
 
-  public AttestationTopicSubscriber(
-      final Eth2Network eth2Network, final RecentChainData recentChainData) {
+  public AttestationTopicSubscriber(final Eth2Network eth2Network) {
     this.eth2Network = eth2Network;
-    this.recentChainData = recentChainData;
   }
 
   public void subscribeToCommitteeForAggregation(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationTopicSubscriberTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationTopicSubscriberTest.java
@@ -26,7 +26,6 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import java.util.Collections;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2Network;
@@ -35,7 +34,6 @@ class AttestationTopicSubscriberTest {
 
   private static final UInt64 COMMITTEES_AT_SLOT = UInt64.valueOf(20);
   private final Eth2Network eth2Network = mock(Eth2Network.class);
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
 
   private final AttestationTopicSubscriber subscriber = new AttestationTopicSubscriber(eth2Network);
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationTopicSubscriberTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationTopicSubscriberTest.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 class AttestationTopicSubscriberTest {
 
+  private static final UInt64 COMMITTEES_AT_SLOT = UInt64.valueOf(20);
   private final Eth2Network eth2Network = mock(Eth2Network.class);
   private final RecentChainData recentChainData = mock(RecentChainData.class);
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
@@ -56,7 +57,7 @@ class AttestationTopicSubscriberTest {
   public void shouldSubscribeToSubnet() {
     final int committeeId = 10;
     final int subnetId = computeSubnetForCommittee(state, ONE, UInt64.valueOf(committeeId));
-    subscriber.subscribeToCommitteeForAggregation(committeeId, ONE);
+    subscriber.subscribeToCommitteeForAggregation(committeeId, COMMITTEES_AT_SLOT, ONE);
 
     verify(eth2Network).subscribeToAttestationSubnetId(subnetId);
   }
@@ -68,7 +69,7 @@ class AttestationTopicSubscriberTest {
     final int subnetId =
         computeSubnetForCommittee(state, aggregationSlot, UInt64.valueOf(committeeId));
 
-    subscriber.subscribeToCommitteeForAggregation(committeeId, aggregationSlot);
+    subscriber.subscribeToCommitteeForAggregation(committeeId, COMMITTEES_AT_SLOT, aggregationSlot);
     subscriber.onSlot(aggregationSlot.plus(ONE));
 
     verify(eth2Network).unsubscribeFromAttestationSubnetId(subnetId);
@@ -79,7 +80,7 @@ class AttestationTopicSubscriberTest {
     final int subnetId = 16;
     final UInt64 aggregationSlot = UInt64.valueOf(10);
 
-    subscriber.subscribeToCommitteeForAggregation(subnetId, aggregationSlot);
+    subscriber.subscribeToCommitteeForAggregation(subnetId, COMMITTEES_AT_SLOT, aggregationSlot);
     subscriber.onSlot(aggregationSlot);
 
     verify(eth2Network, never()).unsubscribeFromAttestationSubnetId(subnetId);
@@ -95,8 +96,8 @@ class AttestationTopicSubscriberTest {
     assertThat(subnetId)
         .isEqualTo(computeSubnetForCommittee(state, secondSlot, UInt64.valueOf(committeeId)));
 
-    subscriber.subscribeToCommitteeForAggregation(committeeId, firstSlot);
-    subscriber.subscribeToCommitteeForAggregation(committeeId, secondSlot);
+    subscriber.subscribeToCommitteeForAggregation(committeeId, COMMITTEES_AT_SLOT, firstSlot);
+    subscriber.subscribeToCommitteeForAggregation(committeeId, COMMITTEES_AT_SLOT, secondSlot);
 
     subscriber.onSlot(firstSlot.plus(ONE));
     verify(eth2Network, never()).unsubscribeFromAttestationSubnetId(anyInt());
@@ -115,8 +116,8 @@ class AttestationTopicSubscriberTest {
     assertThat(computeSubnetForCommittee(state, secondSlot, UInt64.valueOf(committeeId)))
         .isEqualTo(subnetId);
 
-    subscriber.subscribeToCommitteeForAggregation(committeeId, secondSlot);
-    subscriber.subscribeToCommitteeForAggregation(committeeId, firstSlot);
+    subscriber.subscribeToCommitteeForAggregation(committeeId, COMMITTEES_AT_SLOT, secondSlot);
+    subscriber.subscribeToCommitteeForAggregation(committeeId, COMMITTEES_AT_SLOT, firstSlot);
 
     subscriber.onSlot(firstSlot.plus(ONE));
     verify(eth2Network, never()).unsubscribeFromAttestationSubnetId(anyInt());
@@ -145,8 +146,8 @@ class AttestationTopicSubscriberTest {
     UInt64 someSlot = UInt64.valueOf(15);
     Set<SubnetSubscription> subnetSubscription = Set.of(new SubnetSubscription(2, someSlot));
 
-    subscriber.subscribeToCommitteeForAggregation(1, someSlot);
-    subscriber.subscribeToCommitteeForAggregation(2, someSlot);
+    subscriber.subscribeToCommitteeForAggregation(1, COMMITTEES_AT_SLOT, someSlot);
+    subscriber.subscribeToCommitteeForAggregation(2, COMMITTEES_AT_SLOT, someSlot);
 
     verify(eth2Network)
         .subscribeToAttestationSubnetId(
@@ -170,7 +171,7 @@ class AttestationTopicSubscriberTest {
     Set<SubnetSubscription> subnetSubscriptions =
         Set.of(new SubnetSubscription(subnetId, secondSlot));
 
-    subscriber.subscribeToCommitteeForAggregation(subnetId, firstSlot);
+    subscriber.subscribeToCommitteeForAggregation(subnetId, COMMITTEES_AT_SLOT, firstSlot);
     subscriber.subscribeToPersistentSubnets(subnetSubscriptions);
 
     subscriber.onSlot(firstSlot.plus(ONE));
@@ -186,7 +187,7 @@ class AttestationTopicSubscriberTest {
     final UInt64 firstSlot = UInt64.valueOf(10);
     final UInt64 secondSlot = UInt64.valueOf(15);
     final int subnetId = computeSubnetForCommittee(state, secondSlot, UInt64.valueOf(committeeId));
-    subscriber.subscribeToCommitteeForAggregation(committeeId, secondSlot);
+    subscriber.subscribeToCommitteeForAggregation(committeeId, COMMITTEES_AT_SLOT, secondSlot);
     Set<SubnetSubscription> subnetSubscriptions =
         Set.of(new SubnetSubscription(subnetId, firstSlot));
     subscriber.subscribeToPersistentSubnets(subnetSubscriptions);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -471,7 +471,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             eth1DataCache,
             VersionProvider.getDefaultGraffiti());
     final AttestationTopicSubscriber attestationTopicSubscriber =
-        new AttestationTopicSubscriber(p2pNetwork, recentChainData);
+        new AttestationTopicSubscriber(p2pNetwork);
     final BlockImportChannel blockImportChannel =
         eventChannels.getPublisher(BlockImportChannel.class, asyncRunner);
     final ValidatorApiHandler validatorApiHandler =

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/CommitteeSubscriptionRequest.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/CommitteeSubscriptionRequest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.api;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class CommitteeSubscriptionRequest {
+
+  private final int validatorIndex;
+  private final int committeeIndex;
+  private final UInt64 committeesAtSlot;
+  private final UInt64 slot;
+  private final boolean isAggregator;
+
+  public CommitteeSubscriptionRequest(
+      final int validatorIndex,
+      final int committeeIndex,
+      final UInt64 committeesAtSlot,
+      final UInt64 slot,
+      final boolean isAggregator) {
+    this.validatorIndex = validatorIndex;
+    this.committeeIndex = committeeIndex;
+    this.committeesAtSlot = committeesAtSlot;
+    this.slot = slot;
+    this.isAggregator = isAggregator;
+  }
+
+  public int getValidatorIndex() {
+    return validatorIndex;
+  }
+
+  public int getCommitteeIndex() {
+    return committeeIndex;
+  }
+
+  public UInt64 getCommitteesAtSlot() {
+    return committeesAtSlot;
+  }
+
+  public UInt64 getSlot() {
+    return slot;
+  }
+
+  public boolean isAggregator() {
+    return isAggregator;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CommitteeSubscriptionRequest that = (CommitteeSubscriptionRequest) o;
+    return validatorIndex == that.validatorIndex
+        && committeeIndex == that.committeeIndex
+        && isAggregator == that.isAggregator
+        && Objects.equals(committeesAtSlot, that.committeesAtSlot)
+        && Objects.equals(slot, that.slot);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(validatorIndex, committeeIndex, committeesAtSlot, slot, isAggregator);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("validatorIndex", validatorIndex)
+        .add("committeeIndex", committeeIndex)
+        .add("committeesAtSlot", committeesAtSlot)
+        .add("slot", slot)
+        .add("isAggregator", isAggregator)
+        .toString();
+  }
+}

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -57,7 +57,12 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<Optional<Attestation>> createAggregate(Bytes32 attestationHashTreeRoot);
 
-  void subscribeToBeaconCommitteeForAggregation(int committeeIndex, UInt64 aggregationSlot);
+  void subscribeToBeaconCommittee(
+      int validatorIndex,
+      int committeeIndex,
+      UInt64 committeesAtSlot,
+      UInt64 slot,
+      boolean isAggregator);
 
   void subscribeToPersistentSubnets(Set<SubnetSubscription> subnetSubscriptions);
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -57,12 +57,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<Optional<Attestation>> createAggregate(Bytes32 attestationHashTreeRoot);
 
-  void subscribeToBeaconCommittee(
-      int validatorIndex,
-      int committeeIndex,
-      UInt64 committeesAtSlot,
-      UInt64 slot,
-      boolean isAggregator);
+  void subscribeToBeaconCommittee(List<CommitteeSubscriptionRequest> requests);
 
   void subscribeToPersistentSubnets(Set<SubnetSubscription> subnetSubscriptions);
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.AttesterDuties;
+import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
@@ -232,15 +233,9 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public void subscribeToBeaconCommittee(
-      final int validatorIndex,
-      final int committeeIndex,
-      final UInt64 committeesAtSlot,
-      final UInt64 slot,
-      final boolean isAggregator) {
+  public void subscribeToBeaconCommittee(final List<CommitteeSubscriptionRequest> requests) {
     subscribeAggregationRequestCounter.inc();
-    delegate.subscribeToBeaconCommittee(
-        validatorIndex, committeeIndex, committeesAtSlot, slot, isAggregator);
+    delegate.subscribeToBeaconCommittee(requests);
   }
 
   @Override

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -232,10 +232,15 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public void subscribeToBeaconCommitteeForAggregation(
-      final int committeeIndex, final UInt64 aggregationSlot) {
+  public void subscribeToBeaconCommittee(
+      final int validatorIndex,
+      final int committeeIndex,
+      final UInt64 committeesAtSlot,
+      final UInt64 slot,
+      final boolean isAggregator) {
     subscribeAggregationRequestCounter.inc();
-    delegate.subscribeToBeaconCommitteeForAggregation(committeeIndex, aggregationSlot);
+    delegate.subscribeToBeaconCommittee(
+        validatorIndex, committeeIndex, committeesAtSlot, slot, isAggregator);
   }
 
   @Override

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -118,7 +118,8 @@ class MetricRecordingValidatorApiChannelTest {
     return Stream.of(
         noResponseTest(
             "subscribeToBeaconCommitteeForAggregation",
-            channel -> channel.subscribeToBeaconCommitteeForAggregation(1, UInt64.ZERO),
+            channel ->
+                channel.subscribeToBeaconCommittee(2, 1, UInt64.valueOf(3), UInt64.ZERO, true),
             MetricRecordingValidatorApiChannel.AGGREGATION_SUBSCRIPTION_COUNTER_NAME),
         noResponseTest(
             "subscribeToPersistentSubnets",

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.beaconnode.metrics;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -118,8 +119,7 @@ class MetricRecordingValidatorApiChannelTest {
     return Stream.of(
         noResponseTest(
             "subscribeToBeaconCommitteeForAggregation",
-            channel ->
-                channel.subscribeToBeaconCommittee(2, 1, UInt64.valueOf(3), UInt64.ZERO, true),
+            channel -> channel.subscribeToBeaconCommittee(emptyList()),
             MetricRecordingValidatorApiChannel.AGGREGATION_SUBSCRIPTION_COUNTER_NAME),
         noResponseTest(
             "subscribeToPersistentSubnets",

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -75,6 +75,7 @@ public class AttestationDutyLoader extends AbstractDutyLoader<AttesterDuties> {
     return scheduleAggregation(
         scheduledDuties,
         attestationCommitteeIndex,
+        duty.getCommiteesAtSlot(),
         validatorIndex,
         validator,
         slot,
@@ -102,6 +103,7 @@ public class AttestationDutyLoader extends AbstractDutyLoader<AttesterDuties> {
   private SafeFuture<Void> scheduleAggregation(
       final ScheduledDuties scheduledDuties,
       final int attestationCommitteeIndex,
+      final int committeesAtSlot,
       final int validatorIndex,
       final Validator validator,
       final UInt64 slot,
@@ -119,6 +121,7 @@ public class AttestationDutyLoader extends AbstractDutyLoader<AttesterDuties> {
                     validatorIndex,
                     slotSignature,
                     attestationCommitteeIndex,
+                    committeesAtSlot,
                     unsignedAttestationFuture);
               }
             })

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
@@ -72,11 +72,13 @@ public class AggregationDuty implements Duty {
       final int validatorIndex,
       final BLSSignature proof,
       final int attestationCommitteeIndex,
+      final int committeesAtSlot,
       final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture) {
     aggregatorsByCommitteeIndex.computeIfAbsent(
         attestationCommitteeIndex,
         committeeIndex -> {
-          validatorApiChannel.subscribeToBeaconCommitteeForAggregation(committeeIndex, slot);
+          validatorApiChannel.subscribeToBeaconCommittee(
+              validatorIndex, committeeIndex, UInt64.valueOf(committeesAtSlot), slot, true);
           return new CommitteeAggregator(
               validator,
               UInt64.valueOf(validatorIndex),

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
@@ -17,6 +17,7 @@ import static java.util.stream.Collectors.toList;
 import static tech.pegasys.teku.validator.client.duties.DutyResult.combine;
 
 import com.google.common.base.MoreObjects;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
@@ -31,6 +32,7 @@ import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.ForkProvider;
 import tech.pegasys.teku.validator.client.Validator;
@@ -78,7 +80,13 @@ public class AggregationDuty implements Duty {
         attestationCommitteeIndex,
         committeeIndex -> {
           validatorApiChannel.subscribeToBeaconCommittee(
-              validatorIndex, committeeIndex, UInt64.valueOf(committeesAtSlot), slot, true);
+              List.of(
+                  new CommitteeSubscriptionRequest(
+                      validatorIndex,
+                      committeeIndex,
+                      UInt64.valueOf(committeesAtSlot),
+                      slot,
+                      true)));
           return new CommitteeAggregator(
               validator,
               UInt64.valueOf(validatorIndex),

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ScheduledDuties.java
@@ -63,6 +63,7 @@ public class ScheduledDuties {
       final int validatorIndex,
       final BLSSignature slotSignature,
       final int attestationCommitteeIndex,
+      final int committeesAtSlot,
       final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture) {
     aggregationDuties
         .computeIfAbsent(slot, dutyFactory::createAggregationDuty)
@@ -71,6 +72,7 @@ public class ScheduledDuties {
             validatorIndex,
             slotSignature,
             attestationCommitteeIndex,
+            committeesAtSlot,
             unsignedAttestationFuture);
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -540,6 +540,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validator1Index,
             validator1Signature,
             validator1Committee,
+            committeesAtSlot,
             unsignedAttestationFuture);
     verifyNoMoreInteractions(aggregationDuty);
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
@@ -15,8 +15,6 @@ package tech.pegasys.teku.validator.client.duties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -28,6 +26,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,6 +42,7 @@ import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.ForkProvider;
 import tech.pegasys.teku.validator.client.Validator;
@@ -95,7 +95,9 @@ class AggregationDutyTest {
         new SafeFuture<>());
     verify(validatorApiChannel)
         .subscribeToBeaconCommittee(
-            validatorIndex, committeeIndex, UInt64.valueOf(committeesAtSlot), SLOT, true);
+            List.of(
+                new CommitteeSubscriptionRequest(
+                    validatorIndex, committeeIndex, UInt64.valueOf(committeesAtSlot), SLOT, true)));
   }
 
   @Test
@@ -119,7 +121,9 @@ class AggregationDutyTest {
 
     verify(validatorApiChannel, times(1))
         .subscribeToBeaconCommittee(
-            1, committeeIndex, UInt64.valueOf(committeesAtSlot), SLOT, true);
+            List.of(
+                new CommitteeSubscriptionRequest(
+                    1, committeeIndex, UInt64.valueOf(committeesAtSlot), SLOT, true)));
   }
 
   @Test
@@ -270,8 +274,7 @@ class AggregationDutyTest {
         2,
         10,
         completedFuture(Optional.empty()));
-    verify(validatorApiChannel)
-        .subscribeToBeaconCommittee(anyInt(), anyInt(), any(), any(), anyBoolean());
+    verify(validatorApiChannel).subscribeToBeaconCommittee(any());
 
     performAndReportDuty();
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ScheduledDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ScheduledDutiesTest.java
@@ -94,11 +94,11 @@ class ScheduledDutiesTest {
     when(dutyFactory.createAggregationDuty(TWO)).thenReturn(duty2);
 
     duties.scheduleAggregationDuties(
-        ZERO, validator, 0, BLSSignature.empty(), 0, new SafeFuture<>());
+        ZERO, validator, 0, BLSSignature.empty(), 0, 10, new SafeFuture<>());
     duties.scheduleAggregationDuties(
-        ONE, validator, 0, BLSSignature.empty(), 0, new SafeFuture<>());
+        ONE, validator, 0, BLSSignature.empty(), 0, 10, new SafeFuture<>());
     duties.scheduleAggregationDuties(
-        TWO, validator, 0, BLSSignature.empty(), 0, new SafeFuture<>());
+        TWO, validator, 0, BLSSignature.empty(), 0, 10, new SafeFuture<>());
 
     duties.performAggregation(ONE);
     verify(duty1).performDuty();

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -353,9 +353,16 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public void subscribeToBeaconCommitteeForAggregation(
-      final int committeeIndex, final UInt64 aggregationSlot) {
-    attestationTopicSubscriber.subscribeToCommitteeForAggregation(committeeIndex, aggregationSlot);
+  public void subscribeToBeaconCommittee(
+      final int validatorIndex,
+      final int committeeIndex,
+      final UInt64 committeesAtSlot,
+      final UInt64 aggregationSlot,
+      final boolean isAggregator) {
+    if (isAggregator) {
+      attestationTopicSubscriber.subscribeToCommitteeForAggregation(
+          committeeIndex, committeesAtSlot, aggregationSlot);
+    }
   }
 
   @Override

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -75,6 +75,7 @@ import tech.pegasys.teku.sync.SyncState;
 import tech.pegasys.teku.sync.SyncStateTracker;
 import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.validator.api.AttesterDuties;
+import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.NodeSyncingException;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
@@ -353,16 +354,14 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public void subscribeToBeaconCommittee(
-      final int validatorIndex,
-      final int committeeIndex,
-      final UInt64 committeesAtSlot,
-      final UInt64 aggregationSlot,
-      final boolean isAggregator) {
-    if (isAggregator) {
-      attestationTopicSubscriber.subscribeToCommitteeForAggregation(
-          committeeIndex, committeesAtSlot, aggregationSlot);
-    }
+  public void subscribeToBeaconCommittee(final List<CommitteeSubscriptionRequest> requests) {
+    requests.forEach(
+        request -> {
+          if (request.isAggregator()) {
+            attestationTopicSubscriber.subscribeToCommitteeForAggregation(
+                request.getCommitteeIndex(), request.getCommitteesAtSlot(), request.getSlot());
+          }
+        });
   }
 
   @Override

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -533,10 +533,12 @@ class ValidatorApiHandlerTest {
   public void subscribeToBeaconCommittee_shouldSubscribeViaAttestationTopicSubscriptions() {
     final int committeeIndex = 10;
     final UInt64 aggregationSlot = UInt64.valueOf(13);
-    validatorApiHandler.subscribeToBeaconCommitteeForAggregation(committeeIndex, aggregationSlot);
+    final UInt64 committeesAtSlot = UInt64.valueOf(10);
+    validatorApiHandler.subscribeToBeaconCommittee(
+        1, committeeIndex, committeesAtSlot, aggregationSlot, true);
 
     verify(attestationTopicSubscriptions)
-        .subscribeToCommitteeForAggregation(committeeIndex, aggregationSlot);
+        .subscribeToCommitteeForAggregation(committeeIndex, committeesAtSlot, aggregationSlot);
   }
 
   @Test

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -71,6 +71,7 @@ import tech.pegasys.teku.sync.SyncState;
 import tech.pegasys.teku.sync.SyncStateTracker;
 import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.validator.api.AttesterDuties;
+import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.NodeSyncingException;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
@@ -535,7 +536,9 @@ class ValidatorApiHandlerTest {
     final UInt64 aggregationSlot = UInt64.valueOf(13);
     final UInt64 committeesAtSlot = UInt64.valueOf(10);
     validatorApiHandler.subscribeToBeaconCommittee(
-        1, committeeIndex, committeesAtSlot, aggregationSlot, true);
+        List.of(
+            new CommitteeSubscriptionRequest(
+                1, committeeIndex, committeesAtSlot, aggregationSlot, true)));
 
     verify(attestationTopicSubscriptions)
         .subscribeToCommitteeForAggregation(committeeIndex, committeesAtSlot, aggregationSlot);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -283,12 +283,17 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public void subscribeToBeaconCommitteeForAggregation(
-      final int committeeIndex, final UInt64 aggregationSlot) {
+  public void subscribeToBeaconCommittee(
+      final int validatorIndex,
+      final int committeeIndex,
+      final UInt64 committeesAtSlot,
+      final UInt64 slot,
+      final boolean isAggregator) {
     asyncRunner
         .runAsync(
             () ->
-                apiClient.subscribeToBeaconCommitteeForAggregation(committeeIndex, aggregationSlot))
+                apiClient.subscribeToBeaconCommittee(
+                    validatorIndex, committeeIndex, committeesAtSlot, slot, isAggregator))
         .finish(
             error -> LOG.error("Failed to subscribe to beacon committee for aggregation", error));
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -47,6 +47,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.AttesterDuties;
+import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
@@ -283,17 +284,18 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public void subscribeToBeaconCommittee(
-      final int validatorIndex,
-      final int committeeIndex,
-      final UInt64 committeesAtSlot,
-      final UInt64 slot,
-      final boolean isAggregator) {
+  public void subscribeToBeaconCommittee(final List<CommitteeSubscriptionRequest> requests) {
     asyncRunner
         .runAsync(
             () ->
-                apiClient.subscribeToBeaconCommittee(
-                    validatorIndex, committeeIndex, committeesAtSlot, slot, isAggregator))
+                requests.forEach(
+                    request ->
+                        apiClient.subscribeToBeaconCommittee(
+                            request.getValidatorIndex(),
+                            request.getCommitteeIndex(),
+                            request.getCommitteesAtSlot(),
+                            request.getSlot(),
+                            request.isAggregator())))
         .finish(
             error -> LOG.error("Failed to subscribe to beacon committee for aggregation", error));
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -201,10 +201,14 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   }
 
   @Override
-  public void subscribeToBeaconCommitteeForAggregation(
-      final int committeeIndex, final UInt64 aggregationSlot) {
+  public void subscribeToBeaconCommittee(
+      final int validatorIndex,
+      final int committeeIndex,
+      final UInt64 committeesAtSlot,
+      final UInt64 slot,
+      final boolean isAggregator) {
     final SubscribeToBeaconCommitteeRequest request =
-        new SubscribeToBeaconCommitteeRequest(committeeIndex, aggregationSlot);
+        new SubscribeToBeaconCommitteeRequest(committeeIndex, slot);
     post(SUBSCRIBE_TO_COMMITTEE_FOR_AGGREGATION, request, null);
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -65,7 +65,12 @@ public interface ValidatorRestApiClient {
 
   void sendAggregateAndProof(SignedAggregateAndProof signedAggregateAndProof);
 
-  void subscribeToBeaconCommitteeForAggregation(int committeeIndex, UInt64 aggregationSlot);
+  void subscribeToBeaconCommittee(
+      int validatorIndex,
+      int committeeIndex,
+      UInt64 committeesAtSlot,
+      UInt64 slot,
+      boolean isAggregator);
 
   void subscribeToPersistentSubnets(Set<SubnetSubscription> subnetSubscriptions);
 }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -61,6 +61,7 @@ import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.AttesterDuties;
+import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorDuties;
@@ -560,7 +561,9 @@ class RemoteValidatorApiHandlerTest {
     final boolean isAggregator = true;
     final UInt64 committeesAtSlot = UInt64.valueOf(23);
     apiHandler.subscribeToBeaconCommittee(
-        validatorIndex, committeeIndex, committeesAtSlot, aggregationSlot, isAggregator);
+        List.of(
+            new CommitteeSubscriptionRequest(
+                validatorIndex, committeeIndex, committeesAtSlot, aggregationSlot, isAggregator)));
     asyncRunner.executeQueuedActions();
 
     verify(apiClient)

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -554,14 +554,22 @@ class RemoteValidatorApiHandlerTest {
 
   @Test
   public void subscribeToBeaconCommitteeForAggregation_InvokeApi() {
+    final int validatorIndex = 3;
     final int committeeIndex = 1;
     final UInt64 aggregationSlot = UInt64.ONE;
-
-    apiHandler.subscribeToBeaconCommitteeForAggregation(committeeIndex, aggregationSlot);
+    final boolean isAggregator = true;
+    final UInt64 committeesAtSlot = UInt64.valueOf(23);
+    apiHandler.subscribeToBeaconCommittee(
+        validatorIndex, committeeIndex, committeesAtSlot, aggregationSlot, isAggregator);
     asyncRunner.executeQueuedActions();
 
     verify(apiClient)
-        .subscribeToBeaconCommitteeForAggregation(eq(committeeIndex), eq(aggregationSlot));
+        .subscribeToBeaconCommittee(
+            eq(validatorIndex),
+            eq(committeeIndex),
+            eq(committeesAtSlot),
+            eq(aggregationSlot),
+            eq(isAggregator));
   }
 
   @Test

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -624,7 +624,8 @@ class OkHttpValidatorRestApiClientTest {
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(200));
 
-    apiClient.subscribeToBeaconCommitteeForAggregation(committeeIndex, aggregationSlot);
+    apiClient.subscribeToBeaconCommittee(
+        1, committeeIndex, UInt64.valueOf(10), aggregationSlot, true);
 
     RecordedRequest request = mockWebServer.takeRequest();
 
@@ -645,7 +646,8 @@ class OkHttpValidatorRestApiClientTest {
 
     assertThatThrownBy(
             () ->
-                apiClient.subscribeToBeaconCommitteeForAggregation(committeeIndex, aggregationSlot))
+                apiClient.subscribeToBeaconCommittee(
+                    1, committeeIndex, UInt64.valueOf(10), aggregationSlot, true))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -658,7 +660,8 @@ class OkHttpValidatorRestApiClientTest {
 
     assertThatThrownBy(
             () ->
-                apiClient.subscribeToBeaconCommitteeForAggregation(committeeIndex, aggregationSlot))
+                apiClient.subscribeToBeaconCommittee(
+                    1, committeeIndex, UInt64.valueOf(10), aggregationSlot, true))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Unexpected response from Beacon Node API");
   }


### PR DESCRIPTION
## PR Description
Move the `ValidatorApiChannel.subscribeToBeaconCommittee` to align with the standard API by passing `committeesAtSlot`.  Currently we still use our old API for the remote validator.

## Fixed Issue(s)
#2756 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.