### PR TITLE
[Issue 3337] Be more tolerant of missing eth1 blocks

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/AsyncRunner.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/AsyncRunner.java
@@ -72,15 +72,15 @@ public interface AsyncRunner {
   }
 
   /**
-   * Execute the future supplier until it succeeds up to some maximum number of retries.
+   * Execute the future supplier until it completes normally up to some maximum number of retries.
    *
    * @param action The action to run
    * @param retryDelay The time to wait before retrying
    * @param maxRetries The maximum number of retries. A value of 0 means the action is run only once
    *     (no retries).
-   * @param <T> The value return by the action future
-   * @return A future that resolve with the first successful result, or else an error if the maximum
-   *     retries are exhausted.
+   * @param <T> The value returned by the action future
+   * @return A future that resolves with the first successful result, or else an error if the
+   *     maximum retries are exhausted.
    */
   default <T> SafeFuture<T> runWithRetry(
       final ExceptionThrowingFutureSupplier<T> action,

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/AsyncRunnerTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/AsyncRunnerTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+public class AsyncRunnerTest {
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+
+  @Test
+  public void runWithRetry_successOnFirstRun() {
+    final AtomicInteger runCounter = new AtomicInteger(0);
+    final ExceptionThrowingFutureSupplier<Integer> futureSupplier =
+        () -> SafeFuture.completedFuture(runCounter.incrementAndGet());
+
+    final SafeFuture<Integer> res =
+        asyncRunner.runWithRetry(futureSupplier, Duration.ofSeconds(5), 10);
+
+    // We should complete immediately without any upfront retry delay
+    assertThat(res).isCompletedWithValue(1);
+    assertThat(runCounter.get()).isEqualTo(1);
+    assertThat(asyncRunner.countDelayedActions()).isEqualTo(0);
+  }
+
+  @Test
+  public void runWithRetry_successAfterRetry() {
+    final AtomicInteger runCounter = new AtomicInteger(0);
+    final ExceptionThrowingFutureSupplier<Integer> futureSupplier =
+        () -> {
+          final int runs = runCounter.incrementAndGet();
+          if (runs == 1) {
+            // Fail on the first run
+            return SafeFuture.failedFuture(new RuntimeException("Failed"));
+          } else {
+            return SafeFuture.completedFuture(runs);
+          }
+        };
+
+    final SafeFuture<Integer> res =
+        asyncRunner.runWithRetry(futureSupplier, Duration.ofSeconds(5), 10);
+
+    // We should not complete immediately - instead a retry should be queued
+    assertThat(res).isNotDone();
+    assertThat(asyncRunner.countDelayedActions()).isEqualTo(1);
+
+    // Run retry
+    asyncRunner.executeQueuedActions();
+
+    // We should complete on the first retry
+    assertThat(res).isCompletedWithValue(2);
+    assertThat(runCounter.get()).isEqualTo(2);
+    assertThat(asyncRunner.countDelayedActions()).isEqualTo(0);
+  }
+
+  @Test
+  public void runWithRetry_successOnLastRetry() {
+    final AtomicInteger runCounter = new AtomicInteger(0);
+    final ExceptionThrowingFutureSupplier<Integer> futureSupplier =
+        () -> {
+          final int runs = runCounter.incrementAndGet();
+          if (runs < 3) {
+            // Fail on the first run
+            return SafeFuture.failedFuture(new RuntimeException("Failed"));
+          } else {
+            return SafeFuture.completedFuture(runs);
+          }
+        };
+
+    final SafeFuture<Integer> res =
+        asyncRunner.runWithRetry(futureSupplier, Duration.ofSeconds(5), 2);
+
+    // We should retry twice
+    for (int i = 0; i < 2; i++) {
+      // A retry should be queued
+      assertThat(res).isNotDone();
+      assertThat(asyncRunner.countDelayedActions()).isEqualTo(1);
+
+      // Run retry
+      asyncRunner.executeQueuedActions();
+    }
+
+    // We should complete successfully after retrying
+    assertThat(res).isCompletedWithValue(3);
+    assertThat(runCounter.get()).isEqualTo(3);
+    assertThat(asyncRunner.countDelayedActions()).isEqualTo(0);
+  }
+
+  @Test
+  public void runWithRetry_failOnEveryRetry() {
+    final AtomicInteger runCounter = new AtomicInteger(0);
+    final ExceptionThrowingFutureSupplier<Integer> futureSupplier =
+        () -> {
+          final int runs = runCounter.incrementAndGet();
+          return SafeFuture.failedFuture(new RuntimeException("Failed run #" + runs));
+        };
+
+    final SafeFuture<Integer> res =
+        asyncRunner.runWithRetry(futureSupplier, Duration.ofSeconds(5), 2);
+
+    // We should retry twice
+    for (int i = 0; i < 2; i++) {
+      // A retry should be queued
+      assertThat(res).isNotDone();
+      assertThat(asyncRunner.countDelayedActions()).isEqualTo(1);
+
+      // Run retry
+      asyncRunner.executeQueuedActions();
+    }
+
+    // We should complete successfully after retrying
+    assertThat(res).isCompletedExceptionally();
+    assertThat(runCounter.get()).isEqualTo(3);
+    assertThat(asyncRunner.countDelayedActions()).isEqualTo(0);
+    assertThatThrownBy(res::get)
+        .hasCauseInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failed run #3");
+  }
+}

--- a/pow/src/main/java/tech/pegasys/teku/pow/ErrorTrackingEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/ErrorTrackingEth1Provider.java
@@ -45,7 +45,7 @@ public class ErrorTrackingEth1Provider implements Eth1Provider {
   }
 
   @Override
-  public SafeFuture<EthBlock.Block> getEth1BlockWithRetry(
+  public SafeFuture<Optional<EthBlock.Block>> getEth1BlockWithRetry(
       final String blockHash, final Duration retryDuration, final int maxRetries) {
     return delegate.getEth1BlockWithRetry(blockHash, retryDuration, maxRetries);
   }

--- a/pow/src/main/java/tech/pegasys/teku/pow/ErrorTrackingEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/ErrorTrackingEth1Provider.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.pow;
 
 import java.math.BigInteger;
+import java.util.Optional;
 import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.EthCall;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -33,12 +34,12 @@ public class ErrorTrackingEth1Provider implements Eth1Provider {
   }
 
   @Override
-  public SafeFuture<EthBlock.Block> getEth1Block(final UInt64 blockNumber) {
+  public SafeFuture<Optional<EthBlock.Block>> getEth1Block(final UInt64 blockNumber) {
     return logStatus(delegate.getEth1Block(blockNumber));
   }
 
   @Override
-  public SafeFuture<EthBlock.Block> getEth1Block(final String blockHash) {
+  public SafeFuture<Optional<EthBlock.Block>> getEth1Block(final String blockHash) {
     return logStatus(delegate.getEth1Block(blockHash));
   }
 

--- a/pow/src/main/java/tech/pegasys/teku/pow/ErrorTrackingEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/ErrorTrackingEth1Provider.java
@@ -40,14 +40,20 @@ public class ErrorTrackingEth1Provider implements Eth1Provider {
   }
 
   @Override
+  public SafeFuture<Optional<EthBlock.Block>> getEth1BlockWithRetry(
+      final UInt64 blockNumber, final Duration retryDelay, final int maxRetries) {
+    return logStatus(delegate.getEth1BlockWithRetry(blockNumber, retryDelay, maxRetries));
+  }
+
+  @Override
   public SafeFuture<Optional<EthBlock.Block>> getEth1Block(final String blockHash) {
     return logStatus(delegate.getEth1Block(blockHash));
   }
 
   @Override
   public SafeFuture<Optional<EthBlock.Block>> getEth1BlockWithRetry(
-      final String blockHash, final Duration retryDuration, final int maxRetries) {
-    return delegate.getEth1BlockWithRetry(blockHash, retryDuration, maxRetries);
+      final String blockHash, final Duration retryDelay, final int maxRetries) {
+    return delegate.getEth1BlockWithRetry(blockHash, retryDelay, maxRetries);
   }
 
   @Override

--- a/pow/src/main/java/tech/pegasys/teku/pow/ErrorTrackingEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/ErrorTrackingEth1Provider.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.pow;
 
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.Optional;
 import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.EthCall;
@@ -41,6 +42,12 @@ public class ErrorTrackingEth1Provider implements Eth1Provider {
   @Override
   public SafeFuture<Optional<EthBlock.Block>> getEth1Block(final String blockHash) {
     return logStatus(delegate.getEth1Block(blockHash));
+  }
+
+  @Override
+  public SafeFuture<EthBlock.Block> getEth1BlockWithRetry(
+      final String blockHash, final Duration retryDuration, final int maxRetries) {
+    return delegate.getEth1BlockWithRetry(blockHash, retryDuration, maxRetries);
   }
 
   @Override

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1BlockFetcher.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1BlockFetcher.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.math.BigInteger;
 import java.util.NavigableSet;
+import java.util.Optional;
 import java.util.TreeSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -101,6 +102,7 @@ public class Eth1BlockFetcher {
     LOG.debug("Requesting block {}", blockNumberToRequest);
     return eth1Provider
         .getEth1Block(blockNumberToRequest)
+        .thenApply(Optional::get)
         .thenAccept(
             block -> {
               if (isAboveLowerBound(UInt64.valueOf(block.getTimestamp()))) {

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1Provider.java
@@ -25,10 +25,17 @@ public interface Eth1Provider {
 
   SafeFuture<Optional<Block>> getEth1Block(UInt64 blockNumber);
 
+  SafeFuture<Optional<Block>> getEth1BlockWithRetry(
+      UInt64 blockNumber, Duration retryDelay, int maxRetries);
+
+  default SafeFuture<Optional<Block>> getEth1BlockWithRetry(UInt64 blockNumber) {
+    return getEth1BlockWithRetry(blockNumber, Duration.ofSeconds(5), 2);
+  }
+
   SafeFuture<Optional<Block>> getEth1Block(String blockHash);
 
   SafeFuture<Optional<Block>> getEth1BlockWithRetry(
-      String blockHash, Duration retryDuration, int maxRetries);
+      String blockHash, Duration retryDelay, int maxRetries);
 
   default SafeFuture<Optional<Block>> getEth1BlockWithRetry(String blockHash) {
     return getEth1BlockWithRetry(blockHash, Duration.ofSeconds(5), 2);

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1Provider.java
@@ -27,7 +27,12 @@ public interface Eth1Provider {
 
   SafeFuture<Optional<Block>> getEth1Block(String blockHash);
 
-  SafeFuture<Block> getEth1BlockWithRetry(String blockHash, Duration retryDuration, int maxRetries);
+  SafeFuture<Optional<Block>> getEth1BlockWithRetry(
+      String blockHash, Duration retryDuration, int maxRetries);
+
+  default SafeFuture<Optional<Block>> getEth1BlockWithRetry(String blockHash) {
+    return getEth1BlockWithRetry(blockHash, Duration.ofSeconds(5), 2);
+  }
 
   SafeFuture<Block> getGuaranteedEth1Block(String blockHash);
 

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1Provider.java
@@ -27,6 +27,8 @@ public interface Eth1Provider {
 
   SafeFuture<Optional<Block>> getEth1Block(String blockHash);
 
+  SafeFuture<Block> getEth1BlockWithRetry(String blockHash, Duration retryDuration, int maxRetries);
+
   SafeFuture<Block> getGuaranteedEth1Block(String blockHash);
 
   SafeFuture<Block> getGuaranteedEth1Block(UInt64 blockNumber);

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1Provider.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.pow;
 
 import java.math.BigInteger;
+import java.time.Duration;
+import java.util.Optional;
 import org.web3j.protocol.core.methods.response.EthBlock.Block;
 import org.web3j.protocol.core.methods.response.EthCall;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -21,9 +23,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface Eth1Provider {
 
-  SafeFuture<Block> getEth1Block(UInt64 blockNumber);
+  SafeFuture<Optional<Block>> getEth1Block(UInt64 blockNumber);
 
-  SafeFuture<Block> getEth1Block(String blockHash);
+  SafeFuture<Optional<Block>> getEth1Block(String blockHash);
 
   SafeFuture<Block> getGuaranteedEth1Block(String blockHash);
 

--- a/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
@@ -132,9 +132,7 @@ public class MinimumGenesisTimeBlockFinder {
 
   private boolean blockIsAtMinimalMinGenesisPosition(final EthBlock.Block block) {
     final UInt64 candidateBlockNumber = UInt64.valueOf(block.getNumber());
-    return eth1DepositContractDeployBlock
-            .map(b -> b.isGreaterThanOrEqualTo(candidateBlockNumber))
-            .orElse(false)
+    return eth1DepositContractDeployBlock.map(b -> b.equals(candidateBlockNumber)).orElse(false)
         || candidateBlockNumber.equals(ZERO)
         || blockIsAtMinGenesis(block);
   }

--- a/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
@@ -113,7 +113,7 @@ public class MinimumGenesisTimeBlockFinder {
     if (searchContext.low.compareTo(searchContext.high) <= 0) {
       final UInt64 mid = searchContext.low.plus(searchContext.high).dividedBy(TWO);
       return eth1Provider
-          .getEth1Block(mid)
+          .getEth1BlockWithRetry(mid)
           .thenCompose(
               maybeMidBlock -> {
                 if (maybeMidBlock.isEmpty()) {
@@ -142,7 +142,7 @@ public class MinimumGenesisTimeBlockFinder {
               });
     } else {
       // Completed search
-      return eth1Provider.getEth1Block(searchContext.low).thenApply(Optional::get);
+      return eth1Provider.getEth1BlockWithRetry(searchContext.low).thenApply(Optional::get);
     }
   }
 

--- a/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
@@ -189,11 +189,12 @@ public class MinimumGenesisTimeBlockFinder {
   private void assertBlockIsAtOrAfterMinGenesis(final EthBlock.Block block) {
     checkArgument(
         blockIsAtOrAfterMinGenesis(block),
-        "Invalid candidate minimum genesis block (#: %s, hash: %s, timestamp; %s) is prior to MIN_GENESIS_TIME + GENESIS_DELAY (%s)",
+        "Invalid candidate minimum genesis block (#: %s, hash: %s, timestamp; %s) is prior to MIN_GENESIS_TIME (%s) - GENESIS_DELAY (%s)",
         block.getNumber(),
         block.getHash(),
         block.getTimestamp(),
-        Constants.MIN_GENESIS_TIME.plus(Constants.GENESIS_DELAY));
+        Constants.MIN_GENESIS_TIME,
+        Constants.GENESIS_DELAY);
   }
 
   private boolean blockIsAtMinGenesis(final EthBlock.Block block) {

--- a/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
@@ -62,8 +62,8 @@ public class MinimumGenesisTimeBlockFinder {
 
   /**
    * The binary search may return a block that is too new (if historical blocks are unavailable
-   * during the search), so walk back though chain to confirm or else pull the correct min genesis
-   * block.
+   * during the search), so pull the candidate's parent block to confirm that we actually found the
+   * min genesis block.
    *
    * @param candidate A candidate block that may be the min genesis block
    * @return The confirmed min genesis block

--- a/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
@@ -13,11 +13,16 @@
 
 package tech.pegasys.teku.pow;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -26,12 +31,14 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.api.Eth1EventsChannel;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
+import tech.pegasys.teku.pow.exception.FailedToFindMinGenesisBlockException;
 import tech.pegasys.teku.util.config.Constants;
 
 public class MinimumGenesisTimeBlockFinder {
 
   private static final Logger LOG = LogManager.getLogger();
 
+  private static final int MAX_ANCESTORS_TO_SEARCH = 500;
   private static final UInt64 TWO = UInt64.valueOf(2);
 
   private final Eth1Provider eth1Provider;
@@ -52,7 +59,84 @@ public class MinimumGenesisTimeBlockFinder {
   public SafeFuture<EthBlock.Block> findMinGenesisTimeBlockInHistory(
       final BigInteger headBlockNumber) {
     return binarySearchLoop(
-        new SearchContext(eth1DepositContractDeployBlock.orElse(ZERO), headBlockNumber));
+            new SearchContext(eth1DepositContractDeployBlock.orElse(ZERO), headBlockNumber))
+        .thenCompose(this::confirmOrFindMinGenesisBlock);
+  }
+
+  /**
+   * The binary search may return a block that is too new (if historical blocks are unavailable
+   * during the search), so walk back though chain to confirm or else pull the correct min genesis
+   * block.
+   *
+   * @param candidateMinGenesisBlock A candidate block that may be the min genesis block
+   * @return The confirmed min genesis block
+   */
+  @VisibleForTesting
+  SafeFuture<EthBlock.Block> confirmOrFindMinGenesisBlock(
+      final EthBlock.Block candidateMinGenesisBlock) {
+    assertBlockIsAtOrAfterMinGenesis(candidateMinGenesisBlock);
+    if (blockIsAtMinimalMinGenesisPosition(candidateMinGenesisBlock)) {
+      // We've found min genesis
+      return SafeFuture.completedFuture(candidateMinGenesisBlock);
+    }
+
+    final SafeFuture<EthBlock.Block> minGenesisFuture = new SafeFuture<>();
+
+    final AtomicReference<EthBlock.Block> currentMinGenesisCandidate =
+        new AtomicReference<>(candidateMinGenesisBlock);
+    final AtomicInteger examinedAncestorsCount = new AtomicInteger(0);
+    SafeFuture.asyncDoWhile(
+            () ->
+                eth1Provider
+                    .getEth1BlockWithRetry(
+                        currentMinGenesisCandidate.get().getParentHash(), Duration.ofSeconds(5), 3)
+                    .thenApply(
+                        parent -> {
+                          examinedAncestorsCount.incrementAndGet();
+                          if (blockIsPriorToMinGenesis(parent)) {
+                            // We've confirmed the current candidate is at the boundary
+                            minGenesisFuture.complete(currentMinGenesisCandidate.get());
+                            return false;
+                          } else if (blockIsAtMinGenesis(parent)) {
+                            // We've found the min genesis block
+                            minGenesisFuture.complete(parent);
+                            return false;
+                          } else {
+                            // The parent block is after min genesis
+                            // Keep searching through ancestors up to our limit
+                            if (examinedAncestorsCount.get() >= MAX_ANCESTORS_TO_SEARCH) {
+                              throw new IllegalStateException(
+                                  String.format(
+                                      "Unable to locate min genesis block after walking back through %s eth1 blocks to block #%s (%s)",
+                                      examinedAncestorsCount.get(),
+                                      parent.getNumber(),
+                                      parent.getHash()));
+                            }
+                            currentMinGenesisCandidate.set(parent);
+                            return true;
+                          }
+                        }))
+        .finish(
+            () ->
+                minGenesisFuture.completeExceptionally(
+                    new FailedToFindMinGenesisBlockException(
+                        "Failed to retrieve min genesis block.  Check that your eth1 node is fully synced.")),
+            (err) ->
+                minGenesisFuture.completeExceptionally(
+                    new FailedToFindMinGenesisBlockException(
+                        "Failed to retrieve min genesis block.  Check that your eth1 node is fully synced.",
+                        err)));
+
+    return minGenesisFuture;
+  }
+
+  private boolean blockIsAtMinimalMinGenesisPosition(final EthBlock.Block block) {
+    final UInt64 candidateBlockNumber = UInt64.valueOf(block.getNumber());
+    return eth1DepositContractDeployBlock
+            .map(b -> b.isGreaterThanOrEqualTo(candidateBlockNumber))
+            .orElse(false)
+        || candidateBlockNumber.equals(ZERO)
+        || blockIsAtMinGenesis(block);
   }
 
   private SafeFuture<EthBlock.Block> binarySearchLoop(final SearchContext searchContext) {
@@ -61,7 +145,15 @@ public class MinimumGenesisTimeBlockFinder {
       return eth1Provider
           .getEth1Block(mid)
           .thenCompose(
-              midBlock -> {
+              maybeMidBlock -> {
+                if (maybeMidBlock.isEmpty()) {
+                  // Some blocks are missing from the historical range, try to search among
+                  // more recent (presumably available) blocks
+                  searchContext.low = mid.plus(ONE);
+                  return binarySearchLoop(searchContext);
+                }
+
+                final EthBlock.Block midBlock = maybeMidBlock.get();
                 final int cmp = compareBlockTimestampToMinGenesisTime(midBlock);
                 if (cmp < 0) {
                   searchContext.low = mid.plus(ONE);
@@ -80,8 +172,30 @@ public class MinimumGenesisTimeBlockFinder {
               });
     } else {
       // Completed search
-      return eth1Provider.getEth1Block(searchContext.low);
+      return eth1Provider.getEth1Block(searchContext.low).thenApply(Optional::get);
     }
+  }
+
+  private void assertBlockIsAtOrAfterMinGenesis(final EthBlock.Block block) {
+    checkArgument(
+        blockIsAtOrAfterMinGenesis(block),
+        "Invalid candidate minimum genesis block (#: %s, hash: %s, timestamp; %s) is prior to MIN_GENESIS_TIME + GENESIS_DELAY (%s)",
+        block.getNumber(),
+        block.getHash(),
+        block.getTimestamp(),
+        Constants.MIN_GENESIS_TIME.plus(Constants.GENESIS_DELAY));
+  }
+
+  private boolean blockIsAtMinGenesis(final EthBlock.Block block) {
+    return compareBlockTimestampToMinGenesisTime(block) == 0;
+  }
+
+  private boolean blockIsPriorToMinGenesis(final EthBlock.Block block) {
+    return compareBlockTimestampToMinGenesisTime(block) < 0;
+  }
+
+  private boolean blockIsAtOrAfterMinGenesis(final EthBlock.Block block) {
+    return compareBlockTimestampToMinGenesisTime(block) >= 0;
   }
 
   static UInt64 calculateCandidateGenesisTimestamp(BigInteger eth1Timestamp) {

--- a/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
@@ -87,8 +87,11 @@ public class MinimumGenesisTimeBlockFinder {
               if (!blockIsPriorToMinGenesis(parent)) {
                 throw new IllegalStateException(
                     String.format(
-                        "Candidate min genesis block is too recent.  It's parent's timestamp (%s) must be prior to %s.",
-                        candidate.getTimestamp(), calculateMinGenesisTimeThreshold()));
+                        "Candidate min genesis block (#%s, %s) is too recent.  It's parent's timestamp (%s) must be prior to %s.",
+                        candidate.getNumber(),
+                        candidate.getHash(),
+                        parent.getTimestamp(),
+                        calculateMinGenesisTimeThreshold()));
               }
 
               traceWithBlock("Confirmed min genesis block: ", candidate);

--- a/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
@@ -95,6 +95,7 @@ public class MinimumGenesisTimeBlockFinder {
                 eth1Provider
                     .getEth1BlockWithRetry(
                         currentMinGenesisCandidate.get().getParentHash(), Duration.ofSeconds(5), 3)
+                    .thenApply(Optional::get)
                     .thenApply(
                         parent -> {
                           examinedAncestorsCount.incrementAndGet();

--- a/pow/src/main/java/tech/pegasys/teku/pow/ThrottlingEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/ThrottlingEth1Provider.java
@@ -41,6 +41,12 @@ public class ThrottlingEth1Provider implements Eth1Provider {
   }
 
   @Override
+  public SafeFuture<Optional<Block>> getEth1BlockWithRetry(
+      final UInt64 blockNumber, final Duration retryDelay, final int maxRetries) {
+    return queueRequest(() -> delegate.getEth1BlockWithRetry(blockNumber, retryDelay, maxRetries));
+  }
+
+  @Override
   public SafeFuture<Block> getGuaranteedEth1Block(final String blockHash) {
     return queueRequest(() -> delegate.getGuaranteedEth1Block(blockHash));
   }
@@ -57,8 +63,8 @@ public class ThrottlingEth1Provider implements Eth1Provider {
 
   @Override
   public SafeFuture<Optional<Block>> getEth1BlockWithRetry(
-      final String blockHash, final Duration retryDuration, final int maxRetries) {
-    return queueRequest(() -> delegate.getEth1BlockWithRetry(blockHash, retryDuration, maxRetries));
+      final String blockHash, final Duration retryDelay, final int maxRetries) {
+    return queueRequest(() -> delegate.getEth1BlockWithRetry(blockHash, retryDelay, maxRetries));
   }
 
   @Override

--- a/pow/src/main/java/tech/pegasys/teku/pow/ThrottlingEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/ThrottlingEth1Provider.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
-import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.EthBlock.Block;
 import org.web3j.protocol.core.methods.response.EthCall;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -57,7 +56,7 @@ public class ThrottlingEth1Provider implements Eth1Provider {
   }
 
   @Override
-  public SafeFuture<EthBlock.Block> getEth1BlockWithRetry(
+  public SafeFuture<Optional<Block>> getEth1BlockWithRetry(
       final String blockHash, final Duration retryDuration, final int maxRetries) {
     return queueRequest(() -> delegate.getEth1BlockWithRetry(blockHash, retryDuration, maxRetries));
   }

--- a/pow/src/main/java/tech/pegasys/teku/pow/ThrottlingEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/ThrottlingEth1Provider.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.pow;
 
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -53,6 +54,12 @@ public class ThrottlingEth1Provider implements Eth1Provider {
   @Override
   public SafeFuture<Optional<Block>> getEth1Block(final String blockHash) {
     return queueRequest(() -> delegate.getEth1Block(blockHash));
+  }
+
+  @Override
+  public SafeFuture<EthBlock.Block> getEth1BlockWithRetry(
+      final String blockHash, final Duration retryDuration, final int maxRetries) {
+    return queueRequest(() -> delegate.getEth1BlockWithRetry(blockHash, retryDuration, maxRetries));
   }
 
   @Override

--- a/pow/src/main/java/tech/pegasys/teku/pow/ThrottlingEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/ThrottlingEth1Provider.java
@@ -14,9 +14,11 @@
 package tech.pegasys.teku.pow;
 
 import java.math.BigInteger;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
+import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.EthBlock.Block;
 import org.web3j.protocol.core.methods.response.EthCall;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -34,7 +36,7 @@ public class ThrottlingEth1Provider implements Eth1Provider {
   }
 
   @Override
-  public SafeFuture<Block> getEth1Block(final UInt64 blockNumber) {
+  public SafeFuture<Optional<Block>> getEth1Block(final UInt64 blockNumber) {
     return queueRequest(() -> delegate.getEth1Block(blockNumber));
   }
 
@@ -49,7 +51,7 @@ public class ThrottlingEth1Provider implements Eth1Provider {
   }
 
   @Override
-  public SafeFuture<Block> getEth1Block(final String blockHash) {
+  public SafeFuture<Optional<Block>> getEth1Block(final String blockHash) {
     return queueRequest(() -> delegate.getEth1Block(blockHash));
   }
 

--- a/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
@@ -62,10 +62,9 @@ public class Web3jEth1Provider implements Eth1Provider {
   }
 
   @Override
-  public SafeFuture<EthBlock.Block> getEth1BlockWithRetry(
+  public SafeFuture<Optional<EthBlock.Block>> getEth1BlockWithRetry(
       final String blockHash, final Duration retryDuration, final int maxRetries) {
-    return asyncRunner.runWithRetry(
-        () -> getEth1Block(blockHash).thenApply(Optional::get), retryDuration, maxRetries);
+    return asyncRunner.runWithRetry(() -> getEth1Block(blockHash), retryDuration, maxRetries);
   }
 
   @Override

--- a/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
@@ -54,6 +54,12 @@ public class Web3jEth1Provider implements Eth1Provider {
   }
 
   @Override
+  public SafeFuture<Optional<EthBlock.Block>> getEth1BlockWithRetry(
+      final UInt64 blockNumber, final Duration retryDelay, final int maxRetries) {
+    return asyncRunner.runWithRetry(() -> getEth1Block(blockNumber), retryDelay, maxRetries);
+  }
+
+  @Override
   public SafeFuture<Optional<EthBlock.Block>> getEth1Block(final String blockHash) {
     LOG.trace("Getting eth1 block {}", blockHash);
     return sendAsync(web3j.ethGetBlockByHash(blockHash, false))
@@ -63,8 +69,8 @@ public class Web3jEth1Provider implements Eth1Provider {
 
   @Override
   public SafeFuture<Optional<EthBlock.Block>> getEth1BlockWithRetry(
-      final String blockHash, final Duration retryDuration, final int maxRetries) {
-    return asyncRunner.runWithRetry(() -> getEth1Block(blockHash), retryDuration, maxRetries);
+      final String blockHash, final Duration retryDelay, final int maxRetries) {
+    return asyncRunner.runWithRetry(() -> getEth1Block(blockHash), retryDelay, maxRetries);
   }
 
   @Override

--- a/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.pow;
 
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -58,6 +59,13 @@ public class Web3jEth1Provider implements Eth1Provider {
     return sendAsync(web3j.ethGetBlockByHash(blockHash, false))
         .thenApply(EthBlock::getBlock)
         .thenApply(Optional::ofNullable);
+  }
+
+  @Override
+  public SafeFuture<EthBlock.Block> getEth1BlockWithRetry(
+      final String blockHash, final Duration retryDuration, final int maxRetries) {
+    return asyncRunner.runWithRetry(
+        () -> getEth1Block(blockHash).thenApply(Optional::get), retryDuration, maxRetries);
   }
 
   @Override

--- a/pow/src/main/java/tech/pegasys/teku/pow/exception/FailedToFindMinGenesisBlockException.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/exception/FailedToFindMinGenesisBlockException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.pow.exception;
+
+public class FailedToFindMinGenesisBlockException extends RuntimeException {
+  public FailedToFindMinGenesisBlockException(final String message) {
+    super(message);
+  }
+
+  public FailedToFindMinGenesisBlockException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/pow/src/test/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinderTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinderTest.java
@@ -310,7 +310,7 @@ public class MinimumGenesisTimeBlockFinderTest {
 
   private void withUnavailableBlocks(final Block[] blocks) {
     for (Block block : blocks) {
-      when(eth1Provider.getEth1Block(UInt64.valueOf(block.getNumber())))
+      when(eth1Provider.getEth1BlockWithRetry(UInt64.valueOf(block.getNumber())))
           .thenReturn(SafeFuture.completedFuture(Optional.empty()));
       when(eth1Provider.getEth1BlockWithRetry(block.getHash()))
           .thenReturn(SafeFuture.failedFuture(new NoSuchElementException()));
@@ -330,7 +330,7 @@ public class MinimumGenesisTimeBlockFinderTest {
     when(block.toString()).thenReturn("Block " + blockNumber + " at timestamp " + timestamp);
 
     // Setup eth1 provider to return block
-    when(eth1Provider.getEth1Block(UInt64.valueOf(blockNumber)))
+    when(eth1Provider.getEth1BlockWithRetry(UInt64.valueOf(blockNumber)))
         .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
     when(eth1Provider.getEth1BlockWithRetry(blockHash))
         .thenReturn(SafeFuture.completedFuture(Optional.of(block)));

--- a/pow/src/test/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinderTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinderTest.java
@@ -385,7 +385,7 @@ public class MinimumGenesisTimeBlockFinderTest {
     when(eth1Provider.getEth1Block(UInt64.valueOf(blockNumber)))
         .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
     when(eth1Provider.getEth1BlockWithRetry(eq(blockHash), any(), anyInt()))
-        .thenReturn(SafeFuture.completedFuture(block));
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
 
     return block;
   }

--- a/pow/src/test/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinderTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinderTest.java
@@ -287,6 +287,24 @@ public class MinimumGenesisTimeBlockFinderTest {
             "Failed to retrieve min genesis block.  Check that your eth1 node is fully synced.");
   }
 
+  @Test
+  public void confirmOrFindMinGenesisBlock_withCandidateBlockTooRecent() {
+    minimumGenesisTimeBlockFinder =
+        new MinimumGenesisTimeBlockFinder(eth1Provider, Optional.empty());
+
+    final long[] timestamps = {0, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000};
+    final Block[] blocks = withBlockTimestamps(timestamps);
+    withUnavailableBlocks(Arrays.copyOfRange(blocks, 0, 4));
+    Constants.MIN_GENESIS_TIME = UInt64.valueOf(3500);
+
+    final SafeFuture<Block> res = minimumGenesisTimeBlockFinder.confirmMinGenesisBlock(blocks[7]);
+    assertThat(res).isCompletedExceptionally();
+    assertThatThrownBy(res::get)
+        .hasCauseInstanceOf(FailedToFindMinGenesisBlockException.class)
+        .hasMessageContaining(
+            "Failed to retrieve min genesis block.  Check that your eth1 node is fully synced.");
+  }
+
   private void assertMinGenesisBlock(
       final Block[] blocks, final long minGenesisTime, final Block expectedMinGenesisTimeBlock) {
     Constants.MIN_GENESIS_TIME = UInt64.valueOf(minGenesisTime);

--- a/pow/src/test/java/tech/pegasys/teku/pow/ThrottlingEth1ProviderTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/ThrottlingEth1ProviderTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
@@ -40,11 +41,11 @@ class ThrottlingEth1ProviderTest {
   private final Block block2 = mock(Block.class);
   private final Eth1Provider delegateProvider = mock(Eth1Provider.class);
   private final ThrottlingEth1Provider provider = new ThrottlingEth1Provider(delegateProvider, 3);
-  private final List<SafeFuture<Block>> blockRequests = new ArrayList<>();
+  private final List<SafeFuture<Optional<Block>>> blockRequests = new ArrayList<>();
 
   private final Answer<Object> returnBlockFuture =
       call -> {
-        final SafeFuture<Block> future = new SafeFuture<>();
+        final SafeFuture<Optional<Block>> future = new SafeFuture<>();
         blockRequests.add(future);
         return future;
       };
@@ -72,27 +73,27 @@ class ThrottlingEth1ProviderTest {
 
   @Test
   void shouldProcessNextRequestWhenInFlightOneCompletes() {
-    final SafeFuture<Block> request1 = provider.getEth1Block(ONE);
-    final SafeFuture<Block> request2 = provider.getEth1Block(TWO);
-    final SafeFuture<Block> request3 = provider.getEth1Block(THREE);
-    final SafeFuture<Block> request4 = provider.getEth1Block(FOUR);
+    final SafeFuture<Optional<Block>> request1 = provider.getEth1Block(ONE);
+    final SafeFuture<Optional<Block>> request2 = provider.getEth1Block(TWO);
+    final SafeFuture<Optional<Block>> request3 = provider.getEth1Block(THREE);
+    final SafeFuture<Optional<Block>> request4 = provider.getEth1Block(FOUR);
 
     verify(delegateProvider).getEth1Block(ONE);
     verify(delegateProvider).getEth1Block(TWO);
     verify(delegateProvider).getEth1Block(THREE);
     verifyNoMoreInteractions(delegateProvider);
 
-    blockRequests.get(1).complete(block2);
+    blockRequests.get(1).complete(Optional.of(block2));
     assertThat(request1).isNotDone();
-    assertThat(request2).isCompletedWithValue(block2);
+    assertThat(request2).isCompletedWithValue(Optional.of(block2));
     assertThat(request3).isNotDone();
     assertThat(request4).isNotDone();
 
     verify(delegateProvider).getEth1Block(FOUR);
 
-    blockRequests.get(0).complete(block1);
-    assertThat(request1).isCompletedWithValue(block1);
-    assertThat(request2).isCompletedWithValue(block2);
+    blockRequests.get(0).complete(Optional.of(block1));
+    assertThat(request1).isCompletedWithValue(Optional.of(block1));
+    assertThat(request2).isCompletedWithValue(Optional.of(block2));
     assertThat(request3).isNotDone();
     assertThat(request4).isNotDone();
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Be more tolerant of missing eth1 blocks.  Some eth1 clients can be configured to avoid downloading full historical blocks and receipts.  Update `MinimumGenesisTimeBlockFinder`'s binary search to ignore unavailable block ranges, and add extra logic to confirm the min genesis block that is retrieved.  Also add retries for eth1 block requests.  

## Fixed Issue(s)
Part of #3337

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.