### PR TITLE
Implement and use standard post aggregate and proofs API

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -74,6 +74,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeerById;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttestationData;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttesterDuties;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetProposerDuties;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostAggregateAndProofs;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostAttesterDuties;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostSubscribeToBeaconCommitteeSubnet;
 import tech.pegasys.teku.beaconrestapi.handlers.validator.GetAggregate;
@@ -295,6 +296,7 @@ public class BeaconRestApi {
         new tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetNewBlock(
             dataProvider, jsonProvider));
     app.get(GetAttestationData.ROUTE, new GetAttestationData(dataProvider, jsonProvider));
+    app.post(PostAggregateAndProofs.ROUTE, new PostAggregateAndProofs(dataProvider, jsonProvider));
     app.post(
         PostSubscribeToBeaconCommitteeSubnet.ROUTE,
         new PostSubscribeToBeaconCommitteeSubnet(dataProvider, jsonProvider));

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAggregateAndProofs.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAggregateAndProofs.java
@@ -19,7 +19,8 @@ import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
-import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_V1_VALIDATOR;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR_REQUIRED;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import io.javalin.http.Context;
@@ -56,9 +57,10 @@ public class PostAggregateAndProofs implements Handler {
       path = ROUTE,
       method = HttpMethod.POST,
       summary = "Publish aggregate and proofs",
-      tags = {TAG_VALIDATOR},
+      tags = {TAG_V1_VALIDATOR, TAG_VALIDATOR_REQUIRED},
       requestBody =
-          @OpenApiRequestBody(content = {@OpenApiContent(from = SignedAggregateAndProof.class)}),
+          @OpenApiRequestBody(
+              content = {@OpenApiContent(from = SignedAggregateAndProof.class, isArray = true)}),
       description =
           "Verifies given aggregate and proofs and publishes it on appropriate gossipsub topic.",
       responses = {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttestationData;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttesterDuties;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetNewBlock;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetProposerDuties;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostAggregateAndProofs;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostAttesterDuties;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostSubscribeToBeaconCommitteeSubnet;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
@@ -165,6 +166,11 @@ public class BeaconRestApiV1Test {
   @Test
   public void shouldHavePostAttestationDataEndpoint() {
     verify(app).post(eq(PostAttesterDuties.ROUTE), any(PostAttesterDuties.class));
+  }
+
+  @Test
+  public void shouldHavePostAggregateAndProofsEndpoint() {
+    verify(app).post(eq(PostAggregateAndProofs.ROUTE), any(PostAggregateAndProofs.class));
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAggregateAndProofsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAggregateAndProofsTest.java
@@ -11,14 +11,11 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beaconrestapi.handlers.validator;
+package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -34,7 +31,7 @@ import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.provider.JsonProvider;
 
-class PostAggregateAndProofTest {
+class PostAggregateAndProofsTest {
 
   @SuppressWarnings({"unchecked", "unused"})
   private final ArgumentCaptor<SafeFuture<String>> args = ArgumentCaptor.forClass(SafeFuture.class);
@@ -46,11 +43,11 @@ class PostAggregateAndProofTest {
   private final ValidatorDataProvider provider = mock(ValidatorDataProvider.class);
   private final JsonProvider jsonProvider = new JsonProvider();
 
-  private PostAggregateAndProof handler;
+  private PostAggregateAndProofs handler;
 
   @BeforeEach
   public void beforeEach() {
-    handler = new PostAggregateAndProof(provider, jsonProvider);
+    handler = new PostAggregateAndProofs(provider, jsonProvider);
   }
 
   @Test
@@ -61,39 +58,25 @@ class PostAggregateAndProofTest {
     verify(context).status(SC_BAD_REQUEST);
   }
 
-  @Test
-  public void shouldReturnServerErrorWhenFutureHasUnmappedException() throws Exception {
-    final SignedAggregateAndProof signedAggregateAndProof =
-        dataStructureUtil.randomSignedAggregateAndProof();
-
-    final tech.pegasys.teku.api.schema.SignedAggregateAndProof schemaSignedAggregateAndProof =
-        new tech.pegasys.teku.api.schema.SignedAggregateAndProof(signedAggregateAndProof);
-
-    when(context.body()).thenReturn(jsonProvider.objectToJSON(schemaSignedAggregateAndProof));
-    doThrow(new RuntimeException()).when(provider).sendAggregateAndProofs(any());
-
-    handler.handle(context);
-
-    verify(context).status(SC_INTERNAL_SERVER_ERROR);
-  }
-
+  @SuppressWarnings("unchecked")
   @Test
   public void shouldReturnSuccessWhenSendAggregateAndProofSucceeds() throws Exception {
     final SignedAggregateAndProof signedAggregateAndProof =
         dataStructureUtil.randomSignedAggregateAndProof();
 
-    final tech.pegasys.teku.api.schema.SignedAggregateAndProof schemaSignedAggregateAndProof =
-        new tech.pegasys.teku.api.schema.SignedAggregateAndProof(signedAggregateAndProof);
+    final tech.pegasys.teku.api.schema.SignedAggregateAndProof[] schemaSignedAggregateAndProof = {
+      new tech.pegasys.teku.api.schema.SignedAggregateAndProof(signedAggregateAndProof)
+    };
 
     String signedAggregateAndProofAsJson = jsonProvider.objectToJSON(schemaSignedAggregateAndProof);
     when(context.body()).thenReturn(signedAggregateAndProofAsJson);
 
     handler.handle(context);
 
-    ArgumentCaptor<tech.pegasys.teku.api.schema.SignedAggregateAndProof> captor =
-        ArgumentCaptor.forClass(tech.pegasys.teku.api.schema.SignedAggregateAndProof.class);
+    ArgumentCaptor<List<tech.pegasys.teku.api.schema.SignedAggregateAndProof>> captor =
+        ArgumentCaptor.forClass(List.class);
 
-    verify(provider).sendAggregateAndProofs(List.of(captor.capture()));
+    verify(provider).sendAggregateAndProofs(captor.capture());
     verify(context).status(SC_OK);
 
     assertThat(jsonProvider.objectToJSON(captor.getValue()))

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/validator/PostAggregateAndProofTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/validator/PostAggregateAndProofTest.java
@@ -90,13 +90,13 @@ class PostAggregateAndProofTest {
 
     handler.handle(context);
 
-    ArgumentCaptor<tech.pegasys.teku.api.schema.SignedAggregateAndProof> captor =
-        ArgumentCaptor.forClass(tech.pegasys.teku.api.schema.SignedAggregateAndProof.class);
+    ArgumentCaptor<List<tech.pegasys.teku.api.schema.SignedAggregateAndProof>> captor =
+        ArgumentCaptor.forClass(List.class);
 
-    verify(provider).sendAggregateAndProofs(List.of(captor.capture()));
+    verify(provider).sendAggregateAndProofs(captor.capture());
     verify(context).status(SC_OK);
 
-    assertThat(jsonProvider.objectToJSON(captor.getValue()))
+    assertThat(jsonProvider.objectToJSON(captor.getValue().get(0)))
         .isEqualTo(signedAggregateAndProofAsJson);
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/validator/PostAggregateAndProofTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/validator/PostAggregateAndProofTest.java
@@ -77,6 +77,7 @@ class PostAggregateAndProofTest {
     verify(context).status(SC_INTERNAL_SERVER_ERROR);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void shouldReturnSuccessWhenSendAggregateAndProofSucceeds() throws Exception {
     final SignedAggregateAndProof signedAggregateAndProof =

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -201,9 +201,10 @@ public class ValidatorDataProvider {
         .thenApply(maybeAttestation -> maybeAttestation.map(Attestation::new));
   }
 
-  public void sendAggregateAndProof(SignedAggregateAndProof aggregateAndProof) {
-    validatorApiChannel.sendAggregateAndProof(
-        aggregateAndProof.asInternalSignedAggregateAndProof());
+  public void sendAggregateAndProofs(List<SignedAggregateAndProof> aggregateAndProofs) {
+    aggregateAndProofs.stream()
+        .map(SignedAggregateAndProof::asInternalSignedAggregateAndProof)
+        .forEach(validatorApiChannel::sendAggregateAndProof);
   }
 
   public void subscribeToBeaconCommittee(final List<BeaconCommitteeSubscriptionRequest> requests) {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -200,7 +200,7 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
 
   @Override
   public void sendAggregateAndProof(final SignedAggregateAndProof signedAggregateAndProof) {
-    post(SEND_SIGNED_AGGREGATE_AND_PROOF, signedAggregateAndProof, null);
+    post(SEND_SIGNED_AGGREGATE_AND_PROOF, List.of(signedAggregateAndProof), null);
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -29,7 +29,7 @@ public enum ValidatorApiMethod {
   GET_ATTESTATION_DATA("eth/v1/validator/attestation_data"),
   SEND_SIGNED_ATTESTATION("eth/v1/beacon/pool/attestations"),
   GET_AGGREGATE("validator/aggregate_attestation"),
-  SEND_SIGNED_AGGREGATE_AND_PROOF("validator/aggregate_and_proofs"),
+  SEND_SIGNED_AGGREGATE_AND_PROOF("/eth/v1/validator/aggregate_and_proofs"),
   SUBSCRIBE_TO_BEACON_COMMITTEE_SUBNET("eth/v1/validator/beacon_committee_subscriptions"),
   SUBSCRIBE_TO_PERSISTENT_SUBNETS("validator/persistent_subnets_subscription"),
   GET_ATTESTATION_DUTIES("eth/v1/validator/duties/attester/:epoch"),

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -594,7 +594,7 @@ class OkHttpValidatorRestApiClientTest {
     assertThat(request.getPath())
         .contains(ValidatorApiMethod.SEND_SIGNED_AGGREGATE_AND_PROOF.getPath(emptyMap()));
     assertThat(request.getBody().readString(StandardCharsets.UTF_8))
-        .isEqualTo(asJson(signedAggregateAndProof));
+        .isEqualTo(asJson(List.of(signedAggregateAndProof)));
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Implement and use the standard post aggregate and proofs API (`/eth/v1/validator/aggregate_and_proofs`).

## Fixed Issue(s)
#2756 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.