### PR TITLE
Replace batches from old chains with no remaining peers

### DIFF
--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/BatchDataRequester.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/BatchDataRequester.java
@@ -98,7 +98,7 @@ public class BatchDataRequester {
     firstStrandedBatch.ifPresent(
         strandedBatch -> {
           // We have at least one batch from an old chain which no longer has any target peers to
-          // request data from. Remove all batch from that one to where the new chain starts and
+          // request data from. Remove all batches from that one to where the new chain starts and
           // replace with batches from the new chain.
           final List<Batch> batchesToReplace =
               activeBatches.batchesAfterInclusive(strandedBatch).stream()

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/BatchDataRequester.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/BatchDataRequester.java
@@ -93,7 +93,7 @@ public class BatchDataRequester {
   private void replaceBatchesFromOldChainsWithNoSources(final TargetChain targetChain) {
     final Optional<Batch> firstStrandedBatch =
         activeBatches.stream()
-            .filter(batch -> fromOldChainWithNoPeers(targetChain, batch))
+            .filter(batch -> incompleteBatchFromOldChainWithNoPeers(targetChain, batch))
             .findFirst();
     firstStrandedBatch.ifPresent(
         strandedBatch -> {
@@ -113,8 +113,10 @@ public class BatchDataRequester {
         });
   }
 
-  private boolean fromOldChainWithNoPeers(final TargetChain targetChain, final Batch batch) {
-    return !batch.getTargetChain().equals(targetChain)
+  private boolean incompleteBatchFromOldChainWithNoPeers(
+      final TargetChain targetChain, final Batch batch) {
+    return !batch.isComplete()
+        && !batch.getTargetChain().equals(targetChain)
         && batch.getTargetChain().getPeerCount() == 0;
   }
 

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/BatchDataRequester.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/BatchDataRequester.java
@@ -13,6 +13,10 @@
 
 package tech.pegasys.teku.sync.multipeer;
 
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -52,6 +56,8 @@ public class BatchDataRequester {
       final Consumer<Batch> requestCompleteCallback) {
     eventThread.checkOnEventThread();
 
+    replaceBatchesFromOldChainsWithNoSources(targetChain);
+
     final long pendingBatchesCount =
         activeBatches.stream().filter(batch -> !batch.isEmpty() || !batch.isComplete()).count();
 
@@ -76,6 +82,40 @@ public class BatchDataRequester {
         break;
       }
     }
+  }
+
+  /**
+   * All the sync sources on a given target chain may have moved to a new chain or disconnected. To
+   * avoid getting stuck attempting and failing to request data when there are no sync sources, find
+   * the first batch from an old chain with no sources, and replace all batches after it that are
+   * from old chains with batches from our new chain.
+   */
+  private void replaceBatchesFromOldChainsWithNoSources(final TargetChain targetChain) {
+    final Optional<Batch> firstStrandedBatch =
+        activeBatches.stream()
+            .filter(batch -> fromOldChainWithNoPeers(targetChain, batch))
+            .findFirst();
+    firstStrandedBatch.ifPresent(
+        strandedBatch -> {
+          // We have at least one batch from an old chain which no longer has any target peers to
+          // request data from. Remove all batch from that one to where the new chain starts and
+          // replace with batches from the new chain.
+          final List<Batch> batchesToReplace =
+              activeBatches.batchesAfterInclusive(strandedBatch).stream()
+                  .takeWhile(batch -> !batch.getTargetChain().equals(targetChain))
+                  .collect(toList());
+          batchesToReplace.forEach(
+              batchToReplace ->
+                  activeBatches.replace(
+                      batchToReplace,
+                      batchFactory.createBatch(
+                          targetChain, batchToReplace.getFirstSlot(), batchToReplace.getCount())));
+        });
+  }
+
+  private boolean fromOldChainWithNoPeers(final TargetChain targetChain, final Batch batch) {
+    return !batch.getTargetChain().equals(targetChain)
+        && batch.getTargetChain().getPeerCount() == 0;
   }
 
   private UInt64 getNextSlotToRequest(final UInt64 commonAncestorSlot) {

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/batches/Batch.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/batches/Batch.java
@@ -26,6 +26,8 @@ public interface Batch {
 
   UInt64 getLastSlot();
 
+  UInt64 getCount();
+
   Optional<SignedBeaconBlock> getFirstBlock();
 
   Optional<SignedBeaconBlock> getLastBlock();

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/batches/BatchChain.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/batches/BatchChain.java
@@ -95,6 +95,11 @@ public class BatchChain implements Iterable<Batch> {
     batches.clear();
   }
 
+  public void replace(final Batch batchToReplace, final Batch batch) {
+    batches.remove(batchToReplace);
+    batches.add(batch);
+  }
+
   public Optional<Batch> last() {
     return batches.isEmpty() ? Optional.empty() : Optional.of(batches.last());
   }

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/batches/EventThreadOnlyBatch.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/batches/EventThreadOnlyBatch.java
@@ -44,6 +44,12 @@ public class EventThreadOnlyBatch implements Batch {
   }
 
   @Override
+  public UInt64 getCount() {
+    eventThread.checkOnEventThread();
+    return delegate.getCount();
+  }
+
+  @Override
   public Optional<SignedBeaconBlock> getFirstBlock() {
     eventThread.checkOnEventThread();
     return delegate.getFirstBlock();

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/batches/SyncSourceBatch.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/batches/SyncSourceBatch.java
@@ -80,6 +80,11 @@ public class SyncSourceBatch implements Batch {
   }
 
   @Override
+  public UInt64 getCount() {
+    return count;
+  }
+
+  @Override
   public Optional<SignedBeaconBlock> getFirstBlock() {
     return blocks.isEmpty() ? Optional.empty() : Optional.of(blocks.get(0));
   }

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/chains/TargetChain.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/chains/TargetChain.java
@@ -39,7 +39,7 @@ public class TargetChain {
     peers.remove(peer);
   }
 
-  int getPeerCount() {
+  public int getPeerCount() {
     return peers.size();
   }
 

--- a/sync/src/test/java/tech/pegasys/teku/sync/multipeer/batches/BatchChainTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/multipeer/batches/BatchChainTest.java
@@ -393,21 +393,21 @@ class BatchChainTest {
 
   @Test
   void replace_shouldRemoveOldAndAddNewBatch() {
-      final Batch oldBatch = createBatch(1);
-      final Batch newBatch = createBatch(1);
-      batchChain.add(oldBatch);
-      batchChain.replace(oldBatch, newBatch);
-      assertThat(batchChain.contains(oldBatch)).isFalse();
-      assertThat(batchChain.contains(newBatch)).isTrue();
+    final Batch oldBatch = createBatch(1);
+    final Batch newBatch = createBatch(1);
+    batchChain.add(oldBatch);
+    batchChain.replace(oldBatch, newBatch);
+    assertThat(batchChain.contains(oldBatch)).isFalse();
+    assertThat(batchChain.contains(newBatch)).isTrue();
   }
 
   @Test
   void replace_shouldAddNewBatchIfOldIsNotInChain() {
-      final Batch oldBatch = createBatch(1);
-      final Batch newBatch = createBatch(1);
-      batchChain.replace(oldBatch, newBatch);
-      assertThat(batchChain.contains(oldBatch)).isFalse();
-      assertThat(batchChain.contains(newBatch)).isTrue();
+    final Batch oldBatch = createBatch(1);
+    final Batch newBatch = createBatch(1);
+    batchChain.replace(oldBatch, newBatch);
+    assertThat(batchChain.contains(oldBatch)).isFalse();
+    assertThat(batchChain.contains(newBatch)).isTrue();
   }
 
   private Batch createNonEmptyBatch(final int startSlot) {

--- a/sync/src/test/java/tech/pegasys/teku/sync/multipeer/batches/BatchChainTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/multipeer/batches/BatchChainTest.java
@@ -391,6 +391,25 @@ class BatchChainTest {
     assertThat(batchChain.firstImportableBatch()).isEmpty();
   }
 
+  @Test
+  void replace_shouldRemoveOldAndAddNewBatch() {
+      final Batch oldBatch = createBatch(1);
+      final Batch newBatch = createBatch(1);
+      batchChain.add(oldBatch);
+      batchChain.replace(oldBatch, newBatch);
+      assertThat(batchChain.contains(oldBatch)).isFalse();
+      assertThat(batchChain.contains(newBatch)).isTrue();
+  }
+
+  @Test
+  void replace_shouldAddNewBatchIfOldIsNotInChain() {
+      final Batch oldBatch = createBatch(1);
+      final Batch newBatch = createBatch(1);
+      batchChain.replace(oldBatch, newBatch);
+      assertThat(batchChain.contains(oldBatch)).isFalse();
+      assertThat(batchChain.contains(newBatch)).isTrue();
+  }
+
   private Batch createNonEmptyBatch(final int startSlot) {
     final Batch batch =
         batchFactory.createBatch(targetChain, UInt64.valueOf(startSlot), UInt64.valueOf(startSlot));

--- a/sync/src/testFixtures/java/tech/pegasys/teku/sync/multipeer/batches/BatchAssert.java
+++ b/sync/src/testFixtures/java/tech/pegasys/teku/sync/multipeer/batches/BatchAssert.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.assertj.core.api.AbstractAssert;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.sync.multipeer.chains.TargetChain;
 
 public class BatchAssert extends AbstractAssert<BatchAssert, Batch> {
 
@@ -115,6 +116,10 @@ public class BatchAssert extends AbstractAssert<BatchAssert, Batch> {
   public void hasRange(final long firstSlot, final long lastSlot) {
     hasFirstSlot(firstSlot);
     hasLastSlot(lastSlot);
+  }
+
+  public void hasTargetChain(final TargetChain expected) {
+    assertThat(actual.getTargetChain()).isEqualTo(expected);
   }
 
   public void isAwaitingBlocks() {

--- a/sync/src/testFixtures/java/tech/pegasys/teku/sync/multipeer/batches/StubBatchFactory.java
+++ b/sync/src/testFixtures/java/tech/pegasys/teku/sync/multipeer/batches/StubBatchFactory.java
@@ -21,7 +21,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Stream;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
@@ -101,10 +100,6 @@ public class StubBatchFactory extends BatchFactory implements Iterable<Batch> {
   @Override
   public Iterator<Batch> iterator() {
     return batches.iterator();
-  }
-
-  public Stream<Batch> stream() {
-    return batches.stream();
   }
 
   private static final class BatchSupport


### PR DESCRIPTION
## PR Description
In the multipeer sync, when batches from previous target chains are still in the queue (on the assumption the new chain is just an extension of the old) and the old chain no longer has any available sync sources, replace the batches with ones from the new target chain.

For simplicity, this approach avoids having a mix of old and new batches, so finds the first incomplete batch from an old chain with no remaining sync sources and then replaces it and all following batches from old chains, regardless of whether they were complete.

## Fixed Issue(s)
#1844 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.