### PR TITLE
Add metrics to record number of messages received per gossip topic

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -116,7 +116,7 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
     // Setup gossip
     gossip = createGossip();
     final PubsubPublisherApi publisher = gossip.createPublisher(null, NULL_SEQNO_GENERATOR);
-    gossipNetwork = new LibP2PGossipNetwork(gossip, publisher);
+    gossipNetwork = new LibP2PGossipNetwork(metricsSystem, gossip, publisher);
 
     // Setup rpc methods
     rpcMethods.forEach(method -> rpcHandlers.put(method, new RpcHandler(asyncRunner, method)));

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandler.java
@@ -62,7 +62,7 @@ public class GossipHandler implements Function<MessageApi, CompletableFuture<Val
             .createLabelledCounter(
                 TekuMetricCategory.LIBP2P,
                 "gossip_messages_total",
-                "Total number of gossip messages received",
+                "Total number of gossip messages received (avoid libp2p deduplication)",
                 "topic")
             .labels(topic.getTopic());
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetwork.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
 import tech.pegasys.teku.networking.p2p.gossip.TopicHandler;
@@ -36,10 +37,13 @@ import tech.pegasys.teku.networking.p2p.peer.NodeId;
 public class LibP2PGossipNetwork implements tech.pegasys.teku.networking.p2p.gossip.GossipNetwork {
   private static final Logger LOG = LogManager.getLogger();
 
+  private final MetricsSystem metricsSystem;
   private final Gossip gossip;
   private final PubsubPublisherApi publisher;
 
-  public LibP2PGossipNetwork(final Gossip gossip, final PubsubPublisherApi publisher) {
+  public LibP2PGossipNetwork(
+      final MetricsSystem metricsSystem, final Gossip gossip, final PubsubPublisherApi publisher) {
+    this.metricsSystem = metricsSystem;
     this.gossip = gossip;
     this.publisher = publisher;
   }
@@ -54,7 +58,8 @@ public class LibP2PGossipNetwork implements tech.pegasys.teku.networking.p2p.gos
   public TopicChannel subscribe(final String topic, final TopicHandler topicHandler) {
     LOG.trace("Subscribe to topic: {}", topic);
     final Topic libP2PTopic = new Topic(topic);
-    final GossipHandler gossipHandler = new GossipHandler(libP2PTopic, publisher, topicHandler);
+    final GossipHandler gossipHandler =
+        new GossipHandler(metricsSystem, libP2PTopic, publisher, topicHandler);
     PubsubSubscription subscription = gossip.subscribe(gossipHandler, libP2PTopic);
     return new LibP2PTopicChannel(gossipHandler, subscription);
   }

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipHandlerTest.java
@@ -30,6 +30,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.network.p2p.jvmlibp2p.MockMessageApi;
 import tech.pegasys.teku.networking.p2p.gossip.TopicHandler;
 
@@ -37,7 +38,8 @@ public class GossipHandlerTest {
   private final Topic topic = new Topic("Testing");
   private final PubsubPublisherApi publisher = mock(PubsubPublisherApi.class);
   private final TopicHandler topicHandler = mock(TopicHandler.class);
-  private final GossipHandler gossipHandler = new GossipHandler(topic, publisher, topicHandler);
+  private final GossipHandler gossipHandler =
+      new GossipHandler(new StubMetricsSystem(), topic, publisher, topicHandler);
 
   @BeforeEach
   public void setup() {


### PR DESCRIPTION
## PR Description
Add a metric to record the number of gossip messages received by Teku's networking layer.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.