### PR TITLE
Reduce log level for event source time out events

### DIFF
--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/EventSourceHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/EventSourceHandler.java
@@ -16,8 +16,10 @@ package tech.pegasys.teku.validator.remote;
 import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Throwables;
 import com.launchdarkly.eventsource.EventHandler;
 import com.launchdarkly.eventsource.MessageEvent;
+import java.net.SocketTimeoutException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.api.response.v1.ChainReorgEvent;
@@ -96,6 +98,11 @@ class EventSourceHandler implements EventHandler {
 
   @Override
   public void onError(final Throwable t) {
-    VALIDATOR_LOGGER.beaconNodeConnectionError(t);
+    if (Throwables.getRootCause(t) instanceof SocketTimeoutException) {
+      LOG.info(
+          "Timed out waiting for events from beacon node event stream. Reconnecting. This is normal if the beacon node is still syncing.");
+    } else {
+      VALIDATOR_LOGGER.beaconNodeConnectionError(t);
+    }
   }
 }


### PR DESCRIPTION
## PR Description
Reduce log level for timeout events from the event stream. These are expected while the beacon node is syncing because it doesn't send any events during that time.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.