### PR TITLE
Reject gossiped blocks before loading the state when possible

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/BlockValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/BlockValidator.java
@@ -67,14 +67,14 @@ public class BlockValidator {
       return SafeFuture.completedFuture(InternalValidationResult.IGNORE);
     }
 
-    if (recentChainData.containsBlock(block.getRoot())) {
-      LOG.trace("Block is already imported");
-      return SafeFuture.completedFuture(InternalValidationResult.IGNORE);
-    }
-
     if (blockIsFromFutureSlot(block)) {
       LOG.trace("BlockValidator: Block is from the future. It will be saved for future processing");
       return SafeFuture.completedFuture(InternalValidationResult.SAVE_FOR_FUTURE);
+    }
+
+    if (recentChainData.containsBlock(block.getRoot())) {
+      LOG.trace("Block is already imported");
+      return SafeFuture.completedFuture(InternalValidationResult.IGNORE);
     }
 
     if (!recentChainData.containsBlock(block.getParent_root())) {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/BlockValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/validation/BlockValidatorTest.java
@@ -63,6 +63,15 @@ public class BlockValidatorTest {
   }
 
   @Test
+  void shouldIgnoreAlreadyImportedBlock() throws Exception {
+    final SignedBeaconBlock block =
+        beaconChainUtil.createAndImportBlockAtSlot(recentChainData.getHeadSlot().plus(ONE));
+
+    assertThat(blockValidator.validate(block))
+        .isCompletedWithValue(InternalValidationResult.IGNORE);
+  }
+
+  @Test
   void shouldReturnInvalidForSecondValidBlockForSlotAndProposer() throws Exception {
     final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
     beaconChainUtil.setSlot(nextSlot);


### PR DESCRIPTION
## PR Description
Perform block validations that don't require the state prior to fetching it so if the block is invalid we skip regenerating the state.

Ignore gossiped blocks that we've already imported.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.