### PR TITLE
Limit size of range used when requesting deposit logs

### DIFF
--- a/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
@@ -238,7 +238,8 @@ public class DepositFetcher {
       nextBatchStart = getNextBatchEnd().add(BigInteger.ONE);
       if (batchSize < DEFAULT_BATCH_SIZE) {
         // Grow the batch size slowly as we may be past a large blob of logs that caused trouble
-        batchSize = Math.min(DEFAULT_BATCH_SIZE, (int) (batchSize * 1.1));
+        // +1 to guarantee it grows by at least 1
+        batchSize = Math.min(DEFAULT_BATCH_SIZE, (int) (batchSize * 1.1 + 1));
       }
     }
 

--- a/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
@@ -17,7 +17,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 
+import com.google.common.base.Throwables;
 import java.math.BigInteger;
+import java.net.SocketTimeoutException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -37,11 +39,14 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.api.Eth1EventsChannel;
 import tech.pegasys.teku.pow.contract.DepositContract;
 import tech.pegasys.teku.pow.contract.DepositContract.DepositEventEventResponse;
+import tech.pegasys.teku.pow.contract.RejectedRequestException;
 import tech.pegasys.teku.pow.event.Deposit;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.util.config.Constants;
 
 public class DepositFetcher {
+
+  static final int DEFAULT_BATCH_SIZE = 500_000;
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -73,7 +78,57 @@ public class DepositFetcher {
         fromBlockNumber,
         toBlockNumber);
 
-    return getDepositEventsInRangeFromContract(fromBlockNumber, toBlockNumber)
+    final DepositFetchState fetchState = new DepositFetchState(fromBlockNumber, toBlockNumber);
+    return sendNextBatchRequest(fetchState);
+  }
+
+  private SafeFuture<Void> sendNextBatchRequest(final DepositFetchState fetchState) {
+    final BigInteger nextBatchEnd = fetchState.getNextBatchEnd();
+    LOG.info(
+        "Requesting deposits between {} and {}. Batch size: {}",
+        fetchState.nextBatchStart,
+        nextBatchEnd,
+        fetchState.batchSize);
+    return processDepositsInBatch(fetchState.nextBatchStart, nextBatchEnd)
+        .exceptionallyCompose(
+            (err) -> {
+              LOG.debug(
+                  "Failed to request deposit events for block numbers in the range ({}, {}). Retrying.",
+                  fetchState.nextBatchStart,
+                  nextBatchEnd,
+                  err);
+
+              final Throwable rootCause = Throwables.getRootCause(err);
+              if (rootCause instanceof SocketTimeoutException
+                  || rootCause instanceof RejectedRequestException) {
+                LOG.debug("Request timed out or was rejected, reduce the batch size and retry");
+                fetchState.reduceBatchSize();
+              }
+
+              return asyncRunner.runAfterDelay(
+                  () -> sendNextBatchRequest(fetchState),
+                  Constants.ETH1_DEPOSIT_REQUEST_RETRY_TIMEOUT,
+                  TimeUnit.SECONDS);
+            })
+        .thenCompose(
+            __ -> {
+              fetchState.moveToNextBatch();
+              LOG.trace("Batch request completed. Done? {}", fetchState.isDone());
+              if (fetchState.isDone()) {
+                return SafeFuture.COMPLETE;
+              } else {
+                return sendNextBatchRequest(fetchState);
+              }
+            });
+  }
+
+  private SafeFuture<Void> processDepositsInBatch(
+      final BigInteger fromBlockNumber, final BigInteger toBlockNumber) {
+
+    return depositContract
+        .depositEventInRange(
+            DefaultBlockParameter.valueOf(fromBlockNumber),
+            DefaultBlockParameter.valueOf(toBlockNumber))
         .thenApply(this::groupDepositEventResponsesByBlockHash)
         .thenCompose(
             eventResponsesByBlockHash ->
@@ -84,34 +139,12 @@ public class DepositFetcher {
                     toBlockNumber));
   }
 
-  private SafeFuture<List<DepositContract.DepositEventEventResponse>>
-      getDepositEventsInRangeFromContract(BigInteger fromBlockNumber, BigInteger toBlockNumber) {
-
-    DefaultBlockParameter fromBlock = DefaultBlockParameter.valueOf(fromBlockNumber);
-    DefaultBlockParameter toBlock = DefaultBlockParameter.valueOf(toBlockNumber);
-
-    return depositContract
-        .depositEventInRange(fromBlock, toBlock)
-        .exceptionallyCompose(
-            (err) -> {
-              LOG.debug(
-                  "Failed to request deposit events for block numbers in the range ({}, {}). Retrying.",
-                  fromBlockNumber,
-                  toBlockNumber,
-                  err);
-
-              return asyncRunner.runAfterDelay(
-                  () -> getDepositEventsInRangeFromContract(fromBlockNumber, toBlockNumber),
-                  Constants.ETH1_DEPOSIT_REQUEST_RETRY_TIMEOUT,
-                  TimeUnit.SECONDS);
-            });
-  }
-
   private SafeFuture<Void> postDepositEvents(
       List<SafeFuture<EthBlock.Block>> blockRequests,
       Map<BlockNumberAndHash, List<DepositContract.DepositEventEventResponse>> depositEventsByBlock,
       BigInteger fromBlock,
       BigInteger toBlock) {
+    LOG.trace("Posting deposit events for {} blocks", depositEventsByBlock.size());
     BigInteger from = fromBlock;
     // First process completed requests using iteration.
     // Avoid StackOverflowException when there is a long string of requests already completed.
@@ -187,6 +220,40 @@ public class DepositFetcher {
 
   private void postDeposits(DepositsFromBlockEvent event) {
     eth1EventsChannel.onDepositsFromBlock(event);
+  }
+
+  private static class DepositFetchState {
+    // Both inclusive
+    BigInteger nextBatchStart;
+
+    final BigInteger lastBlock;
+    int batchSize = DEFAULT_BATCH_SIZE;
+
+    public DepositFetchState(final BigInteger fromBlockNumber, final BigInteger toBlockNumber) {
+      this.nextBatchStart = fromBlockNumber;
+      this.lastBlock = toBlockNumber;
+    }
+
+    public void moveToNextBatch() {
+      nextBatchStart = getNextBatchEnd().add(BigInteger.ONE);
+      if (batchSize < DEFAULT_BATCH_SIZE) {
+        // Grow the batch size slowly as we may be past a large blob of logs that caused trouble
+        batchSize = Math.min(DEFAULT_BATCH_SIZE, (int) (batchSize * 1.1));
+      }
+    }
+
+    private BigInteger getNextBatchEnd() {
+      return lastBlock.min(nextBatchStart.add(BigInteger.valueOf(batchSize)));
+    }
+
+    public boolean isDone() {
+      return nextBatchStart.compareTo(lastBlock) >= 0;
+    }
+
+    public void reduceBatchSize() {
+      batchSize = Math.max(1, batchSize / 2);
+      LOG.debug("Reduced batch size to {}", batchSize);
+    }
   }
 
   private static class BlockNumberAndHash implements Comparable<BlockNumberAndHash> {

--- a/pow/src/main/java/tech/pegasys/teku/pow/DepositProcessingController.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/DepositProcessingController.java
@@ -100,16 +100,13 @@ public class DepositProcessingController {
   }
 
   private synchronized void fetchLatestSubscriptionDepositsOverRange() {
-    final BigInteger toBlock;
-    final BigInteger fromBlock;
-
     if (active || latestCanonicalBlockNumber.equals(latestSuccessfullyQueriedBlock)) {
       return;
     }
     active = true;
 
-    fromBlock = latestSuccessfullyQueriedBlock.add(BigInteger.ONE);
-    toBlock = latestCanonicalBlockNumber.min(fromBlock.add(BigInteger.valueOf(500_000)));
+    final BigInteger fromBlock = latestSuccessfullyQueriedBlock.add(BigInteger.ONE);
+    final BigInteger toBlock = latestCanonicalBlockNumber;
 
     depositFetcher
         .fetchDepositsInRange(fromBlock, toBlock)

--- a/pow/src/main/java/tech/pegasys/teku/pow/contract/DepositContract.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/contract/DepositContract.java
@@ -140,6 +140,10 @@ public class DepositContract extends Contract {
             .thenApply(
                 logs -> {
                   if (logs.getLogs() == null) {
+                    // We got a response from the node but it didn't include even an empty list
+                    // of logs.  This happens with Infura when more than 10,000 log entries match
+                    // so treat as an explicit rejection of the request to allow the requested block
+                    // range to be reduced.
                     throw new RejectedRequestException("No logs returned by ETH1 node");
                   }
                   return logs.getLogs().stream()

--- a/pow/src/main/java/tech/pegasys/teku/pow/contract/DepositContract.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/contract/DepositContract.java
@@ -138,11 +138,15 @@ public class DepositContract extends Contract {
             .ethGetLogs(filter)
             .sendAsync()
             .thenApply(
-                logs ->
-                    logs.getLogs().stream()
-                        .map(log -> (Log) log.get())
-                        .map(this::convertLogToDepositEventEventResponse)
-                        .collect(Collectors.toList())));
+                logs -> {
+                  if (logs.getLogs() == null) {
+                    throw new RejectedRequestException("No logs returned by ETH1 node");
+                  }
+                  return logs.getLogs().stream()
+                      .map(log -> (Log) log.get())
+                      .map(this::convertLogToDepositEventEventResponse)
+                      .collect(Collectors.toList());
+                }));
   }
 
   private DepositEventEventResponse convertLogToDepositEventEventResponse(final Log log) {

--- a/pow/src/main/java/tech/pegasys/teku/pow/contract/RejectedRequestException.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/contract/RejectedRequestException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.pow.contract;
+
+public class RejectedRequestException extends RuntimeException {
+
+  public RejectedRequestException(final String message) {
+    super(message);
+  }
+}


### PR DESCRIPTION
## PR Description
Infura has a limit of 10,000 log events that it will return from a single call and ETH1 nodes may struggle to respond to requests over a very large range of blocks.  To handle this, `DepositFetcher` now limits the number of blocks requested in each batch and if the request times out or is rejected by Infura, the batch size is halved.

To avoid the batch size being reduced to a very small number because of a busy period and then making a lot of extra requests for the rest of the chain, the batch size increases slightly after each successful request.  The batch size deliberately grows much slower than it shrinks to avoid bouncing around too much.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.