### PR TITLE
reduce duplicate calls to forkProvider for forkInfo in the remote validator client

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ForkProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ForkProvider.java
@@ -63,7 +63,7 @@ public class ForkProvider {
     return genesisDataProvider.getGenesisValidatorsRoot().thenCompose(this::requestFork);
   }
 
-  public SafeFuture<ForkInfo> requestFork(final Bytes32 genesisValidatorsRoot) {
+  private SafeFuture<ForkInfo> requestFork(final Bytes32 genesisValidatorsRoot) {
     return validatorApiChannel
         .getFork()
         .thenCompose(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ForkProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ForkProvider.java
@@ -49,7 +49,7 @@ public class ForkProvider {
     return currentFork.map(SafeFuture::completedFuture).orElseGet(this::loadForkInfo);
   }
 
-  public SafeFuture<ForkInfo> loadForkInfo() {
+  private SafeFuture<ForkInfo> loadForkInfo() {
     return requestForkInfo()
         .exceptionallyCompose(
             error -> {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -83,6 +83,7 @@ public class ValidatorClientService extends Service {
         new GenesisDataProvider(asyncRunner, validatorApiChannel);
     final ForkProvider forkProvider =
         new ForkProvider(asyncRunner, validatorApiChannel, genesisDataProvider);
+    forkProvider.initialize();
     final ValidatorIndexProvider validatorIndexProvider =
         new ValidatorIndexProvider(validators.keySet(), validatorApiChannel);
     final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -83,7 +83,6 @@ public class ValidatorClientService extends Service {
         new GenesisDataProvider(asyncRunner, validatorApiChannel);
     final ForkProvider forkProvider =
         new ForkProvider(asyncRunner, validatorApiChannel, genesisDataProvider);
-    forkProvider.getForkInfo().reportExceptions();
     final ValidatorIndexProvider validatorIndexProvider =
         new ValidatorIndexProvider(validators.keySet(), validatorApiChannel);
     final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -83,6 +83,7 @@ public class ValidatorClientService extends Service {
         new GenesisDataProvider(asyncRunner, validatorApiChannel);
     final ForkProvider forkProvider =
         new ForkProvider(asyncRunner, validatorApiChannel, genesisDataProvider);
+    forkProvider.getForkInfo().reportExceptions();
     final ValidatorIndexProvider validatorIndexProvider =
         new ValidatorIndexProvider(validators.keySet(), validatorApiChannel);
     final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions =

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ForkProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ForkProviderTest.java
@@ -50,6 +50,7 @@ class ForkProviderTest {
     when(genesisDataProvider.getGenesisValidatorsRoot())
         .thenReturn(SafeFuture.completedFuture(forkInfo.getGenesisValidatorsRoot()));
 
+    forkProvider.initialize();
     final SafeFuture<ForkInfo> result = forkProvider.getForkInfo();
 
     assertThat(result).isNotDone();
@@ -65,6 +66,7 @@ class ForkProviderTest {
     when(genesisDataProvider.getGenesisValidatorsRoot())
         .thenReturn(SafeFuture.completedFuture(forkInfo.getGenesisValidatorsRoot()));
 
+    forkProvider.initialize();
     // First request loads the fork
     assertThat(forkProvider.getForkInfo()).isCompletedWithValue(forkInfo);
     verify(validatorApiChannel).getFork();
@@ -83,6 +85,8 @@ class ForkProviderTest {
     when(validatorApiChannel.getFork())
         .thenReturn(completedFuture(Optional.of(forkInfo.getFork())))
         .thenReturn(completedFuture(Optional.of(updatedFork.getFork())));
+
+    forkProvider.initialize();
 
     assertThat(forkProvider.getForkInfo()).isCompletedWithValue(forkInfo);
 
@@ -103,6 +107,7 @@ class ForkProviderTest {
         .thenReturn(completedFuture(Optional.of(forkInfo.getFork())));
 
     // First request fails
+    forkProvider.initialize();
     final SafeFuture<ForkInfo> result = forkProvider.getForkInfo();
     verify(validatorApiChannel).getFork();
     assertThat(result).isNotDone();


### PR DESCRIPTION
fixes #3304

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.