### PR TITLE
Implement and integrate validator status logger

### DIFF
--- a/data/provider/build.gradle
+++ b/data/provider/build.gradle
@@ -13,7 +13,6 @@ dependencies {
     implementation project(':sync')
     implementation project(':util')
     implementation project(':validator:api')
-    implementation project(':validator:coordinator')
 
     implementation 'com.google.code.gson:gson'
     implementation 'org.apache.tuweni:tuweni-units'

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoc
 import static tech.pegasys.teku.util.config.Constants.FAR_FUTURE_EPOCH;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -131,10 +132,12 @@ public class ValidatorResponse {
         && Objects.equals(validator, that.validator);
   }
 
+  @JsonIgnore
   public BLSPublicKey getPublicKey() {
     return validator.pubkey.asBLSPublicKey();
   }
 
+  @JsonIgnore
   public ValidatorStatus getStatus() {
     return status;
   }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
@@ -13,21 +13,20 @@
 
 package tech.pegasys.teku.api.response.v1.beacon;
 
+import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_UINT64;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
+import static tech.pegasys.teku.util.config.Constants.FAR_FUTURE_EPOCH;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
+import java.util.Optional;
 import tech.pegasys.teku.api.schema.Validator;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-
-import java.util.Objects;
-import java.util.Optional;
-
-import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_UINT64;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
-import static tech.pegasys.teku.util.config.Constants.FAR_FUTURE_EPOCH;
 
 public class ValidatorResponse {
 

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
@@ -13,19 +13,21 @@
 
 package tech.pegasys.teku.api.response.v1.beacon;
 
-import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_UINT64;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
-import static tech.pegasys.teku.util.config.Constants.FAR_FUTURE_EPOCH;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.Objects;
-import java.util.Optional;
 import tech.pegasys.teku.api.schema.Validator;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_UINT64;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
+import static tech.pegasys.teku.util.config.Constants.FAR_FUTURE_EPOCH;
 
 public class ValidatorResponse {
 
@@ -128,6 +130,14 @@ public class ValidatorResponse {
         && Objects.equals(balance, that.balance)
         && status == that.status
         && Objects.equals(validator, that.validator);
+  }
+
+  public BLSPublicKey getPublicKey() {
+    return validator.pubkey.asBLSPublicKey();
+  }
+
+  public ValidatorStatus getStatus() {
+    return status;
   }
 
   @Override

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -228,4 +228,28 @@ public class StatusLogger {
         expectedChainId,
         eth1ChainId);
   }
+
+  public void unableToRetrieveValidatorStatusesFromBeaconNode() {
+    log.error("Unable to retrieve validator statuses from BeaconNode.");
+  }
+
+  public void validatorStatus(String validatorStatus, String publicKey) {
+    log.info("Validator {} status is {}.", validatorStatus, publicKey);
+  }
+
+  public void unableToRetrieveValidatorStatus(String publicKey) {
+    log.warn("Unable to retrieve status for validator {}.", publicKey);
+  }
+
+  public void unableToRetrieveValidatorStatusSummary(int n) {
+    log.warn("Unable to retrieve status for {} validators.", n);
+  }
+
+  public void validatorStatusSummary(int n, String validatorStatus) {
+    log.info("{} validators are in {} state.", n, validatorStatus);
+  }
+
+  public void validatorStatusChange(String oldStatus, String newStatus, String publicKey) {
+    log.warn("Validator {} has changed status from {} to {}.", publicKey, oldStatus, newStatus);
+  }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -13,30 +13,17 @@
 
 package tech.pegasys.teku.services.beaconchain;
 
-import static tech.pegasys.teku.core.ForkChoiceUtil.on_tick;
-import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
-import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
-import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
-import static tech.pegasys.teku.util.config.Constants.SECONDS_PER_SLOT;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.eventbus.EventBus;
 import io.libp2p.core.crypto.KEY_TYPE;
 import io.libp2p.core.crypto.KeyKt;
 import io.libp2p.core.crypto.PrivKey;
-import java.io.IOException;
-import java.net.BindException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Duration;
-import java.util.Optional;
-import java.util.Random;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.beaconrestapi.BeaconRestApi;
 import tech.pegasys.teku.core.BlockProposalUtil;
@@ -133,6 +120,21 @@ import tech.pegasys.teku.validator.coordinator.performance.NoOpPerformanceTracke
 import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 import tech.pegasys.teku.validator.coordinator.performance.ValidatorPerformanceMetrics;
 import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
+
+import java.io.IOException;
+import java.net.BindException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Random;
+
+import static tech.pegasys.teku.core.ForkChoiceUtil.on_tick;
+import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
+import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+import static tech.pegasys.teku.util.config.Constants.SECONDS_PER_SLOT;
 
 public class BeaconChainController extends Service implements TimeTickChannel {
   private static final Logger LOG = LogManager.getLogger();
@@ -463,6 +465,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
         eventChannels.getPublisher(BlockImportChannel.class, beaconAsyncRunner);
     final ValidatorApiHandler validatorApiHandler =
         new ValidatorApiHandler(
+                new ChainDataProvider(recentChainData, combinedChainDataClient),
             combinedChainDataClient,
             syncService,
             stateTransition,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -13,12 +13,26 @@
 
 package tech.pegasys.teku.services.beaconchain;
 
+import static tech.pegasys.teku.core.ForkChoiceUtil.on_tick;
+import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
+import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+import static tech.pegasys.teku.util.config.Constants.SECONDS_PER_SLOT;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.eventbus.EventBus;
 import io.libp2p.core.crypto.KEY_TYPE;
 import io.libp2p.core.crypto.KeyKt;
 import io.libp2p.core.crypto.PrivKey;
+import java.io.IOException;
+import java.net.BindException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Random;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -120,21 +134,6 @@ import tech.pegasys.teku.validator.coordinator.performance.NoOpPerformanceTracke
 import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 import tech.pegasys.teku.validator.coordinator.performance.ValidatorPerformanceMetrics;
 import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
-
-import java.io.IOException;
-import java.net.BindException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Duration;
-import java.util.Optional;
-import java.util.Random;
-
-import static tech.pegasys.teku.core.ForkChoiceUtil.on_tick;
-import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
-import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
-import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
-import static tech.pegasys.teku.util.config.Constants.SECONDS_PER_SLOT;
 
 public class BeaconChainController extends Service implements TimeTickChannel {
   private static final Logger LOG = LogManager.getLogger();
@@ -465,7 +464,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
         eventChannels.getPublisher(BlockImportChannel.class, beaconAsyncRunner);
     final ValidatorApiHandler validatorApiHandler =
         new ValidatorApiHandler(
-                new ChainDataProvider(recentChainData, combinedChainDataClient),
+            new ChainDataProvider(recentChainData, combinedChainDataClient),
             combinedChainDataClient,
             syncService,
             stateTransition,

--- a/validator/api/build.gradle
+++ b/validator/api/build.gradle
@@ -3,6 +3,7 @@ dependencies {
   implementation project(':infrastructure:async')
   implementation project(':ethereum:core')
   implementation project(':ethereum:datastructures')
+  implementation project(':data:serializer')
   implementation project(':util')
   implementation 'org.apache.tuweni:tuweni-bytes'
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -13,6 +13,11 @@
 
 package tech.pegasys.teku.validator.api;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -29,12 +34,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.ChannelInterface;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
 public interface ValidatorApiChannel extends ChannelInterface {
   int UKNOWN_VALIDATOR_ID = -1;
 
@@ -44,7 +43,8 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(final List<BLSPublicKey> publicKeys);
 
-  SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(final List<String> validatorIdentifiers);
+  SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
+      final List<String> validatorIdentifiers);
 
   SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndexes);

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -44,7 +44,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
   SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(final List<BLSPublicKey> publicKeys);
 
   SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
-      final List<String> validatorIdentifiers);
+      final Set<BLSPublicKey> validatorIdentifiers);
 
   SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndexes);

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -13,12 +13,8 @@
 
 package tech.pegasys.teku.validator.api;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
@@ -33,6 +29,12 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.ChannelInterface;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
 public interface ValidatorApiChannel extends ChannelInterface {
   int UKNOWN_VALIDATOR_ID = -1;
 
@@ -41,6 +43,8 @@ public interface ValidatorApiChannel extends ChannelInterface {
   SafeFuture<Optional<GenesisData>> getGenesisData();
 
   SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(final List<BLSPublicKey> publicKeys);
+
+  SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(final List<String> validatorIdentifiers);
 
   SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndexes);

--- a/validator/beaconnode/build.gradle
+++ b/validator/beaconnode/build.gradle
@@ -6,6 +6,7 @@ dependencies {
   implementation project(':infrastructure:metrics')
   implementation project(':util')
   implementation project(':validator:api')
+  implementation project(':data:serializer')
 
   implementation 'org.apache.tuweni:tuweni-bytes'
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -182,7 +182,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
-      final List<String> validatorIdentifiers) {
+      final Set<BLSPublicKey> validatorIdentifiers) {
     return delegate.getValidatorStatuses(validatorIdentifiers);
   }
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -13,6 +13,11 @@
 
 package tech.pegasys.teku.validator.beaconnode.metrics;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
@@ -35,12 +40,6 @@ import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
 
@@ -182,7 +181,8 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(final List<String> validatorIdentifiers){
+  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
+      final List<String> validatorIdentifiers) {
     return delegate.getValidatorStatuses(validatorIdentifiers);
   }
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -13,14 +13,10 @@
 
 package tech.pegasys.teku.validator.beaconnode.metrics;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
@@ -39,6 +35,12 @@ import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
 
@@ -177,6 +179,11 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final List<BLSPublicKey> publicKeys) {
     getValidatorIndicesRequestCounter.inc();
     return delegate.getValidatorIndices(publicKeys);
+  }
+
+  @Override
+  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(final List<String> validatorIdentifiers){
+    return delegate.getValidatorStatuses(validatorIdentifiers);
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLogger.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLogger.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+
+public class DefaultValidatorStatusLogger implements ValidatorStatusLogger {
+
+  private static final int VALIDATOR_KEYS_PRINT_LIMIT = 20;
+
+  final Set<BLSPublicKey> validatorPublicKeys;
+  final ValidatorApiChannel validatorApiChannel;
+  final AtomicReference<Map<BLSPublicKey, ValidatorStatus>> latestValidatorStatuses =
+      new AtomicReference<>();
+
+  public DefaultValidatorStatusLogger(
+      Set<BLSPublicKey> validatorPublicKeys, ValidatorApiChannel validatorApiChannel) {
+    checkArgument(!validatorPublicKeys.isEmpty());
+    this.validatorPublicKeys = validatorPublicKeys;
+    this.validatorApiChannel = validatorApiChannel;
+  }
+
+  @Override
+  public void printInitialValidatorStatuses() {
+    validatorApiChannel
+        .getValidatorStatuses(validatorPublicKeys)
+        .thenAccept(
+            maybeValidatorStatuses -> {
+              if (maybeValidatorStatuses.isEmpty()) {
+                STATUS_LOG.unableToRetrieveValidatorStatusesFromBeaconNode();
+                return;
+              }
+
+              Map<BLSPublicKey, ValidatorStatus> validatorStatuses = maybeValidatorStatuses.get();
+              if (validatorPublicKeys.size() < VALIDATOR_KEYS_PRINT_LIMIT) {
+                printValidatorStatusesOneByOne(validatorStatuses);
+              } else {
+                printValidatorStatusSummary(validatorStatuses);
+              }
+            })
+        .reportExceptions();
+  }
+
+  private void printValidatorStatusesOneByOne(
+      Map<BLSPublicKey, ValidatorStatus> validatorStatuses) {
+    for (BLSPublicKey publicKey : validatorPublicKeys) {
+      Optional<ValidatorStatus> maybeValidatorStatus =
+          Optional.ofNullable(validatorStatuses.get(publicKey));
+      maybeValidatorStatus.ifPresentOrElse(
+          validatorStatus ->
+              STATUS_LOG.validatorStatus(validatorStatus.name(), publicKey.toAbbreviatedString()),
+          () -> STATUS_LOG.unableToRetrieveValidatorStatus(publicKey.toAbbreviatedString()));
+    }
+  }
+
+  private void printValidatorStatusSummary(Map<BLSPublicKey, ValidatorStatus> validatorStatuses) {
+    Map<ValidatorStatus, AtomicInteger> validatorStatusCount = new HashMap<>();
+    final AtomicInteger unknownValidatorCountReference = new AtomicInteger(0);
+    for (BLSPublicKey publicKey : validatorPublicKeys) {
+      Optional<ValidatorStatus> maybeValidatorStatus =
+          Optional.ofNullable(validatorStatuses.get(publicKey));
+      maybeValidatorStatus.ifPresentOrElse(
+          status -> {
+            AtomicInteger count =
+                validatorStatusCount.computeIfAbsent(status, __ -> new AtomicInteger(0));
+            count.incrementAndGet();
+          },
+          unknownValidatorCountReference::incrementAndGet);
+    }
+
+    for (Map.Entry<ValidatorStatus, AtomicInteger> statusCount : validatorStatusCount.entrySet()) {
+      STATUS_LOG.validatorStatusSummary(statusCount.getValue().get(), statusCount.getKey().name());
+    }
+
+    final int unknownValidatorCount = unknownValidatorCountReference.get();
+    if (unknownValidatorCount > 0) {
+      STATUS_LOG.unableToRetrieveValidatorStatusSummary(unknownValidatorCountReference.get());
+    }
+  }
+
+  @Override
+  public void checkValidatorStatusChanges() {
+    validatorApiChannel
+        .getValidatorStatuses(validatorPublicKeys)
+        .thenAccept(
+            maybeNewValidatorStatuses -> {
+              if (maybeNewValidatorStatuses.isEmpty()) {
+                STATUS_LOG.unableToRetrieveValidatorStatusesFromBeaconNode();
+                return;
+              }
+
+              Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses =
+                  maybeNewValidatorStatuses.get();
+
+              Map<BLSPublicKey, ValidatorStatus> oldValidatorStatuses =
+                  latestValidatorStatuses.getAndSet(newValidatorStatuses);
+              if (oldValidatorStatuses == null) {
+                return;
+              }
+
+              for (BLSPublicKey key : oldValidatorStatuses.keySet()) {
+                ValidatorStatus oldStatus = oldValidatorStatuses.get(key);
+                ValidatorStatus newStatus = newValidatorStatuses.get(key);
+                if (oldStatus.equals(newStatus)) {
+                  continue;
+                }
+
+                STATUS_LOG.validatorStatusChange(
+                    oldStatus.name(), newStatus.name(), key.toAbbreviatedString());
+              }
+            })
+        .reportExceptions();
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -117,8 +117,13 @@ public class ValidatorClientService extends Service {
 
     addValidatorCountMetric(metricsSystem, validators.size());
 
-    final ValidatorStatusLogger validatorStatusLogger =
-        new ValidatorStatusLogger(validators.keySet(), validatorApiChannel);
+    ValidatorStatusLogger validatorStatusLogger;
+    if (validators.keySet().size() > 0) {
+      validatorStatusLogger =
+          new DefaultValidatorStatusLogger(validators.keySet(), validatorApiChannel);
+    } else {
+      validatorStatusLogger = ValidatorStatusLogger.NOOP;
+    }
 
     return new ValidatorClientService(
         validatorStatusLogger,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -120,13 +120,16 @@ public class ValidatorClientService extends Service {
 
     addValidatorCountMetric(metricsSystem, validators.size());
 
-    ValidatorStatusLogger validatorStatusLogger;
-    if (validators.keySet().size() > 0) {
-      validatorStatusLogger =
-          new DefaultValidatorStatusLogger(validators.keySet(), validatorApiChannel);
-    } else {
-      validatorStatusLogger = ValidatorStatusLogger.NOOP;
-    }
+    //    TODO: once the voluntary exit acceptance test PR is merged, activate validator status
+    // logger.
+    //    ValidatorStatusLogger validatorStatusLogger;
+    //    if (validators.keySet().size() > 0) {
+    //            validatorStatusLogger =
+    //                new DefaultValidatorStatusLogger(validators.keySet(), validatorApiChannel);
+    //    } else {
+    //      validatorStatusLogger = ValidatorStatusLogger.NOOP;
+    //    }
+    ValidatorStatusLogger validatorStatusLogger = ValidatorStatusLogger.NOOP;
 
     return new ValidatorClientService(
         validatorStatusLogger,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.validator.client;
 
+import java.nio.file.Path;
+import java.util.Map;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.core.signatures.LocalSlashingProtector;
@@ -36,9 +38,6 @@ import tech.pegasys.teku.validator.client.loader.ValidatorLoader;
 import tech.pegasys.teku.validator.eventadapter.InProcessBeaconNodeApi;
 import tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi;
 
-import java.nio.file.Path;
-import java.util.Map;
-
 public class ValidatorClientService extends Service {
   private final EventChannels eventChannels;
   private final ValidatorTimingChannel attestationTimingChannel;
@@ -48,7 +47,7 @@ public class ValidatorClientService extends Service {
   private final BeaconNodeApi beaconNodeApi;
 
   private ValidatorClientService(
-          final ValidatorStatusLogger validatorStatusLogger,
+      final ValidatorStatusLogger validatorStatusLogger,
       final EventChannels eventChannels,
       final ValidatorTimingChannel attestationTimingChannel,
       final ValidatorTimingChannel blockProductionTimingChannel,
@@ -119,10 +118,10 @@ public class ValidatorClientService extends Service {
     addValidatorCountMetric(metricsSystem, validators.size());
 
     final ValidatorStatusLogger validatorStatusLogger =
-            new ValidatorStatusLogger(validators.keySet(), validatorApiChannel);
+        new ValidatorStatusLogger(validators.keySet(), validatorApiChannel);
 
     return new ValidatorClientService(
-            validatorStatusLogger,
+        validatorStatusLogger,
         eventChannels,
         attestationDutyScheduler,
         blockDutyScheduler,
@@ -148,8 +147,11 @@ public class ValidatorClientService extends Service {
     validatorIndexProvider.lookupValidators();
     eventChannels.subscribe(
         ValidatorTimingChannel.class,
-        new ValidatorTimingActions(validatorStatusLogger,
-            validatorIndexProvider, blockProductionTimingChannel, attestationTimingChannel));
+        new ValidatorTimingActions(
+            validatorStatusLogger,
+            validatorIndexProvider,
+            blockProductionTimingChannel,
+            attestationTimingChannel));
     validatorStatusLogger.printInitialValidatorStatuses();
     return beaconNodeApi.subscribeToEvents();
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorStatusLogger.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorStatusLogger.java
@@ -94,7 +94,6 @@ public class ValidatorStatusLogger {
     }
 
     final int unknownValidatorCount = unknownValidatorCountReference.get();
-    ;
     if (unknownValidatorCount > 0) {
       STATUS_LOG.unableToRetrieveValidatorStatusSummary(unknownValidatorCountReference.get());
     }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorStatusLogger.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorStatusLogger.java
@@ -1,18 +1,30 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.validator.client;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
-import tech.pegasys.teku.bls.BLSPublicKey;
-import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import static java.util.stream.Collectors.toList;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static java.util.stream.Collectors.toList;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
 public class ValidatorStatusLogger {
 
@@ -20,17 +32,20 @@ public class ValidatorStatusLogger {
 
   final Set<BLSPublicKey> validatorPublicKeys;
   final ValidatorApiChannel validatorApiChannel;
-  final AtomicReference<Map<BLSPublicKey, ValidatorStatus>> latestValidatorStatuses = new AtomicReference<>();
+  final AtomicReference<Map<BLSPublicKey, ValidatorStatus>> latestValidatorStatuses =
+      new AtomicReference<>();
 
-  public ValidatorStatusLogger(Set<BLSPublicKey> validatorPublicKeys, ValidatorApiChannel validatorApiChannel) {
+  public ValidatorStatusLogger(
+      Set<BLSPublicKey> validatorPublicKeys, ValidatorApiChannel validatorApiChannel) {
     this.validatorPublicKeys = validatorPublicKeys;
     this.validatorApiChannel = validatorApiChannel;
   }
 
   public void printInitialValidatorStatuses() {
-    validatorApiChannel.getValidatorStatuses(getAsIdentifiers(validatorPublicKeys))
-            .thenAccept(maybeValidatorStatuses -> {
-
+    validatorApiChannel
+        .getValidatorStatuses(getAsIdentifiers(validatorPublicKeys))
+        .thenAccept(
+            maybeValidatorStatuses -> {
               if (maybeValidatorStatuses.isEmpty()) {
                 LOG.error("Unable to retrieve validator statuses from BeaconNode.");
                 return;
@@ -38,28 +53,34 @@ public class ValidatorStatusLogger {
 
               Map<BLSPublicKey, ValidatorStatus> validatorStatuses = maybeValidatorStatuses.get();
               for (BLSPublicKey publicKey : validatorPublicKeys) {
-                Optional<ValidatorStatus> maybeValidatorStatus = Optional.ofNullable(validatorStatuses.get(publicKey));
+                Optional<ValidatorStatus> maybeValidatorStatus =
+                    Optional.ofNullable(validatorStatuses.get(publicKey));
                 maybeValidatorStatus.ifPresentOrElse(
-                        validatorStatus -> LOG.info("Validator {} status is " + validatorStatus, publicKey.toAbbreviatedString()),
-                        () -> LOG.info("Error retrieving status for validator {}", publicKey)
-                );
+                    validatorStatus ->
+                        LOG.info(
+                            "Validator {} status is " + validatorStatus,
+                            publicKey.toAbbreviatedString()),
+                    () -> LOG.info("Error retrieving status for validator {}", publicKey));
               }
             })
-            .reportExceptions();
+        .reportExceptions();
   }
 
   public void checkValidatorStatusChanges() {
-    validatorApiChannel.getValidatorStatuses(getAsIdentifiers(validatorPublicKeys))
-            .thenAccept(maybeNewValidatorStatuses -> {
-
+    validatorApiChannel
+        .getValidatorStatuses(getAsIdentifiers(validatorPublicKeys))
+        .thenAccept(
+            maybeNewValidatorStatuses -> {
               if (maybeNewValidatorStatuses.isEmpty()) {
                 LOG.error("Unable to retrieve validator statuses from BeaconNode.");
                 return;
               }
 
-              Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses = maybeNewValidatorStatuses.get();
+              Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses =
+                  maybeNewValidatorStatuses.get();
 
-              Map<BLSPublicKey, ValidatorStatus> oldValidatorStatuses = latestValidatorStatuses.getAndSet(newValidatorStatuses);
+              Map<BLSPublicKey, ValidatorStatus> oldValidatorStatuses =
+                  latestValidatorStatuses.getAndSet(newValidatorStatuses);
               if (oldValidatorStatuses == null) {
                 return;
               }
@@ -71,10 +92,12 @@ public class ValidatorStatusLogger {
                   continue;
                 }
 
-                LOG.warn("Validator {} has changed status from " + oldStatus + " to " + newStatus, key::toAbbreviatedString);
+                LOG.warn(
+                    "Validator {} has changed status from " + oldStatus + " to " + newStatus,
+                    key::toAbbreviatedString);
               }
             })
-            .reportExceptions();
+        .reportExceptions();
   }
 
   private static List<String> getAsIdentifiers(Set<BLSPublicKey> validatorPublicKeys) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorStatusLogger.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorStatusLogger.java
@@ -1,0 +1,83 @@
+package tech.pegasys.teku.validator.client;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.stream.Collectors.toList;
+
+public class ValidatorStatusLogger {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  final Set<BLSPublicKey> validatorPublicKeys;
+  final ValidatorApiChannel validatorApiChannel;
+  final AtomicReference<Map<BLSPublicKey, ValidatorStatus>> latestValidatorStatuses = new AtomicReference<>();
+
+  public ValidatorStatusLogger(Set<BLSPublicKey> validatorPublicKeys, ValidatorApiChannel validatorApiChannel) {
+    this.validatorPublicKeys = validatorPublicKeys;
+    this.validatorApiChannel = validatorApiChannel;
+  }
+
+  public void printInitialValidatorStatuses() {
+    validatorApiChannel.getValidatorStatuses(getAsIdentifiers(validatorPublicKeys))
+            .thenAccept(maybeValidatorStatuses -> {
+
+              if (maybeValidatorStatuses.isEmpty()) {
+                LOG.error("Unable to retrieve validator statuses from BeaconNode.");
+                return;
+              }
+
+              Map<BLSPublicKey, ValidatorStatus> validatorStatuses = maybeValidatorStatuses.get();
+              for (BLSPublicKey publicKey : validatorPublicKeys) {
+                Optional<ValidatorStatus> maybeValidatorStatus = Optional.ofNullable(validatorStatuses.get(publicKey));
+                maybeValidatorStatus.ifPresentOrElse(
+                        validatorStatus -> LOG.info("Validator {} status is " + validatorStatus, publicKey.toAbbreviatedString()),
+                        () -> LOG.info("Error retrieving status for validator {}", publicKey)
+                );
+              }
+            })
+            .reportExceptions();
+  }
+
+  public void checkValidatorStatusChanges() {
+    validatorApiChannel.getValidatorStatuses(getAsIdentifiers(validatorPublicKeys))
+            .thenAccept(maybeNewValidatorStatuses -> {
+
+              if (maybeNewValidatorStatuses.isEmpty()) {
+                LOG.error("Unable to retrieve validator statuses from BeaconNode.");
+                return;
+              }
+
+              Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses = maybeNewValidatorStatuses.get();
+
+              Map<BLSPublicKey, ValidatorStatus> oldValidatorStatuses = latestValidatorStatuses.getAndSet(newValidatorStatuses);
+              if (oldValidatorStatuses == null) {
+                return;
+              }
+
+              for (BLSPublicKey key : oldValidatorStatuses.keySet()) {
+                ValidatorStatus oldStatus = oldValidatorStatuses.get(key);
+                ValidatorStatus newStatus = newValidatorStatuses.get(key);
+                if (oldStatus.equals(newStatus)) {
+                  continue;
+                }
+
+                LOG.warn("Validator {} has changed status from " + oldStatus + " to " + newStatus, key::toAbbreviatedString);
+              }
+            })
+            .reportExceptions();
+  }
+
+  private static List<String> getAsIdentifiers(Set<BLSPublicKey> validatorPublicKeys) {
+    return validatorPublicKeys.stream().map(BLSPublicKey::toString).collect(toList());
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -13,10 +13,10 @@
 
 package tech.pegasys.teku.validator.client;
 
+import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_EPOCH;
+
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
-
-import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_EPOCH;
 
 public class ValidatorTimingActions implements ValidatorTimingChannel {
   private final ValidatorIndexProvider validatorIndexProvider;
@@ -25,7 +25,7 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
   private final ValidatorStatusLogger statusLogger;
 
   public ValidatorTimingActions(
-          final ValidatorStatusLogger statusLogger,
+      final ValidatorStatusLogger statusLogger,
       final ValidatorIndexProvider validatorIndexProvider,
       final ValidatorTimingChannel blockDuties,
       final ValidatorTimingChannel attestationDuties) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -16,15 +16,20 @@ package tech.pegasys.teku.validator.client;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 
+import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_EPOCH;
+
 public class ValidatorTimingActions implements ValidatorTimingChannel {
   private final ValidatorIndexProvider validatorIndexProvider;
   private final ValidatorTimingChannel blockDuties;
   private final ValidatorTimingChannel attestationDuties;
+  private final ValidatorStatusLogger statusLogger;
 
   public ValidatorTimingActions(
+          final ValidatorStatusLogger statusLogger,
       final ValidatorIndexProvider validatorIndexProvider,
       final ValidatorTimingChannel blockDuties,
       final ValidatorTimingChannel attestationDuties) {
+    this.statusLogger = statusLogger;
     this.validatorIndexProvider = validatorIndexProvider;
     this.blockDuties = blockDuties;
     this.attestationDuties = attestationDuties;
@@ -35,6 +40,9 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
     validatorIndexProvider.lookupValidators();
     blockDuties.onSlot(slot);
     attestationDuties.onSlot(slot);
+    if (slot.mod(SLOTS_PER_EPOCH).equals(UInt64.ONE)) {
+      statusLogger.checkValidatorStatusChanges();
+    }
   }
 
   @Override

--- a/validator/coordinator/build.gradle
+++ b/validator/coordinator/build.gradle
@@ -15,6 +15,8 @@ dependencies {
   implementation project(':pow')
   implementation project(':ssz')
   implementation project(':sync')
+  implementation project(':data:serializer')
+  implementation project(':data:provider')
   implementation project(':infrastructure:events')
 
   implementation 'org.apache.tuweni:tuweni-kv'

--- a/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -13,17 +13,10 @@
 
 package tech.pegasys.teku.validator.coordinator;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
-import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
-import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
-
 import com.google.common.eventbus.EventBus;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.operations.Attestation;
@@ -44,6 +37,15 @@ import tech.pegasys.teku.sync.events.SyncStateProvider;
 import tech.pegasys.teku.sync.events.SyncStateTracker;
 import tech.pegasys.teku.util.config.StateStorageMode;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
 public class ValidatorApiHandlerIntegrationTest {
 
@@ -66,10 +68,12 @@ public class ValidatorApiHandlerIntegrationTest {
   private final DefaultPerformanceTracker performanceTracker =
       mock(DefaultPerformanceTracker.class);
   private final BlockImportChannel blockImportChannel = mock(BlockImportChannel.class);
+  private final ChainDataProvider chainDataProvider = mock(ChainDataProvider.class);
 
   private final ChainUpdater chainUpdater = storageSystem.chainUpdater();
   private final ValidatorApiHandler handler =
       new ValidatorApiHandler(
+              chainDataProvider,
           combinedChainDataClient,
           syncStateProvider,
           stateTransition,

--- a/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -13,7 +13,15 @@
 
 package tech.pegasys.teku.validator.coordinator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
+
 import com.google.common.eventbus.EventBus;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.ChainDataProvider;
@@ -37,15 +45,6 @@ import tech.pegasys.teku.sync.events.SyncStateProvider;
 import tech.pegasys.teku.sync.events.SyncStateTracker;
 import tech.pegasys.teku.util.config.StateStorageMode;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
-import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
-import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
 public class ValidatorApiHandlerIntegrationTest {
 
@@ -73,7 +72,7 @@ public class ValidatorApiHandlerIntegrationTest {
   private final ChainUpdater chainUpdater = storageSystem.chainUpdater();
   private final ValidatorApiHandler handler =
       new ValidatorApiHandler(
-              chainDataProvider,
+          chainDataProvider,
           combinedChainDataClient,
           syncStateProvider,
           stateTransition,

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -13,8 +13,31 @@
 
 package tech.pegasys.teku.validator.coordinator;
 
+import static java.util.Collections.emptyMap;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getCurrentDutyDependentRoot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getPreviousDutyDependentRoot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_beacon_proposer_index;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_committee_count_per_slot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_current_epoch;
+import static tech.pegasys.teku.infrastructure.logging.LogFormatter.formatBlock;
+import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
+import static tech.pegasys.teku.util.config.Constants.GENESIS_SLOT;
+import static tech.pegasys.teku.util.config.Constants.MAX_VALIDATORS_PER_COMMITTEE;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -66,30 +89,6 @@ import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
-import static java.util.Collections.emptyMap;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getCurrentDutyDependentRoot;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getPreviousDutyDependentRoot;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_beacon_proposer_index;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_committee_count_per_slot;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_current_epoch;
-import static tech.pegasys.teku.infrastructure.logging.LogFormatter.formatBlock;
-import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
-import static tech.pegasys.teku.util.config.Constants.GENESIS_SLOT;
-import static tech.pegasys.teku.util.config.Constants.MAX_VALIDATORS_PER_COMMITTEE;
-
 public class ValidatorApiHandler implements ValidatorApiChannel {
   private static final Logger LOG = LogManager.getLogger();
   /**
@@ -114,19 +113,19 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   private final PerformanceTracker performanceTracker;
 
   public ValidatorApiHandler(
-          final ChainDataProvider chainDataProvider,
-          final CombinedChainDataClient combinedChainDataClient,
-          final SyncStateProvider syncStateProvider,
-          final StateTransition stateTransition,
-          final BlockFactory blockFactory,
-          final BlockImportChannel blockImportChannel,
-          final AggregatingAttestationPool attestationPool,
-          final AttestationManager attestationManager,
-          final AttestationTopicSubscriber attestationTopicSubscriber,
-          final ActiveValidatorTracker activeValidatorTracker,
-          final EventBus eventBus,
-          final DutyMetrics dutyMetrics,
-          final PerformanceTracker performanceTracker) {
+      final ChainDataProvider chainDataProvider,
+      final CombinedChainDataClient combinedChainDataClient,
+      final SyncStateProvider syncStateProvider,
+      final StateTransition stateTransition,
+      final BlockFactory blockFactory,
+      final BlockImportChannel blockImportChannel,
+      final AggregatingAttestationPool attestationPool,
+      final AttestationManager attestationManager,
+      final AttestationTopicSubscriber attestationTopicSubscriber,
+      final ActiveValidatorTracker activeValidatorTracker,
+      final EventBus eventBus,
+      final DutyMetrics dutyMetrics,
+      final PerformanceTracker performanceTracker) {
     this.chainDataProvider = chainDataProvider;
     this.combinedChainDataClient = combinedChainDataClient;
     this.syncStateProvider = syncStateProvider;
@@ -224,11 +223,19 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(List<String> validatorIdentifiers) {
-    return chainDataProvider.getStateValidators("head", validatorIdentifiers, new HashSet<>())
-            .thenApply((maybeList) ->
-                    maybeList.map(list ->
-                            list.stream().collect(toMap(ValidatorResponse::getPublicKey, ValidatorResponse::getStatus))));
+  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
+      List<String> validatorIdentifiers) {
+    return chainDataProvider
+        .getStateValidators("head", validatorIdentifiers, new HashSet<>())
+        .thenApply(
+            (maybeList) ->
+                maybeList.map(
+                    list ->
+                        list.stream()
+                            .collect(
+                                toMap(
+                                    ValidatorResponse::getPublicKey,
+                                    ValidatorResponse::getStatus))));
   }
 
   private BeaconState processSlots(final BeaconState startingState, final UInt64 targetSlot) {

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -224,9 +224,12 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
-      List<String> validatorIdentifiers) {
+      Set<BLSPublicKey> validatorIdentifiers) {
     return chainDataProvider
-        .getStateValidators("head", validatorIdentifiers, new HashSet<>())
+        .getStateValidators(
+            "head",
+            validatorIdentifiers.stream().map(BLSPublicKey::toString).collect(toList()),
+            new HashSet<>())
         .thenApply(
             (maybeList) ->
                 maybeList.map(

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -13,7 +13,30 @@
 
 package tech.pegasys.teku.validator.coordinator;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.core.results.BlockImportResult.FailureReason.DOES_NOT_DESCEND_FROM_LATEST_FINALIZED;
+import static tech.pegasys.teku.datastructures.util.AttestationProcessingResult.SUCCESSFUL;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getCurrentDutyDependentRoot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getPreviousDutyDependentRoot;
+import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+
 import com.google.common.eventbus.EventBus;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,30 +78,6 @@ import tech.pegasys.teku.validator.api.NodeSyncingException;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.core.results.BlockImportResult.FailureReason.DOES_NOT_DESCEND_FROM_LATEST_FINALIZED;
-import static tech.pegasys.teku.datastructures.util.AttestationProcessingResult.SUCCESSFUL;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getCurrentDutyDependentRoot;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getPreviousDutyDependentRoot;
-import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
-import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
-import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
-import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 class ValidatorApiHandlerTest {
 

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -79,13 +79,6 @@ import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
 
-<<<<<<< HEAD
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-=======
->>>>>>> Run spotless
 class ValidatorApiHandlerTest {
 
   private static final UInt64 EPOCH = UInt64.valueOf(13);

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -34,12 +34,10 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import com.google.common.eventbus.EventBus;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.core.StateTransition;
@@ -78,6 +76,10 @@ import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 class ValidatorApiHandlerTest {
 
   private static final UInt64 EPOCH = UInt64.valueOf(13);
@@ -99,9 +101,12 @@ class ValidatorApiHandlerTest {
   private final EventBus eventBus = mock(EventBus.class);
   private final DefaultPerformanceTracker performanceTracker =
       mock(DefaultPerformanceTracker.class);
+  private final ChainDataProvider chainDataProvider =
+          mock(ChainDataProvider.class);
 
   private final ValidatorApiHandler validatorApiHandler =
       new ValidatorApiHandler(
+              chainDataProvider,
           chainDataClient,
           syncStateProvider,
           stateTransition,

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -13,30 +13,7 @@
 
 package tech.pegasys.teku.validator.coordinator;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.core.results.BlockImportResult.FailureReason.DOES_NOT_DESCEND_FROM_LATEST_FINALIZED;
-import static tech.pegasys.teku.datastructures.util.AttestationProcessingResult.SUCCESSFUL;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getCurrentDutyDependentRoot;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getPreviousDutyDependentRoot;
-import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
-import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
-import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
-import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
-
 import com.google.common.eventbus.EventBus;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,6 +55,30 @@ import tech.pegasys.teku.validator.api.NodeSyncingException;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.core.results.BlockImportResult.FailureReason.DOES_NOT_DESCEND_FROM_LATEST_FINALIZED;
+import static tech.pegasys.teku.datastructures.util.AttestationProcessingResult.SUCCESSFUL;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getCurrentDutyDependentRoot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.getPreviousDutyDependentRoot;
+import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 class ValidatorApiHandlerTest {
 

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -34,6 +34,9 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import com.google.common.eventbus.EventBus;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,10 +79,13 @@ import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
 
+<<<<<<< HEAD
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+=======
+>>>>>>> Run spotless
 class ValidatorApiHandlerTest {
 
   private static final UInt64 EPOCH = UInt64.valueOf(13);
@@ -101,12 +107,11 @@ class ValidatorApiHandlerTest {
   private final EventBus eventBus = mock(EventBus.class);
   private final DefaultPerformanceTracker performanceTracker =
       mock(DefaultPerformanceTracker.class);
-  private final ChainDataProvider chainDataProvider =
-          mock(ChainDataProvider.class);
+  private final ChainDataProvider chainDataProvider = mock(ChainDataProvider.class);
 
   private final ValidatorApiHandler validatorApiHandler =
       new ValidatorApiHandler(
-              chainDataProvider,
+          chainDataProvider,
           chainDataClient,
           syncStateProvider,
           stateTransition,

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -113,11 +113,14 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
-      List<String> validatorIdentifiers) {
+      Set<BLSPublicKey> validatorPublicKeys) {
     return sendRequest(
         () ->
             apiClient
-                .getValidators(validatorIdentifiers)
+                .getValidators(
+                    validatorPublicKeys.stream()
+                        .map(BLSPublicKey::toString)
+                        .collect(Collectors.toList()))
                 .map(
                     list ->
                         list.stream()

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -13,7 +13,18 @@
 
 package tech.pegasys.teku.validator.remote;
 
+import static java.util.Collections.emptyMap;
+import static java.util.stream.Collectors.toMap;
+
 import com.google.common.base.Throwables;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -43,18 +54,6 @@ import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.remote.apiclient.RateLimitedException;
 import tech.pegasys.teku.validator.remote.apiclient.ValidatorRestApiClient;
-
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import static java.util.Collections.emptyMap;
-import static java.util.stream.Collectors.toMap;
 
 public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 
@@ -113,12 +112,19 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(List<String> validatorIdentifiers) {
-    return sendRequest(() ->
-            apiClient.getValidators(validatorIdentifiers)
-                    .map(list ->
-                            list.stream()
-                                    .collect(toMap(ValidatorResponse::getPublicKey, ValidatorResponse::getStatus))));
+  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
+      List<String> validatorIdentifiers) {
+    return sendRequest(
+        () ->
+            apiClient
+                .getValidators(validatorIdentifiers)
+                .map(
+                    list ->
+                        list.stream()
+                            .collect(
+                                toMap(
+                                    ValidatorResponse::getPublicKey,
+                                    ValidatorResponse::getStatus))));
   }
 
   private Optional<Map<BLSPublicKey, Integer>> requestValidatorIndices(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -13,21 +13,12 @@
 
 package tech.pegasys.teku.validator.remote;
 
-import static java.util.Collections.emptyMap;
-
 import com.google.common.base.Throwables;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
@@ -52,6 +43,18 @@ import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.remote.apiclient.RateLimitedException;
 import tech.pegasys.teku.validator.remote.apiclient.ValidatorRestApiClient;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyMap;
+import static java.util.stream.Collectors.toMap;
 
 public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 
@@ -107,6 +110,15 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
           }
           return indices;
         });
+  }
+
+  @Override
+  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(List<String> validatorIdentifiers) {
+    return sendRequest(() ->
+            apiClient.getValidators(validatorIdentifiers)
+                    .map(list ->
+                            list.stream()
+                                    .collect(toMap(ValidatorResponse::getPublicKey, ValidatorResponse::getStatus))));
   }
 
   private Optional<Map<BLSPublicKey, Integer>> requestValidatorIndices(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -13,34 +13,7 @@
 
 package tech.pegasys.teku.validator.remote.apiclient;
 
-import static java.util.Collections.emptyMap;
-import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_AGGREGATE;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DATA;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DUTIES;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_FORK;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_GENESIS;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_PROPOSER_DUTIES;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_ATTESTATION;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_VALIDATORS;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_AGGREGATE_AND_PROOF;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_ATTESTATION;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_BLOCK;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_VOLUNTARY_EXIT;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_BEACON_COMMITTEE_SUBNET;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_PERSISTENT_SUBNETS;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 import okhttp3.Credentials;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -74,6 +47,34 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Collections.emptyMap;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_AGGREGATE;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DATA;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DUTIES;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_FORK;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_GENESIS;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_PROPOSER_DUTIES;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_ATTESTATION;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_VALIDATORS;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_AGGREGATE_AND_PROOF;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_ATTESTATION;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_BLOCK;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_VOLUNTARY_EXIT;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_BEACON_COMMITTEE_SUBNET;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_PERSISTENT_SUBNETS;
 
 public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -13,7 +13,34 @@
 
 package tech.pegasys.teku.validator.remote.apiclient;
 
+import static java.util.Collections.emptyMap;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_AGGREGATE;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DATA;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DUTIES;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_FORK;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_GENESIS;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_PROPOSER_DUTIES;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_ATTESTATION;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_VALIDATORS;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_AGGREGATE_AND_PROOF;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_ATTESTATION;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_BLOCK;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_VOLUNTARY_EXIT;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_BEACON_COMMITTEE_SUBNET;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_PERSISTENT_SUBNETS;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import okhttp3.Credentials;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -47,34 +74,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
-
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
-import static java.util.Collections.emptyMap;
-import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_AGGREGATE;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DATA;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DUTIES;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_FORK;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_GENESIS;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_PROPOSER_DUTIES;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_ATTESTATION;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_VALIDATORS;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_AGGREGATE_AND_PROOF;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_ATTESTATION;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_BLOCK;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_VOLUNTARY_EXIT;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_BEACON_COMMITTEE_SUBNET;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_PERSISTENT_SUBNETS;
 
 public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Implement and integrate validator status logger. Prints validator statuses one by one if the number of validators is less than a limit, or else prints a summary.

One by one print example:
```
2020-11-24 16:39:38.351-05:00 | validator-async-1 | INFO  | ValidatorStatusLogger | Validator af344fc is active_ongoing
2020-11-24 16:39:38.351-05:00 | validator-async-1 | INFO  | ValidatorStatusLogger | Validator 8a0d241 is active_ongoing
2020-11-24 16:39:38.351-05:00 | validator-async-1 | INFO  | ValidatorStatusLogger | Validator 8826e82 is active_ongoing
2020-11-24 16:39:38.351-05:00 | validator-async-1 | INFO  | ValidatorStatusLogger | Validator 9977f1c is active_ongoing
2020-11-24 16:39:38.351-05:00 | validator-async-1 | INFO  | ValidatorStatusLogger | Validator 963528a is active_ongoing
```

Summary print example:
```
2020-11-30 17:45:30.893-05:00 | validator-async-1 | INFO  | ValidatorStatusLogger | 64 validators are in active_ongoing state.
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #2267

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.