### PR TITLE
If the requested slot is empty, get the block header for the latest block.

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockHeader.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockHeader.java
@@ -80,7 +80,7 @@ public class GetBlockHeader extends AbstractHandler implements Handler {
     final Map<String, String> pathParams = ctx.pathParamMap();
     try {
       final SafeFuture<Optional<BlockHeader>> future =
-          chainDataProvider.getBlockHeaderByBlockId(pathParams.get(PARAM_BLOCK_ID));
+          chainDataProvider.getBlockHeader(pathParams.get(PARAM_BLOCK_ID));
       handleOptionalResult(ctx, future, this::handleResult, SC_NOT_FOUND);
     } catch (IllegalArgumentException ex) {
       LOG.trace(ex);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -194,19 +194,17 @@ public class ChainDataProvider {
         .thenApply(block -> block.map(GetBlockResponse::new));
   }
 
-  public SafeFuture<Optional<BlockHeader>> getBlockHeaderByBlockId(final String slotParameter) {
+  public SafeFuture<Optional<BlockHeader>> getBlockHeader(final String slotParameter) {
     if (!isStoreAvailable()) {
       return chainUnavailable();
     }
 
     return defaultBlockSelectorFactory
         .defaultBlockSelector(slotParameter)
-        .getBlock()
-        .thenApply(
-            blockList ->
-                blockList.isEmpty()
-                    ? Optional.empty()
-                    : Optional.of(new BlockHeader(blockList.get(0), true)));
+        .getSingleBlock()
+        .thenApply(maybeBlock ->
+            maybeBlock.map(block -> new BlockHeader(block, true)));
+
   }
 
   public boolean isStoreAvailable() {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -203,7 +203,7 @@ public class ChainDataProvider {
 
     final UInt64 slot = maybeSlot.get();
     return combinedChainDataClient
-        .getBlockAtSlotExact(slot)
+        .getBlockInEffectAtSlot(slot)
         .thenApply(maybeBlock -> maybeBlock.map(block -> new BlockHeader(block, true)));
   }
 
@@ -597,7 +597,7 @@ public class ChainDataProvider {
 
     final UInt64 slotToLoad = slot.or(recentChainData::getCurrentSlot).orElseThrow();
     return combinedChainDataClient
-        .getBlockAtSlotExact(slotToLoad)
+        .getBlockInEffectAtSlot(slotToLoad)
         .thenApply(
             maybeBlock ->
                 maybeBlock.map(block -> List.of(new BlockHeader(block, true))).orElse(List.of()));

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -202,9 +202,7 @@ public class ChainDataProvider {
     return defaultBlockSelectorFactory
         .defaultBlockSelector(slotParameter)
         .getSingleBlock()
-        .thenApply(maybeBlock ->
-            maybeBlock.map(block -> new BlockHeader(block, true)));
-
+        .thenApply(maybeBlock -> maybeBlock.map(block -> new BlockHeader(block, true)));
   }
 
   public boolean isStoreAvailable() {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelector.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelector.java
@@ -14,9 +14,17 @@
 package tech.pegasys.teku.api.blockselector;
 
 import java.util.List;
+import java.util.Optional;
+
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
 public interface BlockSelector {
   SafeFuture<List<SignedBeaconBlock>> getBlock();
+
+  default SafeFuture<Optional<SignedBeaconBlock>> getSingleBlock() {
+    return getBlock()
+        .thenApply(blockList ->
+            blockList.stream().findFirst());
+  }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelector.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelector.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.api.blockselector;
 
 import java.util.List;
 import java.util.Optional;
-
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
@@ -23,8 +22,6 @@ public interface BlockSelector {
   SafeFuture<List<SignedBeaconBlock>> getBlock();
 
   default SafeFuture<Optional<SignedBeaconBlock>> getSingleBlock() {
-    return getBlock()
-        .thenApply(blockList ->
-            blockList.stream().findFirst());
+    return getBlock().thenApply(blockList -> blockList.stream().findFirst());
   }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelector.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelector.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.blockselector;
+
+import java.util.List;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+public interface BlockSelector {
+  SafeFuture<List<SignedBeaconBlock>> getBlock();
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactory.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.blockselector;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+import tech.pegasys.teku.util.config.Constants;
+
+public class BlockSelectorFactory {
+  private final CombinedChainDataClient client;
+
+  public BlockSelectorFactory(final CombinedChainDataClient combinedChainDataClient) {
+    this.client = combinedChainDataClient;
+  }
+
+  /**
+   * Default parsing of the slot parameter to determine the block to return - "head" - the head
+   * block - "genesis" - the genesis block - "finalized" - the block in effect at the last slot of
+   * the finalized epoch - 0x00 - the block root (bytes32) to return - {UINT64} - a specific slot to
+   * retrieve a block from
+   *
+   * @param selectorMethod
+   * @return the selector for the requested string
+   */
+  public BlockSelector defaultBlockSelector(final String selectorMethod) {
+    if (selectorMethod.startsWith("0x")) {
+      return forBlockRoot(Bytes32.fromHexString(selectorMethod));
+    }
+    switch (selectorMethod) {
+      case ("head"):
+        return headSelector();
+      case ("genesis"):
+        return genesisSelector();
+      case ("finalized"):
+        return finalizedSelector();
+      default:
+        return forSlot(UInt64.valueOf(selectorMethod));
+    }
+  }
+
+  public BlockSelector headSelector() {
+    return () -> optionalToList(SafeFuture.completedFuture(client.getBestBlock()));
+  }
+
+  public BlockSelector finalizedSelector() {
+    return () -> optionalToList(SafeFuture.completedFuture(client.getFinalizedBlock()));
+  }
+
+  public BlockSelector genesisSelector() {
+    return () -> optionalToList(client.getBlockAtSlotExact(UInt64.valueOf(Constants.GENESIS_SLOT)));
+  }
+
+  public BlockSelector forSlot(final UInt64 slot) {
+    return () -> optionalToList(client.getBlockAtSlotExact(slot));
+  }
+
+  public BlockSelector forBlockRoot(final Bytes32 blockRoot) {
+    return () -> optionalToList(client.getBlockByBlockRoot(blockRoot));
+  }
+
+  private SafeFuture<List<SignedBeaconBlock>> optionalToList(
+      final SafeFuture<Optional<SignedBeaconBlock>> future) {
+    return future.thenApply(
+        maybeBlock -> maybeBlock.map(List::of).orElseGet(Collections::emptyList));
+  }
+}

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -771,7 +771,9 @@ public class ChainDataProviderTest {
     final UInt64 headSlot = recentChainData.getHeadSlot();
     storageSystem.chainUpdater().advanceChain(headSlot.plus(1));
 
-    final SafeFuture<List<BlockHeader>> future = provider.getBlockHeaders(Optional.empty(), Optional.of(recentChainData.getCurrentSlot().get()));
+    final SafeFuture<List<BlockHeader>> future =
+        provider.getBlockHeaders(
+            Optional.empty(), Optional.of(recentChainData.getCurrentSlot().get()));
     final BlockHeader header = future.join().get(0);
     assertThat(header.header.message.slot).isEqualTo(headSlot);
   }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -714,7 +714,7 @@ public class ChainDataProviderTest {
         new ChainDataProvider(recentChainData, combinedChainDataClient);
     final tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock block =
         combinedChainDataClient.getBestBlock().get();
-    BlockHeader result = provider.getBlockHeaderByBlockId("head").get().get();
+    BlockHeader result = provider.getBlockHeader("head").get().get();
     final BeaconBlockHeader beaconBlockHeader =
         new BeaconBlockHeader(
             block.getSlot(),

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -753,18 +753,7 @@ public class ChainDataProviderTest {
   }
 
   @Test
-  public void shouldGetBlockHeaderWithBlockRoot() throws ExecutionException, InterruptedException {
-    final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
-    final SignedBeaconBlock block =
-        new SignedBeaconBlock(combinedChainDataClient.getBestBlock().get());
-    Optional<BlockHeader> results =
-        provider.getBlockHeaderByBlockRoot(block.asInternalSignedBeaconBlock().getRoot()).get();
-    assertThat(results.get().header.message.slot).isEqualTo(slot);
-  }
-
-  @Test
-  public void shouldGetBlockHeadersOnEmptySlot() {
+  public void shouldGetBlockHeadersOnEmptyChainHeadSlot() {
     final ChainDataProvider provider =
         new ChainDataProvider(recentChainData, combinedChainDataClient);
 
@@ -772,22 +761,8 @@ public class ChainDataProviderTest {
     storageSystem.chainUpdater().advanceChain(headSlot.plus(1));
 
     final SafeFuture<List<BlockHeader>> future =
-        provider.getBlockHeaders(
-            Optional.empty(), Optional.of(recentChainData.getCurrentSlot().get()));
+        provider.getBlockHeaders(Optional.empty(), Optional.empty());
     final BlockHeader header = future.join().get(0);
-    assertThat(header.header.message.slot).isEqualTo(headSlot);
-  }
-
-  @Test
-  public void shouldGetBlockHeaderOnEmptySlot() {
-    final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
-
-    final UInt64 headSlot = recentChainData.getHeadSlot();
-    storageSystem.chainUpdater().advanceChain(headSlot.plus(1));
-
-    final SafeFuture<Optional<BlockHeader>> future = provider.getBlockHeaderByBlockId("head");
-    final BlockHeader header = future.join().get();
     assertThat(header.header.message.slot).isEqualTo(headSlot);
   }
 

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -763,6 +763,32 @@ public class ChainDataProviderTest {
     assertThat(results.get().header.message.slot).isEqualTo(slot);
   }
 
+  @Test
+  public void shouldGetBlockHeadersOnEmptySlot() {
+    final ChainDataProvider provider =
+        new ChainDataProvider(recentChainData, combinedChainDataClient);
+
+    final UInt64 headSlot = recentChainData.getHeadSlot();
+    storageSystem.chainUpdater().advanceChain(headSlot.plus(1));
+
+    final SafeFuture<List<BlockHeader>> future = provider.getBlockHeaders(Optional.empty(), Optional.of(recentChainData.getCurrentSlot().get()));
+    final BlockHeader header = future.join().get(0);
+    assertThat(header.header.message.slot).isEqualTo(headSlot);
+  }
+
+  @Test
+  public void shouldGetBlockHeaderOnEmptySlot() {
+    final ChainDataProvider provider =
+        new ChainDataProvider(recentChainData, combinedChainDataClient);
+
+    final UInt64 headSlot = recentChainData.getHeadSlot();
+    storageSystem.chainUpdater().advanceChain(headSlot.plus(1));
+
+    final SafeFuture<Optional<BlockHeader>> future = provider.getBlockHeaderByBlockId("head");
+    final BlockHeader header = future.join().get();
+    assertThat(header.header.message.slot).isEqualTo(headSlot);
+  }
+
   private void assertValidatorRespondsWithCorrectValidatorAtHead(
       final ChainDataProvider provider, final Validator validator, final Integer validatorId) {
     SafeFuture<Optional<ValidatorResponse>> response =

--- a/data/provider/src/test/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactoryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.blockselector;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+
+public class BlockSelectorFactoryTest {
+  private final CombinedChainDataClient client = mock(CombinedChainDataClient.class);
+  private final DataStructureUtil data = new DataStructureUtil();
+  final SignedBeaconBlock block = data.randomSignedBeaconBlock(100);
+
+  private final BlockSelectorFactory blockSelectorFactory = new BlockSelectorFactory(client);
+
+  @Test
+  public void headSelector_shouldGetBestBlock() throws ExecutionException, InterruptedException {
+    when(client.getBestBlock()).thenReturn(Optional.of(block));
+    List<SignedBeaconBlock> blockList = blockSelectorFactory.headSelector().getBlock().get();
+    verify(client).getBestBlock();
+    assertThat(blockList).containsExactly(block);
+  }
+
+  @Test
+  public void finalizedSelector_shouldGetFinalizedBlock()
+      throws ExecutionException, InterruptedException {
+    when(client.getFinalizedBlock()).thenReturn(Optional.of(block));
+    List<SignedBeaconBlock> blockList = blockSelectorFactory.finalizedSelector().getBlock().get();
+    verify(client).getFinalizedBlock();
+    assertThat(blockList).containsExactly(block);
+  }
+
+  @Test
+  public void genesisSelector_shouldGetSlotZero() throws ExecutionException, InterruptedException {
+    when(client.getBlockAtSlotExact(UInt64.ZERO))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
+    List<SignedBeaconBlock> blockList = blockSelectorFactory.genesisSelector().getBlock().get();
+    verify(client).getBlockAtSlotExact(UInt64.ZERO);
+    assertThat(blockList).containsExactly(block);
+  }
+
+  @Test
+  public void blockRootSelector_shouldGetBlockByBlockRoot()
+      throws ExecutionException, InterruptedException {
+    when(client.getBlockByBlockRoot(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
+    List<SignedBeaconBlock> blockList =
+        blockSelectorFactory.forBlockRoot(block.getRoot()).getBlock().get();
+    verify(client).getBlockByBlockRoot(block.getRoot());
+    assertThat(blockList).containsExactly(block);
+  }
+
+  @Test
+  public void slotSelector_shouldGetBlockAtSlotExact()
+      throws ExecutionException, InterruptedException {
+    when(client.getBlockAtSlotExact(block.getSlot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
+    List<SignedBeaconBlock> blockList =
+        blockSelectorFactory.forSlot(block.getSlot()).getBlock().get();
+    verify(client).getBlockAtSlotExact(block.getSlot());
+    assertThat(blockList).containsExactly(block);
+  }
+}

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
@@ -282,7 +282,7 @@ public abstract class Eth2OutgoingRequestHandlerTest
 
     asyncRequestRunner.executeQueuedActions();
 
-    assertThrows(IllegalReferenceCountException.class, this::complete);
+    complete();
 
     assertThat(finishedProcessingFuture).isCompletedExceptionally();
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
@@ -15,10 +15,12 @@ package tech.pegasys.teku.networking.eth2.rpc.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import io.netty.util.IllegalReferenceCountException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -280,7 +282,7 @@ public abstract class Eth2OutgoingRequestHandlerTest
 
     asyncRequestRunner.executeQueuedActions();
 
-    complete();
+    assertThrows(IllegalReferenceCountException.class, this::complete);
 
     assertThat(finishedProcessingFuture).isCompletedExceptionally();
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandlerTest.java
@@ -15,12 +15,10 @@ package tech.pegasys.teku.networking.eth2.rpc.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import io.netty.util.IllegalReferenceCountException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -413,6 +413,14 @@ public class CombinedChainDataClient {
         .thenApply(maybeBlock -> maybeBlock.map(SignedBeaconBlock::getSlot));
   }
 
+  public Optional<SignedBeaconBlock> getFinalizedBlock() {
+    if (recentChainData.isPreGenesis()) {
+      return Optional.empty();
+    }
+
+    return Optional.ofNullable(getStore().getLatestFinalizedBlockAndState().getBlock());
+  }
+
   public Optional<GenesisData> getGenesisData() {
     return recentChainData.getGenesisData();
   }


### PR DESCRIPTION
 - Previously an empty head slot would result in a 404 (not found) error.

 - It was possible for the slot of the finalized epoch to be empty, which would result in 404.

fixes #3071

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.