### PR TITLE
Add task to copy all dependencies of fuzz utils into a single directory

### DIFF
--- a/fuzz/build.gradle
+++ b/fuzz/build.gradle
@@ -9,3 +9,10 @@ dependencies {
 
     testImplementation testFixtures(project(':ethereum:datastructures'))
 }
+
+
+task fuzzDist(type: Copy) {
+    dependsOn([jar])
+    from configurations.runtimeClasspath + configurations.runtimeClasspath.allArtifacts.collect { it.file }
+    destinationDir file("$buildDir/fuzzDist")
+}


### PR DESCRIPTION
## PR Description
To make maintaining the fuzz tool easier, provide a custom task that copies all required dependencies for the `fuzz` module into a single directory.

Build with `./gradlew -P fuzz fuzzDist` and the required jars are all in `fuzz/build/fuzzDist` so can be included in a class path with `-cp 'fuzz/build/fuzzDist/*'

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.