### PR TITLE
Update test case to show validatorSelector behaviour

### DIFF
--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -318,8 +318,10 @@ public class ChainDataProviderTest {
     final ChainDataProvider provider =
         new ChainDataProvider(recentChainData, combinedChainDataClient);
     final String key = internalState.getValidators().get(12).getPubkey().toString();
+    final String missingKey = data.randomPublicKey().toString();
     List<String> pubkeys =
-        provider.getFilteredValidatorList(internalState, List.of(key), emptySet()).stream()
+        provider.getFilteredValidatorList(internalState, List.of(key, missingKey), emptySet())
+            .stream()
             .map(v -> v.validator.pubkey.toHexString())
             .collect(toList());
     assertThat(pubkeys).containsExactly(key);


### PR DESCRIPTION
Update test case to show validatorSelector behaviour when present and missing keys are in one search

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.