### PR TITLE
Reuse pre-block state to avoid slot and epoch processing

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/StateTransition.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/StateTransition.java
@@ -135,7 +135,7 @@ public class StateTransition {
    *
    * @throws BlockProcessingException
    */
-  private BeaconState process_block(BeaconState preState, BeaconBlock block)
+  public BeaconState process_block(BeaconState preState, BeaconBlock block)
       throws BlockProcessingException {
     return preState.updated(
         state -> {

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
@@ -70,7 +70,7 @@ public class BlockProposalTestUtil {
     final BeaconBlockAndState newBlockAndState =
         blockProposalUtil.createNewUnsignedBlock(
             newSlot,
-            get_beacon_proposer_index(state, newSlot),
+            get_beacon_proposer_index(blockSlotState, newSlot),
             randaoReveal,
             blockSlotState,
             parentBlockSigningRoot,

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.core;
 
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_beacon_proposer_index;
 import static tech.pegasys.teku.util.config.Constants.EPOCHS_PER_ETH1_VOTING_PERIOD;
 
 import java.util.Optional;
@@ -59,18 +60,19 @@ public class BlockProposalTestUtil {
       final SSZList<ProposerSlashing> slashings,
       final SSZList<Deposit> deposits,
       final SSZList<SignedVoluntaryExit> exits)
-      throws StateTransitionException {
+      throws StateTransitionException, EpochProcessingException, SlotProcessingException {
 
     final UInt64 newEpoch = compute_epoch_at_slot(newSlot);
     final BLSSignature randaoReveal =
         signer.createRandaoReveal(newEpoch, state.getForkInfo()).join();
 
+    final BeaconState blockSlotState = stateTransition.process_slots(state, newSlot);
     final BeaconBlockAndState newBlockAndState =
         blockProposalUtil.createNewUnsignedBlock(
             newSlot,
-            getProposerIndexForSlot(state, newSlot),
+            get_beacon_proposer_index(state, newSlot),
             randaoReveal,
-            state,
+            blockSlotState,
             parentBlockSigningRoot,
             eth1Data,
             Bytes32.ZERO,
@@ -97,7 +99,7 @@ public class BlockProposalTestUtil {
       final Optional<SSZList<Deposit>> deposits,
       final Optional<SSZList<SignedVoluntaryExit>> exits,
       final Optional<Eth1Data> eth1Data)
-      throws StateTransitionException {
+      throws StateTransitionException, EpochProcessingException, SlotProcessingException {
     final UInt64 newEpoch = compute_epoch_at_slot(newSlot);
     return createNewBlock(
         signer,

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -34,6 +34,8 @@ import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.core.exceptions.EpochProcessingException;
+import tech.pegasys.teku.core.exceptions.SlotProcessingException;
 import tech.pegasys.teku.core.lookup.BlockProvider;
 import tech.pegasys.teku.core.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.core.signatures.LocalSigner;
@@ -392,7 +394,7 @@ public class ChainBuilder {
               options.getEth1Data());
       trackBlock(nextBlockAndState);
       return nextBlockAndState;
-    } catch (StateTransitionException e) {
+    } catch (StateTransitionException | EpochProcessingException | SlotProcessingException e) {
       throw new RuntimeException(e);
     }
   }

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
@@ -113,7 +113,7 @@ public class BlockFactory {
             newSlot,
             get_beacon_proposer_index(blockPreState, newSlot),
             randaoReveal,
-            blockPreState,
+            blockSlotState,
             parentRoot,
             eth1Data,
             optionalGraffiti.orElse(graffiti),


### PR DESCRIPTION
## PR Description
When generating new blocks, reuse the state generated at the block slot by `BlockFactory` in `BlockProposalUtil` instead of reprocessing empty slots again. While empty slots are fairly cheap, an epoch transition can be quite expensive and increase the risk of the first block in the slot being orphaned.

Note that this means we don't use `StateTransition.initiate` when creating a block, just `process_block`.  The empty slot processing and epoch transitions are already done.  The interim state listener is a no-op as is the block validator so those actions in `initiate` aren't required.

## Fixed Issue(s)
Low hanging fruit for #3262 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.