### PR TITLE
[Issue-3063] Use standard error when blocks are unavailable

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -112,7 +112,7 @@ public class BeaconBlocksByRangeMessageHandler
               if (earliestSlot.map(s -> s.isGreaterThan(message.getStartSlot())).orElse(true)) {
                 // We're missing the first block so return an error
                 return SafeFuture.failedFuture(
-                    new RpcException.HistoricalDataUnavailableException(
+                    new RpcException.ResourceUnavailableException(
                         "Requested historical blocks are currently unavailable"));
               }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcException.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcException.java
@@ -14,8 +14,8 @@
 package tech.pegasys.teku.networking.eth2.rpc.core;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.HISTORICAL_DATA_UNAVAILABLE;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
+import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.RESOURCE_UNAVAILABLE;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.SERVER_ERROR_CODE;
 
 import java.nio.charset.StandardCharsets;
@@ -76,10 +76,10 @@ public class RpcException extends Exception {
   }
 
   // Custom errors
-  public static class HistoricalDataUnavailableException extends RpcException {
+  public static class ResourceUnavailableException extends RpcException {
 
-    public HistoricalDataUnavailableException(final String errorMessage) {
-      super(HISTORICAL_DATA_UNAVAILABLE, errorMessage);
+    public ResourceUnavailableException(final String errorMessage) {
+      super(RESOURCE_UNAVAILABLE, errorMessage);
     }
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseStatus.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseStatus.java
@@ -19,7 +19,5 @@ public abstract class RpcResponseStatus {
   // Standard errors
   public static final byte INVALID_REQUEST_CODE = 1;
   public static final byte SERVER_ERROR_CODE = 2;
-
-  // Custom errors
-  public static final byte HISTORICAL_DATA_UNAVAILABLE = (byte) 222;
+  public static final byte RESOURCE_UNAVAILABLE = 3;
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -105,7 +105,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
     requestBlocks(startBlock, count, skip);
 
     final RpcException expectedError =
-        new RpcException.HistoricalDataUnavailableException(
+        new RpcException.ResourceUnavailableException(
             "Requested historical blocks are currently unavailable");
     verify(listener).completeWithErrorResponse(expectedError);
     verifyNoMoreInteractions(listener);
@@ -125,7 +125,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
     requestBlocks(startBlock, count, skip);
 
     final RpcException expectedError =
-        new RpcException.HistoricalDataUnavailableException(
+        new RpcException.ResourceUnavailableException(
             "Requested historical blocks are currently unavailable");
     verify(listener).completeWithErrorResponse(expectedError);
     verifyNoMoreInteractions(listener);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Use standard error when blocks are unavailable.  

This PR is only relevant if we actually decide to standardize the error in this case.  See discussion at: https://github.com/ethereum/eth2.0-specs/pull/2131

## Fixed Issue(s)
Part of #3063

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.