### PR TITLE
Skip loading latest finalized state when updating database

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -492,7 +492,7 @@ public class RocksDbDatabase implements Database {
       switch (stateStorageMode) {
         case ARCHIVE:
           // Get previously finalized block to build on top of
-          final SignedBlockAndState baseBlock = getFinalizedBlockAndState();
+          final SignedBeaconBlock baseBlock = getFinalizedBlock();
 
           final HashTree blockTree =
               HashTree.builder()
@@ -541,11 +541,9 @@ public class RocksDbDatabase implements Database {
     }
   }
 
-  private SignedBlockAndState getFinalizedBlockAndState() {
+  private SignedBeaconBlock getFinalizedBlock() {
     final Bytes32 baseBlockRoot = hotDao.getFinalizedCheckpoint().orElseThrow().getRoot();
-    final SignedBeaconBlock baseBlock = finalizedDao.getFinalizedBlock(baseBlockRoot).orElseThrow();
-    final BeaconState baseState = hotDao.getLatestFinalizedState().orElseThrow();
-    return new SignedBlockAndState(baseBlock, baseState);
+    return finalizedDao.getFinalizedBlock(baseBlockRoot).orElseThrow();
   }
 
   private void putFinalizedState(


### PR DESCRIPTION
## PR Description
When updating the finalized database in archive mode, we need the last finalized block as the starting point to store data from.  Previously we needed the block and state for regeneration but can now skip loading the state.

## Fixed Issue(s)
fixes #2578 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.