### PR TITLE
Move minimum randomly selected peers config out of P2PConfig and into P2POptions

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -31,6 +31,7 @@ public class P2PConfig {
   private final int p2pPeerLowerBound;
   private final int p2pPeerUpperBound;
   private final int targetSubnetSubscriberCount;
+  private final int minimumRandomlySelectedPeerCount;
   private final List<String> p2pStaticPeers;
   private final boolean multiPeerSyncEnabled;
   private final boolean subscribeAllSubnetsEnabled;
@@ -47,6 +48,7 @@ public class P2PConfig {
       final int p2pPeerLowerBound,
       final int p2pPeerUpperBound,
       final int targetSubnetSubscriberCount,
+      final int minimumRandomlySelectedPeerCount,
       final List<String> p2pStaticPeers,
       final boolean multiPeerSyncEnabled,
       final boolean subscribeAllSubnetsEnabled) {
@@ -61,6 +63,7 @@ public class P2PConfig {
     this.p2pPeerLowerBound = p2pPeerLowerBound;
     this.p2pPeerUpperBound = p2pPeerUpperBound;
     this.targetSubnetSubscriberCount = targetSubnetSubscriberCount;
+    this.minimumRandomlySelectedPeerCount = minimumRandomlySelectedPeerCount;
     this.p2pStaticPeers = p2pStaticPeers;
     this.multiPeerSyncEnabled = multiPeerSyncEnabled;
     this.subscribeAllSubnetsEnabled = subscribeAllSubnetsEnabled;
@@ -115,7 +118,7 @@ public class P2PConfig {
   }
 
   public int getMinimumRandomlySelectedPeerCount() {
-    return Math.min(1, p2pPeerLowerBound * 2 / 10);
+    return minimumRandomlySelectedPeerCount;
   }
 
   public List<String> getP2pStaticPeers() {
@@ -143,6 +146,7 @@ public class P2PConfig {
     private int p2pPeerLowerBound;
     private int p2pPeerUpperBound;
     private int targetSubnetSubscriberCount;
+    private int minimumRandomlySelectedPeerCount;
     private List<String> p2pStaticPeers = new ArrayList<>();
     private boolean multiPeerSyncEnabled;
     private boolean subscribeAllSubnetsEnabled;
@@ -204,6 +208,11 @@ public class P2PConfig {
       return this;
     }
 
+    public P2PConfigBuilder minimumRandomlySelectedPeerCount(int minimumRandomlySelectedPeerCount) {
+      this.minimumRandomlySelectedPeerCount = minimumRandomlySelectedPeerCount;
+      return this;
+    }
+
     public P2PConfigBuilder p2pStaticPeers(List<String> p2pStaticPeers) {
       this.p2pStaticPeers = p2pStaticPeers;
       return this;
@@ -232,6 +241,7 @@ public class P2PConfig {
           p2pPeerLowerBound,
           p2pPeerUpperBound,
           targetSubnetSubscriberCount,
+          minimumRandomlySelectedPeerCount,
           p2pStaticPeers,
           multiPeerSyncEnabled,
           subscribeAllSubnetsEnabled);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -107,6 +107,15 @@ public class P2POptions {
   private int p2pTargetSubnetSubscriberCount = 2;
 
   @Option(
+      names = {"--Xp2p-minimum-randomly-selected-peer-count"},
+      paramLabel = "<INTEGER>",
+      description =
+          "Number of peers that should be selected randomly (default 20% of lower-bound target)",
+      arity = "1",
+      hidden = true)
+  private Integer minimumRandomlySelectedPeerCount;
+
+  @Option(
       names = {"--p2p-static-peers"},
       paramLabel = "<PEER_ADDRESSES>",
       description = "Static peers",
@@ -148,6 +157,12 @@ public class P2POptions {
     }
   }
 
+  private int getMinimumRandomlySelectedPeerCount() {
+    return minimumRandomlySelectedPeerCount == null
+        ? Math.max(1, getP2pLowerBound() * 2 / 10)
+        : minimumRandomlySelectedPeerCount;
+  }
+
   public void configure(
       final TekuConfiguration.Builder builder, final NetworkDefinition networkDefinition) {
     builder.p2p(
@@ -170,6 +185,7 @@ public class P2POptions {
                 .p2pPeerLowerBound(getP2pLowerBound())
                 .p2pPeerUpperBound(getP2pUpperBound())
                 .targetSubnetSubscriberCount(p2pTargetSubnetSubscriberCount)
+                .minimumRandomlySelectedPeerCount(getMinimumRandomlySelectedPeerCount())
                 .p2pStaticPeers(p2pStaticPeers)
                 .multiPeerSyncEnabled(multiPeerSyncEnabled)
                 .subscribeAllSubnetsEnabled(subscribeAllSubnetsEnabled));

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -382,6 +382,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                     .p2pPeerLowerBound(64)
                     .p2pPeerUpperBound(74)
                     .targetSubnetSubscriberCount(2)
+                    .minimumRandomlySelectedPeerCount(12) // floor(20% of lower bound)
                     .p2pStaticPeers(Collections.emptyList()))
         .validator(
             b ->

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -38,6 +38,7 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(config.getP2pPeerLowerBound()).isEqualTo(70);
     assertThat(config.getP2pPeerUpperBound()).isEqualTo(85);
     assertThat(config.getTargetSubnetSubscriberCount()).isEqualTo(5);
+    assertThat(config.getMinimumRandomlySelectedPeerCount()).isEqualTo(1);
   }
 
   @Test
@@ -85,5 +86,30 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
                 .p2pConfig()
                 .getP2pAdvertisedPort())
         .hasValue(8056);
+  }
+
+  @Test
+  public void minimumRandomlySelectedPeerCount_shouldDefaultTo20PercentOfLowerBound() {
+    assertThat(
+            getTekuConfigurationFromArguments(
+                    "--p2p-peer-lower-bound", "100",
+                    "--p2p-peer-upper-bound", "110")
+                .beaconChain()
+                .p2pConfig()
+                .getMinimumRandomlySelectedPeerCount())
+        .isEqualTo(20);
+  }
+
+  @Test
+  public void minimumRandomlySelectedPeerCount_canBeOverriden() {
+    assertThat(
+            getTekuConfigurationFromArguments(
+                    "--p2p-peer-lower-bound", "100",
+                    "--p2p-peer-upper-bound", "110",
+                    "--Xp2p-minimum-randomly-selected-peer-count", "40")
+                .beaconChain()
+                .p2pConfig()
+                .getMinimumRandomlySelectedPeerCount())
+        .isEqualTo(40);
   }
 }

--- a/teku/src/test/resources/P2POptions_config.yaml
+++ b/teku/src/test/resources/P2POptions_config.yaml
@@ -10,3 +10,4 @@ p2p-static-peers: "127.1.0.1,127.1.1.1"
 p2p-peer-lower-bound: 70
 p2p-peer-upper-bound: 85
 Xp2p-target-subnet-subscriber-count: 5
+Xp2p-minimum-randomly-selected-peer-count: 1


### PR DESCRIPTION
## PR Description

According to the comment in PeerPools.java some proportion of the peer pool should be randomly selected in order to provide Sybil resistance.

This change was initiated from the observation that the Math.min/max logic was back to front for the 'minimum number of randomly generated peers' config in P2PConfig.

`Math.min(1, p2pPeerLowerBound * 2 / 10);`
should have read
`Math.max(1, p2pPeerLowerBound * 2 / 10);`

In order to explicitly test this behaviour (defaulting to 20% of the lower target bound should be randomly selected) I've moved the logic out of P2PConfig and into P2POptions.

The value is implemented as a --X param and marked hidden - `--Xp2p-minimum-randomly-selected-peer-count` - this may need further discussion.

## Documentation

- [x ] I thought about documentation and added the `documentation` label to this PR if updates are required.

None required while it's a hidden param.
