### PR TITLE
Optimize ListViewRead<BitView> => Bitlist conversion

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/provider/BitlistDeserializer.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/provider/BitlistDeserializer.java
@@ -26,6 +26,6 @@ public class BitlistDeserializer extends JsonDeserializer<Bitlist> {
   public Bitlist deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
     Bytes data = Bytes.fromHexString(p.getValueAsString());
     int length = Constants.MAX_VALIDATORS_PER_COMMITTEE;
-    return Bitlist.fromBytes(data, length);
+    return Bitlist.fromSszBytes(data, length);
   }
 }

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/util/backing/BitlistBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/util/backing/BitlistBenchmark.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.benchmarks.util.backing;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import tech.pegasys.teku.ssz.backing.ListViewRead;
+import tech.pegasys.teku.ssz.backing.ListViewWrite;
+import tech.pegasys.teku.ssz.backing.type.BasicViewTypes;
+import tech.pegasys.teku.ssz.backing.type.ListViewType;
+import tech.pegasys.teku.ssz.backing.view.BasicViews.BitView;
+import tech.pegasys.teku.ssz.backing.view.ViewUtils;
+
+public class BitlistBenchmark {
+
+  static ListViewType<BitView> type = new ListViewType<>(BasicViewTypes.BIT_TYPE, 4096);
+  static ListViewRead<BitView> bitlist;
+
+  static {
+    ListViewWrite<BitView> wBitlist = type.getDefault().createWritableCopy();
+    for (int i = 0; i < type.getMaxLength(); i++) {
+      wBitlist.append(BitView.viewOf(true));
+    }
+    bitlist = wBitlist.commitChanges();
+  }
+
+  @Benchmark
+  @Warmup(iterations = 2, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+  @Measurement(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+  public void fromCachedListView(Blackhole bh) {
+    bh.consume(ViewUtils.getBitlist(bitlist));
+  }
+
+  @Benchmark
+  @Warmup(iterations = 2, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+  @Measurement(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+  public void fromNewListView(Blackhole bh) {
+    ListViewRead<BitView> freshListView = type.createFromBackingNode(bitlist.getBackingNode());
+    bh.consume(ViewUtils.getBitlist(freshListView));
+  }
+}

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/SimpleOffsetSerializer.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/SimpleOffsetSerializer.java
@@ -421,7 +421,7 @@ public class SimpleOffsetSerializer {
         reflectionInformation.getBitlistElementMaxSizes().get(variableObjectCounter);
     int numBytesToRead = currentObjectEndByte - bytesPointer.intValue();
     bytesPointer.add(numBytesToRead);
-    return Bitlist.fromBytes(reader.readFixedBytes(numBytesToRead), bitlistElementMaxSize);
+    return Bitlist.fromSszBytes(reader.readFixedBytes(numBytesToRead), bitlistElementMaxSize);
   }
 
   private static void deserializeVariableElementList(

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/SSZTypes/Bitlist.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/SSZTypes/Bitlist.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.MutableBytes;
 
 public class Bitlist {
 
@@ -154,8 +155,10 @@ public class Bitlist {
       int leadingBit = 1 << (length % 8);
       checkArgument((-leadingBit & lastByte) == 0, "Bits higher than length should be 0");
       int lastByteWithLeadingBit = lastByte ^ leadingBit;
-      Bytes bytesWithoutLast = bytes.slice(0, bytes.size() - 1);
-      return Bytes.concatenate(bytesWithoutLast, Bytes.of(lastByteWithLeadingBit));
+      // workaround for Bytes bug. See BitlistViewTest.tuweniBytesIssue() test
+      MutableBytes resultBytes = bytes.mutableCopy();
+      resultBytes.set(bytes.size() - 1, (byte) lastByteWithLeadingBit);
+      return resultBytes;
     }
   }
 

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/SSZTypes/Bitlist.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/SSZTypes/Bitlist.java
@@ -120,7 +120,7 @@ public class Bitlist {
     return (size / 8) + 1;
   }
 
-  public static Bitlist fromBytes(Bytes bytes, long maxSize) {
+  public static Bitlist fromSszBytes(Bytes bytes, long maxSize) {
     int bitlistSize = sszGetLengthAndValidate(bytes);
     BitSet byteArray = new BitSet(bitlistSize);
 

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/backing/view/ViewUtils.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/backing/view/ViewUtils.java
@@ -68,7 +68,7 @@ public class ViewUtils {
 
   /** Converts list of bits to {@link Bitlist} value */
   public static Bitlist getBitlist(ListViewRead<BitView> bitlistView) {
-    return Bitlist.fromBytes(bitlistView.sszSerialize(), bitlistView.getType().getMaxLength());
+    return Bitlist.fromSszBytes(bitlistView.sszSerialize(), bitlistView.getType().getMaxLength());
   }
 
   /** Creates immutable vector of bits with size `bitvector.size()` from {@link Bitvector} value */

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/backing/view/ViewUtils.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/backing/view/ViewUtils.java
@@ -68,13 +68,7 @@ public class ViewUtils {
 
   /** Converts list of bits to {@link Bitlist} value */
   public static Bitlist getBitlist(ListViewRead<BitView> bitlistView) {
-    Bitlist ret = new Bitlist(bitlistView.size(), bitlistView.getType().getMaxLength());
-    for (int i = 0; i < bitlistView.size(); i++) {
-      if (bitlistView.get(i).get()) {
-        ret.setBit(i);
-      }
-    }
-    return ret;
+    return Bitlist.fromBytes(bitlistView.sszSerialize(), bitlistView.getType().getMaxLength());
   }
 
   /** Creates immutable vector of bits with size `bitvector.size()` from {@link Bitvector} value */

--- a/ssz/src/test/java/tech/pegasys/teku/ssz/backing/BitlistViewTest.java
+++ b/ssz/src/test/java/tech/pegasys/teku/ssz/backing/BitlistViewTest.java
@@ -44,10 +44,7 @@ public class BitlistViewTest {
   @Disabled("the Tuweni Bytes issue: https://github.com/apache/incubator-tuweni/issues/186")
   @Test
   public void tuweniBytesIssue() {
-    Bytes slicedBytes = Bytes.wrap(
-        Bytes.wrap(new byte[32]),
-        Bytes.wrap(new byte[6])
-    ).slice(0, 37);
+    Bytes slicedBytes = Bytes.wrap(Bytes.wrap(new byte[32]), Bytes.wrap(new byte[6])).slice(0, 37);
 
     Assertions.assertThatCode(slicedBytes::copy).doesNotThrowAnyException();
 

--- a/ssz/src/test/java/tech/pegasys/teku/ssz/backing/BitlistViewTest.java
+++ b/ssz/src/test/java/tech/pegasys/teku/ssz/backing/BitlistViewTest.java
@@ -13,7 +13,9 @@
 
 package tech.pegasys.teku.ssz.backing;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ssz.SSZTypes.Bitlist;
 import tech.pegasys.teku.ssz.backing.view.BasicViews.BitView;
@@ -37,5 +39,23 @@ public class BitlistViewTest {
 
       Assertions.assertThat(bitlist1).isEqualTo(bitlist);
     }
+  }
+
+  @Disabled("the Tuweni Bytes issue: https://github.com/apache/incubator-tuweni/issues/186")
+  @Test
+  public void tuweniBytesIssue() {
+    Bytes slicedBytes = Bytes.wrap(
+        Bytes.wrap(new byte[32]),
+        Bytes.wrap(new byte[6])
+    ).slice(0, 37);
+
+    Assertions.assertThatCode(slicedBytes::copy).doesNotThrowAnyException();
+
+    Bytes wrappedBytes = Bytes.wrap(slicedBytes, Bytes.wrap(new byte[1]));
+
+    Assertions.assertThatCode(wrappedBytes::toArrayUnsafe).doesNotThrowAnyException();
+    Assertions.assertThatCode(wrappedBytes::toArray).doesNotThrowAnyException();
+    Assertions.assertThatCode(() -> Bytes.concatenate(slicedBytes, Bytes.wrap(new byte[1])))
+        .doesNotThrowAnyException();
   }
 }

--- a/ssz/src/test/java/tech/pegasys/teku/ssz/ssztypes/BitlistTest.java
+++ b/ssz/src/test/java/tech/pegasys/teku/ssz/ssztypes/BitlistTest.java
@@ -125,7 +125,7 @@ class BitlistTest {
     Bitlist bitlist = createBitlist();
 
     Bytes bitlistSerialized = bitlist.serialize();
-    Bitlist newBitlist = Bitlist.fromBytes(bitlistSerialized, BITLIST_MAX_SIZE);
+    Bitlist newBitlist = Bitlist.fromSszBytes(bitlistSerialized, BITLIST_MAX_SIZE);
     Assertions.assertEquals(bitlist, newBitlist);
   }
 
@@ -155,20 +155,20 @@ class BitlistTest {
     bitlist.setBit(7);
     bitlist.setBit(8);
 
-    Bitlist newBitlist = Bitlist.fromBytes(Bytes.fromHexString("0xf903"), BITLIST_MAX_SIZE);
+    Bitlist newBitlist = Bitlist.fromSszBytes(Bytes.fromHexString("0xf903"), BITLIST_MAX_SIZE);
     Assertions.assertEquals(bitlist, newBitlist);
   }
 
   @Test
   void deserializationShouldRejectZeroLengthBytes() {
-    assertThatThrownBy(() -> Bitlist.fromBytes(Bytes.EMPTY, BITLIST_MAX_SIZE))
+    assertThatThrownBy(() -> Bitlist.fromSszBytes(Bytes.EMPTY, BITLIST_MAX_SIZE))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("at least one byte");
   }
 
   @Test
   void deserializationShouldRejectDataWhenEndMarkerBitNotSet() {
-    assertThatThrownBy(() -> Bitlist.fromBytes(Bytes.of(0), BITLIST_MAX_SIZE))
+    assertThatThrownBy(() -> Bitlist.fromSszBytes(Bytes.of(0), BITLIST_MAX_SIZE))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("marker bit");
   }
@@ -215,7 +215,7 @@ class BitlistTest {
     Bytes bitlistSsz1 = Bitlist.sszAppendLeadingBit(truncBytes, length);
     assertThat(bitlistSsz1).isEqualTo(bitlistSsz);
 
-    Bitlist bitlist = Bitlist.fromBytes(bitlistSsz, length);
+    Bitlist bitlist = Bitlist.fromSszBytes(bitlistSsz, length);
     Bytes bitlistSsz2 = bitlist.serialize();
     assertThat(bitlistSsz2).isEqualTo(bitlistSsz);
   }
@@ -232,7 +232,7 @@ class BitlistTest {
   void testSszMethodsInvalid(Bytes bitlistSsz) {
     assertThatThrownBy(() -> Bitlist.sszGetLengthAndValidate(bitlistSsz))
         .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(() -> Bitlist.fromBytes(bitlistSsz, 1024))
+    assertThatThrownBy(() -> Bitlist.fromSszBytes(bitlistSsz, 1024))
         .isInstanceOf(IllegalArgumentException.class);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

This rather a tweak than full-fledged views refactoring but it works well. 
Since SSZ serialization is now pretty fast (it just iterates leaf nodes), serialize-deserialize `Bitlist` works much faster than accessing individual bits via traversing all backing tree nodes every time. 

Before:
```
Benchmark                             Mode  Cnt      Score     Error  Units
BitlistBenchmark.fromCachedListView  thrpt   25  19158,888    876,506 ops/s
BitlistBenchmark.fromNewListView     thrpt   25   2514,544    123,885 ops/s
```

After:
```
BitlistBenchmark.fromCachedListView  thrpt   25  42554,508    3296,832 ops/s
BitlistBenchmark.fromNewListView     thrpt   25  40462,349    3766,117 ops/s
```

## Fixed Issue(s)

Fix #3375

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.