### PR TITLE
[Issue-2273] Don't treat falling out of WSP as a fatal event

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
 import tech.pegasys.teku.statetransition.events.block.ImportedBlockEvent;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
 
 public class BlockImporter {
@@ -124,10 +125,12 @@ public class BlockImporter {
               // While the node is online, we can defer to fork-choice to choose the right chain.
               // If we have a recent chain head, skip validation since it appears we're online and
               // processing new blocks.
-              final Optional<UInt64> wsPeriod =
-                  weakSubjectivityValidator.getWSPeriod(finalizedCheckpointState);
+              final Optional<UInt64> wsPeriodInSlots =
+                  weakSubjectivityValidator
+                      .getWSPeriod(finalizedCheckpointState)
+                      .map(epochs -> epochs.times(Constants.SLOTS_PER_EPOCH));
               final UInt64 headSlot = recentChainData.getHeadSlot();
-              if (wsPeriod
+              if (wsPeriodInSlots
                   .map(wsp -> headSlot.plus(wsp).isGreaterThanOrEqualTo(currentSlot))
                   .orElse(false)) {
                 return null;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -452,7 +452,7 @@ public class BlockImporterTest {
   @Test
   public void importBlock_nonFinalizingChain_skipWSPChecks() throws Exception {
     final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault();
-    final SignedBlockAndState genesis = storageSystem.chainUpdater().initializeGenesis();
+    storageSystem.chainUpdater().initializeGenesis();
     final ForkChoice forkChoice =
         new ForkChoice(
             new SyncForkChoiceExecutor(), storageSystem.recentChainData(), new StateTransition());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
@@ -26,6 +27,7 @@ import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_star
 import com.google.common.eventbus.EventBus;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -42,6 +44,7 @@ import tech.pegasys.teku.core.signatures.Signer;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
@@ -54,6 +57,8 @@ import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.SyncForkChoiceExecutor;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
@@ -366,6 +371,176 @@ public class BlockImporterTest {
     // Import next valid block
     final BlockImportResult result2 = blockImporter.importBlock(nextBlock).get();
     assertSuccessfulResult(result2);
+  }
+
+  @Test
+  public void importBlock_runWSPChecks() throws Exception {
+    final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault();
+    final SignedBlockAndState genesis = storageSystem.chainUpdater().initializeGenesis();
+    final ForkChoice forkChoice =
+        new ForkChoice(
+            new SyncForkChoiceExecutor(), storageSystem.recentChainData(), new StateTransition());
+    final BlockImporter blockImporter =
+        new BlockImporter(
+            storageSystem.recentChainData(),
+            forkChoice,
+            weakSubjectivityValidator,
+            storageSystem.eventBus());
+
+    // The current slot is far ahead of the block being imported
+    final UInt64 wsPeriod = UInt64.valueOf(10);
+    when(weakSubjectivityValidator.getWSPeriod(any())).thenReturn(Optional.of(wsPeriod));
+    final UInt64 currentSlot = compute_start_slot_at_epoch(wsPeriod).plus(1);
+    storageSystem.chainUpdater().setCurrentSlot(currentSlot);
+
+    final SignedBlockAndState blockToImport = storageSystem.chainBuilder().generateBlockAtSlot(1);
+
+    // Import wsBlock
+    final BlockImportResult result = blockImporter.importBlock(blockToImport.getBlock()).get();
+    assertSuccessfulResult(result);
+
+    // Verify ws period checks were run
+    final CheckpointState finalizedCheckpointState =
+        new CheckpointState(
+            new Checkpoint(UInt64.ZERO, genesis.getRoot()), genesis.getBlock(), genesis.getState());
+    verify(weakSubjectivityValidator)
+        .validateLatestFinalizedCheckpoint(finalizedCheckpointState, currentSlot);
+  }
+
+  @Test
+  public void importBlock_nonFinalizingChain_runWSPChecks() throws Exception {
+    final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault();
+    final SignedBlockAndState genesis = storageSystem.chainUpdater().initializeGenesis();
+    final ForkChoice forkChoice =
+        new ForkChoice(
+            new SyncForkChoiceExecutor(), storageSystem.recentChainData(), new StateTransition());
+    final BlockImporter blockImporter =
+        new BlockImporter(
+            storageSystem.recentChainData(),
+            forkChoice,
+            weakSubjectivityValidator,
+            storageSystem.eventBus());
+
+    // Set current time to be several WSP's ahead of finalized checkpoint
+    final UInt64 wsPeriod = UInt64.valueOf(10);
+    when(weakSubjectivityValidator.getWSPeriod(any())).thenReturn(Optional.of(wsPeriod));
+    final UInt64 currentSlot = compute_start_slot_at_epoch(wsPeriod).times(3).plus(1);
+    storageSystem.chainUpdater().setCurrentSlot(currentSlot);
+
+    // Add a recent block
+    final SignedBlockAndState recentBlock =
+        storageSystem.chainUpdater().advanceChain(currentSlot.minus(wsPeriod).minus(1));
+    storageSystem.chainUpdater().updateBestBlock(recentBlock);
+
+    // Import block new block
+    final SignedBlockAndState blockToImport =
+        storageSystem.chainBuilder().generateBlockAtSlot(currentSlot);
+
+    // Import wsBlock
+    final BlockImportResult result = blockImporter.importBlock(blockToImport.getBlock()).get();
+    assertSuccessfulResult(result);
+
+    // Verify ws period checks were run
+    final CheckpointState finalizedCheckpointState =
+        new CheckpointState(
+            new Checkpoint(UInt64.ZERO, genesis.getRoot()), genesis.getBlock(), genesis.getState());
+    verify(weakSubjectivityValidator)
+        .validateLatestFinalizedCheckpoint(finalizedCheckpointState, currentSlot);
+  }
+
+  @Test
+  public void importBlock_nonFinalizingChain_skipWSPChecks() throws Exception {
+    final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault();
+    final SignedBlockAndState genesis = storageSystem.chainUpdater().initializeGenesis();
+    final ForkChoice forkChoice =
+        new ForkChoice(
+            new SyncForkChoiceExecutor(), storageSystem.recentChainData(), new StateTransition());
+    final BlockImporter blockImporter =
+        new BlockImporter(
+            storageSystem.recentChainData(),
+            forkChoice,
+            weakSubjectivityValidator,
+            storageSystem.eventBus());
+
+    // Set current time to be several WSP's ahead of finalized checkpoint
+    final UInt64 wsPeriod = UInt64.valueOf(10);
+    when(weakSubjectivityValidator.getWSPeriod(any())).thenReturn(Optional.of(wsPeriod));
+    final UInt64 currentSlot = compute_start_slot_at_epoch(wsPeriod).times(3).plus(1);
+    storageSystem.chainUpdater().setCurrentSlot(currentSlot);
+
+    // Add a recent block
+    final SignedBlockAndState recentBlock =
+        storageSystem.chainUpdater().advanceChain(currentSlot.minus(wsPeriod));
+    storageSystem.chainUpdater().updateBestBlock(recentBlock);
+
+    // Import block new block
+    final SignedBlockAndState blockToImport =
+        storageSystem.chainBuilder().generateBlockAtSlot(currentSlot);
+
+    // Import wsBlock
+    final BlockImportResult result = blockImporter.importBlock(blockToImport.getBlock()).get();
+    assertSuccessfulResult(result);
+
+    // Verify ws period checks were skipped
+    verify(weakSubjectivityValidator, never()).validateLatestFinalizedCheckpoint(any(), any());
+  }
+
+  @Test
+  public void getLatestCheckpointState_initialCall() {
+    final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault();
+    final ForkChoice forkChoice =
+        new ForkChoice(
+            new SyncForkChoiceExecutor(), storageSystem.recentChainData(), new StateTransition());
+    final BlockImporter blockImporter =
+        new BlockImporter(
+            storageSystem.recentChainData(),
+            forkChoice,
+            weakSubjectivityValidator,
+            storageSystem.eventBus());
+
+    final SignedBlockAndState genesis = storageSystem.chainUpdater().initializeGenesis();
+
+    SafeFuture<CheckpointState> result = blockImporter.getLatestCheckpointState();
+    assertThat(result).isCompleted();
+    assertThat(result.join().getRoot()).isEqualTo(genesis.getRoot());
+
+    // Second call should be the same
+    result = blockImporter.getLatestCheckpointState();
+    assertThat(result).isCompleted();
+    assertThat(result.join().getRoot()).isEqualTo(genesis.getRoot());
+  }
+
+  @Test
+  public void getLatestCheckpointState_shouldPullUpdatedFinalizedCheckpoint() {
+    final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault();
+    final ForkChoice forkChoice =
+        new ForkChoice(
+            new SyncForkChoiceExecutor(), storageSystem.recentChainData(), new StateTransition());
+    final BlockImporter blockImporter =
+        new BlockImporter(
+            storageSystem.recentChainData(),
+            forkChoice,
+            weakSubjectivityValidator,
+            storageSystem.eventBus());
+
+    final SignedBlockAndState genesis = storageSystem.chainUpdater().initializeGenesis();
+
+    // Pull genesis checkpoint
+    SafeFuture<CheckpointState> result = blockImporter.getLatestCheckpointState();
+    assertThat(result).isCompleted();
+    assertThat(result.join().getRoot()).isEqualTo(genesis.getRoot());
+
+    // Update latest finalized
+    final UInt64 newFinalizedEpoch = UInt64.valueOf(2);
+    final SignedBlockAndState newFinalizedBlock =
+        storageSystem.chainUpdater().advanceChain(compute_start_slot_at_epoch(newFinalizedEpoch));
+    storageSystem.chainUpdater().finalizeEpoch(newFinalizedEpoch);
+
+    // Second call should pull new finalized checkpoint
+    result = blockImporter.getLatestCheckpointState();
+    assertThat(result).isCompleted();
+    assertThat(result.join().getEpoch()).isEqualTo(newFinalizedEpoch);
+    assertThat(result.join().getRoot()).isEqualTo(newFinalizedBlock.getRoot());
   }
 
   private void assertImportFailed(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -423,13 +423,14 @@ public class BlockImporterTest {
 
     // Set current time to be several WSP's ahead of finalized checkpoint
     final UInt64 wsPeriod = UInt64.valueOf(10);
+    final UInt64 wsPeriodInSlots = wsPeriod.times(Constants.SLOTS_PER_EPOCH);
     when(weakSubjectivityValidator.getWSPeriod(any())).thenReturn(Optional.of(wsPeriod));
-    final UInt64 currentSlot = compute_start_slot_at_epoch(wsPeriod).times(3).plus(1);
+    final UInt64 currentSlot = wsPeriodInSlots.times(3).plus(1);
     storageSystem.chainUpdater().setCurrentSlot(currentSlot);
 
     // Add a recent block
     final SignedBlockAndState recentBlock =
-        storageSystem.chainUpdater().advanceChain(currentSlot.minus(wsPeriod).minus(1));
+        storageSystem.chainUpdater().advanceChain(currentSlot.minus(wsPeriodInSlots).minus(1));
     storageSystem.chainUpdater().updateBestBlock(recentBlock);
 
     // Import block new block
@@ -464,13 +465,14 @@ public class BlockImporterTest {
 
     // Set current time to be several WSP's ahead of finalized checkpoint
     final UInt64 wsPeriod = UInt64.valueOf(10);
+    final UInt64 wsPeriodInSlots = wsPeriod.times(Constants.SLOTS_PER_EPOCH);
     when(weakSubjectivityValidator.getWSPeriod(any())).thenReturn(Optional.of(wsPeriod));
-    final UInt64 currentSlot = compute_start_slot_at_epoch(wsPeriod).times(3).plus(1);
+    final UInt64 currentSlot = wsPeriodInSlots.times(3).plus(1);
     storageSystem.chainUpdater().setCurrentSlot(currentSlot);
 
     // Add a recent block
     final SignedBlockAndState recentBlock =
-        storageSystem.chainUpdater().advanceChain(currentSlot.minus(wsPeriod));
+        storageSystem.chainUpdater().advanceChain(currentSlot.minus(wsPeriodInSlots));
     storageSystem.chainUpdater().updateBestBlock(recentBlock);
 
     // Import block new block

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
@@ -83,6 +83,14 @@ public class WeakSubjectivityCalculator {
     return finalizedEpoch.dividedBy(weakSubjectivityMod).times(weakSubjectivityMod);
   }
 
+  /**
+   * @param state A trusted / effectively finalized state
+   * @return The weak subjectivity period in epochs
+   */
+  public UInt64 computeWeakSubjectivityPeriod(final BeaconState state) {
+    return computeWeakSubjectivityPeriod(getActiveValidators(state));
+  }
+
   // TODO(#2779) - This calculation is still under development, make sure it is updated to the
   // latest when possible
   public UInt64 computeWeakSubjectivityPeriod(final int validatorCount) {

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
@@ -68,7 +68,7 @@ public class WeakSubjectivityValidator {
   public static WeakSubjectivityValidator moderate(final WeakSubjectivityConfig config) {
     final WeakSubjectivityCalculator calculator = WeakSubjectivityCalculator.create(config);
     return new WeakSubjectivityValidator(
-        config, calculator, WeakSubjectivityViolationPolicy.moderate(config));
+        config, calculator, WeakSubjectivityViolationPolicy.moderate());
   }
 
   public static WeakSubjectivityValidator lenient() {

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
@@ -110,6 +110,15 @@ public class WeakSubjectivityValidator {
             });
   }
 
+  public Optional<UInt64> getWSPeriod(final CheckpointState latestFinalizedCheckpoint) {
+    if (isPriorToWSCheckpoint(latestFinalizedCheckpoint)) {
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        calculator.computeWeakSubjectivityPeriod(latestFinalizedCheckpoint.getState()));
+  }
+
   /**
    * Validates that the latest finalized checkpoint is within the weak subjectivity period, given
    * the current slot based on clock time. If validation fails, configured policies are run to

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/ModerateWeakSubjectivityViolationPolicy.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/ModerateWeakSubjectivityViolationPolicy.java
@@ -18,16 +18,13 @@ import org.apache.logging.log4j.Level;
 import tech.pegasys.teku.datastructures.state.CheckpointState;
 import tech.pegasys.teku.infrastructure.time.Throttler;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 
 class ModerateWeakSubjectivityViolationPolicy extends CompoundWeakSubjectivityViolationPolicy {
-  private final WeakSubjectivityConfig config;
   private final Throttler<WeakSubjectivityViolationPolicy> warningPolicy =
       new Throttler<>(new LoggingWeakSubjectivityViolationPolicy(Level.WARN), UInt64.valueOf(10));
 
-  public ModerateWeakSubjectivityViolationPolicy(final WeakSubjectivityConfig config) {
+  public ModerateWeakSubjectivityViolationPolicy() {
     super(List.of(WeakSubjectivityViolationPolicy.strict()));
-    this.config = config;
   }
 
   @Override

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/ModerateWeakSubjectivityViolationPolicy.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/ModerateWeakSubjectivityViolationPolicy.java
@@ -36,17 +36,11 @@ class ModerateWeakSubjectivityViolationPolicy extends CompoundWeakSubjectivityVi
       final int activeValidatorCount,
       final UInt64 currentSlot,
       final UInt64 wsPeriod) {
-    if (config.getWeakSubjectivityCheckpoint().isPresent()) {
-      // If WS checkpoint is set, run strict check
-      super.onFinalizedCheckpointOutsideOfWeakSubjectivityPeriod(
-          latestFinalizedCheckpoint, activeValidatorCount, currentSlot, wsPeriod);
-    } else {
-      // Otherwise, warn periodically
-      warningPolicy.invoke(
-          currentSlot,
-          p ->
-              p.onFinalizedCheckpointOutsideOfWeakSubjectivityPeriod(
-                  latestFinalizedCheckpoint, activeValidatorCount, currentSlot, wsPeriod));
-    }
+    // Warn periodically
+    warningPolicy.invoke(
+        currentSlot,
+        p ->
+            p.onFinalizedCheckpointOutsideOfWeakSubjectivityPeriod(
+                latestFinalizedCheckpoint, activeValidatorCount, currentSlot, wsPeriod));
   }
 }

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/WeakSubjectivityViolationPolicy.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/policies/WeakSubjectivityViolationPolicy.java
@@ -19,7 +19,6 @@ import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.state.CheckpointState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 
 public interface WeakSubjectivityViolationPolicy {
 
@@ -27,8 +26,8 @@ public interface WeakSubjectivityViolationPolicy {
     return new LoggingWeakSubjectivityViolationPolicy(Level.TRACE);
   }
 
-  static WeakSubjectivityViolationPolicy moderate(final WeakSubjectivityConfig config) {
-    return new ModerateWeakSubjectivityViolationPolicy(config);
+  static WeakSubjectivityViolationPolicy moderate() {
+    return new ModerateWeakSubjectivityViolationPolicy();
   }
 
   static WeakSubjectivityViolationPolicy strict() {


### PR DESCRIPTION
## PR Description
Don't treat falling out of WSP as a fatal event: just log warnings instead of exiting.  Skip warnings about WSP when the node at least appears to be online (has a recent chain head).

Also:
* Cache latest finalized state so we don't have to look it up on every block import

## Fixed Issue(s)
Part of #2273 
Fixes #3005

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.