### PR TITLE
Support specifying ws initial state and block in config

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/WeakSubjectivityOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/WeakSubjectivityOptions.java
@@ -18,33 +18,27 @@ import tech.pegasys.teku.cli.converter.CheckpointConverter;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.util.config.InvalidConfigurationException;
 
 public class WeakSubjectivityOptions {
 
-  @CommandLine.ArgGroup(exclusive = false)
-  InitialStateArguments initialStateArguments;
+  @CommandLine.Option(
+      names = {"--Xws-initial-state"},
+      paramLabel = "<STRING>",
+      description =
+          "A recent state within the weak subjectivity period.  This value should be a file or URL pointing to an SSZ encoded state.",
+      arity = "1",
+      hidden = true)
+  private String weakSubjectivityState;
 
-  static class InitialStateArguments {
-    @CommandLine.Option(
-        required = true,
-        names = {"--Xws-initial-state"},
-        paramLabel = "<STRING>",
-        description =
-            "A recent state within the weak subjectivity period.  This value should be a file or URL pointing to an SSZ encoded state.",
-        arity = "1",
-        hidden = true)
-    private String weakSubjectivityState;
-
-    @CommandLine.Option(
-        required = true,
-        names = {"--Xws-initial-block"},
-        paramLabel = "<STRING>",
-        description =
-            "A recent block within the weak subjectivity period.  This value should be a file or URL pointing to an SSZ encoded block.",
-        arity = "1",
-        hidden = true)
-    private String weakSubjectivityBlock;
-  }
+  @CommandLine.Option(
+      names = {"--Xws-initial-block"},
+      paramLabel = "<STRING>",
+      description =
+          "A recent block within the weak subjectivity period.  This value should be a file or URL pointing to an SSZ encoded block.",
+      arity = "1",
+      hidden = true)
+  private String weakSubjectivityBlock;
 
   @CommandLine.Option(
       converter = CheckpointConverter.class,
@@ -66,9 +60,13 @@ public class WeakSubjectivityOptions {
   public TekuConfiguration.Builder configure(TekuConfiguration.Builder builder) {
     return builder.weakSubjectivity(
         wsBuilder -> {
-          if (initialStateArguments != null) {
-            wsBuilder.weakSubjectivityStateResource(initialStateArguments.weakSubjectivityState);
-            wsBuilder.weakSubjectivityBlockResource(initialStateArguments.weakSubjectivityBlock);
+          if (weakSubjectivityState != null || weakSubjectivityBlock != null) {
+            if (weakSubjectivityState == null || weakSubjectivityBlock == null) {
+              throw new InvalidConfigurationException(
+                  "Error: --Xws-initial-block and --Xws-initial-state must be specified together");
+            }
+            wsBuilder.weakSubjectivityStateResource(weakSubjectivityState);
+            wsBuilder.weakSubjectivityBlockResource(weakSubjectivityBlock);
           }
           if (weakSubjectivityCheckpoint != null) {
             wsBuilder.weakSubjectivityCheckpoint(weakSubjectivityCheckpoint);

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/WeakSubjectivityOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/WeakSubjectivityOptionsTest.java
@@ -101,7 +101,8 @@ public class WeakSubjectivityOptionsTest extends AbstractBeaconNodeCommandTest {
     final int result = beaconNodeCommand.parse(args);
 
     String str = getCommandLineOutput();
-    assertThat(str).contains("Error: Missing required argument(s): --Xws-initial-block=<STRING>");
+    assertThat(str)
+        .contains("Error: --Xws-initial-block and --Xws-initial-state must be specified together");
     assertThat(str).contains("To display full help:");
     assertThat(str).contains("--help");
     assertThat(result).isGreaterThan(0);
@@ -113,7 +114,8 @@ public class WeakSubjectivityOptionsTest extends AbstractBeaconNodeCommandTest {
     final int result = beaconNodeCommand.parse(args);
 
     String str = getCommandLineOutput();
-    assertThat(str).contains("Error: Missing required argument(s): --Xws-initial-state=<STRING>");
+    assertThat(str)
+        .contains("Error: --Xws-initial-block and --Xws-initial-state must be specified together");
     assertThat(str).contains("To display full help:");
     assertThat(str).contains("--help");
     assertThat(result).isGreaterThan(0);
@@ -123,5 +125,13 @@ public class WeakSubjectivityOptionsTest extends AbstractBeaconNodeCommandTest {
   public void weakSubjectivityState_shouldDefault() {
     final TekuConfiguration config = getTekuConfigurationFromArguments();
     assertThat(config.weakSubjectivity().getWeakSubjectivityStateResource()).isEmpty();
+  }
+
+  @Test
+  public void weakSubjectivityState_fromConfig() {
+    final TekuConfiguration config =
+        getTekuConfigurationFromFile("weakSubjectivityOptions_config.yaml");
+    assertThat(config.weakSubjectivity().getWeakSubjectivityStateResource()).contains("state.ssz");
+    assertThat(config.weakSubjectivity().getWeakSubjectivityBlockResource()).contains("block.ssz");
   }
 }

--- a/teku/src/test/resources/weakSubjectivityOptions_config.yaml
+++ b/teku/src/test/resources/weakSubjectivityOptions_config.yaml
@@ -1,0 +1,2 @@
+Xws-initial-state: state.ssz
+Xws-initial-block: block.ssz


### PR DESCRIPTION
## PR Description
Fix `--Xws-initial-state` and `--Xws-initial-block` so they can be specified in a config file.

Unfortunately `ArgGroup` doesn't work with the config files.

## Fixed Issue(s)
fixes #3148 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.