### PR TITLE
Avoid BigInteger multiplication when calculating base rewards

### DIFF
--- a/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
+++ b/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
@@ -37,7 +37,7 @@ public final class UInt64 implements Comparable<UInt64> {
    */
   static final long SQRT_MAX_VALUE = 4294967295L;
 
-  static final int SPECIAL_CASE_MULTIPLICAND = 64;
+  static final long SPECIAL_CASE_MULTIPLICAND = 64L;
   static final long MAX_SAFE_VALUE_WITH_SPECIAL_CASE_MULTIPLICAND =
       Long.divideUnsigned(-1L, SPECIAL_CASE_MULTIPLICAND);
 

--- a/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
+++ b/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
@@ -37,6 +37,10 @@ public final class UInt64 implements Comparable<UInt64> {
    */
   static final long SQRT_MAX_VALUE = 4294967295L;
 
+  static final int SPECIAL_CASE_MULTIPLICAND = 64;
+  static final long MAX_SAFE_VALUE_WITH_SPECIAL_CASE_MULTIPLICAND =
+      Long.divideUnsigned(-1L, SPECIAL_CASE_MULTIPLICAND);
+
   private final long value;
 
   private UInt64(final long value) {
@@ -235,7 +239,8 @@ public final class UInt64 implements Comparable<UInt64> {
   }
 
   private UInt64 times(final long longBits1, final long longBits2) {
-    if ((isSafeMultiplicand(longBits1) && isSafeMultiplicand(longBits2))
+    if (isSafeMultiplication(longBits1, longBits2)
+        || (isSafeMultiplicand(longBits1) && isSafeMultiplicand(longBits2))
         // 0 and 1 do not increase the size so will not overflow regardless of the second number
         || longBits1 == 0
         || longBits1 == 1
@@ -256,6 +261,13 @@ public final class UInt64 implements Comparable<UInt64> {
       throw new ArithmeticException("uint64 overflow");
     }
     return fromLongBits(result.longValue());
+  }
+
+  private boolean isSafeMultiplication(final long longBits1, final long longBits2) {
+    return (Long.compareUnsigned(longBits1, SPECIAL_CASE_MULTIPLICAND) <= 0
+            && Long.compareUnsigned(longBits2, MAX_SAFE_VALUE_WITH_SPECIAL_CASE_MULTIPLICAND) <= 0)
+        || (Long.compareUnsigned(longBits2, SPECIAL_CASE_MULTIPLICAND) <= 0
+            && Long.compareUnsigned(longBits1, MAX_SAFE_VALUE_WITH_SPECIAL_CASE_MULTIPLICAND) <= 0);
   }
 
   private boolean isSafeMultiplicand(final long longBits) {

--- a/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
+++ b/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
@@ -551,7 +551,10 @@ class UInt64Test {
         Arguments.of(Long.divideUnsigned(-1, 2) + 1, 2),
         Arguments.of(Long.MAX_VALUE, 3),
         Arguments.of(Long.MIN_VALUE, 2),
-        Arguments.of(UInt64.SQRT_MAX_VALUE + 1, UInt64.SQRT_MAX_VALUE + 1));
+        Arguments.of(UInt64.SQRT_MAX_VALUE + 1, UInt64.SQRT_MAX_VALUE + 1),
+        Arguments.of(
+            UInt64.SPECIAL_CASE_MULTIPLICAND,
+            UInt64.MAX_SAFE_VALUE_WITH_SPECIAL_CASE_MULTIPLICAND + 1));
   }
 
   static List<Arguments> additionNumbers() {
@@ -584,6 +587,11 @@ class UInt64Test {
         Arguments.of(0, 1, 0),
         Arguments.of(1, 1, 1),
         Arguments.of(2, 4, 8),
+        Arguments.of(3, 4, 12),
+        Arguments.of(
+            UInt64.SPECIAL_CASE_MULTIPLICAND,
+            UInt64.MAX_SAFE_VALUE_WITH_SPECIAL_CASE_MULTIPLICAND,
+            Long.parseUnsignedLong("18446744073709551552")),
         Arguments.of(Integer.MAX_VALUE, 2, ((long) Integer.MAX_VALUE) * 2),
         Arguments.of(Long.MIN_VALUE, 1, Long.MIN_VALUE),
         Arguments.of(Long.MAX_VALUE, 1, Long.MAX_VALUE),


### PR DESCRIPTION
## PR Description
Previously UInt64.times switched to using BigInteger to perform multiplication when either multiplicand is bigger than the square root of UInt64.MAX_VALUE to provide overflow protection.
Epoch transition multiplies the sum of effective balances by 64 and the effective balances were greater than the square root value, causing the more expensive path to be taken.
Add an additional check that if one multiplicand is 64 or less and the other is less than MAX_VALUE / 64, use the fast path as the result is known to not overflow.

Not a huge performance gain but simple enough.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.