### PR TITLE
Provide friendly error message when network argument is unknown

### DIFF
--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -180,7 +180,7 @@ public class Constants {
     try (final InputStream input = createInputStream(source)) {
       ConstantsReader.loadConstantsFrom(input);
     } catch (IOException e) {
-      throw new IllegalArgumentException("Failed to load constants from " + source, e);
+      throw new InvalidConfigurationException("Failed to load constants from " + source, e);
     }
   }
 

--- a/util/src/test/java/tech/pegasys/teku/util/config/ConstantsReaderTest.java
+++ b/util/src/test/java/tech/pegasys/teku/util/config/ConstantsReaderTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.util.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
@@ -83,6 +84,12 @@ class ConstantsReaderTest {
     Constants.setConstants(Constants.class.getResource("mainnet.yaml").toExternalForm());
     assertThat(Constants.TARGET_COMMITTEE_SIZE).isEqualTo(128);
     assertAllFieldsSet();
+  }
+
+  @Test
+  void shouldThrowInvalidConfigurationExceptionWhenNetworkFileNotFound() {
+    assertThatThrownBy(() -> Constants.setConstants("doesNotExist/notARealFile.yaml"))
+        .isInstanceOf(InvalidConfigurationException.class);
   }
 
   static Stream<Arguments> knownNetworks() {


### PR DESCRIPTION
## PR Description
Don't print a full stack trace if the specified `--network` fails to load.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.