### PR TITLE
Add dependent root to attester duties response

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandler.java
@@ -59,6 +59,26 @@ public abstract class AbstractHandler implements Handler {
       final Context ctx,
       SafeFuture<Optional<T>> future,
       ResultProcessor<T> resultProcessor,
+      ErrorProcessor errorProcessor,
+      final int missingStatus) {
+    ctx.result(
+        future
+            .thenApplyChecked(
+                result -> {
+                  if (result.isPresent()) {
+                    return resultProcessor.process(ctx, result.get()).orElse(null);
+                  } else {
+                    ctx.status(missingStatus);
+                    return null;
+                  }
+                })
+            .exceptionallyCompose(error -> errorProcessor.handleError(ctx, error)));
+  }
+
+  protected <T> void handleOptionalResult(
+      final Context ctx,
+      SafeFuture<Optional<T>> future,
+      ResultProcessor<T> resultProcessor,
       final int missingStatus) {
     ctx.result(
         future.thenApplyChecked(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
@@ -79,10 +79,17 @@ public class PostAttesterDuties extends AbstractHandler implements Handler {
       description =
           "Requests the beacon node to provide a set of attestation duties, "
               + "which should be performed by validators, for a particular epoch. "
-              + "Duties should only need to be checked once per epoch, however a "
-              + "chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur, "
-              + "resulting in a change of duties. For full safety, "
-              + "you should monitor chain reorganizations events.",
+              + "Duties should only need to be checked once per epoch, however a chain "
+              + "reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur, "
+              + "resulting in a change of duties. "
+              + "For full safety, you should monitor head events and confirm the dependent root in "
+              + "this response matches:\n"
+              + "- event.previous_duty_dependent_root when `compute_epoch_at_slot(event.slot) == epoch`\n"
+              + "- event.current_duty_dependent_root when `compute_epoch_at_slot(event.slot) + 1 == epoch`\n"
+              + "- event.block otherwise\n\n"
+              + "The dependent_root value is "
+              + "`get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)` "
+              + "or the genesis block root in the case of underflow.",
       requestBody =
           @OpenApiRequestBody(
               content = @OpenApiContent(from = String[].class),

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
@@ -43,7 +43,7 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
-import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
+import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
 import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -92,7 +92,7 @@ public class PostAttesterDuties extends AbstractHandler implements Handler {
       responses = {
         @OpenApiResponse(
             status = RES_OK,
-            content = @OpenApiContent(from = GetAttesterDutiesResponse.class)),
+            content = @OpenApiContent(from = PostAttesterDutiesResponse.class)),
         @OpenApiResponse(status = RES_BAD_REQUEST),
         @OpenApiResponse(status = RES_INTERNAL_ERROR),
         @OpenApiResponse(status = RES_SERVICE_UNAVAILABLE, description = SERVICE_UNAVAILABLE)
@@ -108,7 +108,7 @@ public class PostAttesterDuties extends AbstractHandler implements Handler {
       final UInt64 epoch = UInt64.valueOf(parameters.get(EPOCH));
       final UInt64[] indexes = jsonProvider.jsonToObject(ctx.body(), UInt64[].class);
 
-      SafeFuture<Optional<GetAttesterDutiesResponse>> future =
+      SafeFuture<Optional<PostAttesterDutiesResponse>> future =
           validatorDataProvider.getAttesterDuties(
               epoch, Arrays.stream(indexes).map(UInt64::intValue).collect(Collectors.toList()));
 
@@ -127,7 +127,7 @@ public class PostAttesterDuties extends AbstractHandler implements Handler {
     }
   }
 
-  private Optional<String> handleResult(Context ctx, final GetAttesterDutiesResponse response)
+  private Optional<String> handleResult(Context ctx, final PostAttesterDutiesResponse response)
       throws JsonProcessingException {
     return Optional.of(jsonProvider.objectToJSON(response));
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDutiesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDutiesTest.java
@@ -28,7 +28,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
-import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
+import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
 import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -62,15 +62,15 @@ public class PostAttesterDutiesTest extends AbstractValidatorApiTest {
     when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
     when(context.body()).thenReturn("[\"2\"]");
 
-    GetAttesterDutiesResponse duties =
-        new GetAttesterDutiesResponse(
+    PostAttesterDutiesResponse duties =
+        new PostAttesterDutiesResponse(
             Bytes32.fromHexString("0x1234"),
             List.of(getDuty(2, 1, 2, 10, 3, compute_start_slot_at_epoch(UInt64.valueOf(100)))));
     when(validatorDataProvider.getAttesterDuties(eq(UInt64.valueOf(100)), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(duties)));
 
     handler.handle(context);
-    GetAttesterDutiesResponse response = getResponseFromFuture(GetAttesterDutiesResponse.class);
+    PostAttesterDutiesResponse response = getResponseFromFuture(PostAttesterDutiesResponse.class);
     assertThat(response).isEqualTo(duties);
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDutiesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDutiesTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -23,6 +24,7 @@ import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_star
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
@@ -41,7 +43,7 @@ public class PostAttesterDutiesTest extends AbstractValidatorApiTest {
   }
 
   @Test
-  public void shouldReturnEmptyListIfValidatorIndexOutOfBounds() throws Exception {
+  public void shouldReturnServiceUnavailableWhenResultIsEmpty() throws Exception {
     when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
     when(syncService.isSyncActive()).thenReturn(false);
     when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
@@ -50,8 +52,7 @@ public class PostAttesterDutiesTest extends AbstractValidatorApiTest {
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
 
     handler.handle(context);
-    GetAttesterDutiesResponse response = getResponseFromFuture(GetAttesterDutiesResponse.class);
-    assertThat(response.data).isEmpty();
+    verifyStatusCode(SC_SERVICE_UNAVAILABLE);
   }
 
   @Test
@@ -60,14 +61,17 @@ public class PostAttesterDutiesTest extends AbstractValidatorApiTest {
     when(syncService.isSyncActive()).thenReturn(false);
     when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
     when(context.body()).thenReturn("[\"2\"]");
-    List<AttesterDuty> duties =
-        List.of(getDuty(2, 1, 2, 10, 3, compute_start_slot_at_epoch(UInt64.valueOf(100))));
+
+    GetAttesterDutiesResponse duties =
+        new GetAttesterDutiesResponse(
+            Bytes32.fromHexString("0x1234"),
+            List.of(getDuty(2, 1, 2, 10, 3, compute_start_slot_at_epoch(UInt64.valueOf(100)))));
     when(validatorDataProvider.getAttesterDuties(eq(UInt64.valueOf(100)), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(duties)));
 
     handler.handle(context);
     GetAttesterDutiesResponse response = getResponseFromFuture(GetAttesterDutiesResponse.class);
-    assertThat(response.data).isEqualTo(duties);
+    assertThat(response).isEqualTo(duties);
   }
 
   @Test

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.request.v1.validator.BeaconCommitteeSubscriptionRequest;
-import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
+import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.AttestationData;
@@ -164,14 +164,14 @@ public class ValidatorDataProvider {
             .collect(toList()));
   }
 
-  public SafeFuture<Optional<GetAttesterDutiesResponse>> getAttesterDuties(
+  public SafeFuture<Optional<PostAttesterDutiesResponse>> getAttesterDuties(
       final UInt64 epoch, final List<Integer> indexes) {
     return SafeFuture.of(() -> validatorApiChannel.getAttestationDuties(epoch, indexes))
         .thenApply(
             res ->
                 res.map(
                     duties ->
-                        new GetAttesterDutiesResponse(
+                        new PostAttesterDutiesResponse(
                             duties.getDependentRoot(),
                             duties.getDuties().stream()
                                 .filter(duty -> duty.getPublicKey() != null)

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
+import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.api.schema.BLSSignature;
@@ -259,10 +259,10 @@ public class ValidatorDataProviderTest {
 
   @Test
   public void getAttesterDuties_shouldHandleEmptyIndexesList() {
-    final SafeFuture<Optional<GetAttesterDutiesResponse>> future =
+    final SafeFuture<Optional<PostAttesterDutiesResponse>> future =
         provider.getAttesterDuties(UInt64.ONE, List.of());
     assertThat(future).isCompleted();
-    Optional<GetAttesterDutiesResponse> maybeData = future.join();
+    Optional<PostAttesterDutiesResponse> maybeData = future.join();
     assertThat(maybeData.isPresent()).isTrue();
     assertThat(maybeData.get().data).isEmpty();
   }
@@ -277,11 +277,11 @@ public class ValidatorDataProviderTest {
                 Optional.of(
                     new AttesterDuties(dataStructureUtil.randomBytes32(), List.of(v1, v2)))));
 
-    final SafeFuture<Optional<GetAttesterDutiesResponse>> future =
+    final SafeFuture<Optional<PostAttesterDutiesResponse>> future =
         provider.getAttesterDuties(ONE, List.of(1, 11));
     assertThat(future).isCompleted();
-    final Optional<GetAttesterDutiesResponse> maybeList = future.join();
-    final GetAttesterDutiesResponse list = maybeList.orElseThrow();
+    final Optional<PostAttesterDutiesResponse> maybeList = future.join();
+    final PostAttesterDutiesResponse list = maybeList.orElseThrow();
     assertThat(list.data).containsExactlyInAnyOrder(asAttesterDuty(v1), asAttesterDuty(v2));
   }
 

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
+import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.api.schema.BLSSignature;
@@ -51,6 +51,7 @@ import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.validator.api.AttesterDuties;
+import tech.pegasys.teku.validator.api.AttesterDuty;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
@@ -258,37 +259,41 @@ public class ValidatorDataProviderTest {
 
   @Test
   public void getAttesterDuties_shouldHandleEmptyIndexesList() {
-    final SafeFuture<Optional<List<AttesterDuty>>> future =
+    final SafeFuture<Optional<GetAttesterDutiesResponse>> future =
         provider.getAttesterDuties(UInt64.ONE, List.of());
     assertThat(future).isCompleted();
-    Optional<List<AttesterDuty>> maybeData = future.join();
+    Optional<GetAttesterDutiesResponse> maybeData = future.join();
     assertThat(maybeData.isPresent()).isTrue();
-    assertThat(maybeData.get()).isEmpty();
+    assertThat(maybeData.get().data).isEmpty();
   }
 
   @Test
   public void getAttesterDuties_shouldReturnDutiesForKnownValidator() {
-    AttesterDuties v1 = new AttesterDuties(BLSPublicKey.random(0), 1, 2, 3, 15, 4, ONE);
-    AttesterDuties v2 = new AttesterDuties(BLSPublicKey.random(1), 11, 12, 13, 15, 14, ZERO);
+    AttesterDuty v1 = new AttesterDuty(BLSPublicKey.random(0), 1, 2, 3, 15, 4, ONE);
+    AttesterDuty v2 = new AttesterDuty(BLSPublicKey.random(1), 11, 12, 13, 15, 14, ZERO);
     when(validatorApiChannel.getAttestationDuties(eq(ONE), any()))
-        .thenReturn(completedFuture(Optional.of(List.of(v1, v2))));
+        .thenReturn(
+            completedFuture(
+                Optional.of(
+                    new AttesterDuties(dataStructureUtil.randomBytes32(), List.of(v1, v2)))));
 
-    final SafeFuture<Optional<List<AttesterDuty>>> future =
+    final SafeFuture<Optional<GetAttesterDutiesResponse>> future =
         provider.getAttesterDuties(ONE, List.of(1, 11));
     assertThat(future).isCompleted();
-    final Optional<List<AttesterDuty>> maybeList = future.join();
-    final List<AttesterDuty> list = maybeList.orElseThrow();
-    assertThat(list).containsExactlyInAnyOrder(asAttesterDuty(v1), asAttesterDuty(v2));
+    final Optional<GetAttesterDutiesResponse> maybeList = future.join();
+    final GetAttesterDutiesResponse list = maybeList.orElseThrow();
+    assertThat(list.data).containsExactlyInAnyOrder(asAttesterDuty(v1), asAttesterDuty(v2));
   }
 
-  private AttesterDuty asAttesterDuty(final tech.pegasys.teku.validator.api.AttesterDuties duties) {
+  private tech.pegasys.teku.api.response.v1.validator.AttesterDuty asAttesterDuty(
+      final AttesterDuty duties) {
 
-    return new AttesterDuty(
+    return new tech.pegasys.teku.api.response.v1.validator.AttesterDuty(
         new BLSPubKey(duties.getPublicKey()),
         UInt64.valueOf(duties.getValidatorIndex()),
         UInt64.valueOf(duties.getCommitteeIndex()),
         UInt64.valueOf(duties.getCommitteeLength()),
-        UInt64.valueOf(duties.getCommiteesAtSlot()),
+        UInt64.valueOf(duties.getCommitteesAtSlot()),
         UInt64.valueOf(duties.getValidatorCommitteeIndex()),
         duties.getSlot());
   }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.api;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -32,6 +33,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
@@ -259,6 +261,13 @@ public class ValidatorDataProviderTest {
 
   @Test
   public void getAttesterDuties_shouldHandleEmptyIndexesList() {
+    final Bytes32 previousTargetRoot = dataStructureUtil.randomBytes32();
+    when(validatorApiChannel.getAttestationDuties(eq(ONE), any()))
+        .thenReturn(
+            completedFuture(
+                Optional.of(
+                    new tech.pegasys.teku.validator.api.AttesterDuties(
+                        previousTargetRoot, emptyList()))));
     final SafeFuture<Optional<PostAttesterDutiesResponse>> future =
         provider.getAttesterDuties(UInt64.ONE, List.of());
     assertThat(future).isCompleted();

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/GetAttesterDutiesResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/GetAttesterDutiesResponse.java
@@ -15,13 +15,47 @@ package tech.pegasys.teku.api.response.v1.validator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import java.util.List;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class GetAttesterDutiesResponse {
+  @JsonProperty("dependent_root")
+  public final Bytes32 dependentRoot;
+
   public final List<AttesterDuty> data;
 
   @JsonCreator
-  public GetAttesterDutiesResponse(@JsonProperty("data") final List<AttesterDuty> data) {
+  public GetAttesterDutiesResponse(
+      @JsonProperty("dependent_root") final Bytes32 dependentRoot,
+      @JsonProperty("data") final List<AttesterDuty> data) {
+    this.dependentRoot = dependentRoot;
     this.data = data;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final GetAttesterDutiesResponse that = (GetAttesterDutiesResponse) o;
+    return Objects.equals(dependentRoot, that.dependentRoot) && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(dependentRoot, data);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("dependentRoot", dependentRoot)
+        .add("data", data)
+        .toString();
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/PostAttesterDutiesResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/PostAttesterDutiesResponse.java
@@ -13,15 +13,24 @@
 
 package tech.pegasys.teku.api.response.v1.validator;
 
+import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_BYTES32;
+import static tech.pegasys.teku.api.schema.SchemaConstants.PATTERN_BYTES32;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
 
 public class PostAttesterDutiesResponse {
   @JsonProperty("dependent_root")
+  @Schema(
+      type = "string",
+      example = EXAMPLE_BYTES32,
+      pattern = PATTERN_BYTES32,
+      description = "The block root that this response is dependent on.")
   public final Bytes32 dependentRoot;
 
   public final List<AttesterDuty> data;

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/PostAttesterDutiesResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/PostAttesterDutiesResponse.java
@@ -20,14 +20,14 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
 
-public class GetAttesterDutiesResponse {
+public class PostAttesterDutiesResponse {
   @JsonProperty("dependent_root")
   public final Bytes32 dependentRoot;
 
   public final List<AttesterDuty> data;
 
   @JsonCreator
-  public GetAttesterDutiesResponse(
+  public PostAttesterDutiesResponse(
       @JsonProperty("dependent_root") final Bytes32 dependentRoot,
       @JsonProperty("data") final List<AttesterDuty> data) {
     this.dependentRoot = dependentRoot;
@@ -42,7 +42,7 @@ public class GetAttesterDutiesResponse {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final GetAttesterDutiesResponse that = (GetAttesterDutiesResponse) o;
+    final PostAttesterDutiesResponse that = (PostAttesterDutiesResponse) o;
     return Objects.equals(dependentRoot, that.dependentRoot) && Objects.equals(data, that.data);
   }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/AttesterDuties.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/AttesterDuties.java
@@ -14,66 +14,25 @@
 package tech.pegasys.teku.validator.api;
 
 import com.google.common.base.MoreObjects;
+import java.util.List;
 import java.util.Objects;
-import tech.pegasys.teku.bls.BLSPublicKey;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class AttesterDuties {
+  private final Bytes32 dependentRoot;
+  private final List<AttesterDuty> duties;
 
-  private final BLSPublicKey publicKey;
-  private final int validatorIndex;
-  private final int committeeLength;
-  /** the committee index of the committee that includes the specified validator */
-  private final int committeeIndex;
-
-  private final int commiteesAtSlot;
-  // index of the validator in the committee
-  private final int validatorCommitteeIndex;
-  private final UInt64 slot;
-
-  public AttesterDuties(
-      final BLSPublicKey publicKey,
-      final int validatorIndex,
-      final int committeeLength,
-      final int committeeIndex,
-      final int commiteesAtSlot,
-      final int validatorCommitteeIndex,
-      final UInt64 slot) {
-    this.publicKey = publicKey;
-    this.validatorIndex = validatorIndex;
-    this.committeeLength = committeeLength;
-    this.committeeIndex = committeeIndex;
-    this.commiteesAtSlot = commiteesAtSlot;
-    this.validatorCommitteeIndex = validatorCommitteeIndex;
-    this.slot = slot;
+  public AttesterDuties(final Bytes32 dependentRoot, final List<AttesterDuty> duties) {
+    this.dependentRoot = dependentRoot;
+    this.duties = duties;
   }
 
-  public BLSPublicKey getPublicKey() {
-    return publicKey;
+  public Bytes32 getDependentRoot() {
+    return dependentRoot;
   }
 
-  public int getValidatorIndex() {
-    return validatorIndex;
-  }
-
-  public int getCommitteeLength() {
-    return committeeLength;
-  }
-
-  public int getCommitteeIndex() {
-    return committeeIndex;
-  }
-
-  public int getCommiteesAtSlot() {
-    return commiteesAtSlot;
-  }
-
-  public int getValidatorCommitteeIndex() {
-    return validatorCommitteeIndex;
-  }
-
-  public UInt64 getSlot() {
-    return slot;
+  public List<AttesterDuty> getDuties() {
+    return duties;
   }
 
   @Override
@@ -85,37 +44,19 @@ public class AttesterDuties {
       return false;
     }
     final AttesterDuties that = (AttesterDuties) o;
-    return validatorIndex == that.validatorIndex
-        && committeeLength == that.committeeLength
-        && committeeIndex == that.committeeIndex
-        && commiteesAtSlot == that.commiteesAtSlot
-        && validatorCommitteeIndex == that.validatorCommitteeIndex
-        && Objects.equals(publicKey, that.publicKey)
-        && Objects.equals(slot, that.slot);
+    return Objects.equals(dependentRoot, that.dependentRoot) && Objects.equals(duties, that.duties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(
-        publicKey,
-        validatorIndex,
-        committeeLength,
-        committeeIndex,
-        commiteesAtSlot,
-        validatorCommitteeIndex,
-        slot);
+    return Objects.hash(dependentRoot, duties);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("publicKey", publicKey)
-        .add("validatorIndex", validatorIndex)
-        .add("committeeLength", committeeLength)
-        .add("committeeIndex", committeeIndex)
-        .add("commiteesAtSlot", commiteesAtSlot)
-        .add("validatorCommitteeIndex", validatorCommitteeIndex)
-        .add("slot", slot)
+        .add("dependentRoot", dependentRoot)
+        .add("duties", duties)
         .toString();
   }
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/AttesterDuty.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/AttesterDuty.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.api;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class AttesterDuty {
+
+  private final BLSPublicKey publicKey;
+  private final int validatorIndex;
+  private final int committeeLength;
+  /** the committee index of the committee that includes the specified validator */
+  private final int committeeIndex;
+
+  private final int committeesAtSlot;
+  // index of the validator in the committee
+  private final int validatorCommitteeIndex;
+  private final UInt64 slot;
+
+  public AttesterDuty(
+      final BLSPublicKey publicKey,
+      final int validatorIndex,
+      final int committeeLength,
+      final int committeeIndex,
+      final int committeesAtSlot,
+      final int validatorCommitteeIndex,
+      final UInt64 slot) {
+    this.publicKey = publicKey;
+    this.validatorIndex = validatorIndex;
+    this.committeeLength = committeeLength;
+    this.committeeIndex = committeeIndex;
+    this.committeesAtSlot = committeesAtSlot;
+    this.validatorCommitteeIndex = validatorCommitteeIndex;
+    this.slot = slot;
+  }
+
+  public BLSPublicKey getPublicKey() {
+    return publicKey;
+  }
+
+  public int getValidatorIndex() {
+    return validatorIndex;
+  }
+
+  public int getCommitteeLength() {
+    return committeeLength;
+  }
+
+  public int getCommitteeIndex() {
+    return committeeIndex;
+  }
+
+  public int getCommitteesAtSlot() {
+    return committeesAtSlot;
+  }
+
+  public int getValidatorCommitteeIndex() {
+    return validatorCommitteeIndex;
+  }
+
+  public UInt64 getSlot() {
+    return slot;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AttesterDuty that = (AttesterDuty) o;
+    return validatorIndex == that.validatorIndex
+        && committeeLength == that.committeeLength
+        && committeeIndex == that.committeeIndex
+        && committeesAtSlot == that.committeesAtSlot
+        && validatorCommitteeIndex == that.validatorCommitteeIndex
+        && Objects.equals(publicKey, that.publicKey)
+        && Objects.equals(slot, that.slot);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        publicKey,
+        validatorIndex,
+        committeeLength,
+        committeeIndex,
+        committeesAtSlot,
+        validatorCommitteeIndex,
+        slot);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("publicKey", publicKey)
+        .add("validatorIndex", validatorIndex)
+        .add("committeeLength", committeeLength)
+        .add("committeeIndex", committeeIndex)
+        .add("commiteesAtSlot", committeesAtSlot)
+        .add("validatorCommitteeIndex", validatorCommitteeIndex)
+        .add("slot", slot)
+        .toString();
+  }
+}

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -42,7 +42,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(final List<BLSPublicKey> publicKeys);
 
-  SafeFuture<Optional<List<AttesterDuties>>> getAttestationDuties(
+  SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndexes);
 
   SafeFuture<Optional<List<ProposerDuties>>> getProposerDuties(final UInt64 epoch);

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -180,7 +180,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<List<AttesterDuties>>> getAttestationDuties(
+  public SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndexes) {
     return countRequest(
         delegate.getAttestationDuties(epoch, validatorIndexes), attestationDutiesRequestCounter);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.AttesterDuties;
+import tech.pegasys.teku.validator.api.AttesterDuty;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.duties.BeaconCommitteeSubscriptions;
@@ -49,7 +50,7 @@ class AttestationDutyLoaderTest {
       mock(BeaconCommitteeSubscriptions.class);
   private final ScheduledDuties scheduledDuties = mock(ScheduledDuties.class);
   private final ValidatorIndexProvider validatorIndexProvider = mock(ValidatorIndexProvider.class);
-  private BLSPublicKey validatorKey = dataStructureUtil.randomPublicKey();
+  private final BLSPublicKey validatorKey = dataStructureUtil.randomPublicKey();
   private final Signer signer = mock(Signer.class);
   private final Validator validator = new Validator(validatorKey, signer, Optional.empty());
   private final Map<BLSPublicKey, Validator> validators = Map.of(validatorKey, validator);
@@ -78,8 +79,8 @@ class AttestationDutyLoaderTest {
     final int committeeLength = 1;
     final int committeeIndex = 3;
     final int committeesAtSlot = 4;
-    final AttesterDuties duty =
-        new AttesterDuties(
+    final AttesterDuty duty =
+        new AttesterDuty(
             validatorKey,
             validatorIndex,
             committeeLength,
@@ -88,7 +89,9 @@ class AttestationDutyLoaderTest {
             0,
             slot);
     when(validatorApiChannel.getAttestationDuties(UInt64.ONE, VALIDATOR_INDICES))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(List.of(duty))));
+        .thenReturn(
+            SafeFuture.completedFuture(
+                Optional.of(new AttesterDuties(dataStructureUtil.randomBytes32(), List.of(duty)))));
 
     when(scheduledDuties.scheduleAttestationProduction(
             any(), any(), anyInt(), anyInt(), anyInt(), anyInt()))
@@ -113,8 +116,8 @@ class AttestationDutyLoaderTest {
     final int committeeLength = 10000000;
     final int committeeIndex = 3;
     final int committeesAtSlot = 4;
-    final AttesterDuties duty =
-        new AttesterDuties(
+    final AttesterDuty duty =
+        new AttesterDuty(
             validatorKey,
             validatorIndex,
             committeeLength,
@@ -123,7 +126,9 @@ class AttestationDutyLoaderTest {
             0,
             slot);
     when(validatorApiChannel.getAttestationDuties(UInt64.ONE, VALIDATOR_INDICES))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(List.of(duty))));
+        .thenReturn(
+            SafeFuture.completedFuture(
+                Optional.of(new AttesterDuties(dataStructureUtil.randomBytes32(), List.of(duty)))));
 
     when(scheduledDuties.scheduleAttestationProduction(
             any(), any(), anyInt(), anyInt(), anyInt(), anyInt()))
@@ -144,7 +149,9 @@ class AttestationDutyLoaderTest {
   @Test
   void shouldSendSubscriptionRequestsWhenAllDutiesAreScheduled() {
     when(validatorApiChannel.getAttestationDuties(UInt64.ONE, VALIDATOR_INDICES))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(emptyList())));
+        .thenReturn(
+            SafeFuture.completedFuture(
+                Optional.of(new AttesterDuties(dataStructureUtil.randomBytes32(), emptyList()))));
     final SafeFuture<ScheduledDuties> result = dutyLoader.loadDutiesForEpoch(UInt64.ONE);
 
     assertThat(result).isCompleted();

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.AttesterDuties;
+import tech.pegasys.teku.validator.api.AttesterDuty;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.client.duties.AggregationDuty;
 import tech.pegasys.teku.validator.client.duties.AttestationProductionDuty;
@@ -64,13 +65,17 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   @BeforeEach
   public void init() {
     when(validatorApiChannel.getAttestationDuties(any(), any()))
-        .thenReturn(completedFuture(Optional.of(emptyList())));
+        .thenReturn(
+            completedFuture(
+                Optional.of(new AttesterDuties(dataStructureUtil.randomBytes32(), emptyList()))));
   }
 
   @Test
   public void shouldFetchDutiesForCurrentAndNextEpoch() {
     when(validatorApiChannel.getAttestationDuties(any(), any()))
-        .thenReturn(completedFuture(Optional.of(emptyList())));
+        .thenReturn(
+            completedFuture(
+                Optional.of(new AttesterDuties(dataStructureUtil.randomBytes32(), emptyList()))));
 
     dutyScheduler.onSlot(compute_start_slot_at_epoch(UInt64.ONE));
 
@@ -125,8 +130,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
 
   @Test
   public void shouldRetryWhenRequestingDutiesFails() {
-    final SafeFuture<Optional<List<AttesterDuties>>> request1 = new SafeFuture<>();
-    final SafeFuture<Optional<List<AttesterDuties>>> request2 = new SafeFuture<>();
+    final SafeFuture<Optional<AttesterDuties>> request1 = new SafeFuture<>();
+    final SafeFuture<Optional<AttesterDuties>> request2 = new SafeFuture<>();
     when(validatorApiChannel.getAttestationDuties(UInt64.ONE, VALIDATOR_INDICES))
         .thenReturn(request1)
         .thenReturn(request2);
@@ -244,11 +249,13 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
                     Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2),
                     validatorIndexProvider,
                     beaconCommitteeSubscriptions)));
-    final SafeFuture<Optional<List<AttesterDuties>>> epoch0Duties = new SafeFuture<>();
+    final SafeFuture<Optional<AttesterDuties>> epoch0Duties = new SafeFuture<>();
 
     when(validatorApiChannel.getAttestationDuties(eq(ZERO), any())).thenReturn(epoch0Duties);
     when(validatorApiChannel.getAttestationDuties(eq(ONE), any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(emptyList())));
+        .thenReturn(
+            SafeFuture.completedFuture(
+                Optional.of(new AttesterDuties(dataStructureUtil.randomBytes32(), emptyList()))));
     dutyScheduler.onSlot(ZERO);
 
     dutyScheduler.onBlockProductionDue(ZERO);
@@ -258,7 +265,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     verify(scheduledDuties, never()).produceAttestations(ZERO);
     verify(scheduledDuties, never()).performAggregation(ZERO);
 
-    epoch0Duties.complete(Optional.of(emptyList()));
+    epoch0Duties.complete(
+        Optional.of(new AttesterDuties(dataStructureUtil.randomBytes32(), emptyList())));
     verify(scheduledDuties).produceAttestations(ZERO);
     verify(scheduledDuties).performAggregation(ZERO);
   }
@@ -267,11 +275,14 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   public void shouldNotPerformDutiesForSameSlotTwice() {
     final UInt64 attestationProductionSlot = UInt64.valueOf(5);
     final int committeesAtSlot = 15;
-    final AttesterDuties validator1Duties =
-        new AttesterDuties(
-            VALIDATOR1_KEY, 5, 10, 3, committeesAtSlot, 6, attestationProductionSlot);
+    final AttesterDuty validator1Duties =
+        new AttesterDuty(VALIDATOR1_KEY, 5, 10, 3, committeesAtSlot, 6, attestationProductionSlot);
     when(validatorApiChannel.getAttestationDuties(eq(ZERO), any()))
-        .thenReturn(completedFuture(Optional.of(List.of(validator1Duties))));
+        .thenReturn(
+            completedFuture(
+                Optional.of(
+                    new AttesterDuties(
+                        dataStructureUtil.randomBytes32(), List.of(validator1Duties)))));
 
     final AttestationProductionDuty attestationDuty = mock(AttestationProductionDuty.class);
     when(attestationDuty.performDuty()).thenReturn(new SafeFuture<>());
@@ -304,8 +315,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     final int validator2CommitteePosition = 8;
     final int validator2CommitteeSize = 11;
     final int committeesAtSlot = 15;
-    final AttesterDuties validator1Duties =
-        new AttesterDuties(
+    final AttesterDuty validator1Duties =
+        new AttesterDuty(
             VALIDATOR1_KEY,
             validator1Index,
             validator1CommitteeSize,
@@ -313,8 +324,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             committeesAtSlot,
             validator1CommitteePosition,
             attestationSlot);
-    final AttesterDuties validator2Duties =
-        new AttesterDuties(
+    final AttesterDuty validator2Duties =
+        new AttesterDuty(
             VALIDATOR2_KEY,
             validator2Index,
             validator2CommitteeSize,
@@ -323,7 +334,12 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validator2CommitteePosition,
             attestationSlot);
     when(validatorApiChannel.getAttestationDuties(eq(ZERO), any()))
-        .thenReturn(completedFuture(Optional.of(List.of(validator1Duties, validator2Duties))));
+        .thenReturn(
+            completedFuture(
+                Optional.of(
+                    new AttesterDuties(
+                        dataStructureUtil.randomBytes32(),
+                        List.of(validator1Duties, validator2Duties)))));
 
     final AttestationProductionDuty attestationDuty = mock(AttestationProductionDuty.class);
     when(attestationDuty.performDuty()).thenReturn(new SafeFuture<>());
@@ -365,8 +381,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     final int validator2CommitteePosition = 8;
     final int validator2CommitteeSize = 11;
     final int committeesAtSlot = 15;
-    final AttesterDuties validator1Duties =
-        new AttesterDuties(
+    final AttesterDuty validator1Duties =
+        new AttesterDuty(
             VALIDATOR1_KEY,
             validator1Index,
             validator1CommitteeSize,
@@ -374,8 +390,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             committeesAtSlot,
             validator1CommitteePosition,
             attestationSlot);
-    final AttesterDuties validator2Duties =
-        new AttesterDuties(
+    final AttesterDuty validator2Duties =
+        new AttesterDuty(
             VALIDATOR2_KEY,
             validator2Index,
             validator2CommitteeSize,
@@ -384,7 +400,12 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validator2CommitteePosition,
             attestationSlot);
     when(validatorApiChannel.getAttestationDuties(eq(ZERO), any()))
-        .thenReturn(completedFuture(Optional.of(List.of(validator1Duties, validator2Duties))));
+        .thenReturn(
+            completedFuture(
+                Optional.of(
+                    new AttesterDuties(
+                        dataStructureUtil.randomBytes32(),
+                        List.of(validator1Duties, validator2Duties)))));
 
     final AttestationProductionDuty attestationDuty = mock(AttestationProductionDuty.class);
     when(attestationDuty.performDuty()).thenReturn(new SafeFuture<>());
@@ -426,8 +447,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     final int validator2CommitteePosition = 8;
     final int validator2CommitteeSize = 11;
     final int committeesAtSlot = 15;
-    final AttesterDuties validator1Duties =
-        new AttesterDuties(
+    final AttesterDuty validator1Duties =
+        new AttesterDuty(
             VALIDATOR1_KEY,
             validator1Index,
             validator1CommitteeSize,
@@ -435,8 +456,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             committeesAtSlot,
             validator1CommitteePosition,
             attestationSlot);
-    final AttesterDuties validator2Duties =
-        new AttesterDuties(
+    final AttesterDuty validator2Duties =
+        new AttesterDuty(
             VALIDATOR2_KEY,
             validator2Index,
             validator2CommitteeSize,
@@ -445,7 +466,12 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validator2CommitteePosition,
             attestationSlot);
     when(validatorApiChannel.getAttestationDuties(eq(ZERO), any()))
-        .thenReturn(completedFuture(Optional.of(List.of(validator1Duties, validator2Duties))));
+        .thenReturn(
+            completedFuture(
+                Optional.of(
+                    new AttesterDuties(
+                        dataStructureUtil.randomBytes32(),
+                        List.of(validator1Duties, validator2Duties)))));
 
     final AttestationProductionDuty attestationDuty = mock(AttestationProductionDuty.class);
     when(attestationDuty.performDuty()).thenReturn(new SafeFuture<>());
@@ -491,8 +517,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     final int validator2CommitteeSize = 1000000000; // Won't be an aggregator
     final int committeesAtSlot = 15;
 
-    final AttesterDuties validator1Duties =
-        new AttesterDuties(
+    final AttesterDuty validator1Duties =
+        new AttesterDuty(
             VALIDATOR1_KEY,
             validator1Index,
             validator1CommitteeSize,
@@ -500,8 +526,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             committeesAtSlot,
             validator1CommitteePosition,
             attestationSlot);
-    final AttesterDuties validator2Duties =
-        new AttesterDuties(
+    final AttesterDuty validator2Duties =
+        new AttesterDuty(
             VALIDATOR2_KEY,
             validator2Index,
             validator2CommitteeSize,
@@ -510,7 +536,12 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validator2CommitteePosition,
             attestationSlot);
     when(validatorApiChannel.getAttestationDuties(eq(ONE), any()))
-        .thenReturn(completedFuture(Optional.of(List.of(validator1Duties, validator2Duties))));
+        .thenReturn(
+            completedFuture(
+                Optional.of(
+                    new AttesterDuties(
+                        dataStructureUtil.randomBytes32(),
+                        List.of(validator1Duties, validator2Duties)))));
 
     final BLSSignature validator1Signature = dataStructureUtil.randomSignature();
     when(validator1.getSigner().signAggregationSlot(attestationSlot, fork))

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -13,13 +13,15 @@
 
 package tech.pegasys.teku.validator.coordinator;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getCurrentDutyDependentRoot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getPreviousDutyDependentRoot;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_beacon_proposer_index;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_committee_count_per_slot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_current_epoch;
 import static tech.pegasys.teku.infrastructure.logging.LogFormatter.formatBlock;
 import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
 import static tech.pegasys.teku.util.config.Constants.GENESIS_SLOT;
@@ -73,6 +75,7 @@ import tech.pegasys.teku.sync.events.SyncState;
 import tech.pegasys.teku.sync.events.SyncStateProvider;
 import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.validator.api.AttesterDuties;
+import tech.pegasys.teku.validator.api.AttesterDuty;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.NodeSyncingException;
 import tech.pegasys.teku.validator.api.ProposerDuties;
@@ -159,13 +162,10 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<List<AttesterDuties>>> getAttestationDuties(
+  public SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndexes) {
     if (isSyncActive()) {
       return NodeSyncingException.failedFuture();
-    }
-    if (validatorIndexes.isEmpty()) {
-      return SafeFuture.completedFuture(Optional.of(emptyList()));
     }
     if (epoch.isGreaterThan(
         combinedChainDataClient
@@ -463,16 +463,22 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     return result;
   }
 
-  private List<AttesterDuties> getAttesterDutiesFromIndexesAndState(
+  private AttesterDuties getAttesterDutiesFromIndexesAndState(
       final BeaconState state, final UInt64 epoch, final Collection<Integer> validatorIndexes) {
-    return validatorIndexes.stream()
-        .map(index -> createAttesterDuties(state, epoch, index))
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .collect(toList());
+    final Bytes32 dependentRoot =
+        epoch.isGreaterThan(get_current_epoch(state))
+            ? getCurrentDutyDependentRoot(state)
+            : getPreviousDutyDependentRoot(state);
+    return new AttesterDuties(
+        dependentRoot,
+        validatorIndexes.stream()
+            .map(index -> createAttesterDuties(state, epoch, index))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(toList()));
   }
 
-  private Optional<AttesterDuties> createAttesterDuties(
+  private Optional<AttesterDuty> createAttesterDuties(
       final BeaconState state, final UInt64 epoch, final Integer validatorIndex) {
     try {
       final BLSPublicKey pkey = state.getValidators().get(validatorIndex).getPubkey();
@@ -480,7 +486,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       return CommitteeAssignmentUtil.get_committee_assignment(state, epoch, validatorIndex)
           .map(
               committeeAssignment ->
-                  new AttesterDuties(
+                  new AttesterDuty(
                       pkey,
                       validatorIndex,
                       committeeAssignment.getCommittee().size(),

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -58,9 +58,9 @@ import tech.pegasys.teku.api.response.v1.beacon.GetStateValidatorsResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
-import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetNewBlockResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
+import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.AttestationData;
@@ -117,13 +117,13 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   }
 
   @Override
-  public Optional<GetAttesterDutiesResponse> getAttestationDuties(
+  public Optional<PostAttesterDutiesResponse> getAttestationDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndexes) {
     return post(
         GET_ATTESTATION_DUTIES,
         Map.of("epoch", epoch.toString()),
         validatorIndexes.toArray(),
-        createHandler(GetAttesterDutiesResponse.class));
+        createHandler(PostAttesterDutiesResponse.class));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -56,7 +56,6 @@ import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateValidatorsResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
-import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
 import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
@@ -118,15 +117,13 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   }
 
   @Override
-  public List<AttesterDuty> getAttestationDuties(
+  public Optional<GetAttesterDutiesResponse> getAttestationDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndexes) {
     return post(
-            GET_ATTESTATION_DUTIES,
-            Map.of("epoch", epoch.toString()),
-            validatorIndexes.toArray(),
-            createHandler(GetAttesterDutiesResponse.class))
-        .map(response -> response.data)
-        .orElse(Collections.emptyList());
+        GET_ATTESTATION_DUTIES,
+        Map.of("epoch", epoch.toString()),
+        validatorIndexes.toArray(),
+        createHandler(GetAttesterDutiesResponse.class));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
-import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
+import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.AttestationData;
@@ -43,7 +43,7 @@ public interface ValidatorRestApiClient {
 
   Optional<List<ValidatorResponse>> getValidators(List<String> validatorIds);
 
-  Optional<GetAttesterDutiesResponse> getAttestationDuties(
+  Optional<PostAttesterDutiesResponse> getAttestationDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndexes);
 
   List<ProposerDuty> getProposerDuties(final UInt64 epoch);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
-import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
+import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.AttestationData;
@@ -43,7 +43,7 @@ public interface ValidatorRestApiClient {
 
   Optional<List<ValidatorResponse>> getValidators(List<String> validatorIds);
 
-  List<AttesterDuty> getAttestationDuties(
+  Optional<GetAttesterDutiesResponse> getAttestationDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndexes);
 
   List<ProposerDuty> getProposerDuties(final UInt64 epoch);

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -43,7 +43,7 @@ import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.api.response.v1.beacon.GenesisData;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
-import tech.pegasys.teku.api.response.v1.validator.AttesterDuty;
+import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -62,6 +62,7 @@ import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.AttesterDuties;
+import tech.pegasys.teku.validator.api.AttesterDuty;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
@@ -218,20 +219,24 @@ class RemoteValidatorApiHandlerTest {
 
   @Test
   public void getAttestationDuties_WithEmptyPublicKeys_ReturnsEmpty() {
-    SafeFuture<Optional<List<AttesterDuties>>> future =
+    SafeFuture<Optional<AttesterDuties>> future =
         apiHandler.getAttestationDuties(UInt64.ONE, emptyList());
 
-    assertThat(unwrapToValue(future)).isEmpty();
+    assertThat(unwrapToValue(future).getDuties()).isEmpty();
   }
 
   @Test
   public void getAttestationDuties_WhenNoneFound_ReturnsEmpty() {
-    when(apiClient.getAttestationDuties(any(), any())).thenReturn(Collections.emptyList());
+    when(apiClient.getAttestationDuties(any(), any()))
+        .thenReturn(
+            Optional.of(
+                new GetAttesterDutiesResponse(
+                    dataStructureUtil.randomBytes32(), Collections.emptyList())));
 
-    SafeFuture<Optional<List<AttesterDuties>>> future =
+    SafeFuture<Optional<AttesterDuties>> future =
         apiHandler.getAttestationDuties(UInt64.ONE, List.of(1234));
 
-    assertThat(unwrapToValue(future)).isEmpty();
+    assertThat(unwrapToValue(future).getDuties()).isEmpty();
   }
 
   @Test
@@ -242,8 +247,8 @@ class RemoteValidatorApiHandlerTest {
     final int committeeIndex = 1;
     final int validatorCommitteeIndex = 3;
     final int committeesAtSlot = 15;
-    final AttesterDuty schemaValidatorDuties =
-        new AttesterDuty(
+    final tech.pegasys.teku.api.response.v1.validator.AttesterDuty schemaValidatorDuties =
+        new tech.pegasys.teku.api.response.v1.validator.AttesterDuty(
             new BLSPubKey(blsPublicKey),
             UInt64.valueOf(validatorIndex),
             UInt64.valueOf(committeeIndex),
@@ -251,8 +256,8 @@ class RemoteValidatorApiHandlerTest {
             UInt64.valueOf(committeesAtSlot),
             UInt64.valueOf(validatorCommitteeIndex),
             UInt64.ZERO);
-    final AttesterDuties expectedValidatorDuties =
-        new AttesterDuties(
+    final AttesterDuty expectedValidatorDuties =
+        new AttesterDuty(
             blsPublicKey,
             validatorIndex,
             committeeLength,
@@ -262,14 +267,17 @@ class RemoteValidatorApiHandlerTest {
             UInt64.ZERO);
 
     when(apiClient.getAttestationDuties(UInt64.ONE, List.of(validatorIndex)))
-        .thenReturn(List.of(schemaValidatorDuties));
+        .thenReturn(
+            Optional.of(
+                new GetAttesterDutiesResponse(
+                    dataStructureUtil.randomBytes32(), List.of(schemaValidatorDuties))));
 
-    SafeFuture<Optional<List<AttesterDuties>>> future =
+    SafeFuture<Optional<AttesterDuties>> future =
         apiHandler.getAttestationDuties(UInt64.ONE, List.of(validatorIndex));
 
-    List<AttesterDuties> validatorDuties = unwrapToValue(future);
+    AttesterDuties validatorDuties = unwrapToValue(future);
 
-    assertThat(validatorDuties.get(0))
+    assertThat(validatorDuties.getDuties().get(0))
         .usingRecursiveComparison()
         .isEqualTo(expectedValidatorDuties);
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -43,7 +43,7 @@ import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.api.response.v1.beacon.GenesisData;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
-import tech.pegasys.teku.api.response.v1.validator.GetAttesterDutiesResponse;
+import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -230,7 +230,7 @@ class RemoteValidatorApiHandlerTest {
     when(apiClient.getAttestationDuties(any(), any()))
         .thenReturn(
             Optional.of(
-                new GetAttesterDutiesResponse(
+                new PostAttesterDutiesResponse(
                     dataStructureUtil.randomBytes32(), Collections.emptyList())));
 
     SafeFuture<Optional<AttesterDuties>> future =
@@ -269,7 +269,7 @@ class RemoteValidatorApiHandlerTest {
     when(apiClient.getAttestationDuties(UInt64.ONE, List.of(validatorIndex)))
         .thenReturn(
             Optional.of(
-                new GetAttesterDutiesResponse(
+                new PostAttesterDutiesResponse(
                     dataStructureUtil.randomBytes32(), List.of(schemaValidatorDuties))));
 
     SafeFuture<Optional<AttesterDuties>> future =

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -222,7 +222,7 @@ class RemoteValidatorApiHandlerTest {
     SafeFuture<Optional<AttesterDuties>> future =
         apiHandler.getAttestationDuties(UInt64.ONE, emptyList());
 
-    assertThat(unwrapToValue(future).getDuties()).isEmpty();
+    assertThat(unwrapToOptional(future)).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Add dependent root to the `PostAttesterDuties` response.

## Fixed Issue(s)
Part of implementing https://github.com/ethereum/eth2.0-APIs/pull/117

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.