### PR TITLE
update post `/eth/v1/beacon/pool/attestations` to expect a list of attestations

### DIFF
--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttestationTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttestationTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.javalin.http.Context;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.ValidatorDataProvider;
@@ -33,6 +34,7 @@ public class PostAttestationTest {
   private ValidatorDataProvider provider = mock(ValidatorDataProvider.class);
   private final JsonProvider jsonProvider = new JsonProvider();
   private PostAttestation handler;
+  final Attestation attestation = new Attestation(dataStructureUtil.randomAttestation());
 
   @BeforeEach
   public void setup() {
@@ -41,8 +43,7 @@ public class PostAttestationTest {
 
   @Test
   void shouldBeAbleToSubmitAttestation() throws Exception {
-    final Attestation attestation = new Attestation(dataStructureUtil.randomAttestation());
-    when(context.body()).thenReturn(jsonProvider.objectToJSON(attestation));
+    when(context.body()).thenReturn(jsonProvider.objectToJSON(List.of(attestation)));
     handler.handle(context);
 
     verify(context).status(SC_OK);
@@ -51,6 +52,14 @@ public class PostAttestationTest {
   @Test
   void shouldReturnBadRequestIfAttestationInvalid() throws Exception {
     when(context.body()).thenReturn("{\"a\": \"field\"}");
+    handler.handle(context);
+
+    verify(context).status(SC_BAD_REQUEST);
+  }
+
+  @Test
+  void shouldReturnBadRequestIfSingleAttestationPassed() throws Exception {
+    when(context.body()).thenReturn(jsonProvider.objectToJSON(attestation));
     handler.handle(context);
 
     verify(context).status(SC_BAD_REQUEST);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -107,6 +107,10 @@ public class ValidatorDataProvider {
                             new BLSSignature(attestation.getAggregate_signature()))));
   }
 
+  public void submitAttestations(List<Attestation> attestations) {
+    attestations.forEach(this::submitAttestation);
+  }
+
   public void submitAttestation(Attestation attestation) {
     if (attestation.signature.asInternalBLSSignature().toSSZBytes().isZero()) {
       throw new IllegalArgumentException("Signed attestations must have a non zero signature");

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -179,7 +179,7 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
 
   @Override
   public void sendSignedAttestation(final Attestation attestation) {
-    post(SEND_SIGNED_ATTESTATION, attestation, createHandler());
+    post(SEND_SIGNED_ATTESTATION, List.of(attestation), createHandler());
   }
 
   @Override

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -471,7 +471,8 @@ class OkHttpValidatorRestApiClientTest {
     assertThat(request.getMethod()).isEqualTo("POST");
     assertThat(request.getPath())
         .contains(ValidatorApiMethod.SEND_SIGNED_ATTESTATION.getPath(emptyMap()));
-    assertThat(request.getBody().readString(StandardCharsets.UTF_8)).isEqualTo(asJson(attestation));
+    assertThat(request.getBody().readString(StandardCharsets.UTF_8))
+        .isEqualTo(asJson(List.of(attestation)));
   }
 
   @Test


### PR DESCRIPTION
Breaking change - used to only allow a single attestation to be posted, now requires a list of attestations.

Updated the remote validator handler to post a list of attestations, but didn't restructure to consolidate, due to time pressure.

fixes #3302

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.