### PR TITLE
Move p2p options out of global configuration

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public class P2PConfig {
+
+  // P2P
+  private final boolean p2pEnabled;
+  private final String p2pInterface;
+  private final int p2pPort;
+  private final boolean p2pDiscoveryEnabled;
+  private final List<String> p2pDiscoveryBootnodes;
+  private final Optional<String> p2pAdvertisedIp;
+  private final OptionalInt p2pAdvertisedPort;
+  private final String p2pPrivateKeyFile;
+  private final int p2pPeerLowerBound;
+  private final int p2pPeerUpperBound;
+  private final int targetSubnetSubscriberCount;
+  private final List<String> p2pStaticPeers;
+  private final boolean multiPeerSyncEnabled;
+
+  private P2PConfig(
+      final boolean p2pEnabled,
+      final String p2pInterface,
+      final int p2pPort,
+      final boolean p2pDiscoveryEnabled,
+      final List<String> p2pDiscoveryBootnodes,
+      final Optional<String> p2pAdvertisedIp,
+      final OptionalInt p2pAdvertisedPort,
+      final String p2pPrivateKeyFile,
+      final int p2pPeerLowerBound,
+      final int p2pPeerUpperBound,
+      final int targetSubnetSubscriberCount,
+      final List<String> p2pStaticPeers,
+      final boolean multiPeerSyncEnabled) {
+    this.p2pEnabled = p2pEnabled;
+    this.p2pInterface = p2pInterface;
+    this.p2pPort = p2pPort;
+    this.p2pDiscoveryEnabled = p2pDiscoveryEnabled;
+    this.p2pDiscoveryBootnodes = p2pDiscoveryBootnodes;
+    this.p2pAdvertisedIp = p2pAdvertisedIp;
+    this.p2pAdvertisedPort = p2pAdvertisedPort;
+    this.p2pPrivateKeyFile = p2pPrivateKeyFile;
+    this.p2pPeerLowerBound = p2pPeerLowerBound;
+    this.p2pPeerUpperBound = p2pPeerUpperBound;
+    this.targetSubnetSubscriberCount = targetSubnetSubscriberCount;
+    this.p2pStaticPeers = p2pStaticPeers;
+    this.multiPeerSyncEnabled = multiPeerSyncEnabled;
+  }
+
+  public static P2PConfigBuilder builder() {
+    return new P2PConfigBuilder();
+  }
+
+  public boolean isP2pEnabled() {
+    return p2pEnabled;
+  }
+
+  public String getP2pInterface() {
+    return p2pInterface;
+  }
+
+  public int getP2pPort() {
+    return p2pPort;
+  }
+
+  public boolean isP2pDiscoveryEnabled() {
+    return p2pDiscoveryEnabled;
+  }
+
+  public List<String> getP2pDiscoveryBootnodes() {
+    return p2pDiscoveryBootnodes;
+  }
+
+  public Optional<String> getP2pAdvertisedIp() {
+    return p2pAdvertisedIp;
+  }
+
+  public OptionalInt getP2pAdvertisedPort() {
+    return p2pAdvertisedPort;
+  }
+
+  public String getP2pPrivateKeyFile() {
+    return p2pPrivateKeyFile;
+  }
+
+  public int getP2pPeerLowerBound() {
+    return p2pPeerLowerBound;
+  }
+
+  public int getP2pPeerUpperBound() {
+    return p2pPeerUpperBound;
+  }
+
+  public int getTargetSubnetSubscriberCount() {
+    return targetSubnetSubscriberCount;
+  }
+
+  public int getMinimumRandomlySelectedPeerCount() {
+    return Math.min(1, p2pPeerLowerBound * 2 / 10);
+  }
+
+  public List<String> getP2pStaticPeers() {
+    return p2pStaticPeers;
+  }
+
+  public boolean isMultiPeerSyncEnabled() {
+    return multiPeerSyncEnabled;
+  }
+
+  public static final class P2PConfigBuilder {
+
+    private boolean p2pEnabled;
+    private String p2pInterface;
+    private int p2pPort;
+    private boolean p2pDiscoveryEnabled;
+    private List<String> p2pDiscoveryBootnodes = new ArrayList<>();
+    private Optional<String> p2pAdvertisedIp;
+    private OptionalInt p2pAdvertisedPort;
+    private String p2pPrivateKeyFile;
+    private int p2pPeerLowerBound;
+    private int p2pPeerUpperBound;
+    private int targetSubnetSubscriberCount;
+    private List<String> p2pStaticPeers = new ArrayList<>();
+    private boolean multiPeerSyncEnabled;
+
+    private P2PConfigBuilder() {}
+
+    public P2PConfigBuilder p2pEnabled(boolean p2pEnabled) {
+      this.p2pEnabled = p2pEnabled;
+      return this;
+    }
+
+    public P2PConfigBuilder p2pInterface(String p2pInterface) {
+      this.p2pInterface = p2pInterface;
+      return this;
+    }
+
+    public P2PConfigBuilder p2pPort(int p2pPort) {
+      this.p2pPort = p2pPort;
+      return this;
+    }
+
+    public P2PConfigBuilder p2pDiscoveryEnabled(boolean p2pDiscoveryEnabled) {
+      this.p2pDiscoveryEnabled = p2pDiscoveryEnabled;
+      return this;
+    }
+
+    public P2PConfigBuilder p2pDiscoveryBootnodes(List<String> p2pDiscoveryBootnodes) {
+      this.p2pDiscoveryBootnodes = p2pDiscoveryBootnodes;
+      return this;
+    }
+
+    public P2PConfigBuilder p2pAdvertisedIp(Optional<String> p2pAdvertisedIp) {
+      this.p2pAdvertisedIp = p2pAdvertisedIp;
+      return this;
+    }
+
+    public P2PConfigBuilder p2pAdvertisedPort(OptionalInt p2pAdvertisedPort) {
+      this.p2pAdvertisedPort = p2pAdvertisedPort;
+      return this;
+    }
+
+    public P2PConfigBuilder p2pPrivateKeyFile(String p2pPrivateKeyFile) {
+      this.p2pPrivateKeyFile = p2pPrivateKeyFile;
+      return this;
+    }
+
+    public P2PConfigBuilder p2pPeerLowerBound(int p2pPeerLowerBound) {
+      this.p2pPeerLowerBound = p2pPeerLowerBound;
+      return this;
+    }
+
+    public P2PConfigBuilder p2pPeerUpperBound(int p2pPeerUpperBound) {
+      this.p2pPeerUpperBound = p2pPeerUpperBound;
+      return this;
+    }
+
+    public P2PConfigBuilder targetSubnetSubscriberCount(int targetSubnetSubscriberCount) {
+      this.targetSubnetSubscriberCount = targetSubnetSubscriberCount;
+      return this;
+    }
+
+    public P2PConfigBuilder p2pStaticPeers(List<String> p2pStaticPeers) {
+      this.p2pStaticPeers = p2pStaticPeers;
+      return this;
+    }
+
+    public P2PConfigBuilder multiPeerSyncEnabled(boolean multiPeerSyncEnabled) {
+      this.multiPeerSyncEnabled = multiPeerSyncEnabled;
+      return this;
+    }
+
+    public P2PConfig build() {
+      return new P2PConfig(
+          p2pEnabled,
+          p2pInterface,
+          p2pPort,
+          p2pDiscoveryEnabled,
+          p2pDiscoveryBootnodes,
+          p2pAdvertisedIp,
+          p2pAdvertisedPort,
+          p2pPrivateKeyFile,
+          p2pPeerLowerBound,
+          p2pPeerUpperBound,
+          targetSubnetSubscriberCount,
+          p2pStaticPeers,
+          multiPeerSyncEnabled);
+    }
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -20,7 +20,6 @@ import java.util.OptionalInt;
 
 public class P2PConfig {
 
-  // P2P
   private final boolean p2pEnabled;
   private final String p2pInterface;
   private final int p2pPort;

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainConfiguration.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainConfiguration.java
@@ -13,17 +13,22 @@
 
 package tech.pegasys.teku.services.beaconchain;
 
+import tech.pegasys.teku.networking.eth2.P2PConfig;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
 import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 
 public class BeaconChainConfiguration {
   private final WeakSubjectivityConfig weakSubjectivityConfig;
   private final ValidatorConfig validatorConfig;
+  private final P2PConfig p2pConfig;
 
   public BeaconChainConfiguration(
-      final WeakSubjectivityConfig weakSubjectivityConfig, final ValidatorConfig validatorConfig) {
+      final WeakSubjectivityConfig weakSubjectivityConfig,
+      final ValidatorConfig validatorConfig,
+      final P2PConfig p2pConfig) {
     this.weakSubjectivityConfig = weakSubjectivityConfig;
     this.validatorConfig = validatorConfig;
+    this.p2pConfig = p2pConfig;
   }
 
   public WeakSubjectivityConfig weakSubjectivity() {
@@ -32,5 +37,9 @@ public class BeaconChainConfiguration {
 
   public ValidatorConfig validatorConfig() {
     return validatorConfig;
+  }
+
+  public P2PConfig p2pConfig() {
+    return p2pConfig;
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -64,6 +64,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2Config;
 import tech.pegasys.teku.networking.eth2.Eth2Network;
 import tech.pegasys.teku.networking.eth2.Eth2NetworkBuilder;
+import tech.pegasys.teku.networking.eth2.P2PConfig;
 import tech.pegasys.teku.networking.eth2.gossip.subnets.AttestationTopicSubscriber;
 import tech.pegasys.teku.networking.eth2.gossip.subnets.StableSubnetSubscriber;
 import tech.pegasys.teku.networking.eth2.mock.NoOpEth2Network;
@@ -325,7 +326,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   private void initRecentBlockFetcher() {
     LOG.debug("BeaconChainController.initRecentBlockFetcher()");
-    if (!config.isP2pEnabled()) {
+    if (!beaconConfig.p2pConfig().isP2pEnabled()) {
       recentBlockFetcher = new NoopRecentBlockFetcher();
     } else {
       recentBlockFetcher = FetchRecentBlocksService.create(asyncRunner, p2pNetwork, pendingBlocks);
@@ -529,7 +530,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   public void initP2PNetwork() {
     LOG.debug("BeaconChainController.initP2PNetwork()");
-    if (!config.isP2pEnabled()) {
+    final P2PConfig configOptions = beaconConfig.p2pConfig();
+    if (!configOptions.isP2pEnabled()) {
       this.p2pNetwork = new NoOpEth2Network();
     } else {
       final KeyValueStore<String, Bytes> keyValueStore =
@@ -539,18 +541,18 @@ public class BeaconChainController extends Service implements TimeTickChannel {
       final NetworkConfig p2pConfig =
           new NetworkConfig(
               pk,
-              config.getP2pInterface(),
-              config.getP2pAdvertisedIp(),
-              config.getP2pPort(),
-              config.getP2pAdvertisedPort(),
-              config.getP2pStaticPeers(),
-              config.isP2pDiscoveryEnabled(),
-              config.getP2pDiscoveryBootnodes(),
+              configOptions.getP2pInterface(),
+              configOptions.getP2pAdvertisedIp(),
+              configOptions.getP2pPort(),
+              configOptions.getP2pAdvertisedPort(),
+              configOptions.getP2pStaticPeers(),
+              configOptions.isP2pDiscoveryEnabled(),
+              configOptions.getP2pDiscoveryBootnodes(),
               new TargetPeerRange(
-                  config.getP2pPeerLowerBound(),
-                  config.getP2pPeerUpperBound(),
-                  config.getMinimumRandomlySelectedPeerCount()),
-              config.getTargetSubnetSubscriberCount(),
+                  configOptions.getP2pPeerLowerBound(),
+                  configOptions.getP2pPeerUpperBound(),
+                  configOptions.getMinimumRandomlySelectedPeerCount()),
+              configOptions.getTargetSubnetSubscriberCount(),
               GossipConfig.DEFAULT_CONFIG,
               new WireLogsConfig(
                   config.isLogWireCipher(),
@@ -610,7 +612,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   @VisibleForTesting
   Bytes getP2pPrivateKeyBytes(KeyValueStore<String, Bytes> keyValueStore) {
     final Bytes privateKey;
-    final String p2pPrivateKeyFile = config.getP2pPrivateKeyFile();
+    final String p2pPrivateKeyFile = beaconConfig.p2pConfig().getP2pPrivateKeyFile();
     if (p2pPrivateKeyFile != null) {
       try {
         privateKey = Bytes.fromHexString(Files.readString(Paths.get(p2pPrivateKeyFile)));
@@ -685,9 +687,9 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   public void initSyncManager() {
     LOG.debug("BeaconChainController.initSyncManager()");
-    if (!config.isP2pEnabled()) {
+    if (!beaconConfig.p2pConfig().isP2pEnabled()) {
       syncService = new NoopSyncService();
-    } else if (config.isMultiPeerSyncEnabled()) {
+    } else if (beaconConfig.p2pConfig().isMultiPeerSyncEnabled()) {
       syncService =
           MultipeerSyncService.create(
               asyncRunnerFactory,

--- a/teku/build.gradle
+++ b/teku/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   implementation project(':infrastructure:async')
   implementation project(':infrastructure:logging')
   implementation project(':networking:p2p')
+  implementation project(':networking:eth2')
   implementation project(':protoarray')
   implementation project(':pow')
   implementation project(':services:beaconchain')

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -324,11 +324,14 @@ public class BeaconNodeCommand implements Callable<Integer> {
   protected TekuConfiguration tekuConfiguration() {
     try {
       TekuConfiguration.Builder builder = TekuConfiguration.builder();
-
-      builder.globalConfig(this::buildGlobalConfiguration);
+      final NetworkDefinition networkDefinition =
+          NetworkDefinition.fromCliArg(networkOptions.getNetwork());
+      builder.globalConfig(
+          globalBuilder -> buildGlobalConfiguration(globalBuilder, networkDefinition));
       weakSubjectivityOptions.configure(builder);
       validatorOptions.configure(builder);
       dataOptions.configure(builder);
+      p2POptions.configure(builder, networkDefinition);
 
       return builder.build();
     } catch (IllegalArgumentException e) {
@@ -336,26 +339,14 @@ public class BeaconNodeCommand implements Callable<Integer> {
     }
   }
 
-  private void buildGlobalConfiguration(final GlobalConfigurationBuilder builder) {
+  private void buildGlobalConfiguration(
+      final GlobalConfigurationBuilder builder, final NetworkDefinition networkDefinition) {
     builder
-        .setNetwork(NetworkDefinition.fromCliArg(networkOptions.getNetwork()))
+        .setNetwork(networkDefinition)
         .setStartupTargetPeerCount(networkOptions.getStartupTargetPeerCount())
         .setStartupTimeoutSeconds(networkOptions.getStartupTimeoutSeconds())
         .setPeerRateLimit(networkOptions.getPeerRateLimit())
         .setPeerRequestLimit(networkOptions.getPeerRequestLimit())
-        .setP2pEnabled(p2POptions.isP2pEnabled())
-        .setP2pInterface(p2POptions.getP2pInterface())
-        .setP2pPort(p2POptions.getP2pPort())
-        .setP2pDiscoveryEnabled(p2POptions.isP2pDiscoveryEnabled())
-        .setP2pDiscoveryBootnodes(p2POptions.getP2pDiscoveryBootnodes())
-        .setP2pAdvertisedIp(p2POptions.getP2pAdvertisedIp())
-        .setP2pAdvertisedPort(p2POptions.getP2pAdvertisedPort())
-        .setP2pPrivateKeyFile(p2POptions.getP2pPrivateKeyFile())
-        .setP2pPeerLowerBound(p2POptions.getP2pLowerBound())
-        .setP2pPeerUpperBound(p2POptions.getP2pUpperBound())
-        .setTargetSubnetSubscriberCount(p2POptions.getP2pTargetSubnetSubscriberCount())
-        .setP2pStaticPeers(p2POptions.getP2pStaticPeers())
-        .setMultiPeerSyncEnabled(p2POptions.isMultiPeerSyncEnabled())
         .setInteropGenesisTime(interopOptions.getInteropGenesisTime())
         .setInteropOwnedValidatorStartIndex(interopOptions.getInteropOwnerValidatorStartIndex())
         .setInteropOwnedValidatorCount(interopOptions.getInteropOwnerValidatorCount())

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import picocli.CommandLine.Option;
+import tech.pegasys.teku.config.TekuConfiguration;
+import tech.pegasys.teku.util.config.NetworkDefinition;
 
 public class P2POptions {
 
@@ -120,39 +122,7 @@ public class P2POptions {
       arity = "1")
   private boolean multiPeerSyncEnabled = false;
 
-  public boolean isP2pEnabled() {
-    return p2pEnabled;
-  }
-
-  public String getP2pInterface() {
-    return p2pInterface;
-  }
-
-  public int getP2pPort() {
-    return p2pPort;
-  }
-
-  public boolean isP2pDiscoveryEnabled() {
-    return p2pDiscoveryEnabled;
-  }
-
-  public List<String> getP2pDiscoveryBootnodes() {
-    return p2pDiscoveryBootnodes;
-  }
-
-  public Optional<String> getP2pAdvertisedIp() {
-    return Optional.ofNullable(p2pAdvertisedIp);
-  }
-
-  public OptionalInt getP2pAdvertisedPort() {
-    return p2pAdvertisedPort == null ? OptionalInt.empty() : OptionalInt.of(p2pAdvertisedPort);
-  }
-
-  public String getP2pPrivateKeyFile() {
-    return p2pPrivateKeyFile;
-  }
-
-  public int getP2pLowerBound() {
+  private int getP2pLowerBound() {
     if (p2pLowerBound > p2pUpperBound) {
       STATUS_LOG.adjustingP2pLowerBoundToUpperBound(p2pUpperBound);
       return p2pUpperBound;
@@ -161,7 +131,7 @@ public class P2POptions {
     }
   }
 
-  public int getP2pUpperBound() {
+  private int getP2pUpperBound() {
     if (p2pUpperBound < p2pLowerBound) {
       STATUS_LOG.adjustingP2pUpperBoundToLowerBound(p2pLowerBound);
       return p2pLowerBound;
@@ -170,15 +140,29 @@ public class P2POptions {
     }
   }
 
-  public int getP2pTargetSubnetSubscriberCount() {
-    return p2pTargetSubnetSubscriberCount;
-  }
-
-  public List<String> getP2pStaticPeers() {
-    return p2pStaticPeers;
-  }
-
-  public boolean isMultiPeerSyncEnabled() {
-    return multiPeerSyncEnabled;
+  public void configure(
+      final TekuConfiguration.Builder builder, final NetworkDefinition networkDefinition) {
+    builder.p2p(
+        p2pBuilder ->
+            p2pBuilder
+                .p2pEnabled(p2pEnabled)
+                .p2pInterface(p2pInterface)
+                .p2pPort(p2pPort)
+                .p2pDiscoveryEnabled(p2pDiscoveryEnabled)
+                .p2pDiscoveryBootnodes(
+                    p2pDiscoveryBootnodes == null
+                        ? networkDefinition.getDiscoveryBootnodes()
+                        : p2pDiscoveryBootnodes)
+                .p2pAdvertisedIp(Optional.ofNullable(p2pAdvertisedIp))
+                .p2pAdvertisedPort(
+                    p2pAdvertisedPort == null
+                        ? OptionalInt.empty()
+                        : OptionalInt.of(p2pAdvertisedPort))
+                .p2pPrivateKeyFile(p2pPrivateKeyFile)
+                .p2pPeerLowerBound(getP2pLowerBound())
+                .p2pPeerUpperBound(getP2pUpperBound())
+                .targetSubnetSubscriberCount(p2pTargetSubnetSubscriberCount)
+                .p2pStaticPeers(p2pStaticPeers)
+                .multiPeerSyncEnabled(multiPeerSyncEnabled));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.config;
 
 import java.util.function.Consumer;
+import tech.pegasys.teku.networking.eth2.P2PConfig;
+import tech.pegasys.teku.networking.eth2.P2PConfig.P2PConfigBuilder;
 import tech.pegasys.teku.service.serviceutils.layout.DataConfig;
 import tech.pegasys.teku.services.beaconchain.BeaconChainConfiguration;
 import tech.pegasys.teku.util.config.GlobalConfiguration;
@@ -33,11 +35,13 @@ public class TekuConfiguration {
       GlobalConfiguration globalConfiguration,
       WeakSubjectivityConfig weakSubjectivityConfig,
       final ValidatorConfig validatorConfig,
-      final DataConfig dataConfig) {
+      final DataConfig dataConfig,
+      final P2PConfig p2pConfig) {
     this.globalConfiguration = globalConfiguration;
     this.weakSubjectivityConfig = weakSubjectivityConfig;
     this.dataConfig = dataConfig;
-    this.beaconChainConfig = new BeaconChainConfiguration(weakSubjectivityConfig, validatorConfig);
+    this.beaconChainConfig =
+        new BeaconChainConfiguration(weakSubjectivityConfig, validatorConfig, p2pConfig);
     this.validatorClientConfig =
         new ValidatorClientConfiguration(globalConfiguration, validatorConfig, dataConfig);
   }
@@ -77,6 +81,7 @@ public class TekuConfiguration {
         WeakSubjectivityConfig.builder();
     private final ValidatorConfig.Builder validatorConfigBuilder = ValidatorConfig.builder();
     private final DataConfig.Builder dataConfigBuilder = DataConfig.builder();
+    private final P2PConfigBuilder p2pConfigBuilder = P2PConfig.builder();
 
     private Builder() {}
 
@@ -85,7 +90,8 @@ public class TekuConfiguration {
           globalConfigurationBuilder.build(),
           weakSubjectivityBuilder.build(),
           validatorConfigBuilder.build(),
-          dataConfigBuilder.build());
+          dataConfigBuilder.build(),
+          p2pConfigBuilder.build());
     }
 
     public Builder globalConfig(final Consumer<GlobalConfigurationBuilder> globalConfigConsumer) {
@@ -106,6 +112,11 @@ public class TekuConfiguration {
 
     public Builder data(final Consumer<DataConfig.Builder> dataConfigConsumer) {
       dataConfigConsumer.accept(dataConfigBuilder);
+      return this;
+    }
+
+    public Builder p2p(final Consumer<P2PConfigBuilder> p2pConfigConsumer) {
+      p2pConfigConsumer.accept(p2pConfigBuilder);
       return this;
     }
   }

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -281,29 +281,30 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   private TekuConfiguration.Builder expectedDefaultConfigurationBuilder() {
+    final NetworkDefinition networkDefinition = NetworkDefinition.fromCliArg("medalla");
     return expectedConfigurationBuilder()
         .globalConfig(
-            b -> {
-              b.setNetwork(NetworkDefinition.fromCliArg("medalla"))
-                  .setEth1DepositContractAddress(null)
-                  .setEth1Endpoint(null)
-                  .setMetricsCategories(
-                      DEFAULT_METRICS_CATEGORIES.stream()
-                          .map(Object::toString)
-                          .collect(Collectors.toList()))
-                  .setInteropEnabled(false)
-                  .setPeerRateLimit(500)
-                  .setPeerRequestLimit(50)
-                  .setInteropGenesisTime(0)
-                  .setInteropOwnedValidatorCount(0)
-                  .setLogDestination(DEFAULT_BOTH)
-                  .setLogFile(DEFAULT_LOG_FILE)
-                  .setLogFileNamePattern(DEFAULT_LOG_FILE_NAME_PATTERN);
-            })
+            b ->
+                b.setNetwork(networkDefinition)
+                    .setEth1DepositContractAddress(null)
+                    .setEth1Endpoint(null)
+                    .setMetricsCategories(
+                        DEFAULT_METRICS_CATEGORIES.stream()
+                            .map(Object::toString)
+                            .collect(Collectors.toList()))
+                    .setInteropEnabled(false)
+                    .setPeerRateLimit(500)
+                    .setPeerRequestLimit(50)
+                    .setInteropGenesisTime(0)
+                    .setInteropOwnedValidatorCount(0)
+                    .setLogDestination(DEFAULT_BOTH)
+                    .setLogFile(DEFAULT_LOG_FILE)
+                    .setLogFileNamePattern(DEFAULT_LOG_FILE_NAME_PATTERN))
         .p2p(
             b ->
                 b.p2pAdvertisedPort(OptionalInt.empty())
                     .p2pDiscoveryEnabled(true)
+                    .p2pDiscoveryBootnodes(networkDefinition.getDiscoveryBootnodes())
                     .p2pInterface("0.0.0.0")
                     .p2pPort(9000)
                     .p2pPrivateKeyFile(null))

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -120,9 +120,9 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
 
     TekuConfiguration expected =
         expectedConfigurationBuilder()
-            .globalConfig(
+            .p2p(
                 b -> {
-                  b.setP2pInterface("1.2.3.5");
+                  b.p2pInterface("1.2.3.5");
                 })
             .build();
     assertTekuConfiguration(expected);
@@ -143,9 +143,9 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
 
     final TekuConfiguration expected =
         expectedCompleteConfigInFileBuilder()
-            .globalConfig(
+            .p2p(
                 b -> {
-                  b.setP2pInterface("1.2.3.5");
+                  b.p2pInterface("1.2.3.5");
                 })
             .build();
     assertTekuConfiguration(expected);
@@ -162,9 +162,9 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
 
     final TekuConfiguration expected =
         expectedCompleteConfigInFileBuilder()
-            .globalConfig(
+            .p2p(
                 b -> {
-                  b.setP2pInterface("1.2.3.5");
+                  b.p2pInterface("1.2.3.5");
                 })
             .build();
     assertTekuConfiguration(expected);
@@ -291,11 +291,6 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                       DEFAULT_METRICS_CATEGORIES.stream()
                           .map(Object::toString)
                           .collect(Collectors.toList()))
-                  .setP2pAdvertisedPort(OptionalInt.empty())
-                  .setP2pDiscoveryEnabled(true)
-                  .setP2pInterface("0.0.0.0")
-                  .setP2pPort(9000)
-                  .setP2pPrivateKeyFile(null)
                   .setInteropEnabled(false)
                   .setPeerRateLimit(500)
                   .setPeerRequestLimit(50)
@@ -305,6 +300,13 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                   .setLogFile(DEFAULT_LOG_FILE)
                   .setLogFileNamePattern(DEFAULT_LOG_FILE_NAME_PATTERN);
             })
+        .p2p(
+            b ->
+                b.p2pAdvertisedPort(OptionalInt.empty())
+                    .p2pDiscoveryEnabled(true)
+                    .p2pInterface("0.0.0.0")
+                    .p2pPort(9000)
+                    .p2pPrivateKeyFile(null))
         .validator(b -> b.validatorKeystoreLockingEnabled(true));
   }
 
@@ -322,6 +324,19 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
     return TekuConfiguration.builder()
         .globalConfig(this::buildExpectedGlobalConfiguration)
         .data(b -> b.dataBasePath(dataPath))
+        .p2p(
+            b ->
+                b.p2pEnabled(false)
+                    .p2pInterface("1.2.3.4")
+                    .p2pPort(1234)
+                    .p2pDiscoveryEnabled(false)
+                    .p2pAdvertisedPort(OptionalInt.of(9000))
+                    .p2pAdvertisedIp(Optional.empty())
+                    .p2pPrivateKeyFile("path/to/file")
+                    .p2pPeerLowerBound(64)
+                    .p2pPeerUpperBound(74)
+                    .targetSubnetSubscriberCount(2)
+                    .p2pStaticPeers(Collections.emptyList()))
         .validator(
             b -> b.validatorExternalSignerTimeout(1000).validatorKeystoreLockingEnabled(true));
   }
@@ -330,20 +345,9 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
     Eth1Address address = Eth1Address.fromHexString("0x77f7bED277449F51505a4C54550B074030d989bC");
     builder
         .setNetwork(NetworkDefinition.fromCliArg("minimal"))
-        .setP2pEnabled(false)
-        .setP2pInterface("1.2.3.4")
+        .setInteropGenesisTime(1)
         .setPeerRateLimit(500)
         .setPeerRequestLimit(50)
-        .setP2pPort(1234)
-        .setP2pDiscoveryEnabled(false)
-        .setP2pAdvertisedPort(OptionalInt.of(9000))
-        .setP2pAdvertisedIp(Optional.empty())
-        .setP2pPrivateKeyFile("path/to/file")
-        .setP2pPeerLowerBound(64)
-        .setP2pPeerUpperBound(74)
-        .setTargetSubnetSubscriberCount(2)
-        .setP2pStaticPeers(Collections.emptyList())
-        .setInteropGenesisTime(1)
         .setInteropOwnedValidatorStartIndex(0)
         .setInteropOwnedValidatorCount(64)
         .setInteropNumberOfValidators(64)

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/NetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/NetworkOptionsTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
+import tech.pegasys.teku.config.TekuConfiguration;
+import tech.pegasys.teku.networking.eth2.P2PConfig;
 import tech.pegasys.teku.util.config.GlobalConfiguration;
 import tech.pegasys.teku.util.config.NetworkDefinition;
 
@@ -38,8 +40,9 @@ public class NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
     final NetworkDefinition networkDefinition = NetworkDefinition.fromCliArg(networkName);
 
     beaconNodeCommand.parse(new String[] {"--network", networkName});
-    final GlobalConfiguration config = getResultingGlobalConfiguration();
-    assertThat(config.getP2pDiscoveryBootnodes())
+    final TekuConfiguration tekuConfig = getResultingTekuConfiguration();
+    final GlobalConfiguration config = tekuConfig.global();
+    assertThat(tekuConfig.beaconChain().p2pConfig().getP2pDiscoveryBootnodes())
         .isEqualTo(networkDefinition.getDiscoveryBootnodes());
     assertThat(config.getConstants()).isEqualTo(networkDefinition.getConstants());
     assertThat(config.getInitialState())
@@ -58,8 +61,8 @@ public class NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
   public void overrideDefaultBootnodesWithEmptyList() {
     beaconNodeCommand.parse(new String[] {"--network", "topaz", "--p2p-discovery-bootnodes"});
 
-    final GlobalConfiguration globalConfiguration = getResultingGlobalConfiguration();
-    assertThat(globalConfiguration.getP2pDiscoveryBootnodes()).isEmpty();
+    final P2PConfig config = getResultingTekuConfiguration().beaconChain().p2pConfig();
+    assertThat(config.getP2pDiscoveryBootnodes()).isEmpty();
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -19,13 +19,14 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
-import tech.pegasys.teku.util.config.GlobalConfiguration;
+import tech.pegasys.teku.networking.eth2.P2PConfig;
 
 public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
   public void shouldReadFromConfigurationFile() {
-    final GlobalConfiguration config = getGlobalConfigurationFromFile("P2POptions_config.yaml");
+    final P2PConfig config =
+        getTekuConfigurationFromFile("P2POptions_config.yaml").beaconChain().p2pConfig();
 
     assertThat(config.getP2pAdvertisedIp()).isEqualTo(Optional.of("127.200.0.1"));
     assertThat(config.getP2pInterface()).isEqualTo("127.100.0.1");
@@ -41,39 +42,47 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
   public void p2pEnabled_shouldNotRequireAValue() {
-    final GlobalConfiguration globalConfiguration =
-        getGlobalConfigurationFromArguments("--p2p-enabled");
+    final P2PConfig globalConfiguration =
+        getTekuConfigurationFromArguments("--p2p-enabled").beaconChain().p2pConfig();
     assertThat(globalConfiguration.isP2pEnabled()).isTrue();
   }
 
   @Test
   public void p2pDiscoveryEnabled_shouldNotRequireAValue() {
-    final GlobalConfiguration globalConfiguration =
-        getGlobalConfigurationFromArguments("--p2p-discovery-enabled");
+    final P2PConfig globalConfiguration =
+        getTekuConfigurationFromArguments("--p2p-discovery-enabled").beaconChain().p2pConfig();
     assertThat(globalConfiguration.isP2pEnabled()).isTrue();
   }
 
   @Test
   public void advertisedIp_shouldDefaultToEmpty() {
-    assertThat(getGlobalConfigurationFromArguments().getP2pAdvertisedIp()).isEmpty();
+    assertThat(getTekuConfigurationFromArguments().beaconChain().p2pConfig().getP2pAdvertisedIp())
+        .isEmpty();
   }
 
   @Test
   public void advertisedIp_shouldAcceptValue() {
     final String ip = "10.0.1.200";
-    assertThat(getGlobalConfigurationFromArguments("--p2p-advertised-ip", ip).getP2pAdvertisedIp())
+    assertThat(
+            getTekuConfigurationFromArguments("--p2p-advertised-ip", ip)
+                .beaconChain()
+                .p2pConfig()
+                .getP2pAdvertisedIp())
         .contains(ip);
   }
 
   @Test
   public void advertisedPort_shouldDefaultToEmpty() {
-    assertThat(getGlobalConfigurationFromArguments().getP2pAdvertisedPort()).isEmpty();
+    assertThat(getTekuConfigurationFromArguments().beaconChain().p2pConfig().getP2pAdvertisedPort())
+        .isEmpty();
   }
 
   @Test
   public void advertisedPort_shouldAcceptValue() {
     assertThat(
-            getGlobalConfigurationFromArguments("--p2p-advertised-port", "8056")
+            getTekuConfigurationFromArguments("--p2p-advertised-port", "8056")
+                .beaconChain()
+                .p2pConfig()
                 .getP2pAdvertisedPort())
         .hasValue(8056);
   }

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
@@ -14,8 +14,6 @@
 package tech.pegasys.teku.util.config;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
 import org.apache.commons.lang3.StringUtils;
 import tech.pegasys.teku.infrastructure.logging.LoggingDestination;
 import tech.pegasys.teku.infrastructure.metrics.MetricsConfig;
@@ -30,21 +28,6 @@ public class GlobalConfiguration implements MetricsConfig {
   private final Integer startupTimeoutSeconds;
   private final Integer peerRateLimit;
   private final Integer peerRequestLimit;
-
-  // P2P
-  private final boolean p2pEnabled;
-  private final String p2pInterface;
-  private final int p2pPort;
-  private final boolean p2pDiscoveryEnabled;
-  private final List<String> p2pDiscoveryBootnodes;
-  private final Optional<String> p2pAdvertisedIp;
-  private final OptionalInt p2pAdvertisedPort;
-  private final String p2pPrivateKeyFile;
-  private final int p2pPeerLowerBound;
-  private final int p2pPeerUpperBound;
-  private final int targetSubnetSubscriberCount;
-  private final List<String> p2pStaticPeers;
-  private final boolean multiPeerSyncEnabled;
 
   // Interop
   private final Integer interopGenesisTime;
@@ -106,19 +89,6 @@ public class GlobalConfiguration implements MetricsConfig {
       final Integer startupTimeoutSeconds,
       final Integer peerRateLimit,
       final Integer peerRequestLimit,
-      final boolean p2pEnabled,
-      final String p2pInterface,
-      final int p2pPort,
-      final boolean p2pDiscoveryEnabled,
-      final List<String> p2pDiscoveryBootnodes,
-      final Optional<String> p2pAdvertisedIp,
-      final OptionalInt p2pAdvertisedPort,
-      final String p2pPrivateKeyFile,
-      final int p2pPeerLowerBound,
-      final int p2pPeerUpperBound,
-      final int targetSubnetSubscriberCount,
-      final List<String> p2pStaticPeers,
-      final boolean multiPeerSyncEnabled,
       final Integer interopGenesisTime,
       final int interopOwnedValidatorStartIndex,
       final int interopOwnedValidatorCount,
@@ -159,19 +129,6 @@ public class GlobalConfiguration implements MetricsConfig {
     this.startupTimeoutSeconds = startupTimeoutSeconds;
     this.peerRateLimit = peerRateLimit;
     this.peerRequestLimit = peerRequestLimit;
-    this.p2pEnabled = p2pEnabled;
-    this.p2pInterface = p2pInterface;
-    this.p2pPort = p2pPort;
-    this.p2pDiscoveryEnabled = p2pDiscoveryEnabled;
-    this.p2pDiscoveryBootnodes = p2pDiscoveryBootnodes;
-    this.p2pAdvertisedIp = p2pAdvertisedIp;
-    this.p2pAdvertisedPort = p2pAdvertisedPort;
-    this.p2pPrivateKeyFile = p2pPrivateKeyFile;
-    this.p2pPeerLowerBound = p2pPeerLowerBound;
-    this.p2pPeerUpperBound = p2pPeerUpperBound;
-    this.targetSubnetSubscriberCount = targetSubnetSubscriberCount;
-    this.p2pStaticPeers = p2pStaticPeers;
-    this.multiPeerSyncEnabled = multiPeerSyncEnabled;
     this.interopGenesisTime = interopGenesisTime;
     this.interopOwnedValidatorStartIndex = interopOwnedValidatorStartIndex;
     this.interopOwnedValidatorCount = interopOwnedValidatorCount;
@@ -227,62 +184,6 @@ public class GlobalConfiguration implements MetricsConfig {
 
   public int getPeerRequestLimit() {
     return peerRequestLimit;
-  }
-
-  public boolean isP2pEnabled() {
-    return p2pEnabled;
-  }
-
-  public String getP2pInterface() {
-    return p2pInterface;
-  }
-
-  public int getP2pPort() {
-    return p2pPort;
-  }
-
-  public boolean isP2pDiscoveryEnabled() {
-    return p2pDiscoveryEnabled;
-  }
-
-  public List<String> getP2pDiscoveryBootnodes() {
-    return p2pDiscoveryBootnodes;
-  }
-
-  public Optional<String> getP2pAdvertisedIp() {
-    return p2pAdvertisedIp;
-  }
-
-  public OptionalInt getP2pAdvertisedPort() {
-    return p2pAdvertisedPort;
-  }
-
-  public String getP2pPrivateKeyFile() {
-    return p2pPrivateKeyFile;
-  }
-
-  public int getP2pPeerLowerBound() {
-    return p2pPeerLowerBound;
-  }
-
-  public int getP2pPeerUpperBound() {
-    return p2pPeerUpperBound;
-  }
-
-  public int getMinimumRandomlySelectedPeerCount() {
-    return Math.min(1, p2pPeerLowerBound * 2 / 10);
-  }
-
-  public int getTargetSubnetSubscriberCount() {
-    return targetSubnetSubscriberCount;
-  }
-
-  public List<String> getP2pStaticPeers() {
-    return p2pStaticPeers;
-  }
-
-  public boolean isMultiPeerSyncEnabled() {
-    return multiPeerSyncEnabled;
   }
 
   public Integer getInteropGenesisTime() {

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.util.config;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.function.Supplier;
 import tech.pegasys.teku.infrastructure.logging.LoggingDestination;
 
@@ -31,19 +30,6 @@ public class GlobalConfigurationBuilder {
   private Integer startupTimeoutSeconds;
   private Integer peerRateLimit;
   private Integer peerRequestLimit;
-  private boolean p2pEnabled;
-  private String p2pInterface;
-  private int p2pPort;
-  private boolean p2pDiscoveryEnabled;
-  private List<String> p2pDiscoveryBootnodes;
-  private Optional<String> p2pAdvertisedIp = Optional.empty();
-  private OptionalInt p2pAdvertisedPort = OptionalInt.empty();
-  private String p2pPrivateKeyFile;
-  private int p2pPeerLowerBound;
-  private int p2pPeerUpperBound;
-  private int targetSubnetSubscriberCount;
-  private List<String> p2pStaticPeers;
-  private boolean multiPeerSyncEnabled = false;
   private Integer interopGenesisTime;
   private int interopOwnedValidatorStartIndex;
   private int interopOwnedValidatorCount;
@@ -104,73 +90,6 @@ public class GlobalConfigurationBuilder {
 
   public GlobalConfigurationBuilder setPeerRequestLimit(final Integer peerRequestLimit) {
     this.peerRequestLimit = peerRequestLimit;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setP2pEnabled(final boolean p2pEnabled) {
-    this.p2pEnabled = p2pEnabled;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setP2pInterface(final String p2pInterface) {
-    this.p2pInterface = p2pInterface;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setP2pPort(final int p2pPort) {
-    this.p2pPort = p2pPort;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setP2pDiscoveryEnabled(final boolean p2pDiscoveryEnabled) {
-    this.p2pDiscoveryEnabled = p2pDiscoveryEnabled;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setP2pDiscoveryBootnodes(
-      final List<String> p2pDiscoveryBootnodes) {
-    this.p2pDiscoveryBootnodes = p2pDiscoveryBootnodes;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setP2pAdvertisedIp(final Optional<String> p2pAdvertisedIp) {
-    this.p2pAdvertisedIp = p2pAdvertisedIp;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setP2pAdvertisedPort(final OptionalInt p2pAdvertisedPort) {
-    this.p2pAdvertisedPort = p2pAdvertisedPort;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setP2pPrivateKeyFile(final String p2pPrivateKeyFile) {
-    this.p2pPrivateKeyFile = p2pPrivateKeyFile;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setP2pPeerLowerBound(final int p2pPeerLowerBound) {
-    this.p2pPeerLowerBound = p2pPeerLowerBound;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setP2pPeerUpperBound(final int p2pPeerUpperBound) {
-    this.p2pPeerUpperBound = p2pPeerUpperBound;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setTargetSubnetSubscriberCount(
-      final int targetSubnetSubscriberCount) {
-    this.targetSubnetSubscriberCount = targetSubnetSubscriberCount;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setP2pStaticPeers(final List<String> p2pStaticPeers) {
-    this.p2pStaticPeers = p2pStaticPeers;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setMultiPeerSyncEnabled(final boolean multiPeerSyncEnabled) {
-    this.multiPeerSyncEnabled = multiPeerSyncEnabled;
     return this;
   }
 
@@ -377,7 +296,6 @@ public class GlobalConfigurationBuilder {
           getOrDefault(startupTimeoutSeconds, network::getStartupTimeoutSeconds);
       eth1DepositContractAddress =
           getOrOptionalDefault(eth1DepositContractAddress, network::getEth1DepositContractAddress);
-      p2pDiscoveryBootnodes = getOrDefault(p2pDiscoveryBootnodes, network::getDiscoveryBootnodes);
       eth1Endpoint = getOrOptionalDefault(eth1Endpoint, network::getEth1Endpoint);
     }
 
@@ -392,19 +310,6 @@ public class GlobalConfigurationBuilder {
         startupTimeoutSeconds,
         peerRateLimit,
         peerRequestLimit,
-        p2pEnabled,
-        p2pInterface,
-        p2pPort,
-        p2pDiscoveryEnabled,
-        p2pDiscoveryBootnodes,
-        p2pAdvertisedIp,
-        p2pAdvertisedPort,
-        p2pPrivateKeyFile,
-        p2pPeerLowerBound,
-        p2pPeerUpperBound,
-        targetSubnetSubscriberCount,
-        p2pStaticPeers,
-        multiPeerSyncEnabled,
         interopGenesisTime,
         interopOwnedValidatorStartIndex,
         interopOwnedValidatorCount,


### PR DESCRIPTION
## PR Description
Move p2p options out of global configuration to the new config approach.  Preps the way for adding a new option.

## Fixed Issue(s)
#2808 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.