### PR TITLE
Publish all docker variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Upcoming Breaking Changes
 
+- The default docker image will be updated to Java 15. Java 15 based images are available now for testing with the `-jdk15` suffix (e.g `consensys/teku:develop-jdk15`)
 - Docker images are now being published to `consensys/teku`. The `pegasys/teku` images will continue to be updated for the next few releases but please update your configuration to use `consensys/teku`.
 - `--validators-key-files` and `--validators-key-password-files` have been replaced by `--validator-keys`. The old arguments will be removed in a future release.
 

--- a/build.gradle
+++ b/build.gradle
@@ -742,16 +742,14 @@ bintray {
 bintrayUpload.mustRunAfter(distTar)
 bintrayUpload.mustRunAfter(distZip)
 
-task dockerUpload(type: Exec) {
+task dockerUpload {
   dependsOn([distDocker])
   def dockerBuildVersion = "${rootProject.version}"
   def imageName = "consensys/teku"
   def image = "${imageName}:${dockerBuildVersion}"
-  def cmd = "docker tag '${imageName}:develop' '${image}' && docker push '${image}'"
 
   def psImageName = "pegasyseng/teku"
   def psImage = "${psImageName}:${dockerBuildVersion}"
-  cmd += " && docker tag '${image}' '${psImage}' && docker push '${psImage}'"
 
   def additionalTags = []
   if (project.hasProperty('branch') && project.property('branch') == 'master') {
@@ -763,8 +761,26 @@ task dockerUpload(type: Exec) {
     additionalTags.add(dockerBuildVersion.split(/\./)[0..1].join('.'))
   }
 
-  additionalTags.each { tag -> cmd += " && docker tag '${image}' '${imageName}:${tag.trim()}' && docker push '${imageName}:${tag.trim()}'" }
-  additionalTags.each { tag -> cmd += " && docker tag '${image}' '${psImageName}:${tag.trim()}' && docker push '${psImageName}:${tag.trim()}'" }
-  executable "sh"
-  args '-c', cmd
+  doLast {
+    for (def variant in dockerVariants) {
+      def variantImage = "${image}-${variant}"
+      def variantBuildImage = "${imageName}:develop-${variant}"
+      def cmd = "docker tag '${variantBuildImage}' '${variantImage}' && docker push '${variantImage}'"
+      exec {
+        additionalTags.each { tag -> cmd += " && docker tag '${variantBuildImage}' '${imageName}:${tag.trim()}-${variant}' && docker push '${imageName}:${tag.trim()}-${variant}'" }
+        executable "sh"
+        args '-c', cmd
+      }
+    }
+
+    // Publish default version without variant suffix
+    exec {
+      def cmd = "docker tag '${imageName}:develop' '${image}' && docker push '${image}'"
+      cmd += " && docker tag '${image}' '${psImage}' && docker push '${psImage}'"
+      additionalTags.each { tag -> cmd += " && docker tag '${image}' '${imageName}:${tag.trim()}' && docker push '${imageName}:${tag.trim()}'" }
+      additionalTags.each { tag -> cmd += " && docker tag '${image}' '${psImageName}:${tag.trim()}' && docker push '${psImageName}:${tag.trim()}'" }
+      executable "sh"
+      args '-c', cmd
+    }
+  }
 }


### PR DESCRIPTION
## PR Description
Publish all docker variants, not just the default one.

## Fixed Issue(s)
fixes #3388 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

Docs - not sure if we need to discuss the availability of these variants or not.  The `-jdk15` variant does support ARM which may be worth noting but we'll likely make it the default at some point once its had enough testing.  The unsuffixed versions still exist (eg. `consensys/teku:develop` or `consensys/teku:latest`) so users don't need to make any changes.