### PR TITLE
Don't expect our finalized epoch to match the remote peers after syncing to finalized chain

### DIFF
--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/BatchSync.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/BatchSync.java
@@ -337,6 +337,7 @@ public class BatchSync implements Sync {
     }
     progressSync();
     if (activeBatches.isEmpty()) {
+      LOG.trace("Marking sync to {} as complete", targetChain);
       syncResult.complete(SyncResult.COMPLETE);
     }
   }
@@ -374,6 +375,7 @@ public class BatchSync implements Sync {
       // Waiting for last import to complete to switch branches so don't start new tasks
       checkState(
           importingBatch.isPresent(), "Waiting for import to complete but no import in progress");
+      LOG.debug("Not adding new batches on new chain while waiting for import to complete");
       return;
     }
     startNextImport();

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/ChainSelector.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/ChainSelector.java
@@ -29,9 +29,7 @@ public class ChainSelector {
   private final TargetChains availableChains;
   private final RecentChainData recentChainData;
 
-  public ChainSelector(
-      final RecentChainData recentChainData,
-      final TargetChains availableChains) {
+  public ChainSelector(final RecentChainData recentChainData, final TargetChains availableChains) {
     this.availableChains = availableChains;
     this.recentChainData = recentChainData;
   }
@@ -57,5 +55,4 @@ public class ChainSelector {
         .filter(chain -> chain.getChainHead().getSlot().isGreaterThan(minimumSlot))
         .findFirst();
   }
-
 }

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/MultipeerSyncService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/MultipeerSyncService.java
@@ -79,9 +79,8 @@ public class MultipeerSyncService extends Service implements SyncService {
             eventThread,
             new OrderedAsyncRunner(asyncRunner),
             recentChainData,
-            ChainSelector.createFinalizedChainSelector(recentChainData, finalizedTargetChains),
-            ChainSelector.createNonfinalizedChainSelector(
-                recentChainData, nonfinalizedTargetChains),
+            new ChainSelector(recentChainData, finalizedTargetChains),
+            new ChainSelector(recentChainData, nonfinalizedTargetChains),
             batchSync);
     final PeerChainTracker peerChainTracker =
         new PeerChainTracker(

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/SyncController.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/SyncController.java
@@ -71,7 +71,6 @@ public class SyncController {
    */
   public void onTargetChainsUpdated() {
     eventThread.checkOnEventThread();
-    LOG.trace("Target chains updated, checking for better sync target");
     final boolean currentlySyncing = isSyncActive();
     final Optional<InProgressSync> newSync = selectNewSyncTarget(currentlySyncing);
     if (newSync.isEmpty() && currentlySyncing) {
@@ -89,7 +88,6 @@ public class SyncController {
     // We may not have run fork choice to update our chain head, so check if the best finalized
     // chain is the one we just finished syncing and move on to non-finalized if it is.
     if (bestFinalizedChain.isPresent() && !isCompletedSync(bestFinalizedChain.get())) {
-      LOG.trace("Found finalized chain to sync to {}", bestFinalizedChain.get());
       return bestFinalizedChain.map(chain -> startSync(chain, true));
     } else if (!isSyncingFinalizedChain()) {
       final Optional<TargetChain> targetChain =

--- a/sync/src/main/java/tech/pegasys/teku/sync/multipeer/SyncController.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/multipeer/SyncController.java
@@ -71,6 +71,7 @@ public class SyncController {
    */
   public void onTargetChainsUpdated() {
     eventThread.checkOnEventThread();
+    LOG.trace("Target chains updated, checking for better sync target");
     final boolean currentlySyncing = isSyncActive();
     final Optional<InProgressSync> newSync = selectNewSyncTarget(currentlySyncing);
     if (newSync.isEmpty() && currentlySyncing) {
@@ -88,6 +89,7 @@ public class SyncController {
     // We may not have run fork choice to update our chain head, so check if the best finalized
     // chain is the one we just finished syncing and move on to non-finalized if it is.
     if (bestFinalizedChain.isPresent() && !isCompletedSync(bestFinalizedChain.get())) {
+      LOG.trace("Found finalized chain to sync to {}", bestFinalizedChain.get());
       return bestFinalizedChain.map(chain -> startSync(chain, true));
     } else if (!isSyncingFinalizedChain()) {
       final Optional<TargetChain> targetChain =
@@ -111,6 +113,8 @@ public class SyncController {
     eventThread.checkOnEventThread();
     if (isSyncActive() || result == SyncResult.TARGET_CHANGED) {
       // A different sync is now running so ignore this change.
+      LOG.debug(
+          "Ignoring sync complete because another sync is already active. Result: {}", result);
       return;
     }
     LOG.debug(


### PR DESCRIPTION
## PR Description
Don't expect that our finalized epoch will match the remote peer's after syncing to a finalized chain.  The finalisation only happens later when further blocks are imported, but the sync only imports the blocks the remote peer had finalized.  We'll need to continue syncing the non-finalised portion in order to finalize the same epoch.

## Fixed Issue(s)
#1844 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.