### PR TITLE
Update validator to expect data wrapper in create attestation response

### DIFF
--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -57,6 +57,7 @@ import tech.pegasys.teku.api.response.v1.beacon.GetStateValidatorsResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
 import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationResponse;
+import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetNewBlockResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
@@ -177,7 +178,8 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
     queryParams.put("slot", encodeQueryParam(slot));
     queryParams.put("committee_index", String.valueOf(committeeIndex));
 
-    return get(GET_ATTESTATION_DATA, queryParams, createHandler(AttestationData.class));
+    return get(GET_ATTESTATION_DATA, queryParams, createHandler(GetAttestationDataResponse.class))
+        .map(response -> response.data);
   }
 
   @Override

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.api.response.v1.beacon.GetStateForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateValidatorsResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationResponse;
+import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetNewBlockResponse;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.AttestationData;
@@ -434,7 +435,9 @@ class OkHttpValidatorRestApiClientTest {
     final int committeeIndex = 1;
     final AttestationData expectedAttestationData = schemaObjects.attestation().data;
     mockWebServer.enqueue(
-        new MockResponse().setResponseCode(SC_OK).setBody(asJson(expectedAttestationData)));
+        new MockResponse()
+            .setResponseCode(SC_OK)
+            .setBody(asJson(new GetAttestationDataResponse(expectedAttestationData))));
     Optional<AttestationData> attestationData =
         apiClient.createAttestationData(slot, committeeIndex);
     assertThat(attestationData).isPresent();


### PR DESCRIPTION
## PR Description
The remote validator API was expecting to receive attestation data directly in the get attestation response instead of in a data wrapper.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.