### PR TITLE
Put network saved_for_future items immediately to future pools

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
@@ -114,14 +114,15 @@ public class AttestationManager extends Service implements SlotEventsChannel {
       SafeFuture<InternalValidationResult> validationResult, ValidateableAttestation attestation) {
     validationResult.thenAccept(
         internalValidationResult -> {
-          if (internalValidationResult.equals(InternalValidationResult.ACCEPT)
-              || internalValidationResult.equals(InternalValidationResult.SAVE_FOR_FUTURE)) {
+          if (internalValidationResult.equals(InternalValidationResult.ACCEPT)) {
             onAttestation(attestation)
                 .finish(
                     result ->
                         result.ifInvalid(
                             reason -> LOG.debug("Rejected received attestation: " + reason)),
                     err -> LOG.error("Failed to process received attestation.", err));
+          } else if (internalValidationResult.equals(InternalValidationResult.SAVE_FOR_FUTURE)) {
+            futureAttestations.add(attestation);
           }
         });
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
@@ -104,9 +104,10 @@ public class BlockManager extends Service implements SlotEventsChannel, BlockImp
     SafeFuture<InternalValidationResult> validationResult = validator.validate(block);
     validationResult.thenAccept(
         result -> {
-          if (result.equals(InternalValidationResult.ACCEPT)
-              || result.equals(InternalValidationResult.SAVE_FOR_FUTURE)) {
+          if (result.equals(InternalValidationResult.ACCEPT)) {
             importBlock(block).finish(err -> LOG.error("Failed to process received block.", err));
+          } else if (result.equals(InternalValidationResult.SAVE_FOR_FUTURE)) {
+            futureBlocks.add(block);
           }
         });
     return validationResult;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Put network `SAVED_FOR_FUTURE` items immediately to future pools.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #3114 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.