### PR TITLE
Make eth1 max block range for requesting deposit event logs configurable

### DIFF
--- a/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
@@ -47,8 +47,6 @@ import tech.pegasys.teku.util.config.Constants;
 
 public class DepositFetcher {
 
-  static final int DEFAULT_BATCH_SIZE = 10_000;
-
   private static final Logger LOG = LogManager.getLogger();
 
   private final Eth1Provider eth1Provider;
@@ -56,18 +54,21 @@ public class DepositFetcher {
   private final DepositContract depositContract;
   private final Eth1BlockFetcher eth1BlockFetcher;
   private final AsyncRunner asyncRunner;
+  private final int maxBlockRange;
 
   public DepositFetcher(
       final Eth1Provider eth1Provider,
       final Eth1EventsChannel eth1EventsChannel,
       final DepositContract depositContract,
       final Eth1BlockFetcher eth1BlockFetcher,
-      final AsyncRunner asyncRunner) {
+      final AsyncRunner asyncRunner,
+      final int maxBlockRange) {
     this.eth1Provider = eth1Provider;
     this.eth1EventsChannel = eth1EventsChannel;
     this.depositContract = depositContract;
     this.eth1BlockFetcher = eth1BlockFetcher;
     this.asyncRunner = asyncRunner;
+    this.maxBlockRange = maxBlockRange;
   }
 
   // Inclusive on both sides
@@ -222,12 +223,12 @@ public class DepositFetcher {
     eth1EventsChannel.onDepositsFromBlock(event);
   }
 
-  private static class DepositFetchState {
+  private class DepositFetchState {
     // Both inclusive
     BigInteger nextBatchStart;
 
     final BigInteger lastBlock;
-    int batchSize = DEFAULT_BATCH_SIZE;
+    int batchSize = maxBlockRange;
 
     public DepositFetchState(final BigInteger fromBlockNumber, final BigInteger toBlockNumber) {
       this.nextBatchStart = fromBlockNumber;
@@ -236,10 +237,10 @@ public class DepositFetcher {
 
     public void moveToNextBatch() {
       nextBatchStart = getNextBatchEnd().add(BigInteger.ONE);
-      if (batchSize < DEFAULT_BATCH_SIZE) {
+      if (batchSize < maxBlockRange) {
         // Grow the batch size slowly as we may be past a large blob of logs that caused trouble
         // +1 to guarantee it grows by at least 1
-        batchSize = Math.min(DEFAULT_BATCH_SIZE, (int) (batchSize * 1.1 + 1));
+        batchSize = Math.min(maxBlockRange, (int) (batchSize * 1.1 + 1));
       }
     }
 

--- a/pow/src/test/java/tech/pegasys/teku/pow/DepositsFetcherTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/DepositsFetcherTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.pow.DepositFetcher.DEFAULT_BATCH_SIZE;
 
 import com.google.common.primitives.Longs;
 import java.math.BigInteger;
@@ -46,6 +45,7 @@ import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 
 public class DepositsFetcherTest {
 
+  private static final int MAX_BLOCK_RANGE = 10_000;
   private final Eth1Provider eth1Provider = mock(Eth1Provider.class);
   private final Eth1EventsChannel eth1EventsChannel = mock(Eth1EventsChannel.class);
   private final DepositContract depositContract = mock(DepositContract.class);
@@ -54,7 +54,12 @@ public class DepositsFetcherTest {
 
   private final DepositFetcher depositFetcher =
       new DepositFetcher(
-          eth1Provider, eth1EventsChannel, depositContract, eth1BlockFetcher, asyncRunner);
+          eth1Provider,
+          eth1EventsChannel,
+          depositContract,
+          eth1BlockFetcher,
+          asyncRunner,
+          MAX_BLOCK_RANGE);
 
   @Test
   void depositsInConsecutiveBlocks() {
@@ -86,11 +91,11 @@ public class DepositsFetcherTest {
   @Test
   void shouldUseMultipleBatchesWhenRangeIsLarge() {
     final BigInteger fromBlockNumber = BigInteger.ZERO;
-    final BigInteger toBlockNumber = BigInteger.valueOf(3 * DEFAULT_BATCH_SIZE - 10);
+    final BigInteger toBlockNumber = BigInteger.valueOf(3 * MAX_BLOCK_RANGE - 10);
 
-    final BigInteger batch1End = fromBlockNumber.add(BigInteger.valueOf(DEFAULT_BATCH_SIZE));
+    final BigInteger batch1End = fromBlockNumber.add(BigInteger.valueOf(MAX_BLOCK_RANGE));
     final BigInteger batch2Start = batch1End.add(BigInteger.ONE);
-    final BigInteger batch2End = batch2Start.add(BigInteger.valueOf(DEFAULT_BATCH_SIZE));
+    final BigInteger batch2End = batch2Start.add(BigInteger.valueOf(MAX_BLOCK_RANGE));
     final BigInteger batch3Start = batch2End.add(BigInteger.ONE);
     final SafeFuture<List<DepositContract.DepositEventEventResponse>> batch1Response =
         new SafeFuture<>();
@@ -135,7 +140,7 @@ public class DepositsFetcherTest {
   @Test
   void shouldReduceBatchSizeWhenRequestIsRejected() {
     final BigInteger fromBlockNumber = BigInteger.ZERO;
-    final BigInteger toBlockNumber = BigInteger.valueOf(DEFAULT_BATCH_SIZE + 100);
+    final BigInteger toBlockNumber = BigInteger.valueOf(MAX_BLOCK_RANGE + 100);
 
     final SafeFuture<List<DepositContract.DepositEventEventResponse>> request1Response =
         new SafeFuture<>();
@@ -157,7 +162,7 @@ public class DepositsFetcherTest {
     verify(depositContract)
         .depositEventInRange(
             refEq(DefaultBlockParameter.valueOf(fromBlockNumber)),
-            refEq(DefaultBlockParameter.valueOf(BigInteger.valueOf(DEFAULT_BATCH_SIZE))));
+            refEq(DefaultBlockParameter.valueOf(BigInteger.valueOf(MAX_BLOCK_RANGE))));
     verifyNoMoreInteractions(depositContract);
 
     // But there are too many results
@@ -166,7 +171,7 @@ public class DepositsFetcherTest {
     // So it halves the batch size and retries
     asyncRunner.executeQueuedActions();
     final BigInteger endSuccessfulRange =
-        fromBlockNumber.add(BigInteger.valueOf(DEFAULT_BATCH_SIZE / 2));
+        fromBlockNumber.add(BigInteger.valueOf(MAX_BLOCK_RANGE / 2));
     verify(depositContract)
         .depositEventInRange(
             refEq(DefaultBlockParameter.valueOf(fromBlockNumber)),

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -89,7 +89,8 @@ public class PowchainService extends Service {
             eth1EventsPublisher,
             depositContractAccessor.getContract(),
             eth1BlockFetcher,
-            asyncRunner);
+            asyncRunner,
+            tekuConfig.getEth1LogsMaxBlockRange());
 
     headTracker = new Eth1HeadTracker(asyncRunner, eth1Provider);
     final DepositProcessingController depositProcessingController =

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -351,6 +351,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setInteropEnabled(interopOptions.isInteropEnabled())
         .setEth1DepositContractAddress(depositOptions.getEth1DepositContractAddress())
         .setEth1Endpoint(depositOptions.getEth1Endpoint())
+        .setEth1LogsMaxBlockRange(depositOptions.getEth1LogsMaxBlockRange())
         .setEth1DepositsFromStorageEnabled(depositOptions.isEth1DepositsFromStorageEnabled())
         .setLogColorEnabled(loggingOptions.isLogColorEnabled())
         .setLogIncludeEventsEnabled(loggingOptions.isLogIncludeEventsEnabled())

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
@@ -45,11 +45,10 @@ public class DepositOptions {
   private boolean eth1DepositsFromStorageEnabled = true;
 
   @Option(
-      hidden = true,
-      names = {"--Xeth1-logs-max-block-range"},
+      names = {"--eth1-deposit-contract-max-request-size"},
       paramLabel = "<INTEGER>",
       description =
-          "Maximum number of blocks to request deposit event logs for in a single request.",
+          "Maximum number of blocks to request deposit contract event logs for in a single request.",
       arity = "1")
   private int eth1LogsMaxBlockRange = 10_000;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
@@ -44,12 +44,25 @@ public class DepositOptions {
       arity = "0..1")
   private boolean eth1DepositsFromStorageEnabled = true;
 
+  @Option(
+      hidden = true,
+      names = {"--Xeth1-logs-max-block-range"},
+      paramLabel = "<INTEGER>",
+      description =
+          "Maximum number of blocks to request deposit event logs for in a single request.",
+      arity = "1")
+  private int eth1LogsMaxBlockRange = 10_000;
+
   public Eth1Address getEth1DepositContractAddress() {
     return eth1DepositContractAddress;
   }
 
   public String getEth1Endpoint() {
     return eth1Endpoint;
+  }
+
+  public int getEth1LogsMaxBlockRange() {
+    return eth1LogsMaxBlockRange;
   }
 
   public boolean isEth1DepositsFromStorageEnabled() {

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -403,6 +403,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setInteropEnabled(true)
         .setEth1DepositContractAddress(address)
         .setEth1Endpoint("http://localhost:8545")
+        .setEth1LogsMaxBlockRange(10_000)
         .setEth1DepositsFromStorageEnabled(true)
         .setMetricsEnabled(false)
         .setMetricsPort(8008)

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
@@ -43,6 +43,7 @@ public class GlobalConfiguration implements MetricsConfig {
   private final String eth1Endpoint;
   private final boolean eth1DepositsFromStorageEnabled;
   private final Optional<UInt64> eth1DepositContractDeployBlock;
+  private final int eth1LogsMaxBlockRange;
 
   // Logging
   private final boolean logColorEnabled;
@@ -102,6 +103,7 @@ public class GlobalConfiguration implements MetricsConfig {
       final Eth1Address eth1DepositContractAddress,
       final String eth1Endpoint,
       final Optional<UInt64> eth1DepositContractDeployBlock,
+      final int eth1LogsMaxBlockRange,
       final boolean eth1DepositsFromStorageEnabled,
       final boolean logColorEnabled,
       final boolean logIncludeEventsEnabled,
@@ -144,6 +146,7 @@ public class GlobalConfiguration implements MetricsConfig {
     this.eth1DepositContractAddress = eth1DepositContractAddress;
     this.eth1Endpoint = eth1Endpoint;
     this.eth1DepositContractDeployBlock = eth1DepositContractDeployBlock;
+    this.eth1LogsMaxBlockRange = eth1LogsMaxBlockRange;
     this.eth1DepositsFromStorageEnabled = eth1DepositsFromStorageEnabled;
     this.logColorEnabled = logColorEnabled;
     this.logIncludeEventsEnabled = logIncludeEventsEnabled;
@@ -232,6 +235,10 @@ public class GlobalConfiguration implements MetricsConfig {
 
   public Optional<UInt64> getEth1DepositContractDeployBlock() {
     return eth1DepositContractDeployBlock;
+  }
+
+  public int getEth1LogsMaxBlockRange() {
+    return eth1LogsMaxBlockRange;
   }
 
   public String getEth1Endpoint() {

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
@@ -39,6 +39,7 @@ public class GlobalConfigurationBuilder {
   private Eth1Address eth1DepositContractAddress;
   private String eth1Endpoint;
   private Optional<UInt64> eth1DepositContractDeployBlock = Optional.empty();
+  private int eth1LogsMaxBlockRange;
   private boolean eth1DepositsFromStorageEnabled;
   private boolean logColorEnabled;
   private boolean logIncludeEventsEnabled;
@@ -137,6 +138,11 @@ public class GlobalConfigurationBuilder {
   public GlobalConfigurationBuilder setEth1DepositContractDeployBlock(
       final Optional<UInt64> eth1DepositContractDeployBlock) {
     this.eth1DepositContractDeployBlock = eth1DepositContractDeployBlock;
+    return this;
+  }
+
+  public GlobalConfigurationBuilder setEth1LogsMaxBlockRange(final int eth1LogsMaxBlockRange) {
+    this.eth1LogsMaxBlockRange = eth1LogsMaxBlockRange;
     return this;
   }
 
@@ -328,6 +334,7 @@ public class GlobalConfigurationBuilder {
         eth1DepositContractAddress,
         eth1Endpoint,
         eth1DepositContractDeployBlock,
+        eth1LogsMaxBlockRange,
         eth1DepositsFromStorageEnabled,
         logColorEnabled,
         logIncludeEventsEnabled,


### PR DESCRIPTION
## PR Description
To provide more flexibility with eth1 nodes that are unable to respond to deposit log requests in time, make the `--eth1-deposit-contract-max-request-size` option.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.