### PR TITLE
Duty scheduling needs to wait until validator indices are known.

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyLoader.java
@@ -47,17 +47,15 @@ public abstract class AbstractDutyLoader<D> implements DutyLoader {
     final ScheduledDuties scheduledDuties = scheduledDutiesFactory.get();
     return validatorIndexProvider
         .getValidatorIndices(validators.keySet())
-        .thenCompose(
-            validatorIndices ->
-                requestDuties(epoch, validatorIndices)
-                    .thenApply(
-                        maybeDuties ->
-                            maybeDuties.orElseThrow(
-                                () ->
-                                    new NodeDataUnavailableException(
-                                        "Duties could not be calculated because chain data was not yet available")))
-                    .thenCompose(duties -> scheduleAllDuties(scheduledDuties, duties))
-                    .thenApply(__ -> scheduledDuties));
+        .thenCompose(validatorIndices -> requestDuties(epoch, validatorIndices))
+        .thenApply(
+            maybeDuties ->
+                maybeDuties.orElseThrow(
+                    () ->
+                        new NodeDataUnavailableException(
+                            "Duties could not be calculated because chain data was not yet available")))
+        .thenCompose(duties -> scheduleAllDuties(scheduledDuties, duties))
+        .thenApply(__ -> scheduledDuties);
   }
 
   protected abstract SafeFuture<Optional<List<D>>> requestDuties(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIndexProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIndexProvider.java
@@ -84,13 +84,10 @@ public class ValidatorIndexProvider {
     return Optional.ofNullable(validatorIndexesByPublicKey.get(publicKey));
   }
 
-  public Collection<Integer> getValidatorIndices(final Collection<BLSPublicKey> publicKeys) {
-    return future
-        .thenApply(
-            __ ->
-                publicKeys.stream()
-                    .flatMap(key -> getValidatorIndex(key).stream())
-                    .collect(toList()))
-        .join();
+  public SafeFuture<Collection<Integer>> getValidatorIndices(
+      final Collection<BLSPublicKey> publicKeys) {
+    return future.thenApply(
+        __ ->
+            publicKeys.stream().flatMap(key -> getValidatorIndex(key).stream()).collect(toList()));
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AbstractDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AbstractDutySchedulerTest.java
@@ -58,7 +58,8 @@ public abstract class AbstractDutySchedulerTest {
 
   @BeforeEach
   public void setUp() {
-    when(validatorIndexProvider.getValidatorIndices(VALIDATOR_KEYS)).thenReturn(VALIDATOR_INDICES);
+    when(validatorIndexProvider.getValidatorIndices(VALIDATOR_KEYS))
+        .thenReturn(SafeFuture.completedFuture(VALIDATOR_INDICES));
     when(dutyFactory.createAttestationProductionDuty(any()))
         .thenReturn(mock(AttestationProductionDuty.class));
     final SafeFuture<BLSSignature> rejectAggregationSignature =

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
@@ -66,7 +66,8 @@ class AttestationDutyLoaderTest {
 
   @BeforeEach
   void setUp() {
-    when(validatorIndexProvider.getValidatorIndices(any())).thenReturn(VALIDATOR_INDICES);
+    when(validatorIndexProvider.getValidatorIndices(any()))
+        .thenReturn(SafeFuture.completedFuture(VALIDATOR_INDICES));
     when(forkProvider.getForkInfo()).thenReturn(SafeFuture.completedFuture(forkInfo));
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/EventSourceBeaconChainEventAdapter.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.remote;
 import static java.util.Collections.emptyMap;
 
 import com.launchdarkly.eventsource.EventSource;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import okhttp3.Credentials;
 import okhttp3.HttpUrl;
@@ -25,6 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.api.response.v1.EventType;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.beaconnode.BeaconChainEventAdapter;
 import tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod;
@@ -50,6 +52,7 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
                 + EventType.chain_reorg);
     this.eventSource =
         new EventSource.Builder(new EventSourceHandler(validatorTimingChannel), eventSourceUrl)
+            .maxReconnectTime(Duration.ofSeconds(Constants.SECONDS_PER_SLOT))
             .client(okHttpClient)
             .requestTransformer(request -> applyBasicAuthentication(eventSourceUrl, request))
             .build();


### PR DESCRIPTION
- Retries shouldn't back off too far, once per slot to attempt to connect seems to be a fair compromise.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.