### PR TITLE
Add dependent root to proposer duties

### DIFF
--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDutiesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDutiesTest.java
@@ -22,6 +22,7 @@ import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_star
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
@@ -44,14 +45,16 @@ public class GetProposerDutiesTest extends AbstractValidatorApiTest {
     when(syncService.isSyncActive()).thenReturn(false);
     when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
 
-    List<ProposerDuty> duties =
-        List.of(getProposerDuty(2, compute_start_slot_at_epoch(UInt64.valueOf(100))));
+    GetProposerDutiesResponse duties =
+        new GetProposerDutiesResponse(
+            Bytes32.fromHexString("0x1234"),
+            List.of(getProposerDuty(2, compute_start_slot_at_epoch(UInt64.valueOf(100)))));
     when(validatorDataProvider.getProposerDuties(eq(UInt64.valueOf(100))))
         .thenReturn(SafeFuture.completedFuture(Optional.of(duties)));
 
     handler.handle(context);
     GetProposerDutiesResponse response = getResponseFromFuture(GetProposerDutiesResponse.class);
-    assertThat(response.data).isEqualTo(duties);
+    assertThat(response).isEqualTo(duties);
   }
 
   @Test

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -20,8 +20,8 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.request.v1.validator.BeaconCommitteeSubscriptionRequest;
+import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
-import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.AttestationData;
 import tech.pegasys.teku.api.schema.BLSPubKey;
@@ -37,7 +37,7 @@ import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.validator.api.AttesterDuty;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
-import tech.pegasys.teku.validator.api.ProposerDuties;
+import tech.pegasys.teku.validator.api.ProposerDuty;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
 public class ValidatorDataProvider {
@@ -179,20 +179,23 @@ public class ValidatorDataProvider {
                                 .collect(toList()))));
   }
 
-  public SafeFuture<Optional<List<ProposerDuty>>> getProposerDuties(final UInt64 epoch) {
+  public SafeFuture<Optional<GetProposerDutiesResponse>> getProposerDuties(final UInt64 epoch) {
     return SafeFuture.of(() -> validatorApiChannel.getProposerDuties(epoch))
         .thenApply(
             res ->
                 res.map(
                     duties ->
-                        duties.stream()
-                            .filter(duty -> duty.getPublicKey() != null)
-                            .map(this::mapToProposerDuties)
-                            .collect(toList())));
+                        new GetProposerDutiesResponse(
+                            duties.getDependentRoot(),
+                            duties.getDuties().stream()
+                                .filter(duty -> duty.getPublicKey() != null)
+                                .map(this::mapToProposerDuties)
+                                .collect(toList()))));
   }
 
-  private ProposerDuty mapToProposerDuties(final ProposerDuties duties) {
-    return new ProposerDuty(
+  private tech.pegasys.teku.api.response.v1.validator.ProposerDuty mapToProposerDuties(
+      final ProposerDuty duties) {
+    return new tech.pegasys.teku.api.response.v1.validator.ProposerDuty(
         new BLSPubKey(duties.getPublicKey()), duties.getValidatorIndex(), duties.getSlot());
   }
 

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/GetProposerDutiesResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/GetProposerDutiesResponse.java
@@ -13,15 +13,58 @@
 
 package tech.pegasys.teku.api.response.v1.validator;
 
+import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_BYTES32;
+import static tech.pegasys.teku.api.schema.SchemaConstants.PATTERN_BYTES32;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class GetProposerDutiesResponse {
+  @JsonProperty("dependent_root")
+  @Schema(
+      type = "string",
+      example = EXAMPLE_BYTES32,
+      pattern = PATTERN_BYTES32,
+      description = "The block root that this response is dependent on.")
+  public final Bytes32 dependentRoot;
+
   public final List<ProposerDuty> data;
 
   @JsonCreator
-  public GetProposerDutiesResponse(@JsonProperty("data") final List<ProposerDuty> data) {
+  public GetProposerDutiesResponse(
+      @JsonProperty("dependent_root") final Bytes32 dependentRoot,
+      @JsonProperty("data") final List<ProposerDuty> data) {
+    this.dependentRoot = dependentRoot;
     this.data = data;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final GetProposerDutiesResponse that = (GetProposerDutiesResponse) o;
+    return Objects.equals(dependentRoot, that.dependentRoot) && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(dependentRoot, data);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("dependentRoot", dependentRoot)
+        .add("data", data)
+        .toString();
   }
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ProposerDuties.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ProposerDuties.java
@@ -13,29 +13,50 @@
 
 package tech.pegasys.teku.validator.api;
 
-import tech.pegasys.teku.bls.BLSPublicKey;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import com.google.common.base.MoreObjects;
+import java.util.List;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class ProposerDuties {
-  private final BLSPublicKey publicKey;
-  private final int validatorIndex;
-  private final UInt64 slot;
+  private final Bytes32 dependentRoot;
+  private final List<ProposerDuty> duties;
 
-  public ProposerDuties(final BLSPublicKey publicKey, final int validatorIndex, final UInt64 slot) {
-    this.publicKey = publicKey;
-    this.validatorIndex = validatorIndex;
-    this.slot = slot;
+  public ProposerDuties(final Bytes32 dependentRoot, final List<ProposerDuty> duties) {
+    this.dependentRoot = dependentRoot;
+    this.duties = duties;
   }
 
-  public BLSPublicKey getPublicKey() {
-    return publicKey;
+  public Bytes32 getDependentRoot() {
+    return dependentRoot;
   }
 
-  public int getValidatorIndex() {
-    return validatorIndex;
+  public List<ProposerDuty> getDuties() {
+    return duties;
   }
 
-  public UInt64 getSlot() {
-    return slot;
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProposerDuties that = (ProposerDuties) o;
+    return Objects.equals(dependentRoot, that.dependentRoot) && Objects.equals(duties, that.duties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(dependentRoot, duties);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("dependentRoot", dependentRoot)
+        .add("duties", duties)
+        .toString();
   }
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ProposerDuty.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ProposerDuty.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.api;
+
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class ProposerDuty {
+  private final BLSPublicKey publicKey;
+  private final int validatorIndex;
+  private final UInt64 slot;
+
+  public ProposerDuty(final BLSPublicKey publicKey, final int validatorIndex, final UInt64 slot) {
+    this.publicKey = publicKey;
+    this.validatorIndex = validatorIndex;
+    this.slot = slot;
+  }
+
+  public BLSPublicKey getPublicKey() {
+    return publicKey;
+  }
+
+  public int getValidatorIndex() {
+    return validatorIndex;
+  }
+
+  public UInt64 getSlot() {
+    return slot;
+  }
+}

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -45,7 +45,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
   SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndexes);
 
-  SafeFuture<Optional<List<ProposerDuties>>> getProposerDuties(final UInt64 epoch);
+  SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch);
 
   SafeFuture<Optional<BeaconBlock>> createUnsignedBlock(
       UInt64 slot, BLSSignature randaoReveal, Optional<Bytes32> graffiti);

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -187,7 +187,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<List<ProposerDuties>>> getProposerDuties(final UInt64 epoch) {
+  public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
     return countRequest(delegate.getProposerDuties(epoch), proposerDutiesRequestCounter);
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.ProposerDuties;
+import tech.pegasys.teku.validator.api.ProposerDuty;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.client.duties.BlockProductionDuty;
 import tech.pegasys.teku.validator.client.duties.ScheduledDuties;
@@ -54,7 +55,9 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
   @Test
   public void shouldFetchDutiesForCurrentEpoch() {
     when(validatorApiChannel.getProposerDuties(any()))
-        .thenReturn(completedFuture(Optional.of(emptyList())));
+        .thenReturn(
+            completedFuture(
+                Optional.of(new ProposerDuties(dataStructureUtil.randomBytes32(), emptyList()))));
 
     dutyScheduler.onSlot(compute_start_slot_at_epoch(UInt64.ONE));
 
@@ -65,16 +68,17 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
   @Test
   public void shouldNotPerformDutiesForSameSlotTwice() {
     final UInt64 blockProposerSlot = UInt64.valueOf(5);
-    final ProposerDuties validator1Duties =
-        new ProposerDuties(VALIDATOR1_KEY, 5, blockProposerSlot);
+    final ProposerDuty validator1Duties = new ProposerDuty(VALIDATOR1_KEY, 5, blockProposerSlot);
     when(validatorApiChannel.getProposerDuties(eq(ZERO)))
         .thenReturn(
             completedFuture(
                 Optional.of(
-                    List.of(
-                        validator1Duties,
-                        new ProposerDuties(
-                            dataStructureUtil.randomPublicKey(), 6, UInt64.valueOf(4))))));
+                    new ProposerDuties(
+                        dataStructureUtil.randomBytes32(),
+                        List.of(
+                            validator1Duties,
+                            new ProposerDuty(
+                                dataStructureUtil.randomPublicKey(), 6, UInt64.valueOf(4)))))));
 
     final BlockProductionDuty blockCreationDuty = mock(BlockProductionDuty.class);
     when(blockCreationDuty.performDuty()).thenReturn(new SafeFuture<>());
@@ -97,10 +101,13 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
   @Test
   public void shouldScheduleBlockProposalDuty() {
     final UInt64 blockProposerSlot = UInt64.valueOf(5);
-    final ProposerDuties validator1Duties =
-        new ProposerDuties(VALIDATOR1_KEY, 5, blockProposerSlot);
+    final ProposerDuty validator1Duties = new ProposerDuty(VALIDATOR1_KEY, 5, blockProposerSlot);
     when(validatorApiChannel.getProposerDuties(ZERO))
-        .thenReturn(completedFuture(Optional.of(List.of(validator1Duties))));
+        .thenReturn(
+            completedFuture(
+                Optional.of(
+                    new ProposerDuties(
+                        dataStructureUtil.randomBytes32(), List.of(validator1Duties)))));
 
     final BlockProductionDuty blockCreationDuty = mock(BlockProductionDuty.class);
     when(blockCreationDuty.performDuty()).thenReturn(new SafeFuture<>());
@@ -129,18 +136,21 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
                     () -> scheduledDuties,
                     Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2),
                     validatorIndexProvider)));
-    final SafeFuture<Optional<List<ProposerDuties>>> epoch0Duties = new SafeFuture<>();
+    final SafeFuture<Optional<ProposerDuties>> epoch0Duties = new SafeFuture<>();
 
     when(validatorApiChannel.getProposerDuties(ZERO)).thenReturn(epoch0Duties);
     when(validatorApiChannel.getProposerDuties(ONE))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(emptyList())));
+        .thenReturn(
+            SafeFuture.completedFuture(
+                Optional.of(new ProposerDuties(dataStructureUtil.randomBytes32(), emptyList()))));
     dutyScheduler.onSlot(ZERO);
 
     dutyScheduler.onBlockProductionDue(ZERO);
     // Duties haven't been loaded yet.
     verify(scheduledDuties, never()).produceBlock(ZERO);
 
-    epoch0Duties.complete(Optional.of(emptyList()));
+    epoch0Duties.complete(
+        Optional.of(new ProposerDuties(dataStructureUtil.randomBytes32(), emptyList())));
     verify(scheduledDuties).produceBlock(ZERO);
   }
 

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -79,6 +79,7 @@ import tech.pegasys.teku.validator.api.AttesterDuty;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.NodeSyncingException;
 import tech.pegasys.teku.validator.api.ProposerDuties;
+import tech.pegasys.teku.validator.api.ProposerDuty;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
@@ -191,7 +192,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<List<ProposerDuties>>> getProposerDuties(final UInt64 epoch) {
+  public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
     if (isSyncActive()) {
       return NodeSyncingException.failedFuture();
     }
@@ -445,9 +446,9 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     return headEpoch.plus(1).isLessThan(currentEpoch);
   }
 
-  private List<ProposerDuties> getProposerDutiesFromIndexesAndState(
+  private ProposerDuties getProposerDutiesFromIndexesAndState(
       final BeaconState state, final UInt64 epoch) {
-    final List<ProposerDuties> result = new ArrayList<>();
+    final List<ProposerDuty> result = new ArrayList<>();
     getProposalSlotsForEpoch(state, epoch)
         .forEach(
             (slot, publicKey) -> {
@@ -458,9 +459,9 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                         "Assigned public key %s could not be found at epoch %s",
                         publicKey.toString(), epoch.toString()));
               }
-              result.add(new ProposerDuties(publicKey, maybeIndex.get(), slot));
+              result.add(new ProposerDuty(publicKey, maybeIndex.get(), slot));
             });
-    return result;
+    return new ProposerDuties(getCurrentDutyDependentRoot(state), result);
   }
 
   private AttesterDuties getAttesterDutiesFromIndexesAndState(

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -257,7 +257,7 @@ class ValidatorApiHandlerTest {
   @Test
   public void getProposerDuties_shouldFailWhenNodeIsSyncing() {
     nodeIsSyncing();
-    final SafeFuture<Optional<List<ProposerDuties>>> duties =
+    final SafeFuture<Optional<ProposerDuties>> duties =
         validatorApiHandler.getProposerDuties(EPOCH);
     assertThat(duties).isCompletedExceptionally();
     assertThatThrownBy(duties::get).hasRootCauseInstanceOf(NodeSyncingException.class);
@@ -267,7 +267,7 @@ class ValidatorApiHandlerTest {
   public void getProposerDuties_shouldFailForEpochTooFarAhead() {
     when(chainDataClient.getCurrentEpoch()).thenReturn(EPOCH.minus(2));
 
-    final SafeFuture<Optional<List<ProposerDuties>>> result =
+    final SafeFuture<Optional<ProposerDuties>> result =
         validatorApiHandler.getProposerDuties(EPOCH);
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get).hasRootCauseInstanceOf(IllegalArgumentException.class);
@@ -280,10 +280,11 @@ class ValidatorApiHandlerTest {
         .thenReturn(completedFuture(Optional.of(state)));
     when(chainDataClient.getCurrentEpoch()).thenReturn(EPOCH);
 
-    final SafeFuture<Optional<List<ProposerDuties>>> result =
+    final SafeFuture<Optional<ProposerDuties>> result =
         validatorApiHandler.getProposerDuties(EPOCH);
-    final Optional<List<ProposerDuties>> duties = assertCompletedSuccessfully(result);
-    assertThat(duties.get().size()).isEqualTo(Constants.SLOTS_PER_EPOCH);
+    final ProposerDuties duties = assertCompletedSuccessfully(result).orElseThrow();
+    assertThat(duties.getDuties().size()).isEqualTo(Constants.SLOTS_PER_EPOCH);
+    assertThat(duties.getDependentRoot()).isEqualTo(getCurrentDutyDependentRoot(state));
   }
 
   @Test
@@ -293,10 +294,10 @@ class ValidatorApiHandlerTest {
         .thenReturn(completedFuture(Optional.of(state)));
     when(chainDataClient.getCurrentEpoch()).thenReturn(EPOCH.minus(1));
 
-    final SafeFuture<Optional<List<ProposerDuties>>> result =
+    final SafeFuture<Optional<ProposerDuties>> result =
         validatorApiHandler.getProposerDuties(EPOCH);
-    final Optional<List<ProposerDuties>> duties = assertCompletedSuccessfully(result);
-    assertThat(duties.get().size()).isEqualTo(Constants.SLOTS_PER_EPOCH);
+    final Optional<ProposerDuties> duties = assertCompletedSuccessfully(result);
+    assertThat(duties.orElseThrow().getDuties().size()).isEqualTo(Constants.SLOTS_PER_EPOCH);
   }
 
   @Test

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -61,7 +61,6 @@ import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetNewBlockResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
-import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.AttestationData;
 import tech.pegasys.teku.api.schema.BLSSignature;
@@ -127,14 +126,12 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   }
 
   @Override
-  public List<ProposerDuty> getProposerDuties(final UInt64 epoch) {
+  public Optional<GetProposerDutiesResponse> getProposerDuties(final UInt64 epoch) {
     return get(
-            GET_PROPOSER_DUTIES,
-            Map.of("epoch", epoch.toString()),
-            emptyMap(),
-            createHandler(GetProposerDutiesResponse.class))
-        .map(response -> response.data)
-        .orElse(Collections.emptyList());
+        GET_PROPOSER_DUTIES,
+        Map.of("epoch", epoch.toString()),
+        emptyMap(),
+        createHandler(GetProposerDutiesResponse.class));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -20,8 +20,8 @@ import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
+import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
-import tech.pegasys.teku.api.response.v1.validator.ProposerDuty;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.AttestationData;
 import tech.pegasys.teku.api.schema.BLSSignature;
@@ -46,7 +46,7 @@ public interface ValidatorRestApiClient {
   Optional<PostAttesterDutiesResponse> getAttestationDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndexes);
 
-  List<ProposerDuty> getProposerDuties(final UInt64 epoch);
+  Optional<GetProposerDutiesResponse> getProposerDuties(final UInt64 epoch);
 
   Optional<BeaconBlock> createUnsignedBlock(
       UInt64 slot, BLSSignature randaoReveal, Optional<Bytes32> graffiti);


### PR DESCRIPTION
## PR Description
Add `dependent_root` field to get proposer duties responses.

## Fixed Issue(s)
Final piece of the server side for https://github.com/ethereum/eth2.0-APIs/pull/117/

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.