### PR TITLE
Add benchmark for VoteTracker serialization

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/VoteTrackerSerialize.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/VoteTrackerSerialize.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.benchmarks;
+
+import static tech.pegasys.teku.datastructures.util.SimpleOffsetSerializer.deserialize;
+import static tech.pegasys.teku.datastructures.util.SimpleOffsetSerializer.serialize;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.tuweni.bytes.Bytes;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Warmup;
+import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+
+@Fork(5)
+public class VoteTrackerSerialize {
+
+  private static VoteTracker votes = new DataStructureUtil().randomVoteTracker();
+  private static Bytes votesSerialized = serialize(votes);
+
+  @Benchmark
+  @Warmup(iterations = 3, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+  @Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+  public void VoteTrackerSerialization() {
+    serialize(votes);
+  }
+
+  @Benchmark
+  @Warmup(iterations = 3, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+  @Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+  public void VoteTrackerDeserialization() {
+    deserialize(votesSerialized, VoteTracker.class);
+  }
+}

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/VoteTrackerSerialize.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/VoteTrackerSerialize.java
@@ -24,13 +24,13 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Warmup;
 import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
-import tech.pegasys.teku.storage.server.rocksdb.serialization.VotesTrackerSerializer;
+import tech.pegasys.teku.storage.server.rocksdb.serialization.VoteTrackerSerializer;
 
 public class VoteTrackerSerialize {
 
   private static VoteTracker votes = new DataStructureUtil().randomVoteTracker();
   private static Bytes votesSerialized = serialize(votes);
-  private static VotesTrackerSerializer serializer = new VotesTrackerSerializer();
+  private static VoteTrackerSerializer serializer = new VoteTrackerSerializer();
 
   @Benchmark
   @Warmup(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/RocksDbSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/RocksDbSerializer.java
@@ -33,7 +33,7 @@ public interface RocksDbSerializer<T> {
       new SszSerializer<>(SignedBeaconBlock.class);
   RocksDbSerializer<BeaconState> STATE_SERIALIZER = new SszSerializer<>(BeaconStateImpl.class);
   RocksDbSerializer<Checkpoint> CHECKPOINT_SERIALIZER = new SszSerializer<>(Checkpoint.class);
-  RocksDbSerializer<VoteTracker> VOTES_SERIALIZER = new VotesTrackerSerializer();
+  RocksDbSerializer<VoteTracker> VOTES_SERIALIZER = new VoteTrackerSerializer();
   RocksDbSerializer<DepositsFromBlockEvent> DEPOSITS_FROM_BLOCK_EVENT_SERIALIZER =
       new DepositsFromBlockEventSerializer();
   RocksDbSerializer<MinGenesisTimeBlockEvent> MIN_GENESIS_TIME_BLOCK_EVENT_SERIALIZER =

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/RocksDbSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/RocksDbSerializer.java
@@ -33,7 +33,7 @@ public interface RocksDbSerializer<T> {
       new SszSerializer<>(SignedBeaconBlock.class);
   RocksDbSerializer<BeaconState> STATE_SERIALIZER = new SszSerializer<>(BeaconStateImpl.class);
   RocksDbSerializer<Checkpoint> CHECKPOINT_SERIALIZER = new SszSerializer<>(Checkpoint.class);
-  RocksDbSerializer<VoteTracker> VOTES_SERIALIZER = new SszSerializer<>(VoteTracker.class);
+  RocksDbSerializer<VoteTracker> VOTES_SERIALIZER = new VotesTrackerSerializer();
   RocksDbSerializer<DepositsFromBlockEvent> DEPOSITS_FROM_BLOCK_EVENT_SERIALIZER =
       new DepositsFromBlockEventSerializer();
   RocksDbSerializer<MinGenesisTimeBlockEvent> MIN_GENESIS_TIME_BLOCK_EVENT_SERIALIZER =

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/VoteTrackerSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/VoteTrackerSerializer.java
@@ -19,7 +19,7 @@ import org.apache.tuweni.ssz.SSZ;
 import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class VotesTrackerSerializer implements RocksDbSerializer<VoteTracker> {
+public class VoteTrackerSerializer implements RocksDbSerializer<VoteTracker> {
   @Override
   public VoteTracker deserialize(final byte[] data) {
     return SSZ.decode(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/VotesTrackerSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/VotesTrackerSerializer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.rocksdb.serialization;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.ssz.SSZ;
+import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class VotesTrackerSerializer implements RocksDbSerializer<VoteTracker> {
+  @Override
+  public VoteTracker deserialize(final byte[] data) {
+    return SSZ.decode(
+        Bytes.of(data),
+        reader -> {
+          final Bytes32 currentRoot = Bytes32.wrap(reader.readFixedBytes(Bytes32.SIZE));
+          final Bytes32 nextRoot = Bytes32.wrap(reader.readFixedBytes(Bytes32.SIZE));
+          final UInt64 nextEpoch = UInt64.fromLongBits(reader.readUInt64());
+          return new VoteTracker(currentRoot, nextRoot, nextEpoch);
+        });
+  }
+
+  @Override
+  public byte[] serialize(final VoteTracker value) {
+    Bytes bytes =
+        SSZ.encode(
+            writer -> {
+              writer.writeFixedBytes(value.getCurrentRoot());
+              writer.writeFixedBytes(value.getNextRoot());
+              writer.writeUInt64(value.getNextEpoch().longValue());
+            });
+    return bytes.toArrayUnsafe();
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/serialization/VoteTrackerSerializerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/serialization/VoteTrackerSerializerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.rocksdb.serialization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.datastructures.util.SimpleOffsetSerializer.serialize;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+
+public class VoteTrackerSerializerTest {
+  private static VoteTracker votes = new DataStructureUtil().randomVoteTracker();
+  private static Bytes votesSerialized = serialize(votes);
+  private static VoteTrackerSerializer serializer = new VoteTrackerSerializer();
+
+  @Test
+  public void serializesConsistentlyToGenericSerializer() {
+    assertThat(Bytes.wrap(serializer.serialize(votes))).isEqualTo(votesSerialized);
+  }
+
+  @Test
+  public void deserializesConsistentlyToGenericSerializer() {
+    assertThat(serializer.deserialize(votesSerialized.toArrayUnsafe())).isEqualTo(votes);
+  }
+}


### PR DESCRIPTION
Also wrote VoteTrackerSerializer rather than using the generic serializer. There was a move previously to use custom serializers in case we ever have to change object structures, and I was trying to determine whether a custom serializer would perform any better than the generic. It didn't perform any worse, so I've left it in.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.