### PR TITLE
Fix attestation_pool_size metric: update size when pool is pruned

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -104,7 +104,14 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
     final UInt64 firstValidAttestationSlot = slot.minus(attestationRetentionSlots);
     final Collection<Set<Bytes>> dataHashesToRemove =
         dataHashBySlot.headMap(firstValidAttestationSlot, false).values();
-    dataHashesToRemove.stream().flatMap(Set::stream).forEach(attestationGroupByDataHash::remove);
+    dataHashesToRemove.stream()
+        .flatMap(Set::stream)
+        .forEach(
+            key -> {
+              final int removed = Math.toIntExact(attestationGroupByDataHash.get(key).size());
+              attestationGroupByDataHash.remove(key);
+              updateSize(-removed);
+            });
     dataHashesToRemove.clear();
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -99,6 +99,10 @@ class MatchingDataAttestationGroup implements Iterable<ValidateableAttestation> 
     return attestationsByValidatorCount.isEmpty();
   }
 
+  public long size() {
+    return attestationsByValidatorCount.values().stream().map(Set::size).reduce(0, Integer::sum);
+  }
+
   /**
    * Removes any attestation from this group whose validators are all included in the specified
    * attestation. Attestations that include some but not all validators in the specified attestation

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -207,6 +207,7 @@ class AggregatingAttestationPoolTest {
     final Attestation preserveAttestation =
         addAttestationFromValidators(preserveAttestationData, 2);
 
+    assertThat(aggregatingPool.getSize()).isEqualTo(2);
     aggregatingPool.onSlot(
         pruneAttestationData
             .getSlot()
@@ -217,6 +218,7 @@ class AggregatingAttestationPoolTest {
             aggregatingPool.getAttestationsForBlock(
                 dataStructureUtil.randomBeaconState(), forkChecker))
         .containsOnly(preserveAttestation);
+    assertThat(aggregatingPool.getSize()).isEqualTo(1);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
@@ -123,6 +123,26 @@ class MatchingDataAttestationGroupTest {
     assertThat(group).containsExactly(aggregate);
   }
 
+  @Test
+  public void size() {
+    assertThat(group.size()).isEqualTo(0);
+    final ValidateableAttestation attestation1 = addAttestation(1);
+    assertThat(group.size()).isEqualTo(1);
+    final ValidateableAttestation attestation2 = addAttestation(2);
+    assertThat(group.size()).isEqualTo(2);
+    addAttestation(3, 4);
+    assertThat(group.size()).isEqualTo(3);
+    addAttestation(1, 2);
+    assertThat(group.size()).isEqualTo(4);
+
+    int numRemoved =
+        group.remove(
+            aggregateAttestations(attestation1.getAttestation(), attestation2.getAttestation()));
+
+    assertThat(numRemoved).isEqualTo(3);
+    assertThat(group.size()).isEqualTo(1);
+  }
+
   private ValidateableAttestation addAttestation(final int... validators) {
     final ValidateableAttestation attestation = createAttestation(validators);
     final boolean added = group.add(attestation);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fix attestation_pool_size metric: update size when pool is pruned.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.