### PR TITLE
Add mainnet deposit contract to the network definition

### DIFF
--- a/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
@@ -26,7 +26,13 @@ public class NetworkDefinition {
   private static final ImmutableMap<String, NetworkDefinition> NETWORKS =
       ImmutableMap.<String, NetworkDefinition>builder()
           .put("minimal", builder().constants("minimal").startupTargetPeerCount(0).build())
-          .put("mainnet", builder().constants("mainnet").build())
+          .put(
+              "mainnet",
+              builder()
+                  .constants("mainnet")
+                  .startupTimeoutSeconds(120)
+                  .eth1DepositContractAddress("0x00000000219ab540356cBB839Cbe05303d7705Fa")
+                  .build())
           .put(
               "medalla",
               builder()


### PR DESCRIPTION
## PR Description
Add the deposit contract address to the network definition, not just the main net.yaml.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.