### PR TITLE
Epoch information for ValidatorResponse and ValidatorBalanceResponse

### DIFF
--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorBalancesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorBalancesTest.java
@@ -31,7 +31,7 @@ public class GetStateValidatorBalancesTest extends AbstractBeaconHandlerTest {
   private final GetStateValidatorBalances handler =
       new GetStateValidatorBalances(chainDataProvider, jsonProvider);
   private final ValidatorBalanceResponse validatorBalanceResponse =
-      new ValidatorBalanceResponse(ONE, UInt64.valueOf("32000000000"));
+      new ValidatorBalanceResponse(ONE, UInt64.valueOf("32000000000"), ONE);
 
   @Test
   public void shouldGetValidatorBalancesFromState() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorTest.java
@@ -50,7 +50,8 @@ public class GetStateValidatorTest extends AbstractBeaconHandlerTest {
               ZERO,
               ZERO,
               FAR_FUTURE_EPOCH,
-              FAR_FUTURE_EPOCH));
+              FAR_FUTURE_EPOCH),
+          ONE);
 
   @Test
   public void shouldGetValidatorFromState() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorsTest.java
@@ -53,7 +53,8 @@ public class GetStateValidatorsTest extends AbstractBeaconHandlerTest {
               ZERO,
               ZERO,
               FAR_FUTURE_EPOCH,
-              FAR_FUTURE_EPOCH));
+              FAR_FUTURE_EPOCH),
+          ONE);
 
   @Test
   public void shouldGetValidatorFromState() throws Exception {

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorBalanceResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorBalanceResponse.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.api.response.v1.beacon;
 
 import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_UINT64;
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -39,11 +40,18 @@ public class ValidatorBalanceResponse {
       description = "Current validator balance in gwei.")
   public final UInt64 balance;
 
+  @JsonProperty("epoch")
+  @Schema(type = "string", example = EXAMPLE_UINT64, description = "Referred epoch.")
+  public final UInt64 epoch;
+
   @JsonCreator
   public ValidatorBalanceResponse(
-      @JsonProperty("index") final UInt64 index, @JsonProperty("balance") final UInt64 balance) {
+      @JsonProperty("index") final UInt64 index,
+      @JsonProperty("balance") final UInt64 balance,
+      @JsonProperty("epoch") final UInt64 epoch) {
     this.index = index;
     this.balance = balance;
+    this.epoch = epoch;
   }
 
   public static Optional<ValidatorBalanceResponse> fromState(
@@ -52,7 +60,10 @@ public class ValidatorBalanceResponse {
       return Optional.empty();
     }
     return Optional.of(
-        new ValidatorBalanceResponse(UInt64.valueOf(index), state.getBalances().get(index)));
+        new ValidatorBalanceResponse(
+            UInt64.valueOf(index),
+            state.getBalances().get(index),
+            compute_epoch_at_slot(state.getSlot())));
   }
 
   @Override
@@ -60,7 +71,9 @@ public class ValidatorBalanceResponse {
     if (this == o) return true;
     if (!(o instanceof ValidatorBalanceResponse)) return false;
     ValidatorBalanceResponse that = (ValidatorBalanceResponse) o;
-    return Objects.equal(index, that.index) && Objects.equal(balance, that.balance);
+    return Objects.equal(index, that.index)
+        && Objects.equal(balance, that.balance)
+        && Objects.equal(epoch, that.epoch);
   }
 
   @Override
@@ -70,6 +83,10 @@ public class ValidatorBalanceResponse {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("index", index).add("balance", balance).toString();
+    return MoreObjects.toStringHelper(this)
+        .add("index", index)
+        .add("balance", balance)
+        .add("epoch", epoch)
+        .toString();
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorResponse.java
@@ -56,12 +56,18 @@ public class ValidatorResponse {
       @JsonProperty("index") final UInt64 index,
       @JsonProperty("balance") final UInt64 balance,
       @JsonProperty("status") final ValidatorStatus status,
-      @JsonProperty("validator") final Validator validator) {
+      @JsonProperty("validator") final Validator validator,
+      @JsonProperty("epoch") final UInt64 epoch) {
     this.index = index;
     this.balance = balance;
     this.status = status;
     this.validator = validator;
+    this.epoch = epoch;
   }
+
+  @JsonProperty("epoch")
+  @Schema(type = "string", example = EXAMPLE_UINT64, description = "Referred epoch.")
+  public final UInt64 epoch;
 
   public static Optional<ValidatorResponse> fromState(
       final BeaconState state, final Integer index) {
@@ -76,7 +82,8 @@ public class ValidatorResponse {
             UInt64.valueOf(index),
             state.getBalances().get(index),
             getValidatorStatus(current_epoch, validatorInternal),
-            new Validator(validatorInternal)));
+            new Validator(validatorInternal),
+            current_epoch));
   }
 
   public static ValidatorStatus getValidatorStatus(
@@ -129,7 +136,8 @@ public class ValidatorResponse {
     return Objects.equals(index, that.index)
         && Objects.equals(balance, that.balance)
         && status == that.status
-        && Objects.equals(validator, that.validator);
+        && Objects.equals(validator, that.validator)
+        && Objects.equals(epoch, that.epoch);
   }
 
   @JsonIgnore
@@ -149,7 +157,7 @@ public class ValidatorResponse {
 
   @Override
   public int hashCode() {
-    return Objects.hash(index, balance, status, validator);
+    return Objects.hash(index, balance, status, validator, epoch);
   }
 
   @Override
@@ -159,6 +167,7 @@ public class ValidatorResponse {
         .add("balance", balance)
         .add("status", status)
         .add("validator", validator)
+        .add("epoch", epoch)
         .toString();
   }
 }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/SchemaObjectsTestFixture.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/SchemaObjectsTestFixture.java
@@ -78,7 +78,8 @@ public class SchemaObjectsTestFixture {
             UInt64.ZERO,
             UInt64.ZERO,
             Constants.FAR_FUTURE_EPOCH,
-            Constants.FAR_FUTURE_EPOCH));
+            Constants.FAR_FUTURE_EPOCH),
+        dataStructureUtil.randomUInt64());
   }
 
   public BeaconBlock beaconBlock() {


### PR DESCRIPTION
## PR Description
This PR adds information about the referred epoch when querying validator states and balances. This is an essential information when client use labels like `head`, `finalized`, and so on, as `state_id` parameter.

The official eth2.0 API reference does not include this parameter but because this is a new attribute in the response, and the old ones are still there untouched, I presume this modification can be applied even if it will not become standard. In any case, I already sent a [dedicated PR]((https://github.com/ethereum/eth2.0-APIs/pull/120) to the official eth2.0 repo.

## Documentation

Documentation for this PR will be automatically generated.

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.