### PR TITLE
Report when validator indices are unavailable because the best state is not set

### DIFF
--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -143,8 +142,6 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   public SafeFuture<Optional<GenesisData>> getGenesisData() {
     return SafeFuture.completedFuture(combinedChainDataClient.getGenesisData());
   }
-
-  private static final AtomicInteger counter = new AtomicInteger();
 
   @Override
   public SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.validator.coordinator;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -526,12 +525,14 @@ class ValidatorApiHandlerTest {
   }
 
   @Test
-  void getValidatorIndices_shouldReturnEmptyMapWhenBestStateNotAvailable() {
+  void getValidatorIndices_shouldThrowExceptionWhenBestStateNotAvailable() {
     when(chainDataClient.getBestState()).thenReturn(Optional.empty());
 
+    // The validator client needs to be able to differentiate between the state not yet being loaded
+    // and the requested validators not existing so it doesn't skip scheduling duties.
     assertThatSafeFuture(
             validatorApiHandler.getValidatorIndices(List.of(dataStructureUtil.randomPublicKey())))
-        .isCompletedWithValue(emptyMap());
+        .isCompletedExceptionallyWith(IllegalStateException.class);
   }
 
   @Test


### PR DESCRIPTION
## PR Description
The validator client needs to differentiate between validator indices not being available because the public keys are unknown and when the state has not yet been set after startup.  Otherwise it may calculate duties for the first two epochs after startup believing it has no active validators causing a delay in attestations starting.

The remote validator already gets an error as the API it calls returns 404 if the state isn't available.

In both cases once the exception is received its logged at debug level and the validator client retries loading validators on the next slot (but crucially continues waiting to schedule the duties for the epoch until a successful validator index response is received).

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.