### PR TITLE
[Issue-2423] Handle UNKNOWN_PARENT errors more carefully

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.datastructures.networking.libp2p.rpc.MetadataMessage;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.PingMessage;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.RpcRequest;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.StatusMessage;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -145,6 +146,11 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   @Override
   public UInt64 finalizedEpoch() {
     return getStatus().getFinalizedEpoch();
+  }
+
+  @Override
+  public Checkpoint finalizedCheckpoint() {
+    return getStatus().getFinalizedCheckpoint();
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -19,6 +19,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.MetadataMessage;
 import tech.pegasys.teku.datastructures.networking.libp2p.rpc.RpcRequest;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
@@ -63,6 +64,8 @@ public interface Eth2Peer extends Peer, SyncSource {
   Optional<Bitvector> getRemoteAttestationSubnets();
 
   UInt64 finalizedEpoch();
+
+  Checkpoint finalizedCheckpoint();
 
   int getOutstandingRequests();
 

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -162,6 +162,11 @@ public class RespondingEth2Peer implements Eth2Peer {
   }
 
   @Override
+  public Checkpoint finalizedCheckpoint() {
+    return status.getFinalizedCheckpoint();
+  }
+
+  @Override
   public boolean hasStatus() {
     return true;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Handle UNKNOWN_PARENT errors more carefully in `PeerSync`.  If we receive a non-final block (from our peer's perspective), the UNKNOWN_PARENT error likely just indicates that our peer is sending us stale blocks from a fork that we've pruned locally. 

Shout out to @cemozerr for identifying this issue!

## Fixed Issue(s)
Fixes #2423 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.