### PR TITLE
Avoid loading states from disk unless it is significantly better

### DIFF
--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/stategenerator/StateGenerationTaskTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/stategenerator/StateGenerationTaskTest.java
@@ -37,6 +37,8 @@ import tech.pegasys.teku.datastructures.state.BlockRootAndState;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
 class StateGenerationTaskTest {
+
+  private static final int REPLAY_TOLERANCE_TO_AVOID_LOADING_IN_EPOCHS = 0;
   private final ChainBuilder chainBuilder = ChainBuilder.createDefault();
   private TrackingBlockProvider blockProvider;
 
@@ -140,7 +142,8 @@ class StateGenerationTaskTest {
                         startBlockAndState.getRoot(), startBlockAndState.getState())),
             chainBuilder.getStateAndBlockProvider(),
             blockProvider,
-            Optional.empty()));
+            Optional.empty(),
+            REPLAY_TOLERANCE_TO_AVOID_LOADING_IN_EPOCHS));
   }
 
   private static class TrackingBlockProvider implements BlockProvider {

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/stategenerator/StateRegenerationBaseSelectorTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/stategenerator/StateRegenerationBaseSelectorTest.java
@@ -32,6 +32,8 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 class StateRegenerationBaseSelectorTest {
+
+  private static final int REPLAY_TOLERANCE_TO_AVOID_LOADING_IN_EPOCHS = 2;
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
 
   @SuppressWarnings("unchecked")
@@ -76,7 +78,7 @@ class StateRegenerationBaseSelectorTest {
   void shouldUseLatestEpochBoundaryWhenBetterThanOtherOptions() {
     withClosestAvailableFromStoreAtSlot(100);
     withRebasedStartingPointAtSlot(1);
-    final SignedBlockAndState latestEpochBoundary = withLatestEpochBoundaryAtSlot(101);
+    final SignedBlockAndState latestEpochBoundary = withLatestEpochBoundaryAtSlot(200);
 
     assertSelectedBase(latestEpochBoundary);
   }
@@ -84,9 +86,26 @@ class StateRegenerationBaseSelectorTest {
   @Test
   void shouldUseLatestEpochBoundaryWhenBetterThanStoreAndNoRebasedOptionAvailable() {
     withClosestAvailableFromStoreAtSlot(100);
-    final SignedBlockAndState latestEpochBoundary = withLatestEpochBoundaryAtSlot(101);
+    final SignedBlockAndState latestEpochBoundary = withLatestEpochBoundaryAtSlot(200);
 
     assertSelectedBase(latestEpochBoundary);
+  }
+
+  @Test
+  void shouldNotUseLatestEpochBoundaryWhenNotMuchBetterThanStore() {
+    final SignedBlockAndState storeState = withClosestAvailableFromStoreAtSlot(100);
+    withLatestEpochBoundaryAtSlot(101);
+
+    assertSelectedBase(storeState);
+  }
+
+  @Test
+  void shouldNotUseLatestEpochBoundaryWhenNotMuchBetterThanRebasedOption() {
+    withClosestAvailableFromStoreAtSlot(1);
+    final SignedBlockAndState rebasedState = withRebasedStartingPointAtSlot(100);
+    withLatestEpochBoundaryAtSlot(101);
+
+    assertSelectedBase(rebasedState);
   }
 
   @Test
@@ -214,6 +233,7 @@ class StateRegenerationBaseSelectorTest {
         closestAvailableStateSupplier,
         stateAndBlockProvider,
         blockProvider,
-        rebasedStartingPoint);
+        rebasedStartingPoint,
+        REPLAY_TOLERANCE_TO_AVOID_LOADING_IN_EPOCHS);
   }
 }

--- a/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
+++ b/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
@@ -171,6 +171,14 @@ public final class UInt64 implements Comparable<UInt64> {
     return fromLongBits(longBits1 - longBits2);
   }
 
+  public UInt64 minusMinZero(final long other) {
+    return minusMinZero(valueOf(other));
+  }
+
+  public UInt64 minusMinZero(final UInt64 other) {
+    return isGreaterThan(other) ? minus(other) : ZERO;
+  }
+
   /**
    * Return the result of multiplying the specified value with this one.
    *

--- a/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
+++ b/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
@@ -276,6 +276,27 @@ class UInt64Test {
         .isInstanceOf(IllegalArgumentException.class);
   }
 
+  @Test
+  void minusMinZero_shouldReturnZeroWhenResultUnderflows() {
+    assertThat(UInt64.valueOf(10).minusMinZero(11)).isEqualTo(UInt64.ZERO);
+  }
+
+  @Test
+  void minusMinZero_shouldReturnZeroWhenParamsEqual() {
+    assertThat(UInt64.valueOf(10).minusMinZero(10)).isEqualTo(UInt64.ZERO);
+  }
+
+  @Test
+  void minusMinZero_shouldPerformMinusWhenResultLargerThanZero() {
+    assertThat(UInt64.valueOf(10).minusMinZero(8)).isEqualTo(UInt64.valueOf(2));
+  }
+
+  @Test
+  void minusMinZero_shouldThrowIllegalArgumentExceptionWhenArgumentIsNegative() {
+    assertThatThrownBy(() -> UInt64.valueOf(10).minusMinZero(-1))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
   @ParameterizedTest
   @MethodSource("modNumbers")
   void mod_shouldCalculateRemainder(

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -498,7 +498,7 @@ class Store implements UpdatableStore {
                     () -> getClosestAvailableBlockRootAndState(blockRoot),
                     stateAndBlockProvider,
                     blockProvider,
-                    Optional.empty()))));
+                    Optional.empty(), hotStatePersistenceFrequencyInEpochs))));
   }
 
   private Optional<BlockRootAndState> getClosestAvailableBlockRootAndState(

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -498,7 +498,8 @@ class Store implements UpdatableStore {
                     () -> getClosestAvailableBlockRootAndState(blockRoot),
                     stateAndBlockProvider,
                     blockProvider,
-                    Optional.empty(), hotStatePersistenceFrequencyInEpochs))));
+                    Optional.empty(),
+                    hotStatePersistenceFrequencyInEpochs))));
   }
 
   private Optional<BlockRootAndState> getClosestAvailableBlockRootAndState(


### PR DESCRIPTION
## PR Description
If a state regeneration has an in-memory state that is almost as good as the one it could load from disk, prefer the in-memory state to reduce memory usage.

The tolerance is set to be equal to the number of epochs that states are stored on disk - so by default if the in-memory state is within two epochs of the one on disk we use the in-memory state.

Also adds the very handy `minusMinZero` method to `UInt64` which performs a minus but returns zero if it would have underflowed avoiding a lot of `x.isGreaterThan(y) ? x.minus(y) : ZERO` conditionals.

## Fixed Issue(s)
fixes #3019 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.