### PR TITLE
Reduce log level for errors when retrieving validator indices. 

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
@@ -32,11 +32,6 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
   }
 
   @Override
-  public void onSlot(final UInt64 slot) {
-    super.onSlot(slot);
-  }
-
-  @Override
   public void onAttestationCreationDue(final UInt64 slot) {
     // Check slot being null for the edge case of genesis slot (i.e. slot 0)
     if (lastAttestationCreationSlot != null && slot.compareTo(lastAttestationCreationSlot) <= 0) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIndexProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIndexProvider.java
@@ -55,7 +55,7 @@ public class ValidatorIndexProvider {
             })
         .orTimeout(30, TimeUnit.SECONDS)
         .whenComplete((result, error) -> requestInProgress.set(false))
-        .finish(error -> LOG.error("Failed to load validator indexes.", error));
+        .finish(error -> LOG.debug("Failed to load validator indexes.", error));
   }
 
   public Optional<Integer> getValidatorIndex(final BLSPublicKey publicKey) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIndexProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIndexProvider.java
@@ -46,6 +46,9 @@ public class ValidatorIndexProvider {
     if (!requestInProgress.compareAndSet(false, true)) {
       return;
     }
+    if (unknownValidators.isEmpty()) {
+      return;
+    }
     validatorApiChannel
         .getValidatorIndices(unknownValidators)
         .thenAccept(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorIndexProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorIndexProviderTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -101,5 +102,21 @@ class ValidatorIndexProviderTest {
     result.complete(Collections.emptyMap());
     provider.lookupValidators();
     verify(validatorApiChannel, times(2)).getValidatorIndices(List.of(key1));
+  }
+
+  @Test
+  void shouldNotMakeRequestWhenAllValidatorsAreKnown() {
+    final ValidatorIndexProvider provider =
+        new ValidatorIndexProvider(List.of(key1), validatorApiChannel);
+
+    when(validatorApiChannel.getValidatorIndices(List.of(key1)))
+        .thenReturn(SafeFuture.completedFuture(Map.of(key1, 1)));
+    provider.lookupValidators();
+
+    verify(validatorApiChannel).getValidatorIndices(any());
+
+    provider.lookupValidators();
+
+    verifyNoMoreInteractions(validatorApiChannel);
   }
 }

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -146,6 +146,9 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(
       final List<BLSPublicKey> publicKeys) {
+    if (isSyncActive()) {
+      return NodeSyncingException.failedFuture();
+    }
     return SafeFuture.completedFuture(
         combinedChainDataClient
             .getBestState()

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -146,9 +146,6 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(
       final List<BLSPublicKey> publicKeys) {
-    if (isSyncActive()) {
-      return NodeSyncingException.failedFuture();
-    }
     return SafeFuture.completedFuture(
         combinedChainDataClient
             .getBestState()


### PR DESCRIPTION
## PR Description
Reduce log level for errors loading validator indices.  There are a lot of reasons it could happen and it will retry next slot anyway (and there's at least an epoch before a new validator can become active so it's not time sensitive).

Don't send requests for validator indices when all indices are already known.

## Fixed Issue(s)
fixes #3014 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.