### PR TITLE
Handle requests for a single block by slot or root not returning any result

### DIFF
--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
@@ -155,7 +155,7 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
     recentChainData1.updateHead(block2Root, block2.getSlot());
 
     peer1.disconnectImmediately(Optional.empty(), false);
-    final SafeFuture<SignedBeaconBlock> res = peer1.requestBlockBySlot(UInt64.ONE);
+    final SafeFuture<Optional<SignedBeaconBlock>> res = peer1.requestBlockBySlot(UInt64.ONE);
 
     waitFor(() -> assertThat(res).isDone());
     assertThat(res).isCompletedExceptionally();
@@ -171,11 +171,18 @@ public abstract class BeaconBlocksByRangeIntegrationTest {
     recentChainData1.updateHead(block2Root, block2.getSlot());
 
     Waiter.waitFor(peer1.disconnectCleanly(DisconnectReason.TOO_MANY_PEERS));
-    final SafeFuture<SignedBeaconBlock> res = peer1.requestBlockBySlot(UInt64.ONE);
+    final SafeFuture<Optional<SignedBeaconBlock>> res = peer1.requestBlockBySlot(UInt64.ONE);
 
     waitFor(() -> assertThat(res).isDone());
     assertThat(res).isCompletedExceptionally();
     assertThatThrownBy(res::get).hasRootCauseInstanceOf(PeerDisconnectedException.class);
+  }
+
+  @Test
+  void requestBlockBySlot_shouldReturnEmptyWhenBlockIsNotKnown() throws Exception {
+    final Optional<SignedBeaconBlock> result =
+        waitFor(peer1.requestBlockBySlot(UInt64.valueOf(49382982)));
+    assertThat(result).isEmpty();
   }
 
   private List<SignedBeaconBlock> requestBlocks()

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRootIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRootIntegrationTest.java
@@ -148,7 +148,7 @@ public abstract class BeaconBlocksByRootIntegrationTest {
     final Bytes32 blockHash = block.getMessage().hash_tree_root();
 
     peer1.disconnectImmediately(Optional.empty(), false);
-    final SafeFuture<SignedBeaconBlock> res = peer1.requestBlockByRoot(blockHash);
+    final SafeFuture<Optional<SignedBeaconBlock>> res = peer1.requestBlockByRoot(blockHash);
 
     waitFor(() -> assertThat(res).isDone());
     assertThat(res).isCompletedExceptionally();
@@ -162,7 +162,7 @@ public abstract class BeaconBlocksByRootIntegrationTest {
     final Bytes32 blockHash = block.getMessage().hash_tree_root();
 
     Waiter.waitFor(peer1.disconnectCleanly(DisconnectReason.TOO_MANY_PEERS));
-    final SafeFuture<SignedBeaconBlock> res = peer1.requestBlockByRoot(blockHash);
+    final SafeFuture<Optional<SignedBeaconBlock>> res = peer1.requestBlockByRoot(blockHash);
 
     waitFor(() -> assertThat(res).isDone());
     assertThat(res).isCompletedExceptionally();
@@ -204,6 +204,13 @@ public abstract class BeaconBlocksByRootIntegrationTest {
 
     final List<SignedBeaconBlock> response = requestBlocks(blockRoots);
     assertThat(response).containsExactlyElementsOf(blocks);
+  }
+
+  @Test
+  void requestBlockByRoot_shouldReturnEmptyWhenBlockIsNotKnown() throws Exception {
+    final Optional<SignedBeaconBlock> result =
+        waitFor(peer1.requestBlockByRoot(Bytes32.fromHexStringLenient("0x123456789")));
+    assertThat(result).isEmpty();
   }
 
   private SignedBeaconBlock addBlock() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidator.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.networking.eth2.peers;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -183,13 +182,6 @@ public class PeerChainValidator {
       LOG.trace(
           "Request required checkpoint block from peer {}: {}", peer.getId(), checkpointToVerify);
       return peer.requestBlockByRoot(checkpointToVerify.getRoot())
-          .exceptionally(
-              err -> {
-                if (Throwables.getRootCause(err) instanceof NullPointerException) {
-                  return Optional.empty();
-                }
-                throw new RuntimeException(err);
-              })
           // When requesting block by root, there is no explicit guarantee that the block is
           // canonical.
           // So, double-check by requesting the block by slot to make sure the peer considers this

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/ResponseStream.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/ResponseStream.java
@@ -13,10 +13,21 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.core;
 
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
 public interface ResponseStream<O> {
-  SafeFuture<O> expectSingleResponse();
+  default SafeFuture<O> expectSingleResponse() {
+    return expectOptionalResponse()
+        .thenApply(
+            maybeResult ->
+                maybeResult.orElseThrow(
+                    () ->
+                        new IllegalStateException(
+                            "No response received when single repsonse expected")));
+  }
+
+  SafeFuture<Optional<O>> expectOptionalResponse();
 
   SafeFuture<Void> expectNoResponse();
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/ResponseStreamImpl.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/ResponseStreamImpl.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2.rpc.core;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Preconditions;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -27,7 +28,7 @@ public class ResponseStreamImpl<O> implements ResponseStream<O> {
   private volatile ResponseStreamListener<O> responseListener;
 
   @Override
-  public SafeFuture<O> expectSingleResponse() {
+  public SafeFuture<Optional<O>> expectOptionalResponse() {
     final AtomicReference<O> firstResponse = new AtomicReference<>();
     return expectMultipleResponses(
             response -> {
@@ -37,12 +38,7 @@ public class ResponseStreamImpl<O> implements ResponseStream<O> {
               }
               return SafeFuture.COMPLETE;
             })
-        .thenApply(
-            done -> {
-              checkNotNull(
-                  firstResponse.get(), "No response received when single response expected");
-              return firstResponse.get();
-            });
+        .thenApply(done -> Optional.ofNullable(firstResponse.get()));
   }
 
   @Override

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
@@ -23,7 +23,6 @@ import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoc
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 
 import java.util.Optional;
-import java.util.concurrent.CompletionException;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
@@ -283,7 +282,7 @@ public class PeerChainValidatorTest {
     forksMatch();
     finalizedCheckpointsMatch();
     when(peer.requestBlockByRoot(requiredCheckpoint.getRoot()))
-        .thenReturn(SafeFuture.failedFuture(new CompletionException(new NullPointerException())));
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
 
     final SafeFuture<Boolean> result = peerChainValidator.validate(peer, remoteStatus);
     assertPeerChainRejected(result, DisconnectReason.IRRELEVANT_NETWORK);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
@@ -247,9 +247,9 @@ public class PeerChainValidatorTest {
     forksMatch();
     finalizedCheckpointsMatch();
     when(peer.requestBlockByRoot(requiredCheckpoint.getRoot()))
-        .thenReturn(SafeFuture.completedFuture(earlierBlock));
+        .thenReturn(SafeFuture.completedFuture(Optional.of(earlierBlock)));
     when(peer.requestBlockBySlot(earlierBlock.getSlot()))
-        .thenReturn(SafeFuture.completedFuture(earlierBlock));
+        .thenReturn(SafeFuture.completedFuture(Optional.of(earlierBlock)));
 
     final SafeFuture<Boolean> result = peerChainValidator.validate(peer, remoteStatus);
     assertPeerChainVerified(result);
@@ -266,9 +266,9 @@ public class PeerChainValidatorTest {
     final SignedBeaconBlock nonMatchingBlock =
         dataStructureUtil.randomSignedBeaconBlock(earlierCheckpoint.getEpochStartSlot());
     when(peer.requestBlockByRoot(requiredCheckpoint.getRoot()))
-        .thenReturn(SafeFuture.completedFuture(earlierBlock));
+        .thenReturn(SafeFuture.completedFuture(Optional.of(earlierBlock)));
     when(peer.requestBlockBySlot(earlierBlock.getSlot()))
-        .thenReturn(SafeFuture.completedFuture(nonMatchingBlock));
+        .thenReturn(SafeFuture.completedFuture(Optional.of(nonMatchingBlock)));
 
     final SafeFuture<Boolean> result = peerChainValidator.validate(peer, remoteStatus);
     assertPeerChainRejected(result, DisconnectReason.IRRELEVANT_NETWORK);
@@ -370,7 +370,8 @@ public class PeerChainValidatorTest {
   }
 
   private void remoteChainIsAheadOnSameChain() {
-    final SafeFuture<SignedBeaconBlock> blockFuture = SafeFuture.completedFuture(earlierBlock);
+    final SafeFuture<Optional<SignedBeaconBlock>> blockFuture =
+        SafeFuture.completedFuture(Optional.of(earlierBlock));
     final SafeFuture<Optional<SignedBeaconBlock>> optionalBlockFuture =
         SafeFuture.completedFuture(Optional.of(earlierBlock));
 
@@ -394,8 +395,8 @@ public class PeerChainValidatorTest {
   }
 
   private void remoteChainIsAheadOnDifferentChain() {
-    final SafeFuture<SignedBeaconBlock> blockFuture =
-        SafeFuture.completedFuture(randomBlock(earlierBlockSlot));
+    final SafeFuture<Optional<SignedBeaconBlock>> blockFuture =
+        SafeFuture.completedFuture(Optional.of(randomBlock(earlierBlockSlot)));
     final SafeFuture<Optional<SignedBeaconBlock>> optionalBlockFuture =
         SafeFuture.completedFuture(Optional.of(earlierBlock));
 
@@ -406,7 +407,7 @@ public class PeerChainValidatorTest {
   }
 
   private void remoteChainIsAheadAndUnresponsive() {
-    final SafeFuture<SignedBeaconBlock> blockFuture =
+    final SafeFuture<Optional<SignedBeaconBlock>> blockFuture =
         SafeFuture.failedFuture(new NullPointerException());
     final SafeFuture<Optional<SignedBeaconBlock>> optionalBlockFuture =
         SafeFuture.completedFuture(Optional.of(earlierBlock));

--- a/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchBlockTask.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchBlockTask.java
@@ -86,7 +86,11 @@ class FetchBlockTask {
     numberOfRuns.incrementAndGet();
     queriedPeers.add(peer.getId());
     return peer.requestBlockByRoot(blockRoot)
-        .thenApply(FetchBlockResult::createSuccessful)
+        .thenApply(
+            maybeBlock ->
+                maybeBlock
+                    .map(FetchBlockResult::createSuccessful)
+                    .orElseGet(() -> FetchBlockResult.createFailed(Status.FETCH_FAILED)))
         .exceptionally(
             err -> {
               LOG.debug("Failed to fetch block " + blockRoot, err);

--- a/sync/src/test/java/tech/pegasys/teku/sync/gossip/FetchBlockTaskTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/gossip/FetchBlockTaskTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,7 +51,8 @@ public class FetchBlockTaskTest {
     assertThat(task.getBlockRoot()).isEqualTo(blockRoot);
 
     final Eth2Peer peer = registerNewPeer(1);
-    when(peer.requestBlockByRoot(blockRoot)).thenReturn(SafeFuture.completedFuture(block));
+    when(peer.requestBlockByRoot(blockRoot))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
 
     final SafeFuture<FetchBlockResult> result = task.run();
     assertThat(result).isDone();
@@ -117,7 +119,8 @@ public class FetchBlockTaskTest {
 
     // Add another peer
     final Eth2Peer peer2 = registerNewPeer(2);
-    when(peer2.requestBlockByRoot(blockRoot)).thenReturn(SafeFuture.completedFuture(block));
+    when(peer2.requestBlockByRoot(blockRoot))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
 
     // Retry
     final SafeFuture<FetchBlockResult> result2 = task.run();
@@ -140,7 +143,8 @@ public class FetchBlockTaskTest {
     when(peer.getOutstandingRequests()).thenReturn(1);
     // Add another peer
     final Eth2Peer peer2 = registerNewPeer(2);
-    when(peer2.requestBlockByRoot(blockRoot)).thenReturn(SafeFuture.completedFuture(block));
+    when(peer2.requestBlockByRoot(blockRoot))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
     when(peer2.getOutstandingRequests()).thenReturn(0);
 
     // We should choose the peer that is less busy, which successfully returns the block
@@ -158,7 +162,8 @@ public class FetchBlockTaskTest {
     FetchBlockTask task = FetchBlockTask.create(eth2Network, blockRoot);
 
     final Eth2Peer peer = registerNewPeer(1);
-    when(peer.requestBlockByRoot(blockRoot)).thenReturn(SafeFuture.completedFuture(block));
+    when(peer.requestBlockByRoot(blockRoot))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
 
     task.cancel();
     final SafeFuture<FetchBlockResult> result = task.run();


### PR DESCRIPTION
## PR Description
When the requested block is unknown the remote peer should return no results.  We were incorrectly requiring a block to be returned in the utility methods that request a single block by root or slot.

## Fixed Issue(s)
fixes #3027 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.