### PR TITLE
Move get_ancestor into ProtoArrayForkChoiceStrategy

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -93,13 +93,7 @@ public class ForkChoiceUtil {
    */
   public static Optional<Bytes32> get_ancestor(
       ForkChoiceStrategy forkChoiceStrategy, Bytes32 root, UInt64 slot) {
-    Bytes32 parentRoot = root;
-    Optional<UInt64> blockSlot = forkChoiceStrategy.blockSlot(root);
-    while (blockSlot.isPresent() && blockSlot.get().compareTo(slot) > 0) {
-      parentRoot = forkChoiceStrategy.blockParentRoot(parentRoot).orElseThrow();
-      blockSlot = forkChoiceStrategy.blockSlot(parentRoot);
-    }
-    return blockSlot.isPresent() ? Optional.of(parentRoot) : Optional.empty();
+    return forkChoiceStrategy.getAncestor(root, slot);
   }
 
   public static NavigableMap<UInt64, Bytes32> getAncestors(

--- a/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidatorTest.java
+++ b/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidatorTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.weaksubjectivity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -575,6 +576,8 @@ public class WeakSubjectivityValidatorTest {
       when(forkChoiceStrategy.blockSlot(block.getRoot())).thenReturn(Optional.of(block.getSlot()));
       when(forkChoiceStrategy.blockParentRoot(block.getRoot()))
           .thenReturn(Optional.of(block.getParent_root()));
+      when(forkChoiceStrategy.getAncestor(any(), eq(block.getSlot())))
+          .thenReturn(Optional.of(block.getRoot()));
     }
   }
 

--- a/protoarray/build.gradle
+++ b/protoarray/build.gradle
@@ -5,7 +5,9 @@ dependencies {
     implementation project(':infrastructure:async')
     implementation project(':util')
 
+    testImplementation testFixtures(project(':ethereum:core'))
     testImplementation testFixtures(project(':ethereum:datastructures'))
+    testImplementation testFixtures(project(':storage'))
 
     testFixturesApi 'org.apache.tuweni:tuweni-bytes'
     testFixturesImplementation project(':ethereum:datastructures')

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ForkChoiceStrategy.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ForkChoiceStrategy.java
@@ -38,6 +38,8 @@ public interface ForkChoiceStrategy {
 
   Optional<Bytes32> blockParentRoot(Bytes32 blockRoot);
 
+  Optional<Bytes32> getAncestor(Bytes32 blockRoot, UInt64 slot);
+
   boolean contains(Bytes32 blockRoot);
 
   void save();

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategyTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategyTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,17 +33,18 @@ import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
 public class ProtoArrayForkChoiceStrategyTest {
-  private final MutableStore store = new TestStoreFactory().createGenesisStore();
-  private final SignedBlockAndState genesis =
-      store.retrieveBlockAndState(store.getFinalizedCheckpoint().getRoot()).join().get();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final ProtoArrayStorageChannel storageChannel = new StubProtoArrayStorageChannel();
 
   @Test
   public void initialize_withLargeChain() {
+    final MutableStore store = new TestStoreFactory().createGenesisStore();
     final int chainSize = 2_000;
-    saveChainToStore(chainSize);
+    saveChainToStore(chainSize, store);
     final SafeFuture<ProtoArrayForkChoiceStrategy> future =
         ProtoArrayForkChoiceStrategy.initialize(store, storageChannel);
 
@@ -56,7 +58,6 @@ public class ProtoArrayForkChoiceStrategyTest {
     // Set up store with an anchor point that has justified and finalized checkpoints prior to its
     // epoch
     final UInt64 anchorEpoch = UInt64.valueOf(100);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil();
     final BeaconState anchorState =
         dataStructureUtil
             .stateBuilder()
@@ -79,13 +80,65 @@ public class ProtoArrayForkChoiceStrategyTest {
     assertThat(head).isEqualTo(anchor.getRoot());
   }
 
-  private void saveChainToStore(final int blockCount) {
-    final List<SignedBlockAndState> chain = generateChain(blockCount);
+  @Test
+  void getAncestor_specifiedBlockIsAtSlot() {
+    final StorageSystem storageSystem = initStorageSystem();
+    final SignedBlockAndState block = storageSystem.chainUpdater().addNewBestBlock();
+    final ProtoArrayForkChoiceStrategy protoArrayStrategy = createProtoArray(storageSystem);
+    assertThat(protoArrayStrategy.getAncestor(block.getRoot(), block.getSlot()))
+        .contains(block.getRoot());
+  }
+
+  @Test
+  void getAncestor_ancestorIsFound() {
+    final StorageSystem storageSystem = initStorageSystem();
+    storageSystem.chainUpdater().advanceChain(1);
+    final SignedBlockAndState ancestor = storageSystem.chainUpdater().advanceChain(2);
+    storageSystem.chainUpdater().advanceChain(3);
+    final SignedBlockAndState head = storageSystem.chainUpdater().advanceChain(5);
+    final ProtoArrayForkChoiceStrategy protoArrayStrategy = createProtoArray(storageSystem);
+    assertThat(protoArrayStrategy.getAncestor(head.getRoot(), ancestor.getSlot()))
+        .contains(ancestor.getRoot());
+  }
+
+  @Test
+  void getAncestor_headIsUnknown() {
+    final StorageSystem storageSystem = initStorageSystem();
+    final ProtoArrayForkChoiceStrategy protoArrayStrategy = createProtoArray(storageSystem);
+    assertThat(protoArrayStrategy.getAncestor(dataStructureUtil.randomBytes32(), ZERO)).isEmpty();
+  }
+
+  @Test
+  void getAncestor_noBlockAtSlot() {
+    final StorageSystem storageSystem = initStorageSystem();
+    final SignedBlockAndState head = storageSystem.chainUpdater().advanceChain(5);
+    final ProtoArrayForkChoiceStrategy protoArrayStrategy = createProtoArray(storageSystem);
+    assertThat(protoArrayStrategy.getAncestor(head.getRoot(), ONE)).contains(head.getParentRoot());
+  }
+
+  private StorageSystem initStorageSystem() {
+    final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault();
+    storageSystem.chainUpdater().initializeGenesis();
+    return storageSystem;
+  }
+
+  private ProtoArrayForkChoiceStrategy createProtoArray(final StorageSystem storageSystem) {
+    final SafeFuture<ProtoArrayForkChoiceStrategy> future =
+        ProtoArrayForkChoiceStrategy.initialize(
+            storageSystem.recentChainData().getStore(), storageSystem.createProtoArrayStorage());
+    assertThat(future).isCompleted();
+    return future.join();
+  }
+
+  private void saveChainToStore(final int blockCount, final MutableStore store) {
+    final List<SignedBlockAndState> chain = generateChain(blockCount, store);
     chain.forEach(store::putBlockAndState);
   }
 
   // Creating mocks is much faster than generating random blocks via DataStructureUtil
-  private List<SignedBlockAndState> generateChain(final int count) {
+  private List<SignedBlockAndState> generateChain(final int count, final MutableStore store) {
+    final SignedBlockAndState genesis =
+        store.retrieveBlockAndState(store.getFinalizedCheckpoint().getRoot()).join().orElseThrow();
     final List<SignedBlockAndState> chain = new ArrayList<>();
 
     final Checkpoint checkpoint = store.getFinalizedCheckpoint();

--- a/protoarray/src/testFixtures/java/tech/pegasys/teku/protoarray/StubForkChoiceStrategy.java
+++ b/protoarray/src/testFixtures/java/tech/pegasys/teku/protoarray/StubForkChoiceStrategy.java
@@ -50,6 +50,11 @@ public class StubForkChoiceStrategy implements ForkChoiceStrategy {
   }
 
   @Override
+  public Optional<Bytes32> getAncestor(final Bytes32 blockRoot, final UInt64 slot) {
+    return Optional.empty();
+  }
+
+  @Override
   public boolean contains(Bytes32 blockRoot) {
     return false;
   }


### PR DESCRIPTION
## PR Description
Move get_ancestor into ProtoArrayForkChoiceStrategy.

Allows it to work on ProtoNode directly and lookup by parent index instead of mapping between parent hash and index all the time.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.