### PR TITLE
Fix previous correct validators metric

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
@@ -182,7 +182,7 @@ public class BeaconChainMetrics implements SlotEventsChannel {
     CorrectAndLiveValidators previousEpochValidators =
         getNumberOfValidators(head, state.getPrevious_epoch_attestations());
     previousLiveValidators.set(previousEpochValidators.numberOfLiveValidators);
-    previousCorrectValidators.set(currentEpochValidators.numberOfCorrectValidators);
+    previousCorrectValidators.set(previousEpochValidators.numberOfCorrectValidators);
     previousActiveValidators.set(
         get_active_validator_indices(state, get_previous_epoch(state)).size());
 


### PR DESCRIPTION
## PR Description
Report the value from the previous epoch, not the current one.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.