### PR TITLE
Fix Shuffle benchmark test for gradle and jar execution

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ShuffleBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ShuffleBenchmark.java
@@ -28,7 +28,7 @@ import org.openjdk.jmh.infra.Blackhole;
 import tech.pegasys.teku.datastructures.util.CommitteeUtil;
 import tech.pegasys.teku.util.config.Constants;
 
-@Fork(0)
+@Fork(3)
 @BenchmarkMode(Mode.SingleShotTime)
 @State(Scope.Thread)
 public class ShuffleBenchmark {

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/BeaconStateUtil.java
@@ -82,7 +82,7 @@ import tech.pegasys.teku.util.config.Constants;
 
 public class BeaconStateUtil {
 
-  private static final Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger(BeaconStateUtil.class);
 
   /**
    * For debug/test purposes only enables/disables {@link DepositData} BLS signature verification

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -126,7 +126,7 @@ dependencyManagement {
     dependency 'org.mockito:mockito-core:3.3.3'
     dependency 'org.mockito:mockito-junit-jupiter:3.3.3'
 
-    dependencySet(group: "org.openjdk.jmh", version: "1.25.2") {
+    dependencySet(group: "org.openjdk.jmh", version: "1.27") {
       entry 'jmh-core'
       entry 'jmh-generator-annprocess'
     }


### PR DESCRIPTION
Doesnt like running in intellij, but runs from jar and gradle after this change.

Also updated jmh version to current (1.27).

fixes #3384

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.