### PR TITLE
[Issue-3337] Minimize deposit request block range

### DIFF
--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1DepositManager.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1DepositManager.java
@@ -159,9 +159,11 @@ public class Eth1DepositManager {
 
   private SafeFuture<EthBlock.Block> sendDepositsUpToMinGenesis(
       final EthBlock.Block minGenesisTimeBlock, final ReplayDepositsResult replayDepositsResult) {
+    final BigInteger startBlock =
+        getFirstUnprocessedBlockNumber(replayDepositsResult)
+            .max(minimumGenesisTimeBlockFinder.getMinFirstDepositBlock().bigIntegerValue());
     return depositProcessingController
-        .fetchDepositsInRange(
-            getFirstUnprocessedBlockNumber(replayDepositsResult), minGenesisTimeBlock.getNumber())
+        .fetchDepositsInRange(startBlock, minGenesisTimeBlock.getNumber())
         .thenApply(__ -> minGenesisTimeBlock);
   }
 

--- a/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinder.java
@@ -55,6 +55,10 @@ public class MinimumGenesisTimeBlockFinder {
         new SearchContext(eth1DepositContractDeployBlock.orElse(ZERO), headBlockNumber));
   }
 
+  public UInt64 getMinFirstDepositBlock() {
+    return eth1DepositContractDeployBlock.orElse(UInt64.ZERO);
+  }
+
   private SafeFuture<EthBlock.Block> binarySearchLoop(final SearchContext searchContext) {
     if (searchContext.low.compareTo(searchContext.high) <= 0) {
       final UInt64 mid = searchContext.low.plus(searchContext.high).dividedBy(TWO);

--- a/pow/src/test/java/tech/pegasys/teku/pow/Eth1DepositManagerTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/Eth1DepositManagerTest.java
@@ -279,11 +279,12 @@ class Eth1DepositManagerTest {
 
   @Test
   void shouldStartWithNoStoredDepositsAndHeadAfterMinGenesisTime_withDeployBlockNumber() {
+    final UInt64 deployBlockNumber = UInt64.valueOf(50);
     final BigInteger headBlockNumber = BigInteger.valueOf(100);
     final BigInteger minGenesisBlockNumber = BigInteger.valueOf(60);
     when(eth1DepositStorageChannel.replayDepositEvents()).thenReturn(NOTHING_REPLAYED);
     withFollowDistanceHead(headBlockNumber, MIN_GENESIS_BLOCK_TIMESTAMP + 1000);
-    withMinGenesisBlock(headBlockNumber, minGenesisBlockNumber, UInt64.valueOf(50));
+    withMinGenesisBlock(headBlockNumber, minGenesisBlockNumber, deployBlockNumber);
     when(depositProcessingController.fetchDepositsInRange(any(), any())).thenReturn(COMPLETE);
 
     manager.start();
@@ -294,7 +295,7 @@ class Eth1DepositManagerTest {
     // Process blocks from genesis to min genesis block
     inOrder
         .verify(depositProcessingController)
-        .fetchDepositsInRange(BigInteger.valueOf(50), minGenesisBlockNumber);
+        .fetchDepositsInRange(deployBlockNumber.bigIntegerValue(), minGenesisBlockNumber);
 
     // Send min genesis event
     inOrder

--- a/pow/src/test/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinderTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/MinimumGenesisTimeBlockFinderTest.java
@@ -48,6 +48,23 @@ public class MinimumGenesisTimeBlockFinderTest {
   }
 
   @Test
+  public void getMinFirstDepositBlock_withDeployBlock() {
+    final UInt64 deployBlock = UInt64.valueOf(2); // Block number
+    minimumGenesisTimeBlockFinder =
+        new MinimumGenesisTimeBlockFinder(eth1Provider, Optional.of(deployBlock));
+
+    assertThat(minimumGenesisTimeBlockFinder.getMinFirstDepositBlock()).isEqualTo(deployBlock);
+  }
+
+  @Test
+  public void getMinFirstDepositBlock_withNoDeployBlock() {
+    minimumGenesisTimeBlockFinder =
+        new MinimumGenesisTimeBlockFinder(eth1Provider, Optional.empty());
+
+    assertThat(minimumGenesisTimeBlockFinder.getMinFirstDepositBlock()).isEqualTo(UInt64.ZERO);
+  }
+
+  @Test
   public void shouldFindMinGenesisTime() {
     final long[] timestamps = {0, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000};
     final Block[] blocks = withBlockTimestamps(timestamps);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
If we know the deploy contract block number when pulling deposits up to the min genesis block, only search for deposits from the deploy contract block through the min genesis block rather than searching all of the way from block 0 to the min genesis block. 

## Fixed Issue(s)
Relates to #3337

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.