### PR TITLE
Update signer keystore library to 1.0.13

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -148,6 +148,6 @@ dependencyManagement {
 
     dependency 'tech.pegasys.discovery:discovery:0.4.0-dev-4ec8e5ee'
 
-    dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.5'
+    dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.13'
   }
 }


### PR DESCRIPTION
## PR Description
-- Update signer keystore library to 1.0.13
 -- Allows to read BLS keystores (EIP-2335) without UUID and Path fields

Signed-off-by: Usman Saleem <usman@usmans.info>

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.