### PR TITLE
Support basic authentication when credentials are specified in the URL

### DIFF
--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -45,7 +45,6 @@ import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import okhttp3.Request.Builder;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.apache.logging.log4j.LogManager;

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -40,10 +40,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import okhttp3.Credentials;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.Request.Builder;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.apache.logging.log4j.LogManager;
@@ -243,7 +245,7 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
       queryParams.forEach(httpUrlBuilder::addQueryParameter);
     }
 
-    final Request request = new Request.Builder().url(httpUrlBuilder.build()).build();
+    final Request request = requestBuilder().url(httpUrlBuilder.build()).build();
     return executeCall(request, responseClass);
   }
 
@@ -261,12 +263,22 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
     }
 
     final Request request =
-        new Request.Builder()
+        requestBuilder()
             .url(httpUrlBuilder.build())
             .post(RequestBody.create(requestBody, APPLICATION_JSON))
             .build();
 
     return executeCall(request, responseClass);
+  }
+
+  private Request.Builder requestBuilder() {
+    final Request.Builder builder = new Builder();
+    if (!baseEndpoint.username().isEmpty()) {
+      builder.header(
+          "Authorization",
+          Credentials.basic(baseEndpoint.encodedUsername(), baseEndpoint.encodedPassword()));
+    }
+    return builder;
   }
 
   private <T> Optional<T> post(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -272,7 +272,7 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   }
 
   private Request.Builder requestBuilder() {
-    final Request.Builder builder = new Builder();
+    final Request.Builder builder = new Request.Builder();
     if (!baseEndpoint.username().isEmpty()) {
       builder.header(
           "Authorization",


### PR DESCRIPTION
## PR Description
Update the remote validator to support sending basic auth credentials when the beacon node API endpoint includes them in the URL (e.g `https://username:password@hostname`).

Infura's ETH2 beta currently requires Basic auth to access.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.