### PR TITLE
Specify and use slot param for create aggregate

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/validator/GetAggregateIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/validator/GetAggregateIntegrationTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.beaconrestapi.validator;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
@@ -44,9 +43,9 @@ public class GetAggregateIntegrationTest extends AbstractDataBackedRestAPIIntegr
     final Map<String, String> params =
         Map.of(
             "attestation_data_root", attestation.hash_tree_root().toHexString(),
-            "slot", UInt64.valueOf(1).toString());
+            "slot", UInt64.ONE.toString());
 
-    when(validatorApiChannel.createAggregate(eq(attestation.hash_tree_root())))
+    when(validatorApiChannel.createAggregate(UInt64.ONE, attestation.hash_tree_root()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
 
     Response response = getResponse(GetAggregate.ROUTE, params);
@@ -59,9 +58,9 @@ public class GetAggregateIntegrationTest extends AbstractDataBackedRestAPIIntegr
     final Map<String, String> params =
         Map.of(
             "attestation_data_root", attestation.hash_tree_root().toHexString(),
-            "slot", UInt64.valueOf(1).toString());
+            "slot", UInt64.ONE.toString());
 
-    when(validatorApiChannel.createAggregate(eq(attestation.hash_tree_root())))
+    when(validatorApiChannel.createAggregate(UInt64.ONE, attestation.hash_tree_root()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(attestation)));
 
     Response response = getResponse(GetAggregate.ROUTE, params);

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAggregateAttestation.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAggregateAttestation.java
@@ -49,6 +49,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.beaconrestapi.schema.ErrorResponse;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 
 public class GetAggregateAttestation extends AbstractHandler implements Handler {
@@ -104,13 +105,11 @@ public class GetAggregateAttestation extends AbstractHandler implements Handler 
             String.format("Please specify both %s and %s", ATTESTATION_DATA_ROOT, SLOT));
       }
       Bytes32 beacon_block_root = getParameterValueAsBytes32(parameters, ATTESTATION_DATA_ROOT);
-      // Teku isn't using this parameter at the moment. We are enforcing it to stay compatible with
-      // the standard api
-      getParameterValueAsUInt64(parameters, SLOT);
+      final UInt64 slot = getParameterValueAsUInt64(parameters, SLOT);
 
       ctx.result(
           provider
-              .createAggregate(beacon_block_root)
+              .createAggregate(slot, beacon_block_root)
               .thenApplyChecked(optionalAttestation -> serializeResult(ctx, optionalAttestation))
               .exceptionallyCompose(error -> handleError(ctx, error)));
     } catch (final IllegalArgumentException e) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/validator/GetAggregate.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/validator/GetAggregate.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.beaconrestapi.schema.ErrorResponse;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 
 public class GetAggregate implements Handler {
@@ -101,13 +102,11 @@ public class GetAggregate implements Handler {
             String.format("Please specify both %s and %s", ATTESTATION_DATA_ROOT, SLOT));
       }
       Bytes32 beacon_block_root = getParameterValueAsBytes32(parameters, ATTESTATION_DATA_ROOT);
-      // Teku isn't using this parameter at the moment. We are enforcing it to stay compatible with
-      // the standard api
-      getParameterValueAsUInt64(parameters, SLOT);
+      final UInt64 slot = getParameterValueAsUInt64(parameters, SLOT);
 
       ctx.result(
           provider
-              .createAggregate(beacon_block_root)
+              .createAggregate(slot, beacon_block_root)
               .thenApplyChecked(optionalAttestation -> serializeResult(ctx, optionalAttestation))
               .exceptionallyCompose(error -> handleError(ctx, error)));
     } catch (final IllegalArgumentException e) {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/validator/GetAggregateTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/validator/GetAggregateTest.java
@@ -149,7 +149,7 @@ class GetAggregateTest {
     final Map<String, List<String>> validQueryParams =
         Map.of(
             "attestation_data_root", List.of(attestation.hash_tree_root().toHexString()),
-            "slot", List.of("1"));
+            "slot", List.of(attestation.getData().getSlot().toString()));
     when(context.queryParamMap()).thenReturn(validQueryParams);
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/validator/GetAggregateTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/validator/GetAggregateTest.java
@@ -93,7 +93,8 @@ class GetAggregateTest {
   public void shouldReturnNotFoundWhenAttestationIsNotPresent() throws Exception {
     final Attestation attestation = dataStructureUtil.randomAttestation();
     mockContextWithAttestationParams(attestation);
-    when(provider.createAggregate(eq(attestation.hash_tree_root())))
+    when(provider.createAggregate(
+            eq(attestation.getData().getSlot()), eq(attestation.hash_tree_root())))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
 
     handler.handle(context);
@@ -106,7 +107,8 @@ class GetAggregateTest {
     mockContextWithAttestationParams(attestation);
     final tech.pegasys.teku.api.schema.Attestation schemaAttestation =
         new tech.pegasys.teku.api.schema.Attestation(attestation);
-    when(provider.createAggregate(eq(attestation.hash_tree_root())))
+    when(provider.createAggregate(
+            eq(attestation.getData().getSlot()), eq(attestation.hash_tree_root())))
         .thenReturn(SafeFuture.completedFuture(Optional.of(schemaAttestation)));
 
     handler.handle(context);
@@ -123,7 +125,8 @@ class GetAggregateTest {
   public void shouldReturnBadRequestWhenFutureExceptionIsIllegalArgument() throws Exception {
     final Attestation attestation = dataStructureUtil.randomAttestation();
     mockContextWithAttestationParams(attestation);
-    when(provider.createAggregate(eq(attestation.hash_tree_root())))
+    when(provider.createAggregate(
+            eq(attestation.getData().getSlot()), eq(attestation.hash_tree_root())))
         .thenReturn(SafeFuture.failedFuture(new IllegalArgumentException()));
 
     handler.handle(context);
@@ -134,7 +137,8 @@ class GetAggregateTest {
   public void shouldReturnServerErrorWhenFutureHasUnmappedException() throws Exception {
     final Attestation attestation = dataStructureUtil.randomAttestation();
     mockContextWithAttestationParams(attestation);
-    when(provider.createAggregate(eq(attestation.hash_tree_root())))
+    when(provider.createAggregate(
+            eq(attestation.getData().getSlot()), eq(attestation.hash_tree_root())))
         .thenReturn(SafeFuture.failedFuture(new RuntimeException()));
 
     handler.handle(context);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -196,9 +196,10 @@ public class ValidatorDataProvider {
             });
   }
 
-  public SafeFuture<Optional<Attestation>> createAggregate(final Bytes32 attestationHashTreeRoot) {
+  public SafeFuture<Optional<Attestation>> createAggregate(
+      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
     return validatorApiChannel
-        .createAggregate(attestationHashTreeRoot)
+        .createAggregate(slot, attestationHashTreeRoot)
         .thenApply(maybeAttestation -> maybeAttestation.map(Attestation::new));
   }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -57,7 +57,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<Optional<AttestationData>> createAttestationData(UInt64 slot, int committeeIndex);
 
-  SafeFuture<Optional<Attestation>> createAggregate(Bytes32 attestationHashTreeRoot);
+  SafeFuture<Optional<Attestation>> createAggregate(UInt64 slot, Bytes32 attestationHashTreeRoot);
 
   void subscribeToBeaconCommittee(List<CommitteeSubscriptionRequest> requests);
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -227,9 +227,10 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Attestation>> createAggregate(final Bytes32 attestationHashTreeRoot) {
+  public SafeFuture<Optional<Attestation>> createAggregate(
+      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
     return countRequest(
-        delegate.createAggregate(attestationHashTreeRoot), aggregateRequestsCounter);
+        delegate.createAggregate(slot, attestationHashTreeRoot), aggregateRequestsCounter);
   }
 
   @Override

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -174,7 +174,8 @@ class MetricRecordingValidatorApiChannelTest {
             dataStructureUtil.randomAttestation()),
         requestDataTest(
             "createAggregate",
-            channel -> channel.createAggregate(attestationData.hashTreeRoot()),
+            channel ->
+                channel.createAggregate(attestationData.getSlot(), attestationData.hashTreeRoot()),
             MetricRecordingValidatorApiChannel.AGGREGATE_REQUESTS_COUNTER_NAME,
             dataStructureUtil.randomAttestation()));
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
@@ -107,7 +107,7 @@ public class AggregationDuty implements Duty {
             () ->
                 new IllegalStateException(
                     "Unable to perform aggregation for committee because no attestation was produced"));
-    return validatorApiChannel.createAggregate(attestationData.hashTreeRoot());
+    return validatorApiChannel.createAggregate(slot, attestationData.hashTreeRoot());
   }
 
   private SafeFuture<DutyResult> sendAggregate(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
@@ -93,7 +93,7 @@ class AggregationDutyTest {
         attestationCommitteeIndex,
         completedFuture(Optional.of(attestationData)));
 
-    when(validatorApiChannel.createAggregate(attestationData.hashTreeRoot()))
+    when(validatorApiChannel.createAggregate(SLOT, attestationData.hashTreeRoot()))
         .thenReturn(completedFuture(Optional.of(aggregate)));
 
     final AggregateAndProof expectedAggregateAndProof =
@@ -136,9 +136,9 @@ class AggregationDutyTest {
         validator2CommitteeIndex,
         completedFuture(Optional.of(committee2AttestationData)));
 
-    when(validatorApiChannel.createAggregate(committee1AttestationData.hashTreeRoot()))
+    when(validatorApiChannel.createAggregate(SLOT, committee1AttestationData.hashTreeRoot()))
         .thenReturn(completedFuture(Optional.of(committee1Aggregate)));
-    when(validatorApiChannel.createAggregate(committee2AttestationData.hashTreeRoot()))
+    when(validatorApiChannel.createAggregate(SLOT, committee2AttestationData.hashTreeRoot()))
         .thenReturn(completedFuture(Optional.of(committee2Aggregate)));
 
     final AggregateAndProof aggregateAndProof1 =
@@ -190,7 +190,7 @@ class AggregationDutyTest {
         committeeIndex,
         completedFuture(Optional.of(attestationData)));
 
-    when(validatorApiChannel.createAggregate(attestationData.hashTreeRoot()))
+    when(validatorApiChannel.createAggregate(SLOT, attestationData.hashTreeRoot()))
         .thenReturn(completedFuture(Optional.of(aggregate)));
 
     final AggregateAndProof aggregateAndProof =
@@ -244,7 +244,7 @@ class AggregationDutyTest {
         dataStructureUtil.randomSignature(),
         2,
         completedFuture(Optional.of(attestationData)));
-    when(validatorApiChannel.createAggregate(attestationData.hashTreeRoot()))
+    when(validatorApiChannel.createAggregate(SLOT, attestationData.hashTreeRoot()))
         .thenReturn(completedFuture(Optional.empty()));
 
     assertThat(duty.performDuty()).isCompleted();
@@ -263,7 +263,7 @@ class AggregationDutyTest {
         dataStructureUtil.randomSignature(),
         2,
         completedFuture(Optional.of(attestationData)));
-    when(validatorApiChannel.createAggregate(attestationData.hashTreeRoot()))
+    when(validatorApiChannel.createAggregate(SLOT, attestationData.hashTreeRoot()))
         .thenReturn(failedFuture(exception));
 
     performAndReportDuty();

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -346,13 +346,15 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Attestation>> createAggregate(final Bytes32 attestationHashTreeRoot) {
+  public SafeFuture<Optional<Attestation>> createAggregate(
+      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
     if (isSyncActive()) {
       return NodeSyncingException.failedFuture();
     }
     return SafeFuture.completedFuture(
         attestationPool
             .createAggregateFor(attestationHashTreeRoot)
+            .filter(attestation -> attestation.getData().getSlot().equals(slot))
             .map(ValidateableAttestation::getAttestation));
   }
 

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -512,7 +512,9 @@ class ValidatorApiHandlerTest {
     when(attestationPool.createAggregateFor(eq(attestationData.hashTreeRoot())))
         .thenReturn(aggregate.map(ValidateableAttestation::fromAttestation));
 
-    assertThat(validatorApiHandler.createAggregate(ONE, attestationData.hashTreeRoot()))
+    assertThat(
+            validatorApiHandler.createAggregate(
+                aggregate.get().getData().getSlot(), attestationData.hashTreeRoot()))
         .isCompletedWithValue(aggregate);
   }
 

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -499,7 +499,7 @@ class ValidatorApiHandlerTest {
     nodeIsSyncing();
     final SafeFuture<Optional<Attestation>> result =
         validatorApiHandler.createAggregate(
-            dataStructureUtil.randomAttestationData().hashTreeRoot());
+            ONE, dataStructureUtil.randomAttestationData().hashTreeRoot());
 
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get).hasRootCauseInstanceOf(NodeSyncingException.class);
@@ -512,7 +512,7 @@ class ValidatorApiHandlerTest {
     when(attestationPool.createAggregateFor(eq(attestationData.hashTreeRoot())))
         .thenReturn(aggregate.map(ValidateableAttestation::fromAttestation));
 
-    assertThat(validatorApiHandler.createAggregate(attestationData.hashTreeRoot()))
+    assertThat(validatorApiHandler.createAggregate(ONE, attestationData.hashTreeRoot()))
         .isCompletedWithValue(aggregate);
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -268,11 +268,12 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Attestation>> createAggregate(final Bytes32 attestationHashTreeRoot) {
+  public SafeFuture<Optional<Attestation>> createAggregate(
+      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
     return sendRequest(
         () ->
             apiClient
-                .createAggregate(attestationHashTreeRoot)
+                .createAggregate(slot, attestationHashTreeRoot)
                 .map(tech.pegasys.teku.api.schema.Attestation::asInternalAttestation));
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -197,9 +197,10 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   }
 
   @Override
-  public Optional<Attestation> createAggregate(final Bytes32 attestationHashTreeRoot) {
+  public Optional<Attestation> createAggregate(
+      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
     final Map<String, String> queryParams = new HashMap<>();
-    queryParams.put("slot", encodeQueryParam(UInt64.ZERO));
+    queryParams.put("slot", encodeQueryParam(slot));
     queryParams.put("attestation_data_root", encodeQueryParam(attestationHashTreeRoot));
 
     return get(GET_AGGREGATE, queryParams, GetAggregatedAttestationResponse.class)

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -62,7 +62,7 @@ public interface ValidatorRestApiClient {
 
   void sendSignedAttestation(Attestation attestation);
 
-  Optional<Attestation> createAggregate(Bytes32 attestationHashTreeRoot);
+  Optional<Attestation> createAggregate(UInt64 slot, Bytes32 attestationHashTreeRoot);
 
   void sendAggregateAndProofs(List<SignedAggregateAndProof> signedAggregateAndProof);
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -508,26 +508,29 @@ class RemoteValidatorApiHandlerTest {
 
   @Test
   public void createAggregate_WhenNotFound_ReturnsEmpty() {
+    final UInt64 slot = dataStructureUtil.randomUInt64();
     final Bytes32 attHashTreeRoot = Bytes32.random();
 
-    when(apiClient.createAggregate(eq(attHashTreeRoot))).thenReturn(Optional.empty());
+    when(apiClient.createAggregate(eq(slot), eq(attHashTreeRoot))).thenReturn(Optional.empty());
 
-    SafeFuture<Optional<Attestation>> future = apiHandler.createAggregate(attHashTreeRoot);
+    SafeFuture<Optional<Attestation>> future = apiHandler.createAggregate(slot, attHashTreeRoot);
 
     assertThat(unwrapToOptional(future)).isEmpty();
   }
 
   @Test
   public void createAggregate_WhenFound_ReturnsAttestation() {
+    final UInt64 slot = dataStructureUtil.randomUInt64();
     final Bytes32 attHashTreeRoot = Bytes32.random();
 
     final Attestation attestation = dataStructureUtil.randomAttestation();
     final tech.pegasys.teku.api.schema.Attestation schemaAttestation =
         new tech.pegasys.teku.api.schema.Attestation(attestation);
 
-    when(apiClient.createAggregate(eq(attHashTreeRoot))).thenReturn(Optional.of(schemaAttestation));
+    when(apiClient.createAggregate(eq(slot), eq(attHashTreeRoot)))
+        .thenReturn(Optional.of(schemaAttestation));
 
-    SafeFuture<Optional<Attestation>> future = apiHandler.createAggregate(attHashTreeRoot);
+    SafeFuture<Optional<Attestation>> future = apiHandler.createAggregate(slot, attHashTreeRoot);
 
     assertThat(unwrapToValue(future)).usingRecursiveComparison().isEqualTo(attestation);
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -545,12 +545,12 @@ class OkHttpValidatorRestApiClientTest {
 
   @Test
   public void createAggregate_MakesExpectedRequest() throws Exception {
-    final UInt64 slot = UInt64.ZERO;
+    final UInt64 slot = UInt64.valueOf(323);
     final Bytes32 attestationHashTreeRoot = Bytes32.random();
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NO_CONTENT));
 
-    apiClient.createAggregate(attestationHashTreeRoot);
+    apiClient.createAggregate(slot, attestationHashTreeRoot);
 
     RecordedRequest request = mockWebServer.takeRequest();
 
@@ -567,7 +567,7 @@ class OkHttpValidatorRestApiClientTest {
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_BAD_REQUEST));
 
-    assertThatThrownBy(() -> apiClient.createAggregate(attestationHashTreeRoot))
+    assertThatThrownBy(() -> apiClient.createAggregate(UInt64.ONE, attestationHashTreeRoot))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -577,7 +577,7 @@ class OkHttpValidatorRestApiClientTest {
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_INTERNAL_SERVER_ERROR));
 
-    assertThatThrownBy(() -> apiClient.createAggregate(attestationHashTreeRoot))
+    assertThatThrownBy(() -> apiClient.createAggregate(UInt64.ONE, attestationHashTreeRoot))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Unexpected response from Beacon Node API");
   }
@@ -592,7 +592,8 @@ class OkHttpValidatorRestApiClientTest {
             .setResponseCode(SC_OK)
             .setBody(asJson(new GetAggregatedAttestationResponse(expectedAttestation))));
 
-    final Optional<Attestation> attestation = apiClient.createAggregate(attestationHashTreeRoot);
+    final Optional<Attestation> attestation =
+        apiClient.createAggregate(UInt64.ONE, attestationHashTreeRoot);
 
     assertThat(attestation).isPresent();
     assertThat(attestation.get()).usingRecursiveComparison().isEqualTo(expectedAttestation);


### PR DESCRIPTION
## PR Description
The create aggregate REST API accepts a slot param which teku was ignoring.  When the remote validator sent the request it hard coded the slot to zero which is very confusing.  This changes it so the Validator Client specifies the slot correctly and the created aggregate is only returned if the specified attestation data is from the specified slot.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.