### PR TITLE
Optimise finalized state updates

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbAccessor.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbAccessor.java
@@ -59,6 +59,16 @@ public interface RocksDbAccessor extends AutoCloseable {
    */
   <K, V> Optional<ColumnEntry<K, V>> getLastEntry(RocksDbColumn<K, V> column);
 
+  /**
+   * Returns the last key in the given column without loading the associated value.
+   *
+   * @param column The column we want to query
+   * @param <K> The key type of the column
+   * @param <V> The value type of the column
+   * @return The last key in this column - the key with the greatest value
+   */
+  <K, V> Optional<K> getLastKey(RocksDbColumn<K, V> column);
+
   @MustBeClosed
   <K, V> Stream<ColumnEntry<K, V>> stream(RocksDbColumn<K, V> column);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstance.java
@@ -119,6 +119,18 @@ public class RocksDbInstance implements RocksDbAccessor {
   }
 
   @Override
+  public <K, V> Optional<K> getLastKey(final RocksDbColumn<K, V> column) {
+    assertOpen();
+    final ColumnFamilyHandle handle = columnHandles.get(column);
+    try (final RocksIterator rocksDbIterator = db.newIterator(handle)) {
+      rocksDbIterator.seekToLast();
+      return rocksDbIterator.isValid()
+          ? Optional.of(column.getKeySerializer().deserialize(rocksDbIterator.key()))
+          : Optional.empty();
+    }
+  }
+
+  @Override
   @MustBeClosed
   public <K, V> Stream<ColumnEntry<K, V>> stream(RocksDbColumn<K, V> column) {
     assertOpen();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V4FinalizedRocksDbDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V4FinalizedRocksDbDao.java
@@ -122,8 +122,7 @@ public class V4FinalizedRocksDbDao implements RocksDbFinalizedDao {
       this.transaction = db.startTransaction();
       this.schema = schema;
       this.stateStorageFrequency = stateStorageFrequency;
-      lastStateStoredSlot =
-          db.getLastEntry(schema.getColumnFinalizedStatesBySlot()).map(ColumnEntry::getKey);
+      lastStateStoredSlot = db.getLastKey(schema.getColumnFinalizedStatesBySlot());
     }
 
     @Override

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/rocksdb/core/MockRocksDbInstance.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/rocksdb/core/MockRocksDbInstance.java
@@ -124,6 +124,14 @@ public class MockRocksDbInstance implements RocksDbAccessor {
   }
 
   @Override
+  public <K, V> Optional<K> getLastKey(final RocksDbColumn<K, V> column) {
+    assertOpen();
+    assertValidColumn(column);
+    return Optional.ofNullable(columnData.get(column).lastKey())
+        .map(data -> columnKey(column, data));
+  }
+
+  @Override
   public <K, V> Stream<ColumnEntry<K, V>> stream(final RocksDbColumn<K, V> column) {
     assertOpen();
     assertValidColumn(column);

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/rocksdb/core/MockRocksDbInstance.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/rocksdb/core/MockRocksDbInstance.java
@@ -127,8 +127,10 @@ public class MockRocksDbInstance implements RocksDbAccessor {
   public <K, V> Optional<K> getLastKey(final RocksDbColumn<K, V> column) {
     assertOpen();
     assertValidColumn(column);
-    return Optional.ofNullable(columnData.get(column).lastKey())
-        .map(data -> columnKey(column, data));
+    final NavigableMap<Bytes, Bytes> values = columnData.get(column);
+    return values.isEmpty()
+        ? Optional.empty()
+        : Optional.of(values.lastKey()).map(data -> columnKey(column, data));
   }
 
   @Override
@@ -144,8 +146,11 @@ public class MockRocksDbInstance implements RocksDbAccessor {
   public <K extends Comparable<K>, V> Stream<ColumnEntry<K, V>> stream(
       final RocksDbColumn<K, V> column, final K from, final K to) {
     assertOpen();
-    return columnData.get(column)
-        .subMap(keyToBytes(column, from), true, keyToBytes(column, to), true).entrySet().stream()
+    return columnData
+        .get(column)
+        .subMap(keyToBytes(column, from), true, keyToBytes(column, to), true)
+        .entrySet()
+        .stream()
         .peek(value -> assertOpen())
         .map(e -> columnEntry(column, e));
   }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/rocksdb/core/MockRocksDbInstance.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/rocksdb/core/MockRocksDbInstance.java
@@ -146,11 +146,8 @@ public class MockRocksDbInstance implements RocksDbAccessor {
   public <K extends Comparable<K>, V> Stream<ColumnEntry<K, V>> stream(
       final RocksDbColumn<K, V> column, final K from, final K to) {
     assertOpen();
-    return columnData
-        .get(column)
-        .subMap(keyToBytes(column, from), true, keyToBytes(column, to), true)
-        .entrySet()
-        .stream()
+    return columnData.get(column)
+        .subMap(keyToBytes(column, from), true, keyToBytes(column, to), true).entrySet().stream()
         .peek(value -> assertOpen())
         .map(e -> columnEntry(column, e));
   }


### PR DESCRIPTION
## PR Description
Avoid deserializing the last finalized state when only the last key is required.  Deserializing the entire state is quite slow (#3371 logged) and was causing delays importing the first block of an epoch if a finalisation occurred because the updater needs to find the latest slot a finalized state is stored at, and it was deserializing the whole state in the process.

Added an accessor method to get only the latest key for a column instead of the latest complete entry to avoid this.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.