### PR TITLE
fix retrieval of validators from beacon state.

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.beaconrestapi;
 
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
@@ -42,6 +43,7 @@ import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
+import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.beaconrestapi.handlers.admin.PutLogLevel;
 import tech.pegasys.teku.beaconrestapi.handlers.beacon.GetBlock;
 import tech.pegasys.teku.beaconrestapi.handlers.beacon.GetChainHead;
@@ -196,6 +198,12 @@ public class BeaconRestApi {
         (e, ctx) -> {
           ctx.status(SC_SERVICE_UNAVAILABLE);
           setErrorBody(ctx, () -> BadRequest.serviceUnavailable(jsonProvider));
+        });
+    app.exception(
+        BadRequestException.class,
+        (e, ctx) -> {
+          ctx.status(SC_BAD_REQUEST);
+          setErrorBody(ctx, () -> BadRequest.badRequest(jsonProvider, e.getMessage()));
         });
     // Add catch-all handler
     app.exception(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidator.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidator.java
@@ -89,10 +89,6 @@ public class GetStateValidator extends AbstractHandler {
 
   private Optional<String> handleResult(Context ctx, final ValidatorResponse response)
       throws JsonProcessingException {
-    if (response.equals(ValidatorResponse.EMPTY)) {
-      ctx.status(SC_NOT_FOUND);
-      return Optional.empty();
-    }
     return Optional.of(jsonProvider.objectToJSON(new GetStateValidatorResponse(response)));
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidators.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidators.java
@@ -81,7 +81,6 @@ public class GetStateValidators extends AbstractHandler {
             isRepeatable = true),
         @OpenApiParam(
             name = STATUS,
-            type = ValidatorStatus.class,
             description =
                 "valid values:   pending_initialized, "
                     + "  pending_queued, "

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/StateValidatorsUtil.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/StateValidatorsUtil.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.api.ChainDataProvider;
+import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.beaconrestapi.ListQueryParameterUtils;
 
@@ -32,9 +33,13 @@ public class StateValidatorsUtil {
       return Set.of();
     }
 
-    return ListQueryParameterUtils.getParameterAsStringList(queryParameters, STATUS).stream()
-        .map(ValidatorStatus::valueOf)
-        .collect(Collectors.toSet());
+    try {
+      return ListQueryParameterUtils.getParameterAsStringList(queryParameters, STATUS).stream()
+          .map(ValidatorStatus::valueOf)
+          .collect(Collectors.toSet());
+    } catch (IllegalArgumentException ex) {
+      throw new BadRequestException("Invalid validator state requested: " + ex.getMessage());
+    }
   }
 
   public List<Integer> parseValidatorsParam(final ChainDataProvider provider, final Context ctx) {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorTest.java
@@ -13,7 +13,9 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
@@ -52,14 +54,20 @@ public class GetStateValidatorTest extends AbstractBeaconHandlerTest {
 
   @Test
   public void shouldGetValidatorFromState() throws Exception {
-    final UInt64 slot = dataStructureUtil.randomUInt64();
     when(context.pathParamMap()).thenReturn(Map.of("state_id", "head", "validator_id", "1"));
-    when(chainDataProvider.stateParameterToSlot("head")).thenReturn(Optional.of(slot));
-    when(chainDataProvider.validatorParameterToIndex("1")).thenReturn(Optional.of(1));
-    when(chainDataProvider.getValidatorDetailsBySlot(slot, Optional.of(1)))
+    when(chainDataProvider.getStateValidator("head", "1"))
         .thenReturn(SafeFuture.completedFuture(Optional.of(validatorResponse)));
     handler.handle(context);
     GetStateValidatorResponse response = getResponseFromFuture(GetStateValidatorResponse.class);
     assertThat(response.data).isEqualTo(validatorResponse);
+  }
+
+  @Test
+  public void shouldGetNotFoundForMissingState() throws Exception {
+    when(context.pathParamMap()).thenReturn(Map.of("state_id", "1", "validator_id", "1"));
+    when(chainDataProvider.getStateValidator("1", "1"))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+    handler.handle(context);
+    verify(context).status(SC_NOT_FOUND);
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorsTest.java
@@ -14,7 +14,9 @@
 package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 
 import static java.util.Collections.emptySet;
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
@@ -62,5 +64,15 @@ public class GetStateValidatorsTest extends AbstractBeaconHandlerTest {
     handler.handle(context);
     GetStateValidatorsResponse response = getResponseFromFuture(GetStateValidatorsResponse.class);
     assertThat(response.data).containsExactly(validatorResponse);
+  }
+
+  @Test
+  public void shouldGetNotFoundForMissingState() throws Exception {
+    when(context.pathParamMap()).thenReturn(Map.of("state_id", "1"));
+    when(context.queryParamMap()).thenReturn(Map.of("id", List.of("1")));
+    when(chainDataProvider.getStateValidators("1", List.of("1"), emptySet()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+    handler.handle(context);
+    verify(context).status(SC_NOT_FOUND);
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/StateValidatorsUtilTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/StateValidatorsUtilTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import tech.pegasys.teku.api.exceptions.BadRequestException;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
+
+public class StateValidatorsUtilTest {
+  private final StateValidatorsUtil util = new StateValidatorsUtil();
+
+  @Test
+  public void shouldRaiseExceptionIfInputIsInvalid() {
+    assertThrows(
+        BadRequestException.class,
+        () -> util.parseStatusFilter(Map.of("status", List.of("withdraw"))));
+  }
+
+  @ParameterizedTest
+  @EnumSource(ValidatorStatus.class)
+  public void shouldParseValidatorSource(final ValidatorStatus status) {
+    assertThat(util.parseStatusFilter(Map.of("status", List.of(status.name()))))
+        .containsExactly(status);
+  }
+
+  @Test
+  public void shouldParseMultipleValidatorStatuses() {
+    assertThat(
+            util.parseStatusFilter(
+                Map.of("status", List.of("active_ongoing", "active_exiting, withdrawal_done"))))
+        .containsExactlyInAnyOrder(
+            ValidatorStatus.active_ongoing,
+            ValidatorStatus.active_exiting,
+            ValidatorStatus.withdrawal_done);
+  }
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -449,25 +449,21 @@ public class ChainDataProvider {
       } catch (PublicKeyException ex) {
         throw new BadRequestException(String.format("Invalid public key: %s", validatorParameter));
       }
-    } else {
-      try {
-        final UInt64 numericValidator = UInt64.valueOf(validatorParameter);
-        if (numericValidator.isGreaterThan(UInt64.valueOf(Integer.MAX_VALUE))) {
-          throw new BadRequestException(
-              String.format("Validator Index is too high to use: %s", validatorParameter));
-        }
-        final int validatorIndex = numericValidator.intValue();
-        final int validatorCount = state.getValidators().size();
-        if (validatorIndex > validatorCount) {
-          throw new BadRequestException(
-              String.format(
-                  "Invalid validator index: %d, exceeds validator count: %d",
-                  validatorIndex, validatorCount));
-        }
-        return Optional.of(validatorIndex);
-      } catch (NumberFormatException ex) {
-        throw new BadRequestException(String.format("Invalid validator: %s", validatorParameter));
+    }
+    try {
+      final UInt64 numericValidator = UInt64.valueOf(validatorParameter);
+      if (numericValidator.isGreaterThan(UInt64.valueOf(Integer.MAX_VALUE))) {
+        throw new BadRequestException(
+            String.format("Validator Index is too high to use: %s", validatorParameter));
       }
+      final int validatorIndex = numericValidator.intValue();
+      final int validatorCount = state.getValidators().size();
+      if (validatorIndex > validatorCount) {
+        return Optional.empty();
+      }
+      return Optional.of(validatorIndex);
+    } catch (NumberFormatException ex) {
+      throw new BadRequestException(String.format("Invalid validator: %s", validatorParameter));
     }
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -558,8 +558,7 @@ public class ChainDataProvider {
       final List<Integer> validatorIndices,
       final tech.pegasys.teku.datastructures.state.BeaconState state) {
     return validatorIndices.stream()
-        .map(index -> ValidatorResponse.fromState(state, index))
-        .flatMap(Optional::stream)
+        .flatMap(index -> ValidatorResponse.fromState(state, index).stream())
         .collect(toList());
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -30,6 +30,7 @@ import java.util.function.Predicate;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.blockselector.BlockSelectorFactory;
+import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.response.GetBlockResponse;
 import tech.pegasys.teku.api.response.GetForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.BlockHeader;
@@ -428,12 +429,10 @@ public class ChainDataProvider {
     if (!isStoreAvailable()) {
       throw new ChainDataUnavailableException();
     }
-    final Optional<tech.pegasys.teku.datastructures.state.BeaconState> maybeState =
-        recentChainData.getBestState();
-    if (maybeState.isEmpty()) {
-      return Optional.empty();
-    }
-    return validatorParameterToIndex(maybeState.get(), validatorParameter);
+    return recentChainData
+        .getBestState()
+        .map(state -> validatorParameterToIndex(state, validatorParameter))
+        .orElse(Optional.empty());
   }
 
   private Optional<Integer> validatorParameterToIndex(
@@ -448,28 +447,26 @@ public class ChainDataProvider {
         BLSPubKey publicKey = BLSPubKey.fromHexString(validatorParameter);
         return getValidatorIndex(state, publicKey.asBLSPublicKey());
       } catch (PublicKeyException ex) {
-        throw new IllegalArgumentException(
-            String.format("Invalid public key: %s", validatorParameter));
+        throw new BadRequestException(String.format("Invalid public key: %s", validatorParameter));
       }
     } else {
       try {
         final UInt64 numericValidator = UInt64.valueOf(validatorParameter);
         if (numericValidator.isGreaterThan(UInt64.valueOf(Integer.MAX_VALUE))) {
-          throw new IllegalArgumentException(
+          throw new BadRequestException(
               String.format("Validator Index is too high to use: %s", validatorParameter));
         }
         final int validatorIndex = numericValidator.intValue();
         final int validatorCount = state.getValidators().size();
         if (validatorIndex > validatorCount) {
-          throw new IllegalArgumentException(
+          throw new BadRequestException(
               String.format(
                   "Invalid validator index: %d, exceeds validator count: %d",
                   validatorIndex, validatorCount));
         }
         return Optional.of(validatorIndex);
       } catch (NumberFormatException ex) {
-        throw new IllegalArgumentException(
-            String.format("Invalid validator: %s", validatorParameter));
+        throw new BadRequestException(String.format("Invalid validator: %s", validatorParameter));
       }
     }
   }
@@ -617,7 +614,26 @@ public class ChainDataProvider {
     return getValidatorSelector(state, validators)
         .filter(getStatusPredicate(state, statusFilter))
         .mapToObj(index -> ValidatorResponse.fromState(state, index))
+        .filter(v -> !v.equals(ValidatorResponse.EMPTY))
         .collect(toList());
+  }
+
+  public SafeFuture<Optional<ValidatorResponse>> getStateValidator(
+      final String stateIdParam, final String validatorIdParam) {
+    return defaultStateSelectorFactory
+        .defaultStateSelector(stateIdParam)
+        .getState()
+        .thenApply(
+            maybeState -> maybeState.map(state -> getValidatorFromState(state, validatorIdParam)));
+  }
+
+  private ValidatorResponse getValidatorFromState(
+      final tech.pegasys.teku.datastructures.state.BeaconState state,
+      final String validatorIdParam) {
+    return getValidatorSelector(state, List.of(validatorIdParam))
+        .mapToObj(index -> ValidatorResponse.fromState(state, index))
+        .findFirst()
+        .orElse(ValidatorResponse.EMPTY);
   }
 
   private IntPredicate getStatusPredicate(

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -559,6 +559,7 @@ public class ChainDataProvider {
       final tech.pegasys.teku.datastructures.state.BeaconState state) {
     return validatorIndices.stream()
         .map(index -> ValidatorResponse.fromState(state, index))
+        .flatMap(Optional::stream)
         .collect(toList());
   }
 
@@ -614,7 +615,7 @@ public class ChainDataProvider {
     return getValidatorSelector(state, validators)
         .filter(getStatusPredicate(state, statusFilter))
         .mapToObj(index -> ValidatorResponse.fromState(state, index))
-        .filter(v -> !v.equals(ValidatorResponse.EMPTY))
+        .flatMap(Optional::stream)
         .collect(toList());
   }
 
@@ -632,8 +633,9 @@ public class ChainDataProvider {
       final String validatorIdParam) {
     return getValidatorSelector(state, List.of(validatorIdParam))
         .mapToObj(index -> ValidatorResponse.fromState(state, index))
+        .flatMap(Optional::stream)
         .findFirst()
-        .orElse(ValidatorResponse.EMPTY);
+        .orElseThrow(() -> new BadRequestException("Validator not found: " + validatorIdParam));
   }
 
   private IntPredicate getStatusPredicate(

--- a/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactory.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -50,8 +51,11 @@ public class BlockSelectorFactory {
         return genesisSelector();
       case ("finalized"):
         return finalizedSelector();
-      default:
-        return forSlot(UInt64.valueOf(selectorMethod));
+    }
+    try {
+      return forSlot(UInt64.valueOf(selectorMethod));
+    } catch (NumberFormatException ex) {
+      throw new BadRequestException("Invalid block: " + selectorMethod);
     }
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/stateselector/StateSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/stateselector/StateSelectorFactory.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.api.stateselector;
 
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -39,8 +40,11 @@ public class StateSelectorFactory {
         return finalizedSelector();
       case ("justified"):
         return justifiedSelector();
-      default:
-        return forSlot(UInt64.valueOf(selectorMethod));
+    }
+    try {
+      return forSlot(UInt64.valueOf(selectorMethod));
+    } catch (NumberFormatException ex) {
+      throw new BadRequestException("Invalid state: " + selectorMethod);
     }
   }
 

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -867,6 +867,7 @@ public class ChainDataProviderTest {
     final List<ValidatorResponse> expectedValidators =
         validatorIds.stream()
             .map(id -> ValidatorResponse.fromState(beaconStateInternal, id))
+            .flatMap(Optional::stream)
             .collect(toList());
     SafeFuture<Optional<List<ValidatorResponse>>> response =
         provider.getValidatorsDetailsBySlot(slot, validatorIds);

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -578,14 +578,6 @@ public class ChainDataProviderTest {
   }
 
   @Test
-  public void validatorParameterToIndex_shouldDetectIndexOutOfBounds() {
-    final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
-
-    assertThrows(BadRequestException.class, () -> provider.validatorParameterToIndex("1234567"));
-  }
-
-  @Test
   public void validatorParameterToIndex_shouldDetectAboveMaxInt() {
     final ChainDataProvider provider =
         new ChainDataProvider(recentChainData, combinedChainDataClient);
@@ -806,10 +798,10 @@ public class ChainDataProviderTest {
   }
 
   @Test
-  public void validatorParameterToIndex_shouldThrowBadRequestExceptionWhenIndexTooHigh() {
+  public void validatorParameterToIndex_shouldReturnEmptyIfIndexOutOfBounds() {
     final ChainDataProvider provider =
         new ChainDataProvider(recentChainData, combinedChainDataClient);
-    assertThrows(BadRequestException.class, () -> provider.validatorParameterToIndex("1024000"));
+    assertThat(provider.validatorParameterToIndex("1024000")).isEmpty();
   }
 
   @Test

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ExecutionException;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.response.GetBlockResponse;
 import tech.pegasys.teku.api.response.GetForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.BlockHeader;
@@ -573,7 +574,7 @@ public class ChainDataProviderTest {
     final ChainDataProvider provider =
         new ChainDataProvider(recentChainData, combinedChainDataClient);
 
-    assertThrows(IllegalArgumentException.class, () -> provider.validatorParameterToIndex("2a"));
+    assertThrows(BadRequestException.class, () -> provider.validatorParameterToIndex("2a"));
   }
 
   @Test
@@ -581,8 +582,7 @@ public class ChainDataProviderTest {
     final ChainDataProvider provider =
         new ChainDataProvider(recentChainData, combinedChainDataClient);
 
-    assertThrows(
-        IllegalArgumentException.class, () -> provider.validatorParameterToIndex("1234567"));
+    assertThrows(BadRequestException.class, () -> provider.validatorParameterToIndex("1234567"));
   }
 
   @Test
@@ -591,7 +591,7 @@ public class ChainDataProviderTest {
         new ChainDataProvider(recentChainData, combinedChainDataClient);
 
     assertThrows(
-        IllegalArgumentException.class,
+        BadRequestException.class,
         () ->
             provider.validatorParameterToIndex(
                 UInt64.valueOf(Integer.MAX_VALUE).increment().toString()));
@@ -603,7 +603,7 @@ public class ChainDataProviderTest {
         new ChainDataProvider(recentChainData, combinedChainDataClient);
 
     assertThrows(
-        IllegalArgumentException.class,
+        BadRequestException.class,
         () -> provider.validatorParameterToIndex(Bytes32.EMPTY.toHexString()));
   }
 
@@ -796,6 +796,29 @@ public class ChainDataProviderTest {
             .map(v -> v.validator.pubkey.toHexString())
             .collect(toList());
     assertThat(pubkeys).containsExactly(key);
+  }
+
+  @Test
+  public void validatorParameterToIndex_shouldThrowBadRequestExceptionWhenIndexInvalid() {
+    final ChainDataProvider provider =
+        new ChainDataProvider(recentChainData, combinedChainDataClient);
+    assertThrows(BadRequestException.class, () -> provider.validatorParameterToIndex("a"));
+  }
+
+  @Test
+  public void validatorParameterToIndex_shouldThrowBadRequestExceptionWhenIndexTooHigh() {
+    final ChainDataProvider provider =
+        new ChainDataProvider(recentChainData, combinedChainDataClient);
+    assertThrows(BadRequestException.class, () -> provider.validatorParameterToIndex("1024000"));
+  }
+
+  @Test
+  public void validatorParameterToIndex_shouldThrowBadRequestExceptionWhenKeyNotFound() {
+    final ChainDataProvider provider =
+        new ChainDataProvider(recentChainData, combinedChainDataClient);
+    assertThrows(
+        BadRequestException.class,
+        () -> provider.validatorParameterToIndex(Bytes32.fromHexString("0x00").toHexString()));
   }
 
   @Test

--- a/data/provider/src/test/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactoryTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.api.blockselector;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -82,5 +84,10 @@ public class BlockSelectorFactoryTest {
         blockSelectorFactory.forSlot(block.getSlot()).getBlock().get();
     verify(client).getBlockAtSlotExact(block.getSlot());
     assertThat(blockList).containsExactly(block);
+  }
+
+  @Test
+  public void defaultBlockSelector_shouldThrowBadRequestException() {
+    assertThrows(BadRequestException.class, () -> blockSelectorFactory.defaultBlockSelector("a"));
   }
 }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/stateselector/StateSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/stateselector/StateSelectorFactoryTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.api.stateselector;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -21,6 +22,7 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -87,5 +89,10 @@ public class StateSelectorFactoryTest {
     Optional<BeaconState> result = factory.forStateRoot(state.hash_tree_root()).getState().get();
     assertThat(result).isEqualTo(Optional.of(state));
     verify(client).getStateByStateRoot(state.hash_tree_root());
+  }
+
+  @Test
+  public void defaultBlockSelector_shouldThrowBadRequestException() {
+    assertThrows(BadRequestException.class, () -> factory.defaultStateSelector("a"));
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/exceptions/BadRequestException.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/exceptions/BadRequestException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.exceptions;
+
+public class BadRequestException extends RuntimeException {
+  public BadRequestException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public BadRequestException(String message) {
+    super(message);
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
@@ -23,7 +23,6 @@ import com.google.common.base.MoreObjects;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
 import java.util.Optional;
-import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.schema.Validator;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
@@ -65,7 +65,7 @@ public class ValidatorResponse {
   public static Optional<ValidatorResponse> fromState(
       final BeaconState state, final Integer index) {
     if (index >= state.getValidators().size()) {
-      throw new BadRequestException("Validator index out of bounds: " + index);
+      return Optional.empty();
     }
     tech.pegasys.teku.datastructures.state.Validator validatorInternal =
         state.getValidators().get(index);

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
@@ -22,13 +22,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
+import java.util.Optional;
+import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.schema.Validator;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class ValidatorResponse {
-  public static final ValidatorResponse EMPTY =
-      new ValidatorResponse(UInt64.MAX_VALUE, UInt64.ZERO, ValidatorStatus.withdrawal_done, null);
 
   @JsonProperty("index")
   @Schema(
@@ -62,19 +62,20 @@ public class ValidatorResponse {
     this.validator = validator;
   }
 
-  public static ValidatorResponse fromState(final BeaconState state, final Integer index) {
-    try {
-      tech.pegasys.teku.datastructures.state.Validator validatorInternal =
-          state.getValidators().get(index);
-      final UInt64 current_epoch = compute_epoch_at_slot(state.getSlot());
-      return new ValidatorResponse(
-          UInt64.valueOf(index),
-          state.getBalances().get(index),
-          getValidatorStatus(current_epoch, validatorInternal),
-          new Validator(validatorInternal));
-    } catch (IndexOutOfBoundsException ex) {
-      return ValidatorResponse.EMPTY;
+  public static Optional<ValidatorResponse> fromState(
+      final BeaconState state, final Integer index) {
+    if (index >= state.getValidators().size()) {
+      throw new BadRequestException("Validator index out of bounds: " + index);
     }
+    tech.pegasys.teku.datastructures.state.Validator validatorInternal =
+        state.getValidators().get(index);
+    final UInt64 current_epoch = compute_epoch_at_slot(state.getSlot());
+    return Optional.of(
+        new ValidatorResponse(
+            UInt64.valueOf(index),
+            state.getBalances().get(index),
+            getValidatorStatus(current_epoch, validatorInternal),
+            new Validator(validatorInternal)));
   }
 
   public static ValidatorStatus getValidatorStatus(

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
@@ -27,6 +27,9 @@ import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class ValidatorResponse {
+  public static final ValidatorResponse EMPTY =
+      new ValidatorResponse(UInt64.MAX_VALUE, UInt64.ZERO, ValidatorStatus.withdrawal_done, null);
+
   @JsonProperty("index")
   @Schema(
       type = "string",
@@ -60,14 +63,18 @@ public class ValidatorResponse {
   }
 
   public static ValidatorResponse fromState(final BeaconState state, final Integer index) {
-    tech.pegasys.teku.datastructures.state.Validator validatorInternal =
-        state.getValidators().get(index);
-    final UInt64 current_epoch = compute_epoch_at_slot(state.getSlot());
-    return new ValidatorResponse(
-        UInt64.valueOf(index),
-        state.getBalances().get(index),
-        getValidatorStatus(current_epoch, validatorInternal),
-        new Validator(validatorInternal));
+    try {
+      tech.pegasys.teku.datastructures.state.Validator validatorInternal =
+          state.getValidators().get(index);
+      final UInt64 current_epoch = compute_epoch_at_slot(state.getSlot());
+      return new ValidatorResponse(
+          UInt64.valueOf(index),
+          state.getBalances().get(index),
+          getValidatorStatus(current_epoch, validatorInternal),
+          new Validator(validatorInternal));
+    } catch (IndexOutOfBoundsException ex) {
+      return ValidatorResponse.EMPTY;
+    }
   }
 
   public static ValidatorStatus getValidatorStatus(


### PR DESCRIPTION
 - Error codes were returning 500 for any issue, rather than the expected codes (#3105)

 - `/eth/v1/state/{state_id}/validators/{validator_id}` needed to get the correct state to work from (#3071)

 Fixes #3077 
 Fixes #3105

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.