### PR TITLE
Coalesce head update events when syncing to avoid redundant noise

### DIFF
--- a/sync/src/main/java/tech/pegasys/teku/sync/CoalescingChainHeadChannel.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/CoalescingChainHeadChannel.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.sync;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.api.ChainHeadChannel;
+import tech.pegasys.teku.storage.api.ReorgContext;
+import tech.pegasys.teku.sync.SyncService.SyncSubscriber;
+
+public class CoalescingChainHeadChannel implements ChainHeadChannel, SyncSubscriber {
+
+  private final ChainHeadChannel delegate;
+  private boolean syncing = false;
+
+  private Optional<PendingEvent> pendingEvent = Optional.empty();
+
+  public CoalescingChainHeadChannel(final ChainHeadChannel delegate) {
+    this.delegate = delegate;
+  }
+
+  public static ChainHeadChannel create(
+      final ChainHeadChannel delegate, final SyncService syncService) {
+    final CoalescingChainHeadChannel channel = new CoalescingChainHeadChannel(delegate);
+    syncService.subscribeToSyncChanges(channel);
+    return channel;
+  }
+
+  @Override
+  public synchronized void chainHeadUpdated(
+      final UInt64 slot,
+      final Bytes32 stateRoot,
+      final Bytes32 bestBlockRoot,
+      final boolean epochTransition,
+      final Optional<ReorgContext> optionalReorgContext) {
+    if (!syncing) {
+      delegate.chainHeadUpdated(
+          slot, stateRoot, bestBlockRoot, epochTransition, optionalReorgContext);
+    } else {
+      pendingEvent =
+          pendingEvent
+              .map(
+                  current ->
+                      current.update(
+                          slot, stateRoot, bestBlockRoot, epochTransition, optionalReorgContext))
+              .or(
+                  () ->
+                      Optional.of(
+                          new PendingEvent(
+                              slot,
+                              stateRoot,
+                              bestBlockRoot,
+                              epochTransition,
+                              optionalReorgContext)));
+    }
+  }
+
+  @Override
+  public synchronized void onSyncingChange(final boolean isSyncing) {
+    syncing = isSyncing;
+    if (!syncing) {
+      pendingEvent.ifPresent(PendingEvent::send);
+      pendingEvent = Optional.empty();
+    }
+  }
+
+  private class PendingEvent {
+    private UInt64 slot;
+    private Bytes32 stateRoot;
+    private Bytes32 bestBlockRoot;
+    private boolean epochTransition;
+    private Optional<ReorgContext> reorgContext;
+
+    private PendingEvent(
+        final UInt64 slot,
+        final Bytes32 stateRoot,
+        final Bytes32 bestBlockRoot,
+        final boolean epochTransition,
+        final Optional<ReorgContext> reorgContext) {
+      this.slot = slot;
+      this.stateRoot = stateRoot;
+      this.bestBlockRoot = bestBlockRoot;
+      this.epochTransition = epochTransition;
+      this.reorgContext = reorgContext;
+    }
+
+    public void send() {
+      delegate.chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+    }
+
+    public PendingEvent update(
+        final UInt64 slot,
+        final Bytes32 stateRoot,
+        final Bytes32 bestBlockRoot,
+        final boolean epochTransition,
+        final Optional<ReorgContext> reorgContext) {
+      this.slot = slot;
+      this.stateRoot = stateRoot;
+      this.bestBlockRoot = bestBlockRoot;
+      if (epochTransition) {
+        this.epochTransition = true;
+      }
+      if (reorgContext.isPresent() && hasEarlierCommonAncestor(reorgContext)) {
+        this.reorgContext = reorgContext;
+      }
+      return this;
+    }
+
+    private boolean hasEarlierCommonAncestor(final Optional<ReorgContext> reorgContext) {
+      return this.reorgContext.isEmpty()
+          || reorgContext
+              .orElseThrow()
+              .getCommonAncestorSlot()
+              .isLessThan(this.reorgContext.orElseThrow().getCommonAncestorSlot());
+    }
+  }
+}

--- a/sync/src/test/java/tech/pegasys/teku/sync/CoalescingChainHeadChannelTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/CoalescingChainHeadChannelTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.sync;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.api.ChainHeadChannel;
+import tech.pegasys.teku.storage.api.ReorgContext;
+
+class CoalescingChainHeadChannelTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+
+  private final ChainHeadChannel delegate = Mockito.mock(ChainHeadChannel.class);
+
+  private final CoalescingChainHeadChannel channel = new CoalescingChainHeadChannel(delegate);
+
+  @Test
+  void shouldNotBeSyncingInitially() {
+    final UInt64 slot = dataStructureUtil.randomUInt64();
+    final Bytes32 stateRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 bestBlockRoot = dataStructureUtil.randomBytes32();
+    final boolean epochTransition = true;
+    final Optional<ReorgContext> reorgContext = Optional.empty();
+    channel.chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+    verify(delegate)
+        .chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+  }
+
+  @Test
+  void shouldDelegateEventImmediatelyWhenNotSyncing() {
+    final UInt64 slot = dataStructureUtil.randomUInt64();
+    final Bytes32 stateRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 bestBlockRoot = dataStructureUtil.randomBytes32();
+    final boolean epochTransition = true;
+    final Optional<ReorgContext> reorgContext = Optional.empty();
+
+    channel.onSyncingChange(false);
+
+    channel.chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+    verify(delegate)
+        .chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+  }
+
+  @Test
+  void shouldNotDelegateEventsWhileSyncing() {
+    final UInt64 slot = dataStructureUtil.randomUInt64();
+    final Bytes32 stateRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 bestBlockRoot = dataStructureUtil.randomBytes32();
+    final boolean epochTransition = true;
+    final Optional<ReorgContext> reorgContext = Optional.empty();
+
+    channel.onSyncingChange(true);
+
+    channel.chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+    verifyNoInteractions(delegate);
+  }
+
+  @Test
+  void shouldSendLatestHeadUpdateWhenSyncingCompletes() {
+    final UInt64 slot = dataStructureUtil.randomUInt64();
+    final Bytes32 stateRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 bestBlockRoot = dataStructureUtil.randomBytes32();
+    final boolean epochTransition = true;
+    final Optional<ReorgContext> reorgContext = Optional.empty();
+
+    channel.onSyncingChange(true);
+
+    channel.chainHeadUpdated(
+        dataStructureUtil.randomUInt64(),
+        dataStructureUtil.randomBytes32(),
+        dataStructureUtil.randomBytes32(),
+        false,
+        Optional.empty());
+
+    channel.chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+
+    verifyNoInteractions(delegate);
+
+    channel.onSyncingChange(false);
+    verify(delegate)
+        .chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+    verifyNoMoreInteractions(delegate);
+  }
+
+  @Test
+  void shouldNotSendHeadEventWhenSyncingFinishesIfNoneOccurredDuringSyncing() {
+    final UInt64 slot = dataStructureUtil.randomUInt64();
+    final Bytes32 stateRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 bestBlockRoot = dataStructureUtil.randomBytes32();
+    final boolean epochTransition = true;
+    final Optional<ReorgContext> reorgContext = Optional.empty();
+
+    channel.chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+    verify(delegate)
+        .chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+
+    channel.onSyncingChange(true);
+    channel.onSyncingChange(false);
+
+    verifyNoMoreInteractions(delegate);
+  }
+
+  @Test
+  void shouldNotResendPreviousCoalescedHeadEventWhenSyncingFinishesASecondTime() {
+    final UInt64 slot = dataStructureUtil.randomUInt64();
+    final Bytes32 stateRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 bestBlockRoot = dataStructureUtil.randomBytes32();
+    final boolean epochTransition = true;
+    final Optional<ReorgContext> reorgContext = Optional.empty();
+
+    channel.onSyncingChange(true);
+    channel.chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+    channel.onSyncingChange(false);
+    verify(delegate)
+        .chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+
+    channel.onSyncingChange(true);
+    channel.onSyncingChange(false);
+
+    verifyNoMoreInteractions(delegate);
+  }
+
+  @Test
+  void shouldUseReorgContextWithEarliestCommonAncestorSlotWhenMultipleEventsReceived() {
+    final UInt64 slot = dataStructureUtil.randomUInt64();
+    final Bytes32 stateRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 bestBlockRoot = dataStructureUtil.randomBytes32();
+    final boolean epochTransition = true;
+    final Optional<ReorgContext> reorgContext1 =
+        Optional.of(
+            new ReorgContext(
+                dataStructureUtil.randomBytes32(),
+                dataStructureUtil.randomBytes32(),
+                UInt64.valueOf(100)));
+    final Optional<ReorgContext> reorgContext2 =
+        Optional.of(
+            new ReorgContext(
+                dataStructureUtil.randomBytes32(),
+                dataStructureUtil.randomBytes32(),
+                UInt64.valueOf(80)));
+
+    channel.onSyncingChange(true);
+
+    channel.chainHeadUpdated(
+        dataStructureUtil.randomUInt64(),
+        dataStructureUtil.randomBytes32(),
+        dataStructureUtil.randomBytes32(),
+        false,
+        reorgContext2);
+
+    channel.chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext1);
+
+    verifyNoInteractions(delegate);
+
+    channel.onSyncingChange(false);
+    verify(delegate)
+        .chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext2);
+    verifyNoMoreInteractions(delegate);
+  }
+}


### PR DESCRIPTION
## PR Description
Avoid publishing head update events (including reorgs) while sync is in progress.  When sync completes, a single event is published with the latest head information and the deepest reorg that was sent during the sync.

## Fixed Issue(s)
fixes #3018 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.