### PR TITLE
Reduce eth_getLogs batch size further

### DIFF
--- a/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
@@ -46,7 +46,7 @@ import tech.pegasys.teku.util.config.Constants;
 
 public class DepositFetcher {
 
-  static final int DEFAULT_BATCH_SIZE = 50_000;
+  static final int DEFAULT_BATCH_SIZE = 10_000;
 
   private static final Logger LOG = LogManager.getLogger();
 

--- a/pow/src/test/java/tech/pegasys/teku/pow/DepositsFetcherTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/DepositsFetcherTest.java
@@ -135,7 +135,7 @@ public class DepositsFetcherTest {
   @Test
   void shouldReduceBatchSizeWhenRequestIsRejected() {
     final BigInteger fromBlockNumber = BigInteger.ZERO;
-    final BigInteger toBlockNumber = BigInteger.valueOf(DEFAULT_BATCH_SIZE + 1000);
+    final BigInteger toBlockNumber = BigInteger.valueOf(DEFAULT_BATCH_SIZE + 100);
 
     final SafeFuture<List<DepositContract.DepositEventEventResponse>> request1Response =
         new SafeFuture<>();


### PR DESCRIPTION
## PR Description
Some Geth instances are still struggling to respond to eth_getLogs so reduce the batch size further.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.