### PR TITLE
Log a warning if deposit logs can't be retrieved because of timeouts

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.infrastructure.logging;
 
 import static java.util.stream.Collectors.joining;
 
+import java.math.BigInteger;
 import java.nio.file.Path;
 import java.util.List;
 import org.apache.commons.lang3.time.DateFormatUtils;
@@ -199,8 +200,8 @@ public class StatusLogger {
     log.warn("Eth1 service down for {}s, retrying", interval);
   }
 
-  public void eth1AtHead() {
-    log.info("Eth1 tracker successfully caught up to chain head");
+  public void eth1AtHead(final BigInteger headBlockNumber) {
+    log.info("Successfully loaded deposits up to Eth1 block {}", headBlockNumber);
   }
 
   public void usingGeneratedP2pPrivateKey(final String key, final boolean justGenerated) {

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -58,6 +58,12 @@ public class StatusLogger {
         cause);
   }
 
+  public void eth1FetchDepositsTimeout(final int batchSize) {
+    log.warn(
+        "Request for eth1 deposit logs from {} blocks failed. Retrying with a smaller block range.",
+        batchSize);
+  }
+
   public void unexpectedFailure(final String description, final Throwable cause) {
     log.error("PLEASE FIX OR REPORT | Unexpected exception thrown for {}", description, cause);
   }

--- a/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.pow;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
+import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 
 import com.google.common.base.Throwables;
 import java.math.BigInteger;
@@ -101,7 +102,7 @@ public class DepositFetcher {
               final Throwable rootCause = Throwables.getRootCause(err);
               if (rootCause instanceof SocketTimeoutException
                   || rootCause instanceof RejectedRequestException) {
-                LOG.debug("Request timed out or was rejected, reduce the batch size and retry");
+                STATUS_LOG.eth1FetchDepositsTimeout(fetchState.batchSize);
                 fetchState.reduceBatchSize();
               }
 

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1DepositManager.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1DepositManager.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.pow;
 
+import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 import static tech.pegasys.teku.pow.MinimumGenesisTimeBlockFinder.isBlockAfterMinGenesis;
 import static tech.pegasys.teku.pow.MinimumGenesisTimeBlockFinder.notifyMinGenesisTimeBlockReached;
 
@@ -70,9 +71,9 @@ public class Eth1DepositManager {
                   .map(UInt64::valueOf)
                   .ifPresent(eth1EventsPublisher::setLatestPublishedDeposit);
               return getHead()
-                  .thenCompose(headBlock -> processStart(headBlock, replayDepositsResult));
+                  .thenCompose(headBlock -> processStart(headBlock, replayDepositsResult).thenApply(__ -> headBlock));
             })
-        .thenAccept(__ -> LOG.info("Eth1DepositsManager successfully ran startup sequence."))
+        .thenAccept(headBlock -> STATUS_LOG.eth1AtHead(headBlock.getNumber()))
         .exceptionally(
             (err) -> {
               throw new FatalServiceFailureException(getClass(), err);

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1DepositManager.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1DepositManager.java
@@ -71,7 +71,9 @@ public class Eth1DepositManager {
                   .map(UInt64::valueOf)
                   .ifPresent(eth1EventsPublisher::setLatestPublishedDeposit);
               return getHead()
-                  .thenCompose(headBlock -> processStart(headBlock, replayDepositsResult).thenApply(__ -> headBlock));
+                  .thenCompose(
+                      headBlock ->
+                          processStart(headBlock, replayDepositsResult).thenApply(__ -> headBlock));
             })
         .thenAccept(headBlock -> STATUS_LOG.eth1AtHead(headBlock.getNumber()))
         .exceptionally(

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1HeadTracker.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1HeadTracker.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.pow;
 
-import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 import static tech.pegasys.teku.util.config.Constants.ETH1_FOLLOW_DISTANCE;
 
 import java.util.Optional;
@@ -85,7 +84,6 @@ public class Eth1HeadTracker {
         .map(current -> current.compareTo(newHeadAtFollowDistance) < 0)
         .orElse(true)) {
       if (reachedHead.compareAndSet(false, true)) {
-        STATUS_LOG.eth1AtHead();
         reachedHead.set(true);
       }
       headAtFollowDistance = Optional.of(newHeadAtFollowDistance);


### PR DESCRIPTION
## PR Description
Move the console log message that eth1 chain head has been reached to only print when all deposits up to that block have been processed instead of just when the head block is found.  Also include the block number that was reached in the message.

If requests to the Eth1 node for deposits fail, log a warning so users are aware.  The eth1 node down detection doesn't kick in because other API calls are still working, leaving users unaware they aren't getting eth1 data correctly.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.