### PR TITLE
[Issue-3063] Handle missing historical blocks for BlocksByRange requests

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -199,6 +199,10 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     return of(CompletableFuture.anyOf(futures));
   }
 
+  public SafeFuture<Void> toVoid() {
+    return thenAccept(__ -> {});
+  }
+
   @Override
   public <U> SafeFuture<U> newIncompleteFuture() {
     return new SafeFuture<>();

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
@@ -17,15 +17,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.infrastructure.async.Waiter.waitFor;
 
-import com.google.common.eventbus.EventBus;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -34,43 +33,40 @@ import tech.pegasys.teku.networking.eth2.rpc.core.ResponseStreamListener;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
-import tech.pegasys.teku.statetransition.BeaconChainUtil;
-import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
-import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
 public abstract class BeaconBlocksByRangeIntegrationTest {
 
   private final Eth2NetworkFactory networkFactory = new Eth2NetworkFactory();
-  private Eth2Peer peer1;
-  private RecentChainData recentChainData1;
-  private BeaconChainUtil beaconChainUtil;
+  private final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault();
+  private Eth2Peer peer;
 
   @BeforeEach
   public void setUp() throws Exception {
-    final EventBus eventBus1 = new EventBus();
+    final StorageSystem storageSystem2 = InMemoryStorageSystemBuilder.buildDefault();
     final RpcEncoding rpcEncoding = getEncoding();
-    recentChainData1 = MemoryOnlyRecentChainData.create(eventBus1);
-    beaconChainUtil = BeaconChainUtil.create(1, recentChainData1);
-    beaconChainUtil.initializeStorage();
+    storageSystem.chainUpdater().initializeGenesis();
+    storageSystem2.chainUpdater().initializeGenesis();
 
     final Eth2Network network1 =
         networkFactory
             .builder()
             .rpcEncoding(rpcEncoding)
-            .eventBus(eventBus1)
-            .recentChainData(recentChainData1)
+            .eventBus(storageSystem.eventBus())
+            .recentChainData(storageSystem.recentChainData())
+            .historicalChainData(storageSystem.chainStorage())
             .startNetwork();
 
-    final RecentChainData recentChainData2 = MemoryOnlyRecentChainData.create(new EventBus());
-    BeaconChainUtil.create(1, recentChainData2).initializeStorage();
     final Eth2Network network2 =
         networkFactory
             .builder()
             .rpcEncoding(rpcEncoding)
             .peer(network1)
-            .recentChainData(recentChainData2)
+            .recentChainData(storageSystem2.recentChainData())
+            .historicalChainData(storageSystem2.chainStorage())
             .startNetwork();
-    peer1 = network2.getPeer(network1.getNodeId()).orElseThrow();
+    peer = network2.getPeer(network1.getNodeId()).orElseThrow();
   }
 
   protected abstract RpcEncoding getEncoding();
@@ -94,30 +90,25 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
 
   @Test
   public void shouldRespondWithBlocksFromCanonicalChain() throws Exception {
-    final SignedBeaconBlock block1 = beaconChainUtil.createAndImportBlockAtSlot(1);
-    final Bytes32 block1Root = block1.getMessage().hash_tree_root();
-    recentChainData1.updateHead(block1Root, block1.getSlot());
-
-    final SignedBeaconBlock block2 = beaconChainUtil.createAndImportBlockAtSlot(2);
-    final Bytes32 block2Root = block2.getMessage().hash_tree_root();
-    recentChainData1.updateHead(block2Root, block2.getSlot());
+    final SignedBlockAndState block1 = storageSystem.chainUpdater().advanceChain();
+    final SignedBlockAndState block2 = storageSystem.chainUpdater().advanceChain();
+    storageSystem.chainUpdater().updateBestBlock(block2);
 
     final List<SignedBeaconBlock> response = requestBlocks();
-    assertThat(response).containsExactly(block1, block2);
+    assertThat(response).containsExactly(block1.getBlock(), block2.getBlock());
   }
 
   @Test
   public void requestBlocksByRangeAfterPeerDisconnectedImmediately() throws Exception {
     // Setup chain
-    beaconChainUtil.createAndImportBlockAtSlot(1);
-    final SignedBeaconBlock block2 = beaconChainUtil.createAndImportBlockAtSlot(2);
-    final Bytes32 block2Root = block2.getMessage().hash_tree_root();
-    recentChainData1.updateHead(block2Root, block2.getSlot());
+    storageSystem.chainUpdater().advanceChain();
+    final SignedBlockAndState block2 = storageSystem.chainUpdater().advanceChain();
+    storageSystem.chainUpdater().updateBestBlock(block2);
 
-    peer1.disconnectImmediately(Optional.empty(), false);
+    peer.disconnectImmediately(Optional.empty(), false);
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
     final SafeFuture<Void> res =
-        peer1.requestBlocksByRange(
+        peer.requestBlocksByRange(
             UInt64.ONE, UInt64.valueOf(10), UInt64.ONE, ResponseStreamListener.from(blocks::add));
 
     waitFor(() -> assertThat(res).isDone());
@@ -129,15 +120,14 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
   @Test
   public void requestBlocksByRangeAfterPeerDisconnected() throws Exception {
     // Setup chain
-    beaconChainUtil.createAndImportBlockAtSlot(1);
-    final SignedBeaconBlock block2 = beaconChainUtil.createAndImportBlockAtSlot(2);
-    final Bytes32 block2Root = block2.getMessage().hash_tree_root();
-    recentChainData1.updateHead(block2Root, block2.getSlot());
+    storageSystem.chainUpdater().advanceChain();
+    final SignedBlockAndState block2 = storageSystem.chainUpdater().advanceChain();
+    storageSystem.chainUpdater().updateBestBlock(block2);
 
-    Waiter.waitFor(peer1.disconnectCleanly(DisconnectReason.TOO_MANY_PEERS));
+    Waiter.waitFor(peer.disconnectCleanly(DisconnectReason.TOO_MANY_PEERS));
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
     final SafeFuture<Void> res =
-        peer1.requestBlocksByRange(
+        peer.requestBlocksByRange(
             UInt64.ONE, UInt64.valueOf(10), UInt64.ONE, ResponseStreamListener.from(blocks::add));
 
     waitFor(() -> assertThat(res).isDone());
@@ -149,13 +139,12 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
   @Test
   public void requestBlockBySlotAfterPeerDisconnectedImmediately() throws Exception {
     // Setup chain
-    beaconChainUtil.createAndImportBlockAtSlot(1);
-    final SignedBeaconBlock block2 = beaconChainUtil.createAndImportBlockAtSlot(2);
-    final Bytes32 block2Root = block2.getMessage().hash_tree_root();
-    recentChainData1.updateHead(block2Root, block2.getSlot());
+    storageSystem.chainUpdater().advanceChain();
+    final SignedBlockAndState block2 = storageSystem.chainUpdater().advanceChain();
+    storageSystem.chainUpdater().updateBestBlock(block2);
 
-    peer1.disconnectImmediately(Optional.empty(), false);
-    final SafeFuture<SignedBeaconBlock> res = peer1.requestBlockBySlot(UInt64.ONE);
+    peer.disconnectImmediately(Optional.empty(), false);
+    final SafeFuture<SignedBeaconBlock> res = peer.requestBlockBySlot(UInt64.ONE);
 
     waitFor(() -> assertThat(res).isDone());
     assertThat(res).isCompletedExceptionally();
@@ -165,13 +154,12 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
   @Test
   public void requestBlockByRootAfterPeerDisconnected() throws Exception {
     // Setup chain
-    beaconChainUtil.createAndImportBlockAtSlot(1);
-    final SignedBeaconBlock block2 = beaconChainUtil.createAndImportBlockAtSlot(2);
-    final Bytes32 block2Root = block2.getMessage().hash_tree_root();
-    recentChainData1.updateHead(block2Root, block2.getSlot());
+    storageSystem.chainUpdater().advanceChain();
+    final SignedBlockAndState block2 = storageSystem.chainUpdater().advanceChain();
+    storageSystem.chainUpdater().updateBestBlock(block2);
 
-    Waiter.waitFor(peer1.disconnectCleanly(DisconnectReason.TOO_MANY_PEERS));
-    final SafeFuture<SignedBeaconBlock> res = peer1.requestBlockBySlot(UInt64.ONE);
+    Waiter.waitFor(peer.disconnectCleanly(DisconnectReason.TOO_MANY_PEERS));
+    final SafeFuture<SignedBeaconBlock> res = peer.requestBlockBySlot(UInt64.ONE);
 
     waitFor(() -> assertThat(res).isDone());
     assertThat(res).isCompletedExceptionally();
@@ -183,7 +171,7 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
           java.util.concurrent.TimeoutException {
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
     waitFor(
-        peer1.requestBlocksByRange(
+        peer.requestBlocksByRange(
             UInt64.ONE, UInt64.valueOf(10), UInt64.ONE, ResponseStreamListener.from(blocks::add)));
     return blocks;
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -106,7 +106,7 @@ public class BeaconBlocksByRangeMessageHandler
     final UInt64 endSlot = message.getStartSlot().plus(message.getStep().times(count)).minus(ONE);
 
     return combinedChainDataClient
-        .getEarliestHistoricalBlockSlot()
+        .getEarliestAvailableBlockSlot()
         .thenCompose(
             earliestSlot -> {
               if (earliestSlot.map(s -> s.isGreaterThan(message.getStartSlot())).orElse(true)) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -105,24 +105,45 @@ public class BeaconBlocksByRangeMessageHandler
     final UInt64 count = maxRequestSize.min(message.getCount());
     final UInt64 endSlot = message.getStartSlot().plus(message.getStep().times(count)).minus(ONE);
 
-    final UInt64 headBlockSlot =
-        combinedChainDataClient.getBestBlock().map(SignedBeaconBlock::getSlot).orElse(ZERO);
-    final NavigableMap<UInt64, Bytes32> hotRoots;
-    if (combinedChainDataClient.isFinalized(endSlot)) {
-      // All blocks are finalized so skip scanning the protoarray
-      hotRoots = new TreeMap<>();
-    } else {
-      hotRoots =
-          combinedChainDataClient.getAncestorRoots(
-              message.getStartSlot(), message.getStep(), count);
-    }
-    // Don't send anything past the last slot found in protoarray to ensure blocks are consistent
-    // If we didn't find any blocks in protoarray, every block in the range must be finalized
-    // so we don't need to worry about inconsistent blocks
-    final UInt64 headSlot = hotRoots.isEmpty() ? headBlockSlot : hotRoots.lastKey();
-    return sendNextBlock(
-        new RequestState(
-            message.getStartSlot(), message.getStep(), count, headSlot, hotRoots, callback));
+    return combinedChainDataClient
+        .getEarliestHistoricalBlockSlot()
+        .thenCompose(
+            earliestSlot -> {
+              if (earliestSlot.map(s -> s.isGreaterThan(message.getStartSlot())).orElse(true)) {
+                // We're missing the first block, so we have nothing to send
+                return SafeFuture.COMPLETE;
+              }
+
+              final UInt64 headBlockSlot =
+                  combinedChainDataClient
+                      .getBestBlock()
+                      .map(SignedBeaconBlock::getSlot)
+                      .orElse(ZERO);
+              final NavigableMap<UInt64, Bytes32> hotRoots;
+              if (combinedChainDataClient.isFinalized(endSlot)) {
+                // All blocks are finalized so skip scanning the protoarray
+                hotRoots = new TreeMap<>();
+              } else {
+                hotRoots =
+                    combinedChainDataClient.getAncestorRoots(
+                        message.getStartSlot(), message.getStep(), count);
+              }
+              // Don't send anything past the last slot found in protoarray to ensure blocks are
+              // consistent
+              // If we didn't find any blocks in protoarray, every block in the range must be
+              // finalized
+              // so we don't need to worry about inconsistent blocks
+              final UInt64 headSlot = hotRoots.isEmpty() ? headBlockSlot : hotRoots.lastKey();
+              return sendNextBlock(
+                      new RequestState(
+                          message.getStartSlot(),
+                          message.getStep(),
+                          count,
+                          headSlot,
+                          hotRoots,
+                          callback))
+                  .toVoid();
+            });
   }
 
   private SafeFuture<RequestState> sendNextBlock(final RequestState requestState) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -110,8 +110,10 @@ public class BeaconBlocksByRangeMessageHandler
         .thenCompose(
             earliestSlot -> {
               if (earliestSlot.map(s -> s.isGreaterThan(message.getStartSlot())).orElse(true)) {
-                // We're missing the first block, so we have nothing to send
-                return SafeFuture.COMPLETE;
+                // We're missing the first block so return an error
+                return SafeFuture.failedFuture(
+                    new RpcException.HistoricalDataUnavailableException(
+                        "Requested historical blocks are currently unavailable"));
               }
 
               final UInt64 headBlockSlot =

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcException.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcException.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2.rpc.core;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.HISTORICAL_DATA_UNAVAILABLE;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.SERVER_ERROR_CODE;
 
@@ -71,6 +72,14 @@ public class RpcException extends Exception {
   public static class ChunkTooLongException extends RpcException {
     public ChunkTooLongException() {
       super(INVALID_REQUEST_CODE, "Chunk exceeds maximum allowed length");
+    }
+  }
+
+  // Custom errors
+  public static class HistoricalDataUnavailableException extends RpcException {
+
+    public HistoricalDataUnavailableException(final String errorMessage) {
+      super(HISTORICAL_DATA_UNAVAILABLE, errorMessage);
     }
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseStatus.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseStatus.java
@@ -21,5 +21,5 @@ public abstract class RpcResponseStatus {
   public static final byte SERVER_ERROR_CODE = 2;
 
   // Custom errors
-  public static final byte HISTORICAL_DATA_UNAVAILABLE = (byte) 128;
+  public static final byte HISTORICAL_DATA_UNAVAILABLE = (byte) 222;
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseStatus.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseStatus.java
@@ -19,4 +19,7 @@ public abstract class RpcResponseStatus {
   // Standard errors
   public static final byte INVALID_REQUEST_CODE = 1;
   public static final byte SERVER_ERROR_CODE = 2;
+
+  // Custom errors
+  public static final byte HISTORICAL_DATA_UNAVAILABLE = (byte) 128;
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -92,7 +92,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
   }
 
   @Test
-  public void shouldReturnNoBlocksWhenFirstBlockIsMissing() {
+  public void shouldReturnErrorWhenFirstBlockIsMissing() {
     final int startBlock = 1;
     final int count = 5;
     final int skip = 1;
@@ -104,11 +104,15 @@ class BeaconBlocksByRangeMessageHandlerTest {
 
     requestBlocks(startBlock, count, skip);
 
-    verifyNoBlocksReturned();
+    final RpcException expectedError =
+        new RpcException.HistoricalDataUnavailableException(
+            "Requested historical blocks are currently unavailable");
+    verify(listener).completeWithErrorResponse(expectedError);
+    verifyNoMoreInteractions(listener);
   }
 
   @Test
-  public void shouldReturnNoBlocksWhenEarliestHistoricalBlockUnknown() {
+  public void shouldReturnErrorWhenEarliestHistoricalBlockUnknown() {
     final int startBlock = 1;
     final int count = 5;
     final int skip = 1;
@@ -120,7 +124,11 @@ class BeaconBlocksByRangeMessageHandlerTest {
 
     requestBlocks(startBlock, count, skip);
 
-    verifyNoBlocksReturned();
+    final RpcException expectedError =
+        new RpcException.HistoricalDataUnavailableException(
+            "Requested historical blocks are currently unavailable");
+    verify(listener).completeWithErrorResponse(expectedError);
+    verifyNoMoreInteractions(listener);
   }
 
   @Test

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -69,7 +69,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
   public void setup() {
     when(peer.wantToMakeRequest()).thenReturn(true);
     when(peer.wantToReceiveObjects(any(), anyLong())).thenReturn(true);
-    when(combinedChainDataClient.getEarliestHistoricalBlockSlot())
+    when(combinedChainDataClient.getEarliestAvailableBlockSlot())
         .thenReturn(completedFuture(Optional.of(UInt64.valueOf(0))));
   }
 
@@ -99,7 +99,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
     withCanonicalHeadBlock(BLOCKS.get(8));
     withFinalizedBlocks(0, 1, 2, 3, 4, 5, 6, 7);
 
-    when(combinedChainDataClient.getEarliestHistoricalBlockSlot())
+    when(combinedChainDataClient.getEarliestAvailableBlockSlot())
         .thenReturn(completedFuture(Optional.of(UInt64.valueOf(2))));
 
     requestBlocks(startBlock, count, skip);
@@ -119,7 +119,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
     withCanonicalHeadBlock(BLOCKS.get(8));
     withFinalizedBlocks(0, 1, 2, 3, 4, 5, 6, 7);
 
-    when(combinedChainDataClient.getEarliestHistoricalBlockSlot())
+    when(combinedChainDataClient.getEarliestAvailableBlockSlot())
         .thenReturn(completedFuture(Optional.empty()));
 
     requestBlocks(startBlock, count, skip);

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2NetworkFactory.java
@@ -106,6 +106,7 @@ public class Eth2NetworkFactory {
     protected AsyncRunner asyncRunner;
     protected EventBus eventBus;
     protected RecentChainData recentChainData;
+    protected StorageQueryChannel historicalChainData = new StubStorageQueryChannel();
     protected GossipedItemConsumer<SignedBeaconBlock> gossipedBlockConsumer;
     protected GossipedItemConsumer<ValidateableAttestation> gossipedAttestationConsumer;
     protected GossipedItemConsumer<AttesterSlashing> gossipedAttesterSlashingConsumer;
@@ -160,7 +161,6 @@ public class Eth2NetworkFactory {
     protected Eth2Network buildNetwork(final NetworkConfig config) {
       {
         // Setup eth2 handlers
-        final StorageQueryChannel historicalChainData = new StubStorageQueryChannel();
         final AttestationSubnetService attestationSubnetService = new AttestationSubnetService();
         final Eth2PeerManager eth2PeerManager =
             Eth2PeerManager.create(
@@ -337,6 +337,13 @@ public class Eth2NetworkFactory {
     public Eth2P2PNetworkBuilder recentChainData(final RecentChainData recentChainData) {
       checkNotNull(recentChainData);
       this.recentChainData = recentChainData;
+      return this;
+    }
+
+    public Eth2P2PNetworkBuilder historicalChainData(
+        final StorageQueryChannel historicalChainData) {
+      checkNotNull(historicalChainData);
+      this.historicalChainData = historicalChainData;
       return this;
     }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
@@ -33,6 +33,9 @@ public interface StorageQueryChannel extends ChannelInterface {
 
   SafeFuture<WeakSubjectivityState> getWeakSubjectivityState();
 
+  /** @return The slot at which our historical (finalized) block data starts */
+  SafeFuture<Optional<UInt64>> getEarliestHistoricalBlockSlot();
+
   SafeFuture<Optional<SignedBeaconBlock>> getFinalizedBlockAtSlot(final UInt64 slot);
 
   SafeFuture<Optional<SignedBeaconBlock>> getLatestFinalizedBlockAtSlot(final UInt64 slot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
@@ -33,8 +33,8 @@ public interface StorageQueryChannel extends ChannelInterface {
 
   SafeFuture<WeakSubjectivityState> getWeakSubjectivityState();
 
-  /** @return The slot at which our historical (finalized) block data starts */
-  SafeFuture<Optional<UInt64>> getEarliestHistoricalBlockSlot();
+  /** @return The earliest available block's slot */
+  SafeFuture<Optional<UInt64>> getEarliestAvailableBlockSlot();
 
   SafeFuture<Optional<SignedBeaconBlock>> getFinalizedBlockAtSlot(final UInt64 slot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -382,6 +382,11 @@ public class CombinedChainDataClient {
     return recentChainData.getAncestorRootsOnHeadChain(startSlot, step, count);
   }
 
+  /** @return The slot at which our historical (finalized) block data starts */
+  public SafeFuture<Optional<UInt64>> getEarliestHistoricalBlockSlot() {
+    return historicalChainData.getEarliestHistoricalBlockSlot();
+  }
+
   public SafeFuture<Optional<SignedBeaconBlock>> getBlockByBlockRoot(final Bytes32 blockRoot) {
     return recentChainData
         .retrieveSignedBlockByRoot(blockRoot)

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -382,9 +382,9 @@ public class CombinedChainDataClient {
     return recentChainData.getAncestorRootsOnHeadChain(startSlot, step, count);
   }
 
-  /** @return The slot at which our historical (finalized) block data starts */
-  public SafeFuture<Optional<UInt64>> getEarliestHistoricalBlockSlot() {
-    return historicalChainData.getEarliestHistoricalBlockSlot();
+  /** @return The earliest available block's slot */
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableBlockSlot() {
+    return historicalChainData.getEarliestAvailableBlockSlot();
   }
 
   public SafeFuture<Optional<SignedBeaconBlock>> getBlockByBlockRoot(final Bytes32 blockRoot) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -116,8 +116,8 @@ public class ChainStorage implements StorageUpdateChannel, StorageQueryChannel {
   }
 
   @Override
-  public SafeFuture<Optional<UInt64>> getEarliestHistoricalBlockSlot() {
-    return SafeFuture.of(database::getEarliestHistoricalBlockSlot);
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableBlockSlot() {
+    return SafeFuture.of(database::getEarliestAvailableBlockSlot);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -116,6 +116,11 @@ public class ChainStorage implements StorageUpdateChannel, StorageQueryChannel {
   }
 
   @Override
+  public SafeFuture<Optional<UInt64>> getEarliestHistoricalBlockSlot() {
+    return SafeFuture.of(database::getEarliestHistoricalBlockSlot);
+  }
+
+  @Override
   public SafeFuture<Optional<SignedBeaconBlock>> getFinalizedBlockAtSlot(final UInt64 slot) {
     return SafeFuture.of(() -> database.getFinalizedBlockAtSlot(slot));
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -60,6 +60,9 @@ public interface Database extends AutoCloseable {
    */
   Optional<SignedBeaconBlock> getFinalizedBlockAtSlot(UInt64 slot);
 
+  /** @return The slot at which our historical (finalized) block data starts */
+  Optional<UInt64> getEarliestHistoricalBlockSlot();
+
   /**
    * Returns the latest finalized block at or prior to the given slot
    *

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -60,8 +60,8 @@ public interface Database extends AutoCloseable {
    */
   Optional<SignedBeaconBlock> getFinalizedBlockAtSlot(UInt64 slot);
 
-  /** @return The slot at which our historical (finalized) block data starts */
-  Optional<UInt64> getEarliestHistoricalBlockSlot();
+  /** @return The earliest available block's slot */
+  Optional<UInt64> getEarliestAvailableBlockSlot();
 
   /**
    * Returns the latest finalized block at or prior to the given slot

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -77,7 +77,7 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public Optional<UInt64> getEarliestHistoricalBlockSlot() {
+  public Optional<UInt64> getEarliestAvailableBlockSlot() {
     return Optional.empty();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -77,6 +77,11 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
+  public Optional<UInt64> getEarliestHistoricalBlockSlot() {
+    return Optional.empty();
+  }
+
+  @Override
   public Optional<SignedBeaconBlock> getLatestFinalizedBlockAtSlot(final UInt64 slot) {
     return Optional.empty();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -319,6 +319,11 @@ public class RocksDbDatabase implements Database {
   }
 
   @Override
+  public Optional<UInt64> getEarliestHistoricalBlockSlot() {
+    return finalizedDao.getEarliestFinalizedBlockSlot();
+  }
+
+  @Override
   public Optional<SignedBeaconBlock> getLatestFinalizedBlockAtSlot(final UInt64 slot) {
     return finalizedDao.getLatestFinalizedBlockAtSlot(slot);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -319,7 +319,7 @@ public class RocksDbDatabase implements Database {
   }
 
   @Override
-  public Optional<UInt64> getEarliestHistoricalBlockSlot() {
+  public Optional<UInt64> getEarliestAvailableBlockSlot() {
     return finalizedDao.getEarliestFinalizedBlockSlot();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbAccessor.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbAccessor.java
@@ -40,6 +40,16 @@ public interface RocksDbAccessor extends AutoCloseable {
   <K, V> Optional<ColumnEntry<K, V>> getFloorEntry(RocksDbColumn<K, V> column, K key);
 
   /**
+   * Returns the first entry in the given column.
+   *
+   * @param column The column we want to query
+   * @param <K> The key type of the column
+   * @param <V> The value type of the column
+   * @return The first entry in this column - the entry with the lowest key value
+   */
+  <K, V> Optional<ColumnEntry<K, V>> getFirstEntry(RocksDbColumn<K, V> column);
+
+  /**
    * Returns the last entry in the given column.
    *
    * @param column The column we want to query

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstance.java
@@ -101,6 +101,15 @@ public class RocksDbInstance implements RocksDbAccessor {
   }
 
   @Override
+  public <K, V> Optional<ColumnEntry<K, V>> getFirstEntry(final RocksDbColumn<K, V> column) {
+    assertOpen();
+    try (final Stream<ColumnEntry<K, V>> stream =
+        createStream(column, AbstractRocksIterator::seekToFirst)) {
+      return stream.findFirst();
+    }
+  }
+
+  @Override
   public <K, V> Optional<ColumnEntry<K, V>> getLastEntry(RocksDbColumn<K, V> column) {
     assertOpen();
     try (final Stream<ColumnEntry<K, V>> stream =

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbFinalizedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbFinalizedDao.java
@@ -34,6 +34,8 @@ public interface RocksDbFinalizedDao extends AutoCloseable {
 
   Optional<SignedBeaconBlock> getFinalizedBlockAtSlot(UInt64 slot);
 
+  Optional<UInt64> getEarliestFinalizedBlockSlot();
+
   Optional<SignedBeaconBlock> getLatestFinalizedBlockAtSlot(UInt64 slot);
 
   Optional<BeaconState> getLatestAvailableFinalizedState(UInt64 maxSlot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V4FinalizedRocksDbDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V4FinalizedRocksDbDao.java
@@ -48,6 +48,11 @@ public class V4FinalizedRocksDbDao implements RocksDbFinalizedDao {
   }
 
   @Override
+  public Optional<UInt64> getEarliestFinalizedBlockSlot() {
+    return db.getFirstEntry(schema.getColumnFinalizedBlocksBySlot()).map(ColumnEntry::getKey);
+  }
+
+  @Override
   public Optional<SignedBeaconBlock> getLatestFinalizedBlockAtSlot(final UInt64 slot) {
     return db.getFloorEntry(schema.getColumnFinalizedBlocksBySlot(), slot)
         .map(ColumnEntry::getValue);

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
@@ -545,7 +545,7 @@ public abstract class AbstractDatabaseTest {
   }
 
   @Test
-  public void getEarliestHistoricalBlockSlot_withMissingHistoricalBlocks() {
+  public void getEarliestAvailableBlockSlot_withMissingFinalizedBlocks() {
     // Set up database from an anchor point
     final UInt64 anchorEpoch = UInt64.valueOf(10);
     final SignedBlockAndState anchorBlockAndState =
@@ -561,17 +561,17 @@ public abstract class AbstractDatabaseTest {
     // And finalize them
     justifyAndFinalizeEpoch(anchorEpoch.plus(1), chainBuilder.getLatestBlockAndState());
 
-    assertThat(database.getEarliestHistoricalBlockSlot()).contains(anchorBlockAndState.getSlot());
+    assertThat(database.getEarliestAvailableBlockSlot()).contains(anchorBlockAndState.getSlot());
   }
 
   @Test
-  public void getEarliestHistoricalBlockSlot_startFromGenesis() {
+  public void getEarliestAvailableBlockSlot_noBlocksMissing() {
     // Add some blocks
     addBlocks(chainBuilder.generateNextBlock(), chainBuilder.generateNextBlock());
     // And finalize them
     justifyAndFinalizeEpoch(UInt64.valueOf(1), chainBuilder.getLatestBlockAndState());
 
-    assertThat(database.getEarliestHistoricalBlockSlot()).contains(genesisBlockAndState.getSlot());
+    assertThat(database.getEarliestAvailableBlockSlot()).contains(genesisBlockAndState.getSlot());
   }
 
   @Test

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
@@ -133,7 +133,7 @@ public abstract class AbstractDatabaseTest {
 
   protected void setDefaultStorage(final StorageSystem storageSystem) {
     this.storageSystem = storageSystem;
-    database = storageSystem.getDatabase();
+    database = storageSystem.database();
     recentChainData = storageSystem.recentChainData();
     storageSystems.add(storageSystem);
   }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractStorageBackedDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractStorageBackedDatabaseTest.java
@@ -94,7 +94,7 @@ public abstract class AbstractStorageBackedDatabaseTest extends AbstractDatabase
 
     final UpdatableStore memoryStore = recreateStore();
     assertStoresMatch(memoryStore, store);
-    assertThat(database.getEarliestHistoricalBlockSlot()).contains(genesisBlockAndState.getSlot());
+    assertThat(database.getEarliestAvailableBlockSlot()).contains(genesisBlockAndState.getSlot());
   }
 
   @Test
@@ -178,6 +178,6 @@ public abstract class AbstractStorageBackedDatabaseTest extends AbstractDatabase
     final UpdatableStore memoryStore = recreateStore();
     assertStoresMatch(memoryStore, store);
     assertThat(memoryStore.getAnchor()).contains(anchor.getCheckpoint());
-    assertThat(database.getEarliestHistoricalBlockSlot()).contains(anchorBlockAndState.getSlot());
+    assertThat(database.getEarliestAvailableBlockSlot()).contains(anchorBlockAndState.getSlot());
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractStorageBackedDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractStorageBackedDatabaseTest.java
@@ -94,6 +94,7 @@ public abstract class AbstractStorageBackedDatabaseTest extends AbstractDatabase
 
     final UpdatableStore memoryStore = recreateStore();
     assertStoresMatch(memoryStore, store);
+    assertThat(database.getEarliestHistoricalBlockSlot()).contains(genesisBlockAndState.getSlot());
   }
 
   @Test
@@ -177,5 +178,6 @@ public abstract class AbstractStorageBackedDatabaseTest extends AbstractDatabase
     final UpdatableStore memoryStore = recreateStore();
     assertStoresMatch(memoryStore, store);
     assertThat(memoryStore.getAnchor()).contains(anchor.getCheckpoint());
+    assertThat(database.getEarliestHistoricalBlockSlot()).contains(anchorBlockAndState.getSlot());
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/DepositStorageTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/DepositStorageTest.java
@@ -62,7 +62,7 @@ public class DepositStorageTest {
   private void setup(
       final StorageSystemArgumentsProvider.StorageSystemSupplier storageSystemSupplier) {
     storageSystem = storageSystemSupplier.get(dataDirectory);
-    database = storageSystem.getDatabase();
+    database = storageSystem.database();
     eventsChannel = storageSystem.eth1EventsChannel();
 
     storageSystem.chainUpdater().initializeGenesis();

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
@@ -40,7 +40,7 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
   }
 
   @Override
-  public SafeFuture<Optional<UInt64>> getEarliestHistoricalBlockSlot() {
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableBlockSlot() {
     return SafeFuture.completedFuture(Optional.empty());
   }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
@@ -40,6 +40,11 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
   }
 
   @Override
+  public SafeFuture<Optional<UInt64>> getEarliestHistoricalBlockSlot() {
+    return SafeFuture.completedFuture(Optional.empty());
+  }
+
+  @Override
   public SafeFuture<Optional<SignedBeaconBlock>> getFinalizedBlockAtSlot(UInt64 slot) {
     return SafeFuture.completedFuture(Optional.empty());
   }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/rocksdb/core/MockRocksDbInstance.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/rocksdb/core/MockRocksDbInstance.java
@@ -109,6 +109,14 @@ public class MockRocksDbInstance implements RocksDbAccessor {
   }
 
   @Override
+  public <K, V> Optional<ColumnEntry<K, V>> getFirstEntry(final RocksDbColumn<K, V> column) {
+    assertOpen();
+    assertValidColumn(column);
+    return Optional.ofNullable(columnData.get(column).firstEntry())
+        .map(e -> columnEntry(column, e));
+  }
+
+  @Override
   public <K, V> Optional<ColumnEntry<K, V>> getLastEntry(final RocksDbColumn<K, V> column) {
     assertOpen();
     assertValidColumn(column);

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
@@ -45,6 +45,7 @@ public class StorageSystem implements AutoCloseable {
   private final RecentChainData recentChainData;
   private final StateStorageMode storageMode;
   private final CombinedChainDataClient combinedChainDataClient;
+  private final ChainStorage chainStorage;
   private final Database database;
   private final RestartedStorageSupplier restartedSupplier;
 
@@ -53,11 +54,13 @@ public class StorageSystem implements AutoCloseable {
       final EventBus eventBus,
       final TrackingChainHeadChannel reorgEventChannel,
       final StateStorageMode storageMode,
+      final ChainStorage chainStorage,
       final Database database,
       final RecentChainData recentChainData,
       final CombinedChainDataClient combinedChainDataClient,
       final RestartedStorageSupplier restartedSupplier) {
     this.metricsSystem = metricsSystem;
+    this.chainStorage = chainStorage;
     this.recentChainData = recentChainData;
     this.eventBus = eventBus;
     this.reorgEventChannel = reorgEventChannel;
@@ -107,6 +110,7 @@ public class StorageSystem implements AutoCloseable {
         eventBus,
         reorgEventChannel,
         storageMode,
+        chainStorageServer,
         database,
         recentChainData,
         combinedChainDataClient,
@@ -137,8 +141,12 @@ public class StorageSystem implements AutoCloseable {
     return new ProtoArrayStorage(database);
   }
 
-  public Database getDatabase() {
+  public Database database() {
     return database;
+  }
+
+  public ChainStorage chainStorage() {
+    return chainStorage;
   }
 
   public StorageSystem restarted() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add API's for querying for the earliest available finalized block.  Handle missing historical blocks for blocksByRange requests: if the first requested block is not available locally, send back an error.

## Fixed Issue(s)
Part of #3063 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.