### PR TITLE
update ForkProvider to run as a service

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ForkProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ForkProvider.java
@@ -34,7 +34,7 @@ public class ForkProvider extends Service {
   private final ValidatorApiChannel validatorApiChannel;
   private final GenesisDataProvider genesisDataProvider;
 
-  private volatile SafeFuture<ForkInfo> currentFork;
+  private volatile SafeFuture<ForkInfo> currentFork = new SafeFuture<>();
 
   public ForkProvider(
       final AsyncRunner asyncRunner,
@@ -43,7 +43,6 @@ public class ForkProvider extends Service {
     this.asyncRunner = asyncRunner;
     this.validatorApiChannel = validatorApiChannel;
     this.genesisDataProvider = genesisDataProvider;
-    currentFork = new SafeFuture<>();
   }
 
   public SafeFuture<ForkInfo> getForkInfo() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ForkProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ForkProvider.java
@@ -16,25 +16,25 @@ package tech.pegasys.teku.validator.client;
 import static tech.pegasys.teku.util.config.Constants.FORK_REFRESH_TIME_SECONDS;
 import static tech.pegasys.teku.util.config.Constants.FORK_RETRY_DELAY_SECONDS;
 
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.datastructures.state.Fork;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.beaconnode.GenesisDataProvider;
 
-public class ForkProvider {
+public class ForkProvider extends Service {
   private static final Logger LOG = LogManager.getLogger();
 
   private final AsyncRunner asyncRunner;
   private final ValidatorApiChannel validatorApiChannel;
   private final GenesisDataProvider genesisDataProvider;
 
-  private volatile Optional<ForkInfo> currentFork = Optional.empty();
+  private volatile SafeFuture<ForkInfo> currentFork;
 
   public ForkProvider(
       final AsyncRunner asyncRunner,
@@ -43,49 +43,63 @@ public class ForkProvider {
     this.asyncRunner = asyncRunner;
     this.validatorApiChannel = validatorApiChannel;
     this.genesisDataProvider = genesisDataProvider;
+    currentFork = new SafeFuture<>();
   }
 
   public SafeFuture<ForkInfo> getForkInfo() {
-    return currentFork.map(SafeFuture::completedFuture).orElseGet(this::loadForkInfo);
+    return currentFork;
   }
 
-  public SafeFuture<ForkInfo> loadForkInfo() {
-    return requestForkInfo()
-        .exceptionallyCompose(
-            error -> {
-              LOG.error("Failed to retrieve current fork info. Retrying after delay", error);
-              return asyncRunner.runAfterDelay(
-                  this::getForkInfo, FORK_RETRY_DELAY_SECONDS, TimeUnit.SECONDS);
-            });
-  }
-
-  private SafeFuture<ForkInfo> requestForkInfo() {
-    return genesisDataProvider.getGenesisValidatorsRoot().thenCompose(this::requestFork);
-  }
-
-  public SafeFuture<ForkInfo> requestFork(final Bytes32 genesisValidatorsRoot) {
+  private SafeFuture<ForkInfo> getForkAndPeriodicallyUpdate() {
     return validatorApiChannel
         .getFork()
         .thenCompose(
             maybeFork -> {
               if (maybeFork.isEmpty()) {
                 LOG.trace("Fork info not available, retrying");
-                return asyncRunner.runAfterDelay(
-                    this::requestForkInfo, FORK_RETRY_DELAY_SECONDS, TimeUnit.SECONDS);
+                return scheduleNextRequest(FORK_RETRY_DELAY_SECONDS);
               }
-              final ForkInfo forkInfo =
-                  new ForkInfo(maybeFork.orElseThrow(), genesisValidatorsRoot);
-              currentFork = Optional.of(forkInfo);
-              // Periodically refresh the current fork info.
-              asyncRunner
-                  .runAfterDelay(this::loadForkInfo, FORK_REFRESH_TIME_SECONDS, TimeUnit.SECONDS)
-                  .reportExceptions();
-              return SafeFuture.completedFuture(forkInfo);
+
+              scheduleNextRequest(FORK_REFRESH_TIME_SECONDS).reportExceptions();
+              return getValidatorsRootAndCreateForkInfo(maybeFork.orElseThrow());
+            })
+        .exceptionallyCompose(
+            error -> {
+              LOG.error("Failed to retrieve current fork info. Retrying after delay", error);
+              return scheduleNextRequest(FORK_RETRY_DELAY_SECONDS);
             });
+  }
+
+  private SafeFuture<ForkInfo> getValidatorsRootAndCreateForkInfo(Fork fork) {
+    return genesisDataProvider
+        .getGenesisValidatorsRoot()
+        .thenCompose(
+            root -> {
+              final ForkInfo forkInfo = new ForkInfo(fork, root);
+              // anything waiting on the current future needs to be notified
+              currentFork.complete(forkInfo);
+              currentFork = SafeFuture.completedFuture(forkInfo);
+              return currentFork;
+            });
+  }
+
+  private SafeFuture<ForkInfo> scheduleNextRequest(final long seconds) {
+    return asyncRunner.runAfterDelay(this::getForkAndPeriodicallyUpdate, seconds, TimeUnit.SECONDS);
   }
 
   @Override
   public String toString() {
     return "ForkProvider{" + "currentFork=" + currentFork + '}';
+  }
+
+  @Override
+  protected SafeFuture<?> doStart() {
+    currentFork = getForkAndPeriodicallyUpdate();
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
+  protected SafeFuture<?> doStop() {
+    return SafeFuture.COMPLETE;
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -141,7 +141,7 @@ public class ValidatorClientService extends Service {
 
   @Override
   protected SafeFuture<?> doStart() {
-    forkProvider.doStart().reportExceptions();
+    forkProvider.start().reportExceptions();
     validatorIndexProvider.lookupValidators();
     eventChannels.subscribe(
         ValidatorTimingChannel.class,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -44,18 +44,21 @@ public class ValidatorClientService extends Service {
   private final ValidatorTimingChannel blockProductionTimingChannel;
   private final ValidatorIndexProvider validatorIndexProvider;
   private final BeaconNodeApi beaconNodeApi;
+  private final ForkProvider forkProvider;
 
   private ValidatorClientService(
       final EventChannels eventChannels,
       final ValidatorTimingChannel attestationTimingChannel,
       final ValidatorTimingChannel blockProductionTimingChannel,
       final ValidatorIndexProvider validatorIndexProvider,
-      final BeaconNodeApi beaconNodeApi) {
+      final BeaconNodeApi beaconNodeApi,
+      final ForkProvider forkProvider) {
     this.eventChannels = eventChannels;
     this.attestationTimingChannel = attestationTimingChannel;
     this.blockProductionTimingChannel = blockProductionTimingChannel;
     this.validatorIndexProvider = validatorIndexProvider;
     this.beaconNodeApi = beaconNodeApi;
+    this.forkProvider = forkProvider;
   }
 
   public static ValidatorClientService create(
@@ -119,7 +122,8 @@ public class ValidatorClientService extends Service {
         attestationDutyScheduler,
         blockDutyScheduler,
         validatorIndexProvider,
-        beaconNodeApi);
+        beaconNodeApi,
+        forkProvider);
   }
 
   public static Path getSlashingProtectionPath(final DataDirLayout dataDirLayout) {
@@ -137,6 +141,7 @@ public class ValidatorClientService extends Service {
 
   @Override
   protected SafeFuture<?> doStart() {
+    forkProvider.doStart().reportExceptions();
     validatorIndexProvider.lookupValidators();
     eventChannels.subscribe(
         ValidatorTimingChannel.class,

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ForkProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ForkProviderTest.java
@@ -50,6 +50,7 @@ class ForkProviderTest {
     when(genesisDataProvider.getGenesisValidatorsRoot())
         .thenReturn(SafeFuture.completedFuture(forkInfo.getGenesisValidatorsRoot()));
 
+    forkProvider.doStart().reportExceptions();
     final SafeFuture<ForkInfo> result = forkProvider.getForkInfo();
 
     assertThat(result).isNotDone();
@@ -66,6 +67,7 @@ class ForkProviderTest {
         .thenReturn(SafeFuture.completedFuture(forkInfo.getGenesisValidatorsRoot()));
 
     // First request loads the fork
+    forkProvider.doStart().reportExceptions();
     assertThat(forkProvider.getForkInfo()).isCompletedWithValue(forkInfo);
     verify(validatorApiChannel).getFork();
 
@@ -84,6 +86,7 @@ class ForkProviderTest {
         .thenReturn(completedFuture(Optional.of(forkInfo.getFork())))
         .thenReturn(completedFuture(Optional.of(updatedFork.getFork())));
 
+    forkProvider.doStart().reportExceptions();
     assertThat(forkProvider.getForkInfo()).isCompletedWithValue(forkInfo);
 
     // Update is scheduled
@@ -101,7 +104,7 @@ class ForkProviderTest {
     when(validatorApiChannel.getFork())
         .thenReturn(failedFuture(new RuntimeException("Nope")))
         .thenReturn(completedFuture(Optional.of(forkInfo.getFork())));
-
+    forkProvider.doStart().reportExceptions();
     // First request fails
     final SafeFuture<ForkInfo> result = forkProvider.getForkInfo();
     verify(validatorApiChannel).getFork();

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ForkProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ForkProviderTest.java
@@ -50,7 +50,7 @@ class ForkProviderTest {
     when(genesisDataProvider.getGenesisValidatorsRoot())
         .thenReturn(SafeFuture.completedFuture(forkInfo.getGenesisValidatorsRoot()));
 
-    forkProvider.doStart().reportExceptions();
+    forkProvider.start().reportExceptions();
     final SafeFuture<ForkInfo> result = forkProvider.getForkInfo();
 
     assertThat(result).isNotDone();
@@ -67,7 +67,7 @@ class ForkProviderTest {
         .thenReturn(SafeFuture.completedFuture(forkInfo.getGenesisValidatorsRoot()));
 
     // First request loads the fork
-    forkProvider.doStart().reportExceptions();
+    forkProvider.start().reportExceptions();
     assertThat(forkProvider.getForkInfo()).isCompletedWithValue(forkInfo);
     verify(validatorApiChannel).getFork();
 
@@ -86,7 +86,7 @@ class ForkProviderTest {
         .thenReturn(completedFuture(Optional.of(forkInfo.getFork())))
         .thenReturn(completedFuture(Optional.of(updatedFork.getFork())));
 
-    forkProvider.doStart().reportExceptions();
+    forkProvider.start().reportExceptions();
     assertThat(forkProvider.getForkInfo()).isCompletedWithValue(forkInfo);
 
     // Update is scheduled
@@ -98,13 +98,38 @@ class ForkProviderTest {
   }
 
   @Test
+  public void shouldOnlySendSingleRequestWhenForkNotPreviouslyLoaded() {
+    final SafeFuture<Optional<Fork>> forkFuture = new SafeFuture<>();
+    when(validatorApiChannel.getFork()).thenReturn(forkFuture);
+    when(genesisDataProvider.getGenesisValidatorsRoot())
+        .thenReturn(SafeFuture.completedFuture(forkInfo.getGenesisValidatorsRoot()));
+
+    forkProvider.start().reportExceptions();
+    // First request loads the fork
+    final SafeFuture<ForkInfo> result1 = forkProvider.getForkInfo();
+    final SafeFuture<ForkInfo> result2 = forkProvider.getForkInfo();
+    assertThat(result1).isNotCompleted();
+    assertThat(result2).isNotCompleted();
+    verify(validatorApiChannel).getFork();
+    verifyNoMoreInteractions(validatorApiChannel);
+
+    forkFuture.complete(Optional.of(forkInfo.getFork()));
+    assertThat(result1).isCompletedWithValue(this.forkInfo);
+    assertThat(result2).isCompletedWithValue(this.forkInfo);
+
+    // Subsequent requests just return the cached version
+    assertThat(forkProvider.getForkInfo()).isCompletedWithValue(this.forkInfo);
+    verifyNoMoreInteractions(validatorApiChannel);
+  }
+
+  @Test
   public void shouldRetryWhenForkFailsToLoad() {
     when(genesisDataProvider.getGenesisValidatorsRoot())
         .thenReturn(SafeFuture.completedFuture(forkInfo.getGenesisValidatorsRoot()));
     when(validatorApiChannel.getFork())
         .thenReturn(failedFuture(new RuntimeException("Nope")))
         .thenReturn(completedFuture(Optional.of(forkInfo.getFork())));
-    forkProvider.doStart().reportExceptions();
+    forkProvider.start().reportExceptions();
     // First request fails
     final SafeFuture<ForkInfo> result = forkProvider.getForkInfo();
     verify(validatorApiChannel).getFork();


### PR DESCRIPTION
Fork requests will now only happen once per client, per period of time, rather than each validator potentially initiating its own request over http.

fixes #3304

Signed-off-by: Paul Harris <paul.harris@consensys.net>
## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.