### PR TITLE
Use ValidatorsUtil.getValidatorPubKey where possible

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/Validator.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/Validator.java
@@ -94,7 +94,7 @@ public class Validator {
   }
 
   public Validator(final tech.pegasys.teku.datastructures.state.Validator validator) {
-    this.pubkey = new BLSPubKey(validator.getPubkey().toSSZBytes());
+    this.pubkey = new BLSPubKey(validator.getPubkey());
     this.withdrawal_credentials = validator.getWithdrawal_credentials();
     this.effective_balance = validator.getEffective_balance();
     this.slashed = validator.isSlashed();
@@ -106,7 +106,7 @@ public class Validator {
 
   public tech.pegasys.teku.datastructures.state.Validator asInternalValidator() {
     return tech.pegasys.teku.datastructures.state.Validator.create(
-        pubkey.asBLSPublicKey(),
+        pubkey.asBLSPublicKey().toBytesCompressed(),
         withdrawal_credentials,
         effective_balance,
         slashed,

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/ValidatorWithIndex.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/ValidatorWithIndex.java
@@ -57,7 +57,7 @@ public class ValidatorWithIndex {
   public ValidatorWithIndex(
       final tech.pegasys.teku.datastructures.state.Validator validator,
       tech.pegasys.teku.datastructures.state.BeaconState state) {
-    BLSPublicKey blsPublicKey = validator.getPubkey();
+    BLSPublicKey blsPublicKey = BLSPublicKey.fromBytesCompressed(validator.getPubkey());
     Optional<Integer> optionalInteger = ValidatorsUtil.getValidatorIndex(state, blsPublicKey);
     if (optionalInteger.isPresent()) {
       this.validator_index = optionalInteger.get();

--- a/data/serializer/src/test/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponseTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponseTest.java
@@ -19,15 +19,15 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.util.config.Constants.FAR_FUTURE_EPOCH;
 
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.datastructures.state.Validator;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class ValidatorResponseTest {
   final DataStructureUtil dataStructureUtil = new DataStructureUtil();
-  final BLSPublicKey key = dataStructureUtil.randomPublicKey();
+  final Bytes48 key = dataStructureUtil.randomPublicKeyBytes();
   final Bytes32 creds = dataStructureUtil.randomBytes32();
   final UInt64 ONE_HUNDRED = UInt64.valueOf(100);
   final UInt64 TWO_HUNDRED = UInt64.valueOf(200);

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/BlockProcessorUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/BlockProcessorUtil.java
@@ -40,6 +40,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.Hash;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.bls.BLSSignatureVerifier.InvalidSignatureException;
 import tech.pegasys.teku.core.exceptions.BlockProcessingException;
@@ -66,6 +67,7 @@ import tech.pegasys.teku.datastructures.state.MutableBeaconState;
 import tech.pegasys.teku.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.datastructures.state.Validator;
 import tech.pegasys.teku.datastructures.util.AttestationProcessingResult;
+import tech.pegasys.teku.datastructures.util.ValidatorsUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 
@@ -137,12 +139,12 @@ public final class BlockProcessorUtil {
       throws InvalidSignatureException {
     UInt64 epoch = compute_epoch_at_slot(block.getSlot());
     // Verify RANDAO reveal
-    Validator proposer =
-        state.getValidators().get(toIntExact(block.getProposerIndex().longValue()));
+    final BLSPublicKey proposerPublicKey =
+        ValidatorsUtil.getValidatorPubKey(state, block.getProposerIndex()).orElseThrow();
     final Bytes signing_root =
         compute_signing_root(epoch.longValue(), get_domain(state, DOMAIN_RANDAO));
     bls.verifyAndThrow(
-        proposer.getPubkey(),
+        proposerPublicKey,
         signing_root,
         block.getBody().getRandao_reveal(),
         "process_randao: Verify that the provided randao value is valid");

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/blockvalidator/SimpleBlockValidator.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/blockvalidator/SimpleBlockValidator.java
@@ -124,7 +124,11 @@ public class SimpleBlockValidator implements BlockValidator {
       throws BlockProcessingException {
     final int proposerIndex = get_beacon_proposer_index(state, signed_block.getSlot());
     final BLSPublicKey proposerPublicKey =
-        ValidatorsUtil.getValidatorPubKey(state, UInt64.valueOf(proposerIndex)).orElseThrow(() -> new BlockProcessingException("Public key not found for validator " + proposerIndex));
+        ValidatorsUtil.getValidatorPubKey(state, UInt64.valueOf(proposerIndex))
+            .orElseThrow(
+                () ->
+                    new BlockProcessingException(
+                        "Public key not found for validator " + proposerIndex));
     final Bytes signing_root =
         compute_signing_root(signed_block.getMessage(), get_domain(state, DOMAIN_BEACON_PROPOSER));
     try {

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/blockvalidator/SimpleBlockValidator.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/blockvalidator/SimpleBlockValidator.java
@@ -124,7 +124,7 @@ public class SimpleBlockValidator implements BlockValidator {
       throws BlockProcessingException {
     final int proposerIndex = get_beacon_proposer_index(state, signed_block.getSlot());
     final BLSPublicKey proposerPublicKey =
-        ValidatorsUtil.getValidatorPubKey(state, UInt64.valueOf(proposerIndex)).orElseThrow();
+        ValidatorsUtil.getValidatorPubKey(state, UInt64.valueOf(proposerIndex)).orElseThrow(() -> new BlockProcessingException("Public key not found for validator " + proposerIndex));
     final Bytes signing_root =
         compute_signing_root(signed_block.getMessage(), get_domain(state, DOMAIN_BEACON_PROPOSER));
     try {

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/operationsignatureverifiers/ProposerSlashingSignatureVerifier.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/operationsignatureverifiers/ProposerSlashingSignatureVerifier.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_sign
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_domain;
 import static tech.pegasys.teku.util.config.Constants.DOMAIN_BEACON_PROPOSER;
 
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -38,8 +39,13 @@ public class ProposerSlashingSignatureVerifier {
 
     final BeaconBlockHeader header1 = proposerSlashing.getHeader_1().getMessage();
     final BeaconBlockHeader header2 = proposerSlashing.getHeader_2().getMessage();
-    BLSPublicKey publicKey =
-        ValidatorsUtil.getValidatorPubKey(state, header1.getProposerIndex()).orElseThrow();
+
+    Optional<BLSPublicKey> maybePublicKey =
+        ValidatorsUtil.getValidatorPubKey(state, header1.getProposerIndex());
+    if (maybePublicKey.isEmpty()) {
+      return false;
+    }
+    BLSPublicKey publicKey = maybePublicKey.get();
 
     if (!signatureVerifier.verify(
         publicKey,

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/operationsignatureverifiers/ProposerSlashingSignatureVerifier.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/operationsignatureverifiers/ProposerSlashingSignatureVerifier.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.core.operationsignatureverifiers;
 
-import static java.lang.Math.toIntExact;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_signing_root;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_domain;
@@ -26,7 +25,7 @@ import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.datastructures.state.BeaconState;
-import tech.pegasys.teku.datastructures.state.BeaconStateCache;
+import tech.pegasys.teku.datastructures.util.ValidatorsUtil;
 
 public class ProposerSlashingSignatureVerifier {
 
@@ -40,11 +39,7 @@ public class ProposerSlashingSignatureVerifier {
     final BeaconBlockHeader header1 = proposerSlashing.getHeader_1().getMessage();
     final BeaconBlockHeader header2 = proposerSlashing.getHeader_2().getMessage();
     BLSPublicKey publicKey =
-        BeaconStateCache.getTransitionCaches(state)
-            .getValidatorsPubKeys()
-            .get(
-                header1.getProposerIndex(),
-                idx -> state.getValidators().get(toIntExact(idx.longValue())).getPubkey());
+        ValidatorsUtil.getValidatorPubKey(state, header1.getProposerIndex()).orElseThrow();
 
     if (!signatureVerifier.verify(
         publicKey,

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/operationsignatureverifiers/VoluntaryExitSignatureVerifier.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/operationsignatureverifiers/VoluntaryExitSignatureVerifier.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.core.operationsignatureverifiers;
 
-import static java.lang.Math.toIntExact;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_signing_root;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_domain;
 import static tech.pegasys.teku.util.config.Constants.DOMAIN_VOLUNTARY_EXIT;
@@ -25,7 +24,7 @@ import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.datastructures.state.BeaconState;
-import tech.pegasys.teku.datastructures.state.BeaconStateCache;
+import tech.pegasys.teku.datastructures.util.ValidatorsUtil;
 
 public class VoluntaryExitSignatureVerifier {
 
@@ -34,11 +33,7 @@ public class VoluntaryExitSignatureVerifier {
     final VoluntaryExit exit = signedExit.getMessage();
 
     BLSPublicKey publicKey =
-        BeaconStateCache.getTransitionCaches(state)
-            .getValidatorsPubKeys()
-            .get(
-                exit.getValidator_index(),
-                idx -> state.getValidators().get(toIntExact(idx.longValue())).getPubkey());
+        ValidatorsUtil.getValidatorPubKey(state, exit.getValidator_index()).orElseThrow();
 
     final Bytes32 domain = get_domain(state, DOMAIN_VOLUNTARY_EXIT, exit.getEpoch());
     final Bytes signing_root = compute_signing_root(exit, domain);

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/Validator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/Validator.java
@@ -176,6 +176,15 @@ public class Validator extends AbstractImmutableContainer
         withdrawable_epoch);
   }
 
+  /**
+   * Returns compressed BLS public key bytes
+   *
+   * <p>{@link BLSPublicKey} instance can be created with {@link
+   * BLSPublicKey#fromBytesCompressed(Bytes48)} method. However this method is pretty 'expensive'
+   * and the preferred way would be to use {@link
+   * tech.pegasys.teku.datastructures.util.ValidatorsUtil#getValidatorPubKey(BeaconState, UInt64)}
+   * if the {@link BeaconState} instance and validator index is available
+   */
   public Bytes48 getPubkey() {
     return Bytes48.wrap(ViewUtils.getAllBytes(getAny(0)));
   }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/Validator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/Validator.java
@@ -129,7 +129,7 @@ public class Validator extends AbstractImmutableContainer
   @Override
   public List<Bytes> get_fixed_parts() {
     List<Bytes> fixedPartsList = new ArrayList<>();
-    fixedPartsList.addAll(Collections.singleton(getPubkey()));
+    fixedPartsList.add(getPubkey());
     fixedPartsList.addAll(
         List.of(
             SSZ.encode(writer -> writer.writeFixedBytes(getWithdrawal_credentials())),

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/Validator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/Validator.java
@@ -58,7 +58,7 @@ public class Validator extends AbstractImmutableContainer
 
   // BLS public key
   @SuppressWarnings("unused")
-  private final BLSPublicKey pubkey = null;
+  private final Bytes48 pubkey = null;
 
   // Withdrawal credentials
   @SuppressWarnings("unused")

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/Validator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/Validator.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.datastructures.state;
 
 import com.google.common.base.MoreObjects;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/Validator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/Validator.java
@@ -15,9 +15,11 @@ package tech.pegasys.teku.datastructures.state;
 
 import com.google.common.base.MoreObjects;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.Bytes48;
 import org.apache.tuweni.ssz.SSZ;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.datastructures.util.Merkleizable;
@@ -91,7 +93,7 @@ public class Validator extends AbstractImmutableContainer
   }
 
   public Validator(
-      BLSPublicKey pubkey,
+      Bytes48 pubkey,
       Bytes32 withdrawal_credentials,
       UInt64 effective_balance,
       boolean slashed,
@@ -101,7 +103,7 @@ public class Validator extends AbstractImmutableContainer
       UInt64 withdrawable_epoch) {
     super(
         TYPE,
-        ViewUtils.createVectorFromBytes(pubkey.toSSZBytes()),
+        ViewUtils.createVectorFromBytes(pubkey),
         new Bytes32View(withdrawal_credentials),
         new UInt64View(effective_balance),
         BitView.viewOf(slashed),
@@ -127,7 +129,7 @@ public class Validator extends AbstractImmutableContainer
   @Override
   public List<Bytes> get_fixed_parts() {
     List<Bytes> fixedPartsList = new ArrayList<>();
-    fixedPartsList.addAll(getPubkey().get_fixed_parts());
+    fixedPartsList.addAll(Collections.singleton(getPubkey()));
     fixedPartsList.addAll(
         List.of(
             SSZ.encode(writer -> writer.writeFixedBytes(getWithdrawal_credentials())),
@@ -155,7 +157,7 @@ public class Validator extends AbstractImmutableContainer
   }
 
   public static Validator create(
-      BLSPublicKey pubkey,
+      Bytes48 pubkey,
       Bytes32 withdrawal_credentials,
       UInt64 effective_balance,
       boolean slashed,
@@ -174,8 +176,8 @@ public class Validator extends AbstractImmutableContainer
         withdrawable_epoch);
   }
 
-  public BLSPublicKey getPubkey() {
-    return BLSPublicKey.fromSSZBytes(ViewUtils.getAllBytes(getAny(0)));
+  public Bytes48 getPubkey() {
+    return Bytes48.wrap(ViewUtils.getAllBytes(getAny(0)));
   }
 
   public Bytes32 getWithdrawal_credentials() {

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/LengthBoundCalculator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/LengthBoundCalculator.java
@@ -24,6 +24,7 @@ import static tech.pegasys.teku.util.config.Constants.BYTES_PER_LENGTH_OFFSET;
 
 import java.lang.reflect.Field;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.Bytes48;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -143,6 +144,8 @@ public class LengthBoundCalculator {
       case "ArrayWrappingBytes32":
       case "Bytes32":
         return Bytes32.SIZE;
+      case "Bytes48":
+        return Bytes48.SIZE;
       case "Bytes4":
         return Bytes4.SIZE;
       case "BLSSignature":

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/SimpleOffsetSerializer.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/SimpleOffsetSerializer.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.Bytes48;
 import org.apache.tuweni.ssz.SSZ;
 import org.apache.tuweni.ssz.SSZReader;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -495,6 +496,9 @@ public class SimpleOffsetSerializer {
       case "Bytes32":
         bytePointer.add(Bytes32.SIZE);
         return Bytes32.wrap(reader.readFixedBytes(Bytes32.SIZE));
+      case "Bytes48":
+        bytePointer.add(Bytes48.SIZE);
+        return Bytes48.wrap(reader.readFixedBytes(Bytes48.SIZE));
       case "Bytes4":
         bytePointer.add(Bytes4.SIZE);
         return new Bytes4(reader.readFixedBytes(Bytes4.SIZE));

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/ValidatorsUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/ValidatorsUtil.java
@@ -77,7 +77,11 @@ public class ValidatorsUtil {
     return Optional.of(
         BeaconStateCache.getTransitionCaches(state)
             .getValidatorsPubKeys()
-            .get(validatorIndex, i -> state.getValidators().get(i.intValue()).getPubkey()));
+            .get(
+                validatorIndex,
+                i ->
+                    BLSPublicKey.fromBytesCompressed(
+                        state.getValidators().get(i.intValue()).getPubkey())));
   }
 
   /**
@@ -113,8 +117,9 @@ public class ValidatorsUtil {
                 key -> {
                   SSZList<Validator> validators = state.getValidators();
                   for (int i = 0; i < validators.size(); i++) {
-                    final Validator validator = validators.get(i);
-                    if (validator.getPubkey().equals(publicKey)) {
+                    if (getValidatorPubKey(state, UInt64.valueOf(i))
+                        .orElseThrow()
+                        .equals(publicKey)) {
                       return i;
                     }
                   }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/state/ValidatorTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/state/ValidatorTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
@@ -28,7 +29,7 @@ class ValidatorTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
 
   private int seed = 100;
-  private BLSPublicKey pubkey = BLSPublicKey.random(seed);
+  private Bytes48 pubkey = BLSPublicKey.random(seed).toBytesCompressed();
   private Bytes32 withdrawalCredentials = dataStructureUtil.randomBytes32();
   private UInt64 activationEligibilityEpoch = dataStructureUtil.randomUInt64();
   private UInt64 activationEpoch = dataStructureUtil.randomUInt64();
@@ -73,7 +74,7 @@ class ValidatorTest {
 
   @Test
   void equalsReturnsFalseWhenPubkeysAreDifferent() {
-    BLSPublicKey differentPublicKey = BLSPublicKey.random(99);
+    Bytes48 differentPublicKey = BLSPublicKey.random(99).toBytesCompressed();
     Validator testValidator =
         Validator.create(
             differentPublicKey,

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/BeaconStateUtilTest.java
@@ -409,8 +409,12 @@ class BeaconStateUtilTest {
     deposits.get(1).getData().setSignature(BLSSignature.empty());
     BeaconState state = initialize_beacon_state_from_eth1(Bytes32.ZERO, UInt64.ZERO, deposits);
     assertEquals(2, state.getValidators().size());
-    assertEquals(deposits.get(0).getData().getPubkey(), state.getValidators().get(0).getPubkey());
-    assertEquals(deposits.get(2).getData().getPubkey(), state.getValidators().get(1).getPubkey());
+    assertEquals(
+        deposits.get(0).getData().getPubkey().toBytesCompressed(),
+        state.getValidators().get(0).getPubkey());
+    assertEquals(
+        deposits.get(2).getData().getPubkey().toBytesCompressed(),
+        state.getValidators().get(1).getPubkey());
   }
 
   @Test

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/GenesisGeneratorTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/GenesisGeneratorTest.java
@@ -147,7 +147,7 @@ class GenesisGeneratorTest {
     // And the validator with an invalid deposit should wind up at index 3, not 0 because their
     // first deposit was completely ignored
     final Validator validator = state.getValidators().get(expectedIndex);
-    assertThat(validator.getPubkey()).isEqualTo(validData.getPubkey());
+    assertThat(validator.getPubkey()).isEqualTo(validData.getPubkey().toBytesCompressed());
     assertThat(is_active_validator(validator, GENESIS_EPOCH)).isTrue();
   }
 }

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/MockStartBeaconStateGeneratorTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/MockStartBeaconStateGeneratorTest.java
@@ -50,6 +50,7 @@ class MockStartBeaconStateGeneratorTest {
     final List<BLSPublicKey> actualValidatorPublicKeys =
         initialBeaconState.getValidators().stream()
             .map(Validator::getPubkey)
+            .map(BLSPublicKey::fromBytesCompressed)
             .collect(Collectors.toList());
     final List<BLSPublicKey> expectedValidatorPublicKeys =
         validatorKeyPairs.stream().map(BLSKeyPair::getPublicKey).collect(Collectors.toList());

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/ValidatorsUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/ValidatorsUtilTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Validator;
 
@@ -29,7 +30,10 @@ class ValidatorsUtilTest {
     assertThat(state.getValidators()).hasSizeGreaterThan(5);
     for (int i = 0; i < 5; i++) {
       final Validator validator = state.getValidators().get(i);
-      assertThat(ValidatorsUtil.getValidatorIndex(state, validator.getPubkey())).contains(i);
+      assertThat(
+              ValidatorsUtil.getValidatorIndex(
+                  state, BLSPublicKey.fromBytesCompressed(validator.getPubkey())))
+          .contains(i);
     }
   }
 
@@ -51,9 +55,14 @@ class ValidatorsUtilTest {
     final Validator validator = dataStructureUtil.randomValidator();
     final BeaconState nextState = state.updated(s -> s.getValidators().add(validator));
 
-    assertThat(ValidatorsUtil.getValidatorIndex(nextState, validator.getPubkey()))
+    assertThat(
+            ValidatorsUtil.getValidatorIndex(
+                nextState, BLSPublicKey.fromBytesCompressed(validator.getPubkey())))
         .contains(nextState.getValidators().size() - 1);
-    assertThat(ValidatorsUtil.getValidatorIndex(state, validator.getPubkey())).isEmpty();
+    assertThat(
+            ValidatorsUtil.getValidatorIndex(
+                state, BLSPublicKey.fromBytesCompressed(validator.getPubkey())))
+        .isEmpty();
   }
 
   @Test
@@ -62,11 +71,16 @@ class ValidatorsUtilTest {
 
     final Validator validator = dataStructureUtil.randomValidator();
     // Lookup the validator before it's in the list.
-    assertThat(ValidatorsUtil.getValidatorIndex(state, validator.getPubkey())).isEmpty();
+    assertThat(
+            ValidatorsUtil.getValidatorIndex(
+                state, BLSPublicKey.fromBytesCompressed(validator.getPubkey())))
+        .isEmpty();
 
     // Then add it to the list and we should be able to find the index.
     final BeaconState nextState = state.updated(s -> s.getValidators().add(validator));
-    assertThat(ValidatorsUtil.getValidatorIndex(nextState, validator.getPubkey()))
+    assertThat(
+            ValidatorsUtil.getValidatorIndex(
+                nextState, BLSPublicKey.fromBytesCompressed(validator.getPubkey())))
         .contains(nextState.getValidators().size() - 1);
   }
 }

--- a/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/util/DataStructureUtil.java
+++ b/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/util/DataStructureUtil.java
@@ -27,6 +27,7 @@ import java.util.function.Supplier;
 import java.util.stream.LongStream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.Bytes48;
 import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -183,6 +184,10 @@ public final class DataStructureUtil {
 
   public BLSPublicKey randomPublicKey() {
     return pubKeyGenerator.get();
+  }
+
+  public Bytes48 randomPublicKeyBytes() {
+    return pubKeyGenerator.get().toBytesCompressed();
   }
 
   public Eth1Data randomEth1Data() {
@@ -565,7 +570,7 @@ public final class DataStructureUtil {
 
   public Validator randomValidator() {
     return Validator.create(
-        randomPublicKey(),
+        randomPublicKeyBytes(),
         randomBytes32(),
         UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE),
         false,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockProcessorUtilTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockProcessorUtilTest.java
@@ -214,7 +214,7 @@ class BlockProcessorUtilTest {
 
   private Validator makeValidator(BLSPublicKey pubkey, Bytes32 withdrawalCredentials) {
     return Validator.create(
-        pubkey,
+        pubkey.toBytesCompressed(),
         withdrawalCredentials,
         UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE),
         false,

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -515,7 +515,7 @@ class BeaconChainMetricsTest {
   private Validator validator(
       final long activationEpoch, final long exitEpoch, final boolean slashed) {
     return new Validator(
-        dataStructureUtil.randomPublicKey(),
+        dataStructureUtil.randomPublicKeyBytes(),
         dataStructureUtil.randomBytes32(),
         dataStructureUtil.randomUInt64(),
         slashed,

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/DutyResultTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/DutyResultTest.java
@@ -37,8 +37,7 @@ class DutyResultTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final ValidatorLogger validatorLogger = mock(ValidatorLogger.class);
   private final Optional<String> validatorId =
-      Optional.of(
-          dataStructureUtil.randomValidator().getPubkey().toBytesCompressed().toShortHexString());
+      Optional.of(dataStructureUtil.randomValidator().getPubkey().toShortHexString());
 
   @Test
   void shouldReportSuccess() {

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -481,7 +481,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   private Optional<AttesterDuty> createAttesterDuties(
       final BeaconState state, final UInt64 epoch, final Integer validatorIndex) {
     try {
-      final BLSPublicKey pkey = state.getValidators().get(validatorIndex).getPubkey();
+      final BLSPublicKey pkey =
+          ValidatorsUtil.getValidatorPubKey(state, UInt64.valueOf(validatorIndex)).orElseThrow();
       final UInt64 committeeCountPerSlot = get_committee_count_per_slot(state, epoch);
       return CommitteeAssignmentUtil.get_committee_assignment(state, epoch, validatorIndex)
           .map(
@@ -508,7 +509,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     final Map<UInt64, BLSPublicKey> proposerSlots = new HashMap<>();
     for (UInt64 slot = startSlot; slot.compareTo(endSlot) < 0; slot = slot.plus(UInt64.ONE)) {
       final int proposerIndex = get_beacon_proposer_index(state, slot);
-      final BLSPublicKey publicKey = state.getValidators().get(proposerIndex).getPubkey();
+      final BLSPublicKey publicKey =
+          ValidatorsUtil.getValidatorPubKey(state, UInt64.valueOf(proposerIndex)).orElseThrow();
       proposerSlots.put(slot, publicKey);
     }
     return proposerSlots;

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -84,6 +85,7 @@ import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 
 public class ValidatorApiHandler implements ValidatorApiChannel {
+
   private static final Logger LOG = LogManager.getLogger();
   /**
    * Number of epochs ahead of the current head that duties can be requested. This provides some
@@ -480,25 +482,29 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
 
   private Optional<AttesterDuty> createAttesterDuties(
       final BeaconState state, final UInt64 epoch, final Integer validatorIndex) {
-    try {
-      final BLSPublicKey pkey =
-          ValidatorsUtil.getValidatorPubKey(state, UInt64.valueOf(validatorIndex)).orElseThrow();
-      final UInt64 committeeCountPerSlot = get_committee_count_per_slot(state, epoch);
-      return CommitteeAssignmentUtil.get_committee_assignment(state, epoch, validatorIndex)
-          .map(
-              committeeAssignment ->
-                  new AttesterDuty(
-                      pkey,
-                      validatorIndex,
-                      committeeAssignment.getCommittee().size(),
-                      committeeAssignment.getCommitteeIndex().intValue(),
-                      committeeCountPerSlot.intValue(),
-                      committeeAssignment.getCommittee().indexOf(validatorIndex),
-                      committeeAssignment.getSlot()));
-    } catch (IndexOutOfBoundsException ex) {
-      LOG.debug(ex);
+
+    return combine(
+        ValidatorsUtil.getValidatorPubKey(state, UInt64.valueOf(validatorIndex)),
+        CommitteeAssignmentUtil.get_committee_assignment(state, epoch, validatorIndex),
+        (pkey, committeeAssignment) -> {
+          final UInt64 committeeCountPerSlot = get_committee_count_per_slot(state, epoch);
+          return new AttesterDuty(
+              pkey,
+              validatorIndex,
+              committeeAssignment.getCommittee().size(),
+              committeeAssignment.getCommitteeIndex().intValue(),
+              committeeCountPerSlot.intValue(),
+              committeeAssignment.getCommittee().indexOf(validatorIndex),
+              committeeAssignment.getSlot());
+        });
+  }
+
+  private static <A, B, R> Optional<R> combine(
+      Optional<A> a, Optional<B> b, BiFunction<A, B, R> fun) {
+    if (a.isEmpty() || b.isEmpty()) {
       return Optional.empty();
     }
+    return Optional.ofNullable(fun.apply(a.get(), b.get()));
   }
 
   private Map<UInt64, BLSPublicKey> getProposalSlotsForEpoch(

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -227,7 +227,8 @@ class ValidatorApiHandlerTest {
   @Test
   public void getAttestationDuties_shouldReturnDutiesAndSkipMissingValidators() {
     final BeaconState state = createStateWithActiveValidators();
-    final BLSPublicKey validator1Key = state.getValidators().get(1).getPubkey();
+    final BLSPublicKey validator1Key =
+        BLSPublicKey.fromBytesCompressed(state.getValidators().get(1).getPubkey());
     when(chainDataClient.getLatestStateAtSlot(PREVIOUS_EPOCH_START_SLOT))
         .thenReturn(completedFuture(Optional.of(state)));
     when(chainDataClient.getCurrentEpoch()).thenReturn(EPOCH.minus(ONE));
@@ -242,7 +243,8 @@ class ValidatorApiHandlerTest {
   @Test
   public void getAttestationDuties_shouldAllowOneEpochTolerance() {
     final BeaconState state = createStateWithActiveValidators();
-    final BLSPublicKey validator1Key = state.getValidators().get(1).getPubkey();
+    final BLSPublicKey validator1Key =
+        BLSPublicKey.fromBytesCompressed(state.getValidators().get(1).getPubkey());
     when(chainDataClient.getLatestStateAtSlot(PREVIOUS_EPOCH_START_SLOT))
         .thenReturn(completedFuture(Optional.of(state)));
     when(chainDataClient.getCurrentEpoch()).thenReturn(EPOCH.minus(2));
@@ -538,7 +540,8 @@ class ValidatorApiHandlerTest {
   @Test
   void getValidatorIndices_shouldReturnMapWithKnownValidatorsWhenBestStateAvailable() {
     final BeaconState state = dataStructureUtil.randomBeaconState();
-    final BLSPublicKey validator0 = state.getValidators().get(0).getPubkey();
+    final BLSPublicKey validator0 =
+        BLSPublicKey.fromBytesCompressed(state.getValidators().get(0).getPubkey());
     final BLSPublicKey unknownValidator = dataStructureUtil.randomPublicKey();
     when(chainDataClient.getBestState()).thenReturn(Optional.of(state));
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
`Validator.getPubkey()` deserializes compressed pubkey bytes and creates `BLSPublicKey` instance on every invocation. That's pretty expensive operation. 
Whenever possible the `ValidatorsUtil.getValidatorPubKey` should be used as it caches `BLSPublicKey` instances for validators. 

Would also be good to make `Validator.getPubkey()` returning `Bytes48` to make creation of `BLSPublicKey` explicit. 

## Fixed Issue(s)

Partially fix #3294 (speedup ~x50-x100)

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.