### PR TITLE
Fix help display for --network option

### DIFF
--- a/teku/src/test/java/tech/pegasys/teku/cli/options/NetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/NetworkOptionsTest.java
@@ -87,4 +87,15 @@ public class NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
         getGlobalConfigurationFromArguments("--Xpeer-request-limit", "10");
     assertThat(config.getPeerRequestLimit()).isEqualTo(10);
   }
+
+  @Test
+  public void helpDisplaysDefaultNetwork() {
+    beaconNodeCommand.parse(new String[] {"--help"});
+
+    final String output = getCommandLineOutput();
+    assertThat(output)
+        .contains(
+            "-n, --network=<NETWORK>    Represents which network to use.\n"
+                + "                               Default: mainnet");
+  }
 }

--- a/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
@@ -165,6 +165,11 @@ public class NetworkDefinition {
     return eth1Endpoint;
   }
 
+  @Override
+  public String toString() {
+    return constants;
+  }
+
   private static class Builder {
     private String constants;
     private Optional<String> initialState = Optional.empty();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fix bug introduced in #3220 - define a `toString()` method on `NetworkDefinition` so that the default value is printed as expected in the help text.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.