### PR TITLE
Clean up async apis

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/AsyncRunner.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/AsyncRunner.java
@@ -17,7 +17,6 @@ import com.google.common.base.Preconditions;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 public interface AsyncRunner {
 
@@ -25,10 +24,10 @@ public interface AsyncRunner {
     return runAsync(() -> SafeFuture.fromRunnable(action));
   }
 
-  <U> SafeFuture<U> runAsync(final Supplier<SafeFuture<U>> action);
+  <U> SafeFuture<U> runAsync(final ExceptionThrowingFutureSupplier<U> action);
 
   <U> SafeFuture<U> runAfterDelay(
-      Supplier<SafeFuture<U>> action, long delayAmount, TimeUnit delayUnit);
+      ExceptionThrowingFutureSupplier<U> action, long delayAmount, TimeUnit delayUnit);
 
   void shutdown();
 

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -80,15 +80,6 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     }
   }
 
-  public static <U> SafeFuture<U> ofComposed(
-      final ExceptionThrowingFutureSupplier<U> futureSupplier) {
-    try {
-      return SafeFuture.of(futureSupplier.get());
-    } catch (final Throwable e) {
-      return SafeFuture.failedFuture(e);
-    }
-  }
-
   /**
    * Creates a completed {@link SafeFuture} instance if none of the supplied interruptors are
    * completed, else creates an exceptionally completed {@link SafeFuture} instance

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -81,7 +81,7 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   }
 
   public static <U> SafeFuture<U> ofComposed(
-      final ExceptionThrowingSupplier<CompletionStage<U>> futureSupplier) {
+      final ExceptionThrowingFutureSupplier<U> futureSupplier) {
     try {
       return SafeFuture.of(futureSupplier.get());
     } catch (final Throwable e) {

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
@@ -117,6 +117,6 @@ public class ScheduledExecutorAsyncRunner implements AsyncRunner {
 
   private <U> Runnable createRunnableForAction(
       final ExceptionThrowingFutureSupplier<U> action, final SafeFuture<U> result) {
-    return () -> SafeFuture.ofComposed(action::get).propagateTo(result);
+    return () -> SafeFuture.ofComposed(action).propagateTo(result);
   }
 }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
@@ -117,6 +117,6 @@ public class ScheduledExecutorAsyncRunner implements AsyncRunner {
 
   private <U> Runnable createRunnableForAction(
       final ExceptionThrowingFutureSupplier<U> action, final SafeFuture<U> result) {
-    return () -> SafeFuture.ofComposed(action).propagateTo(result);
+    return () -> SafeFuture.of(action).propagateTo(result);
   }
 }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
@@ -20,7 +20,6 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -58,7 +57,7 @@ public class ScheduledExecutorAsyncRunner implements AsyncRunner {
   }
 
   @Override
-  public <U> SafeFuture<U> runAsync(final Supplier<SafeFuture<U>> action) {
+  public <U> SafeFuture<U> runAsync(final ExceptionThrowingFutureSupplier<U> action) {
     if (shutdown.get()) {
       LOG.debug("Ignoring async task because shutdown is in progress");
       return new SafeFuture<>();
@@ -75,7 +74,9 @@ public class ScheduledExecutorAsyncRunner implements AsyncRunner {
   @Override
   @SuppressWarnings("FutureReturnValueIgnored")
   public <U> SafeFuture<U> runAfterDelay(
-      final Supplier<SafeFuture<U>> action, final long delayAmount, final TimeUnit delayUnit) {
+      final ExceptionThrowingFutureSupplier<U> action,
+      final long delayAmount,
+      final TimeUnit delayUnit) {
     if (shutdown.get()) {
       LOG.debug("Ignoring async task because shutdown is in progress");
       return new SafeFuture<>();
@@ -115,7 +116,7 @@ public class ScheduledExecutorAsyncRunner implements AsyncRunner {
   }
 
   private <U> Runnable createRunnableForAction(
-      final Supplier<SafeFuture<U>> action, final SafeFuture<U> result) {
+      final ExceptionThrowingFutureSupplier<U> action, final SafeFuture<U> result) {
     return () -> SafeFuture.ofComposed(action::get).propagateTo(result);
   }
 }

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/DelayedExecutorAsyncRunnerTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/DelayedExecutorAsyncRunnerTest.java
@@ -28,7 +28,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -44,10 +43,11 @@ public class DelayedExecutorAsyncRunnerTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void runAsync_shouldExecuteActionWithExecutorAndReturnResult() {
+  public void runAsync_shouldExecuteActionWithExecutorAndReturnResult() throws Throwable {
     final SafeFuture<String> actionResult = new SafeFuture<>();
     final Executor executor = mock(Executor.class);
-    final Supplier<SafeFuture<String>> action = mock(Supplier.class);
+    final ExceptionThrowingFutureSupplier<String> action =
+        mock(ExceptionThrowingFutureSupplier.class);
     when(action.get()).thenReturn(actionResult);
 
     final SafeFuture<String> result = asyncRunner.runAsync(action, executor);
@@ -66,10 +66,12 @@ public class DelayedExecutorAsyncRunnerTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void runAsync_shouldExecuteActionWithExecutorAndReturnExceptionalResult() {
+  public void runAsync_shouldExecuteActionWithExecutorAndReturnExceptionalResult()
+      throws Throwable {
     final SafeFuture<String> actionResult = new SafeFuture<>();
     final Executor executor = mock(Executor.class);
-    final Supplier<SafeFuture<String>> action = mock(Supplier.class);
+    final ExceptionThrowingFutureSupplier<String> action =
+        mock(ExceptionThrowingFutureSupplier.class);
     when(action.get()).thenReturn(actionResult);
 
     final SafeFuture<String> result = asyncRunner.runAsync(action, executor);
@@ -89,9 +91,10 @@ public class DelayedExecutorAsyncRunnerTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void runAsync_shouldCompleteExceptionallyWhenExecutorFails() {
+  public void runAsync_shouldCompleteExceptionallyWhenExecutorFails() throws Throwable {
     final Executor executor = mock(Executor.class);
-    final Supplier<SafeFuture<String>> action = mock(Supplier.class);
+    final ExceptionThrowingFutureSupplier<String> action =
+        mock(ExceptionThrowingFutureSupplier.class);
     final RuntimeException exception = new RuntimeException("Nope");
     doThrow(exception).when(executor).execute(any());
 
@@ -114,7 +117,7 @@ public class DelayedExecutorAsyncRunnerTest {
             executorException.set(t);
           }
         };
-    final Supplier<SafeFuture<String>> action =
+    final ExceptionThrowingFutureSupplier<String> action =
         () -> {
           throw exception;
         };

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
@@ -185,7 +185,7 @@ public class SafeFutureTest {
     final SafeFuture<Void> suppliedFuture = new SafeFuture<>();
     final AtomicBoolean supplierWasProcessed = new AtomicBoolean(false);
     final SafeFuture<Void> future =
-        SafeFuture.ofComposed(
+        SafeFuture.of(
             () -> {
               supplierWasProcessed.set(true);
               return suppliedFuture;
@@ -202,7 +202,7 @@ public class SafeFutureTest {
     final AtomicBoolean supplierWasProcessed = new AtomicBoolean(false);
     final Throwable error = new IOException("failed");
     final SafeFuture<Void> future =
-        SafeFuture.ofComposed(
+        SafeFuture.of(
             () -> {
               supplierWasProcessed.set(true);
               throw error;

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunnerTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunnerTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,9 +70,10 @@ class ScheduledExecutorAsyncRunnerTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void runAsync_shouldExecuteActionWithExecutorAndReturnResult() {
+  public void runAsync_shouldExecuteActionWithExecutorAndReturnResult() throws Throwable {
     final SafeFuture<String> actionResult = new SafeFuture<>();
-    final Supplier<SafeFuture<String>> action = mock(Supplier.class);
+    final ExceptionThrowingFutureSupplier<String> action =
+        mock(ExceptionThrowingFutureSupplier.class);
     when(action.get()).thenReturn(actionResult);
 
     final SafeFuture<String> result = asyncRunner.runAsync(action);
@@ -87,9 +87,11 @@ class ScheduledExecutorAsyncRunnerTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void runAsync_shouldExecuteActionWithExecutorAndReturnExceptionalResult() {
+  public void runAsync_shouldExecuteActionWithExecutorAndReturnExceptionalResult()
+      throws Throwable {
     final SafeFuture<String> actionResult = new SafeFuture<>();
-    final Supplier<SafeFuture<String>> action = mock(Supplier.class);
+    final ExceptionThrowingFutureSupplier<String> action =
+        mock(ExceptionThrowingFutureSupplier.class);
     when(action.get()).thenReturn(actionResult);
 
     final SafeFuture<String> result = asyncRunner.runAsync(action);
@@ -104,8 +106,9 @@ class ScheduledExecutorAsyncRunnerTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void runAsync_shouldCompleteExceptionallyWhenExecutorFails() {
-    final Supplier<SafeFuture<String>> action = mock(Supplier.class);
+  public void runAsync_shouldCompleteExceptionallyWhenExecutorFails() throws Throwable {
+    final ExceptionThrowingFutureSupplier<String> action =
+        mock(ExceptionThrowingFutureSupplier.class);
     final RuntimeException exception = new RuntimeException("Nope");
     doThrow(exception).when(workerPool).execute(any());
 
@@ -118,7 +121,7 @@ class ScheduledExecutorAsyncRunnerTest {
   @Test
   void runAsyc_shouldCompleteExceptionallyWhenSupplierThrowsException() {
     final RuntimeException exception = new RuntimeException("My bad...");
-    final Supplier<SafeFuture<String>> action =
+    final ExceptionThrowingFutureSupplier<String> action =
         () -> {
           throw exception;
         };

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/DelayedExecutorAsyncRunner.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/DelayedExecutorAsyncRunner.java
@@ -58,7 +58,7 @@ public class DelayedExecutorAsyncRunner implements AsyncRunner {
       final ExceptionThrowingFutureSupplier<U> action, final Executor executor) {
     final SafeFuture<U> result = new SafeFuture<>();
     try {
-      executor.execute(() -> SafeFuture.ofComposed(action::get).propagateTo(result));
+      executor.execute(() -> SafeFuture.ofComposed(action).propagateTo(result));
     } catch (final RejectedExecutionException ex) {
       LOG.debug("shutting down ", ex);
     } catch (final Throwable t) {

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/DelayedExecutorAsyncRunner.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/DelayedExecutorAsyncRunner.java
@@ -58,7 +58,7 @@ public class DelayedExecutorAsyncRunner implements AsyncRunner {
       final ExceptionThrowingFutureSupplier<U> action, final Executor executor) {
     final SafeFuture<U> result = new SafeFuture<>();
     try {
-      executor.execute(() -> SafeFuture.ofComposed(action).propagateTo(result));
+      executor.execute(() -> SafeFuture.of(action).propagateTo(result));
     } catch (final RejectedExecutionException ex) {
       LOG.debug("shutting down ", ex);
     } catch (final Throwable t) {

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/DelayedExecutorAsyncRunner.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/DelayedExecutorAsyncRunner.java
@@ -18,7 +18,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -39,14 +38,14 @@ public class DelayedExecutorAsyncRunner implements AsyncRunner {
   }
 
   @Override
-  public <U> SafeFuture<U> runAsync(final Supplier<SafeFuture<U>> action) {
+  public <U> SafeFuture<U> runAsync(final ExceptionThrowingFutureSupplier<U> action) {
     final Executor executor = getAsyncExecutor();
     return runAsync(action, executor);
   }
 
   @Override
   public <U> SafeFuture<U> runAfterDelay(
-      Supplier<SafeFuture<U>> action, long delayAmount, TimeUnit delayUnit) {
+      ExceptionThrowingFutureSupplier<U> action, long delayAmount, TimeUnit delayUnit) {
     final Executor executor = getDelayedExecutor(delayAmount, delayUnit);
     return runAsync(action, executor);
   }
@@ -55,7 +54,8 @@ public class DelayedExecutorAsyncRunner implements AsyncRunner {
   public void shutdown() {}
 
   @VisibleForTesting
-  <U> SafeFuture<U> runAsync(final Supplier<SafeFuture<U>> action, final Executor executor) {
+  <U> SafeFuture<U> runAsync(
+      final ExceptionThrowingFutureSupplier<U> action, final Executor executor) {
     final SafeFuture<U> result = new SafeFuture<>();
     try {
       executor.execute(() -> SafeFuture.ofComposed(action::get).propagateTo(result));

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/StubAsyncRunner.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/StubAsyncRunner.java
@@ -21,7 +21,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
@@ -40,13 +39,13 @@ public class StubAsyncRunner implements AsyncRunner {
   }
 
   @Override
-  public <U> SafeFuture<U> runAsync(final Supplier<SafeFuture<U>> action) {
+  public <U> SafeFuture<U> runAsync(final ExceptionThrowingFutureSupplier<U> action) {
     // Schedule for immediate execution
     return schedule(action, 0L);
   }
 
   private <U> SafeFuture<U> schedule(
-      final Supplier<SafeFuture<U>> action, final long scheduledTimeMillis) {
+      final ExceptionThrowingFutureSupplier<U> action, final long scheduledTimeMillis) {
     final SafeFuture<U> result = new SafeFuture<>();
     queuedActions.add(
         new Task(
@@ -63,7 +62,7 @@ public class StubAsyncRunner implements AsyncRunner {
 
   @Override
   public <U> SafeFuture<U> runAfterDelay(
-      Supplier<SafeFuture<U>> action, long delayAmount, TimeUnit delayUnit) {
+      ExceptionThrowingFutureSupplier<U> action, long delayAmount, TimeUnit delayUnit) {
     return schedule(
         action, timeProvider.getTimeInMillis().longValue() + delayUnit.toMillis(delayAmount));
   }

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/SyncAsyncRunner.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/SyncAsyncRunner.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.infrastructure.async;
 
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 public class SyncAsyncRunner implements AsyncRunner {
   public static final SyncAsyncRunner SYNC_RUNNER = new SyncAsyncRunner();
@@ -22,13 +21,15 @@ public class SyncAsyncRunner implements AsyncRunner {
   private SyncAsyncRunner() {}
 
   @Override
-  public <U> SafeFuture<U> runAsync(final Supplier<SafeFuture<U>> action) {
+  public <U> SafeFuture<U> runAsync(final ExceptionThrowingFutureSupplier<U> action) {
     return SafeFuture.ofComposed(action::get);
   }
 
   @Override
   public <U> SafeFuture<U> runAfterDelay(
-      final Supplier<SafeFuture<U>> action, final long delayAmount, final TimeUnit delayUnit) {
+      final ExceptionThrowingFutureSupplier<U> action,
+      final long delayAmount,
+      final TimeUnit delayUnit) {
     throw new UnsupportedOperationException(
         "Delayed execution not possible using " + SyncAsyncRunner.class.getName());
   }

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/SyncAsyncRunner.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/SyncAsyncRunner.java
@@ -22,7 +22,7 @@ public class SyncAsyncRunner implements AsyncRunner {
 
   @Override
   public <U> SafeFuture<U> runAsync(final ExceptionThrowingFutureSupplier<U> action) {
-    return SafeFuture.ofComposed(action);
+    return SafeFuture.of(action);
   }
 
   @Override

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/SyncAsyncRunner.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/SyncAsyncRunner.java
@@ -22,7 +22,7 @@ public class SyncAsyncRunner implements AsyncRunner {
 
   @Override
   public <U> SafeFuture<U> runAsync(final ExceptionThrowingFutureSupplier<U> action) {
-    return SafeFuture.ofComposed(action::get);
+    return SafeFuture.ofComposed(action);
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -160,7 +160,7 @@ public class ExternalSigner implements Signer {
       final Map<String, Object> metadata,
       final Supplier<String> slashableMessage) {
     final String publicKey = blsPublicKey.toBytesCompressed().toString();
-    return SafeFuture.ofComposed(
+    return SafeFuture.of(
         () -> {
           final String requestBody = createSigningRequestBody(signingRoot, type, metadata);
           final URI uri =


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Minor clean-up of async APIs:
* Update `AsyncRunner` to accept exception-throwing future suppliers
* Cut duplicate method `SafeFuture.ofComposed()` in favor of existing `SafeFuture.of()` method

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.