### PR TITLE
Update links and info in README to use ConsenSys org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # teku
 
- [![Build Status](https://circleci.com/gh/PegaSysEng/teku.svg?style=svg)](https://circleci.com/gh/PegaSysEng/workflows/teku)
- [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/PegasysEng/teku/blob/master/LICENSE)
+ [![Build Status](https://circleci.com/gh/ConsenSys/teku.svg?style=svg)](https://circleci.com/gh/ConsenSys/workflows/teku)
+ [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/ConsenSys/teku/blob/master/LICENSE)
  [![Discord](https://img.shields.io/badge/Chat-on%20Discord-blue)](https://discord.gg/7hPv2T6)
 
 Teku is a Java implementation of the Ethereum 2.0 Beacon Chain. Teku is changing rapidly hence we recommend building from the latest master. See the [Changelog](CHANGELOG.md) for known issues and breaking changes.
@@ -10,8 +10,8 @@ Teku is a Java implementation of the Ethereum 2.0 Beacon Chain. Teku is changing
 
 * [Ethereum 2.0 Beacon Chain specification](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md) 
 * [Teku user documentation](https://docs.teku.pegasys.tech/)
-* [Teku REST API reference documentation](https://pegasyseng.github.io/teku/)
-* [Teku issues](https://github.com/PegaSysEng/teku/issues)
+* [Teku REST API reference documentation](https://consensys.github.io/teku/)
+* [Teku issues](https://github.com/ConsenSys/teku/issues)
 * [Contribution guidelines](CONTRIBUTING.md)
 * [Teku Changelog](CHANGELOG.md)
 
@@ -19,7 +19,7 @@ Teku is a Java implementation of the Ethereum 2.0 Beacon Chain. Teku is changing
 
 See our [user documentation](https://docs.teku.pegasys.tech/). 
 
-Raise a [documentation issue](https://github.com/PegaSysEng/doc.teku/issues) or get in touch in 
+Raise a [documentation issue](https://github.com/ConsenSys/doc.teku/issues) or get in touch in 
 the #teku channel on [Discord](https://discord.gg/7hPv2T6) if you've got questions or feedback. 
 
 ## Teku developers 
@@ -38,7 +38,7 @@ the #teku channel on [Discord](https://discord.gg/7hPv2T6) if you've got questio
 To create a ready to run distribution:
 
 ```shell script
-git clone https://github.com/PegaSysEng/teku.git
+git clone https://github.com/ConsenSys/teku.git
 cd teku && ./gradlew distTar installDist
 ```
 
@@ -51,7 +51,7 @@ This produces:
 To build, clone this repo and run with `gradle`:
 
 ```shell script
-git clone https://github.com/PegaSysEng/teku.git
+git clone https://github.com/ConsenSys/teku.git
 cd teku && ./gradlew
 
 ```
@@ -59,7 +59,7 @@ cd teku && ./gradlew
 Or clone it manually:
 
 ```shell script
-git clone https://github.com/PegaSysEng/teku.git
+git clone https://github.com/ConsenSys/teku.git
 cd teku && ./gradlew
 ```
 
@@ -72,7 +72,7 @@ After a successful build, distribution packages are available in `build/distribu
 | distTar      | Full distribution in build/distributions (as `.tar.gz`)
 | distZip      | Full distribution in build/distributions (as `.zip`)
 | installDist  | Expanded distribution in `build/install/teku`
-| distDocker   | The `pegasyseng/teku` docker image
+| distDocker   | The `consensys/teku` docker image
 
 ## Code Style
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,4 +7,4 @@ This directory contains base files to generate REST API doc with CI.
 - README.md will not be copied, it's this file.
 - .circleci directory contains a configuration for CircleCI that does nothing but prevents CI to fail.
 
-The actual up to date generated doc is available at https://pegasyseng.github.io/teku/
+The actual up to date generated doc is available at https://consensys.github.io/teku/

--- a/docs/TARGET_README.md
+++ b/docs/TARGET_README.md
@@ -1,8 +1,8 @@
 # Teku REST API documentation
 
-OpenAPI documentation for Pegasys Teku Ethereum 2.0 beacon chain client REST API.
+OpenAPI documentation for ConsenSys Teku Ethereum 2.0 beacon chain client REST API.
 
 This documentation is generated from Teku OpenAPI JSON spec and rendered with
 [ReDoc](https://github.com/Redocly/redoc).
 
-The rendered REST API documentation is available at https://pegasyseng.github.io/teku/
+The rendered REST API documentation is available at https://consensys.github.io/teku/

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="Pegasys Teku REST API documentation (stable)">
-    <title>Pegasys Teku REST API documentation</title>
+    <meta name="description" content="ConsenSys Teku REST API documentation (stable)">
+    <title>ConsenSys Teku REST API documentation</title>
 
     <!-- Bootstrap core CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
@@ -45,7 +45,7 @@
   </head>
   <body>
     <nav class="navbar navbar-expand-md navbar-dark bg-dark mb-4">
-      <a class="navbar-brand" href="#">Pegasys Teku REST API</a>
+      <a class="navbar-brand" href="#">ConsenSys Teku REST API</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
@@ -106,7 +106,7 @@
           if(isDisplayedVersion(version)){
             item.addClass("active");
             $('#dropdownMenuButton').text(`${version}${sourceText}`);
-            document.title = `Pegasys Teku REST API documentation - ${version}`;
+            document.title = `ConsenSys Teku REST API documentation - ${version}`;
           }
 
           item.appendTo("#versionsList");

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,14 +7,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/PegaSysEng/teku.git"
+    "url": "git+https://github.com/ConsenSys/teku.git"
   },
   "author": "Consensys/Pegasys",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/PegaSysEng/teku/issues"
+    "url": "https://github.com/ConsenSys/teku/issues"
   },
-  "homepage": "https://pegasyseng.github.io/teku",
+  "homepage": "https://consensys.github.io/teku",
   "dependencies": {
     "minimist": "~1.2.5"
   }


### PR DESCRIPTION
## PR Description
Update the links in the README to point to the ConsenSys org instead of PegaSysEng.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.