### PR TITLE
Load duties inside EpochDuties instead of directly in the DutyScheduler

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -29,7 +29,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   private final DutyLoader epochDutiesScheduler;
   private final int lookAheadEpochs;
 
-  protected final NavigableMap<UInt64, DutyQueue> dutiesByEpoch = new TreeMap<>();
+  protected final NavigableMap<UInt64, EpochDuties> dutiesByEpoch = new TreeMap<>();
   private Optional<UInt64> currentEpoch = Optional.empty();
 
   protected AbstractDutyScheduler(
@@ -38,14 +38,10 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
     this.lookAheadEpochs = lookAheadEpochs;
   }
 
-  protected DutyQueue requestDutiesForEpoch(final UInt64 epochNumber) {
-    return new DutyQueue(epochDutiesScheduler.loadDutiesForEpoch(epochNumber));
-  }
-
-  protected void notifyDutyQueue(final BiConsumer<DutyQueue, UInt64> action, final UInt64 slot) {
-    final DutyQueue dutyQueue = dutiesByEpoch.get(compute_epoch_at_slot(slot));
-    if (dutyQueue != null) {
-      action.accept(dutyQueue, slot);
+  protected void notifyDutyQueue(final BiConsumer<EpochDuties, UInt64> action, final UInt64 slot) {
+    final EpochDuties epochDuties = dutiesByEpoch.get(compute_epoch_at_slot(slot));
+    if (epochDuties != null) {
+      action.accept(epochDuties, slot);
     }
   }
 
@@ -54,7 +50,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
     final UInt64 currentEpoch = compute_epoch_at_slot(slot);
     this.currentEpoch = Optional.of(currentEpoch);
     removePriorEpochs(currentEpoch);
-    recalculateDuties(currentEpoch);
+    calculateDuties(currentEpoch);
   }
 
   @Override
@@ -67,32 +63,35 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
     LOG.debug(
         "Chain reorganisation detected. Invalidating validator duties after epoch {}",
         lastUnaffectedEpoch);
-    removeEpochs(dutiesByEpoch.tailMap(lastUnaffectedEpoch, false));
-    recalculateDuties(compute_epoch_at_slot(newSlot));
+    invalidateEpochs(dutiesByEpoch.tailMap(lastUnaffectedEpoch, false));
+    calculateDuties(compute_epoch_at_slot(newSlot));
   }
 
   @Override
   public void onPossibleMissedEvents() {
     // We may have missed a re-org notification so we need to recalculate all duties.
-    removeEpochs(dutiesByEpoch);
-    currentEpoch.ifPresent(this::recalculateDuties);
+    invalidateEpochs(dutiesByEpoch);
   }
 
-  protected void recalculateDuties(final UInt64 epochNumber) {
-    dutiesByEpoch.computeIfAbsent(epochNumber, this::requestDutiesForEpoch);
+  private void calculateDuties(final UInt64 epochNumber) {
+    dutiesByEpoch.computeIfAbsent(epochNumber, this::createEpochDuties);
     for (int i = 1; i <= lookAheadEpochs; i++) {
-      dutiesByEpoch.computeIfAbsent(epochNumber.plus(i), this::requestDutiesForEpoch);
+      dutiesByEpoch.computeIfAbsent(epochNumber.plus(i), this::createEpochDuties);
     }
   }
 
-  protected void removePriorEpochs(final UInt64 epochNumber) {
-    final NavigableMap<UInt64, DutyQueue> toRemove = dutiesByEpoch.headMap(epochNumber, false);
-    removeEpochs(toRemove);
+  private EpochDuties createEpochDuties(final UInt64 epochNumber) {
+    return EpochDuties.calculateDuties(epochDutiesScheduler, epochNumber);
   }
 
-  protected void removeEpochs(final NavigableMap<UInt64, DutyQueue> toRemove) {
-    toRemove.values().forEach(DutyQueue::cancel);
+  private void removePriorEpochs(final UInt64 epochNumber) {
+    final NavigableMap<UInt64, EpochDuties> toRemove = dutiesByEpoch.headMap(epochNumber, false);
+    toRemove.values().forEach(EpochDuties::cancel);
     toRemove.clear();
+  }
+
+  private void invalidateEpochs(final NavigableMap<UInt64, EpochDuties> toInvalidate) {
+    toInvalidate.values().forEach(EpochDuties::recalculate);
   }
 
   protected Optional<UInt64> getCurrentEpoch() {
@@ -105,10 +104,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
     }
     final UInt64 signingEpoch = compute_epoch_at_slot(slot);
     final UInt64 epoch = currentEpoch.get();
-    if (signingEpoch.isGreaterThan(epoch.plus(lookAheadEpochs + 1))) {
-      return false;
-    }
-    return true;
+    return !signingEpoch.isGreaterThan(epoch.plus(lookAheadEpochs + 1));
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -38,7 +38,8 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
     this.lookAheadEpochs = lookAheadEpochs;
   }
 
-  protected void notifyDutyQueue(final BiConsumer<EpochDuties, UInt64> action, final UInt64 slot) {
+  protected void notifyEpochDuties(
+      final BiConsumer<EpochDuties, UInt64> action, final UInt64 slot) {
     final EpochDuties epochDuties = dutiesByEpoch.get(compute_epoch_at_slot(slot));
     if (epochDuties != null) {
       action.accept(epochDuties, slot);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
@@ -32,7 +32,7 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
         TekuMetricCategory.VALIDATOR,
         "scheduled_attestation_duties_current",
         "Current number of pending attestation duties that have been scheduled",
-        () -> dutiesByEpoch.values().stream().mapToInt(DutyQueue::countDuties).sum());
+        () -> dutiesByEpoch.values().stream().mapToInt(EpochDuties::countDuties).sum());
   }
 
   @Override
@@ -55,7 +55,7 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
     }
 
     lastAttestationCreationSlot = slot;
-    notifyDutyQueue(DutyQueue::onAttestationCreationDue, slot);
+    notifyDutyQueue(EpochDuties::onAttestationCreationDue, slot);
   }
 
   @Override
@@ -68,6 +68,6 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
       return;
     }
 
-    notifyDutyQueue(DutyQueue::onAttestationAggregationDue, slot);
+    notifyDutyQueue(EpochDuties::onAttestationAggregationDue, slot);
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
@@ -55,7 +55,7 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
     }
 
     lastAttestationCreationSlot = slot;
-    notifyDutyQueue(EpochDuties::onAttestationCreationDue, slot);
+    notifyEpochDuties(EpochDuties::onAttestationCreationDue, slot);
   }
 
   @Override
@@ -68,6 +68,6 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
       return;
     }
 
-    notifyDutyQueue(EpochDuties::onAttestationAggregationDue, slot);
+    notifyEpochDuties(EpochDuties::onAttestationAggregationDue, slot);
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -31,7 +31,7 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
         TekuMetricCategory.VALIDATOR,
         "scheduled_block_duties_current",
         "Current number of pending block duties that have been scheduled",
-        () -> dutiesByEpoch.values().stream().mapToInt(DutyQueue::countDuties).sum());
+        () -> dutiesByEpoch.values().stream().mapToInt(EpochDuties::countDuties).sum());
   }
 
   @Override
@@ -44,6 +44,6 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
       return;
     }
 
-    notifyDutyQueue(DutyQueue::onBlockProductionDue, slot);
+    notifyDutyQueue(EpochDuties::onBlockProductionDue, slot);
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -44,6 +44,6 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
       return;
     }
 
-    notifyDutyQueue(EpochDuties::onBlockProductionDue, slot);
+    notifyEpochDuties(EpochDuties::onBlockProductionDue, slot);
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/EpochDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/EpochDutiesTest.java
@@ -144,12 +144,12 @@ class EpochDutiesTest {
 
   @Test
   void shouldNotUsePreviouslyRequestedDutiesReceivedAfterRecalculationStarted() {
-
     final ScheduledDuties newDuties = mock(ScheduledDuties.class);
     final SafeFuture<ScheduledDuties> recalculatedDuties = new SafeFuture<>();
     when(dutyLoader.loadDutiesForEpoch(EPOCH)).thenReturn(recalculatedDuties);
 
     duties.recalculate();
+    assertThat(scheduledDutiesFuture).isCancelled();
     verify(dutyLoader, times(2)).loadDutiesForEpoch(EPOCH);
 
     duties.onBlockProductionDue(ZERO);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/EpochDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/EpochDutiesTest.java
@@ -16,30 +16,45 @@ package tech.pegasys.teku.validator.client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.client.duties.ScheduledDuties;
 
-class DutyQueueTest {
-  private final SafeFuture<ScheduledDuties> scheduledDutiesFuture = new SafeFuture<>();
+class EpochDutiesTest {
+
+  private static final UInt64 EPOCH = UInt64.valueOf(10);
+  //  private final SafeFuture<ScheduledDuties> scheduledDutiesFuture = new SafeFuture<>();
+  private final DutyLoader dutyLoader = mock(DutyLoader.class);
   private final ScheduledDuties scheduledDuties = mock(ScheduledDuties.class);
 
-  private final DutyQueue duties = new DutyQueue(scheduledDutiesFuture);
+  private EpochDuties duties;
+  private final SafeFuture<ScheduledDuties> scheduledDutiesFuture = new SafeFuture<>();
+
+  @BeforeEach
+  void setUp() {
+    when(dutyLoader.loadDutiesForEpoch(EPOCH)).thenReturn(scheduledDutiesFuture);
+    duties = EpochDuties.calculateDuties(dutyLoader, EPOCH);
+    verify(dutyLoader).loadDutiesForEpoch(EPOCH);
+  }
 
   @Test
-  public void cancel_shouldCancelFuture() {
+  void cancel_shouldCancelFuture() {
     duties.cancel();
     assertThat(scheduledDutiesFuture).isCancelled();
   }
 
   @Test
-  public void onBlockProductionDue_shouldActImmediatelyIfDutiesLoaded() {
+  void onBlockProductionDue_shouldActImmediatelyIfDutiesLoaded() {
     scheduledDutiesFuture.complete(scheduledDuties);
     duties.onBlockProductionDue(ONE);
 
@@ -47,7 +62,7 @@ class DutyQueueTest {
   }
 
   @Test
-  public void onBlockProductionDue_shouldDeferUntilDutiesLoaded() {
+  void onBlockProductionDue_shouldDeferUntilDutiesLoaded() {
     duties.onBlockProductionDue(ONE);
     verifyNoInteractions(scheduledDuties);
 
@@ -56,7 +71,7 @@ class DutyQueueTest {
   }
 
   @Test
-  public void onAttestationProductionDue_shouldActImmediatelyIfDutiesLoaded() {
+  void onAttestationProductionDue_shouldActImmediatelyIfDutiesLoaded() {
     scheduledDutiesFuture.complete(scheduledDuties);
     duties.onAttestationCreationDue(ONE);
 
@@ -64,7 +79,7 @@ class DutyQueueTest {
   }
 
   @Test
-  public void onAttestationProductionDue_shouldDeferUntilDutiesLoaded() {
+  void onAttestationProductionDue_shouldDeferUntilDutiesLoaded() {
     duties.onAttestationCreationDue(ONE);
     verifyNoInteractions(scheduledDuties);
 
@@ -73,7 +88,7 @@ class DutyQueueTest {
   }
 
   @Test
-  public void onAttestationAggregationDue_shouldActImmediatelyIfDutiesLoaded() {
+  void onAttestationAggregationDue_shouldActImmediatelyIfDutiesLoaded() {
     scheduledDutiesFuture.complete(scheduledDuties);
     duties.onAttestationAggregationDue(ONE);
 
@@ -81,7 +96,7 @@ class DutyQueueTest {
   }
 
   @Test
-  public void onAttestationAggregationDue_shouldDeferUntilDutiesLoaded() {
+  void onAttestationAggregationDue_shouldDeferUntilDutiesLoaded() {
     duties.onAttestationAggregationDue(ONE);
     verifyNoInteractions(scheduledDuties);
 
@@ -90,7 +105,7 @@ class DutyQueueTest {
   }
 
   @Test
-  public void shouldPerformDelayedDutiesInOrder() {
+  void shouldPerformDelayedDutiesInOrder() {
     duties.onBlockProductionDue(ZERO);
     duties.onAttestationCreationDue(ZERO);
     duties.onAttestationAggregationDue(ZERO);
@@ -107,5 +122,45 @@ class DutyQueueTest {
     inOrder.verify(scheduledDuties).produceAttestations(ONE);
     inOrder.verify(scheduledDuties).performAggregation(ONE);
     inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  void shouldRecalculateDuties() {
+    scheduledDutiesFuture.complete(scheduledDuties);
+
+    final ScheduledDuties newDuties = mock(ScheduledDuties.class);
+    final SafeFuture<ScheduledDuties> recalculatedDuties = new SafeFuture<>();
+    when(dutyLoader.loadDutiesForEpoch(EPOCH)).thenReturn(recalculatedDuties);
+
+    duties.recalculate();
+    verify(dutyLoader, times(2)).loadDutiesForEpoch(EPOCH);
+
+    // Should use new duties to perform actions
+    duties.onBlockProductionDue(ZERO);
+    verifyNoInteractions(scheduledDuties);
+
+    recalculatedDuties.complete(newDuties);
+    verify(newDuties).produceBlock(ZERO);
+  }
+
+  @Test
+  void shouldNotUsePreviouslyRequestedDutiesReceivedAfterRecalculationStarted() {
+
+    final ScheduledDuties newDuties = mock(ScheduledDuties.class);
+    final SafeFuture<ScheduledDuties> recalculatedDuties = new SafeFuture<>();
+    when(dutyLoader.loadDutiesForEpoch(EPOCH)).thenReturn(recalculatedDuties);
+
+    duties.recalculate();
+    verify(dutyLoader, times(2)).loadDutiesForEpoch(EPOCH);
+
+    duties.onBlockProductionDue(ZERO);
+
+    // Old request completes and should be ignored.
+    scheduledDutiesFuture.complete(scheduledDuties);
+    verifyNoInteractions(scheduledDuties);
+
+    // Duties are performed when recalculation completes
+    recalculatedDuties.complete(newDuties);
+    verify(newDuties).produceBlock(ZERO);
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/EpochDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/EpochDutiesTest.java
@@ -33,12 +33,11 @@ import tech.pegasys.teku.validator.client.duties.ScheduledDuties;
 class EpochDutiesTest {
 
   private static final UInt64 EPOCH = UInt64.valueOf(10);
-  //  private final SafeFuture<ScheduledDuties> scheduledDutiesFuture = new SafeFuture<>();
+  private final SafeFuture<ScheduledDuties> scheduledDutiesFuture = new SafeFuture<>();
   private final DutyLoader dutyLoader = mock(DutyLoader.class);
   private final ScheduledDuties scheduledDuties = mock(ScheduledDuties.class);
 
   private EpochDuties duties;
-  private final SafeFuture<ScheduledDuties> scheduledDutiesFuture = new SafeFuture<>();
 
   @BeforeEach
   void setUp() {


### PR DESCRIPTION
## PR Description
Renamed `DutyQueue` to `EpochDuties` and make it responsible for loading the duties. Rather than creating a new `EpochDuties` each time duties are invalidated, the existing one is reused and told to reload.  This sets up the model in a way that it will be able to use the `dependent_root` information from duties to decide if they need to be invalidated, even when a head event is received between requesting and actually receiving the duties.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.