### PR TITLE
Revert default database format to version 5

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseVersion.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseVersion.java
@@ -22,7 +22,7 @@ public enum DatabaseVersion {
   V5("5"),
   V6("6");
 
-  public static final DatabaseVersion DEFAULT_VERSION = DatabaseVersion.V6;
+  public static final DatabaseVersion DEFAULT_VERSION = DatabaseVersion.V5;
   private String value;
 
   DatabaseVersion(final String value) {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/DatabaseVersionTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/DatabaseVersionTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 public class DatabaseVersionTest {
   @Test
   public void defaultVersion() {
-    assertThat(DatabaseVersion.DEFAULT_VERSION).isEqualTo(DatabaseVersion.V6);
+    assertThat(DatabaseVersion.DEFAULT_VERSION).isEqualTo(DatabaseVersion.V5);
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DataOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DataOptionsTest.java
@@ -74,7 +74,7 @@ public class DataOptionsTest extends AbstractBeaconNodeCommandTest {
   @Test
   public void dataStorageCreateDbVersion_shouldDefault() {
     final GlobalConfiguration globalConfiguration = getGlobalConfigurationFromArguments();
-    assertThat(globalConfiguration.getDataStorageCreateDbVersion()).isEqualTo("6");
+    assertThat(globalConfiguration.getDataStorageCreateDbVersion()).isEqualTo("5");
   }
 
   @Test


### PR DESCRIPTION
## PR Description
With db v6, the process memory grows significantly compared to v5 to the point of causing dramatic slow downs in sync speed and being terminated by the system out of memory killer.

Revert the default database version to the previous v5 while we investigate further.

## Fixed Issue(s)
#3000 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.