### PR TITLE
Ensure first successful validator index lookup is complete before scheduling duties

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -137,11 +137,11 @@ public class ValidatorClientService extends Service {
 
   @Override
   protected SafeFuture<?> doStart() {
+    validatorIndexProvider.lookupValidators();
     eventChannels.subscribe(
         ValidatorTimingChannel.class,
         new ValidatorTimingActions(
             validatorIndexProvider, blockProductionTimingChannel, attestationTimingChannel));
-    validatorIndexProvider.lookupValidators();
     return beaconNodeApi.subscribeToEvents();
   }
 


### PR DESCRIPTION
## PR Description
We were previously only waiting for the request to get validator indices to complete, but not for the data from that request to actually be added to the lookup map.  Additionally if the validator indices were looked up prior to any request being sent, they would incorrectly return an empty list instead of waiting for the request.

We now wait for the first successful request to complete and process data into the lookup map. Also ensure we trigger loading validator indices before starting any other event streams.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.