### PR TITLE
Fix --config-file option so it really can be used before or after subcommands

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -131,7 +131,9 @@ public class BeaconNodeCommand implements Callable<Integer> {
       names = {"-c", CONFIG_FILE_OPTION_NAME},
       paramLabel = "<FILENAME>",
       description = "Path/filename of the yaml config file (default: none)",
-      arity = "1")
+      arity = "1",
+      // Available to all subcommands
+      scope = ScopeType.INHERIT)
   private File configFile;
 
   @Mixin(name = "Network")


### PR DESCRIPTION
## PR Description
Allow the `--config-file` option to be specified either before or after subcommands instead of only before. Also makes it show up in the subcommand help output.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.