### PR TITLE
Use the correct expected block root for previous epoch attestations

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
@@ -178,16 +178,14 @@ public class BeaconChainMetrics implements SlotEventsChannel {
     final Bytes32 previousEpochCorrectTarget = getCorrectTargetRoot(head, previousEpoch);
 
     CorrectAndLiveValidators currentEpochValidators =
-        getNumberOfValidators(
-            head, state.getCurrent_epoch_attestations(), currentEpochCorrectTarget);
+        getNumberOfValidators(state.getCurrent_epoch_attestations(), currentEpochCorrectTarget);
     currentLiveValidators.set(currentEpochValidators.numberOfLiveValidators);
     currentCorrectValidators.set(currentEpochValidators.numberOfCorrectValidators);
     currentActiveValidators.set(
         get_active_validator_indices(state, get_current_epoch(state)).size());
 
     CorrectAndLiveValidators previousEpochValidators =
-        getNumberOfValidators(
-            head, state.getPrevious_epoch_attestations(), previousEpochCorrectTarget);
+        getNumberOfValidators(state.getPrevious_epoch_attestations(), previousEpochCorrectTarget);
     previousLiveValidators.set(previousEpochValidators.numberOfLiveValidators);
     previousCorrectValidators.set(previousEpochValidators.numberOfCorrectValidators);
     previousActiveValidators.set(
@@ -207,9 +205,7 @@ public class BeaconChainMetrics implements SlotEventsChannel {
   }
 
   private CorrectAndLiveValidators getNumberOfValidators(
-      final StateAndBlockSummary stateAndBlock,
-      final SSZList<PendingAttestation> attestations,
-      final Bytes32 correctTargetRoot) {
+      final SSZList<PendingAttestation> attestations, final Bytes32 correctTargetRoot) {
 
     final Map<UInt64, Map<UInt64, Bitlist>> liveValidatorsAggregationBitsBySlotAndCommittee =
         new HashMap<>();


### PR DESCRIPTION
## PR Description
Previous epoch attestations should have a target that matches the first block of the previous epoch, not the current (which is in the future relative to those attestations).

Update tests to actually have different block roots in the state history to verify the right root is used.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.