### PR TITLE
fix slashing protection export for attestations

### DIFF
--- a/data/dataexchange/src/main/java/tech/pegasys/teku/data/slashinginterchange/SignedAttestation.java
+++ b/data/dataexchange/src/main/java/tech/pegasys/teku/data/slashinginterchange/SignedAttestation.java
@@ -23,8 +23,13 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SignedAttestation {
+  @JsonProperty("source_epoch")
   public final UInt64 sourceEpoch;
+
+  @JsonProperty("target_epoch")
   public final UInt64 targetEpoch;
+
+  @JsonProperty("signing_root")
   public final Bytes32 signingRoot;
 
   @JsonCreator

--- a/data/dataexchange/src/main/java/tech/pegasys/teku/data/slashinginterchange/SignedBlock.java
+++ b/data/dataexchange/src/main/java/tech/pegasys/teku/data/slashinginterchange/SignedBlock.java
@@ -23,7 +23,10 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SignedBlock {
+  @JsonProperty("slot")
   public final UInt64 slot;
+
+  @JsonProperty("signing_root")
   public final Bytes32 signingRoot;
 
   @JsonCreator

--- a/data/dataexchange/src/test/resources/signedAttestation.json
+++ b/data/dataexchange/src/test/resources/signedAttestation.json
@@ -1,5 +1,5 @@
 {
-  "sourceEpoch" : "2048",
-  "targetEpoch" : "1024",
-  "signingRoot" : "0x6e2c5d8a89dfe121a92c8812bea69fe9f84ae48f63aafe34ef7e18c7eac9af70"
+  "source_epoch" : "2048",
+  "target_epoch" : "1024",
+  "signing_root" : "0x6e2c5d8a89dfe121a92c8812bea69fe9f84ae48f63aafe34ef7e18c7eac9af70"
 }

--- a/data/dataexchange/src/test/resources/signedBlock.json
+++ b/data/dataexchange/src/test/resources/signedBlock.json
@@ -1,4 +1,4 @@
 {
   "slot" : "18446744073709551615",
-  "signingRoot" : "0x6e2c5d8a89dfe121a92c8812bea69fe9f84ae48f63aafe34ef7e18c7eac9af70"
+  "signing_root" : "0x6e2c5d8a89dfe121a92c8812bea69fe9f84ae48f63aafe34ef7e18c7eac9af70"
 }


### PR DESCRIPTION
Attestation exports were camel casing fields, and should have been underscore separated.

One of the generated test files hid the issue, so I've addressed that so that it comes up as a difference next time if it happens again.

fixes #3223

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.