### PR TITLE
update `/eth/v1/beacon/states/{state_id}/finality_checkpoints` to select state more efficiently

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetStateFinalityCheckpointsTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetStateFinalityCheckpointsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.v1.beacon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+
+import java.io.IOException;
+import okhttp3.Response;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.response.v1.beacon.FinalityCheckpointsResponse;
+import tech.pegasys.teku.api.response.v1.beacon.GetStateFinalityCheckpointsResponse;
+import tech.pegasys.teku.api.schema.Checkpoint;
+import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetStateFinalityCheckpoints;
+
+public class GetStateFinalityCheckpointsTest extends AbstractDataBackedRestAPIIntegrationTest {
+
+  @Test
+  public void shouldGetEmptyCheckpointsAtGenesis() throws IOException {
+    startRestAPIAtGenesis();
+    final Response response = get("genesis");
+
+    assertThat(response.code()).isEqualTo(SC_OK);
+    final GetStateFinalityCheckpointsResponse body =
+        jsonProvider.jsonToObject(
+            response.body().string(), GetStateFinalityCheckpointsResponse.class);
+    final FinalityCheckpointsResponse data = body.data;
+
+    assertThat(data.current_justified).isEqualTo(Checkpoint.EMPTY);
+    assertThat(data.previous_justified).isEqualTo(Checkpoint.EMPTY);
+    assertThat(data.finalized).isEqualTo(Checkpoint.EMPTY);
+  }
+
+  public Response get(final String stateIdString) throws IOException {
+    return getResponse(GetStateFinalityCheckpoints.ROUTE.replace(":state_id", stateIdString));
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateFinalityCheckpoints.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateFinalityCheckpoints.java
@@ -22,6 +22,7 @@ import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_V1_BEACON;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.Context;
@@ -31,19 +32,16 @@ import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiParam;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
-import org.apache.tuweni.bytes.Bytes32;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.response.v1.beacon.FinalityCheckpointsResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateFinalityCheckpointsResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateRootResponse;
-import tech.pegasys.teku.api.schema.Checkpoint;
 import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 
 public class GetStateFinalityCheckpoints extends AbstractHandler implements Handler {
@@ -81,25 +79,15 @@ public class GetStateFinalityCheckpoints extends AbstractHandler implements Hand
       })
   @Override
   public void handle(@NotNull final Context ctx) throws Exception {
-    final Function<Bytes32, SafeFuture<Optional<FinalityCheckpointsResponse>>> rootHandler =
-        chainDataProvider::getStateFinalityCheckpointsByStateRootV1;
-    final Function<UInt64, SafeFuture<Optional<FinalityCheckpointsResponse>>> slotHandler =
-        chainDataProvider::getStateFinalityCheckpointsBySlot;
-
-    processStateEndpointRequest(
-        chainDataProvider, ctx, rootHandler, slotHandler, this::handleResult);
+    final Map<String, String> pathParamMap = ctx.pathParamMap();
+    final SafeFuture<Optional<FinalityCheckpointsResponse>> future =
+        chainDataProvider.getStateFinalityCheckpoints(pathParamMap.get(PARAM_STATE_ID));
+    handleOptionalResult(ctx, future, this::handleResult, SC_NOT_FOUND);
   }
 
   private Optional<String> handleResult(Context ctx, final FinalityCheckpointsResponse response)
       throws JsonProcessingException {
-    boolean isFinalized = response.finalized.epoch.isGreaterThan(UInt64.ZERO);
-    FinalityCheckpointsResponse finalityCheckpointsResponse =
-        new FinalityCheckpointsResponse(
-            isFinalized ? response.previous_justified : Checkpoint.EMPTY,
-            isFinalized ? response.current_justified : Checkpoint.EMPTY,
-            isFinalized ? response.finalized : Checkpoint.EMPTY);
     return Optional.of(
-        jsonProvider.objectToJSON(
-            new GetStateFinalityCheckpointsResponse(finalityCheckpointsResponse)));
+        jsonProvider.objectToJSON(new GetStateFinalityCheckpointsResponse(response)));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateFinalityCheckpointsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateFinalityCheckpointsTest.java
@@ -13,9 +13,7 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 
-import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
@@ -28,42 +26,31 @@ import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class GetStateFinalityCheckpointsTest extends AbstractBeaconHandlerTest {
   final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   final BeaconState state = dataStructureUtil.randomBeaconState();
 
   @Test
-  public void shouldReturnUnavailableWhenStoreNotAvailable() throws Exception {
-    final GetStateFinalityCheckpoints handler =
-        new GetStateFinalityCheckpoints(chainDataProvider, jsonProvider);
-    when(context.pathParamMap()).thenReturn(Map.of("state_id", "head"));
-    when(chainDataProvider.isStoreAvailable()).thenReturn(false);
-
-    handler.handle(context);
-    verifyStatusCode(SC_NOT_FOUND);
-  }
-
-  @Test
   public void shouldReturnFinalityCheckpointsInfo() throws Exception {
     final GetStateFinalityCheckpoints handler =
         new GetStateFinalityCheckpoints(chainDataProvider, jsonProvider);
     when(context.pathParamMap()).thenReturn(Map.of("state_id", "head"));
-    when(chainDataProvider.isStoreAvailable()).thenReturn(true);
-    when(chainDataProvider.stateParameterToSlot("head")).thenReturn(Optional.of(UInt64.ONE));
-    when(chainDataProvider.getStateFinalityCheckpointsBySlot(any()))
+    when(chainDataProvider.getStateFinalityCheckpoints("head"))
         .thenReturn(
             SafeFuture.completedFuture(Optional.of(FinalityCheckpointsResponse.fromState(state))));
 
     handler.handle(context);
 
+    final FinalityCheckpointsResponse expectedResponse =
+        new FinalityCheckpointsResponse(
+            new Checkpoint(state.getPrevious_justified_checkpoint()),
+            new Checkpoint(state.getCurrent_justified_checkpoint()),
+            new Checkpoint(state.getFinalized_checkpoint()));
+
     final GetStateFinalityCheckpointsResponse response =
         getResponseFromFuture(GetStateFinalityCheckpointsResponse.class);
-    assertThat(new Checkpoint(state.getPrevious_justified_checkpoint()))
-        .isEqualTo(response.data.previous_justified);
-    assertThat(new Checkpoint(state.getCurrent_justified_checkpoint()))
-        .isEqualTo(response.data.current_justified);
-    assertThat(new Checkpoint(state.getFinalized_checkpoint())).isEqualTo(response.data.finalized);
+
+    assertThat(response.data).isEqualTo(expectedResponse);
   }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -253,20 +253,6 @@ public class ChainDataProvider {
         .thenApply(state -> state.map(FinalityCheckpointsResponse::fromState));
   }
 
-  public SafeFuture<Optional<FinalityCheckpointsResponse>> getStateFinalityCheckpointsByStateRootV1(
-      final Bytes32 stateRoot) {
-    return combinedChainDataClient
-        .getStateByStateRoot(stateRoot)
-        .thenApply(state -> state.map(FinalityCheckpointsResponse::fromState));
-  }
-
-  public SafeFuture<Optional<FinalityCheckpointsResponse>> getStateFinalityCheckpointsBySlot(
-      final UInt64 slot) {
-    return combinedChainDataClient
-        .getStateAtSlotExact(slot)
-        .thenApply(state -> state.map(FinalityCheckpointsResponse::fromState));
-  }
-
   public SafeFuture<Optional<BeaconState>> getStateByStateRoot(final Bytes32 stateRoot) {
     if (!isStoreAvailable()) {
       return chainUnavailable();

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -245,6 +245,14 @@ public class ChainDataProvider {
         .thenApply(state -> state.map(BeaconState::new));
   }
 
+  public SafeFuture<Optional<FinalityCheckpointsResponse>> getStateFinalityCheckpoints(
+      final String stateIdParam) {
+    return defaultStateSelectorFactory
+        .defaultStateSelector(stateIdParam)
+        .getState()
+        .thenApply(state -> state.map(FinalityCheckpointsResponse::fromState));
+  }
+
   public SafeFuture<Optional<FinalityCheckpointsResponse>> getStateFinalityCheckpointsByStateRootV1(
       final Bytes32 stateRoot) {
     return combinedChainDataClient

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/FinalityCheckpointsResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/FinalityCheckpointsResponse.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.api.response.v1.beacon;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import java.util.Objects;
 import tech.pegasys.teku.api.schema.Checkpoint;
 import tech.pegasys.teku.datastructures.state.BeaconState;
@@ -63,5 +64,14 @@ public class FinalityCheckpointsResponse {
   @Override
   public int hashCode() {
     return Objects.hash(previous_justified, current_justified, finalized);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("previous_justified", previous_justified)
+        .add("current_justified", current_justified)
+        .add("finalized", finalized)
+        .toString();
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/FinalityCheckpointsResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/FinalityCheckpointsResponse.java
@@ -15,8 +15,10 @@ package tech.pegasys.teku.api.response.v1.beacon;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import tech.pegasys.teku.api.schema.Checkpoint;
 import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class FinalityCheckpointsResponse {
   @JsonProperty("previous_justified")
@@ -39,9 +41,27 @@ public class FinalityCheckpointsResponse {
   }
 
   public static FinalityCheckpointsResponse fromState(BeaconState state) {
+    if (state.getFinalized_checkpoint().getEpoch().equals(UInt64.ZERO)) {
+      return new FinalityCheckpointsResponse(Checkpoint.EMPTY, Checkpoint.EMPTY, Checkpoint.EMPTY);
+    }
     return new FinalityCheckpointsResponse(
         new Checkpoint(state.getPrevious_justified_checkpoint()),
         new Checkpoint(state.getCurrent_justified_checkpoint()),
         new Checkpoint(state.getFinalized_checkpoint()));
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final FinalityCheckpointsResponse that = (FinalityCheckpointsResponse) o;
+    return Objects.equals(previous_justified, that.previous_justified)
+        && Objects.equals(current_justified, that.current_justified)
+        && Objects.equals(finalized, that.finalized);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previous_justified, current_justified, finalized);
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/Checkpoint.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/Checkpoint.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES32;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.apache.tuweni.bytes.Bytes32;
@@ -58,5 +59,10 @@ public class Checkpoint {
   @Override
   public int hashCode() {
     return Objects.hashCode(epoch, root);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("epoch", epoch).add("root", root).toString();
   }
 }


### PR DESCRIPTION
Because states were always being translated to slot, there were efficiencies to be gained by making better use of stored states.

There are still times that the slot needs to be used, states like 'head' and 'finalized' are readily accessible and should be retrieved as efficiently as possible.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.