### PR TITLE
Update git repo url references to reflect https://github.com/ConsenSy…

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,10 +1,10 @@
 <!-- Have you done the following? -->
 <!--   * read the Code of Conduct? By filing an Issue, you are expected to -->  
 <!--     comply with it, including treating everyone with respect: -->
-<!--     https://github.com/PegasysEng/teku/blob/master/CODE-OF-CONDUCT.md -->
+<!--     https://github.com/ConsenSys/teku/blob/master/CODE-OF-CONDUCT.md -->
 <!--   * Reproduced the issue in the latest version of the software -->
-<!--   * Read the debugging wiki: https://github.com/PegasysEng/teku/wiki/debugging -->
-<!--   * Duplicate Issue check:  https://github.com/search?q=+is%3Aissue+repo%3APegasysEng/Teku -->
+<!--   * Read the debugging wiki: https://github.com/ConsenSys/teku/wiki/debugging -->
+<!--   * Duplicate Issue check:  https://github.com/search?q=+is%3Aissue+repo%3AConsenSys/Teku -->
 <!-- Note:  Not all sections will apply to all issue types. -->
 
 ### Description

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
-<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->
+<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->
 
 ## PR Description
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,7 +323,7 @@ New REST APIs
 - Operations (e.g. attestations, slashings etc) included in blocks are now readded to the pending pool if a reorg causes them to no longer be in the canonical chain
 - Removed support for generating unencrypted keystores
 - Discv5 now caches the hash of the local node to reduce load caused by significant numbers of incoming discovery messages
-- Early access support for running the validator node independently of the beacon node (see [#2683](https://github.com/PegaSysEng/teku/pull/2683) for details). Please note this is not yet a recommended configuration and the CLI options and APIs used are subject to change.
+- Early access support for running the validator node independently of the beacon node (see [#2683](https://github.com/ConsenSys/teku/pull/2683) for details). Please note this is not yet a recommended configuration and the CLI options and APIs used are subject to change.
 
 ### Bug Fixes
 - Gossip messages with null `from`, `signature` or `seqNo` fields are now rebroadcast with the fields still null instead of replaced by default values
@@ -351,7 +351,7 @@ New REST APIs
 
 ### Additions and Improvements
 
-- Includes a significant number of bug fixes and performance improvements as a result of the recent issues on the Medalla testnet. See https://github.com/PegaSysEng/teku/issues/2596 for a full list of related issues.
+- Includes a significant number of bug fixes and performance improvements as a result of the recent issues on the Medalla testnet. See https://github.com/ConsenSys/teku/issues/2596 for a full list of related issues.
 - Support loading an entire directory of validator keys using `--validator-keys=<keyDir>:<passDir>`. Individual keystore and password files can also be specified using this new argument. 
 - Major reduction in CPU and memory usage during periods of non-finalization by intelligently queuing and combining requests for beacon states and checkpoint states
 - Fixed slow startup times during long periods of non-finalization.  Non-finalized states are now periodically persisted to disk to avoid needing to replay large numbers of blocks to regenerate state.
@@ -415,7 +415,7 @@ New REST APIs
 
 - Fixed vector for DOS attack caused by not throttling libp2p response rate. (See https://github.com/libp2p/jvm-libp2p/pull/127 and https://github.com/ethereum/public-attacknets/issues/7 for futher details)
 - Fixed issue that delayed publication of created attestations by a slot
-- Fixed "Invalid attestation: Signature is invalid" errors caused by incorrect caching of committee selections (see https://github.com/PegaSysEng/teku/pull/2501 for further details)
+- Fixed "Invalid attestation: Signature is invalid" errors caused by incorrect caching of committee selections (see https://github.com/ConsenSys/teku/pull/2501 for further details)
 - Fixed issues where validators failed to perform duties because the node incorrectly returned to syncing state
 - Fixed `--logging` option to accept lowercase `debug` option. Renamed the `debug` subcommand to avoid the naming conflict
 - Avoid lock contention when reading in-memory storage metrics
@@ -547,7 +547,7 @@ New REST APIs
 
 ### Known Issues
 
-- Validator may produce attestations in the incorrect slot or committee resulting in `Produced invalid attestation` messages ([#2179](https://github.com/PegaSysEng/teku/issues/2179))
+- Validator may produce attestations in the incorrect slot or committee resulting in `Produced invalid attestation` messages ([#2179](https://github.com/ConsenSys/teku/issues/2179))
 
 
 ## 0.11.5

--- a/build.gradle
+++ b/build.gradle
@@ -61,9 +61,9 @@ def bintrayPackage = bintray.pkg {
   userOrg = 'consensys'
   desc = 'Java Implementation of the Ethereum 2.0 Beacon Chain'
   licenses = ['Apache-2.0']
-  websiteUrl = 'https://github.com/PegaSysEng/teku'
-  issueTrackerUrl = 'https://github.com/PegaSysEng/teku/issues'
-  vcsUrl = 'https://github.com/PegaSysEng/teku.git'
+  websiteUrl = 'https://github.com/ConsenSys/teku'
+  issueTrackerUrl = 'https://github.com/ConsenSys/teku/issues'
+  vcsUrl = 'https://github.com/ConsenSys/teku.git'
 
   version {
     name = project.version
@@ -472,7 +472,7 @@ subprojects {
           }
           pom {
             name = "Teku - ${project.name}"
-            url = 'https://github.com/PegaSysEng/teku'
+            url = 'https://github.com/ConsenSys/teku'
             licenses {
               license {
                 name = 'The Apache License, Version 2.0'
@@ -480,9 +480,9 @@ subprojects {
               }
             }
             scm {
-              connection = 'scm:git:git://github.com/PegaSysEng/teku.git'
-              developerConnection = 'https://github.com/PegaSysEng/teku.git'
-              url = 'https://github.com/PegaSysEng/teku'
+              connection = 'scm:git:git://github.com/ConsenSys/teku.git'
+              developerConnection = 'https://github.com/ConsenSys/teku.git'
+              url = 'https://github.com/ConsenSys/teku'
             }
           }
         }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,9 +27,9 @@ ARG VERSION
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.name="Teku" \
       org.label-schema.description="Ethereum 2.0 Beacon Chain Client" \
-      org.label-schema.url="https://pegasys.tech/teku/" \
+      org.label-schema.url="https://consensys.net/knowledge-base/ethereum-2/teku/" \
       org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.vcs-url="https://github.com/PegaSysEng/teku.git" \
-      org.label-schema.vendor="PegaSys" \
+      org.label-schema.vcs-url="https://github.com/ConsenSys/teku.git" \
+      org.label-schema.vendor="ConsenSys" \
       org.label-schema.version=$VERSION \
       org.label-schema.schema-version="1.0"


### PR DESCRIPTION
Git repo url has been migrated to https://github.com/ConsenSys/teku.git from https://github.com/pegaSyseng/teku and redirections also setup. Updated references in the code to new url. Dockerfile also updated to reflect the github repo location, vendor name and web page url.
