### PR TITLE
cleanup return path as part of best practices from audit

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockValidator.java
@@ -109,12 +109,11 @@ public class BlockValidator {
                         block, preState.get(), postState)) {
                   return InternalValidationResult.ACCEPT;
                 }
+                return InternalValidationResult.REJECT;
               } catch (EpochProcessingException | SlotProcessingException e) {
                 LOG.error("BlockValidator: Unable to process block state.", e);
                 return InternalValidationResult.REJECT;
               }
-
-              return InternalValidationResult.REJECT;
             });
   }
 


### PR DESCRIPTION
This keeps to the spirit of the audit feedback, but adheres closer to our own practices of keeping catch segments self contained and not falling through and relying on another return.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.