### PR TITLE
Use cached pre-states when importing blocks

### DIFF
--- a/data/recorder/src/main/java/tech/pegasys/teku/data/recorder/SSZTransitionRecorder.java
+++ b/data/recorder/src/main/java/tech/pegasys/teku/data/recorder/SSZTransitionRecorder.java
@@ -49,7 +49,6 @@ public class SSZTransitionRecorder {
   @Subscribe
   public void onBlockProcessingRecord(final BlockProcessingRecord record) {
     final Path slotDirectory = slotDirectory(record.getBlock().getSlot());
-    store(slotDirectory.resolve("pre.ssz"), record.getPreState());
     store(slotDirectory.resolve("block.ssz"), record.getBlock());
     store(slotDirectory.resolve("post.ssz"), record.getPostState());
   }

--- a/data/src/main/java/tech/pegasys/teku/data/BlockProcessingRecord.java
+++ b/data/src/main/java/tech/pegasys/teku/data/BlockProcessingRecord.java
@@ -17,19 +17,12 @@ import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 
 public class BlockProcessingRecord {
-  private final BeaconState preState;
   private final SignedBeaconBlock block;
   private final BeaconState postState;
 
-  public BlockProcessingRecord(
-      final BeaconState preState, final SignedBeaconBlock block, final BeaconState postState) {
-    this.preState = preState;
+  public BlockProcessingRecord(final SignedBeaconBlock block, final BeaconState postState) {
     this.block = block;
     this.postState = postState;
-  }
-
-  public BeaconState getPreState() {
-    return preState;
   }
 
   public SignedBeaconBlock getBlock() {

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -299,14 +299,7 @@ public class ForkChoiceUtil {
     if (blockSlotState == null) {
       return Optional.of(BlockImportResult.FAILED_UNKNOWN_PARENT);
     }
-    if (blockSlotState.getSlot().isGreaterThan(blockSlot)) {
-      return Optional.of(BlockImportResult.FAILED_INVALID_ANCESTRY);
-    }
     if (!blockSlotState.getSlot().equals(blockSlot)) {
-      LOG.warn(
-          "Attempting to process block on old state. Block slot {}, state slot {}",
-          blockSlot,
-          blockSlotState.getSlot());
       return Optional.of(BlockImportResult.FAILED_INVALID_ANCESTRY);
     }
     if (blockSlot.isGreaterThan(UInt64.valueOf(GENESIS_SLOT))

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -28,8 +28,6 @@ import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
 import javax.annotation.CheckReturnValue;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.core.lookup.IndexedAttestationProvider;
 import tech.pegasys.teku.core.results.BlockImportResult;
@@ -48,7 +46,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
 
 public class ForkChoiceUtil {
-  private static final Logger LOG = LogManager.getLogger();
 
   public static UInt64 get_slots_since_genesis(ReadOnlyStore store, boolean useUnixTime) {
     UInt64 time = useUnixTime ? UInt64.valueOf(Instant.now().getEpochSecond()) : store.getTime();

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.core;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.datastructures.util.AttestationProcessingResult.SUCCESSFUL;
 import static tech.pegasys.teku.datastructures.util.AttestationUtil.is_valid_indexed_attestation;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
@@ -209,6 +210,10 @@ public class ForkChoiceUtil {
     }
   }
 
+  /**
+   * Perform block processing. The supplied blockSlotState must already have empty slots processed
+   * to the same slot as the block.
+   */
   @CheckReturnValue
   public static BlockImportResult on_block(
       final MutableStore store,
@@ -217,6 +222,9 @@ public class ForkChoiceUtil {
       final StateTransition st,
       final ForkChoiceStrategy forkChoiceStrategy,
       final IndexedAttestationProvider indexedAttestationProvider) {
+    checkArgument(
+        blockSlotState.getSlot().equals(signed_block.getSlot()),
+        "State must have slots processed up to the block slot");
     final BeaconBlock block = signed_block.getMessage();
 
     // Return early if precondition checks fail;

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/stategenerator/CachingTaskQueue.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/stategenerator/CachingTaskQueue.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntSupplier;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
@@ -216,6 +217,10 @@ public class CachingTaskQueue<K, V> {
 
   public void remove(final K key) {
     cache.remove(key);
+  }
+
+  public void removeIf(final Predicate<K> removalCondition) {
+    cache.keySet().removeIf(removalCondition);
   }
 
   public interface CacheableTask<K, V> {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.core.results.BlockImportResult;
 import tech.pegasys.teku.data.BlockProcessingRecord;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.datastructures.operations.ProposerSlashing;
@@ -84,8 +85,11 @@ public class BlockImporter {
     }
 
     return validateWeakSubjectivityPeriod()
-        .thenCompose(__ -> recentChainData.retrieveBlockState(block.getParentRoot()))
-        .thenCompose(preState -> forkChoice.onBlock(block, preState))
+        .thenCompose(
+            __ ->
+                recentChainData.retrieveStateAtSlot(
+                    new SlotAndBlockRoot(block.getSlot(), block.getParentRoot())))
+        .thenCompose(blockSlotState -> forkChoice.onBlock(block, blockSlotState))
         .thenApply(
             result -> {
               if (!result.isSuccessful()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -114,6 +114,10 @@ public class ForkChoice {
         .join();
   }
 
+  /**
+   * Import a block to the store. The supplied blockSlotState must already have empty slots
+   * processed to the same slot as the block.
+   */
   public SafeFuture<BlockImportResult> onBlock(
       final SignedBeaconBlock block, Optional<BeaconState> blockSlotState) {
     if (blockSlotState.isEmpty()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.statetransition.forkchoice;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.core.ForkChoiceUtil.on_attestation;
 import static tech.pegasys.teku.core.ForkChoiceUtil.on_block;
 import static tech.pegasys.teku.statetransition.forkchoice.StateRootCollector.addParentStateRoots;
@@ -118,6 +119,11 @@ public class ForkChoice {
     if (blockSlotState.isEmpty()) {
       return SafeFuture.completedFuture(BlockImportResult.FAILED_UNKNOWN_PARENT);
     }
+    checkArgument(
+        block.getSlot().equals(blockSlotState.get().getSlot()),
+        "State must have processed slots up to the block slot. Block slot %s, state slot %s",
+        block.getSlot(),
+        blockSlotState.get().getSlot());
     return onForkChoiceThread(
         () -> {
           final ForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/StateRootCollector.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/StateRootCollector.java
@@ -35,7 +35,7 @@ public class StateRootCollector {
     final UInt64 minimumSlot = newBlockSlot.minusMinZero(SLOTS_PER_HISTORICAL_ROOT);
     // Get the parent block root from the state as the genesis block root is recorded as 0
     final Bytes32 parentBlockRoot =
-        blockRoots.get(newBlockSlot.minus(1).mod(SLOTS_PER_HISTORICAL_ROOT).intValue());
+        blockRoots.get(newBlockSlot.minusMinZero(1).mod(SLOTS_PER_HISTORICAL_ROOT).intValue());
     UInt64 slot = newBlockSlot.minus(1);
     while (slot.isGreaterThanOrEqualTo(minimumSlot) && !slot.isZero()) {
       final Bytes32 previousBlockRoot = getValue(blockRoots, slot.minus(1));

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/StateRootCollector.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/StateRootCollector.java
@@ -36,7 +36,7 @@ public class StateRootCollector {
     // Get the parent block root from the state as the genesis block root is recorded as 0
     final Bytes32 parentBlockRoot =
         blockRoots.get(newBlockSlot.minusMinZero(1).mod(SLOTS_PER_HISTORICAL_ROOT).intValue());
-    UInt64 slot = newBlockSlot.minus(1);
+    UInt64 slot = newBlockSlot.minusMinZero(1);
     while (slot.isGreaterThanOrEqualTo(minimumSlot) && !slot.isZero()) {
       final Bytes32 previousBlockRoot = getValue(blockRoots, slot.minus(1));
       if (!previousBlockRoot.equals(parentBlockRoot)) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/StateRootCollector.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/StateRootCollector.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_HISTORICAL_ROOT;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.ssz.SSZTypes.SSZVector;
+import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
+
+public class StateRootCollector {
+  private static final Logger LOG = LogManager.getLogger();
+
+  public static void addParentStateRoots(
+      final BeaconState blockSlotState, final StoreTransaction transaction) {
+    final UInt64 newBlockSlot = blockSlotState.getSlot();
+    final SSZVector<Bytes32> blockRoots = blockSlotState.getBlock_roots();
+    final SSZVector<Bytes32> stateRoots = blockSlotState.getState_roots();
+    final UInt64 minimumSlot = newBlockSlot.minusMinZero(SLOTS_PER_HISTORICAL_ROOT);
+    // Get the parent block root from the state as the genesis block root is recorded as 0
+    final Bytes32 parentBlockRoot =
+        blockRoots.get(newBlockSlot.minus(1).mod(SLOTS_PER_HISTORICAL_ROOT).intValue());
+    UInt64 slot = newBlockSlot.minus(1);
+    while (slot.isGreaterThanOrEqualTo(minimumSlot) && !slot.isZero()) {
+      final Bytes32 previousBlockRoot = getValue(blockRoots, slot.minus(1));
+      if (!previousBlockRoot.equals(parentBlockRoot)) {
+        // Reached the first slot of the parent block - its state root is already be imported
+        return;
+      }
+      transaction.putStateRoot(
+          getValue(stateRoots, slot), new SlotAndBlockRoot(slot, parentBlockRoot));
+      slot = slot.decrement();
+    }
+    if (!slot.isZero()) {
+      LOG.warn("Missing some state root mappings prior to slot {}", minimumSlot);
+    }
+  }
+
+  private static Bytes32 getValue(final SSZVector<Bytes32> roots, final UInt64 slot) {
+    return roots.get(slot.mod(SLOTS_PER_HISTORICAL_ROOT).intValue());
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -288,13 +288,13 @@ class ForkChoiceTest {
     assertBlockImportedSuccessfully(result);
   }
 
-  private BeaconState processSlots(final SignedBlockAndState block, BeaconState preState) {
-    try {
-      if (preState.getSlot().isLessThan(block.getSlot())) {
-        preState = new StateTransition().process_slots(preState, block.getSlot());
+  private BeaconState processSlots(final SignedBlockAndState block, final BeaconState preState) {
+    if (preState.getSlot().isLessThan(block.getSlot())) {
+      try {
+        return new StateTransition().process_slots(preState, block.getSlot());
+      } catch (final SlotProcessingException | EpochProcessingException e) {
+        Assertions.fail("State transition failed", e);
       }
-    } catch (final SlotProcessingException | EpochProcessingException e) {
-      Assertions.fail("State transition failed", e);
     }
     return preState;
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -75,7 +75,7 @@ class ForkChoiceTest {
 
     storageSystem
         .chainUpdater()
-        .setTime(genesis.getState().getGenesis_time().plus(10 * SECONDS_PER_SLOT));
+        .setTime(genesis.getState().getGenesis_time().plus(10L * SECONDS_PER_SLOT));
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/StateRootCollectorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/StateRootCollectorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_HISTORICAL_ROOT;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.core.StateTransition;
+import tech.pegasys.teku.datastructures.blocks.BeaconBlockSummary;
+import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
+import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
+
+class StateRootCollectorTest {
+  private final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault();
+  private final StoreTransaction transaction = mock(StoreTransaction.class);
+  private SignedBlockAndState genesis;
+
+  @BeforeEach
+  void setUp() {
+    genesis = storageSystem.chainUpdater().initializeGenesis();
+  }
+
+  @Test
+  void shouldNotCaptureAnyStateRootsForBlockInSlot1() {
+    final BeaconState state = storageSystem.chainUpdater().advanceChain(1).getState();
+
+    StateRootCollector.addParentStateRoots(state, transaction);
+    verifyNoInteractions(transaction);
+  }
+
+  @Test
+  void shouldCaptureRootsForEmptySlotsAfterGenesis() {
+    final BeaconState state = storageSystem.chainUpdater().advanceChain(3).getState();
+
+    StateRootCollector.addParentStateRoots(state, transaction);
+
+    verifyStateRootRecorded(state, 2, genesis);
+    verifyStateRootRecorded(state, 1, genesis);
+    verifyNoMoreInteractions(transaction);
+  }
+
+  @Test
+  void shouldNotCaptureStatesPriorToSlotsPerHistoricalRoot() throws Exception {
+    final BeaconState state =
+        storageSystem.chainUpdater().advanceChain(SLOTS_PER_HISTORICAL_ROOT + 2).getState();
+
+    StateRootCollector.addParentStateRoots(state, transaction);
+
+    final StateTransition stateTransition = new StateTransition();
+    BeaconState historicState = genesis.getState();
+    for (int i = 2; i < SLOTS_PER_HISTORICAL_ROOT + 2; i++) {
+      final UInt64 slot = UInt64.valueOf(i);
+      // Regenerate states to ensure we don't wrap around and record the wrong values.
+      historicState = stateTransition.process_slots(historicState, slot);
+      verify(transaction)
+          .putStateRoot(
+              historicState.hashTreeRoot(), new SlotAndBlockRoot(slot, genesis.getRoot()));
+    }
+    verifyNoMoreInteractions(transaction);
+  }
+
+  @Test
+  void shouldStopRecordingStatesWhenParentBlockSlotReached() {
+    final SignedBlockAndState parentBlock = storageSystem.chainUpdater().advanceChain(4);
+    final BeaconState state = storageSystem.chainUpdater().advanceChain(7).getState();
+
+    StateRootCollector.addParentStateRoots(state, transaction);
+    verifyStateRootRecorded(state, 5, parentBlock);
+    verifyStateRootRecorded(state, 6, parentBlock);
+    verifyNoMoreInteractions(transaction);
+  }
+
+  private void verifyStateRootRecorded(
+      final BeaconState state, final int slot, final BeaconBlockSummary parentBlock) {
+    verify(transaction)
+        .putStateRoot(
+            getStateRoot(state, slot),
+            new SlotAndBlockRoot(UInt64.valueOf(slot), parentBlock.getRoot()));
+  }
+
+  private Bytes32 getStateRoot(final BeaconState state, final int slot) {
+    return state.getState_roots().get(slot % SLOTS_PER_HISTORICAL_ROOT);
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/StateRootCollectorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/StateRootCollectorTest.java
@@ -44,8 +44,6 @@ class StateRootCollectorTest {
 
   @Test
   void shouldNotCaptureAnyStateRootsForGenesisState() {
-    final BeaconState state = storageSystem.chainUpdater().advanceChain(1).getState();
-
     StateRootCollector.addParentStateRoots(genesis.getState(), transaction);
     verifyNoInteractions(transaction);
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/StateRootCollectorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/StateRootCollectorTest.java
@@ -43,6 +43,14 @@ class StateRootCollectorTest {
   }
 
   @Test
+  void shouldNotCaptureAnyStateRootsForGenesisState() {
+    final BeaconState state = storageSystem.chainUpdater().advanceChain(1).getState();
+
+    StateRootCollector.addParentStateRoots(genesis.getState(), transaction);
+    verifyNoInteractions(transaction);
+  }
+
+  @Test
   void shouldNotCaptureAnyStateRootsForBlockInSlot1() {
     final BeaconState state = storageSystem.chainUpdater().advanceChain(1).getState();
 

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.core.signatures.Signer;
 import tech.pegasys.teku.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.datastructures.interop.InteropStartupUtil;
 import tech.pegasys.teku.datastructures.interop.MockStartValidatorKeyPairFactory;
@@ -191,7 +192,9 @@ public class BeaconChainUtil {
         createBlockAndStateAtSlot(slot, true, attestations, deposits, exits, eth1Data).getBlock();
     setSlot(slot);
     final Optional<BeaconState> preState =
-        recentChainData.retrieveBlockState(block.getParentRoot()).join();
+        recentChainData
+            .retrieveStateAtSlot(new SlotAndBlockRoot(block.getSlot(), block.getParentRoot()))
+            .join();
     final BlockImportResult importResult = forkChoice.onBlock(block, preState).join();
     if (!importResult.isSuccessful()) {
       throw new IllegalStateException(

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceTestExecutor.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceTestExecutor.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.results.BlockImportResult;
 import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.BeaconStateImpl;
@@ -259,7 +260,12 @@ public class ForkChoiceTestExecutor {
       RecentChainData recentChainData, ForkChoice fc, SignedBeaconBlock block) {
     BlockImportResult blockImportResult =
         fc.onBlock(
-                block, recentChainData.getStore().getBlockStateIfAvailable(block.getParentRoot()))
+                block,
+                recentChainData
+                    .getStore()
+                    .retrieveStateAtSlot(
+                        new SlotAndBlockRoot(block.getSlot(), block.getParentRoot()))
+                    .join())
             .join();
     return blockImportResult.isSuccessful();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -93,7 +93,7 @@ class Store implements UpdatableStore {
   Checkpoint best_justified_checkpoint;
   final CachingTaskQueue<Bytes32, StateAndBlockSummary> states;
   final Map<Bytes32, SignedBeaconBlock> blocks;
-  private final CachingTaskQueue<SlotAndBlockRoot, BeaconState> checkpointStates;
+  final CachingTaskQueue<SlotAndBlockRoot, BeaconState> checkpointStates;
   final Map<UInt64, VoteTracker> votes;
   private ProtoArrayForkChoiceStrategy forkChoiceStrategy;
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -98,6 +98,8 @@ class StoreTransactionUpdates {
         (root) -> {
           store.blocks.remove(root);
           store.states.remove(root);
+          store.checkpointStates.removeIf(
+              slotAndBlockRoot -> slotAndBlockRoot.getBlockRoot().equals(root));
         });
 
     store.blockMetadata =

--- a/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/BatchImporterTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/BatchImporterTest.java
@@ -161,7 +161,6 @@ class BatchImporterTest {
     ignoreFuture(verify(blockImporter).importBlock(block));
     verifyNoMoreInteractions(blockImporter);
 
-    importResult1.complete(
-        BlockImportResult.successful(new BlockProcessingRecord(null, block, null)));
+    importResult1.complete(BlockImportResult.successful(new BlockProcessingRecord(block, null)));
   }
 }

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -513,10 +513,7 @@ class ValidatorApiHandlerTest {
         .thenReturn(
             SafeFuture.completedFuture(
                 BlockImportResult.successful(
-                    new BlockProcessingRecord(
-                        dataStructureUtil.randomBeaconState(),
-                        block,
-                        dataStructureUtil.randomBeaconState()))));
+                    new BlockProcessingRecord(block, dataStructureUtil.randomBeaconState()))));
     final SafeFuture<SendSignedBlockResult> result = validatorApiHandler.sendSignedBlock(block);
 
     verify(eventBus).post(new ProposedBlockEvent(block));


### PR DESCRIPTION
## PR Description
When importing blocks, get the state at the block's slot (prior to applying the block) via `Store.retrieveStateAtSlot` so it benefits from any cached states that performed the required slot and epoch processing.

Note that the `SSZTransitionRecorder` no longer captures the pre-state because we don't have the state at the previous block anymore - however it is still recorded as the post state for the previous block.

State roots are now captured from the state roots vector in the state rather than while processing slots as if the value came from cache we won't have done the slot processing.  If there are more than `SLOTS_PER_HISTORICAL_ROOT` empty slots in a row, we may not record some state roots, but this just matches the behaviour in `RocksDbDatabase` for finalized states.

## Fixed Issue(s)
#3262 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.