### PR TITLE
Fixed response for GetStateValidatorBalances in OpenAPI docs

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorBalances.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorBalances.java
@@ -39,7 +39,6 @@ import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
-import tech.pegasys.teku.api.response.v1.beacon.GetStateRootResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateValidatorBalancesResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorBalanceResponse;
 import tech.pegasys.teku.beaconrestapi.ListQueryParameterUtils;
@@ -80,7 +79,7 @@ public class GetStateValidatorBalances extends AbstractHandler implements Handle
       responses = {
         @OpenApiResponse(
             status = RES_OK,
-            content = @OpenApiContent(from = GetStateRootResponse.class)),
+            content = @OpenApiContent(from = GetStateValidatorBalancesResponse.class)),
         @OpenApiResponse(status = RES_BAD_REQUEST),
         @OpenApiResponse(status = RES_NOT_FOUND),
         @OpenApiResponse(status = RES_INTERNAL_ERROR)


### PR DESCRIPTION
## PR Description

## Fixed Issue(s)
- Fixed response for GetStateValidatorBalances in OpenAPI docs

## Documentation

As I understood, the generated documentation will be automatically fixed after this PR, but I've no permissions to assign any label to this PR in any case.

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.