### PR TITLE
Add pyrmont network definition

### DIFF
--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -27,7 +27,9 @@ import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
 
 public class Constants {
 
-  static final String[] NETWORK_DEFINITIONS = {"mainnet", "minimal", "swift", "medalla", "toledo"};
+  static final String[] NETWORK_DEFINITIONS = {
+    "mainnet", "minimal", "swift", "medalla", "toledo", "pyrmont"
+  };
 
   // Non-configurable constants
   public static final UInt64 FAR_FUTURE_EPOCH = UInt64.MAX_VALUE;

--- a/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
@@ -89,6 +89,19 @@ public class NetworkDefinition {
                       // Prysm @protolambda
                       "enr:-LK4QAhU5smiLgU0AgrdFv8eCKmDPCBkXCMCIy8Aktaci5qvCYOsW98xVqJS6OoPWt4Sz_YoTdLQBWxd-RZ756vmGPMBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCXm69nAHAe0P__________gmlkgnY0gmlwhDTTDL2Jc2VjcDI1NmsxoQOmSJ0mKsQjab7Zralm1Hi0AEReZ2SEqYdKoOPmoA98DoN0Y3CCIyiDdWRwgiMo")
                   .build())
+          .put(
+              "pyrmont",
+              builder()
+                  .constants("pyrmont")
+                  .startupTimeoutSeconds(120)
+                  .eth1DepositContractAddress("0x2c539a95d2a3f9b10681D9c0dD7cCE37D40c7B79")
+                  .initialStateFromClasspath("pyrmont-genesis.ssz")
+                  .discoveryBootnodes(
+                      // @protolambda bootnode 1
+                      "enr:-Ku4QDuuQGbUpzWMW1IUZpvt3xUzZuEwm2CvHqWQ-EGGzWXPYNc-PZPIfm05R7W3YwEIGM2_2-Y3JHQuEiizbYlW-HoBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhDQPSjiJc2VjcDI1NmsxoQM6yTQB6XGWYJbI7NZFBjp4Yb9AYKQPBhVrfUclQUobb4N1ZHCCIyg",
+                      // @protolambda bootnode 2
+                      "enr:-Ku4QAOnRymufUy7UbyxheWFbV9WAtt7BlvoixBz8-Xstb0oBui0ERAiBcsY5xDbE2YxvT7u6gwZPju9V_ecAAJMddUBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhDaa13aJc2VjcDI1NmsxoQKdNQJvnohpf0VO0ZYCAJxGjT0uwJoAHbAiBMujGjK0SoN1ZHCCIyg")
+                  .build())
           .build();
 
   private final String constants;

--- a/util/src/main/resources/tech/pegasys/teku/util/config/pyrmont.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/pyrmont.yaml
@@ -1,0 +1,155 @@
+# Pyrmont preset
+
+CONFIG_NAME: "pyrmont"
+
+# Misc
+# ---------------------------------------------------------------
+# 2**6 (= 64)
+MAX_COMMITTEES_PER_SLOT: 64
+# 2**7 (= 128)
+TARGET_COMMITTEE_SIZE: 128
+# 2**11 (= 2,048)
+MAX_VALIDATORS_PER_COMMITTEE: 2048
+# 2**2 (= 4)
+MIN_PER_EPOCH_CHURN_LIMIT: 4
+# 2**16 (= 65,536)
+CHURN_LIMIT_QUOTIENT: 65536
+# See issue 563
+SHUFFLE_ROUND_COUNT: 90
+# `2**14` (= 16,384)
+MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 16384
+# Nov 18, 2020, 12pm UTC
+MIN_GENESIS_TIME: 1605700800
+# 4
+HYSTERESIS_QUOTIENT: 4
+# 1 (minus 0.25)
+HYSTERESIS_DOWNWARD_MULTIPLIER: 1
+# 5 (plus 1.25)
+HYSTERESIS_UPWARD_MULTIPLIER: 5
+
+
+# Fork Choice
+# ---------------------------------------------------------------
+# 2**3 (= 8)
+SAFE_SLOTS_TO_UPDATE_JUSTIFIED: 8
+
+
+# Validator
+# ---------------------------------------------------------------
+# 2**11 (= 2,048)
+ETH1_FOLLOW_DISTANCE: 2048
+# 2**4 (= 16)
+TARGET_AGGREGATORS_PER_COMMITTEE: 16
+# 2**0 (= 1)
+RANDOM_SUBNETS_PER_VALIDATOR: 1
+# 2**8 (= 256)
+EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION: 256
+# 14 (estimate from Eth1 mainnet)
+SECONDS_PER_ETH1_BLOCK: 14
+
+
+# Deposit contract
+# ---------------------------------------------------------------
+# Ethereum Goerli testnet
+DEPOSIT_CHAIN_ID: 5
+DEPOSIT_NETWORK_ID: 5
+# Pyrmont test deposit contract on Goerli
+DEPOSIT_CONTRACT_ADDRESS: 0x2c539a95d2a3f9b10681D9c0dD7cCE37D40c7B79
+
+
+# Gwei values
+# ---------------------------------------------------------------
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
+MIN_DEPOSIT_AMOUNT: 1000000000
+# 2**5 * 10**9 (= 32,000,000,000) Gwei
+MAX_EFFECTIVE_BALANCE: 32000000000
+# 2**4 * 10**9 (= 16,000,000,000) Gwei
+EJECTION_BALANCE: 16000000000
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
+EFFECTIVE_BALANCE_INCREMENT: 1000000000
+
+
+# Initial values
+# ---------------------------------------------------------------
+# Mainnet initial fork version, recommend altering for testnets
+GENESIS_FORK_VERSION: 0x00000000
+BLS_WITHDRAWAL_PREFIX: 0x00
+
+
+# Time parameters
+# ---------------------------------------------------------------
+# 604800 seconds (7 days)
+GENESIS_DELAY: 604800
+# 12 seconds
+SECONDS_PER_SLOT: 12
+# 2**0 (= 1) slots 12 seconds
+MIN_ATTESTATION_INCLUSION_DELAY: 1
+# 2**5 (= 32) slots 6.4 minutes
+SLOTS_PER_EPOCH: 32
+# 2**0 (= 1) epochs 6.4 minutes
+MIN_SEED_LOOKAHEAD: 1
+# 2**2 (= 4) epochs 25.6 minutes
+MAX_SEED_LOOKAHEAD: 4
+# 2**6 (= 64) epochs ~6.8 hours
+EPOCHS_PER_ETH1_VOTING_PERIOD: 64
+# 2**13 (= 8,192) slots ~13 hours
+SLOTS_PER_HISTORICAL_ROOT: 8192
+# 2**8 (= 256) epochs ~27 hours
+MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256
+# 2**8 (= 256) epochs ~27 hours
+SHARD_COMMITTEE_PERIOD: 256
+# 2**2 (= 4) epochs 25.6 minutes
+MIN_EPOCHS_TO_INACTIVITY_PENALTY: 4
+
+
+# State vector lengths
+# ---------------------------------------------------------------
+# 2**16 (= 65,536) epochs ~0.8 years
+EPOCHS_PER_HISTORICAL_VECTOR: 65536
+# 2**13 (= 8,192) epochs ~36 days
+EPOCHS_PER_SLASHINGS_VECTOR: 8192
+# 2**24 (= 16,777,216) historical roots, ~26,131 years
+HISTORICAL_ROOTS_LIMIT: 16777216
+# 2**40 (= 1,099,511,627,776) validator spots
+VALIDATOR_REGISTRY_LIMIT: 1099511627776
+
+
+# Reward and penalty quotients
+# ---------------------------------------------------------------
+# 2**6 (= 64)
+BASE_REWARD_FACTOR: 64
+# 2**9 (= 512)
+WHISTLEBLOWER_REWARD_QUOTIENT: 512
+# 2**3 (= 8)
+PROPOSER_REWARD_QUOTIENT: 8
+# 2**26 (= 67,108,864)
+INACTIVITY_PENALTY_QUOTIENT: 67108864
+# 2**7 (= 128) (lower safety margin at Phase 0 genesis)
+MIN_SLASHING_PENALTY_QUOTIENT: 128
+# 1 (lower safety margin at Phase 0 genesis)
+PROPORTIONAL_SLASHING_MULTIPLIER: 1
+
+
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**4 (= 16)
+MAX_PROPOSER_SLASHINGS: 16
+# 2**1 (= 2)
+MAX_ATTESTER_SLASHINGS: 2
+# 2**7 (= 128)
+MAX_ATTESTATIONS: 128
+# 2**4 (= 16)
+MAX_DEPOSITS: 16
+# 2**4 (= 16)
+MAX_VOLUNTARY_EXITS: 16
+
+
+# Signature domains
+# ---------------------------------------------------------------
+DOMAIN_BEACON_PROPOSER: 0x00000000
+DOMAIN_BEACON_ATTESTER: 0x01000000
+DOMAIN_RANDAO: 0x02000000
+DOMAIN_DEPOSIT: 0x03000000
+DOMAIN_VOLUNTARY_EXIT: 0x04000000
+DOMAIN_SELECTION_PROOF: 0x05000000
+DOMAIN_AGGREGATE_AND_PROOF: 0x06000000


### PR DESCRIPTION
## PR Description
Add network definition and genesis state for Pyrmont. This is a short-lived testnet that's very close to the MainNet specs.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.