### PR TITLE
initial-state should not be a hidden option.

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/WeakSubjectivityOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/WeakSubjectivityOptions.java
@@ -28,8 +28,7 @@ public class WeakSubjectivityOptions {
       paramLabel = "<STRING>",
       description =
           "The initial state. This value should be a file or URL pointing to an SSZ encoded state.",
-      arity = "1",
-      hidden = true)
+      arity = "1")
   private String weakSubjectivityState;
 
   @CommandLine.Option(


### PR DESCRIPTION
fixes #3313

Signed-off-by: Paul Harris <paul.harris@consensys.net>

i've added the documentation flag, the 'initial-state' parameter currently is described as `Path or URL to the network genesis file.` but it should probably say `Path or URL to the network checkpoint state file.`

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.