### PR TITLE
Disable jmh plugin in util module

### DIFF
--- a/util/build.gradle
+++ b/util/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-  id 'me.champeau.gradle.jmh'
-}
-
 dependencies {
   api project(':infrastructure:crypto')
   api project(':infrastructure:metrics')


### PR DESCRIPTION
## PR Description
There are no benchmarks in the `util` module so don't enable the jmh plugin.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.