### PR TITLE
Upgrade libp2p to 0.6.1

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -38,7 +38,7 @@ dependencyManagement {
     dependency 'io.protostuff:protostuff-core:1.6.2'
     dependency 'io.protostuff:protostuff-runtime:1.6.2'
 
-    dependency 'io.libp2p:jvm-libp2p-minimal:0.6.0-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p-minimal:0.6.1-RELEASE'
     dependency 'tech.pegasys:jblst:0.2.0-RELEASE'
 
     dependency 'org.hdrhistogram:HdrHistogram:2.1.12'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Minor Libp2p upgrade to include the very latest Libp2p fix to Teku RC-1.0
Depends on https://github.com/libp2p/jvm-libp2p/pull/162

## Fixed Issue(s)

Fix #3214 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.