### PR TITLE
[Issue-2192] Improve attestation prioritization for block proposal

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -179,8 +179,8 @@ class MatchingDataAttestationGroup implements Iterable<ValidateableAttestation> 
               attestationsByOldCount.removeAll(attestations);
               attestations.forEach(this::add);
 
-              // We're processing in reverse order so items should only move to lower values
-              // So, should we safe to remove here
+              // We're processing in reverse order and items should only move to lower values
+              // So, we should be safe to remove here
               if (attestationsByOldCount.isEmpty()) {
                 attestationsByValidatorCount.remove(oldValidatorCount);
               }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
@@ -184,21 +184,19 @@ class MatchingDataAttestationGroupTest {
             createAttestation(12).getAttestation(),
             createAttestation(8).getAttestation(),
             createAttestation(17).getAttestation(),
+            createAttestation(13).getAttestation(),
             createAttestation(18).getAttestation(),
             createAttestation(7).getAttestation());
 
     final ValidateableAttestation attestationA = addAttestation(19, 0, 4, 8, 12, 16);
     final ValidateableAttestation attestationB = addAttestation(0, 1, 5, 9, 13, 17);
-    final ValidateableAttestation attestationC = addAttestation(4, 2, 6, 10, 14, 18);
+    final ValidateableAttestation attestationC = addAttestation(0, 2, 6, 10, 14, 18);
     final ValidateableAttestation attestationD = addAttestation(0, 3, 7);
 
-    // Remove some attesters, which should reprioritize the attestations
+    // Remove multiple attesters all at once, which should reprioritize the attestations
     group.remove(toRemove);
 
-    final ValidateableAttestation attestationBC =
-        ValidateableAttestation.fromAttestation(
-            aggregateAttestations(attestationB.getAttestation(), attestationC.getAttestation()));
-    assertThat(group).containsExactly(attestationBC, attestationA, attestationD);
+    assertThat(group).containsExactly(attestationC, attestationB, attestationA, attestationD);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
@@ -154,6 +154,28 @@ class MatchingDataAttestationGroupTest {
   }
 
   @Test
+  public void
+      iterator_shouldAggregateAttestationsWithMoreValidatorsFirst_updatingValidatorCountAfterRemoval() {
+    final ValidateableAttestation attestation1 = createAttestation(1);
+    final ValidateableAttestation attestation3 = createAttestation(3);
+
+    final ValidateableAttestation attestationA = addAttestation(1, 3, 5, 7);
+    final ValidateableAttestation attestationB = addAttestation(5, 7, 9);
+    final ValidateableAttestation attestationC = addAttestation(2);
+
+    // Remove some attesters, which should lower attestationA's priority
+    group.remove(attestation1.getAttestation());
+    group.remove(attestation3.getAttestation());
+
+    assertThat(group)
+        .containsExactly(
+            ValidateableAttestation.fromAttestation(
+                aggregateAttestations(
+                    attestationB.getAttestation(), attestationC.getAttestation())),
+            attestationA);
+  }
+
+  @Test
   public void iterator_shouldNotAggregateAttestationsWhenValidatorsOverlap() {
     final ValidateableAttestation attestation1 = addAttestation(1, 2, 5);
     final ValidateableAttestation attestation2 = addAttestation(1, 2, 3);

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/SSZTypes/Bitlist.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/SSZTypes/Bitlist.java
@@ -52,6 +52,11 @@ public class Bitlist {
     data.set(i);
   }
 
+  public void setBit(final int i, final boolean value) {
+    checkElementIndex(i, size);
+    data.set(i, value);
+  }
+
   public void setBits(int... indexes) {
     for (int i : indexes) {
       setBit(i);
@@ -73,6 +78,10 @@ public class Bitlist {
 
   public boolean isSuperSetOf(final Bitlist other) {
     return other.streamAllSetBits().allMatch(this::getBit);
+  }
+
+  public long countMatchingBits(final Bitlist other) {
+    return other.streamAllSetBits().filter(this::getBit).count();
   }
 
   public List<Integer> getAllSetBits() {

--- a/ssz/src/test/java/tech/pegasys/teku/ssz/ssztypes/BitlistTest.java
+++ b/ssz/src/test/java/tech/pegasys/teku/ssz/ssztypes/BitlistTest.java
@@ -104,6 +104,33 @@ class BitlistTest {
   }
 
   @Test
+  void countMatchingBits_someMatch() {
+    Bitlist bitlist1 = create(1, 3, 5, 7, 9);
+    Bitlist bitlist2 = create(1, 2, 5, 6);
+
+    assertThat(bitlist1.countMatchingBits(bitlist2)).isEqualTo(2);
+    assertThat(bitlist2.countMatchingBits(bitlist1)).isEqualTo(2);
+  }
+
+  @Test
+  void countMatchingBits_noMatches() {
+    Bitlist bitlist1 = create(1, 3, 5, 7, 9);
+    Bitlist bitlist2 = create(2, 4, 6);
+
+    assertThat(bitlist1.countMatchingBits(bitlist2)).isEqualTo(0);
+    assertThat(bitlist2.countMatchingBits(bitlist1)).isEqualTo(0);
+  }
+
+  @Test
+  void countMatchingBits_allMatch() {
+    Bitlist bitlist1 = create(1, 3, 5);
+    Bitlist bitlist2 = create(1, 3, 5);
+
+    assertThat(bitlist1.countMatchingBits(bitlist2)).isEqualTo(3);
+    assertThat(bitlist2.countMatchingBits(bitlist1)).isEqualTo(3);
+  }
+
+  @Test
   void countSetBits() {
     assertThat(create(1, 2, 6, 7, 9).getBitCount()).isEqualTo(5);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Reprioritize attestations as on-chain attestations are processed.  Previously, we prioritized attestations based on total number of set attester bits.  With these changes, we now prioritize by number of attester bits that have not been seen on chain in another block.  This should make it easier to collect high value attestations for inclusion in proposed blocks.

## Fixed Issue(s)
Part of #2192

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.