### PR TITLE
Add option to export the latest finalized block

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -13,14 +13,13 @@
 
 package tech.pegasys.teku.cli.subcommand.debug;
 
-import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;


### PR DESCRIPTION
## PR Description
Add option to export the latest finalized block along with the latest finalized state using debug tools. Really useful for testing #3065 

Update DebugDbCommand to provide the `StateAndBlockProvider` when creating the store.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.