### PR TITLE
Upgrade libp2p to 0.6.2

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -38,7 +38,7 @@ dependencyManagement {
     dependency 'io.protostuff:protostuff-core:1.6.2'
     dependency 'io.protostuff:protostuff-runtime:1.6.2'
 
-    dependency 'io.libp2p:jvm-libp2p-minimal:0.6.1-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p-minimal:0.6.2-RELEASE'
     dependency 'tech.pegasys:jblst:0.2.0-RELEASE'
 
     dependency 'org.hdrhistogram:HdrHistogram:2.1.12'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Upgrade libp2p to 0.6.2: 
- https://github.com/libp2p/jvm-libp2p/pull/164: Critical Gossip performance fixes

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.