### PR TITLE
Use UInt64 for balance constants to avoid repeatedly creating new UInt64 instances

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/GenesisStateAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/GenesisStateAcceptanceTest.java
@@ -57,7 +57,7 @@ public class GenesisStateAcceptanceTest extends AcceptanceTestBase {
         depositSender.generateValidatorKeys(numberOfValidators);
     depositSender.sendValidatorDeposits(eth1Node, validatorKeys, MIN_DEPOSIT_AMOUNT);
     depositSender.sendValidatorDeposits(
-        eth1Node, validatorKeys, MAX_EFFECTIVE_BALANCE - MIN_DEPOSIT_AMOUNT);
+        eth1Node, validatorKeys, MAX_EFFECTIVE_BALANCE.minus(MIN_DEPOSIT_AMOUNT));
 
     final TekuNode teku = createTekuNode(config -> config.withDepositsFrom(eth1Node));
     teku.start();

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuDepositSender.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuDepositSender.java
@@ -46,18 +46,17 @@ public class TekuDepositSender extends Node {
   }
 
   public void sendValidatorDeposits(
-      final BesuNode eth1Node, final int numberOfValidators, long amount)
+      final BesuNode eth1Node, final int numberOfValidators, UInt64 amount)
       throws InterruptedException, ExecutionException, TimeoutException {
     final Eth1Address eth1Address = Eth1Address.fromHexString(eth1Node.getDepositContractAddress());
     final Credentials eth1Credentials = Credentials.create(eth1Node.getRichBenefactorKey());
-    final UInt64 depositAmount = UInt64.valueOf(amount);
     try (final DepositGenerator depositGenerator =
         new DepositGenerator(
             eth1Node.getExternalJsonRpcUrl(),
             eth1Address,
             eth1Credentials,
             numberOfValidators,
-            depositAmount)) {
+            amount)) {
       final SafeFuture<Void> future = depositGenerator.generate();
       Waiter.waitFor(future, Duration.ofMinutes(2));
     }
@@ -66,14 +65,13 @@ public class TekuDepositSender extends Node {
   public void sendValidatorDeposits(
       final BesuNode eth1Node,
       final List<ValidatorKeyGenerator.ValidatorKeys> validatorKeys,
-      long amount)
+      UInt64 amount)
       throws InterruptedException, ExecutionException, TimeoutException {
     final Eth1Address eth1Address = Eth1Address.fromHexString(eth1Node.getDepositContractAddress());
     final Credentials eth1Credentials = Credentials.create(eth1Node.getRichBenefactorKey());
-    final UInt64 depositAmount = UInt64.valueOf(amount);
     final DepositSenderService depositSenderService =
         new DepositSenderService(
-            eth1Node.getExternalJsonRpcUrl(), eth1Credentials, eth1Address, depositAmount);
+            eth1Node.getExternalJsonRpcUrl(), eth1Credentials, eth1Address, amount);
     final List<SafeFuture<TransactionReceipt>> transactionReceipts =
         validatorKeys.stream().map(depositSenderService::sendDeposit).collect(Collectors.toList());
     final SafeFuture<Void> future =

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetStateValidatorBalancesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetStateValidatorBalancesIntegrationTest.java
@@ -56,8 +56,7 @@ public class GetStateValidatorBalancesIntegrationTest
             response.body().string(), GetStateValidatorBalancesResponse.class);
     assertThat(body.data)
         .containsExactly(
-            new ValidatorBalanceResponse(
-                UInt64.valueOf(1), UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE)));
+            new ValidatorBalanceResponse(UInt64.valueOf(1), Constants.MAX_EFFECTIVE_BALANCE));
   }
 
   @Test

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -82,7 +82,7 @@ public class ChainDataProviderTest {
   @BeforeEach
   public void setup() {
     slot = UInt64.valueOf(SLOTS_PER_EPOCH * 3);
-    actualBalance = UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE + 100000);
+    actualBalance = Constants.MAX_EFFECTIVE_BALANCE.plus(100000);
     storageSystem.chainUpdater().initializeGenesis(true, actualBalance);
     bestBlock = storageSystem.chainUpdater().advanceChain(slot);
     storageSystem.chainUpdater().updateBestBlock(bestBlock);

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/epoch/EpochProcessorUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/epoch/EpochProcessorUtil.java
@@ -241,9 +241,7 @@ public final class EpochProcessorUtil {
         }
 
         if (is_active_validator(validator, get_current_epoch(state))
-            && validator
-                .getEffective_balance()
-                .isLessThanOrEqualTo(UInt64.valueOf(EJECTION_BALANCE))) {
+            && validator.getEffective_balance().isLessThanOrEqualTo(EJECTION_BALANCE)) {
           initiate_validator_exit(state, index);
         }
       }
@@ -366,7 +364,7 @@ public final class EpochProcessorUtil {
                 validator.withEffective_balance(
                     balance
                         .minus(balance.mod(EFFECTIVE_BALANCE_INCREMENT))
-                        .min(UInt64.valueOf(MAX_EFFECTIVE_BALANCE))));
+                        .min(MAX_EFFECTIVE_BALANCE)));
       }
     }
 

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -225,8 +225,7 @@ public class ChainBuilder {
   }
 
   public SignedBlockAndState generateGenesis(final UInt64 genesisTime, final boolean signDeposits) {
-    return generateGenesis(
-        genesisTime, signDeposits, UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE));
+    return generateGenesis(genesisTime, signDeposits, Constants.MAX_EFFECTIVE_BALANCE);
   }
 
   public SignedBlockAndState generateGenesis(

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/interop/MockStartDepositGenerator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/interop/MockStartDepositGenerator.java
@@ -46,7 +46,7 @@ public class MockStartDepositGenerator {
 
   private DepositData createDepositData(final BLSKeyPair keyPair) {
     return depositGenerator.createDepositData(
-        keyPair, UInt64.valueOf(MAX_EFFECTIVE_BALANCE), keyPair.getPublicKey());
+        keyPair, MAX_EFFECTIVE_BALANCE, keyPair.getPublicKey());
   }
 
   private DepositData createDepositData(final BLSKeyPair keyPair, final UInt64 depositBalance) {

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/BeaconStateUtil.java
@@ -185,9 +185,7 @@ public class BeaconStateUtil {
   private static Validator getValidatorFromDeposit(Deposit deposit) {
     final UInt64 amount = deposit.getData().getAmount();
     final UInt64 effectiveBalance =
-        amount
-            .minus(amount.mod(EFFECTIVE_BALANCE_INCREMENT))
-            .min(UInt64.valueOf(MAX_EFFECTIVE_BALANCE));
+        amount.minus(amount.mod(EFFECTIVE_BALANCE_INCREMENT)).min(MAX_EFFECTIVE_BALANCE);
     return new Validator(
         deposit.getData().getPubkey().toBytesCompressed(),
         deposit.getData().getWithdrawal_credentials(),

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
@@ -178,7 +178,7 @@ public class CommitteeUtil {
       UInt64 effective_balance = state.getValidators().get(candidate_index).getEffective_balance();
       if (effective_balance
           .times(MAX_RANDOM_BYTE)
-          .isGreaterThanOrEqualTo(UInt64.valueOf(MAX_EFFECTIVE_BALANCE).times(random_byte))) {
+          .isGreaterThanOrEqualTo(MAX_EFFECTIVE_BALANCE.times(random_byte))) {
         return candidate_index;
       }
       i++;

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/DepositUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/DepositUtil.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.datastructures.operations.DepositData;
 import tech.pegasys.teku.datastructures.operations.DepositWithIndex;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.contract.DepositContract;
 
 public class DepositUtil {
@@ -29,8 +28,7 @@ public class DepositUtil {
   public static DepositWithIndex convertDepositEventToOperationDeposit(
       tech.pegasys.teku.pow.event.Deposit event) {
     checkArgument(
-        event.getAmount().compareTo(UInt64.valueOf(MIN_DEPOSIT_AMOUNT)) >= 0,
-        "Deposit amount too low");
+        event.getAmount().isGreaterThanOrEqualTo(MIN_DEPOSIT_AMOUNT), "Deposit amount too low");
     DepositData data =
         new DepositData(
             event.getPubkey(),

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/GenesisGenerator.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/GenesisGenerator.java
@@ -99,14 +99,12 @@ public class GenesisGenerator {
     }
     UInt64 balance = state.getBalances().get(index);
     UInt64 effective_balance =
-        balance
-            .minus(balance.mod(EFFECTIVE_BALANCE_INCREMENT))
-            .min(UInt64.valueOf(MAX_EFFECTIVE_BALANCE));
+        balance.minus(balance.mod(EFFECTIVE_BALANCE_INCREMENT)).min(MAX_EFFECTIVE_BALANCE);
 
     UInt64 activation_eligibility_epoch = validator.getActivation_eligibility_epoch();
     UInt64 activation_epoch = validator.getActivation_epoch();
 
-    if (effective_balance.equals(UInt64.valueOf(MAX_EFFECTIVE_BALANCE))) {
+    if (effective_balance.equals(MAX_EFFECTIVE_BALANCE)) {
       activation_eligibility_epoch = UInt64.valueOf(GENESIS_EPOCH);
       activation_epoch = UInt64.valueOf(GENESIS_EPOCH);
       activeValidatorCount++;

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/ValidatorsUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/ValidatorsUtil.java
@@ -50,7 +50,7 @@ public class ValidatorsUtil {
    */
   public static boolean is_eligible_for_activation_queue(Validator validator) {
     return validator.getActivation_eligibility_epoch().equals(Constants.FAR_FUTURE_EPOCH)
-        && validator.getEffective_balance().equals(UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE));
+        && validator.getEffective_balance().equals(Constants.MAX_EFFECTIVE_BALANCE);
   }
 
   /**

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/BeaconStateUtilTest.java
@@ -157,7 +157,7 @@ class BeaconStateUtilTest {
     // Calculate Expected Results
     UInt64 expectedBalance = UInt64.ZERO;
     for (UInt64 balance : state.getBalances()) {
-      if (balance.isLessThan(UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE))) {
+      if (balance.isLessThan(Constants.MAX_EFFECTIVE_BALANCE)) {
         expectedBalance = expectedBalance.plus(balance);
       } else {
         expectedBalance = expectedBalance.plus(Constants.MAX_EFFECTIVE_BALANCE);
@@ -363,8 +363,7 @@ class BeaconStateUtilTest {
                           dataStructureUtil.randomValidator(),
                           dataStructureUtil.randomValidator()));
               List<UInt64> balanceList =
-                  new ArrayList<>(
-                      Collections.nCopies(3, UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE)));
+                  new ArrayList<>(Collections.nCopies(3, Constants.MAX_EFFECTIVE_BALANCE));
 
               if (addToList) {
                 validatorList.add(knownValidator);

--- a/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/util/DataStructureUtil.java
+++ b/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/util/DataStructureUtil.java
@@ -463,8 +463,7 @@ public final class DataStructureUtil {
     Bytes32 withdrawal_credentials = randomBytes32();
 
     DepositMessage proof_of_possession_data =
-        new DepositMessage(
-            pubkey, withdrawal_credentials, UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE));
+        new DepositMessage(pubkey, withdrawal_credentials, Constants.MAX_EFFECTIVE_BALANCE);
 
     final Bytes32 domain = compute_domain(DOMAIN_DEPOSIT);
     final Bytes signing_root = compute_signing_root(proof_of_possession_data, domain);
@@ -558,7 +557,7 @@ public final class DataStructureUtil {
       BLSKeyPair keypair = BLSKeyPair.random(i);
       DepositData depositData =
           depositGenerator.createDepositData(
-              keypair, UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE), keypair.getPublicKey());
+              keypair, Constants.MAX_EFFECTIVE_BALANCE, keypair.getPublicKey());
 
       SSZVector<Bytes32> proof =
           SSZVector.createMutable(Constants.DEPOSIT_CONTRACT_TREE_DEPTH + 1, Bytes32.ZERO);
@@ -572,7 +571,7 @@ public final class DataStructureUtil {
     return Validator.create(
         randomPublicKeyBytes(),
         randomBytes32(),
-        UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE),
+        Constants.MAX_EFFECTIVE_BALANCE,
         false,
         Constants.FAR_FUTURE_EPOCH,
         Constants.FAR_FUTURE_EPOCH,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockProcessorUtilTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockProcessorUtilTest.java
@@ -216,7 +216,7 @@ class BlockProcessorUtilTest {
     return Validator.create(
         pubkey.toBytesCompressed(),
         withdrawalCredentials,
-        UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE),
+        Constants.MAX_EFFECTIVE_BALANCE,
         false,
         Constants.FAR_FUTURE_EPOCH,
         Constants.FAR_FUTURE_EPOCH,

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -61,7 +61,7 @@ public class ChainUpdater {
   }
 
   public SignedBlockAndState initializeGenesis(final boolean signDeposits) {
-    return initializeGenesis(signDeposits, UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE));
+    return initializeGenesis(signDeposits, Constants.MAX_EFFECTIVE_BALANCE);
   }
 
   public SignedBlockAndState initializeGenesis(

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/internal/validator/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/internal/validator/options/DepositOptions.java
@@ -108,7 +108,7 @@ public class DepositOptions {
   }
 
   UInt64 getAmount() {
-    return Optional.ofNullable(this.amount).orElse(UInt64.valueOf(MAX_EFFECTIVE_BALANCE));
+    return Optional.ofNullable(this.amount).orElse(MAX_EFFECTIVE_BALANCE);
   }
 
   private Eth1Address getContractAddress(final NetworkDefinition networkDefinition) {

--- a/teku/src/test/java/tech/pegasys/teku/cli/subcommand/internal/validator/options/DepositOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/subcommand/internal/validator/options/DepositOptionsTest.java
@@ -155,13 +155,12 @@ class DepositOptionsTest {
 
   @Test
   public void shouldUseMaxEffectiveBalanceAsDefaultAmount() {
-    Constants.MAX_EFFECTIVE_BALANCE = 12345678;
+    Constants.MAX_EFFECTIVE_BALANCE = UInt64.valueOf(12345678);
     final Eth1PrivateKeyOptions eth1PrivateKeyOptions = new Eth1PrivateKeyOptions();
     eth1PrivateKeyOptions.eth1PrivateKey = ETH1_PRIVATE_KEY;
     final DepositOptions depositOptions =
         new DepositOptions(commandSpec, eth1PrivateKeyOptions, SHUTDOWN_FUNCTION, consoleAdapter);
 
-    assertThat(depositOptions.getAmount())
-        .isEqualTo(UInt64.valueOf(Constants.MAX_EFFECTIVE_BALANCE));
+    assertThat(depositOptions.getAmount()).isEqualTo(Constants.MAX_EFFECTIVE_BALANCE);
   }
 }

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -55,9 +55,9 @@ public class Constants {
   public static final int MAX_REQUEST_BLOCKS = 1024;
 
   // Gwei values
-  public static long MIN_DEPOSIT_AMOUNT;
-  public static long MAX_EFFECTIVE_BALANCE;
-  public static long EJECTION_BALANCE;
+  public static UInt64 MIN_DEPOSIT_AMOUNT;
+  public static UInt64 MAX_EFFECTIVE_BALANCE;
+  public static UInt64 EJECTION_BALANCE;
   public static UInt64 EFFECTIVE_BALANCE_INCREMENT;
 
   // Initial values


### PR DESCRIPTION
## PR Description
All the usages of `MIN_DEPOSIT_AMOUNT`, `MAX_EFFECTIVE_BALANCE` and `EJECTION_BALANCE` need them to be `UInt64` so switch `Constants` to hold them in that format instead of having to convert from long to `UInt64` on every usage.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.