### PR TITLE
Reduce state scanning for retrieving validator indexes

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/TransitionCaches.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/TransitionCaches.java
@@ -38,7 +38,7 @@ public class TransitionCaches {
           NoOpCache.getNoOpCache(),
           NoOpCache.getNoOpCache(),
           NoOpCache.getNoOpCache(),
-          NoOpCache.getNoOpCache(),
+          ValidatorIndexCache.NO_OP_INSTANCE,
           NoOpCache.getNoOpCache()) {
 
         @Override
@@ -62,7 +62,7 @@ public class TransitionCaches {
   private final Cache<Pair<UInt64, UInt64>, List<Integer>> beaconCommittee;
   private final Cache<UInt64, Pair<UInt64, UInt64>> totalActiveBalance;
   private final Cache<UInt64, BLSPublicKey> validatorsPubKeys;
-  private final Cache<BLSPublicKey, Integer> validatorIndex;
+  private final ValidatorIndexCache validatorIndexCache;
   private final Cache<Bytes32, List<Integer>> committeeShuffle;
 
   private TransitionCaches() {
@@ -71,24 +71,24 @@ public class TransitionCaches {
     beaconCommittee = new LRUCache<>(MAX_BEACON_COMMITTEE_CACHE);
     totalActiveBalance = new LRUCache<>(MAX_TOTAL_ACTIVE_BALANCE_CACHE);
     validatorsPubKeys = new LRUCache<>(Integer.MAX_VALUE - 1);
-    validatorIndex = new LRUCache<>(Integer.MAX_VALUE - 1);
+    validatorIndexCache = new ValidatorIndexCache();
     committeeShuffle = new LRUCache<>(MAX_COMMITTEE_SHUFFLE_CACHE);
   }
 
-  public TransitionCaches(
+  private TransitionCaches(
       Cache<UInt64, List<Integer>> activeValidators,
       Cache<UInt64, Integer> beaconProposerIndex,
       Cache<Pair<UInt64, UInt64>, List<Integer>> beaconCommittee,
       Cache<UInt64, Pair<UInt64, UInt64>> totalActiveBalance,
       Cache<UInt64, BLSPublicKey> validatorsPubKeys,
-      Cache<BLSPublicKey, Integer> validatorIndex,
+      ValidatorIndexCache validatorIndexCache,
       Cache<Bytes32, List<Integer>> committeeShuffle) {
     this.activeValidators = activeValidators;
     this.beaconProposerIndex = beaconProposerIndex;
     this.beaconCommittee = beaconCommittee;
     this.totalActiveBalance = totalActiveBalance;
     this.validatorsPubKeys = validatorsPubKeys;
-    this.validatorIndex = validatorIndex;
+    this.validatorIndexCache = validatorIndexCache;
     this.committeeShuffle = committeeShuffle;
   }
 
@@ -124,8 +124,8 @@ public class TransitionCaches {
    * this state (but when registered are guaranteed to be at that index). Check index < total
    * validator count before looking up the cache
    */
-  public Cache<BLSPublicKey, Integer> getValidatorIndex() {
-    return validatorIndex;
+  public ValidatorIndexCache getValidatorIndexCache() {
+    return validatorIndexCache;
   }
 
   /** (epoch committee seed) -> (validators shuffle for epoch) cache */
@@ -153,7 +153,7 @@ public class TransitionCaches {
         beaconCommittee.copy(),
         totalActiveBalance.copy(),
         validatorsPubKeys,
-        validatorIndex,
+        validatorIndexCache,
         committeeShuffle.copy());
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/ValidatorIndexCache.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/ValidatorIndexCache.java
@@ -36,11 +36,6 @@ public class ValidatorIndexCache {
     this.lastIndex = new AtomicInteger(lastIndex);
   }
 
-  @VisibleForTesting
-  ValidatorIndexCache(final Cache<BLSPublicKey, Integer> validatorIndexes) {
-    this(validatorIndexes, INDEX_NONE);
-  }
-
   public ValidatorIndexCache() {
     this.validatorIndexes = new LRUCache<>(Integer.MAX_VALUE - 1);
     this.lastIndex = new AtomicInteger(INDEX_NONE);
@@ -53,15 +48,11 @@ public class ValidatorIndexCache {
       return validatorIndex.filter(index -> index < state.getValidators().size());
     }
 
-    if (lastIndex.get() < state.getValidators().size()) {
-      return findIndexFromState(state, publicKey);
-    }
-    return Optional.empty();
+    return findIndexFromState(state.getValidators(), publicKey);
   }
 
   private Optional<Integer> findIndexFromState(
-      final BeaconState state, final BLSPublicKey publicKey) {
-    final SSZList<Validator> validatorList = state.getValidators();
+      final SSZList<Validator> validatorList, final BLSPublicKey publicKey) {
     for (int i = Math.max(lastIndex.get(), 0); i < validatorList.size(); i++) {
       final int currentIndex = i;
       lastIndex.updateAndGet(curr -> Math.max(curr, currentIndex));

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/ValidatorIndexCache.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/ValidatorIndexCache.java
@@ -26,8 +26,9 @@ public class ValidatorIndexCache {
   private final Cache<BLSPublicKey, Integer> validatorIndexes;
   private final AtomicInteger lastIndex;
 
+  private static final int INDEX_NONE = -1;
   static final ValidatorIndexCache NO_OP_INSTANCE =
-      new ValidatorIndexCache(NoOpCache.getNoOpCache(), Integer.MAX_VALUE - 1);
+      new ValidatorIndexCache(NoOpCache.getNoOpCache(), INDEX_NONE);
 
   @VisibleForTesting
   ValidatorIndexCache(final Cache<BLSPublicKey, Integer> validatorIndexes, final int lastIndex) {
@@ -37,12 +38,12 @@ public class ValidatorIndexCache {
 
   @VisibleForTesting
   ValidatorIndexCache(final Cache<BLSPublicKey, Integer> validatorIndexes) {
-    this(validatorIndexes, -1);
+    this(validatorIndexes, INDEX_NONE);
   }
 
   public ValidatorIndexCache() {
     this.validatorIndexes = new LRUCache<>(Integer.MAX_VALUE - 1);
-    this.lastIndex = new AtomicInteger(-1);
+    this.lastIndex = new AtomicInteger(INDEX_NONE);
   }
 
   public Optional<Integer> getValidatorIndex(

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/ValidatorIndexCache.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/ValidatorIndexCache.java
@@ -43,7 +43,11 @@ public class ValidatorIndexCache {
 
   public Optional<Integer> getValidatorIndex(
       final BeaconState state, final BLSPublicKey publicKey) {
+    // Store lastIndex here in case we need to scan keys from the state.
+    // This ensures we're adding from a point that we're confident the cache is at
+    // when we scan for more keys through the state later.
     final int lastIndexSnapshot = lastIndex.get();
+
     final Optional<Integer> validatorIndex = validatorIndexes.getCached(publicKey);
     if (validatorIndex.isPresent()) {
       return validatorIndex.filter(index -> index < state.getValidators().size());

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/ValidatorIndexCache.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/ValidatorIndexCache.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.datastructures.state;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.collections.cache.Cache;
+import tech.pegasys.teku.infrastructure.collections.cache.LRUCache;
+import tech.pegasys.teku.infrastructure.collections.cache.NoOpCache;
+import tech.pegasys.teku.ssz.SSZTypes.SSZList;
+
+public class ValidatorIndexCache {
+  private final Cache<BLSPublicKey, Integer> validatorIndexes;
+  private final AtomicInteger lastIndex;
+
+  static final ValidatorIndexCache NO_OP_INSTANCE =
+      new ValidatorIndexCache(NoOpCache.getNoOpCache(), Integer.MAX_VALUE - 1);
+
+  @VisibleForTesting
+  ValidatorIndexCache(final Cache<BLSPublicKey, Integer> validatorIndexes, final int lastIndex) {
+    this.validatorIndexes = validatorIndexes;
+    this.lastIndex = new AtomicInteger(lastIndex);
+  }
+
+  @VisibleForTesting
+  ValidatorIndexCache(final Cache<BLSPublicKey, Integer> validatorIndexes) {
+    this(validatorIndexes, -1);
+  }
+
+  public ValidatorIndexCache() {
+    this.validatorIndexes = new LRUCache<>(Integer.MAX_VALUE - 1);
+    this.lastIndex = new AtomicInteger(-1);
+  }
+
+  public Optional<Integer> getValidatorIndex(
+      final BeaconState state, final BLSPublicKey publicKey) {
+    final Optional<Integer> validatorIndex = validatorIndexes.getCached(publicKey);
+    if (validatorIndex.isPresent()) {
+      return validatorIndex.filter(index -> index < state.getValidators().size());
+    }
+
+    if (lastIndex.get() < state.getValidators().size()) {
+      return findIndexFromState(state, publicKey);
+    }
+    return Optional.empty();
+  }
+
+  private Optional<Integer> findIndexFromState(
+      final BeaconState state, final BLSPublicKey publicKey) {
+    final SSZList<Validator> validatorList = state.getValidators();
+    for (int i = Math.max(lastIndex.get(), 0); i < validatorList.size(); i++) {
+      final int currentIndex = i;
+      lastIndex.updateAndGet(curr -> Math.max(curr, currentIndex));
+      BLSPublicKey pubKey = BLSPublicKey.fromBytesCompressed(validatorList.get(i).getPubkey());
+      validatorIndexes.invalidateWithNewValue(pubKey, i);
+      if (pubKey.equals(publicKey)) {
+        return Optional.of(i);
+      }
+    }
+    return Optional.empty();
+  }
+
+  public void invalidateWithNewValue(final BLSPublicKey pubKey, final int updatedIndex) {
+    if (lastIndex.get() < updatedIndex) {
+      // won't reset last index here, as we haven't scanned from last index up to this index
+      validatorIndexes.invalidateWithNewValue(pubKey, updatedIndex);
+    }
+  }
+
+  @VisibleForTesting
+  int getLastIndex() {
+    return lastIndex.get();
+  }
+
+  @VisibleForTesting
+  Cache<BLSPublicKey, Integer> getValidatorIndexes() {
+    return validatorIndexes;
+  }
+}

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/ValidatorIndexCache.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/ValidatorIndexCache.java
@@ -63,7 +63,7 @@ public class ValidatorIndexCache {
       }
     }
     if (validatorList.size() > lastIndexSnapshot) {
-      validatorList.size();
+      updateLastIndex(validatorList.size());
     }
     return Optional.empty();
   }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/ValidatorsUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/ValidatorsUtil.java
@@ -86,7 +86,7 @@ public class ValidatorsUtil {
 
                   // eagerly pre-cache pubKey => validatorIndex mapping
                   BeaconStateCache.getTransitionCaches(state)
-                      .getValidatorIndex()
+                      .getValidatorIndexCache()
                       .invalidateWithNewValue(pubKey, i.intValue());
                   return pubKey;
                 }));
@@ -117,26 +117,9 @@ public class ValidatorsUtil {
 
   @SuppressWarnings("DoNotReturnNullOptionals")
   public static Optional<Integer> getValidatorIndex(BeaconState state, BLSPublicKey publicKey) {
-    final Integer validatorIndex =
-        BeaconStateCache.getTransitionCaches(state)
-            .getValidatorIndex()
-            .get(
-                publicKey,
-                key -> {
-                  SSZList<Validator> validators = state.getValidators();
-                  for (int i = 0; i < validators.size(); i++) {
-                    if (getValidatorPubKey(state, UInt64.valueOf(i))
-                        .orElseThrow()
-                        .equals(publicKey)) {
-                      return i;
-                    }
-                  }
-                  return null;
-                });
-    return Optional.ofNullable(validatorIndex)
-        // The cache is shared between all states, so filter out any cached responses for validators
-        // that are only added into later states
-        .filter(index -> index < state.getValidators().size());
+    return BeaconStateCache.getTransitionCaches(state)
+        .getValidatorIndexCache()
+        .getValidatorIndex(state, publicKey);
   }
 
   /**

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/state/ValidatorIndexCacheTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/state/ValidatorIndexCacheTest.java
@@ -61,6 +61,15 @@ public class ValidatorIndexCacheTest {
   }
 
   @Test
+  public void shouldGetAllValidatorKeysCachedIfMissingKeyPassed() {
+    final ValidatorIndexCache validatorIndexCache = new ValidatorIndexCache();
+    final Optional<Integer> index = validatorIndexCache.getValidatorIndex(state, missingPublicKey);
+    assertThat(index).isEmpty();
+    assertThat(validatorIndexCache.getValidatorIndexes().size())
+        .isEqualTo(state.getValidators().size());
+  }
+
+  @Test
   public void shouldPopulateCacheItemsFromState() {
     final ValidatorIndexCache validatorIndexCache = new ValidatorIndexCache();
     final BLSPublicKey foundKey =

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/state/ValidatorIndexCacheTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/state/ValidatorIndexCacheTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.datastructures.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.collections.cache.Cache;
+
+public class ValidatorIndexCacheTest {
+  final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  final BeaconState state = dataStructureUtil.randomBeaconState();
+  final BLSPublicKey missingPublicKey = dataStructureUtil.randomPublicKey();
+
+  @SuppressWarnings("unchecked")
+  final Cache<BLSPublicKey, Integer> cache = mock(Cache.class);
+
+  @Test
+  public void shouldNotScanStateIfAlreadyHaveValidators() {
+    final ValidatorIndexCache validatorIndexCache =
+        new ValidatorIndexCache(cache, state.getValidators().size());
+
+    when(cache.getCached(missingPublicKey)).thenReturn(Optional.empty());
+    final Optional<Integer> index = validatorIndexCache.getValidatorIndex(state, missingPublicKey);
+
+    verify(cache).getCached(missingPublicKey);
+    verify(cache, never()).invalidateWithNewValue(any(), any());
+    assertThat(index).isEmpty();
+  }
+
+  @Test
+  public void shouldScanNewValidatorsInSuppliedState() {
+    final ValidatorIndexCache validatorIndexCache =
+        new ValidatorIndexCache(cache, state.getValidators().size() - 5);
+
+    when(cache.getCached(missingPublicKey)).thenReturn(Optional.empty());
+    final Optional<Integer> index = validatorIndexCache.getValidatorIndex(state, missingPublicKey);
+    verify(cache).getCached(missingPublicKey);
+    verify(cache, times(5)).invalidateWithNewValue(any(), any());
+    assertThat(index).isEmpty();
+  }
+
+  @Test
+  public void shouldPopulateCacheItemsFromState() {
+    final ValidatorIndexCache validatorIndexCache = new ValidatorIndexCache();
+    final BLSPublicKey foundKey =
+        BLSPublicKey.fromBytesCompressed(state.getValidators().get(10).getPubkey());
+
+    final Optional<Integer> index = validatorIndexCache.getValidatorIndex(state, foundKey);
+    assertThat(index.get()).isEqualTo(10);
+    assertThat(validatorIndexCache.getLastIndex()).isEqualTo(10);
+    assertThat(validatorIndexCache.getValidatorIndexes().size()).isEqualTo(11);
+  }
+
+  @Test
+  public void shouldFilterItemsBeyondStateIndex() {
+    final ValidatorIndexCache validatorIndexCache = new ValidatorIndexCache();
+    validatorIndexCache.invalidateWithNewValue(missingPublicKey, 100);
+    final Optional<Integer> index = validatorIndexCache.getValidatorIndex(state, missingPublicKey);
+
+    assertThat(index).isEmpty();
+    // state didn't get scanned, because we had the index but it was out of bounds
+    assertThat(validatorIndexCache.getLastIndex()).isEqualTo(-1);
+    assertThat(validatorIndexCache.getValidatorIndexes().size()).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
The validator index cache would scan for missing indexes, which can be a lot of scanning on larger networks if we start from index 0 for each key.

Instead, cache known keys and indexes, and only look for more indexes on cache misses. Also only start from the high water mark, since validator index never changes for a validator.

fixes #3316

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.