### PR TITLE
default the epoch for the voluntary-exit command to current epoch

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidator.java
@@ -52,7 +52,9 @@ public class VoluntaryExitValidator implements OperationValidator<SignedVoluntar
   @Override
   public InternalValidationResult validateFully(SignedVoluntaryExit exit) {
     if (!isFirstValidExitForValidator(exit)) {
-      LOG.trace("VoluntaryExitValidator: Exit is not the first one for the given validator.");
+      LOG.trace(
+          "VoluntaryExitValidator: Exit is not the first one for validator {}.",
+          exit.getMessage().getValidator_index());
       return IGNORE;
     }
 
@@ -63,7 +65,9 @@ public class VoluntaryExitValidator implements OperationValidator<SignedVoluntar
     if (receivedValidExitSet.add(exit.getMessage().getValidator_index())) {
       return ACCEPT;
     } else {
-      LOG.trace("VoluntaryExitValidator: Exit is not the first one for the given validator.");
+      LOG.trace(
+          "VoluntaryExitValidator: Exit is not the first one for validator {}.",
+          exit.getMessage().getValidator_index());
       return IGNORE;
     }
   }
@@ -73,8 +77,9 @@ public class VoluntaryExitValidator implements OperationValidator<SignedVoluntar
     Optional<OperationInvalidReason> invalidReason = stateTransitionValidator.validate(state, exit);
 
     if (invalidReason.isPresent()) {
-      LOG.trace(
-          "VoluntaryExitValidator: Exit fails process voluntary exit conditions {}.",
+      LOG.debug(
+          "VoluntaryExitValidator: Exit for validator {} fails process voluntary exit conditions {}.",
+          exit.getMessage().getValidator_index(),
           invalidReason.get().describe());
       return false;
     }
@@ -89,7 +94,9 @@ public class VoluntaryExitValidator implements OperationValidator<SignedVoluntar
     }
 
     if (!signatureVerifier.verifySignature(state, exit, BLSSignatureVerifier.SIMPLE)) {
-      LOG.trace("VoluntaryExitValidator: Exit fails signature verification.");
+      LOG.trace(
+          "VoluntaryExitValidator: Exit for validator {} fails signature verification.",
+          exit.getMessage().getValidator_index());
       return false;
     }
     return true;

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.cli.subcommand;
 
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
+
 import com.google.common.base.Throwables;
 import java.io.UncheckedIOException;
 import java.net.ConnectException;
@@ -81,17 +83,26 @@ public class VoluntaryExitCommand implements Runnable {
   @CommandLine.Option(
       names = {"--epoch"},
       paramLabel = "<EPOCH>",
-      description = "Earliest epoch that the voluntary exit can be processed.",
-      required = true,
+      description =
+          "Earliest epoch that the voluntary exit can be processed. Defaults to current epoch.",
       arity = "1")
   private UInt64 epoch;
+
+  @CommandLine.Option(
+      names = {"--confirmation-enabled"},
+      description = "Request confirmation before submitting voluntary exits.",
+      paramLabel = "<BOOLEAN>",
+      arity = "1")
+  private boolean confirmationEnabled = true;
 
   @Override
   public void run() {
     SUB_COMMAND_LOG.display("Loading configuration...");
     try {
       initialise();
-      confirmExits();
+      if (confirmationEnabled) {
+        confirmExits();
+      }
       getValidatorIndices(blsPublicKeyValidatorMap).forEach(this::submitExitForValidator);
     } catch (UncheckedIOException ex) {
       if (Throwables.getRootCause(ex) instanceof ConnectException) {
@@ -102,10 +113,6 @@ public class VoluntaryExitCommand implements Runnable {
   }
 
   private void confirmExits() {
-    if (blsPublicKeyValidatorMap.isEmpty()) {
-      SUB_COMMAND_LOG.error("No validators were found to exit.");
-      System.exit(1);
-    }
     SUB_COMMAND_LOG.display("Exits are going to be generated for validators: ");
     SUB_COMMAND_LOG.display(getValidatorAbbreviatedKeys());
     SUB_COMMAND_LOG.display("");
@@ -115,7 +122,7 @@ public class VoluntaryExitCommand implements Runnable {
     Scanner scanner = new Scanner(System.in, Charset.defaultCharset().name());
     final String confirmation = scanner.next();
 
-    if (!confirmation.toLowerCase().equals("yes")) {
+    if (!confirmation.equalsIgnoreCase("yes")) {
       SUB_COMMAND_LOG.display("Cancelled sending voluntary exit.");
       System.exit(1);
     }
@@ -161,7 +168,14 @@ public class VoluntaryExitCommand implements Runnable {
     } catch (IllegalArgumentException ex) {
       SUB_COMMAND_LOG.error(
           "Failed to submit exit for validator " + publicKey.toAbbreviatedString());
+      SUB_COMMAND_LOG.error(ex.getMessage());
     }
+  }
+
+  private Optional<UInt64> getEpoch() {
+    return apiClient
+        .getBlockHeader("head")
+        .map(response -> compute_epoch_at_slot(response.data.header.message.slot));
   }
 
   private Optional<Bytes32> getGenesisRoot() {
@@ -196,6 +210,16 @@ public class VoluntaryExitCommand implements Runnable {
     }
     fork = maybeFork.get();
 
+    if (epoch == null) {
+      final Optional<UInt64> maybeEpoch = getEpoch();
+      if (maybeEpoch.isEmpty()) {
+        SUB_COMMAND_LOG.error(
+            "Could not calculate epoch from latest block header, please specify --epoch");
+        System.exit(1);
+      }
+      epoch = maybeEpoch.orElseThrow();
+    }
+
     // get genesis time
     final Optional<Bytes32> maybeRoot = getGenesisRoot();
     if (maybeRoot.isEmpty()) {
@@ -213,6 +237,10 @@ public class VoluntaryExitCommand implements Runnable {
               config.validatorClient().getValidatorConfig(), config.global());
     } catch (InvalidConfigurationException ex) {
       SUB_COMMAND_LOG.error(ex.getMessage());
+      System.exit(1);
+    }
+    if (blsPublicKeyValidatorMap.isEmpty()) {
+      SUB_COMMAND_LOG.error("No validators were found to exit.");
       System.exit(1);
     }
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_AGGREGATE;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DATA;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DUTIES;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_BLOCK_HEADER;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_FORK;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_GENESIS;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_PROPOSER_DUTIES;
@@ -52,6 +53,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.request.v1.validator.BeaconCommitteeSubscriptionRequest;
+import tech.pegasys.teku.api.response.v1.beacon.GetBlockHeaderResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateValidatorsResponse;
@@ -105,6 +107,14 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   @Override
   public Optional<GetGenesisResponse> getGenesis() {
     return get(GET_GENESIS, EMPTY_QUERY_PARAMS, createHandler(GetGenesisResponse.class));
+  }
+
+  public Optional<GetBlockHeaderResponse> getBlockHeader(final String blockId) {
+    return get(
+        GET_BLOCK_HEADER,
+        Map.of("block_id", blockId),
+        EMPTY_QUERY_PARAMS,
+        createHandler(GetBlockHeaderResponse.class));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -35,6 +35,7 @@ public enum ValidatorApiMethod {
   SUBSCRIBE_TO_PERSISTENT_SUBNETS("validator/persistent_subnets_subscription"),
   GET_ATTESTATION_DUTIES("eth/v1/validator/duties/attester/:epoch"),
   GET_PROPOSER_DUTIES("eth/v1/validator/duties/proposer/:epoch"),
+  GET_BLOCK_HEADER("eth/v1/beacon/headers/:block_id"),
   EVENTS("eth/v1/events");
 
   private final String path;


### PR DESCRIPTION
Make the --epoch argument of voluntary-exit optional, and default to the current epoch, as future epochs aren't currently supported anyway.

Updated some of the validations to be debug level instead of trace, and added the validator index to the log line, but these would appear in the beacon node log, because that's when they run. Still, it would be helpful if you are looking for why a validator can't be exited, the 'will never pass' message isn't strictly accurate - for example if you're attempting to exit too early.

Added `--confirmation-enabled` to allow skipping user input to exit validators (--confirmation-enabled=false), but the greatest care should be exercised, as exits will be immediately generated with no prompt.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.