### PR TITLE
Reduce log level when fetching deposits

### DIFF
--- a/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
@@ -84,7 +84,7 @@ public class DepositFetcher {
 
   private SafeFuture<Void> sendNextBatchRequest(final DepositFetchState fetchState) {
     final BigInteger nextBatchEnd = fetchState.getNextBatchEnd();
-    LOG.info(
+    LOG.debug(
         "Requesting deposits between {} and {}. Batch size: {}",
         fetchState.nextBatchStart,
         nextBatchEnd,


### PR DESCRIPTION
## PR Description
Reduce log level for message about requesting deposit data to debug instead of info.  It's very noisy.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.