### PR TITLE
Avoid loading Eth1 data prior to deposit contract deploy block for MainNet

### DIFF
--- a/pow/src/test/java/tech/pegasys/teku/pow/Eth1DepositManagerTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/Eth1DepositManagerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.COMPLETE;
 
 import java.math.BigInteger;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -74,7 +75,8 @@ class Eth1DepositManagerTest {
           eth1EventsChannel,
           eth1DepositStorageChannel,
           depositProcessingController,
-          minimumGenesisTimeBlockFinder);
+          minimumGenesisTimeBlockFinder,
+          Optional.empty());
 
   @BeforeAll
   static void setConstants() {

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.services.powchain;
 import static tech.pegasys.teku.pow.api.Eth1DataCachePeriodCalculator.calculateEth1DataCacheDurationPriorToCurrentTime;
 import static tech.pegasys.teku.util.config.Constants.MAXIMUM_CONCURRENT_ETH1_REQUESTS;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
@@ -25,6 +26,7 @@ import org.web3j.protocol.Web3j;
 import org.web3j.protocol.http.HttpService;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.DepositContractAccessor;
 import tech.pegasys.teku.pow.DepositFetcher;
 import tech.pegasys.teku.pow.DepositProcessingController;
@@ -99,6 +101,8 @@ public class PowchainService extends Service {
             eth1BlockFetcher,
             headTracker);
 
+    final Optional<UInt64> eth1DepositContractDeployBlock =
+        tekuConfig.getEth1DepositContractDeployBlock();
     eth1DepositManager =
         new Eth1DepositManager(
             eth1Provider,
@@ -106,7 +110,8 @@ public class PowchainService extends Service {
             eth1EventsPublisher,
             eth1DepositStorageChannel,
             depositProcessingController,
-            new MinimumGenesisTimeBlockFinder(eth1Provider));
+            new MinimumGenesisTimeBlockFinder(eth1Provider, eth1DepositContractDeployBlock),
+            eth1DepositContractDeployBlock);
 
     chainIdValidator = new Eth1ChainIdValidator(eth1Provider, asyncRunner);
   }

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/schema/ReplayDepositsResult.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/schema/ReplayDepositsResult.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 public class ReplayDepositsResult {
   private static final BigInteger NEGATIVE_ONE = BigInteger.valueOf(-1);
-  private static ReplayDepositsResult EMPTY =
+  private static final ReplayDepositsResult EMPTY =
       new ReplayDepositsResult(NEGATIVE_ONE, Optional.empty(), false);
 
   private final BigInteger lastProcessedBlockNumber;

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
@@ -14,9 +14,11 @@
 package tech.pegasys.teku.util.config;
 
 import java.util.List;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import tech.pegasys.teku.infrastructure.logging.LoggingDestination;
 import tech.pegasys.teku.infrastructure.metrics.MetricsConfig;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 /** @deprecated - Use TekuConfiguration where possible. Global application configuration. */
 @Deprecated
@@ -40,6 +42,7 @@ public class GlobalConfiguration implements MetricsConfig {
   private final Eth1Address eth1DepositContractAddress;
   private final String eth1Endpoint;
   private final boolean eth1DepositsFromStorageEnabled;
+  private final Optional<UInt64> eth1DepositContractDeployBlock;
 
   // Logging
   private final boolean logColorEnabled;
@@ -98,6 +101,7 @@ public class GlobalConfiguration implements MetricsConfig {
       final boolean interopEnabled,
       final Eth1Address eth1DepositContractAddress,
       final String eth1Endpoint,
+      final Optional<UInt64> eth1DepositContractDeployBlock,
       final boolean eth1DepositsFromStorageEnabled,
       final boolean logColorEnabled,
       final boolean logIncludeEventsEnabled,
@@ -139,6 +143,7 @@ public class GlobalConfiguration implements MetricsConfig {
     this.interopEnabled = interopEnabled;
     this.eth1DepositContractAddress = eth1DepositContractAddress;
     this.eth1Endpoint = eth1Endpoint;
+    this.eth1DepositContractDeployBlock = eth1DepositContractDeployBlock;
     this.eth1DepositsFromStorageEnabled = eth1DepositsFromStorageEnabled;
     this.logColorEnabled = logColorEnabled;
     this.logIncludeEventsEnabled = logIncludeEventsEnabled;
@@ -223,6 +228,10 @@ public class GlobalConfiguration implements MetricsConfig {
 
   public Eth1Address getEth1DepositContractAddress() {
     return eth1DepositContractAddress;
+  }
+
+  public Optional<UInt64> getEth1DepositContractDeployBlock() {
+    return eth1DepositContractDeployBlock;
   }
 
   public String getEth1Endpoint() {

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import tech.pegasys.teku.infrastructure.logging.LoggingDestination;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 /**
  * @deprecated - Use TekuConfigurationBuilder where possible. Global application configuration
@@ -37,6 +38,7 @@ public class GlobalConfigurationBuilder {
   private boolean interopEnabled;
   private Eth1Address eth1DepositContractAddress;
   private String eth1Endpoint;
+  private Optional<UInt64> eth1DepositContractDeployBlock = Optional.empty();
   private boolean eth1DepositsFromStorageEnabled;
   private boolean logColorEnabled;
   private boolean logIncludeEventsEnabled;
@@ -129,6 +131,12 @@ public class GlobalConfigurationBuilder {
 
   public GlobalConfigurationBuilder setEth1Endpoint(final String eth1Endpoint) {
     this.eth1Endpoint = eth1Endpoint;
+    return this;
+  }
+
+  public GlobalConfigurationBuilder setEth1DepositContractDeployBlock(
+      final Optional<UInt64> eth1DepositContractDeployBlock) {
+    this.eth1DepositContractDeployBlock = eth1DepositContractDeployBlock;
     return this;
   }
 
@@ -297,6 +305,7 @@ public class GlobalConfigurationBuilder {
       eth1DepositContractAddress =
           getOrOptionalDefault(eth1DepositContractAddress, network::getEth1DepositContractAddress);
       eth1Endpoint = getOrOptionalDefault(eth1Endpoint, network::getEth1Endpoint);
+      eth1DepositContractDeployBlock = network.getEth1DepositContractDeployBlock();
     }
 
     if (eth1DepositContractAddress == null && eth1Endpoint != null) {
@@ -318,6 +327,7 @@ public class GlobalConfigurationBuilder {
         interopEnabled,
         eth1DepositContractAddress,
         eth1Endpoint,
+        eth1DepositContractDeployBlock,
         eth1DepositsFromStorageEnabled,
         logColorEnabled,
         logIncludeEventsEnabled,

--- a/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/NetworkDefinition.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class NetworkDefinition {
   private static final ImmutableMap<String, NetworkDefinition> NETWORKS =
@@ -33,6 +34,7 @@ public class NetworkDefinition {
                   .initialStateFromClasspath("mainnet-genesis.ssz")
                   .startupTimeoutSeconds(120)
                   .eth1DepositContractAddress("0x00000000219ab540356cBB839Cbe05303d7705Fa")
+                  .eth1DepositContractDeployBlock(11052984)
                   .discoveryBootnodes(
                       // PegaSys Teku
                       "enr:-KG4QJRlj4pHagfNIm-Fsx9EVjW4rviuZYzle3tyddm2KAWMJBDGAhxfM2g-pDaaiwE8q19uvLSH4jyvWjypLMr3TIcEhGV0aDKQ9aX9QgAAAAD__________4JpZIJ2NIJpcIQDE8KdiXNlY3AyNTZrMaEDhpehBDbZjM_L9ek699Y7vhUJ-eAdMyQW_Fil522Y0fODdGNwgiMog3VkcIIjKA",
@@ -129,6 +131,7 @@ public class NetworkDefinition {
   private final List<String> discoveryBootnodes;
   private final Optional<Eth1Address> eth1DepositContractAddress;
   private final Optional<String> eth1Endpoint;
+  private final Optional<UInt64> eth1DepositContractDeployBlock;
 
   private NetworkDefinition(
       final String constants,
@@ -137,7 +140,8 @@ public class NetworkDefinition {
       final int startupTimeoutSeconds,
       final List<String> discoveryBootnodes,
       final Optional<Eth1Address> eth1DepositContractAddress,
-      final Optional<String> eth1Endpoint) {
+      final Optional<String> eth1Endpoint,
+      final Optional<UInt64> eth1DepositContractDeployBlock) {
     this.constants = constants;
     this.initialState = initialState;
     this.startupTargetPeerCount = startupTargetPeerCount;
@@ -145,6 +149,7 @@ public class NetworkDefinition {
     this.discoveryBootnodes = discoveryBootnodes;
     this.eth1DepositContractAddress = eth1DepositContractAddress;
     this.eth1Endpoint = eth1Endpoint;
+    this.eth1DepositContractDeployBlock = eth1DepositContractDeployBlock;
   }
 
   public static NetworkDefinition fromCliArg(final String arg) {
@@ -179,6 +184,10 @@ public class NetworkDefinition {
     return eth1DepositContractAddress;
   }
 
+  public Optional<UInt64> getEth1DepositContractDeployBlock() {
+    return eth1DepositContractDeployBlock;
+  }
+
   public Optional<String> getEth1Endpoint() {
     return eth1Endpoint;
   }
@@ -196,6 +205,7 @@ public class NetworkDefinition {
     private List<String> discoveryBootnodes = new ArrayList<>();
     private Optional<Eth1Address> eth1DepositContractAddress = Optional.empty();
     private Optional<String> eth1Endpoint = Optional.empty();
+    private Optional<UInt64> eth1DepositContractDeployBlock = Optional.empty();
 
     public Builder constants(final String constants) {
       this.constants = constants;
@@ -238,6 +248,12 @@ public class NetworkDefinition {
       return this;
     }
 
+    public Builder eth1DepositContractDeployBlock(final long eth1DepositContractDeployBlock) {
+      this.eth1DepositContractDeployBlock =
+          Optional.of(UInt64.valueOf(eth1DepositContractDeployBlock));
+      return this;
+    }
+
     public NetworkDefinition build() {
       checkNotNull(constants, "Missing constants");
       return new NetworkDefinition(
@@ -247,7 +263,8 @@ public class NetworkDefinition {
           startupTimeoutSeconds,
           discoveryBootnodes,
           eth1DepositContractAddress,
-          eth1Endpoint);
+          eth1Endpoint,
+          eth1DepositContractDeployBlock);
     }
   }
 }


### PR DESCRIPTION
## PR Description
Nethermind doesn't download all block bodies and returns `null` from `eth_getBlock` requests if the body isn't available.  This causes Teku's binary search for the block meeting the min genesis time definition to fail because it requests some blocks a long way back in the chain.

To avoid this, include the block number the deposit contract was deployed at in the mainnet config and start the search for the min genesis block and deposit logs from that point forward.

## Fixed Issue(s)
May also fix #3337 but will need to sync an open ethereum node to confirm.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.