### PR TITLE
Display apache license notice on startup

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -38,6 +38,10 @@ public class StatusLogger {
 
   public void onStartup(final String version) {
     log.info("Teku version: {}", version);
+    log.info(
+        "This software is licensed under the Apache License, Version 2.0 (the \"License\"); "
+            + "you may not use this software except in compliance with the License. "
+            + "You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0");
   }
 
   public void fatalError(final String description, final Throwable cause) {


### PR DESCRIPTION
## PR Description
Display an license notice on startup.

Note: Deliberately logs the notice on a single line because multiline log messages are generally frowned upon.

## Fixed Issue(s)
fixes #3037 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.