### PR TITLE
Retry ValidatorStatusLogger initial status check until beacon node is ready

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLogger.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLogger.java
@@ -72,7 +72,8 @@ public class DefaultValidatorStatusLogger implements ValidatorStatusLogger {
 
               startupComplete.set(true);
               return SafeFuture.completedFuture(null);
-            });
+            })
+        .exceptionallyCompose((__) -> retryInitialValidatorStatusCheck());
   }
 
   private SafeFuture<Void> retryInitialValidatorStatusCheck() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLogger.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLogger.java
@@ -19,7 +19,6 @@ import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -62,10 +61,6 @@ public class DefaultValidatorStatusLogger implements ValidatorStatusLogger {
               }
 
               Map<BLSPublicKey, ValidatorStatus> validatorStatuses = maybeValidatorStatuses.get();
-              if (validatorStatuses.values().stream().allMatch(Objects::isNull)) {
-                return retryInitialValidatorStatusCheck();
-              }
-
               if (validatorPublicKeys.size() < VALIDATOR_KEYS_PRINT_LIMIT) {
                 printValidatorStatusesOneByOne(validatorStatuses);
               } else {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -138,7 +138,7 @@ public class ValidatorClientService extends Service {
     if (validators.keySet().size() > 0) {
       this.validatorStatusLogger =
           new DefaultValidatorStatusLogger(
-              new ArrayList<>(validators.keySet()), validatorApiChannel);
+              new ArrayList<>(validators.keySet()), validatorApiChannel, asyncRunner);
     } else {
       this.validatorStatusLogger = ValidatorStatusLogger.NOOP;
     }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -171,7 +171,7 @@ public class ValidatorClientService extends Service {
                   validatorIndexProvider,
                   blockProductionTimingChannel,
                   attestationTimingChannel));
-          validatorStatusLogger.printInitialValidatorStatuses();
+          validatorStatusLogger.printInitialValidatorStatuses().reportExceptions();
           return beaconNodeApi.subscribeToEvents();
         });
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorStatusLogger.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorStatusLogger.java
@@ -13,18 +13,22 @@
 
 package tech.pegasys.teku.validator.client;
 
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
 public interface ValidatorStatusLogger {
 
   ValidatorStatusLogger NOOP =
       new ValidatorStatusLogger() {
         @Override
-        public void printInitialValidatorStatuses() {}
+        public SafeFuture<Void> printInitialValidatorStatuses() {
+          return SafeFuture.COMPLETE;
+        }
 
         @Override
         public void checkValidatorStatusChanges() {}
       };
 
-  void printInitialValidatorStatuses();
+  SafeFuture<Void> printInitialValidatorStatuses();
 
   void checkValidatorStatusChanges();
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLoggerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLoggerTest.java
@@ -20,10 +20,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
@@ -43,10 +41,8 @@ public class DefaultValidatorStatusLoggerTest {
   void shouldRetryPrintingInitialValidatorStatuses() {
     when(validatorApiChannel.getValidatorStatuses(validatorKeys))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(Collections.EMPTY_MAP)))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                Optional.of(Map.of(validatorKeys.get(0), ValidatorStatus.active_ongoing))));
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(Collections.EMPTY_MAP)));
 
     logger.printInitialValidatorStatuses().reportExceptions();
     verify(validatorApiChannel).getValidatorStatuses(validatorKeys);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLoggerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLoggerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+
+public class DefaultValidatorStatusLoggerTest {
+
+  private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
+  private final List<BLSPublicKey> validatorKeys = List.of(BLSPublicKey.random(0));
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+
+  private final DefaultValidatorStatusLogger logger =
+      new DefaultValidatorStatusLogger(validatorKeys, validatorApiChannel, asyncRunner);
+
+  @Test
+  void shouldRetryPrintingInitialValidatorStatuses() {
+    when(validatorApiChannel.getValidatorStatuses(validatorKeys))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(Collections.EMPTY_MAP)))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                Optional.of(Map.of(validatorKeys.get(0), ValidatorStatus.active_ongoing))));
+
+    logger.printInitialValidatorStatuses();
+    verify(validatorApiChannel).getValidatorStatuses(validatorKeys);
+
+    asyncRunner.executeQueuedActions();
+
+    verify(validatorApiChannel, times(2)).getValidatorStatuses(validatorKeys);
+
+    asyncRunner.executeQueuedActions();
+
+    verify(validatorApiChannel, times(3)).getValidatorStatuses(validatorKeys);
+
+    asyncRunner.executeUntilDone();
+
+    verify(validatorApiChannel, times(3)).getValidatorStatuses(validatorKeys);
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLoggerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLoggerTest.java
@@ -48,7 +48,7 @@ public class DefaultValidatorStatusLoggerTest {
             SafeFuture.completedFuture(
                 Optional.of(Map.of(validatorKeys.get(0), ValidatorStatus.active_ongoing))));
 
-    logger.printInitialValidatorStatuses();
+    logger.printInitialValidatorStatuses().reportExceptions();
     verify(validatorApiChannel).getValidatorStatuses(validatorKeys);
 
     asyncRunner.executeQueuedActions();

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLoggerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLoggerTest.java
@@ -39,6 +39,7 @@ public class DefaultValidatorStatusLoggerTest {
       new DefaultValidatorStatusLogger(validatorKeys, validatorApiChannel, asyncRunner);
 
   @Test
+  @SuppressWarnings("unchecked")
   void shouldRetryPrintingInitialValidatorStatuses() {
     when(validatorApiChannel.getValidatorStatuses(validatorKeys))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()))

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -216,20 +216,22 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
       List<BLSPublicKey> validatorIdentifiers) {
-    return chainDataProvider
-        .getStateValidators(
-            "head",
-            validatorIdentifiers.stream().map(BLSPublicKey::toString).collect(toList()),
-            new HashSet<>())
-        .thenApply(
-            (maybeList) ->
-                maybeList.map(
-                    list ->
-                        list.stream()
-                            .collect(
-                                toMap(
-                                    ValidatorResponse::getPublicKey,
-                                    ValidatorResponse::getStatus))));
+    return isSyncActive()
+        ? SafeFuture.completedFuture(Optional.empty())
+        : chainDataProvider
+            .getStateValidators(
+                "head",
+                validatorIdentifiers.stream().map(BLSPublicKey::toString).collect(toList()),
+                new HashSet<>())
+            .thenApply(
+                (maybeList) ->
+                    maybeList.map(
+                        list ->
+                            list.stream()
+                                .collect(
+                                    toMap(
+                                        ValidatorResponse::getPublicKey,
+                                        ValidatorResponse::getStatus))));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -13,7 +13,19 @@
 
 package tech.pegasys.teku.validator.remote;
 
+import static java.util.Collections.emptyMap;
+import static java.util.stream.Collectors.toMap;
+
 import com.google.common.base.Throwables;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -43,19 +55,6 @@ import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.remote.apiclient.RateLimitedException;
 import tech.pegasys.teku.validator.remote.apiclient.ValidatorRestApiClient;
-
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import static java.util.Collections.emptyMap;
-import static java.util.stream.Collectors.toMap;
 
 public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -100,25 +100,34 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
     if (publicKeys.isEmpty()) {
       return SafeFuture.completedFuture(emptyMap());
     }
-    return sendRequest(() -> makeBatchedValidatorRequest(publicKeys, ValidatorResponse::getIndex));
+    return sendRequest(
+        () ->
+            makeBatchedValidatorRequest(publicKeys, ValidatorResponse::getIndex)
+                .orElse(emptyMap()));
   }
 
   @Override
   public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
       List<BLSPublicKey> publicKeys) {
-    return sendRequest(
-        () -> Optional.of(makeBatchedValidatorRequest(publicKeys, ValidatorResponse::getStatus)));
+    return sendRequest(() -> makeBatchedValidatorRequest(publicKeys, ValidatorResponse::getStatus));
   }
 
-  private <T> Map<BLSPublicKey, T> makeBatchedValidatorRequest(
+  private <T> Optional<Map<BLSPublicKey, T>> makeBatchedValidatorRequest(
       List<BLSPublicKey> publicKeys, Function<ValidatorResponse, T> valueExtractor) {
     final Map<BLSPublicKey, T> returnedObjects = new HashMap<>();
     for (int i = 0; i < publicKeys.size(); i += MAX_PUBLIC_KEY_BATCH_SIZE) {
       final List<BLSPublicKey> batch =
           publicKeys.subList(i, Math.min(publicKeys.size(), i + MAX_PUBLIC_KEY_BATCH_SIZE));
-      requestValidatorObject(batch, valueExtractor).ifPresent(returnedObjects::putAll);
+      Optional<Map<BLSPublicKey, T>> validatorObjects =
+          requestValidatorObject(batch, valueExtractor);
+      boolean requestSuccesful = validatorObjects.isPresent();
+      if (requestSuccesful) {
+        returnedObjects.putAll(validatorObjects.get());
+      } else {
+        return Optional.empty();
+      }
     }
-    return returnedObjects;
+    return Optional.of(returnedObjects);
   }
 
   private <T> Optional<Map<BLSPublicKey, T>> requestValidatorObject(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -13,19 +13,7 @@
 
 package tech.pegasys.teku.validator.remote;
 
-import static java.util.Collections.emptyMap;
-import static java.util.stream.Collectors.toMap;
-
 import com.google.common.base.Throwables;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -55,6 +43,19 @@ import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.remote.apiclient.RateLimitedException;
 import tech.pegasys.teku.validator.remote.apiclient.ValidatorRestApiClient;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyMap;
+import static java.util.stream.Collectors.toMap;
 
 public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 
@@ -120,12 +121,10 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
           publicKeys.subList(i, Math.min(publicKeys.size(), i + MAX_PUBLIC_KEY_BATCH_SIZE));
       Optional<Map<BLSPublicKey, T>> validatorObjects =
           requestValidatorObject(batch, valueExtractor);
-      boolean requestSuccesful = validatorObjects.isPresent();
-      if (requestSuccesful) {
-        returnedObjects.putAll(validatorObjects.get());
-      } else {
+      if (validatorObjects.isEmpty()) {
         return Optional.empty();
       }
+      returnedObjects.putAll(validatorObjects.get());
     }
     return Optional.of(returnedObjects);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Retry ValidatorStatusLogger initial status check until the beacon node is ready.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.