### PR TITLE
updated javalin to 3.12.0

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -27,7 +27,7 @@ dependencyManagement {
 
     dependency 'info.picocli:picocli:4.4.0'
 
-    dependencySet(group: 'io.javalin', version: '3.11.2') {
+    dependencySet(group: 'io.javalin', version: '3.12.0') {
       entry 'javalin'
       entry('javalin-openapi') {
         exclude 'org.webjars.npm:redoc'
@@ -49,7 +49,7 @@ dependencyManagement {
 
     dependency 'org.mock-server:mockserver-junit-jupiter:5.11.0'
 
-    dependencySet(group: 'io.swagger.core.v3', version: '2.1.3') {
+    dependencySet(group: 'io.swagger.core.v3', version: '2.1.5') {
       entry 'swagger-parser'
       entry 'swagger-core'
       entry 'swagger-models'


### PR DESCRIPTION
 - updated swagger to 2.1.5

Swagger got downgraded last week to address a swagger-docs issue, but javalin has now been updated, so we can go back to the latest swagger version with the new javalin version.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.