### PR TITLE
Fix producing invalid aggregates 

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/BeaconStateUtil.java
@@ -792,8 +792,8 @@ public class BeaconStateUtil {
    * @see
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#bytes_to_int</a>
    */
-  public static long bytes_to_int64(Bytes data) {
-    return data.toLong(ByteOrder.LITTLE_ENDIAN);
+  public static UInt64 bytes_to_int64(Bytes data) {
+    return UInt64.fromLongBits(data.toLong(ByteOrder.LITTLE_ENDIAN));
   }
 
   public static Bytes32 getCurrentDutyDependentRoot(BeaconState state) {

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.datastructures.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.Math.toIntExact;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.bytes_to_int64;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
@@ -66,10 +65,9 @@ public class CommitteeUtil {
 
       // This needs to be unsigned modulo.
       int pivot =
-          toIntExact(
-              Long.remainderUnsigned(
-                  bytes_to_int64(Hash.sha2_256(Bytes.wrap(seed, roundAsByte)).slice(0, 8)),
-                  index_count));
+          bytes_to_int64(Hash.sha2_256(Bytes.wrap(seed, roundAsByte)).slice(0, 8))
+              .mod(index_count)
+              .intValue();
       int flip = Math.floorMod(pivot + index_count - indexRet, index_count);
       int position = Math.max(indexRet, flip);
 
@@ -119,10 +117,9 @@ public class CommitteeUtil {
 
       // This needs to be unsigned modulo.
       int pivot =
-          toIntExact(
-              Long.remainderUnsigned(
-                  bytes_to_int64(Hash.sha2_256(Bytes.wrap(seed, roundAsByte)).slice(0, 8)),
-                  listSize));
+          bytes_to_int64(Hash.sha2_256(Bytes.wrap(seed, roundAsByte)).slice(0, 8))
+              .mod(listSize)
+              .intValue();
 
       Bytes hashBytes = Bytes.EMPTY;
       int mirror1 = (pivot + 2) / 2;
@@ -285,7 +282,9 @@ public class CommitteeUtil {
   }
 
   public static boolean isAggregator(final BLSSignature slot_signature, final int modulo) {
-    return (bytes_to_int64(Hash.sha2_256(slot_signature.toSSZBytes()).slice(0, 8)) % modulo) == 0;
+    return bytes_to_int64(Hash.sha2_256(slot_signature.toSSZBytes()).slice(0, 8))
+        .mod(modulo)
+        .isZero();
   }
 
   /**

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/BeaconStateUtilTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.Bytes48;
 import org.apache.tuweni.junit.BouncyCastleExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,6 +59,32 @@ import tech.pegasys.teku.util.config.Constants;
 @ExtendWith(BouncyCastleExtension.class)
 class BeaconStateUtilTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+
+  @Test
+  void a() {
+    Bytes signingRoot =
+        compute_signing_root(
+            57950,
+            Bytes32.fromHexString(
+                "0x05000000b5303f2ad2010d699a76c8e62350947421a3e4a979779642cfdb0f66"));
+    BLSSignature selectionProof =
+        BLSSignature.fromSSZBytes(
+            Bytes.fromHexString(
+                "0xaa176502f0a5e954e4c6b452d0e11a03513c19b6d189f125f07b6c5c120df011c31da4c4a9c4a52a5a48fcba5b14d7b316b986a146187966d2341388bbf1f86c42e90553ba009ba10edc6b5544a6e945ce6d2419197f66ab2b9df2b0a0c89987"));
+    BLSPublicKey pKey =
+        BLSPublicKey.fromBytesCompressed(
+            Bytes48.fromHexString(
+                "0xb0861f72583516b17a3fdc33419d5c04c0a4444cc2478136b4935f3148797699e3ef4a4b2227b14876b3d49ff03b796d"));
+
+    System.out.println(BLS.verify(pKey, signingRoot, selectionProof));
+
+    int committeeLen = 146;
+
+    int aggregatorModulo = CommitteeUtil.getAggregatorModulo(committeeLen);
+    boolean isAggr = CommitteeUtil.isAggregator(selectionProof, aggregatorModulo);
+
+    System.out.println(isAggr);
+  }
 
   @Test
   void minReturnsMin() {
@@ -257,12 +284,23 @@ class BeaconStateUtilTest {
 
   @Test
   void bytesToInt() {
-    assertEquals(0L, BeaconStateUtil.bytes_to_int64(Bytes.fromHexString("0x00")));
-    assertEquals(1L, BeaconStateUtil.bytes_to_int64(Bytes.fromHexString("0x01")));
-    assertEquals(1L, BeaconStateUtil.bytes_to_int64(Bytes.fromHexString("0x0100000000000000")));
+    assertEquals(UInt64.valueOf(0), BeaconStateUtil.bytes_to_int64(Bytes.fromHexString("0x00")));
+    assertEquals(UInt64.valueOf(1), BeaconStateUtil.bytes_to_int64(Bytes.fromHexString("0x01")));
     assertEquals(
-        0x123456789abcdef0L,
+        UInt64.valueOf(1),
+        BeaconStateUtil.bytes_to_int64(Bytes.fromHexString("0x0100000000000000")));
+    assertEquals(
+        UInt64.valueOf(0x123456789abcdef0L),
         BeaconStateUtil.bytes_to_int64(Bytes.fromHexString("0xf0debc9a78563412")));
+    assertEquals(
+        UInt64.fromLongBits(0xffffffffffffffffL),
+        BeaconStateUtil.bytes_to_int64(Bytes.fromHexString("0xffffffffffffffff")));
+    assertEquals(
+        UInt64.fromLongBits(0x0000000000000080L),
+        BeaconStateUtil.bytes_to_int64(Bytes.fromHexString("0x8000000000000000")));
+    assertEquals(
+        UInt64.fromLongBits(0xffffffffffffff7fL),
+        BeaconStateUtil.bytes_to_int64(Bytes.fromHexString("0x7fffffffffffffff")));
   }
 
   @Test

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/BeaconStateUtilTest.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.bytes.Bytes48;
 import org.apache.tuweni.junit.BouncyCastleExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,32 +58,6 @@ import tech.pegasys.teku.util.config.Constants;
 @ExtendWith(BouncyCastleExtension.class)
 class BeaconStateUtilTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
-
-  @Test
-  void a() {
-    Bytes signingRoot =
-        compute_signing_root(
-            57950,
-            Bytes32.fromHexString(
-                "0x05000000b5303f2ad2010d699a76c8e62350947421a3e4a979779642cfdb0f66"));
-    BLSSignature selectionProof =
-        BLSSignature.fromSSZBytes(
-            Bytes.fromHexString(
-                "0xaa176502f0a5e954e4c6b452d0e11a03513c19b6d189f125f07b6c5c120df011c31da4c4a9c4a52a5a48fcba5b14d7b316b986a146187966d2341388bbf1f86c42e90553ba009ba10edc6b5544a6e945ce6d2419197f66ab2b9df2b0a0c89987"));
-    BLSPublicKey pKey =
-        BLSPublicKey.fromBytesCompressed(
-            Bytes48.fromHexString(
-                "0xb0861f72583516b17a3fdc33419d5c04c0a4444cc2478136b4935f3148797699e3ef4a4b2227b14876b3d49ff03b796d"));
-
-    System.out.println(BLS.verify(pKey, signingRoot, selectionProof));
-
-    int committeeLen = 146;
-
-    int aggregatorModulo = CommitteeUtil.getAggregatorModulo(committeeLen);
-    boolean isAggr = CommitteeUtil.isAggregator(selectionProof, aggregatorModulo);
-
-    System.out.println(isAggr);
-  }
 
   @Test
   void minReturnsMin() {

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/CommitteeUtilTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/CommitteeUtilTest.java
@@ -16,12 +16,18 @@ package tech.pegasys.teku.datastructures.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_signing_root;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
 import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLS;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
@@ -87,5 +93,28 @@ public class CommitteeUtilTest {
 
     final UInt64 oldSlot = epochSlot.minus(ONE);
     assertDoesNotThrow(() -> CommitteeUtil.get_beacon_committee(state, oldSlot, ONE));
+  }
+
+  @Test
+  void testIsAggregatorReturnsFalseOnARealCase() {
+    Bytes signingRoot =
+        compute_signing_root(
+            57950,
+            Bytes32.fromHexString(
+                "0x05000000b5303f2ad2010d699a76c8e62350947421a3e4a979779642cfdb0f66"));
+    BLSSignature selectionProof =
+        BLSSignature.fromSSZBytes(
+            Bytes.fromHexString(
+                "0xaa176502f0a5e954e4c6b452d0e11a03513c19b6d189f125f07b6c5c120df011c31da4c4a9c4a52a5a48fcba5b14d7b316b986a146187966d2341388bbf1f86c42e90553ba009ba10edc6b5544a6e945ce6d2419197f66ab2b9df2b0a0c89987"));
+    BLSPublicKey pKey =
+        BLSPublicKey.fromBytesCompressed(
+            Bytes48.fromHexString(
+                "0xb0861f72583516b17a3fdc33419d5c04c0a4444cc2478136b4935f3148797699e3ef4a4b2227b14876b3d49ff03b796d"));
+    int committeeLen = 146;
+
+    assertThat(BLS.verify(pKey, signingRoot, selectionProof)).isTrue();
+
+    int aggregatorModulo = CommitteeUtil.getAggregatorModulo(committeeLen);
+    assertThat(CommitteeUtil.isAggregator(selectionProof, aggregatorModulo)).isFalse();
   }
 }

--- a/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
+++ b/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
@@ -212,8 +212,7 @@ public class FuzzUtil {
       return Optional.empty();
     }
     // Mask it to make ensure positive before using remainder.
-    int count =
-        ((int) (0xFFFFFFFFL & BeaconStateUtil.bytes_to_int64(Bytes.wrap(input, 0, 2)))) % 100;
+    int count = BeaconStateUtil.bytes_to_int64(Bytes.wrap(input, 0, 2)).mod(100).intValue();
 
     Bytes32 seed = Bytes32.wrap(input, 2);
 


### PR DESCRIPTION
## PR Description

It was noticed that Teku is producing invalid aggregates on mainnet. 
That happens because of `UInt` arithmetic issue in `CommitteeUtil.isAggregator()`

- Fix `CommitteeUtil.isAggregator()`. 
- Make `bytes_to_int64()` returning `UInt64` instead of `long`

The mainnet case which was investigated: 
```
slot = 57950, 
validator_index = 6136, 
selection_proof = 0xaa176502f0a5e954e4c6b452d0e11a03513c19b6d189f125f07b6c5c120df011c31da4c4a9c4a52a5a48fcba5b14d7b316b986a146187966d2341388bbf1f86c42e90553ba009ba10edc6b5544a6e945ce6d2419197f66ab2b9df2b0a0c89987
committee_len = 146
```
Teku produced aggregated attestation while should not do so 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.