### PR TITLE
Add unit tests for getAncestorsOnFork

### DIFF
--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
@@ -128,6 +128,29 @@ class ForkChoiceUtilTest {
   }
 
   @Test
+  void getAncestorsOnFork_shouldIncludeHeadBlockAndExcludeStartSlot() {
+    chainBuilder.generateBlocksUpToSlot(10).forEach(this::addBlock);
+
+    final NavigableMap<UInt64, Bytes32> ancestorsOnFork = ForkChoiceUtil.getAncestorsOnFork(
+        forkChoiceStrategy,
+        chainBuilder.getLatestBlockAndState().getRoot(),
+        UInt64.valueOf(5));
+    assertThat(ancestorsOnFork).doesNotContainKey(UInt64.valueOf(5));
+  }
+
+  @Test
+  void getAncestorsOnFork_shouldNotIncludeHeadBlockWhenItIsAtStartSlot() {
+    chainBuilder.generateBlocksUpToSlot(3).forEach(this::addBlock);
+
+    final SignedBlockAndState headBlock = chainBuilder.getLatestBlockAndState();
+    final NavigableMap<UInt64, Bytes32> ancestorsOnFork = ForkChoiceUtil.getAncestorsOnFork(
+        forkChoiceStrategy,
+        headBlock.getRoot(),
+        headBlock.getSlot());
+    assertThat(ancestorsOnFork).isEmpty();
+  }
+
+  @Test
   public void getCurrentSlot_shouldGetZeroAtGenesis() {
     assertThat(ForkChoiceUtil.getCurrentSlot(GENESIS_TIME, GENESIS_TIME)).isEqualTo(UInt64.ZERO);
   }

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/ForkChoiceUtilTest.java
@@ -131,10 +131,9 @@ class ForkChoiceUtilTest {
   void getAncestorsOnFork_shouldIncludeHeadBlockAndExcludeStartSlot() {
     chainBuilder.generateBlocksUpToSlot(10).forEach(this::addBlock);
 
-    final NavigableMap<UInt64, Bytes32> ancestorsOnFork = ForkChoiceUtil.getAncestorsOnFork(
-        forkChoiceStrategy,
-        chainBuilder.getLatestBlockAndState().getRoot(),
-        UInt64.valueOf(5));
+    final NavigableMap<UInt64, Bytes32> ancestorsOnFork =
+        ForkChoiceUtil.getAncestorsOnFork(
+            forkChoiceStrategy, chainBuilder.getLatestBlockAndState().getRoot(), UInt64.valueOf(5));
     assertThat(ancestorsOnFork).doesNotContainKey(UInt64.valueOf(5));
   }
 
@@ -143,10 +142,9 @@ class ForkChoiceUtilTest {
     chainBuilder.generateBlocksUpToSlot(3).forEach(this::addBlock);
 
     final SignedBlockAndState headBlock = chainBuilder.getLatestBlockAndState();
-    final NavigableMap<UInt64, Bytes32> ancestorsOnFork = ForkChoiceUtil.getAncestorsOnFork(
-        forkChoiceStrategy,
-        headBlock.getRoot(),
-        headBlock.getSlot());
+    final NavigableMap<UInt64, Bytes32> ancestorsOnFork =
+        ForkChoiceUtil.getAncestorsOnFork(
+            forkChoiceStrategy, headBlock.getRoot(), headBlock.getSlot());
     assertThat(ancestorsOnFork).isEmpty();
   }
 


### PR DESCRIPTION
## PR Description
Add a couple of unit tests for `getAncestorsOnFork` to confirm that it excludes the block at start slot (it does thankfully).

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.