### PR TITLE
Split interop config out of GlobalConfiguration

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainConfiguration.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainConfiguration.java
@@ -16,12 +16,14 @@ package tech.pegasys.teku.services.beaconchain;
 import tech.pegasys.teku.beaconrestapi.BeaconRestApiConfig;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfig;
 import tech.pegasys.teku.networking.eth2.P2PConfig;
+import tech.pegasys.teku.validator.api.InteropConfig;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
 import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 
 public class BeaconChainConfiguration {
   private final WeakSubjectivityConfig weakSubjectivityConfig;
   private final ValidatorConfig validatorConfig;
+  private final InteropConfig interopConfig;
   private final P2PConfig p2pConfig;
   private final BeaconRestApiConfig beaconRestApiConfig;
   private final LoggingConfig loggingConfig;
@@ -29,11 +31,13 @@ public class BeaconChainConfiguration {
   public BeaconChainConfiguration(
       final WeakSubjectivityConfig weakSubjectivityConfig,
       final ValidatorConfig validatorConfig,
+      final InteropConfig interopConfig,
       final P2PConfig p2pConfig,
       final BeaconRestApiConfig beaconRestApiConfig,
       final LoggingConfig loggingConfig) {
     this.weakSubjectivityConfig = weakSubjectivityConfig;
     this.validatorConfig = validatorConfig;
+    this.interopConfig = interopConfig;
     this.p2pConfig = p2pConfig;
     this.beaconRestApiConfig = beaconRestApiConfig;
     this.loggingConfig = loggingConfig;
@@ -45,6 +49,10 @@ public class BeaconChainConfiguration {
 
   public ValidatorConfig validatorConfig() {
     return validatorConfig;
+  }
+
+  public InteropConfig interopConfig() {
+    return interopConfig;
   }
 
   public P2PConfig p2pConfig() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -124,6 +124,7 @@ import tech.pegasys.teku.util.config.InvalidConfigurationException;
 import tech.pegasys.teku.util.config.ValidatorPerformanceTrackingMode;
 import tech.pegasys.teku.util.time.channels.SlotEventsChannel;
 import tech.pegasys.teku.util.time.channels.TimeTickChannel;
+import tech.pegasys.teku.validator.api.InteropConfig;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.coordinator.ActiveValidatorTracker;
 import tech.pegasys.teku.validator.coordinator.BlockFactory;
@@ -782,7 +783,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             recentChainData.getBestBlockRoot().orElseThrow(),
             anchor.getState().getGenesis_time());
       }
-    } else if (config.isInteropEnabled()) {
+    } else if (beaconConfig.interopConfig().isInteropEnabled()) {
       setupInteropState();
     } else if (!config.isEth1Enabled()) {
       throw new InvalidConfigurationException(
@@ -791,6 +792,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   }
 
   private void setupInteropState() {
+    final InteropConfig config = beaconConfig.interopConfig();
     STATUS_LOG.generatingMockStartGenesis(
         config.getInteropGenesisTime(), config.getInteropNumberOfValidators());
     final BeaconState genesisState =

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainControllerTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainControllerTest.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.storage.store.MemKeyValueStore;
 import tech.pegasys.teku.util.config.GlobalConfiguration;
 import tech.pegasys.teku.util.time.channels.SlotEventsChannel;
+import tech.pegasys.teku.validator.api.InteropConfig;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
 import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 
@@ -63,6 +64,7 @@ public class BeaconChainControllerTest {
     return new BeaconChainConfiguration(
         WeakSubjectivityConfig.builder().build(),
         ValidatorConfig.builder().build(),
+        InteropConfig.builder().build(),
         p2pConfig,
         restApiConfig,
         loggingConfig);

--- a/teku/src/main/java/tech/pegasys/teku/BeaconNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/BeaconNode.java
@@ -75,7 +75,6 @@ public class BeaconNode implements Node {
             metricsSystem,
             globalConfig,
             DataDirLayout.createFrom(tekuConfig.dataConfig()));
-    tekuConfig.validate();
     Constants.setConstants(globalConfig.getConstants());
 
     final String transitionRecordDir = globalConfig.getTransitionRecordDirectory();

--- a/teku/src/main/java/tech/pegasys/teku/ValidatorNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/ValidatorNode.java
@@ -72,7 +72,6 @@ public class ValidatorNode implements Node {
             metricsSystem,
             globalConfig,
             DataDirLayout.createFrom(tekuConfig.dataConfig()));
-    tekuConfig.validate();
     Constants.setConstants(globalConfig.getConstants());
 
     this.serviceController = new ValidatorNodeServiceController(tekuConfig, serviceConfig);

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -335,6 +335,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
       p2POptions.configure(builder, networkOptions.getNetwork());
       beaconRestApiOptions.configure(builder, networkOptions.getNetwork());
       loggingOptions.configure(builder, dataOptions.getDataBasePath(), LOG_FILE, LOG_PATTERN);
+      interopOptions.configure(builder);
 
       return builder.build();
     } catch (IllegalArgumentException e) {
@@ -349,11 +350,6 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setStartupTimeoutSeconds(networkOptions.getStartupTimeoutSeconds())
         .setPeerRateLimit(networkOptions.getPeerRateLimit())
         .setPeerRequestLimit(networkOptions.getPeerRequestLimit())
-        .setInteropGenesisTime(interopOptions.getInteropGenesisTime())
-        .setInteropOwnedValidatorStartIndex(interopOptions.getInteropOwnerValidatorStartIndex())
-        .setInteropOwnedValidatorCount(interopOptions.getInteropOwnerValidatorCount())
-        .setInteropNumberOfValidators(interopOptions.getInteropNumberOfValidators())
-        .setInteropEnabled(interopOptions.isInteropEnabled())
         .setEth1DepositContractAddress(depositOptions.getEth1DepositContractAddress())
         .setEth1Endpoint(depositOptions.getEth1Endpoint())
         .setEth1LogsMaxBlockRange(depositOptions.getEth1LogsMaxBlockRange())

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/InteropOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/InteropOptions.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.cli.options;
 
 import picocli.CommandLine.Option;
+import tech.pegasys.teku.config.TekuConfiguration;
 
 public class InteropOptions {
 
@@ -57,23 +58,14 @@ public class InteropOptions {
       arity = "0..1")
   private boolean interopEnabled = false;
 
-  public Integer getInteropGenesisTime() {
-    return interopGenesisTime;
-  }
-
-  public int getInteropOwnerValidatorStartIndex() {
-    return interopOwnerValidatorStartIndex;
-  }
-
-  public int getInteropOwnerValidatorCount() {
-    return interopOwnerValidatorCount;
-  }
-
-  public int getInteropNumberOfValidators() {
-    return interopNumberOfValidators;
-  }
-
-  public boolean isInteropEnabled() {
-    return interopEnabled;
+  public TekuConfiguration.Builder configure(final TekuConfiguration.Builder builder) {
+    return builder.interop(
+        interopBuilder ->
+            interopBuilder
+                .interopGenesisTime(interopGenesisTime)
+                .interopOwnedValidatorStartIndex(interopOwnerValidatorStartIndex)
+                .interopOwnedValidatorCount(interopOwnerValidatorCount)
+                .interopNumberOfValidators(interopNumberOfValidators)
+                .interopEnabled(interopEnabled));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
@@ -102,17 +102,13 @@ public class ValidatorClientCommand implements Callable<Integer> {
     validatorClientOptions.configure(builder);
     dataOptions.configure(builder);
     loggingOptions.configure(builder, dataOptions.getDataBasePath(), LOG_FILE, LOG_PATTERN);
+    interopOptions.configure(builder);
     return builder.build();
   }
 
   private void buildGlobalConfiguration(final GlobalConfigurationBuilder builder) {
     builder
         .setNetwork(networkOptions.getNetwork())
-        .setInteropGenesisTime(interopOptions.getInteropGenesisTime())
-        .setInteropOwnedValidatorStartIndex(interopOptions.getInteropOwnerValidatorStartIndex())
-        .setInteropOwnedValidatorCount(interopOptions.getInteropOwnerValidatorCount())
-        .setInteropNumberOfValidators(interopOptions.getInteropNumberOfValidators())
-        .setInteropEnabled(interopOptions.isInteropEnabled())
         .setMetricsEnabled(metricsOptions.isMetricsEnabled())
         .setMetricsPort(metricsOptions.getMetricsPort())
         .setMetricsInterface(metricsOptions.getMetricsInterface())

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -227,7 +227,8 @@ public class VoluntaryExitCommand implements Runnable {
     try {
       blsPublicKeyValidatorMap =
           validatorLoader.initializeValidators(
-              config.validatorClient().getValidatorConfig(), config.global());
+              config.validatorClient().getValidatorConfig(),
+              config.validatorClient().getInteropConfig());
     } catch (InvalidConfigurationException ex) {
       SUB_COMMAND_LOG.error(ex.getMessage());
       System.exit(1);

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -23,6 +23,8 @@ import tech.pegasys.teku.service.serviceutils.layout.DataConfig;
 import tech.pegasys.teku.services.beaconchain.BeaconChainConfiguration;
 import tech.pegasys.teku.util.config.GlobalConfiguration;
 import tech.pegasys.teku.util.config.GlobalConfigurationBuilder;
+import tech.pegasys.teku.validator.api.InteropConfig;
+import tech.pegasys.teku.validator.api.InteropConfig.InteropConfigBuilder;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
 import tech.pegasys.teku.validator.client.ValidatorClientConfiguration;
 import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
@@ -39,6 +41,7 @@ public class TekuConfiguration {
       GlobalConfiguration globalConfiguration,
       WeakSubjectivityConfig weakSubjectivityConfig,
       final ValidatorConfig validatorConfig,
+      final InteropConfig interopConfig,
       final DataConfig dataConfig,
       final P2PConfig p2pConfig,
       final BeaconRestApiConfig beaconRestApiConfig,
@@ -49,9 +52,14 @@ public class TekuConfiguration {
     this.loggingConfig = loggingConfig;
     this.beaconChainConfig =
         new BeaconChainConfiguration(
-            weakSubjectivityConfig, validatorConfig, p2pConfig, beaconRestApiConfig, loggingConfig);
+            weakSubjectivityConfig,
+            validatorConfig,
+            interopConfig,
+            p2pConfig,
+            beaconRestApiConfig,
+            loggingConfig);
     this.validatorClientConfig =
-        new ValidatorClientConfiguration(globalConfiguration, validatorConfig, dataConfig);
+        new ValidatorClientConfiguration(globalConfiguration, validatorConfig, interopConfig);
   }
 
   public static Builder builder() {
@@ -82,16 +90,13 @@ public class TekuConfiguration {
     return loggingConfig;
   }
 
-  public void validate() {
-    globalConfiguration.validate();
-  }
-
   public static class Builder {
     private final GlobalConfigurationBuilder globalConfigurationBuilder =
         new GlobalConfigurationBuilder();
     private final WeakSubjectivityConfig.Builder weakSubjectivityBuilder =
         WeakSubjectivityConfig.builder();
     private final ValidatorConfig.Builder validatorConfigBuilder = ValidatorConfig.builder();
+    private final InteropConfig.InteropConfigBuilder interopConfigBuilder = InteropConfig.builder();
     private final DataConfig.Builder dataConfigBuilder = DataConfig.builder();
     private final P2PConfigBuilder p2pConfigBuilder = P2PConfig.builder();
     private final BeaconRestApiConfig.BeaconRestApiConfigBuilder restApiBuilder =
@@ -105,6 +110,7 @@ public class TekuConfiguration {
           globalConfigurationBuilder.build(),
           weakSubjectivityBuilder.build(),
           validatorConfigBuilder.build(),
+          interopConfigBuilder.build(),
           dataConfigBuilder.build(),
           p2pConfigBuilder.build(),
           restApiBuilder.build(),
@@ -124,6 +130,11 @@ public class TekuConfiguration {
 
     public Builder validator(final Consumer<ValidatorConfig.Builder> validatorConfigConsumer) {
       validatorConfigConsumer.accept(validatorConfigBuilder);
+      return this;
+    }
+
+    public Builder interop(final Consumer<InteropConfigBuilder> interopConfigBuilderConsumer) {
+      interopConfigBuilderConsumer.accept(interopConfigBuilder);
       return this;
     }
 

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -30,7 +30,7 @@ public class BeaconNodeServiceController extends ServiceController {
     services.add(new BeaconChainService(serviceConfig, tekuConfig.beaconChain()));
     services.add(ValidatorClientService.create(serviceConfig, tekuConfig.validatorClient()));
     services.add(new TimerService(serviceConfig));
-    if (!serviceConfig.getConfig().isInteropEnabled()
+    if (!tekuConfig.beaconChain().interopConfig().isInteropEnabled()
         && serviceConfig.getConfig().isEth1Enabled()) {
       services.add(new PowchainService(serviceConfig));
     }

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
@@ -30,13 +30,6 @@ public class GlobalConfiguration implements MetricsConfig {
   private final Integer peerRateLimit;
   private final Integer peerRequestLimit;
 
-  // Interop
-  private final Integer interopGenesisTime;
-  private final int interopOwnedValidatorStartIndex;
-  private final int interopOwnedValidatorCount;
-  private final int interopNumberOfValidators;
-  private final boolean interopEnabled;
-
   // Deposit
   private final Eth1Address eth1DepositContractAddress;
   private final String eth1Endpoint;
@@ -74,11 +67,6 @@ public class GlobalConfiguration implements MetricsConfig {
       final Integer startupTimeoutSeconds,
       final Integer peerRateLimit,
       final Integer peerRequestLimit,
-      final Integer interopGenesisTime,
-      final int interopOwnedValidatorStartIndex,
-      final int interopOwnedValidatorCount,
-      final int interopNumberOfValidators,
-      final boolean interopEnabled,
       final Eth1Address eth1DepositContractAddress,
       final String eth1Endpoint,
       final Optional<UInt64> eth1DepositContractDeployBlock,
@@ -101,11 +89,6 @@ public class GlobalConfiguration implements MetricsConfig {
     this.startupTimeoutSeconds = startupTimeoutSeconds;
     this.peerRateLimit = peerRateLimit;
     this.peerRequestLimit = peerRequestLimit;
-    this.interopGenesisTime = interopGenesisTime;
-    this.interopOwnedValidatorStartIndex = interopOwnedValidatorStartIndex;
-    this.interopOwnedValidatorCount = interopOwnedValidatorCount;
-    this.interopNumberOfValidators = interopNumberOfValidators;
-    this.interopEnabled = interopEnabled;
     this.eth1DepositContractAddress = eth1DepositContractAddress;
     this.eth1Endpoint = eth1Endpoint;
     this.eth1DepositContractDeployBlock = eth1DepositContractDeployBlock;
@@ -146,30 +129,6 @@ public class GlobalConfiguration implements MetricsConfig {
 
   public int getPeerRequestLimit() {
     return peerRequestLimit;
-  }
-
-  public Integer getInteropGenesisTime() {
-    if (interopGenesisTime == 0) {
-      return Math.toIntExact((System.currentTimeMillis() / 1000) + 5);
-    } else {
-      return interopGenesisTime;
-    }
-  }
-
-  public int getInteropOwnedValidatorStartIndex() {
-    return interopOwnedValidatorStartIndex;
-  }
-
-  public int getInteropOwnedValidatorCount() {
-    return interopOwnedValidatorCount;
-  }
-
-  public int getInteropNumberOfValidators() {
-    return interopNumberOfValidators;
-  }
-
-  public boolean isInteropEnabled() {
-    return interopEnabled;
   }
 
   public boolean isEth1Enabled() {
@@ -243,15 +202,5 @@ public class GlobalConfiguration implements MetricsConfig {
 
   public boolean isBlockProcessingAtStartupDisabled() {
     return isBlockProcessingAtStartupDisabled;
-  }
-
-  public void validate() throws IllegalArgumentException {
-    final int interopNumberOfValidators = getInteropNumberOfValidators();
-    if (interopNumberOfValidators < Constants.SLOTS_PER_EPOCH) {
-      throw new InvalidConfigurationException(
-          String.format(
-              "Invalid configuration. Interop number of validators [%d] must be greater than or equal to [%d]",
-              interopNumberOfValidators, Constants.SLOTS_PER_EPOCH));
-    }
   }
 }

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
@@ -30,11 +30,6 @@ public class GlobalConfigurationBuilder {
   private Integer startupTimeoutSeconds;
   private Integer peerRateLimit;
   private Integer peerRequestLimit;
-  private Integer interopGenesisTime;
-  private int interopOwnedValidatorStartIndex;
-  private int interopOwnedValidatorCount;
-  private int interopNumberOfValidators;
-  private boolean interopEnabled;
   private Eth1Address eth1DepositContractAddress;
   private String eth1Endpoint;
   private Optional<UInt64> eth1DepositContractDeployBlock = Optional.empty();
@@ -76,34 +71,6 @@ public class GlobalConfigurationBuilder {
 
   public GlobalConfigurationBuilder setPeerRequestLimit(final Integer peerRequestLimit) {
     this.peerRequestLimit = peerRequestLimit;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setInteropGenesisTime(final Integer interopGenesisTime) {
-    this.interopGenesisTime = interopGenesisTime;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setInteropOwnedValidatorStartIndex(
-      final int interopOwnedValidatorStartIndex) {
-    this.interopOwnedValidatorStartIndex = interopOwnedValidatorStartIndex;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setInteropOwnedValidatorCount(
-      final int interopOwnedValidatorCount) {
-    this.interopOwnedValidatorCount = interopOwnedValidatorCount;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setInteropNumberOfValidators(
-      final int interopNumberOfValidators) {
-    this.interopNumberOfValidators = interopNumberOfValidators;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setInteropEnabled(final boolean interopEnabled) {
-    this.interopEnabled = interopEnabled;
     return this;
   }
 
@@ -225,11 +192,6 @@ public class GlobalConfigurationBuilder {
         startupTimeoutSeconds,
         peerRateLimit,
         peerRequestLimit,
-        interopGenesisTime,
-        interopOwnedValidatorStartIndex,
-        interopOwnedValidatorCount,
-        interopNumberOfValidators,
-        interopEnabled,
         eth1DepositContractAddress,
         eth1Endpoint,
         eth1DepositContractDeployBlock,

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/InteropConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/InteropConfig.java
@@ -70,7 +70,7 @@ public class InteropConfig {
     private Integer interopGenesisTime;
     private int interopOwnedValidatorStartIndex;
     private int interopOwnedValidatorCount;
-    private int interopNumberOfValidators;
+    private int interopNumberOfValidators = 64;
     private boolean interopEnabled;
 
     private InteropConfigBuilder() {}

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/InteropConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/InteropConfig.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.api;
+
+import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.util.config.InvalidConfigurationException;
+
+public class InteropConfig {
+
+  private final Integer interopGenesisTime;
+  private final int interopOwnedValidatorStartIndex;
+  private final int interopOwnedValidatorCount;
+  private final int interopNumberOfValidators;
+  private final boolean interopEnabled;
+
+  private InteropConfig(
+      final Integer interopGenesisTime,
+      final int interopOwnedValidatorStartIndex,
+      final int interopOwnedValidatorCount,
+      final int interopNumberOfValidators,
+      final boolean interopEnabled) {
+    this.interopGenesisTime = interopGenesisTime;
+    this.interopOwnedValidatorStartIndex = interopOwnedValidatorStartIndex;
+    this.interopOwnedValidatorCount = interopOwnedValidatorCount;
+    this.interopNumberOfValidators = interopNumberOfValidators;
+    this.interopEnabled = interopEnabled;
+  }
+
+  public static InteropConfigBuilder builder() {
+    return new InteropConfigBuilder();
+  }
+
+  public Integer getInteropGenesisTime() {
+    if (interopGenesisTime == 0) {
+      return Math.toIntExact((System.currentTimeMillis() / 1000) + 5);
+    } else {
+      return interopGenesisTime;
+    }
+  }
+
+  public int getInteropOwnedValidatorStartIndex() {
+    return interopOwnedValidatorStartIndex;
+  }
+
+  public int getInteropOwnedValidatorCount() {
+    return interopOwnedValidatorCount;
+  }
+
+  public int getInteropNumberOfValidators() {
+    return interopNumberOfValidators;
+  }
+
+  public boolean isInteropEnabled() {
+    return interopEnabled;
+  }
+
+  public static final class InteropConfigBuilder {
+
+    private Integer interopGenesisTime;
+    private int interopOwnedValidatorStartIndex;
+    private int interopOwnedValidatorCount;
+    private int interopNumberOfValidators;
+    private boolean interopEnabled;
+
+    private InteropConfigBuilder() {}
+
+    public InteropConfigBuilder interopGenesisTime(Integer interopGenesisTime) {
+      this.interopGenesisTime = interopGenesisTime;
+      return this;
+    }
+
+    public InteropConfigBuilder interopOwnedValidatorStartIndex(
+        int interopOwnedValidatorStartIndex) {
+      this.interopOwnedValidatorStartIndex = interopOwnedValidatorStartIndex;
+      return this;
+    }
+
+    public InteropConfigBuilder interopOwnedValidatorCount(int interopOwnedValidatorCount) {
+      this.interopOwnedValidatorCount = interopOwnedValidatorCount;
+      return this;
+    }
+
+    public InteropConfigBuilder interopNumberOfValidators(int interopNumberOfValidators) {
+      this.interopNumberOfValidators = interopNumberOfValidators;
+      return this;
+    }
+
+    public InteropConfigBuilder interopEnabled(boolean interopEnabled) {
+      this.interopEnabled = interopEnabled;
+      return this;
+    }
+
+    public InteropConfig build() {
+      validate();
+      return new InteropConfig(
+          interopGenesisTime,
+          interopOwnedValidatorStartIndex,
+          interopOwnedValidatorCount,
+          interopNumberOfValidators,
+          interopEnabled);
+    }
+
+    private void validate() throws IllegalArgumentException {
+      if (interopNumberOfValidators < Constants.SLOTS_PER_EPOCH) {
+        throw new InvalidConfigurationException(
+            String.format(
+                "Invalid configuration. Interop number of validators [%d] must be greater than or equal to [%d]",
+                interopNumberOfValidators, Constants.SLOTS_PER_EPOCH));
+      }
+    }
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientConfiguration.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientConfiguration.java
@@ -13,22 +13,22 @@
 
 package tech.pegasys.teku.validator.client;
 
-import tech.pegasys.teku.service.serviceutils.layout.DataConfig;
 import tech.pegasys.teku.util.config.GlobalConfiguration;
+import tech.pegasys.teku.validator.api.InteropConfig;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
 
 public class ValidatorClientConfiguration {
   private final GlobalConfiguration globalConfiguration;
   private final ValidatorConfig validatorConfig;
-  private final DataConfig dataConfig;
+  private final InteropConfig interopConfig;
 
   public ValidatorClientConfiguration(
       final GlobalConfiguration globalConfiguration,
       final ValidatorConfig validatorConfig,
-      final DataConfig dataConfig) {
+      final InteropConfig interopConfig) {
     this.globalConfiguration = globalConfiguration;
     this.validatorConfig = validatorConfig;
-    this.dataConfig = dataConfig;
+    this.interopConfig = interopConfig;
   }
 
   public GlobalConfiguration getGlobalConfiguration() {
@@ -39,7 +39,7 @@ public class ValidatorClientConfiguration {
     return validatorConfig;
   }
 
-  public DataConfig getDataConfig() {
-    return dataConfig;
+  public InteropConfig getInteropConfig() {
+    return interopConfig;
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -106,7 +106,7 @@ public class ValidatorClientService extends Service {
         ValidatorLoader.create(slashingProtector, asyncRunner, metricsSystem);
     final Map<BLSPublicKey, Validator> validators =
         validatorLoader.initializeValidators(
-            config.getValidatorConfig(), config.getGlobalConfiguration());
+            config.getValidatorConfig(), config.getInteropConfig());
     this.validatorIndexProvider =
         new ValidatorIndexProvider(validators.keySet(), validatorApiChannel);
     final ValidatorDutyFactory validatorDutyFactory =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/MockStartValidatorKeyProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/MockStartValidatorKeyProvider.java
@@ -19,15 +19,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.datastructures.interop.MockStartValidatorKeyPairFactory;
-import tech.pegasys.teku.util.config.GlobalConfiguration;
+import tech.pegasys.teku.validator.api.InteropConfig;
 
 class MockStartValidatorKeyProvider implements ValidatorKeyProvider {
 
   private static final Logger LOG = LogManager.getLogger();
 
-  private final GlobalConfiguration config;
+  private final InteropConfig config;
 
-  public MockStartValidatorKeyProvider(final GlobalConfiguration config) {
+  public MockStartValidatorKeyProvider(final InteropConfig config) {
     this.config = config;
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -47,7 +47,7 @@ import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
-import tech.pegasys.teku.util.config.GlobalConfiguration;
+import tech.pegasys.teku.validator.api.InteropConfig;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
 import tech.pegasys.teku.validator.client.Validator;
 
@@ -93,7 +93,7 @@ class ValidatorLoaderTest {
 
   @Test
   void initializeValidatorsWithExternalSignerAndSlashingProtection() throws Exception {
-    final GlobalConfiguration globalConfig = GlobalConfiguration.builder().build();
+    final InteropConfig interopConfig = InteropConfig.builder().build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -102,7 +102,7 @@ class ValidatorLoaderTest {
             .build();
 
     final Map<BLSPublicKey, Validator> validators =
-        validatorLoader.initializeValidators(config, globalConfig, () -> httpClient);
+        validatorLoader.initializeValidators(config, interopConfig, () -> httpClient);
 
     assertThat(validators).hasSize(1);
     final Validator validator = validators.get(PUBLIC_KEY1);
@@ -124,7 +124,7 @@ class ValidatorLoaderTest {
 
   @Test
   void initializeValidatorsWithExternalSignerAndNoSlashingProtection() throws Exception {
-    final GlobalConfiguration globalConfig = GlobalConfiguration.builder().build();
+    final InteropConfig interopConfig = InteropConfig.builder().build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -133,7 +133,7 @@ class ValidatorLoaderTest {
             .build();
 
     final Map<BLSPublicKey, Validator> validators =
-        validatorLoader.initializeValidators(config, globalConfig, () -> httpClient);
+        validatorLoader.initializeValidators(config, interopConfig, () -> httpClient);
 
     assertThat(validators).hasSize(1);
     final Validator validator = validators.get(PUBLIC_KEY1);
@@ -158,7 +158,7 @@ class ValidatorLoaderTest {
   void initializeValidatorsWithBothLocalAndExternalSigners(@TempDir Path tempDir) throws Exception {
     writeKeystore(tempDir);
 
-    final GlobalConfiguration globalConfig = GlobalConfiguration.builder().build();
+    final InteropConfig interopConfig = InteropConfig.builder().build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -171,7 +171,7 @@ class ValidatorLoaderTest {
             .build();
 
     final Map<BLSPublicKey, Validator> validators =
-        validatorLoader.initializeValidators(config, globalConfig, () -> httpClient);
+        validatorLoader.initializeValidators(config, interopConfig, () -> httpClient);
 
     assertThat(validators).hasSize(2);
 
@@ -191,7 +191,7 @@ class ValidatorLoaderTest {
       @TempDir Path tempDir) throws Exception {
     writeKeystore(tempDir);
 
-    final GlobalConfiguration globalConfig = GlobalConfiguration.builder().build();
+    final InteropConfig interopConfig = InteropConfig.builder().build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -204,7 +204,7 @@ class ValidatorLoaderTest {
             .build();
 
     final Map<BLSPublicKey, Validator> validators =
-        validatorLoader.initializeValidators(config, globalConfig, () -> httpClient);
+        validatorLoader.initializeValidators(config, interopConfig, () -> httpClient);
 
     // Both local and external validators get loaded.
     assertThat(validators).hasSize(1);
@@ -225,14 +225,14 @@ class ValidatorLoaderTest {
   @Test
   void initializeInteropValidatorsWhenInteropIsEnabled() {
     final int ownedValidatorCount = 10;
-    final GlobalConfiguration globalConfig =
-        GlobalConfiguration.builder()
-            .setInteropEnabled(true)
-            .setInteropOwnedValidatorCount(ownedValidatorCount)
+    final InteropConfig interopConfig =
+        InteropConfig.builder()
+            .interopEnabled(true)
+            .interopOwnedValidatorCount(ownedValidatorCount)
             .build();
     final ValidatorConfig config = ValidatorConfig.builder().build();
     final Map<BLSPublicKey, Validator> validators =
-        validatorLoader.initializeValidators(config, globalConfig, () -> httpClient);
+        validatorLoader.initializeValidators(config, interopConfig, () -> httpClient);
 
     assertThat(validators).hasSize(ownedValidatorCount);
   }
@@ -240,14 +240,14 @@ class ValidatorLoaderTest {
   @Test
   void doNotInitializeInteropValidatorsWhenInteropIsDisabled() {
     final int ownedValidatorCount = 10;
-    final GlobalConfiguration globalConfig =
-        GlobalConfiguration.builder()
-            .setInteropEnabled(false)
-            .setInteropOwnedValidatorCount(ownedValidatorCount)
+    final InteropConfig interopConfig =
+        InteropConfig.builder()
+            .interopEnabled(false)
+            .interopOwnedValidatorCount(ownedValidatorCount)
             .build();
     final ValidatorConfig config = ValidatorConfig.builder().build();
     final Map<BLSPublicKey, Validator> validators =
-        validatorLoader.initializeValidators(config, globalConfig, () -> httpClient);
+        validatorLoader.initializeValidators(config, interopConfig, () -> httpClient);
 
     assertThat(validators).isEmpty();
   }


### PR DESCRIPTION
## PR Description
Split the interop config options out of `GlobalConfiguration`.

Builds on #3417 

## Fixed Issue(s)
#2808 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.