### PR TITLE
Update head on new blocks even when syncing

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -15,8 +15,6 @@ package tech.pegasys.teku.statetransition.forkchoice;
 
 import static tech.pegasys.teku.core.ForkChoiceUtil.on_attestation;
 import static tech.pegasys.teku.core.ForkChoiceUtil.on_block;
-import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
-import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_EPOCH;
 
 import com.google.common.base.Throwables;
 import java.util.List;
@@ -43,12 +41,6 @@ import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
 public class ForkChoice {
   private static final Logger LOG = LogManager.getLogger();
-  /**
-   * Number of slots within head that new blocks are automatically set as the new chain head if
-   * possible. The update causes a re-org event so we skip it if we are syncing blocks from a long
-   * way back to avoid unnecessary work and noise about the reorg in the logs.
-   */
-  private static final int SHORT_SYNC_SLOTS = 2 * SLOTS_PER_EPOCH;
 
   private final ForkChoiceExecutor forkChoiceExecutor;
   private final RecentChainData recentChainData;
@@ -69,14 +61,14 @@ public class ForkChoice {
   }
 
   public void processHead() {
-    processHead(Optional.empty(), false);
+    processHead(Optional.empty());
   }
 
-  public void processHead(UInt64 nodeSlot, boolean syncing) {
-    processHead(Optional.of(nodeSlot), syncing);
+  public void processHead(UInt64 nodeSlot) {
+    processHead(Optional.of(nodeSlot));
   }
 
-  private void processHead(Optional<UInt64> nodeSlot, boolean syncing) {
+  private void processHead(Optional<UInt64> nodeSlot) {
     final Checkpoint retrievedJustifiedCheckpoint =
         recentChainData.getStore().getJustifiedCheckpoint();
     recentChainData
@@ -116,8 +108,7 @@ public class ForkChoice {
                                       () ->
                                           new IllegalStateException(
                                               "Unable to retrieve the slot of fork choice head: "
-                                                  + headBlockRoot))),
-                          syncing);
+                                                  + headBlockRoot))));
                       return transaction.commit();
                     }))
         .join();
@@ -178,14 +169,10 @@ public class ForkChoice {
               // a better choice than the block itself.  So the first block we receive that is a
               // child of our current chain head, must be the new chain head. If we'd had any other
               // child of the current chain head we'd have already selected it as head.
-              if (block
-                      .getSlot()
-                      .plus(SHORT_SYNC_SLOTS)
-                      .isGreaterThan(recentChainData.getCurrentSlot().orElse(ZERO))
-                  && recentChainData
-                      .getHeadBlock()
-                      .map(currentHead -> currentHead.getRoot().equals(block.getParent_root()))
-                      .orElse(false)) {
+              if (recentChainData
+                  .getHeadBlock()
+                  .map(currentHead -> currentHead.getRoot().equals(block.getParent_root()))
+                  .orElse(false)) {
                 recentChainData.updateHead(block.getRoot(), block.getSlot());
                 result.markAsCanonical();
               }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -77,11 +77,11 @@ class ForkChoiceTest {
   @Test
   void shouldTriggerReorgWhenEmptyHeadSlotFilled() {
     // Run fork choice with an empty slot 1
-    forkChoice.processHead(ONE, false);
+    forkChoice.processHead(ONE);
 
     // Then rerun with a filled slot 1
     final SignedBlockAndState slot1Block = storageSystem.chainUpdater().advanceChain(ONE);
-    forkChoice.processHead(ONE, false);
+    forkChoice.processHead(ONE);
 
     final List<ReorgEvent> reorgEvents = storageSystem.reorgEventChannel().getReorgEvents();
     assertThat(reorgEvents).hasSize(1);
@@ -118,7 +118,7 @@ class ForkChoiceTest {
   void onBlock_shouldTriggerReorgWhenSelectingChildOfChainHeadWhenForkChoiceSlotHasAdvanced() {
     // Advance the current head
     final UInt64 nodeSlot = UInt64.valueOf(5);
-    forkChoice.processHead(nodeSlot, false);
+    forkChoice.processHead(nodeSlot);
 
     final SignedBlockAndState blockAndState = chainBuilder.generateBlockAtSlot(ONE);
     final SafeFuture<BlockImportResult> importResult =
@@ -165,7 +165,7 @@ class ForkChoiceTest {
     assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock.getRoot());
 
     // Should have processed the attestations and switched to this fork
-    forkChoice.processHead(blockWithAttestations.getSlot(), false);
+    forkChoice.processHead(blockWithAttestations.getSlot());
     assertThat(recentChainData.getBestBlockRoot()).contains(blockWithAttestations.getRoot());
   }
 
@@ -211,7 +211,7 @@ class ForkChoiceTest {
     importBlock(chainBuilder, blockWithAttestations);
 
     // Apply these votes
-    forkChoice.processHead(blockWithAttestations.getSlot(), false);
+    forkChoice.processHead(blockWithAttestations.getSlot());
     assertThat(recentChainData.getBestBlockRoot()).contains(blockWithAttestations.getRoot());
 
     // Now we import the fork block
@@ -223,7 +223,7 @@ class ForkChoiceTest {
 
     // And we should be able to apply the new weightings without making the fork block's weight
     // negative
-    assertDoesNotThrow(() -> forkChoice.processHead(updatedAttestationSlot, false));
+    assertDoesNotThrow(() -> forkChoice.processHead(updatedAttestationSlot));
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -101,20 +101,6 @@ class ForkChoiceTest {
   }
 
   @Test
-  void onBlock_shouldNotImmediatelyMakeChildOfCurrentHeadTheNewHeadWhenItIsTooFarBehind() {
-    storageSystem
-        .chainUpdater()
-        .setTime(genesis.getState().getGenesis_time().plus(34 * SECONDS_PER_SLOT));
-    final SignedBlockAndState blockAndState = chainBuilder.generateBlockAtSlot(ONE);
-    final SafeFuture<BlockImportResult> importResult =
-        forkChoice.onBlock(blockAndState.getBlock(), Optional.of(genesis.getState()));
-    assertBlockImportedSuccessfully(importResult);
-
-    assertThat(recentChainData.getHeadBlock()).contains(genesis.getBlock());
-    assertThat(recentChainData.getHeadSlot()).isEqualTo(genesis.getSlot());
-  }
-
-  @Test
   void onBlock_shouldTriggerReorgWhenSelectingChildOfChainHeadWhenForkChoiceSlotHasAdvanced() {
     // Advance the current head
     final UInt64 nodeSlot = UInt64.valueOf(5);

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -203,7 +203,7 @@ public class BeaconChainUtil {
               + ": "
               + block);
     }
-    forkChoice.processHead(slot, false);
+    forkChoice.processHead(slot);
     return importResult.getBlock();
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
@@ -115,7 +115,7 @@ public class SlotProcessor {
 
   private void processSlotWhileSyncing() {
     UInt64 slot = nodeSlot.getValue();
-    this.forkChoice.processHead(slot, true);
+    this.forkChoice.processHead(slot);
     eventLog.syncEvent(slot, recentChainData.getHeadSlot(), p2pNetwork.getPeerCount());
     slotEventsChannelPublisher.onSlot(slot);
   }
@@ -164,7 +164,7 @@ public class SlotProcessor {
 
   private void processSlotAttestation(final UInt64 nodeEpoch) {
     onTickSlotAttestation = nodeSlot.getValue();
-    this.forkChoice.processHead(onTickSlotAttestation, false);
+    this.forkChoice.processHead(onTickSlotAttestation);
     recentChainData
         .getHeadBlock()
         .ifPresent(

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -209,7 +209,7 @@ public class SlotProcessorTest {
             finalizedCheckpoint.getEpoch(),
             finalizedCheckpoint.getRoot(),
             1);
-    verify(forkChoice).processHead(slot, false);
+    verify(forkChoice).processHead(slot);
   }
 
   @Test
@@ -243,7 +243,7 @@ public class SlotProcessorTest {
     verify(slotEventsChannel).onSlot(ZERO);
     // Attestation due
     slotProcessor.onTick(beaconState.getGenesis_time().plus(SECONDS_PER_SLOT / 3));
-    verify(forkChoice).processHead(ZERO, false);
+    verify(forkChoice).processHead(ZERO);
 
     // Slot 2 start
     final UInt64 slot1Start = beaconState.getGenesis_time().plus(SECONDS_PER_SLOT);
@@ -251,6 +251,6 @@ public class SlotProcessorTest {
     verify(slotEventsChannel).onSlot(ONE);
     // Attestation due
     slotProcessor.onTick(slot1Start.plus(SECONDS_PER_SLOT / 3));
-    verify(forkChoice).processHead(ONE, false);
+    verify(forkChoice).processHead(ONE);
   }
 }

--- a/sync/src/main/java/tech/pegasys/teku/sync/CoalescingChainHeadChannel.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/CoalescingChainHeadChannel.java
@@ -13,7 +13,11 @@
 
 package tech.pegasys.teku.sync;
 
+import static tech.pegasys.teku.infrastructure.logging.LogFormatter.formatHashRoot;
+
 import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.storage.api.ChainHeadChannel;
@@ -21,6 +25,7 @@ import tech.pegasys.teku.storage.api.ReorgContext;
 import tech.pegasys.teku.sync.SyncService.SyncSubscriber;
 
 public class CoalescingChainHeadChannel implements ChainHeadChannel, SyncSubscriber {
+  private static final Logger LOG = LogManager.getLogger();
 
   private final ChainHeadChannel delegate;
   private boolean syncing = false;
@@ -46,6 +51,14 @@ public class CoalescingChainHeadChannel implements ChainHeadChannel, SyncSubscri
       final boolean epochTransition,
       final Optional<ReorgContext> optionalReorgContext) {
     if (!syncing) {
+      optionalReorgContext.ifPresent(
+          reorg ->
+              LOG.info(
+                  "Chain reorg at slot {} from {} to {}. Common ancestor at slot {}",
+                  slot,
+                  formatHashRoot(reorg.getOldBestBlockRoot()),
+                  formatHashRoot(bestBlockRoot),
+                  reorg.getCommonAncestorSlot()));
       delegate.chainHeadUpdated(
           slot, stateRoot, bestBlockRoot, epochTransition, optionalReorgContext);
     } else {


### PR DESCRIPTION
## PR Description
Now that head update and reorg events are coalesced, move the logging of reorg events into the `CoalescingChainHeadUpdateChannel` which already knows whether sync is in progress or not and re-enable automatically updating the fork choice head on block import even if the block is more than two epochs behind the current node slot.

Previously this was disabled because it caused too much noise in the logs and too much unnecessary work as different components responded to the reorg events. Those events and logs are now suppressed during sync so we may as well get the benefit of the head block being updated more smoothly and not just once per epoch.

Note that the log about chain reorgs is not printed when syncing finishes even if there were reorgs. That just creates a lot of noise and it's not particularly surprising to users that things changed around during a sync so no point in the extra logging.

## Fixed Issue(s)
fixes #2773 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.