### PR TITLE
Decouple in-memory storage updates from on-disk storage updates

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainConfiguration.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainConfiguration.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.services.beaconchain;
 
 import tech.pegasys.teku.beaconrestapi.BeaconRestApiConfig;
 import tech.pegasys.teku.networking.eth2.P2PConfig;
+import tech.pegasys.teku.service.serviceutils.FeatureToggleConfig;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
 import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 
@@ -23,16 +24,19 @@ public class BeaconChainConfiguration {
   private final ValidatorConfig validatorConfig;
   private final P2PConfig p2pConfig;
   private final BeaconRestApiConfig beaconRestApiConfig;
+  private final FeatureToggleConfig featureToggleConfig;
 
   public BeaconChainConfiguration(
       final WeakSubjectivityConfig weakSubjectivityConfig,
       final ValidatorConfig validatorConfig,
       final P2PConfig p2pConfig,
-      final BeaconRestApiConfig beaconRestApiConfig) {
+      final BeaconRestApiConfig beaconRestApiConfig,
+      final FeatureToggleConfig featureToggleConfig) {
     this.weakSubjectivityConfig = weakSubjectivityConfig;
     this.validatorConfig = validatorConfig;
     this.p2pConfig = p2pConfig;
     this.beaconRestApiConfig = beaconRestApiConfig;
+    this.featureToggleConfig = featureToggleConfig;
   }
 
   public WeakSubjectivityConfig weakSubjectivity() {
@@ -49,5 +53,9 @@ public class BeaconChainConfiguration {
 
   public BeaconRestApiConfig beaconRestApiConfig() {
     return beaconRestApiConfig;
+  }
+
+  public FeatureToggleConfig featureToggleConfig() {
+    return featureToggleConfig;
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -264,6 +264,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
         StoreConfig.builder()
             .hotStatePersistenceFrequencyInEpochs(config.getHotStatePersistenceFrequencyInEpochs())
             .disableBlockProcessingAtStartup(config.isBlockProcessingAtStartupDisabled())
+            .asyncStorageEnabled(beaconConfig.featureToggleConfig().isAsyncStorageEnabled())
             .build();
     coalescingChainHeadChannel =
         new CoalescingChainHeadChannel(eventChannels.getPublisher(ChainHeadChannel.class));

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainControllerTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainControllerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.io.TempDir;
 import tech.pegasys.teku.beaconrestapi.BeaconRestApiConfig;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.networking.eth2.P2PConfig;
+import tech.pegasys.teku.service.serviceutils.FeatureToggleConfig;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.service.serviceutils.layout.DataConfig;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
@@ -62,7 +63,8 @@ public class BeaconChainControllerTest {
         WeakSubjectivityConfig.builder().build(),
         ValidatorConfig.builder().build(),
         p2pConfig,
-        restApiConfig);
+        restApiConfig,
+        FeatureToggleConfig.builder().build());
   }
 
   @Test

--- a/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/FeatureToggleConfig.java
+++ b/services/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/FeatureToggleConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.service.serviceutils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class FeatureToggleConfig {
+  private static final Logger LOG = LogManager.getLogger();
+  private final boolean asyncStorageEnabled;
+
+  private FeatureToggleConfig(final boolean asyncStorageEnabled) {
+    this.asyncStorageEnabled = asyncStorageEnabled;
+    LOG.info("Configured feature toggled. Async storage enabled: {}", asyncStorageEnabled);
+  }
+
+  public static FeatureToggleConfig.Builder builder() {
+    return new Builder();
+  }
+
+  public boolean isAsyncStorageEnabled() {
+    return asyncStorageEnabled;
+  }
+
+  public static final class Builder {
+
+    private boolean asyncStorageEnabled;
+
+    private Builder() {}
+
+    public Builder asyncStorageEnabled(boolean asyncStorageEnabled) {
+      this.asyncStorageEnabled = asyncStorageEnabled;
+      return this;
+    }
+
+    public FeatureToggleConfig build() {
+      return new FeatureToggleConfig(asyncStorageEnabled);
+    }
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
@@ -51,12 +51,12 @@ public class RetryingStorageUpdateChannel implements StorageUpdateChannel {
   @Override
   public void onChainInitialized(final AnchorPoint initialAnchor) {
     retry(
-        arg -> {
-          delegate.onChainInitialized(arg);
-          return SafeFuture.COMPLETE;
-        },
-        initialAnchor)
-    .reportExceptions();
+            arg -> {
+              delegate.onChainInitialized(arg);
+              return SafeFuture.COMPLETE;
+            },
+            initialAnchor)
+        .reportExceptions();
   }
 
   private <T> SafeFuture<Void> retry(final Function<T, SafeFuture<Void>> method, final T arg) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
@@ -55,7 +55,8 @@ public class RetryingStorageUpdateChannel implements StorageUpdateChannel {
           delegate.onChainInitialized(arg);
           return SafeFuture.COMPLETE;
         },
-        initialAnchor);
+        initialAnchor)
+    .reportExceptions();
   }
 
   private <T> SafeFuture<Void> retry(final Function<T, SafeFuture<Void>> method, final T arg) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server;
+
+import java.util.Collection;
+import java.util.function.Function;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.state.AnchorPoint;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.storage.api.StorageUpdateChannel;
+import tech.pegasys.teku.storage.events.StorageUpdate;
+import tech.pegasys.teku.storage.events.WeakSubjectivityUpdate;
+
+public class RetryingStorageUpdateChannel implements StorageUpdateChannel {
+  private static final Logger LOG = LogManager.getLogger();
+  private final StorageUpdateChannel delegate;
+
+  public RetryingStorageUpdateChannel(final StorageUpdateChannel delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public SafeFuture<Void> onStorageUpdate(final StorageUpdate event) {
+    return retry(delegate::onStorageUpdate, event);
+  }
+
+  @Override
+  public SafeFuture<Void> onFinalizedBlocks(final Collection<SignedBeaconBlock> finalizedBlocks) {
+    return retry(delegate::onFinalizedBlocks, finalizedBlocks);
+  }
+
+  @Override
+  public SafeFuture<Void> onWeakSubjectivityUpdate(
+      final WeakSubjectivityUpdate weakSubjectivityUpdate) {
+    return retry(delegate::onWeakSubjectivityUpdate, weakSubjectivityUpdate);
+  }
+
+  @Override
+  public void onChainInitialized(final AnchorPoint initialAnchor) {
+    retry(
+        arg -> {
+          delegate.onChainInitialized(arg);
+          return SafeFuture.COMPLETE;
+        },
+        initialAnchor);
+  }
+
+  private <T> SafeFuture<Void> retry(final Function<T, SafeFuture<Void>> method, final T arg) {
+    while (true) {
+      try {
+        final SafeFuture<Void> result = method.apply(arg);
+        result.join();
+        return result;
+      } catch (final Throwable t) {
+        LOG.error("Storage update failed. Retrying.", t);
+      }
+    }
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreConfig.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreConfig.java
@@ -32,18 +32,21 @@ public class StoreConfig {
   private final int checkpointStateCacheSize;
   private final int hotStatePersistenceFrequencyInEpochs;
   private final boolean disableBlockProcessingAtStartup;
+  private final boolean asyncStorageEnabled;
 
   private StoreConfig(
       final int stateCacheSize,
       final int blockCacheSize,
       final int checkpointStateCacheSize,
       final int hotStatePersistenceFrequencyInEpochs,
-      boolean disableBlockProcessingAtStartup) {
+      final boolean disableBlockProcessingAtStartup,
+      final boolean asyncStorageEnabled) {
     this.stateCacheSize = stateCacheSize;
     this.blockCacheSize = blockCacheSize;
     this.checkpointStateCacheSize = checkpointStateCacheSize;
     this.hotStatePersistenceFrequencyInEpochs = hotStatePersistenceFrequencyInEpochs;
     this.disableBlockProcessingAtStartup = disableBlockProcessingAtStartup;
+    this.asyncStorageEnabled = asyncStorageEnabled;
   }
 
   public static Builder builder() {
@@ -72,6 +75,10 @@ public class StoreConfig {
 
   public boolean isBlockProcessingAtStartupDisabled() {
     return disableBlockProcessingAtStartup;
+  }
+
+  public boolean isAsyncStorageEnabled() {
+    return asyncStorageEnabled;
   }
 
   @Override
@@ -106,6 +113,7 @@ public class StoreConfig {
     private int hotStatePersistenceFrequencyInEpochs =
         DEFAULT_HOT_STATE_PERSISTENCE_FREQUENCY_IN_EPOCHS;
     private boolean disableBlockProcessingAtStartup = false;
+    private boolean asyncStorageEnabled;
 
     private Builder() {}
 
@@ -115,7 +123,8 @@ public class StoreConfig {
           blockCacheSize,
           checkpointStateCacheSize,
           hotStatePersistenceFrequencyInEpochs,
-          disableBlockProcessingAtStartup);
+          disableBlockProcessingAtStartup,
+          asyncStorageEnabled);
     }
 
     public Builder stateCacheSize(final int stateCacheSize) {
@@ -144,6 +153,11 @@ public class StoreConfig {
 
     public Builder disableBlockProcessingAtStartup(final boolean disableBlockProcessingAtStartup) {
       this.disableBlockProcessingAtStartup = disableBlockProcessingAtStartup;
+      return this;
+    }
+
+    public Builder asyncStorageEnabled(final boolean asyncStorageEnabled) {
+      this.asyncStorageEnabled = asyncStorageEnabled;
       return this;
     }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.cli.options.BeaconNodeDataOptions;
 import tech.pegasys.teku.cli.options.BeaconRestApiOptions;
 import tech.pegasys.teku.cli.options.DataStorageOptions;
 import tech.pegasys.teku.cli.options.DepositOptions;
+import tech.pegasys.teku.cli.options.FeatureToggleOptions;
 import tech.pegasys.teku.cli.options.InteropOptions;
 import tech.pegasys.teku.cli.options.LoggingOptions;
 import tech.pegasys.teku.cli.options.MetricsOptions;
@@ -179,6 +180,9 @@ public class BeaconNodeCommand implements Callable<Integer> {
 
   @Mixin(name = "Weak Subjectivity")
   private WeakSubjectivityOptions weakSubjectivityOptions;
+
+  @Mixin(name = "Feature Toggles")
+  private FeatureToggleOptions featureToggleOptions;
 
   public BeaconNodeCommand(
       final PrintWriter outputWriter,
@@ -335,6 +339,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
       dataOptions.configure(builder);
       p2POptions.configure(builder, networkOptions.getNetwork());
       beaconRestApiOptions.configure(builder, networkOptions.getNetwork());
+      featureToggleOptions.configure(builder);
 
       return builder.build();
     } catch (IllegalArgumentException e) {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/FeatureToggleOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/FeatureToggleOptions.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.options;
+
+import picocli.CommandLine.Option;
+import tech.pegasys.teku.config.TekuConfiguration;
+
+public class FeatureToggleOptions {
+
+  @Option(
+      names = {"--Xasync-storage-enabled"},
+      hidden = true,
+      paramLabel = "<BOOLEAN>",
+      description = "Whether to enable async storage mode. Default: false",
+      arity = "0..1",
+      fallbackValue = "true")
+  private boolean asyncStorageEnabled = false;
+
+  public TekuConfiguration.Builder configure(final TekuConfiguration.Builder builder) {
+    return builder.featureToggle(config -> config.asyncStorageEnabled(asyncStorageEnabled));
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 import tech.pegasys.teku.beaconrestapi.BeaconRestApiConfig;
 import tech.pegasys.teku.networking.eth2.P2PConfig;
 import tech.pegasys.teku.networking.eth2.P2PConfig.P2PConfigBuilder;
+import tech.pegasys.teku.service.serviceutils.FeatureToggleConfig;
 import tech.pegasys.teku.service.serviceutils.layout.DataConfig;
 import tech.pegasys.teku.services.beaconchain.BeaconChainConfiguration;
 import tech.pegasys.teku.util.config.GlobalConfiguration;
@@ -31,6 +32,7 @@ public class TekuConfiguration {
   private final DataConfig dataConfig;
   private final BeaconChainConfiguration beaconChainConfig;
   private final ValidatorClientConfiguration validatorClientConfig;
+  private final FeatureToggleConfig featureToggleConfig;
 
   private TekuConfiguration(
       GlobalConfiguration globalConfiguration,
@@ -38,13 +40,19 @@ public class TekuConfiguration {
       final ValidatorConfig validatorConfig,
       final DataConfig dataConfig,
       final P2PConfig p2pConfig,
-      final BeaconRestApiConfig beaconRestApiConfig) {
+      final BeaconRestApiConfig beaconRestApiConfig,
+      final FeatureToggleConfig featureToggleConfig) {
     this.globalConfiguration = globalConfiguration;
     this.weakSubjectivityConfig = weakSubjectivityConfig;
     this.dataConfig = dataConfig;
+    this.featureToggleConfig = featureToggleConfig;
     this.beaconChainConfig =
         new BeaconChainConfiguration(
-            weakSubjectivityConfig, validatorConfig, p2pConfig, beaconRestApiConfig);
+            weakSubjectivityConfig,
+            validatorConfig,
+            p2pConfig,
+            beaconRestApiConfig,
+            featureToggleConfig);
     this.validatorClientConfig =
         new ValidatorClientConfiguration(globalConfiguration, validatorConfig, dataConfig);
   }
@@ -73,6 +81,10 @@ public class TekuConfiguration {
     return dataConfig;
   }
 
+  public FeatureToggleConfig featureToggleConfig() {
+    return featureToggleConfig;
+  }
+
   public void validate() {
     globalConfiguration.validate();
   }
@@ -87,6 +99,8 @@ public class TekuConfiguration {
     private final P2PConfigBuilder p2pConfigBuilder = P2PConfig.builder();
     private final BeaconRestApiConfig.BeaconRestApiConfigBuilder restApiBuilder =
         BeaconRestApiConfig.builder();
+    private final FeatureToggleConfig.Builder featureToggleConfigBuilder =
+        FeatureToggleConfig.builder();
 
     private Builder() {}
 
@@ -97,7 +111,8 @@ public class TekuConfiguration {
           validatorConfigBuilder.build(),
           dataConfigBuilder.build(),
           p2pConfigBuilder.build(),
-          restApiBuilder.build());
+          restApiBuilder.build(),
+          featureToggleConfigBuilder.build());
     }
 
     public Builder globalConfig(final Consumer<GlobalConfigurationBuilder> globalConfigConsumer) {
@@ -130,6 +145,11 @@ public class TekuConfiguration {
         final Consumer<BeaconRestApiConfig.BeaconRestApiConfigBuilder>
             beaconRestApiConfigConsumer) {
       beaconRestApiConfigConsumer.accept(restApiBuilder);
+      return this;
+    }
+
+    public Builder featureToggle(final Consumer<FeatureToggleConfig.Builder> consumer) {
+      consumer.accept(featureToggleConfigBuilder);
       return this;
     }
   }

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -26,7 +26,7 @@ public class BeaconNodeServiceController extends ServiceController {
   public BeaconNodeServiceController(
       TekuConfiguration tekuConfig, final ServiceConfig serviceConfig) {
     // Note services will be started in the order they are added here.
-    services.add(new StorageService(serviceConfig));
+    services.add(new StorageService(serviceConfig, tekuConfig.featureToggleConfig()));
     services.add(new BeaconChainService(serviceConfig, tekuConfig.beaconChain()));
     services.add(ValidatorClientService.create(serviceConfig, tekuConfig.validatorClient()));
     services.add(new TimerService(serviceConfig));


### PR DESCRIPTION
## PR Description
Adds the ability to apply updates to the in-memory store without first waiting for the on-disk store to be updated.  The on-disk storage will now continually retry updates if they fail to prevent it from winding up in an inconsistent state.  If the error isn't recoverable the event channel will eventually back up and block any further progress - we will likely need to treat too many repeated failures as a fatal error and shutdown to avoid these stalls.

When using archive mode, there is now potentially a period where finalized blocks have been removed from the in-memory store but are not yet available from the on-disk store.  We'll need to resolve that before this can be toggled on by default.

Change is feature toggled off by default.

## Fixed Issue(s)
#1934 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.