### PR TITLE
Rework language around "anchors"

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
@@ -33,12 +33,12 @@ public interface ReadOnlyStore {
   UInt64 getGenesisTime();
 
   /**
-   * Returns the anchor checkpoint from which the chain was started, if such an anchor exists. If
-   * the anchor is missing, the node was started up from genesis.
+   * Returns the initial checkpoint from which the chain was started. If the checkpoint is missing,
+   * the node was started up from genesis.
    *
-   * @return The anchor if it exists.
+   * @return The initial checkpoint if it exists.
    */
-  Optional<Checkpoint> getAnchor();
+  Optional<Checkpoint> getInitialCheckpoint();
 
   Checkpoint getJustifiedCheckpoint();
 

--- a/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreImpl.java
@@ -32,7 +32,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 class TestStoreImpl implements MutableStore {
   protected UInt64 time;
   protected UInt64 genesis_time;
-  protected final Optional<Checkpoint> anchor;
+  protected final Optional<Checkpoint> initialCheckpoint;
   protected Checkpoint justified_checkpoint;
   protected Checkpoint finalized_checkpoint;
   protected Checkpoint best_justified_checkpoint;
@@ -44,7 +44,7 @@ class TestStoreImpl implements MutableStore {
   TestStoreImpl(
       final UInt64 time,
       final UInt64 genesis_time,
-      final Optional<Checkpoint> anchor,
+      final Optional<Checkpoint> initialCheckpoint,
       final Checkpoint justified_checkpoint,
       final Checkpoint finalized_checkpoint,
       final Checkpoint best_justified_checkpoint,
@@ -54,7 +54,7 @@ class TestStoreImpl implements MutableStore {
       final Map<UInt64, VoteTracker> votes) {
     this.time = time;
     this.genesis_time = genesis_time;
-    this.anchor = anchor;
+    this.initialCheckpoint = initialCheckpoint;
     this.justified_checkpoint = justified_checkpoint;
     this.finalized_checkpoint = finalized_checkpoint;
     this.best_justified_checkpoint = best_justified_checkpoint;
@@ -76,8 +76,8 @@ class TestStoreImpl implements MutableStore {
   }
 
   @Override
-  public Optional<Checkpoint> getAnchor() {
-    return anchor;
+  public Optional<Checkpoint> getInitialCheckpoint() {
+    return initialCheckpoint;
   }
 
   @Override

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
@@ -29,9 +29,9 @@ public class ProtoArray {
 
   private UInt64 justifiedEpoch;
   private UInt64 finalizedEpoch;
-  // The epoch of our startup anchor state
+  // The epoch of our initial startup state
   // When starting from genesis, this value is zero (genesis epoch)
-  private final UInt64 anchorEpoch;
+  private final UInt64 initialEpoch;
 
   private final List<ProtoNode> nodes;
   private final Map<Bytes32, Integer> indices;
@@ -40,13 +40,13 @@ public class ProtoArray {
       int pruneThreshold,
       UInt64 justifiedEpoch,
       UInt64 finalizedEpoch,
-      UInt64 anchorEpoch,
+      UInt64 initialEpoch,
       List<ProtoNode> nodes,
       Map<Bytes32, Integer> indices) {
     this.pruneThreshold = pruneThreshold;
     this.justifiedEpoch = justifiedEpoch;
     this.finalizedEpoch = finalizedEpoch;
-    this.anchorEpoch = anchorEpoch;
+    this.initialEpoch = initialEpoch;
     this.nodes = nodes;
     this.indices = indices;
   }
@@ -390,8 +390,8 @@ public class ProtoArray {
    * @return
    */
   private boolean nodeIsViableForHead(ProtoNode node) {
-    return (node.getJustifiedEpoch().equals(justifiedEpoch) || justifiedEpoch.equals(anchorEpoch))
-        && (node.getFinalizedEpoch().equals(finalizedEpoch) || finalizedEpoch.equals(anchorEpoch));
+    return (node.getJustifiedEpoch().equals(justifiedEpoch) || justifiedEpoch.equals(initialEpoch))
+        && (node.getFinalizedEpoch().equals(finalizedEpoch) || finalizedEpoch.equals(initialEpoch));
   }
 
   public UInt64 getJustifiedEpoch() {
@@ -402,7 +402,7 @@ public class ProtoArray {
     return finalizedEpoch;
   }
 
-  public UInt64 getAnchorEpoch() {
-    return anchorEpoch;
+  public UInt64 getInitialEpoch() {
+    return initialEpoch;
   }
 }

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategy.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategy.java
@@ -54,9 +54,12 @@ public class ProtoArrayForkChoiceStrategy implements ForkChoiceStrategy {
   // Public
   public static SafeFuture<ProtoArrayForkChoiceStrategy> initialize(
       ReadOnlyStore store, ProtoArrayStorageChannel storageChannel) {
-    // If no anchor is explicitly set, default to zero (genesis epoch)
-    final UInt64 anchorEpoch =
-        store.getAnchor().map(Checkpoint::getEpoch).orElse(UInt64.valueOf(Constants.GENESIS_EPOCH));
+    // If no initialEpoch is explicitly set, default to zero (genesis epoch)
+    final UInt64 initialEpoch =
+        store
+            .getInitialCheckpoint()
+            .map(Checkpoint::getEpoch)
+            .orElse(UInt64.valueOf(Constants.GENESIS_EPOCH));
     ProtoArray protoArray =
         storageChannel
             .getProtoArraySnapshot()
@@ -67,7 +70,7 @@ public class ProtoArrayForkChoiceStrategy implements ForkChoiceStrategy {
                     Constants.PROTOARRAY_FORKCHOICE_PRUNE_THRESHOLD,
                     store.getJustifiedCheckpoint().getEpoch(),
                     store.getFinalizedCheckpoint().getEpoch(),
-                    anchorEpoch,
+                    initialEpoch,
                     new ArrayList<>(),
                     new HashMap<>()));
 

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArraySnapshot.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArraySnapshot.java
@@ -25,17 +25,17 @@ public class ProtoArraySnapshot {
 
   private final UInt64 justifiedEpoch;
   private final UInt64 finalizedEpoch;
-  private final UInt64 anchorEpoch;
+  private final UInt64 initialEpoch;
   private final List<BlockInformation> blockInformationList;
 
   public ProtoArraySnapshot(
       final UInt64 justifiedEpoch,
       final UInt64 finalizedEpoch,
-      final UInt64 anchorEpoch,
+      final UInt64 initialEpoch,
       final List<BlockInformation> blockInformationList) {
     this.justifiedEpoch = justifiedEpoch;
     this.finalizedEpoch = finalizedEpoch;
-    this.anchorEpoch = anchorEpoch;
+    this.initialEpoch = initialEpoch;
     this.blockInformationList = blockInformationList;
   }
 
@@ -46,8 +46,8 @@ public class ProtoArraySnapshot {
             .collect(Collectors.toList());
     UInt64 justifiedEpoch = protoArray.getJustifiedEpoch();
     UInt64 finalizedEpoch = protoArray.getFinalizedEpoch();
-    UInt64 anchorEpoch = protoArray.getAnchorEpoch();
-    return new ProtoArraySnapshot(justifiedEpoch, finalizedEpoch, anchorEpoch, nodes);
+    UInt64 initialEpoch = protoArray.getInitialEpoch();
+    return new ProtoArraySnapshot(justifiedEpoch, finalizedEpoch, initialEpoch, nodes);
   }
 
   public ProtoArray toProtoArray() {
@@ -56,7 +56,7 @@ public class ProtoArraySnapshot {
             Constants.PROTOARRAY_FORKCHOICE_PRUNE_THRESHOLD,
             justifiedEpoch,
             finalizedEpoch,
-            anchorEpoch,
+            initialEpoch,
             new ArrayList<>(),
             new HashMap<>());
 
@@ -80,8 +80,8 @@ public class ProtoArraySnapshot {
     return finalizedEpoch;
   }
 
-  public UInt64 getAnchorEpoch() {
-    return anchorEpoch;
+  public UInt64 getInitialEpoch() {
+    return initialEpoch;
   }
 
   public List<BlockInformation> getBlockInformationList() {

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategyTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategyTest.java
@@ -57,13 +57,13 @@ public class ProtoArrayForkChoiceStrategyTest {
   public void findHead_worksForChainInitializedFromNonGenesisAnchor() {
     // Set up store with an anchor point that has justified and finalized checkpoints prior to its
     // epoch
-    final UInt64 anchorEpoch = UInt64.valueOf(100);
+    final UInt64 initialEpoch = UInt64.valueOf(100);
     final BeaconState anchorState =
         dataStructureUtil
             .stateBuilder()
-            .setJustifiedCheckpointsToEpoch(anchorEpoch.minus(2))
-            .setFinalizedCheckpointToEpoch(anchorEpoch.minus(3))
-            .setSlotToStartOfEpoch(anchorEpoch)
+            .setJustifiedCheckpointsToEpoch(initialEpoch.minus(2))
+            .setFinalizedCheckpointToEpoch(initialEpoch.minus(3))
+            .setSlotToStartOfEpoch(initialEpoch)
             .build();
     AnchorPoint anchor = dataStructureUtil.createAnchorFromState(anchorState);
     MutableStore store = new TestStoreFactory().createAnchorStore(anchor);

--- a/storage/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
@@ -25,5 +25,5 @@ public interface StorageUpdateChannel extends ChannelInterface {
 
   SafeFuture<Void> onWeakSubjectivityUpdate(WeakSubjectivityUpdate weakSubjectivityUpdate);
 
-  void onAnchorPoint(AnchorPoint anchorPoint);
+  void onChainInitialized(AnchorPoint initialAnchor);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -142,7 +142,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
 
     // Set the head to the anchor point
     updateHead(anchorPoint.getRoot(), anchorPoint.getEpochStartSlot());
-    storageUpdateChannel.onAnchorPoint(anchorPoint);
+    storageUpdateChannel.onChainInitialized(anchorPoint);
   }
 
   public UInt64 getGenesisTime() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -103,8 +103,8 @@ public class ChainStorage implements StorageUpdateChannel, StorageQueryChannel {
   }
 
   @Override
-  public void onAnchorPoint(final AnchorPoint anchorPoint) {
-    database.storeAnchorPoint(anchorPoint);
+  public void onChainInitialized(final AnchorPoint initialAnchor) {
+    database.storeInitialAnchor(initialAnchor);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -36,7 +36,7 @@ import tech.pegasys.teku.storage.store.StoreBuilder;
 
 public interface Database extends AutoCloseable {
 
-  void storeAnchorPoint(AnchorPoint genesis);
+  void storeInitialAnchor(AnchorPoint genesis);
 
   void update(StorageUpdate event);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -38,7 +38,7 @@ import tech.pegasys.teku.storage.store.StoreBuilder;
 public class NoOpDatabase implements Database {
 
   @Override
-  public void storeAnchorPoint(final AnchorPoint genesis) {}
+  public void storeInitialAnchor(final AnchorPoint genesis) {}
 
   @Override
   public void update(final StorageUpdate event) {}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -183,7 +183,7 @@ public class RocksDbDatabase implements Database {
   }
 
   @Override
-  public void storeAnchorPoint(final AnchorPoint anchor) {
+  public void storeInitialAnchor(final AnchorPoint anchor) {
     try (final HotUpdater hotUpdater = hotDao.hotUpdater();
         final FinalizedUpdater finalizedUpdater = finalizedDao.finalizedUpdater()) {
       // We should only have a single block / state / checkpoint at anchorpoint initialization

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/ProtoArraySnapshotSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/ProtoArraySnapshotSerializer.java
@@ -34,18 +34,18 @@ public class ProtoArraySnapshotSerializer implements RocksDbSerializer<ProtoArra
           final List<BlockInformation> blockInformationList =
               reader.readBytesList().stream().map(BlockInformation::fromBytes).collect(toList());
 
-          final UInt64 anchorEpoch;
+          final UInt64 initialEpoch;
           if (reader.isComplete()) {
-            // Read earlier format which is missing an explicit anchorEpoch value
-            // Set anchor epoch to default of zero for genesis
-            anchorEpoch = UInt64.valueOf(Constants.GENESIS_EPOCH);
+            // Read earlier format which is missing an explicit initial epoch value
+            // Set initial epoch to default of zero for genesis
+            initialEpoch = UInt64.valueOf(Constants.GENESIS_EPOCH);
           } else {
-            // Read anchor epoch
-            anchorEpoch = UInt64.fromLongBits(reader.readUInt64());
+            // Read initial epoch
+            initialEpoch = UInt64.fromLongBits(reader.readUInt64());
           }
 
           return new ProtoArraySnapshot(
-              justifiedEpoch, finalizedEpoch, anchorEpoch, blockInformationList);
+              justifiedEpoch, finalizedEpoch, initialEpoch, blockInformationList);
         });
   }
 
@@ -60,7 +60,7 @@ public class ProtoArraySnapshotSerializer implements RocksDbSerializer<ProtoArra
                   protoArraySnapshot.getBlockInformationList().stream()
                       .map(BlockInformation::toBytes)
                       .collect(toList()));
-              writer.writeUInt64(protoArraySnapshot.getAnchorEpoch().longValue());
+              writer.writeUInt64(protoArraySnapshot.getInitialEpoch().longValue());
             });
     return bytes.toArrayUnsafe();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -69,7 +69,7 @@ class Store implements UpdatableStore {
 
   private final BlockProvider blockProvider;
 
-  private final Optional<Checkpoint> anchor;
+  private final Optional<Checkpoint> initialCheckpoint;
   BlockTree blockTree;
   UInt64 time;
   UInt64 genesis_time;
@@ -88,7 +88,7 @@ class Store implements UpdatableStore {
       final BlockProvider blockProvider,
       final StateAndBlockProvider stateAndBlockProvider,
       final CachingTaskQueue<Bytes32, SignedBlockAndState> states,
-      final Optional<Checkpoint> anchor,
+      final Optional<Checkpoint> initialCheckpoint,
       final UInt64 time,
       final UInt64 genesis_time,
       final Checkpoint justified_checkpoint,
@@ -113,7 +113,7 @@ class Store implements UpdatableStore {
     this.checkpointStates = checkpointStates;
 
     // Store instance variables
-    this.anchor = anchor;
+    this.initialCheckpoint = initialCheckpoint;
     this.hotStatePersistenceFrequencyInEpochs = hotStatePersistenceFrequencyInEpochs;
     this.time = time;
     this.genesis_time = genesis_time;
@@ -145,7 +145,7 @@ class Store implements UpdatableStore {
       final MetricsSystem metricsSystem,
       final BlockProvider blockProvider,
       final StateAndBlockProvider stateAndBlockProvider,
-      final Optional<Checkpoint> anchor,
+      final Optional<Checkpoint> initialCheckpoint,
       final UInt64 time,
       final UInt64 genesisTime,
       final Checkpoint justifiedCheckpoint,
@@ -186,7 +186,7 @@ class Store implements UpdatableStore {
         blockProvider,
         stateAndBlockProvider,
         stateTaskQueue,
-        anchor,
+        initialCheckpoint,
         time,
         genesisTime,
         justifiedCheckpoint,
@@ -256,8 +256,8 @@ class Store implements UpdatableStore {
   }
 
   @Override
-  public Optional<Checkpoint> getAnchor() {
-    return anchor;
+  public Optional<Checkpoint> getInitialCheckpoint() {
+    return initialCheckpoint;
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -189,8 +189,8 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
-  public Optional<Checkpoint> getAnchor() {
-    return store.getAnchor();
+  public Optional<Checkpoint> getInitialCheckpoint() {
+    return store.getInitialCheckpoint();
   }
 
   @Override

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractStorageBackedDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractStorageBackedDatabaseTest.java
@@ -177,7 +177,7 @@ public abstract class AbstractStorageBackedDatabaseTest extends AbstractDatabase
 
     final UpdatableStore memoryStore = recreateStore();
     assertStoresMatch(memoryStore, store);
-    assertThat(memoryStore.getAnchor()).contains(anchor.getCheckpoint());
+    assertThat(memoryStore.getInitialCheckpoint()).contains(anchor.getCheckpoint());
     assertThat(database.getEarliestAvailableBlockSlot()).contains(anchorBlockAndState.getSlot());
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/AbstractRocksDbDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/AbstractRocksDbDatabaseTest.java
@@ -57,13 +57,13 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfClosedDatabaseIsModified_setGenesis() throws Exception {
     database.close();
-    assertThatThrownBy(() -> database.storeAnchorPoint(genesisAnchor))
+    assertThatThrownBy(() -> database.storeInitialAnchor(genesisAnchor))
         .isInstanceOf(ShuttingDownException.class);
   }
 
   @Test
   public void shouldThrowIfClosedDatabaseIsModified_update() throws Exception {
-    database.storeAnchorPoint(genesisAnchor);
+    database.storeInitialAnchor(genesisAnchor);
     database.close();
 
     final SignedBlockAndState newValue = chainBuilder.generateBlockAtSlot(1);
@@ -79,7 +79,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
 
   @Test
   public void createMemoryStore_priorToGenesisTime() {
-    database.storeAnchorPoint(genesisAnchor);
+    database.storeInitialAnchor(genesisAnchor);
 
     final Optional<StoreBuilder> storeBuilder =
         ((RocksDbDatabase) database).createMemoryStore(() -> 0L);
@@ -98,7 +98,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
 
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_createMemoryStore() throws Exception {
-    database.storeAnchorPoint(genesisAnchor);
+    database.storeInitialAnchor(genesisAnchor);
     database.close();
 
     assertThatThrownBy(database::createMemoryStore).isInstanceOf(ShuttingDownException.class);
@@ -106,7 +106,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
 
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_getSlotForFinalizedBlockRoot() throws Exception {
-    database.storeAnchorPoint(genesisAnchor);
+    database.storeInitialAnchor(genesisAnchor);
     database.close();
 
     assertThatThrownBy(() -> database.getSlotForFinalizedBlockRoot(Bytes32.ZERO))
@@ -115,7 +115,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
 
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_getSignedBlock() throws Exception {
-    database.storeAnchorPoint(genesisAnchor);
+    database.storeInitialAnchor(genesisAnchor);
     database.close();
 
     assertThatThrownBy(() -> database.getSignedBlock(genesisCheckpoint.getRoot()))
@@ -124,7 +124,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
 
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_streamFinalizedBlocks() throws Exception {
-    database.storeAnchorPoint(genesisAnchor);
+    database.storeInitialAnchor(genesisAnchor);
     database.close();
 
     assertThatThrownBy(() -> database.streamFinalizedBlocks(UInt64.ZERO, UInt64.ONE))
@@ -134,7 +134,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_streamFinalizedBlocksShuttingDown()
       throws Exception {
-    database.storeAnchorPoint(genesisAnchor);
+    database.storeInitialAnchor(genesisAnchor);
     try (final Stream<SignedBeaconBlock> stream =
         database.streamFinalizedBlocks(UInt64.ZERO, UInt64.valueOf(1000L))) {
       database.close();
@@ -145,7 +145,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfTransactionModifiedAfterDatabaseIsClosed_updateHotDao()
       throws Exception {
-    database.storeAnchorPoint(genesisAnchor);
+    database.storeInitialAnchor(genesisAnchor);
 
     try (final RocksDbHotDao.HotUpdater updater =
         ((RocksDbDatabase) database).hotDao.hotUpdater()) {
@@ -159,7 +159,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfTransactionModifiedAfterDatabaseIsClosed_updateFinalizedDao()
       throws Exception {
-    database.storeAnchorPoint(genesisAnchor);
+    database.storeInitialAnchor(genesisAnchor);
 
     try (final RocksDbFinalizedDao.FinalizedUpdater updater =
         ((RocksDbDatabase) database).finalizedDao.finalizedUpdater()) {
@@ -173,7 +173,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfTransactionModifiedAfterDatabaseIsClosed_updateEth1Dao()
       throws Exception {
-    database.storeAnchorPoint(genesisAnchor);
+    database.storeInitialAnchor(genesisAnchor);
 
     final DataStructureUtil dataStructureUtil = new DataStructureUtil();
     try (final RocksDbEth1Dao.Eth1Updater updater =
@@ -189,7 +189,7 @@ public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedD
   @Test
   public void shouldThrowIfClosedDatabaseIsRead_getHistoricalState() throws Exception {
     // Store genesis
-    database.storeAnchorPoint(genesisAnchor);
+    database.storeInitialAnchor(genesisAnchor);
     // Add a new finalized block to supersede genesis
     final SignedBlockAndState newBlock = chainBuilder.generateBlockAtSlot(1);
     final Checkpoint newCheckpoint = getCheckpointForBlock(newBlock.getBlock());

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/serialization/ProtoArraySnapshotSerializerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/serialization/ProtoArraySnapshotSerializerTest.java
@@ -87,7 +87,7 @@ public class ProtoArraySnapshotSerializerTest {
 
     // Deserialize and check that value matches the original
     final ProtoArraySnapshot deserialized = serializer.deserialize(serialized);
-    assertThat(deserialized.getAnchorEpoch()).isEqualTo(anchorEpoch);
+    assertThat(deserialized.getInitialEpoch()).isEqualTo(anchorEpoch);
     assertThat(deserialized).isEqualToComparingFieldByField(protoArraySnapshot);
   }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
@@ -31,5 +31,5 @@ public class StubStorageUpdateChannel implements StorageUpdateChannel {
   }
 
   @Override
-  public void onAnchorPoint(AnchorPoint anchorPoint) {}
+  public void onChainInitialized(AnchorPoint initialAnchor) {}
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
@@ -37,5 +37,5 @@ public class StubStorageUpdateChannelWithDelays implements StorageUpdateChannel 
   }
 
   @Override
-  public void onAnchorPoint(AnchorPoint anchorPoint) {}
+  public void onChainInitialized(AnchorPoint initialAnchor) {}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Rework variable/method names related to `AnchorPoint`'s.  Try to use more specific language about what's being stored rather than referring the "anchor" concept.  This will make it easier to reuse the `AnchorPoint` data structure in new contexts with less confusion. 

**Note**: This PR just contains cosmetic changes - pushing this up as a standalone PR to reduce the noise in follow-up PR's to come.

## Fixed Issue(s)
Related to #3063 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.