### PR TITLE
Find common ancestor when switching chains in multipeer sync

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -415,6 +415,15 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     return (SafeFuture<U>) super.thenComposeAsync(fn, executor);
   }
 
+  @SuppressWarnings("unchecked")
+  @Override
+  public <U, V> SafeFuture<V> thenCombineAsync(
+      final CompletionStage<? extends U> other,
+      final BiFunction<? super T, ? super U, ? extends V> fn,
+      final Executor executor) {
+    return (SafeFuture<V>) super.thenCombineAsync(other, fn, executor);
+  }
+
   @Override
   public SafeFuture<T> exceptionally(final Function<Throwable, ? extends T> fn) {
     return (SafeFuture<T>) super.exceptionally(fn);

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/eventthread/InlineEventThread.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/eventthread/InlineEventThread.java
@@ -61,6 +61,18 @@ public class InlineEventThread implements EventThread {
   }
 
   /**
+   * Available for testing so that tests can call methods which normally must be accessed on the
+   * event thread, without having to actually pass a lambda to execute.
+   */
+  public void markAsOnEventThread() {
+    isEventThread.set(Boolean.TRUE);
+  }
+
+  public void markAsOffEventThread() {
+    isEventThread.set(Boolean.FALSE);
+  }
+
+  /**
    * Executes the specified command with a flag set to identify the current thread as the event
    * thread.
    *
@@ -73,7 +85,7 @@ public class InlineEventThread implements EventThread {
   private void withEventThreadMarkerSet(final Runnable command) {
 
     final Boolean originalEventThread = isEventThread.get();
-    isEventThread.set(Boolean.TRUE);
+    markAsOnEventThread();
     command.run();
 
     isEventThread.set(originalEventThread);

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/BatchSync.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/BatchSync.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.sync.multipeer;
 
 import static com.google.common.base.Preconditions.checkState;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Collection;
@@ -42,13 +41,14 @@ public class BatchSync implements Sync {
   private final RecentChainData recentChainData;
   private final BatchImporter batchImporter;
   private final BatchDataRequester batchDataRequester;
+  private final MultipeerCommonAncestorFinder commonAncestorFinder;
 
   private final BatchChain activeBatches;
 
   private Optional<Batch> importingBatch = Optional.empty();
   private boolean switchingBranches = false;
 
-  private UInt64 commonAncestorSlot;
+  private SafeFuture<UInt64> commonAncestorSlot;
 
   private TargetChain targetChain;
   private SafeFuture<SyncResult> syncResult = SafeFuture.completedFuture(SyncResult.COMPLETE);
@@ -58,12 +58,14 @@ public class BatchSync implements Sync {
       final RecentChainData recentChainData,
       final BatchChain activeBatches,
       final BatchImporter batchImporter,
-      final BatchDataRequester batchDataRequester) {
+      final BatchDataRequester batchDataRequester,
+      final MultipeerCommonAncestorFinder commonAncestorFinder) {
     this.eventThread = eventThread;
     this.recentChainData = recentChainData;
     this.activeBatches = activeBatches;
     this.batchImporter = batchImporter;
     this.batchDataRequester = batchDataRequester;
+    this.commonAncestorFinder = commonAncestorFinder;
   }
 
   public static BatchSync create(
@@ -71,13 +73,19 @@ public class BatchSync implements Sync {
       final RecentChainData recentChainData,
       final BatchImporter batchImporter,
       final BatchFactory batchFactory,
-      final UInt64 batchSize) {
+      final UInt64 batchSize,
+      final MultipeerCommonAncestorFinder commonAncestorFinder) {
     final BatchChain activeBatches = new BatchChain();
     final BatchDataRequester batchDataRequester =
         new BatchDataRequester(
             eventThread, activeBatches, batchFactory, batchSize, MAX_PENDING_BATCHES);
     return new BatchSync(
-        eventThread, recentChainData, activeBatches, batchImporter, batchDataRequester);
+        eventThread,
+        recentChainData,
+        activeBatches,
+        batchImporter,
+        batchDataRequester,
+        commonAncestorFinder);
   }
 
   /**
@@ -106,8 +114,10 @@ public class BatchSync implements Sync {
     progressSync();
   }
 
-  private UInt64 getCommonAncestorSlot() {
-    return compute_start_slot_at_epoch(recentChainData.getFinalizedEpoch());
+  private SafeFuture<UInt64> getCommonAncestorSlot() {
+    final SafeFuture<UInt64> commonAncestor = commonAncestorFinder.findCommonAncestor(targetChain);
+    commonAncestor.thenRunAsync(this::progressSync, eventThread).reportExceptions();
+    return commonAncestor;
   }
 
   private void onBatchReceivedBlocks(final Batch batch) {
@@ -188,7 +198,7 @@ public class BatchSync implements Sync {
       batch.markFirstBlockConfirmed();
       previousBatches.forEach(this::confirmEmptyBatch);
     } else if (previousBatches.isEmpty()) {
-      // There are no previous batches but this doesn't match our chain so must be invalid]
+      // There are no previous batches but this doesn't match our chain so must be invalid
       LOG.debug(
           "Marking batch {} as invalid because there are no previous batches and it does not connect to our chain",
           batch);
@@ -317,7 +327,7 @@ public class BatchSync implements Sync {
     } else {
       // Everything prior to this batch must already exist on our chain so we can drop them all
       activeBatches.removeUpToIncluding(importedBatch);
-      commonAncestorSlot = importedBatch.getLastSlot();
+      commonAncestorSlot = SafeFuture.completedFuture(importedBatch.getLastSlot());
     }
     progressSync();
     if (activeBatches.isEmpty()) {
@@ -365,8 +375,10 @@ public class BatchSync implements Sync {
   }
 
   private void fillRetrievingQueue() {
-    batchDataRequester.fillRetrievingQueue(
-        targetChain, commonAncestorSlot, this::onBatchReceivedBlocks);
+    if (commonAncestorSlot.isDone() && !commonAncestorSlot.isCompletedExceptionally()) {
+      batchDataRequester.fillRetrievingQueue(
+          targetChain, commonAncestorSlot.join(), this::onBatchReceivedBlocks);
+    }
   }
 
   @VisibleForTesting

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/BatchSync.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/BatchSync.java
@@ -108,8 +108,13 @@ public class BatchSync implements Sync {
     eventThread.checkOnEventThread();
     // Cancel the existing sync
     this.syncResult.complete(SyncResult.TARGET_CHANGED);
+    if (this.targetChain == null) {
+      // Only set the common ancestor if we haven't previously sync'd a chain
+      // Otherwise we'll optimistically assume the new chain extends the current one and only reset
+      // the common ancestor if we later find out that's not the case
+      this.commonAncestorSlot = getCommonAncestorSlot();
+    }
     this.targetChain = targetChain;
-    this.commonAncestorSlot = getCommonAncestorSlot();
     this.syncResult = syncResult;
     progressSync();
   }

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/BatchSync.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/BatchSync.java
@@ -108,13 +108,14 @@ public class BatchSync implements Sync {
     eventThread.checkOnEventThread();
     // Cancel the existing sync
     this.syncResult.complete(SyncResult.TARGET_CHANGED);
-    if (this.targetChain == null) {
+    final boolean firstChain = this.targetChain == null;
+    this.targetChain = targetChain;
+    if (firstChain) {
       // Only set the common ancestor if we haven't previously sync'd a chain
       // Otherwise we'll optimistically assume the new chain extends the current one and only reset
       // the common ancestor if we later find out that's not the case
       this.commonAncestorSlot = getCommonAncestorSlot();
     }
-    this.targetChain = targetChain;
     this.syncResult = syncResult;
     progressSync();
   }

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/MultipeerCommonAncestorFinder.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/MultipeerCommonAncestorFinder.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.sync.multipeer;
+
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networking.eth2.peers.SyncSource;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.sync.multipeer.chains.TargetChain;
+import tech.pegasys.teku.sync.singlepeer.CommonAncestor;
+
+public class MultipeerCommonAncestorFinder {
+  private static final Logger LOG = LogManager.getLogger();
+  private final RecentChainData recentChainData;
+  private final CommonAncestor commonAncestorFinder;
+  private final EventThread eventThread;
+
+  @VisibleForTesting
+  MultipeerCommonAncestorFinder(
+      final RecentChainData recentChainData,
+      final CommonAncestor commonAncestorFinder,
+      final EventThread eventThread) {
+    this.recentChainData = recentChainData;
+    this.commonAncestorFinder = commonAncestorFinder;
+    this.eventThread = eventThread;
+  }
+
+  public static MultipeerCommonAncestorFinder create(
+      final RecentChainData recentChainData, final EventThread eventThread) {
+    return new MultipeerCommonAncestorFinder(
+        recentChainData, new CommonAncestor(recentChainData), eventThread);
+  }
+
+  public SafeFuture<UInt64> findCommonAncestor(final TargetChain targetChain) {
+    eventThread.checkOnEventThread();
+    final UInt64 latestFinalizedSlot =
+        compute_start_slot_at_epoch(recentChainData.getFinalizedEpoch());
+    if (targetChain.getPeerCount() == 0) {
+      // No sources to find a common ancestor with, assume its the finalized slot
+      return SafeFuture.completedFuture(latestFinalizedSlot);
+    }
+
+    return findCommonAncestor(latestFinalizedSlot, targetChain)
+        .thenPeek(ancestor -> LOG.trace("Found common ancestor at slot {}", ancestor));
+  }
+
+  private SafeFuture<UInt64> findCommonAncestor(
+      final UInt64 latestFinalizedSlot, final TargetChain targetChain) {
+    eventThread.checkOnEventThread();
+    final SyncSource source1 = targetChain.selectRandomPeer().orElseThrow();
+    final Optional<SyncSource> source2 = targetChain.selectRandomPeer(source1);
+    // Only one peer available, just go with it's common ancestor
+    final SafeFuture<UInt64> source1CommonAncestor =
+        commonAncestorFinder.getCommonAncestor(
+            source1, latestFinalizedSlot, targetChain.getChainHead().getSlot());
+    if (source2.isEmpty()) {
+      LOG.trace("Finding common ancestor from one peer");
+      return source1CommonAncestor;
+    }
+    LOG.trace("Finding common ancestor from two peers");
+    // Two peers available, so check they have the same common ancestor
+    return source1CommonAncestor
+        .thenCombineAsync(
+            commonAncestorFinder.getCommonAncestor(
+                source2.get(), latestFinalizedSlot, targetChain.getChainHead().getSlot()),
+            (commonAncestor1, commonAncestor2) ->
+                verifyResultsMatch(
+                    latestFinalizedSlot, targetChain, commonAncestor1, commonAncestor2),
+            eventThread)
+        .exceptionally(
+            error -> {
+              LOG.debug("Failed to find common ancestor. Starting sync from finalized slot", error);
+              return latestFinalizedSlot;
+            });
+  }
+
+  private UInt64 verifyResultsMatch(
+      final UInt64 latestFinalizedSlot,
+      final TargetChain targetChain,
+      final UInt64 commonAncestor1,
+      final UInt64 commonAncestor2) {
+    eventThread.checkOnEventThread();
+    if (commonAncestor1.equals(commonAncestor2)) {
+      LOG.trace("Found consistent common ancestor at slot {}", commonAncestor1);
+      return commonAncestor1;
+    }
+    LOG.warn(
+        "Found different common ancestors for target chain {}. Starting sync from finalized checkpoint",
+        targetChain);
+    return latestFinalizedSlot;
+  }
+}

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/MultipeerSyncService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/MultipeerSyncService.java
@@ -71,7 +71,8 @@ public class MultipeerSyncService extends Service implements SyncService {
             recentChainData,
             new BatchImporter(blockImporter, asyncRunner),
             new BatchFactory(eventThread),
-            Constants.SYNC_BATCH_SIZE);
+            Constants.SYNC_BATCH_SIZE,
+            MultipeerCommonAncestorFinder.create(recentChainData, eventThread));
     final SyncController syncController =
         new SyncController(
             eventThread,

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/batches/BatchFactory.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/batches/BatchFactory.java
@@ -13,11 +13,8 @@
 
 package tech.pegasys.teku.sync.multipeer.batches;
 
-import java.util.Collection;
-import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.sync.multipeer.chains.TargetChain;
 
 public class BatchFactory {
@@ -29,16 +26,12 @@ public class BatchFactory {
 
   public Batch createBatch(final TargetChain chain, final UInt64 start, final UInt64 count) {
     eventThread.checkOnEventThread();
-    final SyncSourceSelector syncSourceProvider = () -> selectRandomPeer(chain.getPeers());
+    final SyncSourceSelector syncSourceProvider = chain::selectRandomPeer;
     final ConflictResolutionStrategy conflictResolutionStrategy =
         new NaiveConflictResolutionStrategy();
     return new EventThreadOnlyBatch(
         eventThread,
         new SyncSourceBatch(
             eventThread, syncSourceProvider, conflictResolutionStrategy, chain, start, count));
-  }
-
-  private Optional<SyncSource> selectRandomPeer(final Collection<SyncSource> peers) {
-    return peers.stream().skip((int) (peers.size() * Math.random())).findFirst();
   }
 }

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/chains/TargetChain.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/chains/TargetChain.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
@@ -49,6 +50,14 @@ public class TargetChain {
 
   public SlotAndBlockRoot getChainHead() {
     return chainHead;
+  }
+
+  public Optional<SyncSource> selectRandomPeer(final SyncSource... excluding) {
+    final Set<SyncSource> excludedPeers = Set.of(excluding);
+    return peers.stream()
+        .filter(peer -> !excludedPeers.contains(peer))
+        .skip((int) ((peers.size() - excludedPeers.size()) * Math.random()))
+        .findFirst();
   }
 
   @Override

--- a/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/CommonAncestor.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/CommonAncestor.java
@@ -18,8 +18,7 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
+import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseStreamListener;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -38,8 +37,8 @@ public class CommonAncestor {
   }
 
   public SafeFuture<UInt64> getCommonAncestor(
-      final Eth2Peer peer, final PeerStatus status, final UInt64 firstNonFinalSlot) {
-    final UInt64 lowestHeadSlot = storageClient.getHeadSlot().min(status.getHeadSlot());
+      final SyncSource peer, final UInt64 firstNonFinalSlot, final UInt64 peerHeadSlot) {
+    final UInt64 lowestHeadSlot = storageClient.getHeadSlot().min(peerHeadSlot);
     if (lowestHeadSlot.isLessThan(firstNonFinalSlot.plus(OPTIMISTIC_HISTORY_LENGTH))) {
       return SafeFuture.completedFuture(firstNonFinalSlot);
     }
@@ -56,7 +55,7 @@ public class CommonAncestor {
         SAMPLE_RATE,
         firstRequestedSlot,
         lastSlot,
-        status.getHeadSlot());
+        peerHeadSlot);
 
     final BestBlockListener blockListener = new BestBlockListener(storageClient, firstNonFinalSlot);
     final PeerSyncBlockRequest request =

--- a/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/PeerSync.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/singlepeer/PeerSync.java
@@ -139,7 +139,7 @@ public class PeerSync {
                 return SafeFuture.completedFuture(startSlot);
               }
               CommonAncestor ancestor = new CommonAncestor(storageClient);
-              return ancestor.getCommonAncestor(peer, status, startSlot);
+              return ancestor.getCommonAncestor(peer, startSlot, status.getHeadSlot());
             })
         .thenCompose(
             (ancestorStartSlot) -> {

--- a/sync/src/test/java/tech/pegasys/teku/sync/multipeer/BatchSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/multipeer/BatchSyncTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.sync.multipeer.BatchImporter.BatchImportResult.IMPORTED_ALL_BLOCKS;
 import static tech.pegasys.teku.sync.multipeer.BatchImporter.BatchImportResult.IMPORT_FAILED;
@@ -81,8 +82,7 @@ class BatchSyncTest {
     when(commonAncestor.findCommonAncestor(any()))
         .thenAnswer(
             invocation ->
-                SafeFuture.completedFuture(
-                    compute_start_slot_at_epoch(recentChainData.getFinalizedEpoch())));
+                completedFuture(compute_start_slot_at_epoch(recentChainData.getFinalizedEpoch())));
   }
 
   @Test
@@ -140,12 +140,14 @@ class BatchSyncTest {
   }
 
   @Test
-  void shouldResumeSyncFromFinalizedEpochAfterRestart() {
-    // TODO: Should restore the ability to find the common ancestor and sync from there
+  void shouldResumeSyncFromCommonAncestorAfterRestart() {
     storageSystem.chainUpdater().finalizeEpoch(ONE);
+    final UInt64 commonAncestorSlot = UInt64.valueOf(50);
+    when(commonAncestor.findCommonAncestor(targetChain))
+        .thenReturn(completedFuture(commonAncestorSlot));
     assertThat(sync.syncToChain(targetChain)).isNotDone();
 
-    assertThatBatch(batches.get(0)).hasFirstSlot(compute_start_slot_at_epoch(ONE).plus(1));
+    assertThatBatch(batches.get(0)).hasFirstSlot(commonAncestorSlot.plus(1));
   }
 
   @Test
@@ -614,7 +616,7 @@ class BatchSyncTest {
   }
 
   @Test
-  void shouldRestartSyncFromFinalizedCheckpointWhenBatchFromNewChainDoesNotLineUp() {
+  void shouldRestartSyncFromCommonAncestorWhenBatchFromNewChainDoesNotLineUp() {
     // Start sync to first chain
     final SafeFuture<SyncResult> firstSyncResult = sync.syncToChain(targetChain);
 
@@ -644,6 +646,10 @@ class BatchSyncTest {
     // to keep track
     final List<Batch> originalBatches = batches.clearBatchList();
 
+    // Setup an expected common ancestor to start syncing the new chain from
+    final SafeFuture<UInt64> commonAncestorFuture = new SafeFuture<>();
+    when(commonAncestor.findCommonAncestor(targetChain)).thenReturn(commonAncestorFuture);
+
     // And then get the first block of the new chain which doesn't line up
     // So we now know the new chain doesn't extend the old one
     batches.receiveBlocks(batch5, dataStructureUtil.randomSignedBeaconBlock(batch5.getFirstSlot()));
@@ -655,10 +661,17 @@ class BatchSyncTest {
           batches.assertNotMarkedInvalid(batch);
         });
 
+    // Should try to find the common ancestor with the new chain and not create any batches yet
+    verify(commonAncestor).findCommonAncestor(targetChain);
+    assertThat(batches).hasSize(0);
+
+    // Then the common ancestor is found
+    final UInt64 commonAncestorSlot = UInt64.valueOf(70);
+    commonAncestorFuture.complete(commonAncestorSlot);
+
     // Should have recreated the batches from finalized epoch again
     assertThat(batches).hasSize(5);
-    assertThatBatch(batches.get(0))
-        .hasFirstSlot(compute_start_slot_at_epoch(recentChainData.getFinalizedEpoch()).plus(1));
+    assertThatBatch(batches.get(0)).hasFirstSlot(commonAncestorSlot.plus(1));
     assertThat(secondSyncResult).isNotDone();
   }
 

--- a/sync/src/test/java/tech/pegasys/teku/sync/multipeer/BatchSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/multipeer/BatchSyncTest.java
@@ -66,15 +66,23 @@ class BatchSyncTest {
       chainWith(
           new SlotAndBlockRoot(UInt64.valueOf(1000), dataStructureUtil.randomBytes32()),
           syncSource);
+  private final MultipeerCommonAncestorFinder commonAncestor =
+      mock(MultipeerCommonAncestorFinder.class);
 
   private final BatchSync sync =
-      BatchSync.create(eventThread, recentChainData, batchImporter, batches, BATCH_SIZE);
+      BatchSync.create(
+          eventThread, recentChainData, batchImporter, batches, BATCH_SIZE, commonAncestor);
 
   @BeforeEach
   void setUp() {
     storageSystem.chainUpdater().initializeGenesis();
     when(batchImporter.importBatch(any()))
         .thenAnswer(invocation -> batches.getImportResult(invocation.getArgument(0)));
+    when(commonAncestor.findCommonAncestor(any()))
+        .thenAnswer(
+            invocation ->
+                SafeFuture.completedFuture(
+                    compute_start_slot_at_epoch(recentChainData.getFinalizedEpoch())));
   }
 
   @Test

--- a/sync/src/test/java/tech/pegasys/teku/sync/multipeer/MultipeerCommonAncestorFinderTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/multipeer/MultipeerCommonAncestorFinderTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.sync.multipeer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+import static tech.pegasys.teku.sync.multipeer.chains.TargetChainTestUtil.chainWith;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networking.eth2.peers.StubSyncSource;
+import tech.pegasys.teku.networking.eth2.peers.SyncSource;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.sync.multipeer.chains.TargetChain;
+import tech.pegasys.teku.sync.singlepeer.CommonAncestor;
+
+class MultipeerCommonAncestorFinderTest {
+
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final CommonAncestor commonAncestor = mock(CommonAncestor.class);
+  private final RecentChainData recentChainData = mock(RecentChainData.class);
+  private final InlineEventThread eventThread = new InlineEventThread();
+  private final SyncSource syncSource1 = new StubSyncSource();
+  private final SyncSource syncSource2 = new StubSyncSource();
+
+  private final MultipeerCommonAncestorFinder commonAncestorFinder =
+      new MultipeerCommonAncestorFinder(recentChainData, commonAncestor, eventThread);
+  private static final UInt64 FINALIZED_EPOCH = UInt64.valueOf(10);
+  private static final UInt64 FINALIZED_SLOT = compute_start_slot_at_epoch(FINALIZED_EPOCH);
+
+  @BeforeEach
+  void setUp() {
+    when(recentChainData.getFinalizedEpoch()).thenReturn(FINALIZED_EPOCH);
+  }
+
+  @Test
+  void shouldReturnLatestFinalizedSlotWhenNoPeersAvailable() {
+    final TargetChain chain =
+        chainWith(new SlotAndBlockRoot(UInt64.valueOf(10_000), dataStructureUtil.randomBytes32()));
+
+    final SafeFuture<UInt64> result = findCommonAncestor(chain);
+    assertThat(result).isCompletedWithValue(FINALIZED_SLOT);
+  }
+
+  @Test
+  void shouldFindCommonAncestorFromSingleSourceWhenOnlyOneSourceAvailable() {
+    final TargetChain chain =
+        chainWith(
+            new SlotAndBlockRoot(UInt64.valueOf(10_000), dataStructureUtil.randomBytes32()),
+            syncSource1);
+    final SafeFuture<UInt64> source1CommonAncestor = new SafeFuture<>();
+    when(commonAncestor.getCommonAncestor(any(), any(), any())).thenReturn(source1CommonAncestor);
+
+    final SafeFuture<UInt64> result = findCommonAncestor(chain);
+    assertThat(result).isNotDone();
+
+    verify(commonAncestor)
+        .getCommonAncestor(syncSource1, FINALIZED_SLOT, chain.getChainHead().getSlot());
+
+    final UInt64 expected = UInt64.valueOf(4243);
+    source1CommonAncestor.complete(expected);
+    assertThat(result).isCompletedWithValue(expected);
+  }
+
+  @Test
+  void shouldFindCommonAncestorWhenMultipleSourcesAgree() {
+    final TargetChain chain =
+        chainWith(
+            new SlotAndBlockRoot(UInt64.valueOf(10_000), dataStructureUtil.randomBytes32()),
+            syncSource1,
+            syncSource2);
+    final SafeFuture<UInt64> source1CommonAncestor = new SafeFuture<>();
+    final SafeFuture<UInt64> source2CommonAncestor = new SafeFuture<>();
+    when(commonAncestor.getCommonAncestor(any(), any(), any()))
+        .thenReturn(source1CommonAncestor)
+        .thenReturn(source2CommonAncestor);
+
+    final SafeFuture<UInt64> result = findCommonAncestor(chain);
+    assertThat(result).isNotDone();
+
+    verify(commonAncestor)
+        .getCommonAncestor(syncSource1, FINALIZED_SLOT, chain.getChainHead().getSlot());
+
+    verify(commonAncestor)
+        .getCommonAncestor(syncSource2, FINALIZED_SLOT, chain.getChainHead().getSlot());
+
+    final UInt64 expected = UInt64.valueOf(4243);
+    source1CommonAncestor.complete(expected);
+    assertThat(result).isNotDone();
+
+    source2CommonAncestor.complete(expected);
+    assertThat(result).isCompletedWithValue(expected);
+  }
+
+  @Test
+  void shouldUseLatestFinalizedSlotWhenMultipleSourcesDisagree() {
+    final TargetChain chain =
+        chainWith(
+            new SlotAndBlockRoot(UInt64.valueOf(10_000), dataStructureUtil.randomBytes32()),
+            syncSource1,
+            syncSource2);
+    final SafeFuture<UInt64> source1CommonAncestor = new SafeFuture<>();
+    final SafeFuture<UInt64> source2CommonAncestor = new SafeFuture<>();
+    when(commonAncestor.getCommonAncestor(any(), any(), any()))
+        .thenReturn(source1CommonAncestor)
+        .thenReturn(source2CommonAncestor);
+
+    final SafeFuture<UInt64> result = findCommonAncestor(chain);
+    assertThat(result).isNotDone();
+
+    verify(commonAncestor)
+        .getCommonAncestor(syncSource1, FINALIZED_SLOT, chain.getChainHead().getSlot());
+
+    verify(commonAncestor)
+        .getCommonAncestor(syncSource2, FINALIZED_SLOT, chain.getChainHead().getSlot());
+
+    source1CommonAncestor.complete(UInt64.valueOf(4243));
+    assertThat(result).isNotDone();
+
+    source2CommonAncestor.complete(UInt64.valueOf(4355));
+    assertThat(result).isCompletedWithValue(FINALIZED_SLOT);
+  }
+
+  @Test
+  void shouldUseLatestFinalizedSlotWhenOneSourceFailsToFindCommonAncestor() {
+    final TargetChain chain =
+        chainWith(
+            new SlotAndBlockRoot(UInt64.valueOf(10_000), dataStructureUtil.randomBytes32()),
+            syncSource1,
+            syncSource2);
+    final SafeFuture<UInt64> source1CommonAncestor = new SafeFuture<>();
+    final SafeFuture<UInt64> source2CommonAncestor = new SafeFuture<>();
+    when(commonAncestor.getCommonAncestor(any(), any(), any()))
+        .thenReturn(source1CommonAncestor)
+        .thenReturn(source2CommonAncestor);
+
+    final SafeFuture<UInt64> result = findCommonAncestor(chain);
+    assertThat(result).isNotDone();
+
+    verify(commonAncestor)
+        .getCommonAncestor(syncSource1, FINALIZED_SLOT, chain.getChainHead().getSlot());
+
+    verify(commonAncestor)
+        .getCommonAncestor(syncSource2, FINALIZED_SLOT, chain.getChainHead().getSlot());
+
+    source1CommonAncestor.completeExceptionally(new RuntimeException("Doh!"));
+    source2CommonAncestor.complete(UInt64.valueOf(1485));
+    assertThat(result).isCompletedWithValue(FINALIZED_SLOT);
+  }
+
+  private SafeFuture<UInt64> findCommonAncestor(final TargetChain chain) {
+    eventThread.markAsOnEventThread();
+    try {
+      return commonAncestorFinder.findCommonAncestor(chain);
+    } finally {
+      eventThread.markAsOffEventThread();
+    }
+  }
+}

--- a/sync/src/test/java/tech/pegasys/teku/sync/singlepeer/CommonAncestorTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/singlepeer/CommonAncestorTest.java
@@ -44,7 +44,8 @@ public class CommonAncestorTest extends AbstractSyncTest {
             dataStructureUtil.randomBytes32());
     when(storageClient.getHeadSlot()).thenReturn(currentLocalHead);
 
-    assertThat(commonAncestor.getCommonAncestor(peer, status, firstNonFinalSlot).get())
+    assertThat(
+            commonAncestor.getCommonAncestor(peer, firstNonFinalSlot, status.getHeadSlot()).get())
         .isEqualTo(firstNonFinalSlot);
   }
 
@@ -64,7 +65,8 @@ public class CommonAncestorTest extends AbstractSyncTest {
             dataStructureUtil.randomBytes32());
     when(storageClient.getHeadSlot()).thenReturn(currentLocalHead);
 
-    assertThat(commonAncestor.getCommonAncestor(peer, status, firstNonFinalSlot).get())
+    assertThat(
+            commonAncestor.getCommonAncestor(peer, firstNonFinalSlot, status.getHeadSlot()).get())
         .isEqualTo(firstNonFinalSlot);
   }
 
@@ -94,7 +96,7 @@ public class CommonAncestorTest extends AbstractSyncTest {
     when(storageClient.containsBlock(any())).thenReturn(true);
 
     SafeFuture<UInt64> futureSlot =
-        commonAncestor.getCommonAncestor(peer, status, firstNonFinalSlot);
+        commonAncestor.getCommonAncestor(peer, firstNonFinalSlot, status.getHeadSlot());
 
     verify(peer)
         .requestBlocksByRange(


### PR DESCRIPTION
## PR Description
Instead of starting the sync from the latest finalized slot all the time, find the common ancestor with remote peers and begin sync from there to improve performance during periods of non-finalization.

## Fixed Issue(s)
#1844 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.