### PR TITLE
Reduce batch size for retrieving deposits & add deposit count metric

### DIFF
--- a/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
@@ -46,7 +46,7 @@ import tech.pegasys.teku.util.config.Constants;
 
 public class DepositFetcher {
 
-  static final int DEFAULT_BATCH_SIZE = 500_000;
+  static final int DEFAULT_BATCH_SIZE = 50_000;
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -124,7 +124,6 @@ public class DepositFetcher {
 
   private SafeFuture<Void> processDepositsInBatch(
       final BigInteger fromBlockNumber, final BigInteger toBlockNumber) {
-
     return depositContract
         .depositEventInRange(
             DefaultBlockParameter.valueOf(fromBlockNumber),

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -436,7 +436,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   public void initDepositProvider() {
     LOG.debug("BeaconChainController.initDepositProvider()");
-    depositProvider = new DepositProvider(recentChainData, eth1DataCache);
+    depositProvider = new DepositProvider(metricsSystem, recentChainData, eth1DataCache);
     eventChannels
         .subscribe(Eth1EventsChannel.class, depositProvider)
         .subscribe(FinalizedCheckpointChannel.class, depositProvider);

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.datastructures.util.DepositUtil;
 import tech.pegasys.teku.datastructures.util.MerkleTree;
 import tech.pegasys.teku.datastructures.util.OptimizedMerkleTree;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
@@ -56,7 +57,7 @@ public class DepositProviderTest {
   private final Eth1DataCache eth1DataCache = mock(Eth1DataCache.class);
   private List<tech.pegasys.teku.pow.event.Deposit> allSeenDepositsList;
   private final DepositProvider depositProvider =
-      new DepositProvider(recentChainData, eth1DataCache);
+      new DepositProvider(new StubMetricsSystem(), recentChainData, eth1DataCache);
   private final Eth1Data randomEth1Data = dataStructureUtil.randomEth1Data();
 
   private MerkleTree depositMerkleTree;


### PR DESCRIPTION
## PR Description
Reduce the default batch size to be easier on Geth instances with limited resources.  The reduced batch size doesn't cause significant delays in iterating through the early empty sections of the chain.

Add metric to report the number of deposits processed to make it easier to confirm that deposits are working.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.