### PR TITLE
Fix query param for filtering validators

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/RestApiConstants.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/RestApiConstants.java
@@ -86,6 +86,7 @@ public class RestApiConstants {
           + "&lt;slot&gt;, "
           + "&lt;hex encoded stateRoot with 0x prefix&gt;.";
 
+  public static final String PARAM_ID = "id";
   public static final String PARAM_VALIDATOR_ID = "validator_id";
   public static final String PARAM_VALIDATOR_DESCRIPTION =
       "Either hex encoded public key (with 0x prefix) or validator index";

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorBalances.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorBalances.java
@@ -16,10 +16,10 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.beaconrestapi.CacheControlUtils.getMaxAgeForSlot;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.PARAM_ID;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.PARAM_STATE_ID;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.PARAM_STATE_ID_DESCRIPTION;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.PARAM_VALIDATOR_DESCRIPTION;
-import static tech.pegasys.teku.beaconrestapi.RestApiConstants.PARAM_VALIDATOR_ID;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_NOT_FOUND;
@@ -80,7 +80,7 @@ public class GetStateValidatorBalances extends AbstractHandler implements Handle
       pathParams = {@OpenApiParam(name = PARAM_STATE_ID, description = PARAM_STATE_ID_DESCRIPTION)},
       queryParams = {
         @OpenApiParam(
-            name = PARAM_VALIDATOR_ID,
+            name = PARAM_ID,
             description = PARAM_VALIDATOR_DESCRIPTION,
             isRepeatable = true)
       },

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidators.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidators.java
@@ -16,10 +16,10 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.beaconrestapi.CacheControlUtils.getMaxAgeForSlot;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.PARAM_ID;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.PARAM_STATE_ID;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.PARAM_STATE_ID_DESCRIPTION;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.PARAM_VALIDATOR_DESCRIPTION;
-import static tech.pegasys.teku.beaconrestapi.RestApiConstants.PARAM_VALIDATOR_ID;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
@@ -76,7 +76,7 @@ public class GetStateValidators extends AbstractHandler {
       },
       queryParams = {
         @OpenApiParam(
-            name = PARAM_VALIDATOR_ID,
+            name = PARAM_ID,
             description = PARAM_VALIDATOR_DESCRIPTION,
             isRepeatable = true)
       },

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/StateValidatorsUtil.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/StateValidatorsUtil.java
@@ -13,8 +13,8 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.PARAM_ID;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.PARAM_STATE_ID;
-import static tech.pegasys.teku.beaconrestapi.RestApiConstants.PARAM_VALIDATOR_ID;
 
 import io.javalin.http.Context;
 import java.util.List;
@@ -27,8 +27,7 @@ import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
 public class StateValidatorsUtil {
 
   public List<Integer> parseValidatorsParam(final ChainDataProvider provider, final Context ctx) {
-    return ListQueryParameterUtils.getParameterAsStringList(ctx.queryParamMap(), PARAM_VALIDATOR_ID)
-        .stream()
+    return ListQueryParameterUtils.getParameterAsStringList(ctx.queryParamMap(), PARAM_ID).stream()
         .flatMap(
             validatorParameter -> provider.validatorParameterToIndex(validatorParameter).stream())
         .collect(Collectors.toList());

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorBalancesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorBalancesTest.java
@@ -39,7 +39,7 @@ public class GetStateValidatorBalancesTest extends AbstractBeaconHandlerTest {
   public void shouldGetValidatorFromState() throws Exception {
     final UInt64 slot = dataStructureUtil.randomUInt64();
     when(context.pathParamMap()).thenReturn(Map.of("state_id", "head"));
-    when(context.queryParamMap()).thenReturn(Map.of("validator_id", List.of("1", "2", "3,4")));
+    when(context.queryParamMap()).thenReturn(Map.of("id", List.of("1", "2", "3,4")));
     when(chainDataProvider.stateParameterToSlot("head")).thenReturn(Optional.of(slot));
     for (int i = 1; i <= 4; i++) {
       when(chainDataProvider.validatorParameterToIndex(Integer.toString(i)))

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorsTest.java
@@ -56,7 +56,7 @@ public class GetStateValidatorsTest extends AbstractBeaconHandlerTest {
   public void shouldGetValidatorFromState() throws Exception {
     final UInt64 slot = dataStructureUtil.randomUInt64();
     when(context.pathParamMap()).thenReturn(Map.of("state_id", "head"));
-    when(context.queryParamMap()).thenReturn(Map.of("validator_id", List.of("1", "2", "3,4")));
+    when(context.queryParamMap()).thenReturn(Map.of("id", List.of("1", "2", "3,4")));
     when(chainDataProvider.stateParameterToSlot("head")).thenReturn(Optional.of(slot));
     for (int i = 1; i <= 4; i++) {
       when(chainDataProvider.validatorParameterToIndex(Integer.toString(i)))

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -106,7 +106,7 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   @Override
   public Optional<List<ValidatorResponse>> getValidators(final List<String> validatorIds) {
     final Map<String, String> queryParams = new HashMap<>();
-    queryParams.put("validator_id", String.join(",", validatorIds));
+    queryParams.put("id", String.join(",", validatorIds));
     return get(GET_VALIDATORS, queryParams, GetStateValidatorsResponse.class)
         .map(response -> response.data);
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -164,7 +164,7 @@ class OkHttpValidatorRestApiClientTest {
     assertThat(request.getMethod()).isEqualTo("GET");
     assertThat(request.getPath()).contains(ValidatorApiMethod.GET_VALIDATORS.getPath(emptyMap()));
     // %2C is ,
-    assertThat(request.getPath()).contains("?validator_id=1%2C0x1234");
+    assertThat(request.getPath()).contains("?id=1%2C0x1234");
   }
 
   @Test


### PR DESCRIPTION
## PR Description
The query param for filtering validators is `id` not `validator_id`.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.