### PR TITLE
Fix unhandled exception on stream abort

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandler.java
@@ -218,12 +218,15 @@ public class Eth2OutgoingRequestHandler<TRequest extends RpcRequest, TResponse>
       return;
     }
 
-    // releasing any resources
-    responseDecoder.close();
-
     LOG.trace("Abort request: {}", error.getMessage());
-    rpcStream.closeAbruptly().reportExceptions();
-    responseProcessor.finishProcessing().always(() -> responseStream.completeWithError(error));
+
+    // releasing any resources
+    try {
+      responseDecoder.close();
+      rpcStream.closeAbruptly().reportExceptions();
+    } finally {
+      responseProcessor.finishProcessing().always(() -> responseStream.completeWithError(error));
+    }
   }
 
   private void ensureFirstBytesArriveWithinTimeLimit(final RpcStream stream) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoder.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.PayloadTruncatedException;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.RpcErrorMessage;
+import tech.pegasys.teku.networking.eth2.rpc.core.encodings.ByteBufDecoder;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcByteBufDecoder;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 
@@ -101,12 +102,8 @@ public class RpcResponseDecoder<T> {
   }
 
   public void close() {
-    try {
-      complete();
-    } catch (RpcException e) {
-      // decoders should release any resources despite throwing exception
-      LOG.trace("Ignoring any complete() exceptions when close(): %s", e);
-    }
+    payloadDecoder.ifPresent(ByteBufDecoder::close);
+    errorDecoder.ifPresent(ByteBufDecoder::close);
   }
 
   public void complete() throws RpcException {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseDecoder.java
@@ -21,8 +21,6 @@ import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.PayloadTruncatedException;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.RpcErrorMessage;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.ByteBufDecoder;
@@ -35,8 +33,6 @@ import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
  * @param <T>
  */
 public class RpcResponseDecoder<T> {
-  private static final Logger LOG = LogManager.getLogger();
-
   private Optional<Integer> respCodeMaybe = Optional.empty();
   private Optional<RpcByteBufDecoder<T>> payloadDecoder = Optional.empty();
   private Optional<RpcByteBufDecoder<RpcErrorMessage>> errorDecoder = Optional.empty();

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/AbstractByteBufDecoder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/AbstractByteBufDecoder.java
@@ -65,9 +65,19 @@ public abstract class AbstractByteBufDecoder<TMessage, TException extends Except
 
   @Override
   public void complete() throws TException {
+    try {
+      if (compositeByteBuf.isReadable()) {
+        throwUnprocessedDataException(compositeByteBuf.readableBytes());
+      }
+    } finally {
+      close();
+    }
+  }
+
+  @Override
+  public void close() {
     if (compositeByteBuf.isReadable()) {
       compositeByteBuf.release();
-      throwUnprocessedDataException(compositeByteBuf.readableBytes());
     }
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/ByteBufDecoder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/ByteBufDecoder.java
@@ -53,10 +53,22 @@ public interface ByteBufDecoder<TMessage, TException extends Exception> {
 
   /**
    * Tells the decoder that the input stream is over and no more bytes would be supplied. After
-   * {@code complete()} call calling any Decoder method would result in error If any buffered data
-   * still remains unprocessed in the decoder it is released and {@link TException} is thrown
+   * {@code complete()} call calling any Decoder method would result in error
+   *
+   * The {@link #close()} should be invoked by implementation on either success or error so
+   * on {@code complete()} return all resources should be released by a decoder
+   *
+   * To abort the decoder use {@link #close()} method
    *
    * @throws TException if any unprocessed data left
    */
   void complete() throws TException;
+
+  /**
+   * Releases all associated resources. Normally should be used to release resources on abrupt
+   * completion. Use {@link #complete()} method for regular decoder completion.
+   *
+   * After {@code close()} calling any Decoder method would result in error.
+   */
+  void close();
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/ByteBufDecoder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/ByteBufDecoder.java
@@ -55,10 +55,10 @@ public interface ByteBufDecoder<TMessage, TException extends Exception> {
    * Tells the decoder that the input stream is over and no more bytes would be supplied. After
    * {@code complete()} call calling any Decoder method would result in error
    *
-   * The {@link #close()} should be invoked by implementation on either success or error so
-   * on {@code complete()} return all resources should be released by a decoder
+   * <p>The {@link #close()} should be invoked by implementation on either success or error so on
+   * {@code complete()} return all resources should be released by a decoder
    *
-   * To abort the decoder use {@link #close()} method
+   * <p>To abort the decoder use {@link #close()} method
    *
    * @throws TException if any unprocessed data left
    */
@@ -68,7 +68,7 @@ public interface ByteBufDecoder<TMessage, TException extends Exception> {
    * Releases all associated resources. Normally should be used to release resources on abrupt
    * completion. Use {@link #complete()} method for regular decoder completion.
    *
-   * After {@code close()} calling any Decoder method would result in error.
+   * <p>After {@code close()} calling any Decoder method would result in error.
    */
   void close();
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/LengthPrefixedEncoding.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/LengthPrefixedEncoding.java
@@ -33,6 +33,9 @@ public class LengthPrefixedEncoding implements RpcEncoding {
 
         @Override
         public void complete() {}
+
+        @Override
+        public void close() {}
       };
 
   private final String name;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/noop/NoopCompressor.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/noop/NoopCompressor.java
@@ -47,6 +47,11 @@ public class NoopCompressor implements Compressor {
       decoder.complete();
       disposed = true;
     }
+
+    @Override
+    public void close() {
+      decoder.close();
+    }
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/snappy/SnappyFramedCompressor.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/snappy/SnappyFramedCompressor.java
@@ -96,10 +96,10 @@ public class SnappyFramedCompressor implements Compressor {
     public void complete() throws CompressionException {
       try {
         if (broken) {
-            throw new CompressionException("Compressed stream is broken");
+          throw new CompressionException("Compressed stream is broken");
         }
         if (disposed) {
-            throw new DisposedDecompressorException();
+          throw new DisposedDecompressorException();
         }
         disposed = true;
         boolean unreturnedFrames = !decodedSnappyFrames.isEmpty();

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/snappy/SnappyFramedCompressor.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/snappy/SnappyFramedCompressor.java
@@ -95,8 +95,12 @@ public class SnappyFramedCompressor implements Compressor {
     @Override
     public void complete() throws CompressionException {
       try {
-        if (broken) throw new CompressionException("Compressed stream is broken");
-        if (disposed) throw new DisposedDecompressorException();
+        if (broken) {
+            throw new CompressionException("Compressed stream is broken");
+        }
+        if (disposed) {
+            throw new DisposedDecompressorException();
+        }
         disposed = true;
         boolean unreturnedFrames = !decodedSnappyFrames.isEmpty();
         if (unreturnedFrames) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/snappy/SnappyFramedCompressor.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/snappy/SnappyFramedCompressor.java
@@ -19,8 +19,6 @@ import io.netty.util.ReferenceCounted;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.Compressor;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.exceptions.CompressionException;
@@ -30,7 +28,6 @@ import tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.exceptio
 
 /** Implements snappy compression using the "framed" / streaming format. */
 public class SnappyFramedCompressor implements Compressor {
-  private static final Logger LOG = LogManager.getLogger();
 
   private class SnappyFramedDecompressor implements Decompressor {
     private final SnappyFrameDecoder snappyFrameDecoder = new SnappyFrameDecoder();

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
@@ -271,6 +271,21 @@ public abstract class Eth2OutgoingRequestHandlerTest
   }
 
   @Test
+  public void shouldCompleteExceptionallyWhenClosedWithTruncatedMessage() {
+    sendInitialPayload();
+
+    timeProvider.advanceTimeByMillis(100);
+    final Bytes chunkBytes = chunks.get(0);
+    deliverBytes(chunkBytes.slice(0, chunkBytes.size() - 1));
+
+    asyncRequestRunner.executeQueuedActions();
+
+    complete();
+
+    assertThat(finishedProcessingFuture).isCompletedExceptionally();
+  }
+
+  @Test
   public void doNotDisconnectsIfSecondChunkReceivedInTime() throws Exception {
     sendInitialPayload();
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Fixes the regression introduced in #3001 

A remote party may abruptly close a truncated stream. The `Eth2OutgoingRequestHandler.readComplete()` generates an error in this case which causes `abortRequest()` call. `RpcResponseDecoder.close()` throws unexpected `IllegalStateException` which is not caught and the `responseStream` remains uncompleted. 

## Fixed Issue(s)

Fix #3028 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.