### PR TITLE
Always use a state from the current epoch when creating attestations

### DIFF
--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -262,7 +262,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       return NodeSyncingException.failedFuture();
     }
 
-    final UInt64 minQuerySlot = CommitteeUtil.getEarliestQueryableSlotForTargetSlot(slot);
+    final UInt64 epoch = compute_epoch_at_slot(slot);
+    final UInt64 minQuerySlot = compute_start_slot_at_epoch(epoch);
 
     return combinedChainDataClient
         .getSignedBlockAndStateInEffectAtSlot(slot)
@@ -275,8 +276,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
               final BeaconBlock block = blockAndState.getBlock().getMessage();
               if (blockAndState.getSlot().compareTo(minQuerySlot) < 0) {
                 // The current effective block is too far in the past - so roll the state
-                // forward to the minimum epoch
-                final UInt64 epoch = compute_epoch_at_slot(minQuerySlot);
+                // forward to the current epoch. Ensures we have the latest justified checkpoint
                 return combinedChainDataClient
                     .getCheckpointState(epoch, blockAndState)
                     .thenApply(


### PR DESCRIPTION
## PR Description
This ensures the latest justified checkpoint is used if the attestation slot is in a new epoch and the last block is from the previous epoch.

This fixes a corner case where the wrong source checkpoint would be used.  It occurs when an attestation is created for slot in epoch 10, but the most recent block is from epoch 9 *and* epoch 9 had enough attestations to trigger justification.  During epoch processing to go from epoch 9 to 10, the state would be updated with the new checkpoint.  Teku however was only checking that the state from the last block was recent enough to calculate duties (ie anywhere in epoch 9) and then took the justified checkpoint from that old state as the source.

Now it ensures the checkpoint is from the same epoch as the attestation, which guarantees any required epoch processing is complete and the justified checkpoint is updated.

## Fixed Issue(s)
fixes #3328 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.