### PR TITLE
Add simple handling for rate limiting responses

### DIFF
--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -327,8 +327,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
             error -> {
               if (Throwables.getRootCause(error) instanceof RateLimitedException
                   && attempt < MAX_RATE_LIMITING_RETRIES) {
-                LOG.warn(
-                    "Received Too Many Requests response from beacon node. Retrying after a delay.");
+                LOG.warn("Beacon node request rate limit has been exceeded. Retrying after delay.");
                 return asyncRunner.runAfterDelay(
                     () -> sendRequest(requestExecutor, attempt + 1), 2, TimeUnit.SECONDS);
               } else {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.remote;
 
 import static java.util.Collections.emptyMap;
 
+import com.google.common.base.Throwables;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -22,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,6 +44,8 @@ import tech.pegasys.teku.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.datastructures.state.Fork;
 import tech.pegasys.teku.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.ExceptionThrowingRunnable;
+import tech.pegasys.teku.infrastructure.async.ExceptionThrowingSupplier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.AttesterDuties;
@@ -50,6 +54,7 @@ import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.api.ValidatorDuties;
+import tech.pegasys.teku.validator.remote.apiclient.RateLimitedException;
 import tech.pegasys.teku.validator.remote.apiclient.ValidatorRestApiClient;
 
 public class RemoteValidatorApiHandler implements ValidatorApiChannel {
@@ -68,7 +73,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<Fork>> getFork() {
-    return asyncRunner.runAsync(
+    return sendRequest(
         () ->
             apiClient
                 .getFork()
@@ -79,7 +84,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<GenesisData>> getGenesisData() {
-    return asyncRunner.runAsync(
+    return sendRequest(
         () ->
             apiClient
                 .getGenesis()
@@ -95,7 +100,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
     if (publicKeys.isEmpty()) {
       return SafeFuture.completedFuture(emptyMap());
     }
-    return asyncRunner.runAsync(
+    return sendRequest(
         () -> {
           final Map<BLSPublicKey, Integer> indices = new HashMap<>();
           for (int i = 0; i < publicKeys.size(); i += MAX_PUBLIC_KEY_BATCH_SIZE) {
@@ -133,7 +138,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
       return SafeFuture.completedFuture(Optional.of(Collections.emptyList()));
     }
 
-    return asyncRunner.runAsync(
+    return sendRequest(
         () -> {
           final List<BLSPubKey> blsPubKeys =
               publicKeys.stream().map(BLSPubKey::new).collect(Collectors.toList());
@@ -152,7 +157,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<List<AttesterDuties>>> getAttestationDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndexes) {
-    return asyncRunner.runAsync(
+    return sendRequest(
         () -> {
           final List<AttesterDuties> duties =
               apiClient.getAttestationDuties(epoch, validatorIndexes).stream()
@@ -165,7 +170,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<List<ProposerDuties>>> getProposerDuties(final UInt64 epoch) {
-    return asyncRunner.runAsync(
+    return sendRequest(
         () -> {
           final List<ProposerDuties> duties =
               apiClient.getProposerDuties(epoch).stream()
@@ -209,7 +214,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<Attestation>> createUnsignedAttestation(
       final UInt64 slot, final int committeeIndex) {
-    return asyncRunner.runAsync(
+    return sendRequest(
         () ->
             apiClient
                 .createUnsignedAttestation(slot, committeeIndex)
@@ -219,7 +224,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<AttestationData>> createAttestationData(
       final UInt64 slot, final int committeeIndex) {
-    return asyncRunner.runAsync(
+    return sendRequest(
         () ->
             apiClient
                 .createAttestationData(slot, committeeIndex)
@@ -231,8 +236,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
     final tech.pegasys.teku.api.schema.Attestation schemaAttestation =
         new tech.pegasys.teku.api.schema.Attestation(attestation);
 
-    asyncRunner
-        .runAsync(() -> apiClient.sendSignedAttestation(schemaAttestation))
+    sendRequest(() -> apiClient.sendSignedAttestation(schemaAttestation))
         .finish(error -> LOG.error("Failed to send signed attestation", error));
   }
 
@@ -245,7 +249,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<BeaconBlock>> createUnsignedBlock(
       final UInt64 slot, final BLSSignature randaoReveal, final Optional<Bytes32> graffiti) {
-    return asyncRunner.runAsync(
+    return sendRequest(
         () -> {
           final tech.pegasys.teku.api.schema.BLSSignature schemaBLSSignature =
               new tech.pegasys.teku.api.schema.BLSSignature(randaoReveal);
@@ -258,13 +262,13 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<SendSignedBlockResult> sendSignedBlock(final SignedBeaconBlock block) {
-    return asyncRunner.runAsync(
+    return sendRequest(
         () -> apiClient.sendSignedBlock(new tech.pegasys.teku.api.schema.SignedBeaconBlock(block)));
   }
 
   @Override
   public SafeFuture<Optional<Attestation>> createAggregate(final Bytes32 attestationHashTreeRoot) {
-    return asyncRunner.runAsync(
+    return sendRequest(
         () ->
             apiClient
                 .createAggregate(attestationHashTreeRoot)
@@ -273,18 +277,18 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public void sendAggregateAndProof(final SignedAggregateAndProof aggregateAndProof) {
-    asyncRunner
-        .runAsync(
+    sendRequest(
             () ->
-                apiClient.sendAggregateAndProof(
-                    new tech.pegasys.teku.api.schema.SignedAggregateAndProof(aggregateAndProof)))
+                apiClient.sendAggregateAndProofs(
+                    List.of(
+                        new tech.pegasys.teku.api.schema.SignedAggregateAndProof(
+                            aggregateAndProof))))
         .finish(error -> LOG.error("Failed to send aggregate and proof", error));
   }
 
   @Override
   public void subscribeToBeaconCommittee(final List<CommitteeSubscriptionRequest> requests) {
-    asyncRunner
-        .runAsync(() -> apiClient.subscribeToBeaconCommittee(requests))
+    sendRequest(() -> apiClient.subscribeToBeaconCommittee(requests))
         .finish(
             error -> LOG.error("Failed to subscribe to beacon committee for aggregation", error));
   }
@@ -299,8 +303,31 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
                         s.getSubnetId(), s.getUnsubscriptionSlot()))
             .collect(Collectors.toSet());
 
-    asyncRunner
-        .runAsync(() -> apiClient.subscribeToPersistentSubnets(schemaSubscriptions))
+    sendRequest(() -> apiClient.subscribeToPersistentSubnets(schemaSubscriptions))
         .finish(error -> LOG.error("Failed to subscribe to persistent subnets", error));
+  }
+
+  private SafeFuture<Void> sendRequest(final ExceptionThrowingRunnable requestExecutor) {
+    return sendRequest(
+        () -> {
+          requestExecutor.run();
+          return null;
+        });
+  }
+
+  private <T> SafeFuture<T> sendRequest(final ExceptionThrowingSupplier<T> requestExecutor) {
+    return asyncRunner
+        .runAsync(requestExecutor)
+        .exceptionallyCompose(
+            error -> {
+              if (Throwables.getRootCause(error) instanceof RateLimitedException) {
+                LOG.warn(
+                    "Received Too Many Requests response from beacon node. Retrying after a delay.");
+                return asyncRunner.runAfterDelay(
+                    () -> sendRequest(requestExecutor), 2, TimeUnit.SECONDS);
+              } else {
+                return SafeFuture.failedFuture(error);
+              }
+            });
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -202,8 +202,8 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   }
 
   @Override
-  public void sendAggregateAndProof(final SignedAggregateAndProof signedAggregateAndProof) {
-    post(SEND_SIGNED_AGGREGATE_AND_PROOF, List.of(signedAggregateAndProof), null);
+  public void sendAggregateAndProofs(final List<SignedAggregateAndProof> signedAggregateAndProof) {
+    post(SEND_SIGNED_AGGREGATE_AND_PROOF, signedAggregateAndProof, null);
   }
 
   @Override
@@ -323,6 +323,8 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
                     + response.body().string()
                     + ")");
           }
+        case 429:
+          throw new RateLimitedException(request.url().toString());
         default:
           {
             final String responseBody = response.body().string();

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/RateLimitedException.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/RateLimitedException.java
@@ -1,0 +1,7 @@
+package tech.pegasys.teku.validator.remote.apiclient;
+
+public class RateLimitedException extends RuntimeException {
+  public RateLimitedException(final String url) {
+    super("Request rejected due to exceeding rate limit for URL: " + url);
+  }
+}

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/RateLimitedException.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/RateLimitedException.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.validator.remote.apiclient;
 
 public class RateLimitedException extends RuntimeException {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -64,7 +64,7 @@ public interface ValidatorRestApiClient {
 
   Optional<Attestation> createAggregate(Bytes32 attestationHashTreeRoot);
 
-  void sendAggregateAndProof(SignedAggregateAndProof signedAggregateAndProof);
+  void sendAggregateAndProofs(List<SignedAggregateAndProof> signedAggregateAndProof);
 
   void subscribeToBeaconCommittee(List<CommitteeSubscriptionRequest> requests);
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -528,6 +528,7 @@ class RemoteValidatorApiHandlerTest {
     assertThat(unwrapToValue(future)).usingRecursiveComparison().isEqualTo(attestation);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void sendSAggregateAndProof_InvokeApiWithCorrectRequest() {
     final AggregateAndProof aggregateAndProof = dataStructureUtil.randomAggregateAndProof();
@@ -538,13 +539,13 @@ class RemoteValidatorApiHandlerTest {
     tech.pegasys.teku.api.schema.SignedAggregateAndProof schemaSignedAggAndProof =
         new tech.pegasys.teku.api.schema.SignedAggregateAndProof(signedAggregateAndProof);
 
-    ArgumentCaptor<tech.pegasys.teku.api.schema.SignedAggregateAndProof> argumentCaptor =
-        ArgumentCaptor.forClass(tech.pegasys.teku.api.schema.SignedAggregateAndProof.class);
+    ArgumentCaptor<List<tech.pegasys.teku.api.schema.SignedAggregateAndProof>> argumentCaptor =
+        ArgumentCaptor.forClass(List.class);
 
     apiHandler.sendAggregateAndProof(signedAggregateAndProof);
     asyncRunner.executeQueuedActions();
 
-    verify(apiClient).sendAggregateAndProof(argumentCaptor.capture());
+    verify(apiClient).sendAggregateAndProofs(argumentCaptor.capture());
     assertThat(argumentCaptor.getValue())
         .usingRecursiveComparison()
         .isEqualTo(schemaSignedAggAndProof);

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -23,9 +23,12 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 import static tech.pegasys.teku.validator.remote.RemoteValidatorApiHandler.MAX_PUBLIC_KEY_BATCH_SIZE;
+import static tech.pegasys.teku.validator.remote.RemoteValidatorApiHandler.MAX_RATE_LIMITING_RETRIES;
 
 import java.util.Collections;
 import java.util.List;
@@ -64,6 +67,7 @@ import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorDuties;
+import tech.pegasys.teku.validator.remote.apiclient.RateLimitedException;
 import tech.pegasys.teku.validator.remote.apiclient.SchemaObjectsTestFixture;
 import tech.pegasys.teku.validator.remote.apiclient.ValidatorRestApiClient;
 
@@ -591,6 +595,22 @@ class RemoteValidatorApiHandlerTest {
     assertThat(request.stream().findFirst().orElseThrow())
         .usingRecursiveComparison()
         .isEqualTo(schemaSubnetSubscription);
+  }
+
+  @Test
+  void shouldRetryAfterDelayWhenRequestRateLimited() {
+    when(apiClient.getFork()).thenThrow(new RateLimitedException("/fork"));
+
+    final SafeFuture<Optional<Fork>> result = apiHandler.getFork();
+
+    for (int i = 0; i < MAX_RATE_LIMITING_RETRIES; i++) {
+      asyncRunner.executeQueuedActions();
+      assertThat(result).isNotDone();
+      verify(apiClient, times(i + 1)).getFork();
+    }
+
+    asyncRunner.executeQueuedActions();
+    assertThatSafeFuture(result).isCompletedExceptionallyWith(RateLimitedException.class);
   }
 
   private <T> Optional<T> unwrapToOptional(SafeFuture<Optional<T>> future) {

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -552,7 +552,7 @@ class RemoteValidatorApiHandlerTest {
     verify(apiClient).sendAggregateAndProofs(argumentCaptor.capture());
     assertThat(argumentCaptor.getValue())
         .usingRecursiveComparison()
-        .isEqualTo(schemaSignedAggAndProof);
+        .isEqualTo(List.of(schemaSignedAggAndProof));
   }
 
   @Test

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -587,12 +587,12 @@ class OkHttpValidatorRestApiClientTest {
   }
 
   @Test
-  public void sendAggregateAndProof_MakesExpectedRequest() throws Exception {
+  public void sendAggregateAndProofs_MakesExpectedRequest() throws Exception {
     final SignedAggregateAndProof signedAggregateAndProof = schemaObjects.signedAggregateAndProof();
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(200));
 
-    apiClient.sendAggregateAndProof(signedAggregateAndProof);
+    apiClient.sendAggregateAndProofs(List.of(signedAggregateAndProof));
 
     RecordedRequest request = mockWebServer.takeRequest();
 
@@ -604,22 +604,22 @@ class OkHttpValidatorRestApiClientTest {
   }
 
   @Test
-  public void sendAggregateAndProof_WhenBadParameters_ThrowsIllegalArgumentException() {
+  public void sendAggregateAndProofs_WhenBadParameters_ThrowsIllegalArgumentException() {
     final SignedAggregateAndProof signedAggregateAndProof = schemaObjects.signedAggregateAndProof();
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(400));
 
-    assertThatThrownBy(() -> apiClient.sendAggregateAndProof(signedAggregateAndProof))
+    assertThatThrownBy(() -> apiClient.sendAggregateAndProofs(List.of(signedAggregateAndProof)))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void sendAggregateAndProof_WhenServerError_ThrowsRuntimeException() {
+  public void sendAggregateAndProofs_WhenServerError_ThrowsRuntimeException() {
     final SignedAggregateAndProof signedAggregateAndProof = schemaObjects.signedAggregateAndProof();
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(500));
 
-    assertThatThrownBy(() -> apiClient.sendAggregateAndProof(signedAggregateAndProof))
+    assertThatThrownBy(() -> apiClient.sendAggregateAndProofs(List.of(signedAggregateAndProof)))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Unexpected response from Beacon Node API");
   }
@@ -770,6 +770,13 @@ class OkHttpValidatorRestApiClientTest {
     final String authorization = request.getHeader("Authorization");
     // Base64 encoded version of credentials.
     assertThat(authorization).isEqualTo("Basic dXNlcjpwYXNzd29yZA==");
+  }
+
+  @Test
+  void shouldThrowRateLimitedExceptionWhen429ResponseReceived() {
+    mockWebServer.enqueue(new MockResponse().setResponseCode(429));
+
+    assertThatThrownBy(() -> apiClient.getFork()).isInstanceOf(RateLimitedException.class);
   }
 
   private String asJson(Object object) {


### PR DESCRIPTION
## PR Description
Add simple handling for 429 responses from the beacon node API by retrying the request after 2 seconds.  Normally Teku doesn't give 429 responses but Infura might and a short back-off is enough to keep it working.

We may need to do more advanced handling in the future but there's some other clean up for the rest api client that needs to happen first.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.