### PR TITLE
Allow validator client to deserialize new and legacy createAttestationData endpoint

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/TemporaryAttestationData.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/TemporaryAttestationData.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.schema;
+
+import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES32;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class TemporaryAttestationData {
+  @Schema(type = "string", format = "uint64")
+  public final UInt64 slot;
+
+  @Schema(type = "string", format = "uint64")
+  public final UInt64 index;
+
+  @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES32)
+  public final Bytes32 beacon_block_root;
+
+  public final Checkpoint source;
+  public final Checkpoint target;
+
+  @JsonProperty("data")
+  public final AttestationData data;
+
+  @JsonCreator
+  public TemporaryAttestationData(
+      @JsonProperty("data") final AttestationData data,
+      @JsonProperty("slot") final UInt64 slot,
+      @JsonProperty("index") final UInt64 index,
+      @JsonProperty("beacon_block_root") final Bytes32 beacon_block_root,
+      @JsonProperty("source") final Checkpoint source,
+      @JsonProperty("target") final Checkpoint target) {
+    this.data = data;
+    this.slot = slot;
+    this.index = index;
+    this.beacon_block_root = beacon_block_root;
+    this.source = source;
+    this.target = target;
+  }
+
+  public AttestationData getAttestationData() {
+    if (data != null) {
+      return data;
+    }
+
+    return new AttestationData(slot, index, beacon_block_root, source, target);
+  }
+}

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -75,6 +75,7 @@ import tech.pegasys.teku.api.schema.Fork;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SubnetSubscription;
+import tech.pegasys.teku.api.schema.TemporaryAttestationData;
 import tech.pegasys.teku.api.schema.ValidatorDuties;
 import tech.pegasys.teku.api.schema.ValidatorDutiesRequest;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -188,7 +189,8 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
     queryParams.put("slot", encodeQueryParam(slot));
     queryParams.put("committee_index", String.valueOf(committeeIndex));
 
-    return get(GET_ATTESTATION_DATA, queryParams, AttestationData.class);
+    return get(GET_ATTESTATION_DATA, queryParams, TemporaryAttestationData.class)
+        .map(TemporaryAttestationData::getAttestationData);
   }
 
   @Override

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.api.response.v1.beacon.GetStateForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateValidatorsResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationResponse;
+import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetNewBlockResponse;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.AttestationData;
@@ -491,7 +492,26 @@ class OkHttpValidatorRestApiClientTest {
   }
 
   @Test
-  public void createAttestationData_WhenSuccess_ReturnsAttestation() {
+  public void createAttestationData_WhenSuccessWithData_ReturnsAttestationData() {
+    final UInt64 slot = UInt64.ONE;
+    final int committeeIndex = 1;
+    final GetAttestationDataResponse expectedAttestationData =
+        new GetAttestationDataResponse(schemaObjects.attestation().data);
+
+    mockWebServer.enqueue(
+        new MockResponse().setResponseCode(SC_OK).setBody(asJson(expectedAttestationData)));
+
+    Optional<AttestationData> attestationData =
+        apiClient.createAttestationData(slot, committeeIndex);
+
+    assertThat(attestationData).isPresent();
+    assertThat(attestationData.get())
+        .usingRecursiveComparison()
+        .isEqualTo(expectedAttestationData.data);
+  }
+
+  @Test
+  public void createAttestationData_WhenSuccessWithNonData_ReturnsAttestationData() {
     final UInt64 slot = UInt64.ONE;
     final int committeeIndex = 1;
     final AttestationData expectedAttestationData = schemaObjects.attestation().data;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Allow validator client to deserialize both new and legacy createAttestationData endpoint.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.