### PR TITLE
Make Blst and Mikuli BLS implementations interoperable

### DIFF
--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstBLS12381.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstBLS12381.java
@@ -136,13 +136,13 @@ public class BlstBLS12381 implements BLS12381 {
   @Override
   public BlstPublicKey aggregatePublicKeys(List<? extends PublicKey> publicKeys) {
     return BlstPublicKey.aggregate(
-        publicKeys.stream().map(k -> (BlstPublicKey) k).collect(Collectors.toList()));
+        publicKeys.stream().map(BlstPublicKey::fromPublicKey).collect(Collectors.toList()));
   }
 
   @Override
   public BlstSignature aggregateSignatures(List<? extends Signature> signatures) {
     return BlstSignature.aggregate(
-        signatures.stream().map(s -> (BlstSignature) s).collect(Collectors.toList()));
+        signatures.stream().map(BlstSignature::fromSignature).collect(Collectors.toList()));
   }
 
   @Override
@@ -150,7 +150,7 @@ public class BlstBLS12381 implements BLS12381 {
       int index, List<? extends PublicKey> publicKeys, Bytes message, Signature signature) {
 
     BlstPublicKey aggrPubKey = aggregatePublicKeys(publicKeys);
-    BlstSignature blstSignature = (BlstSignature) signature;
+    BlstSignature blstSignature = BlstSignature.fromSignature(signature);
     if (aggrPubKey.isInfinity()) {
       return new BlstInfiniteSemiAggregate(false);
     }

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstPublicKey.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstPublicKey.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.bls.impl.blst.swig.BLST_ERROR;
 import tech.pegasys.teku.bls.impl.blst.swig.blst;
 import tech.pegasys.teku.bls.impl.blst.swig.p1;
 import tech.pegasys.teku.bls.impl.blst.swig.p1_affine;
+import tech.pegasys.teku.bls.impl.mikuli.MikuliPublicKey;
 
 public class BlstPublicKey implements PublicKey {
   private static final int COMPRESSED_PK_SIZE = 48;
@@ -77,6 +78,15 @@ public class BlstPublicKey implements PublicKey {
       throw new DeserializeException("Invalid PublicKey bytes: " + compressed);
     }
   }
+
+  static BlstPublicKey fromPublicKey(PublicKey publicKey) {
+    if (publicKey instanceof BlstPublicKey) {
+      return (BlstPublicKey) publicKey;
+    } else {
+      return fromBytes(publicKey.toBytesCompressed());
+    }
+  }
+
 
   public static BlstPublicKey aggregate(List<BlstPublicKey> publicKeys) {
     checkArgument(publicKeys.size() > 0);
@@ -148,12 +158,11 @@ public class BlstPublicKey implements PublicKey {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof PublicKey)) {
       return false;
     }
 
-    BlstPublicKey that = (BlstPublicKey) o;
-    return Objects.equals(toBytesCompressed(), that.toBytesCompressed());
+    return Objects.equals(toBytesCompressed(), ((PublicKey) o).toBytesCompressed());
   }
 
   @Override

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstPublicKey.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstPublicKey.java
@@ -26,7 +26,6 @@ import tech.pegasys.teku.bls.impl.blst.swig.BLST_ERROR;
 import tech.pegasys.teku.bls.impl.blst.swig.blst;
 import tech.pegasys.teku.bls.impl.blst.swig.p1;
 import tech.pegasys.teku.bls.impl.blst.swig.p1_affine;
-import tech.pegasys.teku.bls.impl.mikuli.MikuliPublicKey;
 
 public class BlstPublicKey implements PublicKey {
   private static final int COMPRESSED_PK_SIZE = 48;
@@ -86,7 +85,6 @@ public class BlstPublicKey implements PublicKey {
       return fromBytes(publicKey.toBytesCompressed());
     }
   }
-
 
   public static BlstPublicKey aggregate(List<BlstPublicKey> publicKeys) {
     checkArgument(publicKeys.size() > 0);

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstSecretKey.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstSecretKey.java
@@ -116,11 +116,9 @@ public class BlstSecretKey implements SecretKey {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof SecretKey)) {
       return false;
     }
-
-    BlstSecretKey that = (BlstSecretKey) o;
-    return Objects.equals(toBytes(), that.toBytes());
+    return Objects.equals(toBytes(), ((SecretKey) o).toBytes());
   }
 }

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstSignature.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstSignature.java
@@ -28,7 +28,6 @@ import tech.pegasys.teku.bls.impl.blst.swig.blst;
 import tech.pegasys.teku.bls.impl.blst.swig.p2;
 import tech.pegasys.teku.bls.impl.blst.swig.p2_affine;
 import tech.pegasys.teku.bls.impl.blst.swig.pairing;
-import tech.pegasys.teku.bls.impl.mikuli.MikuliSignature;
 
 public class BlstSignature implements Signature {
   private static final int COMPRESSED_SIG_SIZE = 96;

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstSignature.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstSignature.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.bls.impl.blst.swig.blst;
 import tech.pegasys.teku.bls.impl.blst.swig.p2;
 import tech.pegasys.teku.bls.impl.blst.swig.p2_affine;
 import tech.pegasys.teku.bls.impl.blst.swig.pairing;
+import tech.pegasys.teku.bls.impl.mikuli.MikuliSignature;
 
 public class BlstSignature implements Signature {
   private static final int COMPRESSED_SIG_SIZE = 96;
@@ -61,6 +62,14 @@ public class BlstSignature implements Signature {
     } catch (Exception e) {
       ec2Point.delete();
       throw e;
+    }
+  }
+
+  static BlstSignature fromSignature(Signature signature) {
+    if (signature instanceof BlstSignature) {
+      return (BlstSignature) signature;
+    } else {
+      return fromBytes(signature.toBytesCompressed());
     }
   }
 
@@ -148,7 +157,7 @@ public class BlstSignature implements Signature {
 
     List<BlstPublicKey> blstPKeys =
         keysToMessages.stream()
-            .map(km -> (BlstPublicKey) km.getPublicKey())
+            .map(km -> BlstPublicKey.fromPublicKey(km.getPublicKey()))
             .collect(Collectors.toList());
 
     List<BlstPublicKey> finitePublicKeys =
@@ -168,7 +177,7 @@ public class BlstSignature implements Signature {
     try {
       blst.pairing_init(ctx);
       for (int i = 0; i < keysToMessages.size(); i++) {
-        BlstPublicKey publicKey = (BlstPublicKey) keysToMessages.get(i).getPublicKey();
+        BlstPublicKey publicKey = BlstPublicKey.fromPublicKey(keysToMessages.get(i).getPublicKey());
         Bytes message = keysToMessages.get(i).getMessage();
         BlstSignature signature = i == 0 ? this : null;
         blstPrepareVerifyAggregated(publicKey, message, ctx, signature);
@@ -183,18 +192,18 @@ public class BlstSignature implements Signature {
   public boolean verify(List<PublicKey> publicKeys, Bytes message) {
     return verify(
         BlstPublicKey.aggregate(
-            publicKeys.stream().map(k -> (BlstPublicKey) k).collect(Collectors.toList())),
+            publicKeys.stream().map(BlstPublicKey::fromPublicKey).collect(Collectors.toList())),
         message);
   }
 
   @Override
   public boolean verify(PublicKey publicKey, Bytes message) {
-    return BlstBLS12381.verify((BlstPublicKey) publicKey, message, this);
+    return BlstBLS12381.verify(BlstPublicKey.fromPublicKey(publicKey), message, this);
   }
 
   @Override
   public boolean verify(PublicKey publicKey, Bytes message, Bytes dst) {
-    return BlstBLS12381.verify((BlstPublicKey) publicKey, message, this, dst);
+    return BlstBLS12381.verify(BlstPublicKey.fromPublicKey(publicKey), message, this, dst);
   }
 
   @SuppressWarnings("ReferenceEquality")
@@ -212,11 +221,9 @@ public class BlstSignature implements Signature {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof Signature)) {
       return false;
     }
-
-    BlstSignature that = (BlstSignature) o;
-    return Objects.equals(toBytesCompressed(), that.toBytesCompressed());
+    return Objects.equals(toBytesCompressed(), ((Signature) o).toBytesCompressed());
   }
 }

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/MikuliKeyPair.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/MikuliKeyPair.java
@@ -69,25 +69,21 @@ public final class MikuliKeyPair extends KeyPair {
     this(secretKey, secretKey.derivePublicKey());
   }
 
-  public MikuliKeyPair(Scalar secretKey) {
-    this(new MikuliSecretKey(secretKey));
-  }
-
   @Override
   public MikuliPublicKey getPublicKey() {
-    return (MikuliPublicKey) super.getPublicKey();
+    return MikuliPublicKey.fromPublicKey(super.getPublicKey());
   }
 
   @Override
   public MikuliSecretKey getSecretKey() {
-    return (MikuliSecretKey) super.getSecretKey();
+    return MikuliSecretKey.fromSecretKey(super.getSecretKey());
   }
 
   @Override
   public boolean equals(final Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    final MikuliKeyPair keyPair = (MikuliKeyPair) o;
+    if (!(o instanceof KeyPair)) return false;
+    final KeyPair keyPair = (KeyPair) o;
     return getSecretKey().equals(keyPair.getSecretKey())
         && getPublicKey().equals(keyPair.getPublicKey());
   }

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/MikuliPublicKey.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/MikuliPublicKey.java
@@ -123,10 +123,10 @@ public final class MikuliPublicKey implements PublicKey {
     if (this == obj) {
       return true;
     }
-    if (!(obj instanceof MikuliPublicKey)) {
+    if (!(obj instanceof PublicKey)) {
       return false;
     }
-    MikuliPublicKey other = (MikuliPublicKey) obj;
+    MikuliPublicKey other = MikuliPublicKey.fromPublicKey((PublicKey) obj);
     try {
       return point.equals(other.point);
     } catch (final IllegalArgumentException e) {

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/MikuliSecretKey.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/MikuliSecretKey.java
@@ -37,6 +37,15 @@ public class MikuliSecretKey implements SecretKey {
     return new MikuliSecretKey(new Scalar(BIG.fromBytes(Bytes48.leftPad(bytes).toArrayUnsafe())));
   }
 
+  public static MikuliSecretKey fromSecretKey(SecretKey genericSecretKey) {
+    if (genericSecretKey instanceof MikuliSecretKey) {
+      return (MikuliSecretKey) genericSecretKey;
+    } else {
+      return fromBytes(genericSecretKey.toBytes());
+    }
+  }
+
+
   private final Scalar scalarValue;
 
   public MikuliSecretKey(Scalar value) {
@@ -84,8 +93,8 @@ public class MikuliSecretKey implements SecretKey {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    MikuliSecretKey secretKey = (MikuliSecretKey) o;
+    if (!(o instanceof SecretKey)) return false;
+    MikuliSecretKey secretKey = MikuliSecretKey.fromSecretKey((SecretKey) o);
     return Objects.equals(scalarValue, secretKey.scalarValue);
   }
 

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/MikuliSecretKey.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/MikuliSecretKey.java
@@ -45,7 +45,6 @@ public class MikuliSecretKey implements SecretKey {
     }
   }
 
-
   private final Scalar scalarValue;
 
   public MikuliSecretKey(Scalar value) {

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/MikuliSignature.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/MikuliSignature.java
@@ -209,11 +209,11 @@ public class MikuliSignature implements Signature {
     if (this == obj) {
       return true;
     }
-    if (!(obj instanceof MikuliSignature)) {
+    if (!(obj instanceof Signature)) {
       return false;
     }
-    MikuliSignature other = (MikuliSignature) obj;
     try {
+      MikuliSignature other = MikuliSignature.fromSignature((Signature) obj);
       return point.equals(other.point);
     } catch (final IllegalArgumentException e) {
       // Invalid points are only equal if they have the exact some data.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Make Blst and Mikuli BLS implementations interoperable. E.g. if a `PublicKey` or `Signature` created in one implementation it should work in another implementation. This couldn't be however implemented for `BatchSemiAggregate`

This generally should not be the case in production and in tests but serves as a temporary solution to prevent flaky BLS tests failing on CI (see #3175). 

## Fixed Issue(s)

Fix #3175 (to be exact just significantly reduces probability of this issue)

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.