### PR TITLE
[Issue-2273] Make weak-subjectivity logging quieter

### DIFF
--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.weaksubjectivity;
 import static tech.pegasys.teku.core.ForkChoiceUtil.get_ancestor;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
-import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
@@ -27,7 +26,7 @@ import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.state.CheckpointState;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.logging.StatusLogger;
+import tech.pegasys.teku.infrastructure.logging.WeakSubjectivityLogger;
 import tech.pegasys.teku.infrastructure.time.Throttler;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
@@ -45,10 +44,8 @@ public class WeakSubjectivityValidator {
 
   private final WeakSubjectivityConfig config;
   private volatile Optional<UInt64> suppressWSPeriodErrorsUntilEpoch = Optional.empty();
-  private final Throttler<StatusLogger> wsChecksSuppressedLogger =
-      new Throttler<>(STATUS_LOG, UInt64.valueOf(10));
-  private final Throttler<StatusLogger> deferValidationLogger =
-      new Throttler<>(STATUS_LOG, UInt64.valueOf(10));
+  private final Throttler<WeakSubjectivityLogger> wsChecksSuppressedLogger;
+  private final Throttler<WeakSubjectivityLogger> deferValidationLogger;
 
   WeakSubjectivityValidator(
       final WeakSubjectivityConfig config,
@@ -57,6 +54,11 @@ public class WeakSubjectivityValidator {
     this.calculator = calculator;
     this.violationPolicy = violationPolicy;
     this.config = config;
+
+    final int throttlingPeriod = 20;
+    final WeakSubjectivityLogger wsLogger = WeakSubjectivityLogger.createFileLogger();
+    this.wsChecksSuppressedLogger = new Throttler<>(wsLogger, UInt64.valueOf(throttlingPeriod));
+    this.deferValidationLogger = new Throttler<>(wsLogger, UInt64.valueOf(throttlingPeriod));
   }
 
   public static WeakSubjectivityValidator strict(final WeakSubjectivityConfig config) {

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/LoggingWeakSubjectivityViolationPolicy.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/LoggingWeakSubjectivityViolationPolicy.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.weaksubjectivity.policies;
 
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
-import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -22,14 +21,19 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.state.CheckpointState;
+import tech.pegasys.teku.infrastructure.logging.WeakSubjectivityLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 class LoggingWeakSubjectivityViolationPolicy implements WeakSubjectivityViolationPolicy {
   private static final Logger LOG = LogManager.getLogger();
-  private final Level level;
 
-  public LoggingWeakSubjectivityViolationPolicy(Level level) {
+  private final Level level;
+  private final WeakSubjectivityLogger wsLogger;
+
+  public LoggingWeakSubjectivityViolationPolicy(
+      final WeakSubjectivityLogger wsLogger, Level level) {
     this.level = level;
+    this.wsLogger = wsLogger;
   }
 
   @Override
@@ -46,19 +50,19 @@ class LoggingWeakSubjectivityViolationPolicy implements WeakSubjectivityViolatio
         activeValidatorCount,
         latestFinalizedCheckpoint.getEpoch().plus(wsPeriod),
         currentEpoch);
-    STATUS_LOG.finalizedCheckpointOutsideOfWeakSubjectivityPeriod(
+    wsLogger.finalizedCheckpointOutsideOfWeakSubjectivityPeriod(
         level, latestFinalizedCheckpoint.getEpoch());
   }
 
   @Override
   public void onChainInconsistentWithWeakSubjectivityCheckpoint(
       Checkpoint wsCheckpoint, SignedBeaconBlock block) {
-    STATUS_LOG.chainInconsistentWithWeakSubjectivityCheckpoint(
+    wsLogger.chainInconsistentWithWeakSubjectivityCheckpoint(
         level, block.getRoot(), block.getSlot(), wsCheckpoint.getRoot(), wsCheckpoint.getEpoch());
   }
 
   @Override
   public void onFailedToPerformValidation(final String message, final Throwable error) {
-    STATUS_LOG.failedToPerformWeakSubjectivityValidation(level, message, error);
+    wsLogger.failedToPerformWeakSubjectivityValidation(level, message, error);
   }
 }

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/ModerateWeakSubjectivityViolationPolicy.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/ModerateWeakSubjectivityViolationPolicy.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.weaksubjectivity.policies;
 import java.util.List;
 import org.apache.logging.log4j.Level;
 import tech.pegasys.teku.datastructures.state.CheckpointState;
+import tech.pegasys.teku.infrastructure.logging.WeakSubjectivityLogger;
 import tech.pegasys.teku.infrastructure.time.Throttler;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
@@ -23,7 +24,10 @@ import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 class ModerateWeakSubjectivityViolationPolicy extends CompoundWeakSubjectivityViolationPolicy {
   private final WeakSubjectivityConfig config;
   private final Throttler<WeakSubjectivityViolationPolicy> warningPolicy =
-      new Throttler<>(new LoggingWeakSubjectivityViolationPolicy(Level.WARN), UInt64.valueOf(10));
+      new Throttler<>(
+          new LoggingWeakSubjectivityViolationPolicy(
+              WeakSubjectivityLogger.createFileLogger(), Level.INFO),
+          UInt64.valueOf(50));
 
   public ModerateWeakSubjectivityViolationPolicy(final WeakSubjectivityConfig config) {
     super(List.of(WeakSubjectivityViolationPolicy.strict()));

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/WeakSubjectivityViolationPolicy.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/WeakSubjectivityViolationPolicy.java
@@ -18,13 +18,15 @@ import org.apache.logging.log4j.Level;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.state.CheckpointState;
+import tech.pegasys.teku.infrastructure.logging.WeakSubjectivityLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 
 public interface WeakSubjectivityViolationPolicy {
 
   static WeakSubjectivityViolationPolicy lenient() {
-    return new LoggingWeakSubjectivityViolationPolicy(Level.TRACE);
+    return new LoggingWeakSubjectivityViolationPolicy(
+        WeakSubjectivityLogger.createFileLogger(), Level.TRACE);
   }
 
   static WeakSubjectivityViolationPolicy moderate(final WeakSubjectivityConfig config) {
@@ -34,7 +36,8 @@ public interface WeakSubjectivityViolationPolicy {
   static WeakSubjectivityViolationPolicy strict() {
     return new CompoundWeakSubjectivityViolationPolicy(
         List.of(
-            new LoggingWeakSubjectivityViolationPolicy(Level.FATAL),
+            new LoggingWeakSubjectivityViolationPolicy(
+                WeakSubjectivityLogger.createConsoleLogger(), Level.FATAL),
             new ExitingWeakSubjectivityViolationPolicy()));
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -14,24 +14,20 @@
 package tech.pegasys.teku.infrastructure.logging;
 
 import static java.util.stream.Collectors.joining;
-import static tech.pegasys.teku.infrastructure.logging.ColorConsolePrinter.print;
 
 import java.nio.file.Path;
 import java.util.List;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class StatusLogger {
 
   public static final StatusLogger STATUS_LOG =
       new StatusLogger(LoggingConfigurator.STATUS_LOGGER_NAME);
 
-  private final Logger log;
+  final Logger log;
 
   private StatusLogger(final String name) {
     this.log = LogManager.getLogger(name);
@@ -203,52 +199,5 @@ public class StatusLogger {
 
   public void performance(final String performance) {
     log.info(performance);
-  }
-
-  public void warnWeakSubjectivityChecksSuppressed(final UInt64 untilEpoch) {
-    final String msg = "Suppressing weak subjectivity errors until epoch " + untilEpoch;
-    logWithColorIfLevelGreaterThanInfo(Level.WARN, msg, ColorConsolePrinter.Color.YELLOW);
-  }
-
-  public void warnWeakSubjectivityFinalizedCheckpointValidationDeferred(
-      final UInt64 finalizedEpoch, final UInt64 wsCheckpointEpoch) {
-    final String msg =
-        String.format(
-            "Deferring weak subjectivity checks for finalized checkpoint at epoch %s.  Checks will resume once weak subjectivity checkpoint at epoch %s is reached.",
-            finalizedEpoch, wsCheckpointEpoch);
-    logWithColorIfLevelGreaterThanInfo(Level.WARN, msg, ColorConsolePrinter.Color.YELLOW);
-  }
-
-  public void finalizedCheckpointOutsideOfWeakSubjectivityPeriod(
-      Level level, final UInt64 latestFinalizedCheckpointEpoch) {
-    final String msg =
-        String.format(
-            "The latest finalized checkpoint at epoch %s is outside of the weak subjectivity period.  Please supply a recent weak subjectivity checkpoint using --ws-checkpoint=<BLOCK_ROOT>:<EPOCH>.",
-            latestFinalizedCheckpointEpoch);
-    logWithColorIfLevelGreaterThanInfo(level, msg, ColorConsolePrinter.Color.RED);
-  }
-
-  public void chainInconsistentWithWeakSubjectivityCheckpoint(
-      final Level level,
-      final Bytes32 blockRoot,
-      final UInt64 blockSlot,
-      final Bytes32 wsCheckpointRoot,
-      final UInt64 wsCheckpointEpoch) {
-    final String msg =
-        String.format(
-            "Block %s at slot %s is inconsistent with weak subjectivity checkpoint (root=%s, epoch=%s)",
-            blockRoot, blockSlot, wsCheckpointRoot, wsCheckpointEpoch);
-    logWithColorIfLevelGreaterThanInfo(level, msg, ColorConsolePrinter.Color.RED);
-  }
-
-  public void failedToPerformWeakSubjectivityValidation(
-      final Level level, final String message, final Throwable error) {
-    log.log(level, "Failed to perform weak subjectivity validation: " + message, error);
-  }
-
-  private void logWithColorIfLevelGreaterThanInfo(
-      final Level level, final String msg, final ColorConsolePrinter.Color color) {
-    final boolean useColor = level.isMoreSpecificThan(Level.INFO);
-    log.log(level, useColor ? print(msg, color) : msg);
   }
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/WeakSubjectivityLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/WeakSubjectivityLogger.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.logging;
+
+import static tech.pegasys.teku.infrastructure.logging.ColorConsolePrinter.print;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class WeakSubjectivityLogger {
+  private static final Logger FILE_LOGGER = LogManager.getLogger();
+  private final Logger log;
+  private final boolean allowColor;
+
+  private WeakSubjectivityLogger(final Logger log, final boolean allowColor) {
+    this.log = log;
+    this.allowColor = allowColor;
+  }
+
+  public static WeakSubjectivityLogger createConsoleLogger() {
+    return new WeakSubjectivityLogger(StatusLogger.STATUS_LOG.log, true);
+  }
+
+  public static WeakSubjectivityLogger createFileLogger() {
+    return new WeakSubjectivityLogger(FILE_LOGGER, false);
+  }
+
+  public void warnWeakSubjectivityChecksSuppressed(final UInt64 untilEpoch) {
+    final String msg = "Suppressing weak subjectivity errors until epoch " + untilEpoch;
+    logWithColorIfLevelGreaterThanInfo(Level.WARN, msg, ColorConsolePrinter.Color.YELLOW);
+  }
+
+  public void warnWeakSubjectivityFinalizedCheckpointValidationDeferred(
+      final UInt64 finalizedEpoch, final UInt64 wsCheckpointEpoch) {
+    final String msg =
+        String.format(
+            "Deferring weak subjectivity checks for finalized checkpoint at epoch %s.  Checks will resume once weak subjectivity checkpoint at epoch %s is reached.",
+            finalizedEpoch, wsCheckpointEpoch);
+    logWithColorIfLevelGreaterThanInfo(Level.WARN, msg, ColorConsolePrinter.Color.YELLOW);
+  }
+
+  public void finalizedCheckpointOutsideOfWeakSubjectivityPeriod(
+      Level level, final UInt64 latestFinalizedCheckpointEpoch) {
+    final String msg =
+        String.format(
+            "The latest finalized checkpoint at epoch %s is outside of the weak subjectivity period.  Please supply a recent weak subjectivity checkpoint using --ws-checkpoint=<BLOCK_ROOT>:<EPOCH>.",
+            latestFinalizedCheckpointEpoch);
+    logWithColorIfLevelGreaterThanInfo(level, msg, ColorConsolePrinter.Color.RED);
+  }
+
+  public void chainInconsistentWithWeakSubjectivityCheckpoint(
+      final Level level,
+      final Bytes32 blockRoot,
+      final UInt64 blockSlot,
+      final Bytes32 wsCheckpointRoot,
+      final UInt64 wsCheckpointEpoch) {
+    final String msg =
+        String.format(
+            "Block %s at slot %s is inconsistent with weak subjectivity checkpoint (root=%s, epoch=%s)",
+            blockRoot, blockSlot, wsCheckpointRoot, wsCheckpointEpoch);
+    logWithColorIfLevelGreaterThanInfo(level, msg, ColorConsolePrinter.Color.RED);
+  }
+
+  public void failedToPerformWeakSubjectivityValidation(
+      final Level level, final String message, final Throwable error) {
+    log.log(level, "Failed to perform weak subjectivity validation: " + message, error);
+  }
+
+  private void logWithColorIfLevelGreaterThanInfo(
+      final Level level, final String msg, final ColorConsolePrinter.Color color) {
+    final boolean useColor = allowColor && level.compareTo(Level.INFO) < 0;
+    log.log(level, useColor ? print(msg, color) : msg);
+  }
+}


### PR DESCRIPTION
Log to file rather than console.  Reduce frequency of warning logs.

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Since we don't currently have the infrastructure in place to easily find values for the ws checkpoint, make ws-related logs quieter for now:
* Log to file rather than console
* Reduce log level from WARN to INFO
* Reduce the frequency of warning logs

Adds a `WeakSubjectivityLogger` that can be configured to log to file or console, so its easy to switch between the 2 strategies. 

## Fixed Issue(s)
Relates to #2999
Part of #2273

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.