### PR TITLE
Update to v1.0.0. ref tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -221,7 +221,7 @@ allprojects {
   }
 }
 
-def refTestVersion = 'v1.0.0-rc.0'
+def refTestVersion = 'v1.0.0'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
 def refTestDownloadDir = "${buildDir}/refTests/${refTestVersion}"
 def refTestExpandDir = "${project.rootDir}/eth-reference-tests/src/referenceTest/resources/eth2.0-spec-tests/"

--- a/build.gradle
+++ b/build.gradle
@@ -221,6 +221,7 @@ allprojects {
   }
 }
 
+// Note: v1.0.0 tests were republished to fix an initial error. This comment forces cache update
 def refTestVersion = 'v1.0.0'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
 def refTestDownloadDir = "${buildDir}/refTests/${refTestVersion}"


### PR DESCRIPTION
## PR Description
Beacon chain spec v1.0.0 ref tests are out so update to them.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.