### PR TITLE
Fix IllegalArgumentException when the chain head is the first slot of the epoch

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
@@ -14,7 +14,8 @@
 package tech.pegasys.teku.services.beaconchain;
 
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_block_root;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_block_root_at_slot;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_current_epoch;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_previous_epoch;
 import static tech.pegasys.teku.datastructures.util.ValidatorsUtil.get_active_validator_indices;
@@ -27,6 +28,7 @@ import java.util.function.Predicate;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.datastructures.blocks.NodeSlot;
+import tech.pegasys.teku.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.state.PendingAttestation;
@@ -165,19 +167,20 @@ public class BeaconChainMetrics implements SlotEventsChannel {
 
   @Override
   public void onSlot(final UInt64 slot) {
-    recentChainData.getBestState().ifPresent(this::updateMetrics);
+    recentChainData.getChainHead().ifPresent(this::updateMetrics);
   }
 
-  private void updateMetrics(final BeaconState state) {
+  private void updateMetrics(final StateAndBlockSummary head) {
+    final BeaconState state = head.getState();
     CorrectAndLiveValidators currentEpochValidators =
-        getNumberOfValidators(state, state.getCurrent_epoch_attestations());
+        getNumberOfValidators(head, state.getCurrent_epoch_attestations());
     currentLiveValidators.set(currentEpochValidators.numberOfLiveValidators);
     currentCorrectValidators.set(currentEpochValidators.numberOfCorrectValidators);
     currentActiveValidators.set(
         get_active_validator_indices(state, get_current_epoch(state)).size());
 
     CorrectAndLiveValidators previousEpochValidators =
-        getNumberOfValidators(state, state.getPrevious_epoch_attestations());
+        getNumberOfValidators(head, state.getPrevious_epoch_attestations());
     previousLiveValidators.set(previousEpochValidators.numberOfLiveValidators);
     previousCorrectValidators.set(currentEpochValidators.numberOfCorrectValidators);
     previousActiveValidators.set(
@@ -197,15 +200,16 @@ public class BeaconChainMetrics implements SlotEventsChannel {
   }
 
   private CorrectAndLiveValidators getNumberOfValidators(
-      final BeaconState state, final SSZList<PendingAttestation> attestations) {
+      final StateAndBlockSummary stateAndBlock, final SSZList<PendingAttestation> attestations) {
 
+    final UInt64 epochStartSlot =
+        compute_start_slot_at_epoch(compute_epoch_at_slot(stateAndBlock.getSlot()));
+    final Bytes32 correctBlockRoot =
+        epochStartSlot.isGreaterThanOrEqualTo(stateAndBlock.getSlot())
+            ? stateAndBlock.getRoot()
+            : get_block_root_at_slot(stateAndBlock.getState(), epochStartSlot);
     final Predicate<PendingAttestation> isCorrectValidatorPredicate =
-        attestation ->
-            attestation
-                .getData()
-                .getTarget()
-                .getRoot()
-                .equals(get_block_root(state, compute_epoch_at_slot(state.getSlot())));
+        attestation -> attestation.getData().getTarget().getRoot().equals(correctBlockRoot);
 
     final Map<UInt64, Map<UInt64, Bitlist>> liveValidatorsAggregationBitsBySlotAndCommittee =
         new HashMap<>();


### PR DESCRIPTION
## PR Description
`BeaconMetrics` as using `get_block_root(state, epoch)` to retrieve the correct block root.  However, if the state is from the first slot of the specified epoch, that will throw an `IllegalArgumentException` because the state doesn't contain its own state root.

We now get the block root from the chain head `StateAndBlockSummary` if the target slot is greater than or equal to the state root (in practice it will be at most equal but may as well be defensive) and only go to the block roots from the state for older slots that will actually be present.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.