### PR TITLE
Split up ForkChoiceUtil and move away from static methods

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -39,6 +39,8 @@ import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.core.ChainBuilder;
+import tech.pegasys.teku.core.ForkChoiceAttestationValidator;
+import tech.pegasys.teku.core.ForkChoiceBlockTasks;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
@@ -131,7 +133,12 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
     forkChoice =
         useMockForkChoice
             ? mock(ForkChoice.class)
-            : new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, stateTransition);
+            : new ForkChoice(
+                new ForkChoiceAttestationValidator(),
+                new ForkChoiceBlockTasks(),
+                new SyncForkChoiceExecutor(),
+                recentChainData,
+                stateTransition);
     beaconChainUtil =
         BeaconChainUtil.create(recentChainData, chainBuilder.getValidatorKeys(), forkChoice, true);
   }

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
@@ -30,6 +30,8 @@ import tech.pegasys.teku.benchmarks.gen.BlockIO.Reader;
 import tech.pegasys.teku.benchmarks.gen.BlsKeyPairIO;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.core.ForkChoiceAttestationValidator;
+import tech.pegasys.teku.core.ForkChoiceBlockTasks;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.results.BlockImportResult;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
@@ -87,7 +89,12 @@ public class ProfilingRun {
       BeaconChainUtil localChain = BeaconChainUtil.create(recentChainData, validatorKeys, false);
       recentChainData.initializeFromGenesis(initialState);
       ForkChoice forkChoice =
-          new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, new StateTransition());
+          new ForkChoice(
+              new ForkChoiceAttestationValidator(),
+              new ForkChoiceBlockTasks(),
+              new SyncForkChoiceExecutor(),
+              recentChainData,
+              new StateTransition());
       BlockImporter blockImporter =
           new BlockImporter(
               recentChainData, forkChoice, WeakSubjectivityValidator.lenient(), localEventBus);
@@ -161,7 +168,12 @@ public class ProfilingRun {
       recentChainData.initializeFromGenesis(initialState);
       initialState = null;
       ForkChoice forkChoice =
-          new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, new StateTransition());
+          new ForkChoice(
+              new ForkChoiceAttestationValidator(),
+              new ForkChoiceBlockTasks(),
+              new SyncForkChoiceExecutor(),
+              recentChainData,
+              new StateTransition());
       BlockImporter blockImporter =
           new BlockImporter(
               recentChainData, forkChoice, WeakSubjectivityValidator.lenient(), localEventBus);

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
@@ -33,6 +33,8 @@ import org.openjdk.jmh.annotations.Warmup;
 import tech.pegasys.teku.benchmarks.gen.BlockIO;
 import tech.pegasys.teku.benchmarks.gen.BlsKeyPairIO;
 import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.core.ForkChoiceAttestationValidator;
+import tech.pegasys.teku.core.ForkChoiceBlockTasks;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.results.BlockImportResult;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
@@ -85,7 +87,12 @@ public abstract class TransitionBenchmark {
     localChain.initializeStorage();
 
     ForkChoice forkChoice =
-        new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, new StateTransition());
+        new ForkChoice(
+            new ForkChoiceAttestationValidator(),
+            new ForkChoiceBlockTasks(),
+            new SyncForkChoiceExecutor(),
+            recentChainData,
+            new StateTransition());
     blockImporter =
         new BlockImporter(
             recentChainData, forkChoice, WeakSubjectivityValidator.lenient(), localEventBus);

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceAttestationValidator.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceAttestationValidator.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.core;
+
+import static tech.pegasys.teku.core.ForkChoiceUtil.get_ancestor;
+import static tech.pegasys.teku.core.ForkChoiceUtil.get_current_slot;
+import static tech.pegasys.teku.datastructures.util.AttestationProcessingResult.SUCCESSFUL;
+import static tech.pegasys.teku.datastructures.util.AttestationUtil.is_valid_indexed_attestation;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+import static tech.pegasys.teku.util.config.Constants.GENESIS_EPOCH;
+
+import java.util.Optional;
+import javax.annotation.CheckReturnValue;
+import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
+import tech.pegasys.teku.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
+import tech.pegasys.teku.datastructures.forkchoice.ReadOnlyStore;
+import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
+import tech.pegasys.teku.datastructures.util.AttestationProcessingResult;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class ForkChoiceAttestationValidator {
+
+  @CheckReturnValue
+  public AttestationProcessingResult validate(
+      final ReadOnlyStore store,
+      final ValidateableAttestation validateableAttestation,
+      final Optional<BeaconState> maybeTargetState) {
+    Attestation attestation = validateableAttestation.getAttestation();
+    return validateOnAttestation(store, attestation)
+        .ifSuccessful(
+            () -> {
+              if (maybeTargetState.isEmpty()) {
+                return AttestationProcessingResult.UNKNOWN_BLOCK;
+              } else {
+                return is_valid_indexed_attestation(
+                    maybeTargetState.get(), validateableAttestation);
+              }
+            })
+        .ifSuccessful(() -> checkIfAttestationShouldBeSavedForFuture(store, attestation));
+  }
+
+  private AttestationProcessingResult validateOnAttestation(
+      final ReadOnlyStore store, final Attestation attestation) {
+    final Checkpoint target = attestation.getData().getTarget();
+    UInt64 current_epoch = compute_epoch_at_slot(get_current_slot(store));
+
+    // Use GENESIS_EPOCH for previous when genesis to avoid underflow
+    UInt64 previous_epoch =
+        current_epoch.compareTo(UInt64.valueOf(GENESIS_EPOCH)) > 0
+            ? current_epoch.minus(UInt64.ONE)
+            : UInt64.valueOf(GENESIS_EPOCH);
+
+    if (!target.getEpoch().equals(previous_epoch) && !target.getEpoch().equals(current_epoch)) {
+      return AttestationProcessingResult.invalid(
+          "Attestations must be from the current or previous epoch");
+    }
+
+    if (!target.getEpoch().equals(compute_epoch_at_slot(attestation.getData().getSlot()))) {
+      return AttestationProcessingResult.invalid("Attestation slot must be within specified epoch");
+    }
+
+    final ReadOnlyForkChoiceStrategy forkChoiceStrategy = store.getForkChoiceStrategy();
+    if (!forkChoiceStrategy.contains(target.getRoot())) {
+      // Attestations target must be for a known block. If a target block is unknown, delay
+      // consideration until the block is found
+      return AttestationProcessingResult.UNKNOWN_BLOCK;
+    }
+
+    Optional<UInt64> blockSlot =
+        forkChoiceStrategy.blockSlot(attestation.getData().getBeacon_block_root());
+    if (blockSlot.isEmpty()) {
+      // Attestations must be for a known block. If block is unknown, delay consideration until the
+      // block is found
+      return AttestationProcessingResult.UNKNOWN_BLOCK;
+    }
+
+    if (blockSlot.get().compareTo(attestation.getData().getSlot()) > 0) {
+      return AttestationProcessingResult.invalid(
+          "Attestations must not be for blocks in the future. If not, the attestation should not be considered");
+    }
+
+    // LMD vote must be consistent with FFG vote target
+    final UInt64 target_slot = compute_start_slot_at_epoch(target.getEpoch());
+    if (get_ancestor(forkChoiceStrategy, attestation.getData().getBeacon_block_root(), target_slot)
+        .map(ancestorRoot -> !ancestorRoot.equals(target.getRoot()))
+        .orElse(true)) {
+      return AttestationProcessingResult.invalid(
+          "LMD vote must be consistent with FFG vote target");
+    }
+
+    return SUCCESSFUL;
+  }
+
+  private AttestationProcessingResult checkIfAttestationShouldBeSavedForFuture(
+      ReadOnlyStore store, Attestation attestation) {
+
+    // Attestations can only affect the fork choice of subsequent slots.
+    // Delay consideration in the fork choice until their slot is in the past.
+    final UInt64 currentSlot = get_current_slot(store);
+    if (currentSlot.compareTo(attestation.getData().getSlot()) < 0) {
+      return AttestationProcessingResult.SAVED_FOR_FUTURE;
+    }
+    if (currentSlot.compareTo(attestation.getData().getSlot()) == 0) {
+      return AttestationProcessingResult.DEFER_FOR_FORK_CHOICE;
+    }
+
+    // Attestations cannot be from future epochs. If they are, delay consideration until the epoch
+    // arrives
+    if (currentSlot.compareTo(attestation.getData().getTarget().getEpochStartSlot()) < 0) {
+      return AttestationProcessingResult.SAVED_FOR_FUTURE;
+    }
+    return SUCCESSFUL;
+  }
+}

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceBlockTasks.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceBlockTasks.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.core;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.core.ForkChoiceUtil.compute_slots_since_epoch_start;
+import static tech.pegasys.teku.core.ForkChoiceUtil.get_ancestor;
+import static tech.pegasys.teku.core.ForkChoiceUtil.get_current_slot;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_block_root_at_slot;
+import static tech.pegasys.teku.util.config.Constants.GENESIS_SLOT;
+import static tech.pegasys.teku.util.config.Constants.SAFE_SLOTS_TO_UPDATE_JUSTIFIED;
+
+import java.util.Optional;
+import javax.annotation.CheckReturnValue;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.core.lookup.IndexedAttestationProvider;
+import tech.pegasys.teku.core.results.BlockImportResult;
+import tech.pegasys.teku.data.BlockProcessingRecord;
+import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.forkchoice.MutableStore;
+import tech.pegasys.teku.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
+import tech.pegasys.teku.datastructures.forkchoice.ReadOnlyStore;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.state.Checkpoint;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class ForkChoiceBlockTasks {
+
+  /**
+   * Perform block processing. The supplied blockSlotState must already have empty slots processed
+   * to the same slot as the block.
+   */
+  @CheckReturnValue
+  public BlockImportResult on_block(
+      final MutableStore store,
+      final SignedBeaconBlock signed_block,
+      BeaconState blockSlotState,
+      final StateTransition st,
+      final IndexedAttestationProvider indexedAttestationProvider) {
+    checkArgument(
+        blockSlotState.getSlot().equals(signed_block.getSlot()),
+        "State must have slots processed up to the block slot");
+    final BeaconBlock block = signed_block.getMessage();
+
+    // Return early if precondition checks fail;
+    final Optional<BlockImportResult> maybeFailure =
+        checkOnBlockConditions(block, blockSlotState, store);
+    if (maybeFailure.isPresent()) {
+      return maybeFailure.get();
+    }
+
+    // Make a copy of the state to avoid mutability issues
+    BeaconState state;
+
+    // Check the block is valid and compute the post-state
+    try {
+      state =
+          st.processAndValidateBlock(
+              signed_block, indexedAttestationProvider, blockSlotState, true);
+    } catch (StateTransitionException e) {
+      return BlockImportResult.failedStateTransition(e);
+    }
+
+    // Add new block to store
+    store.putBlockAndState(signed_block, state);
+
+    // Update justified checkpoint
+    final Checkpoint justifiedCheckpoint = state.getCurrent_justified_checkpoint();
+    if (justifiedCheckpoint.getEpoch().compareTo(store.getJustifiedCheckpoint().getEpoch()) > 0) {
+      if (justifiedCheckpoint.getEpoch().compareTo(store.getBestJustifiedCheckpoint().getEpoch())
+          > 0) {
+        store.setBestJustifiedCheckpoint(justifiedCheckpoint);
+      }
+      if (should_update_justified_checkpoint(
+          store, justifiedCheckpoint, store.getForkChoiceStrategy())) {
+        store.setJustifiedCheckpoint(justifiedCheckpoint);
+      }
+    }
+
+    // Update finalized checkpoint
+    final Checkpoint finalizedCheckpoint = state.getFinalized_checkpoint();
+    if (finalizedCheckpoint.getEpoch().compareTo(store.getFinalizedCheckpoint().getEpoch()) > 0) {
+      store.setFinalizedCheckpoint(finalizedCheckpoint);
+
+      // Potentially update justified if different from store
+      if (!store.getJustifiedCheckpoint().equals(state.getCurrent_justified_checkpoint())) {
+        // Update justified if new justified is later than store justified
+        // or if store justified is not in chain with finalized checkpoint
+        if (state
+                    .getCurrent_justified_checkpoint()
+                    .getEpoch()
+                    .compareTo(store.getJustifiedCheckpoint().getEpoch())
+                > 0
+            || !isFinalizedAncestorOfJustified(store)) {
+          store.setJustifiedCheckpoint(state.getCurrent_justified_checkpoint());
+        }
+      }
+    }
+
+    final BlockProcessingRecord record = new BlockProcessingRecord(signed_block, state);
+    return BlockImportResult.successful(record);
+  }
+
+  private static boolean isFinalizedAncestorOfJustified(ReadOnlyStore store) {
+    UInt64 finalizedSlot = store.getFinalizedCheckpoint().getEpochStartSlot();
+    return hasAncestorAtSlot(
+        store.getForkChoiceStrategy(),
+        store.getJustifiedCheckpoint().getRoot(),
+        finalizedSlot,
+        store.getFinalizedCheckpoint().getRoot());
+  }
+
+  private static Optional<BlockImportResult> checkOnBlockConditions(
+      final BeaconBlock block, final BeaconState blockSlotState, final ReadOnlyStore store) {
+    final UInt64 blockSlot = block.getSlot();
+    if (blockSlotState == null) {
+      return Optional.of(BlockImportResult.FAILED_UNKNOWN_PARENT);
+    }
+    if (!blockSlotState.getSlot().equals(blockSlot)) {
+      return Optional.of(BlockImportResult.FAILED_INVALID_ANCESTRY);
+    }
+    if (blockSlot.isGreaterThan(UInt64.valueOf(GENESIS_SLOT))
+        && !get_block_root_at_slot(blockSlotState, blockSlot.minus(1))
+            .equals(block.getParentRoot())) {
+      // Block is at same slot as its parent or the parent root doesn't match the state
+      return Optional.of(BlockImportResult.FAILED_INVALID_ANCESTRY);
+    }
+    if (blockIsFromFuture(store, blockSlot)) {
+      return Optional.of(BlockImportResult.FAILED_BLOCK_IS_FROM_FUTURE);
+    }
+    if (!blockDescendsFromLatestFinalizedBlock(block, store, store.getForkChoiceStrategy())) {
+      return Optional.of(BlockImportResult.FAILED_INVALID_ANCESTRY);
+    }
+    return Optional.empty();
+  }
+
+  private static boolean blockIsFromFuture(ReadOnlyStore store, final UInt64 blockSlot) {
+    return get_current_slot(store).compareTo(blockSlot) < 0;
+  }
+
+  public static boolean blockDescendsFromLatestFinalizedBlock(
+      final BeaconBlock block,
+      final ReadOnlyStore store,
+      final ReadOnlyForkChoiceStrategy forkChoiceStrategy) {
+    final Checkpoint finalizedCheckpoint = store.getFinalizedCheckpoint();
+    final UInt64 blockSlot = block.getSlot();
+
+    // Make sure this block's slot is after the latest finalized slot
+    return blockIsAfterLatestFinalizedSlot(blockSlot, finalizedCheckpoint.getEpochStartSlot())
+        && hasAncestorAtSlot(
+            forkChoiceStrategy,
+            block.getParentRoot(),
+            finalizedCheckpoint.getEpochStartSlot(),
+            finalizedCheckpoint.getRoot());
+  }
+
+  private static boolean blockIsAfterLatestFinalizedSlot(
+      final UInt64 blockSlot, final UInt64 finalizedEpochStartSlot) {
+    return blockSlot.compareTo(finalizedEpochStartSlot) > 0;
+  }
+
+  /*
+  To address the bouncing attack, only update conflicting justified
+  checkpoints in the fork choice if in the early slots of the epoch.
+  Otherwise, delay incorporation of new justified checkpoint until next epoch boundary.
+  See https://ethresear.ch/t/prevention-of-bouncing-attack-on-ffg/6114 for more detailed analysis and discussion.
+  */
+
+  private static boolean should_update_justified_checkpoint(
+      ReadOnlyStore store,
+      Checkpoint new_justified_checkpoint,
+      ReadOnlyForkChoiceStrategy forkChoiceStrategy) {
+    if (compute_slots_since_epoch_start(get_current_slot(store, true))
+            .compareTo(UInt64.valueOf(SAFE_SLOTS_TO_UPDATE_JUSTIFIED))
+        < 0) {
+      return true;
+    }
+
+    UInt64 justifiedSlot = compute_start_slot_at_epoch(store.getJustifiedCheckpoint().getEpoch());
+    return hasAncestorAtSlot(
+        forkChoiceStrategy,
+        new_justified_checkpoint.getRoot(),
+        justifiedSlot,
+        store.getJustifiedCheckpoint().getRoot());
+  }
+
+  private static boolean hasAncestorAtSlot(
+      ReadOnlyForkChoiceStrategy forkChoiceStrategy,
+      Bytes32 root,
+      UInt64 slot,
+      Bytes32 ancestorRoot) {
+    return get_ancestor(forkChoiceStrategy, root, slot)
+        .map(ancestorAtSlot -> ancestorAtSlot.equals(ancestorRoot))
+        .orElse(false);
+  }
+}

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceUtil.java
@@ -13,37 +13,20 @@
 
 package tech.pegasys.teku.core;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static tech.pegasys.teku.datastructures.util.AttestationProcessingResult.SUCCESSFUL;
-import static tech.pegasys.teku.datastructures.util.AttestationUtil.is_valid_indexed_attestation;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.get_block_root_at_slot;
-import static tech.pegasys.teku.util.config.Constants.GENESIS_EPOCH;
 import static tech.pegasys.teku.util.config.Constants.GENESIS_SLOT;
-import static tech.pegasys.teku.util.config.Constants.SAFE_SLOTS_TO_UPDATE_JUSTIFIED;
 import static tech.pegasys.teku.util.config.Constants.SECONDS_PER_SLOT;
 
 import java.time.Instant;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
-import javax.annotation.CheckReturnValue;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.core.lookup.IndexedAttestationProvider;
-import tech.pegasys.teku.core.results.BlockImportResult;
-import tech.pegasys.teku.data.BlockProcessingRecord;
-import tech.pegasys.teku.datastructures.attestation.ValidateableAttestation;
-import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.forkchoice.MutableStore;
+import tech.pegasys.teku.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.datastructures.forkchoice.ReadOnlyStore;
-import tech.pegasys.teku.datastructures.operations.Attestation;
-import tech.pegasys.teku.datastructures.state.BeaconState;
-import tech.pegasys.teku.datastructures.state.Checkpoint;
-import tech.pegasys.teku.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
 
 public class ForkChoiceUtil {
 
@@ -86,12 +69,12 @@ public class ForkChoiceUtil {
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/fork-choice.md#get_ancestor</a>
    */
   public static Optional<Bytes32> get_ancestor(
-      ForkChoiceStrategy forkChoiceStrategy, Bytes32 root, UInt64 slot) {
+      ReadOnlyForkChoiceStrategy forkChoiceStrategy, Bytes32 root, UInt64 slot) {
     return forkChoiceStrategy.getAncestor(root, slot);
   }
 
   public static NavigableMap<UInt64, Bytes32> getAncestors(
-      ForkChoiceStrategy forkChoiceStrategy,
+      ReadOnlyForkChoiceStrategy forkChoiceStrategy,
       Bytes32 root,
       UInt64 startSlot,
       UInt64 step,
@@ -118,7 +101,7 @@ public class ForkChoiceUtil {
    *     backwards
    */
   public static NavigableMap<UInt64, Bytes32> getAncestorsOnFork(
-      ForkChoiceStrategy forkChoiceStrategy, Bytes32 root, UInt64 startSlot) {
+      ReadOnlyForkChoiceStrategy forkChoiceStrategy, Bytes32 root, UInt64 startSlot) {
     final NavigableMap<UInt64, Bytes32> roots = new TreeMap<>();
     Bytes32 parentRoot = root;
     Optional<UInt64> parentSlot = forkChoiceStrategy.blockSlot(parentRoot);
@@ -145,31 +128,6 @@ public class ForkChoiceUtil {
             roots.put(slot, root);
           }
         });
-  }
-
-  /*
-  To address the bouncing attack, only update conflicting justified
-  checkpoints in the fork choice if in the early slots of the epoch.
-  Otherwise, delay incorporation of new justified checkpoint until next epoch boundary.
-  See https://ethresear.ch/t/prevention-of-bouncing-attack-on-ffg/6114 for more detailed analysis and discussion.
-  */
-
-  private static boolean should_update_justified_checkpoint(
-      ReadOnlyStore store,
-      Checkpoint new_justified_checkpoint,
-      ForkChoiceStrategy forkChoiceStrategy) {
-    if (compute_slots_since_epoch_start(get_current_slot(store, true))
-            .compareTo(UInt64.valueOf(SAFE_SLOTS_TO_UPDATE_JUSTIFIED))
-        < 0) {
-      return true;
-    }
-
-    UInt64 justifiedSlot = compute_start_slot_at_epoch(store.getJustifiedCheckpoint().getEpoch());
-    return hasAncestorAtSlot(
-        forkChoiceStrategy,
-        new_justified_checkpoint.getRoot(),
-        justifiedSlot,
-        store.getJustifiedCheckpoint().getRoot());
   }
 
   // Fork Choice Event Handlers
@@ -207,248 +165,5 @@ public class ForkChoiceUtil {
         > 0) {
       store.setJustifiedCheckpoint(store.getBestJustifiedCheckpoint());
     }
-  }
-
-  /**
-   * Perform block processing. The supplied blockSlotState must already have empty slots processed
-   * to the same slot as the block.
-   */
-  @CheckReturnValue
-  public static BlockImportResult on_block(
-      final MutableStore store,
-      final SignedBeaconBlock signed_block,
-      BeaconState blockSlotState,
-      final StateTransition st,
-      final ForkChoiceStrategy forkChoiceStrategy,
-      final IndexedAttestationProvider indexedAttestationProvider) {
-    checkArgument(
-        blockSlotState.getSlot().equals(signed_block.getSlot()),
-        "State must have slots processed up to the block slot");
-    final BeaconBlock block = signed_block.getMessage();
-
-    // Return early if precondition checks fail;
-    final Optional<BlockImportResult> maybeFailure =
-        checkOnBlockConditions(block, blockSlotState, store, forkChoiceStrategy);
-    if (maybeFailure.isPresent()) {
-      return maybeFailure.get();
-    }
-
-    // Make a copy of the state to avoid mutability issues
-    BeaconState state;
-
-    // Check the block is valid and compute the post-state
-    try {
-      state =
-          st.processAndValidateBlock(
-              signed_block, indexedAttestationProvider, blockSlotState, true);
-    } catch (StateTransitionException e) {
-      return BlockImportResult.failedStateTransition(e);
-    }
-
-    // Add new block to store
-    store.putBlockAndState(signed_block, state);
-
-    // Update justified checkpoint
-    final Checkpoint justifiedCheckpoint = state.getCurrent_justified_checkpoint();
-    if (justifiedCheckpoint.getEpoch().compareTo(store.getJustifiedCheckpoint().getEpoch()) > 0) {
-      if (justifiedCheckpoint.getEpoch().compareTo(store.getBestJustifiedCheckpoint().getEpoch())
-          > 0) {
-        store.setBestJustifiedCheckpoint(justifiedCheckpoint);
-      }
-      if (should_update_justified_checkpoint(store, justifiedCheckpoint, forkChoiceStrategy)) {
-        store.setJustifiedCheckpoint(justifiedCheckpoint);
-      }
-    }
-
-    // Update finalized checkpoint
-    final Checkpoint finalizedCheckpoint = state.getFinalized_checkpoint();
-    if (finalizedCheckpoint.getEpoch().compareTo(store.getFinalizedCheckpoint().getEpoch()) > 0) {
-      store.setFinalizedCheckpoint(finalizedCheckpoint);
-
-      // Potentially update justified if different from store
-      if (!store.getJustifiedCheckpoint().equals(state.getCurrent_justified_checkpoint())) {
-        // Update justified if new justified is later than store justified
-        // or if store justified is not in chain with finalized checkpoint
-        if (state
-                    .getCurrent_justified_checkpoint()
-                    .getEpoch()
-                    .compareTo(store.getJustifiedCheckpoint().getEpoch())
-                > 0
-            || !isFinalizedAncestorOfJustified(forkChoiceStrategy, store)) {
-          store.setJustifiedCheckpoint(state.getCurrent_justified_checkpoint());
-        }
-      }
-    }
-
-    final BlockProcessingRecord record = new BlockProcessingRecord(signed_block, state);
-    return BlockImportResult.successful(record);
-  }
-
-  private static boolean isFinalizedAncestorOfJustified(
-      ForkChoiceStrategy forkChoiceStrategy, ReadOnlyStore store) {
-    UInt64 finalizedSlot = store.getFinalizedCheckpoint().getEpochStartSlot();
-    return hasAncestorAtSlot(
-        forkChoiceStrategy,
-        store.getJustifiedCheckpoint().getRoot(),
-        finalizedSlot,
-        store.getFinalizedCheckpoint().getRoot());
-  }
-
-  private static Optional<BlockImportResult> checkOnBlockConditions(
-      final BeaconBlock block,
-      final BeaconState blockSlotState,
-      final ReadOnlyStore store,
-      final ForkChoiceStrategy forkChoiceStrategy) {
-    final UInt64 blockSlot = block.getSlot();
-    if (blockSlotState == null) {
-      return Optional.of(BlockImportResult.FAILED_UNKNOWN_PARENT);
-    }
-    if (!blockSlotState.getSlot().equals(blockSlot)) {
-      return Optional.of(BlockImportResult.FAILED_INVALID_ANCESTRY);
-    }
-    if (blockSlot.isGreaterThan(UInt64.valueOf(GENESIS_SLOT))
-        && !get_block_root_at_slot(blockSlotState, blockSlot.minus(1))
-            .equals(block.getParentRoot())) {
-      // Block is at same slot as its parent or the parent root doesn't match the state
-      return Optional.of(BlockImportResult.FAILED_INVALID_ANCESTRY);
-    }
-    if (blockIsFromFuture(store, blockSlot)) {
-      return Optional.of(BlockImportResult.FAILED_BLOCK_IS_FROM_FUTURE);
-    }
-    if (!blockDescendsFromLatestFinalizedBlock(block, store, forkChoiceStrategy)) {
-      return Optional.of(BlockImportResult.FAILED_INVALID_ANCESTRY);
-    }
-    return Optional.empty();
-  }
-
-  private static boolean blockIsFromFuture(ReadOnlyStore store, final UInt64 blockSlot) {
-    return get_current_slot(store).compareTo(blockSlot) < 0;
-  }
-
-  private static boolean hasAncestorAtSlot(
-      ForkChoiceStrategy forkChoiceStrategy, Bytes32 root, UInt64 slot, Bytes32 ancestorRoot) {
-    return get_ancestor(forkChoiceStrategy, root, slot)
-        .map(ancestorAtSlot -> ancestorAtSlot.equals(ancestorRoot))
-        .orElse(false);
-  }
-
-  public static boolean blockDescendsFromLatestFinalizedBlock(
-      final BeaconBlock block,
-      final ReadOnlyStore store,
-      final ForkChoiceStrategy forkChoiceStrategy) {
-    final Checkpoint finalizedCheckpoint = store.getFinalizedCheckpoint();
-    final UInt64 blockSlot = block.getSlot();
-
-    // Make sure this block's slot is after the latest finalized slot
-    return blockIsAfterLatestFinalizedSlot(blockSlot, finalizedCheckpoint.getEpochStartSlot())
-        && hasAncestorAtSlot(
-            forkChoiceStrategy,
-            block.getParentRoot(),
-            finalizedCheckpoint.getEpochStartSlot(),
-            finalizedCheckpoint.getRoot());
-  }
-
-  private static boolean blockIsAfterLatestFinalizedSlot(
-      final UInt64 blockSlot, final UInt64 finalizedEpochStartSlot) {
-    if (blockSlot.compareTo(finalizedEpochStartSlot) <= 0) {
-      return false;
-    } else {
-      return true;
-    }
-  }
-
-  @CheckReturnValue
-  public static AttestationProcessingResult validateAttestation(
-      final ReadOnlyStore store,
-      final ValidateableAttestation validateableAttestation,
-      final Optional<BeaconState> maybeTargetState,
-      final ForkChoiceStrategy forkChoiceStrategy) {
-    Attestation attestation = validateableAttestation.getAttestation();
-
-    return validateOnAttestation(store, attestation, forkChoiceStrategy)
-        .ifSuccessful(
-            () -> {
-              if (maybeTargetState.isEmpty()) {
-                return AttestationProcessingResult.UNKNOWN_BLOCK;
-              } else {
-                return is_valid_indexed_attestation(
-                    maybeTargetState.get(), validateableAttestation);
-              }
-            })
-        .ifSuccessful(() -> checkIfAttestationShouldBeSavedForFuture(store, attestation));
-  }
-
-  private static AttestationProcessingResult validateOnAttestation(
-      final ReadOnlyStore store,
-      final Attestation attestation,
-      final ForkChoiceStrategy forkChoiceStrategy) {
-    final Checkpoint target = attestation.getData().getTarget();
-    UInt64 current_epoch = compute_epoch_at_slot(get_current_slot(store));
-
-    // Use GENESIS_EPOCH for previous when genesis to avoid underflow
-    UInt64 previous_epoch =
-        current_epoch.compareTo(UInt64.valueOf(GENESIS_EPOCH)) > 0
-            ? current_epoch.minus(UInt64.ONE)
-            : UInt64.valueOf(GENESIS_EPOCH);
-
-    if (!target.getEpoch().equals(previous_epoch) && !target.getEpoch().equals(current_epoch)) {
-      return AttestationProcessingResult.invalid(
-          "Attestations must be from the current or previous epoch");
-    }
-
-    if (!target.getEpoch().equals(compute_epoch_at_slot(attestation.getData().getSlot()))) {
-      return AttestationProcessingResult.invalid("Attestation slot must be within specified epoch");
-    }
-
-    if (!forkChoiceStrategy.contains(target.getRoot())) {
-      // Attestations target must be for a known block. If a target block is unknown, delay
-      // consideration until the block is found
-      return AttestationProcessingResult.UNKNOWN_BLOCK;
-    }
-
-    Optional<UInt64> blockSlot =
-        forkChoiceStrategy.blockSlot(attestation.getData().getBeacon_block_root());
-    if (blockSlot.isEmpty()) {
-      // Attestations must be for a known block. If block is unknown, delay consideration until the
-      // block is found
-      return AttestationProcessingResult.UNKNOWN_BLOCK;
-    }
-
-    if (blockSlot.get().compareTo(attestation.getData().getSlot()) > 0) {
-      return AttestationProcessingResult.invalid(
-          "Attestations must not be for blocks in the future. If not, the attestation should not be considered");
-    }
-
-    // LMD vote must be consistent with FFG vote target
-    final UInt64 target_slot = compute_start_slot_at_epoch(target.getEpoch());
-    if (get_ancestor(forkChoiceStrategy, attestation.getData().getBeacon_block_root(), target_slot)
-        .map(ancestorRoot -> !ancestorRoot.equals(target.getRoot()))
-        .orElse(true)) {
-      return AttestationProcessingResult.invalid(
-          "LMD vote must be consistent with FFG vote target");
-    }
-
-    return SUCCESSFUL;
-  }
-
-  private static AttestationProcessingResult checkIfAttestationShouldBeSavedForFuture(
-      ReadOnlyStore store, Attestation attestation) {
-
-    // Attestations can only affect the fork choice of subsequent slots.
-    // Delay consideration in the fork choice until their slot is in the past.
-    final UInt64 currentSlot = get_current_slot(store);
-    if (currentSlot.compareTo(attestation.getData().getSlot()) < 0) {
-      return AttestationProcessingResult.SAVED_FOR_FUTURE;
-    }
-    if (currentSlot.compareTo(attestation.getData().getSlot()) == 0) {
-      return AttestationProcessingResult.DEFER_FOR_FORK_CHOICE;
-    }
-
-    // Attestations cannot be from future epochs. If they are, delay consideration until the epoch
-    // arrives
-    if (currentSlot.compareTo(attestation.getData().getTarget().getEpochStartSlot()) < 0) {
-      return AttestationProcessingResult.SAVED_FOR_FUTURE;
-    }
-    return SUCCESSFUL;
   }
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -11,17 +11,22 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.core;
+package tech.pegasys.teku.datastructures.forkchoice;
 
+import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class ForkChoiceUtilWrapper {
+public interface ReadOnlyForkChoiceStrategy {
 
-  public Optional<Bytes32> get_ancestor(
-      ReadOnlyForkChoiceStrategy forkChoiceStrategy, Bytes32 root, UInt64 slot) {
-    return ForkChoiceUtil.get_ancestor(forkChoiceStrategy, root, slot);
-  }
+  Optional<UInt64> blockSlot(Bytes32 blockRoot);
+
+  Optional<Bytes32> blockParentRoot(Bytes32 blockRoot);
+
+  Optional<Bytes32> getAncestor(Bytes32 blockRoot, UInt64 slot);
+
+  Map<Bytes32, UInt64> getChainHeads();
+
+  boolean contains(Bytes32 blockRoot);
 }

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/forkchoice/ReadOnlyStore.java
@@ -59,6 +59,8 @@ public interface ReadOnlyStore {
 
   Checkpoint getBestJustifiedCheckpoint();
 
+  ReadOnlyForkChoiceStrategy getForkChoiceStrategy();
+
   boolean containsBlock(Bytes32 blockRoot);
 
   /**

--- a/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/datastructures/src/testFixtures/java/tech/pegasys/teku/datastructures/forkchoice/TestStoreImpl.java
@@ -109,6 +109,11 @@ class TestStoreImpl implements MutableStore {
     return best_justified_checkpoint;
   }
 
+  @Override
+  public ReadOnlyForkChoiceStrategy getForkChoiceStrategy() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
   private SignedBeaconBlock getSignedBlock(final Bytes32 blockRoot) {
     return blocks.get(blockRoot);
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.core.results.BlockImportResult;
 import tech.pegasys.teku.data.BlockProcessingRecord;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.datastructures.operations.ProposerSlashing;
@@ -34,7 +35,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.LogFormatter;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
 import tech.pegasys.teku.statetransition.events.block.ImportedBlockEvent;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -205,7 +205,7 @@ public class BlockImporter {
     return LogFormatter.formatBlock(block.getSlot(), block.getRoot());
   }
 
-  private ForkChoiceStrategy getForkChoiceStrategy() {
+  private ReadOnlyForkChoiceStrategy getForkChoiceStrategy() {
     return recentChainData
         .getForkChoiceStrategy()
         .orElseThrow(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockValidator.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.statetransition.validation;
 
+import static tech.pegasys.teku.core.ForkChoiceBlockTasks.blockDescendsFromLatestFinalizedBlock;
 import static tech.pegasys.teku.core.ForkChoiceUtil.getCurrentSlot;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_signing_root;
@@ -31,7 +32,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.core.ForkChoiceUtil;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.datastructures.forkchoice.ReadOnlyStore;
@@ -161,7 +161,7 @@ public class BlockValidator {
   }
 
   private boolean currentFinalizedCheckpointIsAncestorOfBlock(SignedBeaconBlock block) {
-    return ForkChoiceUtil.blockDescendsFromLatestFinalizedBlock(
+    return blockDescendsFromLatestFinalizedBlock(
         block.getMessage(),
         recentChainData.getStore(),
         recentChainData.getForkChoiceStrategy().orElseThrow());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -37,6 +37,8 @@ import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.core.AttestationGenerator;
+import tech.pegasys.teku.core.ForkChoiceAttestationValidator;
+import tech.pegasys.teku.core.ForkChoiceBlockTasks;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.results.BlockImportResult;
 import tech.pegasys.teku.core.results.BlockImportResult.FailureReason;
@@ -70,7 +72,12 @@ public class BlockImporterTest {
   private final WeakSubjectivityValidator weakSubjectivityValidator =
       mock(WeakSubjectivityValidator.class);
   private final ForkChoice forkChoice =
-      new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, new StateTransition());
+      new ForkChoice(
+          new ForkChoiceAttestationValidator(),
+          new ForkChoiceBlockTasks(),
+          new SyncForkChoiceExecutor(),
+          recentChainData,
+          new StateTransition());
   private final BeaconChainUtil localChain =
       BeaconChainUtil.create(recentChainData, validatorKeys, forkChoice, false);
 
@@ -386,7 +393,11 @@ public class BlockImporterTest {
     final SignedBlockAndState genesis = storageSystem.chainUpdater().initializeGenesis();
     final ForkChoice forkChoice =
         new ForkChoice(
-            new SyncForkChoiceExecutor(), storageSystem.recentChainData(), new StateTransition());
+            new ForkChoiceAttestationValidator(),
+            new ForkChoiceBlockTasks(),
+            new SyncForkChoiceExecutor(),
+            storageSystem.recentChainData(),
+            new StateTransition());
     final BlockImporter blockImporter =
         new BlockImporter(
             storageSystem.recentChainData(),
@@ -420,7 +431,11 @@ public class BlockImporterTest {
     final SignedBlockAndState genesis = storageSystem.chainUpdater().initializeGenesis();
     final ForkChoice forkChoice =
         new ForkChoice(
-            new SyncForkChoiceExecutor(), storageSystem.recentChainData(), new StateTransition());
+            new ForkChoiceAttestationValidator(),
+            new ForkChoiceBlockTasks(),
+            new SyncForkChoiceExecutor(),
+            storageSystem.recentChainData(),
+            new StateTransition());
     final BlockImporter blockImporter =
         new BlockImporter(
             storageSystem.recentChainData(),
@@ -462,7 +477,11 @@ public class BlockImporterTest {
     storageSystem.chainUpdater().initializeGenesis();
     final ForkChoice forkChoice =
         new ForkChoice(
-            new SyncForkChoiceExecutor(), storageSystem.recentChainData(), new StateTransition());
+            new ForkChoiceAttestationValidator(),
+            new ForkChoiceBlockTasks(),
+            new SyncForkChoiceExecutor(),
+            storageSystem.recentChainData(),
+            new StateTransition());
     final BlockImporter blockImporter =
         new BlockImporter(
             storageSystem.recentChainData(),
@@ -499,7 +518,11 @@ public class BlockImporterTest {
     final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault();
     final ForkChoice forkChoice =
         new ForkChoice(
-            new SyncForkChoiceExecutor(), storageSystem.recentChainData(), new StateTransition());
+            new ForkChoiceAttestationValidator(),
+            new ForkChoiceBlockTasks(),
+            new SyncForkChoiceExecutor(),
+            storageSystem.recentChainData(),
+            new StateTransition());
     final BlockImporter blockImporter =
         new BlockImporter(
             storageSystem.recentChainData(),
@@ -524,7 +547,11 @@ public class BlockImporterTest {
     final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault();
     final ForkChoice forkChoice =
         new ForkChoice(
-            new SyncForkChoiceExecutor(), storageSystem.recentChainData(), new StateTransition());
+            new ForkChoiceAttestationValidator(),
+            new ForkChoiceBlockTasks(),
+            new SyncForkChoiceExecutor(),
+            storageSystem.recentChainData(),
+            new StateTransition());
     final BlockImporter blockImporter =
         new BlockImporter(
             storageSystem.recentChainData(),

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.core.ForkChoiceAttestationValidator;
+import tech.pegasys.teku.core.ForkChoiceBlockTasks;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.results.BlockImportResult;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
@@ -69,7 +71,12 @@ public class BlockManagerTest {
   private final BeaconChainUtil remoteChain =
       BeaconChainUtil.create(remoteRecentChainData, validatorKeys);
   private final ForkChoice forkChoice =
-      new ForkChoice(new SyncForkChoiceExecutor(), localRecentChainData, new StateTransition());
+      new ForkChoice(
+          new ForkChoiceAttestationValidator(),
+          new ForkChoiceBlockTasks(),
+          new SyncForkChoiceExecutor(),
+          localRecentChainData,
+          new StateTransition());
 
   private final BlockImporter blockImporter =
       new BlockImporter(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -32,6 +32,8 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.core.ChainBuilder;
 import tech.pegasys.teku.core.ChainBuilder.BlockOptions;
+import tech.pegasys.teku.core.ForkChoiceAttestationValidator;
+import tech.pegasys.teku.core.ForkChoiceBlockTasks;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.exceptions.EpochProcessingException;
 import tech.pegasys.teku.core.exceptions.SlotProcessingException;
@@ -67,7 +69,12 @@ class ForkChoiceTest {
   private final RecentChainData recentChainData = storageSystem.recentChainData();
 
   private final ForkChoice forkChoice =
-      new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, stateTransition);
+      new ForkChoice(
+          new ForkChoiceAttestationValidator(),
+          new ForkChoiceBlockTasks(),
+          new SyncForkChoiceExecutor(),
+          recentChainData,
+          stateTransition);
 
   @BeforeEach
   public void setup() {

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -24,6 +24,8 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.core.AttestationGenerator;
 import tech.pegasys.teku.core.BlockProposalTestUtil;
+import tech.pegasys.teku.core.ForkChoiceAttestationValidator;
+import tech.pegasys.teku.core.ForkChoiceBlockTasks;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.results.BlockImportResult;
 import tech.pegasys.teku.core.signatures.LocalSigner;
@@ -78,7 +80,12 @@ public class BeaconChainUtil {
     return create(
         storageClient,
         validatorKeys,
-        new ForkChoice(new SyncForkChoiceExecutor(), storageClient, new StateTransition()),
+        new ForkChoice(
+            new ForkChoiceAttestationValidator(),
+            new ForkChoiceBlockTasks(),
+            new SyncForkChoiceExecutor(),
+            storageClient,
+            new StateTransition()),
         true);
   }
 
@@ -89,7 +96,12 @@ public class BeaconChainUtil {
     return new BeaconChainUtil(
         validatorKeys,
         storageClient,
-        new ForkChoice(new SyncForkChoiceExecutor(), storageClient, new StateTransition()),
+        new ForkChoice(
+            new ForkChoiceAttestationValidator(),
+            new ForkChoiceBlockTasks(),
+            new SyncForkChoiceExecutor(),
+            storageClient,
+            new StateTransition()),
         signDeposits);
   }
 

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
@@ -23,13 +23,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.state.CheckpointState;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.WeakSubjectivityLogger;
 import tech.pegasys.teku.infrastructure.time.Throttler;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 import tech.pegasys.teku.weaksubjectivity.policies.WeakSubjectivityViolationPolicy;
@@ -172,7 +172,7 @@ public class WeakSubjectivityValidator {
   }
 
   public boolean isBlockValid(
-      final SignedBeaconBlock block, ForkChoiceStrategy forkChoiceStrategy) {
+      final SignedBeaconBlock block, ReadOnlyForkChoiceStrategy forkChoiceStrategy) {
     if (config.getWeakSubjectivityCheckpoint().isEmpty()) {
       return true;
     }

--- a/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidatorTest.java
+++ b/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidatorTest.java
@@ -31,6 +31,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
 import tech.pegasys.teku.datastructures.state.CheckpointState;
@@ -49,7 +50,7 @@ public class WeakSubjectivityValidatorTest {
 
   // Set up mocks
   private final WeakSubjectivityCalculator calculator = mock(WeakSubjectivityCalculator.class);
-  private final ForkChoiceStrategy forkChoiceStrategy = mock(ForkChoiceStrategy.class);
+  private final ReadOnlyForkChoiceStrategy forkChoiceStrategy = mock(ForkChoiceStrategy.class);
   private final WeakSubjectivityViolationPolicy policy =
       mock(WeakSubjectivityViolationPolicy.class);
   private final CheckpointState checkpointState = mock(CheckpointState.class);

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceTestExecutor.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceTestExecutor.java
@@ -36,6 +36,8 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.core.ForkChoiceAttestationValidator;
+import tech.pegasys.teku.core.ForkChoiceBlockTasks;
 import tech.pegasys.teku.core.ForkChoiceUtil;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.results.BlockImportResult;
@@ -162,7 +164,12 @@ public class ForkChoiceTestExecutor {
     storageClient.initializeFromGenesis(genesis);
 
     ForkChoice forkChoice =
-        new ForkChoice(SingleThreadedForkChoiceExecutor.create(), storageClient, st);
+        new ForkChoice(
+            new ForkChoiceAttestationValidator(),
+            new ForkChoiceBlockTasks(),
+            SingleThreadedForkChoiceExecutor.create(),
+            storageClient,
+            st);
 
     @SuppressWarnings("ModifiedButNotUsed")
     List<SignedBeaconBlock> blockBuffer = new ArrayList<>();

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ForkChoiceStrategy.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ForkChoiceStrategy.java
@@ -13,16 +13,14 @@
 
 package tech.pegasys.teku.protoarray;
 
-import java.util.Map;
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.forkchoice.MutableStore;
+import tech.pegasys.teku.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.datastructures.operations.IndexedAttestation;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Checkpoint;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public interface ForkChoiceStrategy {
+public interface ForkChoiceStrategy extends ReadOnlyForkChoiceStrategy {
 
   Bytes32 findHead(
       final MutableStore store,
@@ -31,14 +29,4 @@ public interface ForkChoiceStrategy {
       final BeaconState justifiedCheckpointState);
 
   void onAttestation(final MutableStore store, final IndexedAttestation attestation);
-
-  Optional<UInt64> blockSlot(Bytes32 blockRoot);
-
-  Optional<Bytes32> blockParentRoot(Bytes32 blockRoot);
-
-  Optional<Bytes32> getAncestor(Bytes32 blockRoot, UInt64 slot);
-
-  Map<Bytes32, UInt64> getChainHeads();
-
-  boolean contains(Bytes32 blockRoot);
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -41,6 +41,8 @@ import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.beaconrestapi.BeaconRestApi;
 import tech.pegasys.teku.core.BlockProposalUtil;
+import tech.pegasys.teku.core.ForkChoiceAttestationValidator;
+import tech.pegasys.teku.core.ForkChoiceBlockTasks;
 import tech.pegasys.teku.core.ForkChoiceUtilWrapper;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.operationsignatureverifiers.ProposerSlashingSignatureVerifier;
@@ -431,7 +433,13 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   private void initForkChoice() {
     LOG.debug("BeaconChainController.initForkChoice()");
     forkChoiceExecutor = SingleThreadedForkChoiceExecutor.create();
-    forkChoice = new ForkChoice(forkChoiceExecutor, recentChainData, stateTransition);
+    forkChoice =
+        new ForkChoice(
+            new ForkChoiceAttestationValidator(),
+            new ForkChoiceBlockTasks(),
+            forkChoiceExecutor,
+            recentChainData,
+            stateTransition);
   }
 
   public void initMetrics() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.datastructures.state.BeaconState;
@@ -455,7 +456,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
 
   public Map<Bytes32, UInt64> getChainHeads() {
     return getForkChoiceStrategy()
-        .map(ForkChoiceStrategy::getChainHeads)
+        .map(ReadOnlyForkChoiceStrategy::getChainHeads)
         .orElse(Collections.emptyMap());
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.datastructures.state.BeaconState;
@@ -257,6 +258,11 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   @Override
   public Checkpoint getBestJustifiedCheckpoint() {
     return best_justified_checkpoint.orElseGet(store::getBestJustifiedCheckpoint);
+  }
+
+  @Override
+  public ReadOnlyForkChoiceStrategy getForkChoiceStrategy() {
+    return store.getForkChoiceStrategy();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/UpdatableStore.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/UpdatableStore.java
@@ -30,6 +30,7 @@ public interface UpdatableStore extends ReadOnlyStore {
 
   void startMetrics();
 
+  @Override
   ForkChoiceStrategy getForkChoiceStrategy();
 
   interface StoreTransaction extends MutableStore {

--- a/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
+++ b/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.function.Consumer;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.core.ForkChoiceAttestationValidator;
+import tech.pegasys.teku.core.ForkChoiceBlockTasks;
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -90,7 +92,12 @@ public class SyncingNodeManager {
     chainUtil.initializeStorage();
 
     ForkChoice forkChoice =
-        new ForkChoice(new SyncForkChoiceExecutor(), recentChainData, new StateTransition());
+        new ForkChoice(
+            new ForkChoiceAttestationValidator(),
+            new ForkChoiceBlockTasks(),
+            new SyncForkChoiceExecutor(),
+            recentChainData,
+            new StateTransition());
     BlockImporter blockImporter =
         new BlockImporter(
             recentChainData, forkChoice, WeakSubjectivityValidator.lenient(), eventBus);


### PR DESCRIPTION
## PR Description
To make supporting future forks easier, move away from using static methods to instance classes.  Split attestation and block handling out of `ForkChoiceUtil` to their own classes to reduce class size.

This won't solve all the issues but its a first step in the direction of being able to plug in different implementations.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.