### PR TITLE
[Issue-3401] Add warnings around initial state

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/AnchorPoint.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/AnchorPoint.java
@@ -43,6 +43,9 @@ public class AnchorPoint extends StateAndBlockSummary {
     super(blockSummary, state);
     checkArgument(
         checkpoint.getRoot().equals(blockSummary.getRoot()), "Checkpoint and block must match");
+    checkArgument(
+        checkpoint.getEpochStartSlot().isGreaterThanOrEqualTo(blockSummary.getSlot()),
+        "Block must be at or prior to the start of the checkpoint epoch");
 
     this.checkpoint = checkpoint;
     this.isGenesis = checkpoint.getEpoch().equals(UInt64.valueOf(Constants.GENESIS_EPOCH));

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/state/AnchorPointTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/state/AnchorPointTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.datastructures.state;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class AnchorPointTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+
+  @Test
+  public void create_withCheckpointPriorToState() {
+    final UInt64 epoch = UInt64.valueOf(10);
+    final UInt64 epochStartSlot = compute_start_slot_at_epoch(epoch);
+
+    final BeaconBlockAndState blockAndState =
+        dataStructureUtil.randomBlockAndState(epochStartSlot.plus(1));
+    final Checkpoint checkpoint = new Checkpoint(epoch, blockAndState.getRoot());
+
+    assertThatThrownBy(
+            () -> AnchorPoint.create(checkpoint, blockAndState.getState(), Optional.empty()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Block must be at or prior to the start of the checkpoint epoch");
+  }
+}

--- a/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
+++ b/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
@@ -352,6 +352,11 @@ public final class UInt64 implements Comparable<UInt64> {
     return Long.compareUnsigned(value, o.value);
   }
 
+  public int compareTo(final long other) {
+    checkPositive(other);
+    return Long.compareUnsigned(value, other);
+  }
+
   /**
    * Returns true if this value is zero.
    *
@@ -372,12 +377,32 @@ public final class UInt64 implements Comparable<UInt64> {
   }
 
   /**
+   * Returns true if this value is strictly greater than the specified value.
+   *
+   * @param other the value to compare to
+   * @return true if this value is strictly greater than the specified value
+   */
+  public boolean isGreaterThan(final long other) {
+    return compareTo(other) > 0;
+  }
+
+  /**
    * Returns true if this value is greater than or equal to the specified value.
    *
    * @param other the value to compare to
    * @return true if this value is greater or equal than the specified value
    */
   public boolean isGreaterThanOrEqualTo(final UInt64 other) {
+    return compareTo(other) >= 0;
+  }
+
+  /**
+   * Returns true if this value is greater than or equal to the specified value.
+   *
+   * @param other the value to compare to
+   * @return true if this value is greater or equal than the specified value
+   */
+  public boolean isGreaterThanOrEqualTo(final long other) {
     return compareTo(other) >= 0;
   }
 
@@ -392,12 +417,32 @@ public final class UInt64 implements Comparable<UInt64> {
   }
 
   /**
+   * Returns true if this value is strictly less than the specified value.
+   *
+   * @param other the value to compare to
+   * @return true if this value is strictly less than the specified value
+   */
+  public boolean isLessThan(final long other) {
+    return compareTo(other) < 0;
+  }
+
+  /**
    * Returns true if this value is less than or equal to the specified value.
    *
    * @param other the value to compare to
    * @return true if this value is less than or equal to the specified value
    */
   public boolean isLessThanOrEqualTo(final UInt64 other) {
+    return compareTo(other) <= 0;
+  }
+
+  /**
+   * Returns true if this value is less than or equal to the specified value.
+   *
+   * @param other the value to compare to
+   * @return true if this value is less than or equal to the specified value
+   */
+  public boolean isLessThanOrEqualTo(final long other) {
     return compareTo(other) <= 0;
   }
 

--- a/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
+++ b/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
@@ -159,6 +159,23 @@ class UInt64Test {
   }
 
   @Test
+  void compareTo_withLongLessThanZero() {
+    assertThatThrownBy(() -> UInt64.valueOf(10).compareTo(-1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must be >= 0");
+  }
+
+  @Test
+  void compareTo_withNonZeroLong() {
+    final UInt64 value = UInt64.valueOf(10);
+    assertThat(value.compareTo(10)).isEqualTo(0);
+    assertThat(value.compareTo(11)).isEqualTo(-1);
+    assertThat(value.compareTo(1111)).isEqualTo(-1);
+    assertThat(value.compareTo(9)).isEqualTo(1);
+    assertThat(value.compareTo(0)).isEqualTo(1);
+  }
+
+  @Test
   void isZero_shouldBeTrueWhenZero() {
     assertThat(UInt64.ZERO.isZero()).isTrue();
     assertThat(UInt64.valueOf(0).isZero()).isTrue();
@@ -186,6 +203,18 @@ class UInt64Test {
   }
 
   @ParameterizedTest
+  @MethodSource("comparableLongValues")
+  void greaterThan_shouldReturnTrueWhenNumberIsStrictlyGreater(
+      final long smaller, final long bigger) {
+    assertThat(UInt64.valueOf(smaller).isGreaterThan(bigger)).isFalse();
+    assertThat(UInt64.valueOf(bigger).isGreaterThan(smaller)).isTrue();
+
+    // Must be strictly greater than
+    assertThat(UInt64.valueOf(smaller).isGreaterThan(smaller)).isFalse();
+    assertThat(UInt64.valueOf(bigger).isGreaterThan(bigger)).isFalse();
+  }
+
+  @ParameterizedTest
   @MethodSource("comparableNumbers")
   void greaterThanOrEqualTo_shouldReturnTrueWhenNumberIsGreaterOrEqual(
       final UInt64 smaller, final UInt64 bigger) {
@@ -195,6 +224,18 @@ class UInt64Test {
     // True when equal
     assertThat(smaller.isGreaterThanOrEqualTo(smaller)).isTrue();
     assertThat(bigger.isGreaterThanOrEqualTo(bigger)).isTrue();
+  }
+
+  @ParameterizedTest
+  @MethodSource("comparableLongValues")
+  void greaterThanOrEqualTo_shouldReturnTrueWhenNumberIsGreaterOrEqual(
+      final long smaller, final long bigger) {
+    assertThat(UInt64.valueOf(smaller).isGreaterThanOrEqualTo(bigger)).isFalse();
+    assertThat(UInt64.valueOf(bigger).isGreaterThanOrEqualTo(smaller)).isTrue();
+
+    // True when equal
+    assertThat(UInt64.valueOf(smaller).isGreaterThanOrEqualTo(smaller)).isTrue();
+    assertThat(UInt64.valueOf(bigger).isGreaterThanOrEqualTo(bigger)).isTrue();
   }
 
   @ParameterizedTest
@@ -210,6 +251,18 @@ class UInt64Test {
   }
 
   @ParameterizedTest
+  @MethodSource("comparableLongValues")
+  void lessThan_shouldReturnTrueWhenNumberIsStrictlyLessThan(
+      final long smaller, final long bigger) {
+    assertThat(UInt64.valueOf(smaller).isLessThan(bigger)).isTrue();
+    assertThat(UInt64.valueOf(bigger).isLessThan(smaller)).isFalse();
+
+    // Must be strictly greater than
+    assertThat(UInt64.valueOf(smaller).isLessThan(smaller)).isFalse();
+    assertThat(UInt64.valueOf(bigger).isLessThan(bigger)).isFalse();
+  }
+
+  @ParameterizedTest
   @MethodSource("comparableNumbers")
   void lessThanOrEqualTo_shouldReturnTrueWhenNumberIsLessThanOrEqual(
       final UInt64 smaller, final UInt64 bigger) {
@@ -219,6 +272,18 @@ class UInt64Test {
     // Must be strictly greater than
     assertThat(smaller.isLessThanOrEqualTo(smaller)).isTrue();
     assertThat(bigger.isLessThanOrEqualTo(bigger)).isTrue();
+  }
+
+  @ParameterizedTest
+  @MethodSource("comparableLongValues")
+  void lessThanOrEqualTo_shouldReturnTrueWhenNumberIsLessThanOrEqual(
+      final long smaller, final long bigger) {
+    assertThat(UInt64.valueOf(smaller).isLessThanOrEqualTo(bigger)).isTrue();
+    assertThat(UInt64.valueOf(bigger).isLessThanOrEqualTo(smaller)).isFalse();
+
+    // Must be strictly greater than
+    assertThat(UInt64.valueOf(smaller).isLessThanOrEqualTo(smaller)).isTrue();
+    assertThat(UInt64.valueOf(bigger).isLessThanOrEqualTo(bigger)).isTrue();
   }
 
   @Test
@@ -620,5 +685,15 @@ class UInt64Test {
         Arguments.of(UInt64.fromLongBits(-445), UInt64.fromLongBits(-444)),
         Arguments.of(UInt64.valueOf(22244), UInt64.valueOf(22245)),
         Arguments.of(UInt64.valueOf(Long.MAX_VALUE), UInt64.fromLongBits(Long.MIN_VALUE)));
+  }
+
+  static List<Arguments> comparableLongValues() {
+    // (Smaller Number, Bigger Number)
+    return List.of(
+        Arguments.of(0, 1),
+        Arguments.of(10, 11),
+        Arguments.of(100, 200),
+        Arguments.of(0, Long.MAX_VALUE),
+        Arguments.of(Long.MAX_VALUE - 1, Long.MAX_VALUE));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/WeakSubjectivityOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/WeakSubjectivityOptions.java
@@ -28,7 +28,7 @@ public class WeakSubjectivityOptions {
       names = {"--initial-state"},
       paramLabel = "<STRING>",
       description =
-          "The initial state. This value should be a file or URL pointing to an SSZ encoded state.",
+          "The initial state. This value should be a file or URL pointing to an SSZ-encoded finalized checkpoint state.",
       arity = "1")
   private String weakSubjectivityState;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add more logging and validation around `--initial-state` selection:
* Add the following text when loading a non-genesis initial state: "Please ensure that the supplied initial state corresponds to the latest finalized block as of the start of epoch 2288 (slot 73216)."
* Throw if the provided initial state is from the future or from the current or previous epoch
* Log a warning if the initial-state indicates any skipped slots: "The provided initial state is 18 slots prior to the start of epoch 2990. Please ensure that slots 95663 - 95680 (inclusive) are empty."

Also:
* Add some more `UInt64` utils
* Add extra validation on `AnchorPoint` creation

## Fixed Issue(s)
Relates to #3401 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.