### PR TITLE
Cache gossip message-id

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/PreparedPubsubMessage.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/PreparedPubsubMessage.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.networking.p2p.libp2p.gossip;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import io.libp2p.core.pubsub.MessageApi;
 import io.libp2p.etc.types.WBytes;
 import io.libp2p.pubsub.PubsubMessage;
@@ -33,16 +35,19 @@ public class PreparedPubsubMessage implements PubsubMessage {
 
   private final Message protobufMessage;
   private final PreparedGossipMessage preparedMessage;
+  private final Supplier<WBytes> cachedMessageId;
 
   public PreparedPubsubMessage(Message protobufMessage, PreparedGossipMessage preparedMessage) {
     this.protobufMessage = protobufMessage;
     this.preparedMessage = preparedMessage;
+    cachedMessageId = Suppliers
+        .memoize(() -> new WBytes(preparedMessage.getMessageId().toArrayUnsafe()));
   }
 
   @NotNull
   @Override
   public WBytes getMessageId() {
-    return new WBytes(preparedMessage.getMessageId().toArrayUnsafe());
+    return cachedMessageId.get();
   }
 
   @NotNull

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/PreparedPubsubMessage.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/PreparedPubsubMessage.java
@@ -40,8 +40,8 @@ public class PreparedPubsubMessage implements PubsubMessage {
   public PreparedPubsubMessage(Message protobufMessage, PreparedGossipMessage preparedMessage) {
     this.protobufMessage = protobufMessage;
     this.preparedMessage = preparedMessage;
-    cachedMessageId = Suppliers
-        .memoize(() -> new WBytes(preparedMessage.getMessageId().toArrayUnsafe()));
+    cachedMessageId =
+        Suppliers.memoize(() -> new WBytes(preparedMessage.getMessageId().toArrayUnsafe()));
   }
 
   @NotNull


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

This is missing optimization of #3188 PR (Implement v1.0.0 message ID calculation).
`PubsubMessage.getMessageId()` method is supposed to be lightweight from the Libp2p implementation perspective, so I just missed `message-Id` caching which still is pretty heavy despite uncompressed payload is cached: `sha256(uncompressedPayload`

## Fixed Issue(s)

Before the fix: 
![изображение](https://user-images.githubusercontent.com/8173857/99544442-5d90d100-29c5-11eb-902a-afe7ee8189c8.png)

After the fix:
![изображение](https://user-images.githubusercontent.com/8173857/99544486-6b465680-29c5-11eb-82ab-327414793b10.png)


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.