### PR TITLE
Fix Gossipsub seenTTL value

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/GossipConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/GossipConfig.java
@@ -28,7 +28,7 @@ public class GossipConfig {
   public static final int DEFAULT_ADVERTISE = 3;
   public static final int DEFAULT_HISTORY = 6;
   public static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(700);
-  public static final Duration DEFAULT_SEEN_TTL = Duration.ofMillis(550);
+  public static final Duration DEFAULT_SEEN_TTL = DEFAULT_HEARTBEAT_INTERVAL.multipliedBy(550);
 
   public static final GossipConfig DEFAULT_CONFIG =
       new GossipConfig(

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/GossipConfigTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/GossipConfigTest.java
@@ -1,0 +1,13 @@
+package tech.pegasys.teku.networking.p2p.network;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class GossipConfigTest {
+  @Test
+  void shouldUseCorrectSeenTtl() {
+    // Should be heartbeat interval * 550
+    assertThat(GossipConfig.DEFAULT_SEEN_TTL.toMillis()).isEqualTo(700 * 550);
+  }
+}

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/GossipConfigTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/network/GossipConfigTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.networking.p2p.network;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
## PR Description
Gossipsub seenTTL should be 550 heartbeat intervals not 550ms.  Works out to more like 6.4 minutes which will remove a lot more duplicates from having to be processed.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.