### PR TITLE
Increase parallelism of reference tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
       - capture_test_artifacts
 
   referenceTests:
-    parallelism: 4
+    parallelism: 5
     executor: large_executor
     steps:
       - prepare


### PR DESCRIPTION
## PR Description
Speed up the build by splitting reference tests across more boxes.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.