### PR TITLE
Add dependent roots to head event

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -84,6 +84,8 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
       final Bytes32 stateRoot,
       final Bytes32 bestBlockRoot,
       final boolean epochTransition,
+      final Bytes32 previousDutyDependentRoot,
+      final Bytes32 currentDutyDependentRoot,
       final Optional<ReorgContext> optionalReorgContext) {
 
     optionalReorgContext.ifPresent(
@@ -107,7 +109,14 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
 
     try {
       final String headEventString =
-          jsonProvider.objectToJSON(new HeadEvent(slot, bestBlockRoot, stateRoot, epochTransition));
+          jsonProvider.objectToJSON(
+              new HeadEvent(
+                  slot,
+                  bestBlockRoot,
+                  stateRoot,
+                  epochTransition,
+                  previousDutyDependentRoot,
+                  currentDutyDependentRoot));
       notifySubscribersOfEvent(EventType.head, headEventString);
     } catch (JsonProcessingException ex) {
       LOG.error(ex);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -69,7 +69,13 @@ public class EventSubscriptionManagerTest {
           epoch);
 
   private final HeadEvent headEvent =
-      new HeadEvent(slot, data.randomBytes32(), data.randomBytes32(), false);
+      new HeadEvent(
+          slot,
+          data.randomBytes32(),
+          data.randomBytes32(),
+          false,
+          data.randomBytes32(),
+          data.randomBytes32());
 
   private final FinalizedCheckpointEvent sampleCheckpointEvent =
       new FinalizedCheckpointEvent(data.randomBytes32(), data.randomBytes32(), epoch);
@@ -205,6 +211,8 @@ public class EventSubscriptionManagerTest {
         chainReorgEvent.newHeadState,
         chainReorgEvent.newHeadBlock,
         chainReorgEvent.slot.mod(Constants.SLOTS_PER_EPOCH).equals(UInt64.ZERO),
+        headEvent.previousDutyDependentRoot,
+        headEvent.currentDutyDependentRoot,
         Optional.of(
             new ReorgContext(
                 chainReorgEvent.oldHeadBlock,
@@ -215,7 +223,13 @@ public class EventSubscriptionManagerTest {
 
   private void triggerHeadEvent() {
     manager.chainHeadUpdated(
-        headEvent.slot, headEvent.state, headEvent.block, false, Optional.empty());
+        headEvent.slot,
+        headEvent.state,
+        headEvent.block,
+        false,
+        headEvent.previousDutyDependentRoot,
+        headEvent.currentDutyDependentRoot,
+        Optional.empty());
     asyncRunner.executeQueuedActions();
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/HeadEvent.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/HeadEvent.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.api.response.v1;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import java.util.Objects;
@@ -35,32 +37,51 @@ public class HeadEvent {
   @JsonProperty("epoch_transition")
   public final boolean epochTransition;
 
+  @JsonProperty("previous_duty_dependent_root")
+  @JsonInclude(Include.NON_NULL)
+  public final Bytes32 previousDutyDependentRoot;
+
+  @JsonProperty("current_duty_dependent_root")
+  @JsonInclude(Include.NON_NULL)
+  public final Bytes32 currentDutyDependentRoot;
+
   @JsonCreator
   public HeadEvent(
       @JsonProperty(value = "slot", required = true) final UInt64 slot,
       @JsonProperty("block") final Bytes32 block,
       @JsonProperty("state") final Bytes32 state,
-      @JsonProperty("epoch_transition") final boolean epochTransition) {
+      @JsonProperty("epoch_transition") final boolean epochTransition,
+      @JsonProperty("previous_duty_dependent_root") final Bytes32 previousDutyDependentRoot,
+      @JsonProperty("current_duty_dependent_root") final Bytes32 currentDutyDependentRoot) {
     this.slot = slot;
     this.block = block;
     this.state = state;
     this.epochTransition = epochTransition;
+    this.previousDutyDependentRoot = previousDutyDependentRoot;
+    this.currentDutyDependentRoot = currentDutyDependentRoot;
   }
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     final HeadEvent headEvent = (HeadEvent) o;
     return epochTransition == headEvent.epochTransition
         && Objects.equals(slot, headEvent.slot)
         && Objects.equals(block, headEvent.block)
-        && Objects.equals(state, headEvent.state);
+        && Objects.equals(state, headEvent.state)
+        && Objects.equals(previousDutyDependentRoot, headEvent.previousDutyDependentRoot)
+        && Objects.equals(currentDutyDependentRoot, headEvent.currentDutyDependentRoot);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(slot, block, state, epochTransition);
+    return Objects.hash(
+        slot, block, state, epochTransition, previousDutyDependentRoot, currentDutyDependentRoot);
   }
 
   @Override
@@ -70,6 +91,8 @@ public class HeadEvent {
         .add("block", block)
         .add("state", state)
         .add("epochTransition", epochTransition)
+        .add("previousDutyDependentRoot", previousDutyDependentRoot)
+        .add("currentDutyDependentRoot", currentDutyDependentRoot)
         .toString();
   }
 }

--- a/data/serializer/src/test/java/tech/pegasys/teku/api/response/v1/HeadEventTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/api/response/v1/HeadEventTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.response.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.provider.JsonProvider;
+
+class HeadEventTest {
+
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+
+  private final JsonProvider jsonProvider = new JsonProvider();
+
+  @Test
+  void shouldParseFromEventWithoutDependentRoots() throws Exception {
+    final String json =
+        "{\"slot\":\"4666673844721362956\",\"block\":\"0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef\",\"state\":\"0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e\",\"epoch_transition\":true}\n";
+    final HeadEvent result = jsonProvider.jsonToObject(json, HeadEvent.class);
+    assertThat(result)
+        .isEqualTo(
+            new HeadEvent(
+                UInt64.valueOf(4666673844721362956L),
+                Bytes32.fromHexString(
+                    "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef"),
+                Bytes32.fromHexString(
+                    "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e"),
+                true,
+                null,
+                null));
+  }
+
+  @Test
+  void shouldRoundTripJsonParsing() throws Exception {
+    final HeadEvent input =
+        new HeadEvent(
+            dataStructureUtil.randomUInt64(),
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomBytes32(),
+            true,
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomBytes32());
+    final String json = jsonProvider.objectToJSON(input);
+    final HeadEvent result = jsonProvider.jsonToObject(json, HeadEvent.class);
+    assertThat(result).isEqualTo(input);
+  }
+}

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/blocks/BeaconBlock.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/blocks/BeaconBlock.java
@@ -24,6 +24,7 @@ import jdk.jfr.Label;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.ssz.SSZ;
+import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.util.HashTreeUtil;
 import tech.pegasys.teku.datastructures.util.HashTreeUtil.SSZTypes;
 import tech.pegasys.teku.datastructures.util.Merkleizable;
@@ -85,6 +86,10 @@ public final class BeaconBlock
     this.parent_root = Bytes32.ZERO;
     this.state_root = state_root;
     this.body = new BeaconBlockBody();
+  }
+
+  public static BeaconBlock fromGenesisState(final BeaconState genesisState) {
+    return new BeaconBlock(genesisState.hash_tree_root());
   }
 
   @Override

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/AnchorPoint.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/AnchorPoint.java
@@ -67,7 +67,7 @@ public class AnchorPoint extends StateAndBlockSummary {
   public static AnchorPoint fromGenesisState(final BeaconState genesisState) {
     checkArgument(isGenesisState(genesisState), "Invalid genesis state supplied");
 
-    final BeaconBlock genesisBlock = new BeaconBlock(genesisState.hash_tree_root());
+    final BeaconBlock genesisBlock = BeaconBlock.fromGenesisState(genesisState);
     final SignedBeaconBlock signedGenesisBlock =
         new SignedBeaconBlock(genesisBlock, BLSSignature.empty());
 

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/BeaconStateUtil.java
@@ -801,7 +801,7 @@ public class BeaconStateUtil {
     return data.toLong(ByteOrder.LITTLE_ENDIAN);
   }
 
-  public static Bytes32 getCurrentTargetRoot(BeaconState state) {
+  public static Bytes32 getCurrentDutyDependentRoot(BeaconState state) {
     final UInt64 slot = compute_start_slot_at_epoch(get_current_epoch(state)).minusMinZero(1);
     // No previous block, use algorithm for calculating the genesis block root
     return slot.equals(state.getSlot())
@@ -809,7 +809,7 @@ public class BeaconStateUtil {
         : get_block_root_at_slot(state, slot);
   }
 
-  public static Bytes32 getPreviousTargetRoot(BeaconState state) {
+  public static Bytes32 getPreviousDutyDependentRoot(BeaconState state) {
     final UInt64 slot = compute_start_slot_at_epoch(get_previous_epoch(state)).minusMinZero(1);
     return slot.equals(state.getSlot())
         // No previous block, use algorithm for calculating the genesis block root

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/BeaconStateUtilTest.java
@@ -435,54 +435,54 @@ class BeaconStateUtilTest {
   }
 
   @Test
-  void getCurrentTargetRoot_genesisStateReturnsFinalizedCheckpointRoot() {
+  void getCurrentDutyDependentRoot_genesisStateReturnsFinalizedCheckpointRoot() {
     final BeaconState state = dataStructureUtil.randomBeaconState(UInt64.valueOf(GENESIS_SLOT));
-    assertThat(BeaconStateUtil.getCurrentTargetRoot(state))
+    assertThat(BeaconStateUtil.getCurrentDutyDependentRoot(state))
         .isEqualTo(new BeaconBlock(state.hash_tree_root()).getRoot());
   }
 
   @Test
-  void getCurrentTargetRoot_returnsGenesisBlockDuringEpochZero() {
+  void getCurrentDutyDependentRoot_returnsGenesisBlockDuringEpochZero() {
     final BeaconState state = dataStructureUtil.randomBeaconState(UInt64.valueOf(GENESIS_SLOT + 3));
-    assertThat(BeaconStateUtil.getCurrentTargetRoot(state))
+    assertThat(BeaconStateUtil.getCurrentDutyDependentRoot(state))
         .isEqualTo(state.getBlock_roots().get(0));
   }
 
   @Test
-  void getCurrentTargetRoot_returnsBlockRootAtLastSlotOfPriorEpoch() {
+  void getCurrentDutyDependentRoot_returnsBlockRootAtLastSlotOfPriorEpoch() {
     final BeaconState state =
         dataStructureUtil.randomBeaconState(UInt64.valueOf(GENESIS_SLOT + SLOTS_PER_EPOCH + 3));
-    assertThat(BeaconStateUtil.getCurrentTargetRoot(state))
+    assertThat(BeaconStateUtil.getCurrentDutyDependentRoot(state))
         .isEqualTo(state.getBlock_roots().get((int) (GENESIS_SLOT + SLOTS_PER_EPOCH - 1)));
   }
 
   @Test
-  void getPreviousTargetRoot_genesisStateReturnsFinalizedCheckpointRoot() {
+  void getPreviousDutyDependentRoot_genesisStateReturnsFinalizedCheckpointRoot() {
     final BeaconState state = dataStructureUtil.randomBeaconState(UInt64.valueOf(GENESIS_SLOT));
-    assertThat(BeaconStateUtil.getPreviousTargetRoot(state))
+    assertThat(BeaconStateUtil.getPreviousDutyDependentRoot(state))
         .isEqualTo(new BeaconBlock(state.hash_tree_root()).getRoot());
   }
 
   @Test
-  void getPreviousTargetRoot_returnsGenesisBlockDuringEpochZero() {
+  void getPreviousDutyDependentRoot_returnsGenesisBlockDuringEpochZero() {
     final BeaconState state = dataStructureUtil.randomBeaconState(UInt64.valueOf(GENESIS_SLOT + 3));
-    assertThat(BeaconStateUtil.getPreviousTargetRoot(state))
+    assertThat(BeaconStateUtil.getPreviousDutyDependentRoot(state))
         .isEqualTo(state.getBlock_roots().get(0));
   }
 
   @Test
-  void getPreviousTargetRoot_returnsGenesisBlockDuringEpochOne() {
+  void getPreviousDutyDependentRoot_returnsGenesisBlockDuringEpochOne() {
     final BeaconState state =
         dataStructureUtil.randomBeaconState(UInt64.valueOf(GENESIS_SLOT + SLOTS_PER_EPOCH + 3));
-    assertThat(BeaconStateUtil.getPreviousTargetRoot(state))
+    assertThat(BeaconStateUtil.getPreviousDutyDependentRoot(state))
         .isEqualTo(state.getBlock_roots().get(0));
   }
 
   @Test
-  void getCurrentTargetRoot_returnsBlockRootAtLastSlotOfTwoEpochsAgo() {
+  void getCurrentDutyDependentRoot_returnsBlockRootAtLastSlotOfTwoEpochsAgo() {
     final BeaconState state =
         dataStructureUtil.randomBeaconState(UInt64.valueOf(GENESIS_SLOT + SLOTS_PER_EPOCH * 2 + 3));
-    assertThat(BeaconStateUtil.getPreviousTargetRoot(state))
+    assertThat(BeaconStateUtil.getPreviousDutyDependentRoot(state))
         .isEqualTo(state.getBlock_roots().get((int) (GENESIS_SLOT + SLOTS_PER_EPOCH - 1)));
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationsReOrgManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationsReOrgManager.java
@@ -66,6 +66,8 @@ public class OperationsReOrgManager implements ChainHeadChannel {
       final Bytes32 stateRoot,
       final Bytes32 bestBlockRoot,
       final boolean epochTransition,
+      final Bytes32 previousDutyDependentRoot,
+      final Bytes32 currentDutyDependentRoot,
       final Optional<ReorgContext> optionalReorgContext) {
     optionalReorgContext.ifPresent(
         reorgContext -> {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationsReOrgManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationsReOrgManagerTest.java
@@ -47,17 +47,19 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 @SuppressWarnings("unchecked")
 public class OperationsReOrgManagerTest {
 
-  private DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
 
-  private OperationPool<ProposerSlashing> proposerSlashingOperationPool = mock(OperationPool.class);
-  private OperationPool<AttesterSlashing> attesterSlashingOperationPool = mock(OperationPool.class);
-  private OperationPool<SignedVoluntaryExit> exitOperationPool = mock(OperationPool.class);
-  private AggregatingAttestationPool attestationPool = mock(AggregatingAttestationPool.class);
-  private AttestationManager attestationManager = mock(AttestationManager.class);
+  private final OperationPool<ProposerSlashing> proposerSlashingOperationPool =
+      mock(OperationPool.class);
+  private final OperationPool<AttesterSlashing> attesterSlashingOperationPool =
+      mock(OperationPool.class);
+  private final OperationPool<SignedVoluntaryExit> exitOperationPool = mock(OperationPool.class);
+  private final AggregatingAttestationPool attestationPool = mock(AggregatingAttestationPool.class);
+  private final AttestationManager attestationManager = mock(AttestationManager.class);
 
-  private RecentChainData recentChainData = mock(RecentChainData.class);
+  private final RecentChainData recentChainData = mock(RecentChainData.class);
 
-  private OperationsReOrgManager operationsReOrgManager =
+  private final OperationsReOrgManager operationsReOrgManager =
       new OperationsReOrgManager(
           proposerSlashingOperationPool,
           attesterSlashingOperationPool,
@@ -106,6 +108,8 @@ public class OperationsReOrgManagerTest {
         fork2Block2.getStateRoot(),
         fork2Block2.hash_tree_root(),
         false,
+        dataStructureUtil.randomBytes32(),
+        dataStructureUtil.randomBytes32(),
         ReorgContext.of(
             fork1Block2.hash_tree_root(), fork1Block2.getStateRoot(), commonAncestorSlot));
 
@@ -175,6 +179,8 @@ public class OperationsReOrgManagerTest {
         block2.getStateRoot(),
         block2.hash_tree_root(),
         false,
+        dataStructureUtil.randomBytes32(),
+        dataStructureUtil.randomBytes32(),
         ReorgContext.of(Bytes32.ZERO, Bytes32.ZERO, commonAncestorSlot));
 
     verify(recentChainData).getAncestorsOnFork(commonAncestorSlot, block2.hash_tree_root());

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/ChainHeadChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/ChainHeadChannel.java
@@ -29,6 +29,8 @@ public interface ChainHeadChannel extends VoidReturningChannelInterface {
    * @param stateRoot the state root of the state containing the new chain head
    * @param bestBlockRoot the block root of the new chain head
    * @param epochTransition if a new epoch has begun
+   * @param previousDutyDependentRoot the duty dependent root from the previous epoch
+   * @param currentDutyDependentRoot the duty dependent root from the current epoch
    * @param optionalReorgContext Roots and common ancestor if a re-org occured
    */
   void chainHeadUpdated(
@@ -36,5 +38,7 @@ public interface ChainHeadChannel extends VoidReturningChannelInterface {
       final Bytes32 stateRoot,
       final Bytes32 bestBlockRoot,
       final boolean epochTransition,
+      final Bytes32 previousDutyDependentRoot,
+      final Bytes32 currentDutyDependentRoot,
       Optional<ReorgContext> optionalReorgContext);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.storage.client;
 
 import static tech.pegasys.teku.core.ForkChoiceUtil.get_ancestor;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getCurrentTargetRoot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getPreviousTargetRoot;
 
 import com.google.common.eventbus.EventBus;
 import java.util.Collections;
@@ -274,6 +276,8 @@ public abstract class RecentChainData implements StoreUpdateHandler {
           newChainHead.getStateRoot(),
           newChainHead.getRoot(),
           epochTransition,
+          getPreviousTargetRoot(newChainHead.getState()),
+          getCurrentTargetRoot(newChainHead.getState()),
           optionalReorgContext);
     }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -15,8 +15,8 @@ package tech.pegasys.teku.storage.client;
 
 import static tech.pegasys.teku.core.ForkChoiceUtil.get_ancestor;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getCurrentTargetRoot;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getPreviousTargetRoot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getCurrentDutyDependentRoot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getPreviousDutyDependentRoot;
 
 import com.google.common.eventbus.EventBus;
 import java.util.Collections;
@@ -276,8 +276,8 @@ public abstract class RecentChainData implements StoreUpdateHandler {
           newChainHead.getStateRoot(),
           newChainHead.getRoot(),
           epochTransition,
-          getPreviousTargetRoot(newChainHead.getState()),
-          getCurrentTargetRoot(newChainHead.getState()),
+          getPreviousDutyDependentRoot(newChainHead.getState()),
+          getCurrentDutyDependentRoot(newChainHead.getState()),
           optionalReorgContext);
     }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -19,6 +19,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getCurrentTargetRoot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getPreviousTargetRoot;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.storage.store.MockStoreHelper.mockChainData;
@@ -49,6 +51,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.protoarray.ProtoArrayForkChoiceStrategy;
+import tech.pegasys.teku.storage.api.TrackingChainHeadChannel.HeadEvent;
 import tech.pegasys.teku.storage.api.TrackingChainHeadChannel.ReorgEvent;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
@@ -90,12 +93,24 @@ class RecentChainDataTest {
 
   @Test
   public void updateHead_validUpdate() throws Exception {
+    // Ensure the current and previous target root blocks are different
+    chainBuilder.generateBlockAtSlot(Constants.SLOTS_PER_EPOCH - 1);
+    chainBuilder.generateBlockAtSlot(Constants.SLOTS_PER_EPOCH * 2 - 1);
     final SignedBlockAndState bestBlock = chainBuilder.generateNextBlock();
     saveBlock(recentChainData, bestBlock);
 
     recentChainData.updateHead(bestBlock.getRoot(), bestBlock.getSlot());
     assertThat(recentChainData.getChainHead().map(StateAndBlockSummary::getRoot))
         .contains(bestBlock.getRoot());
+    assertThat(storageSystem.reorgEventChannel().getHeadEvents())
+        .contains(
+            new HeadEvent(
+                bestBlock.getSlot(),
+                bestBlock.getStateRoot(),
+                bestBlock.getRoot(),
+                true,
+                getPreviousTargetRoot(bestBlock.getState()),
+                getCurrentTargetRoot(bestBlock.getState())));
   }
 
   @Test

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -19,8 +19,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getCurrentTargetRoot;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getPreviousTargetRoot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getCurrentDutyDependentRoot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getPreviousDutyDependentRoot;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.storage.store.MockStoreHelper.mockChainData;
@@ -109,8 +109,8 @@ class RecentChainDataTest {
                 bestBlock.getStateRoot(),
                 bestBlock.getRoot(),
                 true,
-                getPreviousTargetRoot(bestBlock.getState()),
-                getCurrentTargetRoot(bestBlock.getState())));
+                getPreviousDutyDependentRoot(bestBlock.getState()),
+                getCurrentDutyDependentRoot(bestBlock.getState())));
   }
 
   @Test

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubChainHeadChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubChainHeadChannel.java
@@ -24,5 +24,7 @@ public class StubChainHeadChannel implements ChainHeadChannel {
       final Bytes32 stateRoot,
       final Bytes32 bestBlockRoot,
       final boolean epochTransition,
+      final Bytes32 previousDutyDependentRoot,
+      final Bytes32 currentDutyDependentRoot,
       final Optional<ReorgContext> optionalReorgContext) {}
 }

--- a/sync/src/test/java/tech/pegasys/teku/sync/events/CoalescingChainHeadChannelTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/events/CoalescingChainHeadChannelTest.java
@@ -39,10 +39,26 @@ class CoalescingChainHeadChannelTest {
     final Bytes32 stateRoot = dataStructureUtil.randomBytes32();
     final Bytes32 bestBlockRoot = dataStructureUtil.randomBytes32();
     final boolean epochTransition = true;
+    final Bytes32 previousDutyDependentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 currentDutyDependentRoot = dataStructureUtil.randomBytes32();
     final Optional<ReorgContext> reorgContext = Optional.empty();
-    channel.chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+    channel.chainHeadUpdated(
+        slot,
+        stateRoot,
+        bestBlockRoot,
+        epochTransition,
+        previousDutyDependentRoot,
+        currentDutyDependentRoot,
+        reorgContext);
     verify(delegate)
-        .chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+        .chainHeadUpdated(
+            slot,
+            stateRoot,
+            bestBlockRoot,
+            epochTransition,
+            previousDutyDependentRoot,
+            currentDutyDependentRoot,
+            reorgContext);
   }
 
   @Test
@@ -51,13 +67,29 @@ class CoalescingChainHeadChannelTest {
     final Bytes32 stateRoot = dataStructureUtil.randomBytes32();
     final Bytes32 bestBlockRoot = dataStructureUtil.randomBytes32();
     final boolean epochTransition = true;
+    final Bytes32 previousDutyDependentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 currentDutyDependentRoot = dataStructureUtil.randomBytes32();
     final Optional<ReorgContext> reorgContext = Optional.empty();
 
     channel.onSyncingChange(false);
 
-    channel.chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+    channel.chainHeadUpdated(
+        slot,
+        stateRoot,
+        bestBlockRoot,
+        epochTransition,
+        previousDutyDependentRoot,
+        currentDutyDependentRoot,
+        reorgContext);
     verify(delegate)
-        .chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+        .chainHeadUpdated(
+            slot,
+            stateRoot,
+            bestBlockRoot,
+            epochTransition,
+            previousDutyDependentRoot,
+            currentDutyDependentRoot,
+            reorgContext);
   }
 
   @Test
@@ -66,11 +98,20 @@ class CoalescingChainHeadChannelTest {
     final Bytes32 stateRoot = dataStructureUtil.randomBytes32();
     final Bytes32 bestBlockRoot = dataStructureUtil.randomBytes32();
     final boolean epochTransition = true;
+    final Bytes32 previousDutyDependentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 currentDutyDependentRoot = dataStructureUtil.randomBytes32();
     final Optional<ReorgContext> reorgContext = Optional.empty();
 
     channel.onSyncingChange(true);
 
-    channel.chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+    channel.chainHeadUpdated(
+        slot,
+        stateRoot,
+        bestBlockRoot,
+        epochTransition,
+        previousDutyDependentRoot,
+        currentDutyDependentRoot,
+        reorgContext);
     verifyNoInteractions(delegate);
   }
 
@@ -80,6 +121,8 @@ class CoalescingChainHeadChannelTest {
     final Bytes32 stateRoot = dataStructureUtil.randomBytes32();
     final Bytes32 bestBlockRoot = dataStructureUtil.randomBytes32();
     final boolean epochTransition = true;
+    final Bytes32 previousDutyDependentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 currentDutyDependentRoot = dataStructureUtil.randomBytes32();
     final Optional<ReorgContext> reorgContext = Optional.empty();
 
     channel.onSyncingChange(true);
@@ -89,15 +132,31 @@ class CoalescingChainHeadChannelTest {
         dataStructureUtil.randomBytes32(),
         dataStructureUtil.randomBytes32(),
         false,
+        dataStructureUtil.randomBytes32(),
+        dataStructureUtil.randomBytes32(),
         Optional.empty());
 
-    channel.chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+    channel.chainHeadUpdated(
+        slot,
+        stateRoot,
+        bestBlockRoot,
+        epochTransition,
+        previousDutyDependentRoot,
+        currentDutyDependentRoot,
+        reorgContext);
 
     verifyNoInteractions(delegate);
 
     channel.onSyncingChange(false);
     verify(delegate)
-        .chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+        .chainHeadUpdated(
+            slot,
+            stateRoot,
+            bestBlockRoot,
+            epochTransition,
+            previousDutyDependentRoot,
+            currentDutyDependentRoot,
+            reorgContext);
     verifyNoMoreInteractions(delegate);
   }
 
@@ -107,11 +166,27 @@ class CoalescingChainHeadChannelTest {
     final Bytes32 stateRoot = dataStructureUtil.randomBytes32();
     final Bytes32 bestBlockRoot = dataStructureUtil.randomBytes32();
     final boolean epochTransition = true;
+    final Bytes32 previousDutyDependentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 currentDutyDependentRoot = dataStructureUtil.randomBytes32();
     final Optional<ReorgContext> reorgContext = Optional.empty();
 
-    channel.chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+    channel.chainHeadUpdated(
+        slot,
+        stateRoot,
+        bestBlockRoot,
+        epochTransition,
+        previousDutyDependentRoot,
+        currentDutyDependentRoot,
+        reorgContext);
     verify(delegate)
-        .chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+        .chainHeadUpdated(
+            slot,
+            stateRoot,
+            bestBlockRoot,
+            epochTransition,
+            previousDutyDependentRoot,
+            currentDutyDependentRoot,
+            reorgContext);
 
     channel.onSyncingChange(true);
     channel.onSyncingChange(false);
@@ -125,13 +200,29 @@ class CoalescingChainHeadChannelTest {
     final Bytes32 stateRoot = dataStructureUtil.randomBytes32();
     final Bytes32 bestBlockRoot = dataStructureUtil.randomBytes32();
     final boolean epochTransition = true;
+    final Bytes32 previousDutyDependentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 currentDutyDependentRoot = dataStructureUtil.randomBytes32();
     final Optional<ReorgContext> reorgContext = Optional.empty();
 
     channel.onSyncingChange(true);
-    channel.chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+    channel.chainHeadUpdated(
+        slot,
+        stateRoot,
+        bestBlockRoot,
+        epochTransition,
+        previousDutyDependentRoot,
+        currentDutyDependentRoot,
+        reorgContext);
     channel.onSyncingChange(false);
     verify(delegate)
-        .chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext);
+        .chainHeadUpdated(
+            slot,
+            stateRoot,
+            bestBlockRoot,
+            epochTransition,
+            previousDutyDependentRoot,
+            currentDutyDependentRoot,
+            reorgContext);
 
     channel.onSyncingChange(true);
     channel.onSyncingChange(false);
@@ -145,6 +236,8 @@ class CoalescingChainHeadChannelTest {
     final Bytes32 stateRoot = dataStructureUtil.randomBytes32();
     final Bytes32 bestBlockRoot = dataStructureUtil.randomBytes32();
     final boolean epochTransition = true;
+    final Bytes32 previousDutyDependentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 currentDutyDependentRoot = dataStructureUtil.randomBytes32();
     final Optional<ReorgContext> reorgContext1 =
         Optional.of(
             new ReorgContext(
@@ -165,15 +258,31 @@ class CoalescingChainHeadChannelTest {
         dataStructureUtil.randomBytes32(),
         dataStructureUtil.randomBytes32(),
         false,
+        dataStructureUtil.randomBytes32(),
+        dataStructureUtil.randomBytes32(),
         reorgContext2);
 
-    channel.chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext1);
+    channel.chainHeadUpdated(
+        slot,
+        stateRoot,
+        bestBlockRoot,
+        epochTransition,
+        previousDutyDependentRoot,
+        currentDutyDependentRoot,
+        reorgContext1);
 
     verifyNoInteractions(delegate);
 
     channel.onSyncingChange(false);
     verify(delegate)
-        .chainHeadUpdated(slot, stateRoot, bestBlockRoot, epochTransition, reorgContext2);
+        .chainHeadUpdated(
+            slot,
+            stateRoot,
+            bestBlockRoot,
+            epochTransition,
+            previousDutyDependentRoot,
+            currentDutyDependentRoot,
+            reorgContext2);
     verifyNoMoreInteractions(delegate);
   }
 }

--- a/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/IndependentTimerEventChannelEventAdapter.java
+++ b/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/IndependentTimerEventChannelEventAdapter.java
@@ -66,6 +66,8 @@ public class IndependentTimerEventChannelEventAdapter
       final Bytes32 stateRoot,
       final Bytes32 bestBlockRoot,
       final boolean epochTransition,
+      final Bytes32 previousDutyDependentRoot,
+      final Bytes32 currentDutyDependentRoot,
       final Optional<ReorgContext> optionalReorgContext) {
     optionalReorgContext.ifPresent(
         reorgContext ->

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/EventSourceHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/EventSourceHandlerTest.java
@@ -48,7 +48,12 @@ class EventSourceHandlerTest {
     final UInt64 slot = UInt64.valueOf(134);
     final HeadEvent event =
         new HeadEvent(
-            slot, dataStructureUtil.randomBytes32(), dataStructureUtil.randomBytes32(), false);
+            slot,
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomBytes32(),
+            false,
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomBytes32());
     handler.onMessage(EventType.head.name(), new MessageEvent(jsonProvider.objectToJSON(event)));
 
     verify(validatorTimingChannel).onAttestationCreationDue(slot);
@@ -81,7 +86,12 @@ class EventSourceHandlerTest {
     final UInt64 slot = UInt64.valueOf(134);
     final HeadEvent event =
         new HeadEvent(
-            slot, dataStructureUtil.randomBytes32(), dataStructureUtil.randomBytes32(), false);
+            slot,
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomBytes32(),
+            false,
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomBytes32());
     // Head message with a reorg type
     final MessageEvent messageEvent = new MessageEvent(jsonProvider.objectToJSON(event));
     assertDoesNotThrow(() -> handler.onMessage(EventType.chain_reorg.name(), messageEvent));


### PR DESCRIPTION
## PR Description
Add `previous_duty_dependent_root` and `current_duty_dependent_root` to `HeadEvent` inline with https://github.com/ethereum/eth2.0-APIs/pull/117/

Adding `dependent_root` to attester and proposer duty responses to come.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.