### PR TITLE
Use cached states when validating block gossip

### DIFF
--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockValidatorTest.java
@@ -26,7 +26,6 @@ import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.core.ChainBuilder;
-import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
@@ -50,7 +49,7 @@ public class BlockValidatorTest {
   @BeforeEach
   void setUp() {
     beaconChainUtil.initializeStorage();
-    blockValidator = new BlockValidator(recentChainData, new StateTransition());
+    blockValidator = new BlockValidator(recentChainData);
   }
 
   @Test
@@ -182,8 +181,7 @@ public class BlockValidatorTest {
     ChainBuilder chainBuilder = ChainBuilder.create(VALIDATOR_KEYS);
     ChainUpdater chainUpdater = new ChainUpdater(storageSystem.recentChainData(), chainBuilder);
 
-    BlockValidator blockValidator =
-        new BlockValidator(storageSystem.recentChainData(), new StateTransition());
+    BlockValidator blockValidator = new BlockValidator(storageSystem.recentChainData());
     chainUpdater.initializeGenesis();
 
     chainUpdater.updateBestBlock(chainUpdater.advanceChainUntil(1));

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -707,7 +707,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     LOG.debug("BeaconChainController.initBlockManager()");
     final FutureItems<SignedBeaconBlock> futureBlocks =
         FutureItems.create(SignedBeaconBlock::getSlot);
-    BlockValidator blockValidator = new BlockValidator(recentChainData, stateTransition);
+    BlockValidator blockValidator = new BlockValidator(recentChainData);
     blockManager =
         BlockManager.create(
             eventBus, pendingBlocks, futureBlocks, recentChainData, blockImporter, blockValidator);

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.core.lookup.BlockProvider;
 import tech.pegasys.teku.core.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.datastructures.state.AnchorPoint;
@@ -401,6 +402,14 @@ public abstract class RecentChainData implements StoreUpdateHandler {
       return EmptyStoreResults.EMPTY_STATE_FUTURE;
     }
     return store.retrieveBlockState(blockRoot);
+  }
+
+  public SafeFuture<Optional<BeaconState>> retrieveStateAtSlot(
+      final SlotAndBlockRoot slotAndBlockRoot) {
+    if (store == null) {
+      return EmptyStoreResults.EMPTY_STATE_FUTURE;
+    }
+    return store.retrieveStateAtSlot(slotAndBlockRoot);
   }
 
   public SafeFuture<Optional<BeaconState>> retrieveStateInEffectAtSlot(final UInt64 slot) {

--- a/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
+++ b/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
@@ -95,7 +95,7 @@ public class SyncingNodeManager {
         new BlockImporter(
             recentChainData, forkChoice, WeakSubjectivityValidator.lenient(), eventBus);
 
-    BlockValidator blockValidator = new BlockValidator(recentChainData, new StateTransition());
+    BlockValidator blockValidator = new BlockValidator(recentChainData);
     final PendingPool<SignedBeaconBlock> pendingBlocks = PendingPool.createForBlocks();
     final FutureItems<SignedBeaconBlock> futureBlocks =
         FutureItems.create(SignedBeaconBlock::getSlot);


### PR DESCRIPTION
## PR Description
Update `BlockValidator` to use `getStateAtSlot` to get a state in the new block's epoch as part of validation so that the cache is used instead of always processing slots/epochs manually.

Also fixes an issue where the domain used when verifying the block signature was created using the epoch of the parent block, instead of the new block. See https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/validator.md#signature

## Fixed Issue(s)
#3262 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.