### PR TITLE
Add option to invalidate duties based on the dependent root instead of chain reorg events

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -77,6 +77,16 @@ public class ValidatorOptions {
       arity = "0..1")
   private boolean validatorExternalSignerSlashingProtectionEnabled = true;
 
+  @Option(
+      names = {"--Xvalidators-dependent-root-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description =
+          "Invalidate validator duties based on the dependent root information instead of chain re-org events. Default: false",
+      hidden = true,
+      fallbackValue = "true",
+      arity = "0..1")
+  private boolean useDependentRoots = false;
+
   public void configure(TekuConfiguration.Builder builder) {
     if (validatorPerformanceTrackingEnabled != null) {
       if (validatorPerformanceTrackingEnabled) {
@@ -95,7 +105,8 @@ public class ValidatorOptions {
                     validatorExternalSignerSlashingProtectionEnabled)
                 .graffitiProvider(
                     new FileBackedGraffitiProvider(
-                        Optional.ofNullable(graffiti), Optional.ofNullable(graffitiFile))));
+                        Optional.ofNullable(graffiti), Optional.ofNullable(graffitiFile)))
+                .useDependentRoots(useDependentRoots));
     validatorKeysOptions.configure(builder);
   }
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -46,6 +46,7 @@ public class ValidatorConfig {
   private final boolean validatorKeystoreLockingEnabled;
   private final Optional<URI> beaconNodeApiEndpoint;
   private final int validatorExternalSignerConcurrentRequestLimit;
+  private final boolean useDependentRoots;
 
   private ValidatorConfig(
       final List<String> validatorKeys,
@@ -63,7 +64,8 @@ public class ValidatorConfig {
       final ValidatorPerformanceTrackingMode validatorPerformanceTrackingMode,
       final boolean validatorKeystoreLockingEnabled,
       final boolean validatorExternalSignerSlashingProtectionEnabled,
-      final int validatorExternalSignerConcurrentRequestLimit) {
+      final int validatorExternalSignerConcurrentRequestLimit,
+      final boolean useDependentRoots) {
     this.validatorKeys = validatorKeys;
     this.validatorKeystoreFiles = validatorKeystoreFiles;
     this.validatorKeystorePasswordFiles = validatorKeystorePasswordFiles;
@@ -83,6 +85,7 @@ public class ValidatorConfig {
         validatorExternalSignerSlashingProtectionEnabled;
     this.validatorExternalSignerConcurrentRequestLimit =
         validatorExternalSignerConcurrentRequestLimit;
+    this.useDependentRoots = useDependentRoots;
   }
 
   public static Builder builder() {
@@ -158,6 +161,10 @@ public class ValidatorConfig {
     return processor.getFilePairs();
   }
 
+  public boolean useDependentRoots() {
+    return useDependentRoots;
+  }
+
   public static final class Builder {
 
     private List<String> validatorKeys = new ArrayList<>();
@@ -176,6 +183,7 @@ public class ValidatorConfig {
     private boolean validatorKeystoreLockingEnabled;
     private Optional<URI> beaconNodeApiEndpoint = Optional.empty();
     private boolean validatorExternalSignerSlashingProtectionEnabled = true;
+    private boolean useDependentRoots = false;
 
     private Builder() {}
 
@@ -269,6 +277,11 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder useDependentRoots(final boolean useDependentRoots) {
+      this.useDependentRoots = useDependentRoots;
+      return this;
+    }
+
     public ValidatorConfig build() {
       validateKeyStoreFilesAndPasswordFilesConfig();
       validateExternalSignerUrlAndPublicKeys();
@@ -291,7 +304,8 @@ public class ValidatorConfig {
           validatorPerformanceTrackingMode,
           validatorKeystoreLockingEnabled,
           validatorExternalSignerSlashingProtectionEnabled,
-          validatorExternalSignerConcurrentRequestLimit);
+          validatorExternalSignerConcurrentRequestLimit,
+          useDependentRoots);
     }
 
     private void validateKeyStoreFilesAndPasswordFilesConfig() {

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
@@ -22,9 +22,7 @@ public interface ValidatorTimingChannel extends VoidReturningChannelInterface {
 
   void onHeadUpdate(
       UInt64 slot,
-      Bytes32 headBlockRoot,
-      Bytes32 previousDutyDependentRoot,
-      Bytes32 currentDutyDependentRoot);
+      Bytes32 previousDutyDependentRoot, Bytes32 currentDutyDependentRoot, Bytes32 headBlockRoot);
 
   void onChainReorg(UInt64 newSlot, UInt64 commonAncestorSlot);
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
@@ -13,11 +13,18 @@
 
 package tech.pegasys.teku.validator.api;
 
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface ValidatorTimingChannel extends VoidReturningChannelInterface {
   void onSlot(UInt64 slot);
+
+  void onHeadUpdate(
+      UInt64 slot,
+      Bytes32 headBlockRoot,
+      Bytes32 previousDutyDependentRoot,
+      Bytes32 currentDutyDependentRoot);
 
   void onChainReorg(UInt64 newSlot, UInt64 commonAncestorSlot);
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
@@ -22,7 +22,9 @@ public interface ValidatorTimingChannel extends VoidReturningChannelInterface {
 
   void onHeadUpdate(
       UInt64 slot,
-      Bytes32 previousDutyDependentRoot, Bytes32 currentDutyDependentRoot, Bytes32 headBlockRoot);
+      Bytes32 previousDutyDependentRoot,
+      Bytes32 currentDutyDependentRoot,
+      Bytes32 headBlockRoot);
 
   void onChainReorg(UInt64 newSlot, UInt64 commonAncestorSlot);
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 
 public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   private static final Logger LOG = LogManager.getLogger();
-  private final boolean useDependentRoots = false;
+  private final boolean useDependentRoots;
   private final DutyLoader epochDutiesScheduler;
   private final int lookAheadEpochs;
 
@@ -35,9 +35,10 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   private Optional<UInt64> currentEpoch = Optional.empty();
 
   protected AbstractDutyScheduler(
-      final DutyLoader epochDutiesScheduler, final int lookAheadEpochs) {
+      final DutyLoader epochDutiesScheduler, final int lookAheadEpochs, final boolean useDependentRoots) {
     this.epochDutiesScheduler = epochDutiesScheduler;
     this.lookAheadEpochs = lookAheadEpochs;
+    this.useDependentRoots = useDependentRoots;
   }
 
   protected void notifyEpochDuties(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -35,7 +35,9 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   private Optional<UInt64> currentEpoch = Optional.empty();
 
   protected AbstractDutyScheduler(
-      final DutyLoader epochDutiesScheduler, final int lookAheadEpochs, final boolean useDependentRoots) {
+      final DutyLoader epochDutiesScheduler,
+      final int lookAheadEpochs,
+      final boolean useDependentRoots) {
     this.epochDutiesScheduler = epochDutiesScheduler;
     this.lookAheadEpochs = lookAheadEpochs;
     this.useDependentRoots = useDependentRoots;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -60,9 +60,9 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   @Override
   public void onHeadUpdate(
       final UInt64 slot,
-      final Bytes32 headBlockRoot,
       final Bytes32 previousDutyDependentRoot,
-      final Bytes32 currentDutyDependentRoot) {
+      final Bytes32 currentDutyDependentRoot,
+      final Bytes32 headBlockRoot) {
     if (!useDependentRoots) {
       return;
     }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -74,7 +74,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
         .forEach(
             (dutyEpoch, duties) ->
                 duties.onHeadUpdate(
-                    getExpectedTargetRoot(
+                    getExpectedDependentRoot(
                         headBlockRoot,
                         previousDutyDependentRoot,
                         currentDutyDependentRoot,
@@ -82,7 +82,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
                         dutyEpoch)));
   }
 
-  protected abstract Bytes32 getExpectedTargetRoot(
+  protected abstract Bytes32 getExpectedDependentRoot(
       Bytes32 headBlockRoot,
       Bytes32 previousDutyDependentRoot,
       Bytes32 currentDutyDependentRoot,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -57,9 +57,6 @@ public class AttestationDutyLoader extends AbstractDutyLoader<AttesterDuties> {
   @Override
   protected SafeFuture<Optional<AttesterDuties>> requestDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndices) {
-    if (validatorIndices.isEmpty()) {
-      return SafeFuture.completedFuture(Optional.empty());
-    }
     return validatorApiChannel.getAttestationDuties(epoch, validatorIndices);
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
@@ -26,8 +26,10 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
   static final int LOOKAHEAD_EPOCHS = 1;
 
   public AttestationDutyScheduler(
-      final MetricsSystem metricsSystem, final DutyLoader epochDutiesScheduler) {
-    super(epochDutiesScheduler, LOOKAHEAD_EPOCHS);
+      final MetricsSystem metricsSystem,
+      final DutyLoader epochDutiesScheduler,
+      final boolean useDependentRoots) {
+    super(epochDutiesScheduler, LOOKAHEAD_EPOCHS, useDependentRoots);
 
     metricsSystem.createIntegerGauge(
         TekuMetricCategory.VALIDATOR,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.validator.client;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -75,12 +77,17 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
   }
 
   @Override
-  protected Bytes32 getExpectedTargetRoot(
+  protected Bytes32 getExpectedDependentRoot(
       final Bytes32 headBlockRoot,
       final Bytes32 previousDutyDependentRoot,
       final Bytes32 currentDutyDependentRoot,
       final UInt64 headEpoch,
       final UInt64 dutyEpoch) {
+    checkArgument(
+        dutyEpoch.isGreaterThanOrEqualTo(headEpoch),
+        "Attempting to calculate dependent root for duty epoch %s that is before the updated head epoch %s",
+        dutyEpoch,
+        headEpoch);
     if (headEpoch.equals(dutyEpoch)) {
       return previousDutyDependentRoot;
     } else if (headEpoch.plus(1).equals(dutyEpoch)) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -69,5 +70,21 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
     }
 
     notifyEpochDuties(EpochDuties::onAttestationAggregationDue, slot);
+  }
+
+  @Override
+  protected Bytes32 getExpectedTargetRoot(
+      final Bytes32 headBlockRoot,
+      final Bytes32 previousDutyDependentRoot,
+      final Bytes32 currentDutyDependentRoot,
+      final UInt64 headEpoch,
+      final UInt64 dutyEpoch) {
+    if (headEpoch.equals(dutyEpoch)) {
+      return previousDutyDependentRoot;
+    } else if (headEpoch.plus(1).equals(dutyEpoch)) {
+      return currentDutyDependentRoot;
+    } else {
+      return headBlockRoot;
+    }
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -25,8 +25,10 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
   static final int LOOKAHEAD_EPOCHS = 0;
 
   public BlockDutyScheduler(
-      final MetricsSystem metricsSystem, final DutyLoader epochDutiesScheduler) {
-    super(epochDutiesScheduler, LOOKAHEAD_EPOCHS);
+      final MetricsSystem metricsSystem,
+      final DutyLoader epochDutiesScheduler,
+      final boolean useDependentRoots) {
+    super(epochDutiesScheduler, LOOKAHEAD_EPOCHS, useDependentRoots);
 
     metricsSystem.createIntegerGauge(
         TekuMetricCategory.VALIDATOR,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -45,5 +46,15 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
     }
 
     notifyEpochDuties(EpochDuties::onBlockProductionDue, slot);
+  }
+
+  @Override
+  protected Bytes32 getExpectedTargetRoot(
+      final Bytes32 headBlockRoot,
+      final Bytes32 previousTargetRoot,
+      final Bytes32 currentTargetRoot,
+      final UInt64 headEpoch,
+      final UInt64 dutyEpoch) {
+    return headEpoch.equals(dutyEpoch) ? currentTargetRoot : headBlockRoot;
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.validator.client;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -51,12 +53,17 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
   }
 
   @Override
-  protected Bytes32 getExpectedTargetRoot(
+  protected Bytes32 getExpectedDependentRoot(
       final Bytes32 headBlockRoot,
       final Bytes32 previousTargetRoot,
       final Bytes32 currentTargetRoot,
       final UInt64 headEpoch,
       final UInt64 dutyEpoch) {
+    checkArgument(
+        dutyEpoch.isGreaterThanOrEqualTo(headEpoch),
+        "Attempting to calculate dependent root for duty epoch %s that is before the updated head epoch %s",
+        dutyEpoch,
+        headEpoch);
     return headEpoch.equals(dutyEpoch) ? currentTargetRoot : headBlockRoot;
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
@@ -14,10 +14,10 @@
 package tech.pegasys.teku.validator.client;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
+import java.util.function.Function;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -26,13 +26,13 @@ import tech.pegasys.teku.validator.api.ProposerDuty;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.duties.ScheduledDuties;
 
-public class BlockProductionDutyLoader extends AbstractDutyLoader<ProposerDuty> {
+public class BlockProductionDutyLoader extends AbstractDutyLoader<ProposerDuties> {
 
   private final ValidatorApiChannel validatorApiChannel;
 
   protected BlockProductionDutyLoader(
       final ValidatorApiChannel validatorApiChannel,
-      final Supplier<ScheduledDuties> scheduledDutiesFactory,
+      final Function<Bytes32, ScheduledDuties> scheduledDutiesFactory,
       final Map<BLSPublicKey, Validator> validators,
       final ValidatorIndexProvider validatorIndexProvider) {
     super(scheduledDutiesFactory, validators, validatorIndexProvider);
@@ -40,23 +40,25 @@ public class BlockProductionDutyLoader extends AbstractDutyLoader<ProposerDuty> 
   }
 
   @Override
-  protected SafeFuture<Optional<List<ProposerDuty>>> requestDuties(
+  protected SafeFuture<Optional<ProposerDuties>> requestDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndices) {
     if (validatorIndices.isEmpty()) {
       return SafeFuture.completedFuture(Optional.empty());
     }
-    return validatorApiChannel
-        .getProposerDuties(epoch)
-        .thenApply(result -> result.map(ProposerDuties::getDuties));
+    return validatorApiChannel.getProposerDuties(epoch);
   }
 
   @Override
-  protected SafeFuture<Void> scheduleDuties(
-      final ScheduledDuties scheduledDuties, final ProposerDuty duty) {
+  protected SafeFuture<ScheduledDuties> scheduleAllDuties(final ProposerDuties duties) {
+    final ScheduledDuties scheduledDuties = scheduledDutiesFactory.apply(duties.getDependentRoot());
+    duties.getDuties().forEach(duty -> scheduleDuty(scheduledDuties, duty));
+    return SafeFuture.completedFuture(scheduledDuties);
+  }
+
+  private void scheduleDuty(final ScheduledDuties scheduledDuties, final ProposerDuty duty) {
     final Validator validator = validators.get(duty.getPublicKey());
     if (validator != null) {
       scheduledDuties.scheduleBlockProduction(duty.getSlot(), validator);
     }
-    return SafeFuture.COMPLETE;
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
@@ -42,9 +42,6 @@ public class BlockProductionDutyLoader extends AbstractDutyLoader<ProposerDuties
   @Override
   protected SafeFuture<Optional<ProposerDuties>> requestDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndices) {
-    if (validatorIndices.isEmpty()) {
-      return SafeFuture.completedFuture(Optional.empty());
-    }
     return validatorApiChannel.getProposerDuties(epoch);
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/DutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/DutyLoader.java
@@ -13,10 +13,11 @@
 
 package tech.pegasys.teku.validator.client;
 
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.client.duties.ScheduledDuties;
 
 public interface DutyLoader {
-  SafeFuture<ScheduledDuties> loadDutiesForEpoch(final UInt64 epoch);
+  SafeFuture<Optional<ScheduledDuties>> loadDutiesForEpoch(final UInt64 epoch);
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/EpochDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/EpochDuties.java
@@ -31,7 +31,7 @@ class EpochDuties {
   private final List<Consumer<ScheduledDuties>> pendingActions = new ArrayList<>();
   private final DutyLoader dutyLoader;
   private final UInt64 epoch;
-  private SafeFuture<ScheduledDuties> duties = new SafeFuture<>();
+  private SafeFuture<Optional<ScheduledDuties>> duties = new SafeFuture<>();
 
   private EpochDuties(final DutyLoader dutyLoader, final UInt64 epoch) {
     this.dutyLoader = dutyLoader;
@@ -80,8 +80,8 @@ class EpochDuties {
     pendingActions.clear();
   }
 
-  private synchronized void processPendingActions(final ScheduledDuties scheduledDuties) {
-    pendingActions.forEach(action -> action.accept(scheduledDuties));
+  private void processPendingActions(final Optional<ScheduledDuties> scheduledDuties) {
+    scheduledDuties.ifPresent(duties -> pendingActions.forEach(action -> action.accept(duties)));
     pendingActions.clear();
   }
 
@@ -93,6 +93,6 @@ class EpochDuties {
     if (!duties.isCompletedNormally()) {
       return Optional.empty();
     }
-    return Optional.of(duties.join());
+    return duties.join();
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/RetryingDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/RetryingDutyLoader.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.client;
 
 import com.google.common.base.Throwables;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -35,14 +36,14 @@ public class RetryingDutyLoader implements DutyLoader {
   }
 
   @Override
-  public SafeFuture<ScheduledDuties> loadDutiesForEpoch(final UInt64 epoch) {
-    final SafeFuture<ScheduledDuties> duties = new SafeFuture<>();
+  public SafeFuture<Optional<ScheduledDuties>> loadDutiesForEpoch(final UInt64 epoch) {
+    final SafeFuture<Optional<ScheduledDuties>> duties = new SafeFuture<>();
     requestDuties(epoch, duties).propagateTo(duties);
     return duties;
   }
 
-  private SafeFuture<ScheduledDuties> requestDuties(
-      final UInt64 epoch, final SafeFuture<ScheduledDuties> cancellable) {
+  private SafeFuture<Optional<ScheduledDuties>> requestDuties(
+      final UInt64 epoch, final SafeFuture<Optional<ScheduledDuties>> cancellable) {
     LOG.trace("Request duties for epoch {}", epoch);
     return delegate
         .loadDutiesForEpoch(epoch)

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -53,7 +53,7 @@ public class ValidatorClientService extends Service {
   private ValidatorStatusLogger validatorStatusLogger;
   private ValidatorIndexProvider validatorIndexProvider;
 
-  private SafeFuture<Void> initializationComplete = new SafeFuture<>();
+  private final SafeFuture<Void> initializationComplete = new SafeFuture<>();
 
   private ValidatorClientService(
       final EventChannels eventChannels,
@@ -119,7 +119,7 @@ public class ValidatorClientService extends Service {
             new AttestationDutyLoader(
                 validatorApiChannel,
                 forkProvider,
-                () -> new ScheduledDuties(validatorDutyFactory),
+                dependentRoot -> new ScheduledDuties(validatorDutyFactory, dependentRoot),
                 validators,
                 validatorIndexProvider,
                 beaconCommitteeSubscriptions));
@@ -128,7 +128,7 @@ public class ValidatorClientService extends Service {
             asyncRunner,
             new BlockProductionDutyLoader(
                 validatorApiChannel,
-                () -> new ScheduledDuties(validatorDutyFactory),
+                dependentRoot -> new ScheduledDuties(validatorDutyFactory, dependentRoot),
                 validators,
                 validatorIndexProvider));
     this.attestationTimingChannel =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -131,9 +131,11 @@ public class ValidatorClientService extends Service {
                 dependentRoot -> new ScheduledDuties(validatorDutyFactory, dependentRoot),
                 validators,
                 validatorIndexProvider));
+    final boolean useDependentRoots = config.getValidatorConfig().useDependentRoots();
     this.attestationTimingChannel =
-        new AttestationDutyScheduler(metricsSystem, attestationDutyLoader);
-    this.blockProductionTimingChannel = new BlockDutyScheduler(metricsSystem, blockDutyLoader);
+        new AttestationDutyScheduler(metricsSystem, attestationDutyLoader, useDependentRoots);
+    this.blockProductionTimingChannel =
+        new BlockDutyScheduler(metricsSystem, blockDutyLoader, useDependentRoots);
     addValidatorCountMetric(metricsSystem, validators.size());
     if (validators.keySet().size() > 0) {
       this.validatorStatusLogger =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client;
 
 import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_EPOCH;
 
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 
@@ -43,6 +44,18 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
     if (slot.mod(SLOTS_PER_EPOCH).equals(UInt64.ONE)) {
       statusLogger.checkValidatorStatusChanges();
     }
+  }
+
+  @Override
+  public void onHeadUpdate(
+      final UInt64 slot,
+      final Bytes32 headBlockRoot,
+      final Bytes32 previousDutyDependentRoot,
+      final Bytes32 currentDutyDependentRoot) {
+    blockDuties.onHeadUpdate(
+        slot, headBlockRoot, previousDutyDependentRoot, currentDutyDependentRoot);
+    attestationDuties.onHeadUpdate(
+        slot, headBlockRoot, previousDutyDependentRoot, currentDutyDependentRoot);
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -49,13 +49,13 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
   @Override
   public void onHeadUpdate(
       final UInt64 slot,
-      final Bytes32 headBlockRoot,
       final Bytes32 previousDutyDependentRoot,
-      final Bytes32 currentDutyDependentRoot) {
+      final Bytes32 currentDutyDependentRoot,
+      final Bytes32 headBlockRoot) {
     blockDuties.onHeadUpdate(
-        slot, headBlockRoot, previousDutyDependentRoot, currentDutyDependentRoot);
+        slot, previousDutyDependentRoot, currentDutyDependentRoot, headBlockRoot);
     attestationDuties.onHeadUpdate(
-        slot, headBlockRoot, previousDutyDependentRoot, currentDutyDependentRoot);
+        slot, previousDutyDependentRoot, currentDutyDependentRoot, headBlockRoot);
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ScheduledDuties.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -31,9 +32,15 @@ public class ScheduledDuties {
   private final NavigableMap<UInt64, AggregationDuty> aggregationDuties = new TreeMap<>();
 
   private final ValidatorDutyFactory dutyFactory;
+  private final Bytes32 dependentRoot;
 
-  public ScheduledDuties(final ValidatorDutyFactory dutyFactory) {
+  public ScheduledDuties(final ValidatorDutyFactory dutyFactory, final Bytes32 dependentRoot) {
     this.dutyFactory = dutyFactory;
+    this.dependentRoot = dependentRoot;
+  }
+
+  public Bytes32 getDependentRoot() {
+    return dependentRoot;
   }
 
   public synchronized void scheduleBlockProduction(final UInt64 slot, final Validator validator) {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
@@ -62,7 +62,7 @@ class AttestationDutyLoaderTest {
       new AttestationDutyLoader(
           validatorApiChannel,
           forkProvider,
-          () -> scheduledDuties,
+          dependentRoot -> scheduledDuties,
           validators,
           validatorIndexProvider,
           beaconCommitteeSubscriptions);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
@@ -101,7 +101,7 @@ class AttestationDutyLoaderTest {
     when(signer.signAggregationSlot(slot, forkInfo))
         .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()));
 
-    final SafeFuture<ScheduledDuties> result = dutyLoader.loadDutiesForEpoch(UInt64.ONE);
+    final SafeFuture<Optional<ScheduledDuties>> result = dutyLoader.loadDutiesForEpoch(UInt64.ONE);
 
     assertThat(result).isCompleted();
     verify(beaconCommitteeSubscriptions)
@@ -138,7 +138,7 @@ class AttestationDutyLoaderTest {
     when(signer.signAggregationSlot(slot, forkInfo))
         .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()));
 
-    final SafeFuture<ScheduledDuties> result = dutyLoader.loadDutiesForEpoch(UInt64.ONE);
+    final SafeFuture<Optional<ScheduledDuties>> result = dutyLoader.loadDutiesForEpoch(UInt64.ONE);
 
     assertThat(result).isCompleted();
     verify(beaconCommitteeSubscriptions)
@@ -154,7 +154,7 @@ class AttestationDutyLoaderTest {
         .thenReturn(
             SafeFuture.completedFuture(
                 Optional.of(new AttesterDuties(dataStructureUtil.randomBytes32(), emptyList()))));
-    final SafeFuture<ScheduledDuties> result = dutyLoader.loadDutiesForEpoch(UInt64.ONE);
+    final SafeFuture<Optional<ScheduledDuties>> result = dutyLoader.loadDutiesForEpoch(UInt64.ONE);
 
     assertThat(result).isCompleted();
     verify(beaconCommitteeSubscriptions).sendRequests();

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -65,7 +65,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
                   dependentRoot -> scheduledDuties,
                   Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2),
                   validatorIndexProvider,
-                  beaconCommitteeSubscriptions)));
+                  beaconCommitteeSubscriptions)),
+          false);
 
   private final AttestationDutyScheduler dutyScheduler =
       new AttestationDutyScheduler(
@@ -78,7 +79,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
                   dependentRoot -> new ScheduledDuties(dutyFactory, dependentRoot),
                   Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2),
                   validatorIndexProvider,
-                  beaconCommitteeSubscriptions)));
+                  beaconCommitteeSubscriptions)),
+          false);
 
   @BeforeEach
   public void init() {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -231,8 +231,9 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
 
     dutyScheduler.onHeadUpdate(
         currentSlot,
-        dataStructureUtil.randomBytes32(), dataStructureUtil.randomBytes32(), dataStructureUtil.randomBytes32()
-    );
+        dataStructureUtil.randomBytes32(),
+        dataStructureUtil.randomBytes32(),
+        dataStructureUtil.randomBytes32());
 
     verify(validatorApiChannel, times(2)).getAttestationDuties(currentEpoch, VALIDATOR_INDICES);
     verify(validatorApiChannel, times(2)).getAttestationDuties(nextEpoch, VALIDATOR_INDICES);
@@ -262,8 +263,9 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
 
     dutyScheduler.onHeadUpdate(
         currentSlot,
-        previousDutyDependentRoot, dataStructureUtil.randomBytes32(), dataStructureUtil.randomBytes32()
-    );
+        previousDutyDependentRoot,
+        dataStructureUtil.randomBytes32(),
+        dataStructureUtil.randomBytes32());
 
     verify(validatorApiChannel, times(2)).getAttestationDuties(nextEpoch, VALIDATOR_INDICES);
     verifyNoMoreInteractions(validatorApiChannel);
@@ -292,8 +294,9 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
 
     dutyScheduler.onHeadUpdate(
         currentSlot,
-        previousDutyDependentRoot, currentDutyDependentRoot, dataStructureUtil.randomBytes32()
-    );
+        previousDutyDependentRoot,
+        currentDutyDependentRoot,
+        dataStructureUtil.randomBytes32());
 
     verifyNoMoreInteractions(validatorApiChannel);
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -754,7 +754,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     createDutySchedulerWithRealDuties(true);
     final Bytes32 previousDutyDependentRoot = Bytes32.fromHexString("0x1111");
     final Bytes32 result =
-        dutyScheduler.getExpectedTargetRoot(
+        dutyScheduler.getExpectedDependentRoot(
             Bytes32.fromHexString("0x3333"),
             previousDutyDependentRoot,
             Bytes32.fromHexString("0x2222"),
@@ -769,7 +769,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     createDutySchedulerWithRealDuties(true);
     final Bytes32 currentDutyDependentRoot = Bytes32.fromHexString("0x2222");
     final Bytes32 result =
-        dutyScheduler.getExpectedTargetRoot(
+        dutyScheduler.getExpectedDependentRoot(
             Bytes32.fromHexString("0x3333"),
             Bytes32.fromHexString("0x1111"),
             currentDutyDependentRoot,
@@ -784,7 +784,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     createDutySchedulerWithRealDuties(true);
     final Bytes32 headBlockRoot = Bytes32.fromHexString("0x3333");
     final Bytes32 result =
-        dutyScheduler.getExpectedTargetRoot(
+        dutyScheduler.getExpectedDependentRoot(
             headBlockRoot,
             Bytes32.fromHexString("0x1111"),
             Bytes32.fromHexString("0x2222"),

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -61,7 +61,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
               new AttestationDutyLoader(
                   validatorApiChannel,
                   forkProvider,
-                  () -> scheduledDuties,
+                  dependentRoot -> scheduledDuties,
                   Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2),
                   validatorIndexProvider,
                   beaconCommitteeSubscriptions)));
@@ -74,7 +74,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
               new AttestationDutyLoader(
                   validatorApiChannel,
                   forkProvider,
-                  () -> new ScheduledDuties(dutyFactory),
+                  dependentRoot -> new ScheduledDuties(dutyFactory, dependentRoot),
                   Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2),
                   validatorIndexProvider,
                   beaconCommitteeSubscriptions)));

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
@@ -291,7 +291,7 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
     createDutySchedulerWithRealDuties(true);
     final Bytes32 currentDutyDependentRoot = Bytes32.fromHexString("0x2222");
     final Bytes32 result =
-        dutyScheduler.getExpectedTargetRoot(
+        dutyScheduler.getExpectedDependentRoot(
             Bytes32.fromHexString("0x3333"),
             Bytes32.fromHexString("0x1111"),
             currentDutyDependentRoot,
@@ -306,7 +306,7 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
     createDutySchedulerWithRealDuties(true);
     final Bytes32 headBlockRoot = Bytes32.fromHexString("0x3333");
     final Bytes32 result =
-        dutyScheduler.getExpectedTargetRoot(
+        dutyScheduler.getExpectedDependentRoot(
             headBlockRoot,
             Bytes32.fromHexString("0x1111"),
             Bytes32.fromHexString("0x2222"),
@@ -321,7 +321,7 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
     createDutySchedulerWithRealDuties(true);
     final Bytes32 headBlockRoot = Bytes32.fromHexString("0x3333");
     final Bytes32 result =
-        dutyScheduler.getExpectedTargetRoot(
+        dutyScheduler.getExpectedDependentRoot(
             headBlockRoot,
             Bytes32.fromHexString("0x1111"),
             Bytes32.fromHexString("0x2222"),

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
@@ -53,7 +53,8 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
                   validatorApiChannel,
                   dependentRoot -> new ScheduledDuties(dutyFactory, dependentRoot),
                   Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2),
-                  validatorIndexProvider)));
+                  validatorIndexProvider)),
+          false);
   final ScheduledDuties scheduledDuties = mock(ScheduledDuties.class);
   final StubMetricsSystem metricsSystem2 = new StubMetricsSystem();
   final ValidatorTimingChannel dutySchedulerWithMockDuties =
@@ -65,7 +66,8 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
                   validatorApiChannel,
                   dependentRoot -> scheduledDuties,
                   Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2),
-                  validatorIndexProvider)));
+                  validatorIndexProvider)),
+          false);
 
   @Test
   public void shouldFetchDutiesForCurrentEpoch() {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
@@ -49,7 +49,7 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
               asyncRunner,
               new BlockProductionDutyLoader(
                   validatorApiChannel,
-                  () -> new ScheduledDuties(dutyFactory),
+                  dependentRoot -> new ScheduledDuties(dutyFactory, dependentRoot),
                   Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2),
                   validatorIndexProvider)));
   final ScheduledDuties scheduledDuties = mock(ScheduledDuties.class);
@@ -61,7 +61,7 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
               asyncRunner,
               new BlockProductionDutyLoader(
                   validatorApiChannel,
-                  () -> scheduledDuties,
+                  dependentRoot -> scheduledDuties,
                   Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2),
                   validatorIndexProvider)));
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/RetryingDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/RetryingDutyLoaderTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
@@ -31,65 +32,67 @@ class RetryingDutyLoaderTest {
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final DutyLoader delegate = mock(DutyLoader.class);
   private final ScheduledDuties scheduledDuties = mock(ScheduledDuties.class);
+  private final Optional<ScheduledDuties> scheduledDutiesOptional = Optional.of(scheduledDuties);
 
   private final RetryingDutyLoader dutyLoader = new RetryingDutyLoader(asyncRunner, delegate);
 
   @Test
   public void shouldReturnDutiesWhenLoadedSuccessfully() {
-    when(delegate.loadDutiesForEpoch(ONE)).thenReturn(SafeFuture.completedFuture(scheduledDuties));
+    when(delegate.loadDutiesForEpoch(ONE))
+        .thenReturn(SafeFuture.completedFuture(scheduledDutiesOptional));
 
-    assertThat(dutyLoader.loadDutiesForEpoch(ONE)).isCompletedWithValue(scheduledDuties);
+    assertThat(dutyLoader.loadDutiesForEpoch(ONE)).isCompletedWithValue(scheduledDutiesOptional);
   }
 
   @Test
   public void shouldRetryWhenRequestForDutiesFailsBecauseNodeIsSyncing() {
     when(delegate.loadDutiesForEpoch(ONE))
         .thenReturn(NodeSyncingException.failedFuture())
-        .thenReturn(SafeFuture.completedFuture(scheduledDuties));
+        .thenReturn(SafeFuture.completedFuture(scheduledDutiesOptional));
 
-    final SafeFuture<ScheduledDuties> result = dutyLoader.loadDutiesForEpoch(ONE);
+    final SafeFuture<Optional<ScheduledDuties>> result = dutyLoader.loadDutiesForEpoch(ONE);
     assertThat(result).isNotDone();
     assertThat(asyncRunner.hasDelayedActions()).isTrue();
 
     asyncRunner.executeQueuedActions();
-    assertThat(result).isCompletedWithValue(scheduledDuties);
+    assertThat(result).isCompletedWithValue(scheduledDutiesOptional);
   }
 
   @Test
   public void shouldRetryWhenRequestForDutiesFailsBecauseNodeDataIsUnavailable() {
     when(delegate.loadDutiesForEpoch(ONE))
         .thenReturn(SafeFuture.failedFuture(new NodeDataUnavailableException("Sorry")))
-        .thenReturn(SafeFuture.completedFuture(scheduledDuties));
+        .thenReturn(SafeFuture.completedFuture(scheduledDutiesOptional));
 
-    final SafeFuture<ScheduledDuties> result = dutyLoader.loadDutiesForEpoch(ONE);
+    final SafeFuture<Optional<ScheduledDuties>> result = dutyLoader.loadDutiesForEpoch(ONE);
     assertThat(result).isNotDone();
     assertThat(asyncRunner.hasDelayedActions()).isTrue();
 
     asyncRunner.executeQueuedActions();
-    assertThat(result).isCompletedWithValue(scheduledDuties);
+    assertThat(result).isCompletedWithValue(scheduledDutiesOptional);
   }
 
   @Test
   public void shouldRetryWhenUnexpectedErrorOccurs() {
     when(delegate.loadDutiesForEpoch(ONE))
         .thenReturn(SafeFuture.failedFuture(new RuntimeException("No way")))
-        .thenReturn(SafeFuture.completedFuture(scheduledDuties));
+        .thenReturn(SafeFuture.completedFuture(scheduledDutiesOptional));
 
-    final SafeFuture<ScheduledDuties> result = dutyLoader.loadDutiesForEpoch(ONE);
+    final SafeFuture<Optional<ScheduledDuties>> result = dutyLoader.loadDutiesForEpoch(ONE);
     assertThat(result).isNotDone();
     assertThat(asyncRunner.hasDelayedActions()).isTrue();
 
     asyncRunner.executeQueuedActions();
-    assertThat(result).isCompletedWithValue(scheduledDuties);
+    assertThat(result).isCompletedWithValue(scheduledDutiesOptional);
   }
 
   @Test
   public void shouldStopRetryingWhenFutureIsCancelled() {
     final RuntimeException error = new RuntimeException("No way");
-    final SafeFuture<ScheduledDuties> delegateResponse = new SafeFuture<>();
+    final SafeFuture<Optional<ScheduledDuties>> delegateResponse = new SafeFuture<>();
     when(delegate.loadDutiesForEpoch(ONE)).thenReturn(delegateResponse);
 
-    final SafeFuture<ScheduledDuties> result = dutyLoader.loadDutiesForEpoch(ONE);
+    final SafeFuture<Optional<ScheduledDuties>> result = dutyLoader.loadDutiesForEpoch(ONE);
     verify(delegate).loadDutiesForEpoch(ONE);
     assertThat(result).isNotDone();
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ScheduledDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ScheduledDutiesTest.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.infrastructure.async.FutureUtil.ignoreFuture;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -33,7 +34,8 @@ class ScheduledDutiesTest {
   private final Validator validator = mock(Validator.class);
   private final ValidatorDutyFactory dutyFactory = mock(ValidatorDutyFactory.class);
 
-  private final ScheduledDuties duties = new ScheduledDuties(dutyFactory);
+  private final ScheduledDuties duties =
+      new ScheduledDuties(dutyFactory, Bytes32.fromHexString("0x838382"));
 
   @Test
   public void shouldDiscardMissedBlockProductionDuties() {

--- a/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/IndependentTimerEventChannelEventAdapter.java
+++ b/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/IndependentTimerEventChannelEventAdapter.java
@@ -72,6 +72,8 @@ public class IndependentTimerEventChannelEventAdapter
     optionalReorgContext.ifPresent(
         reorgContext ->
             validatorTimingChannel.onChainReorg(slot, reorgContext.getCommonAncestorSlot()));
+    validatorTimingChannel.onHeadUpdate(
+        slot, bestBlockRoot, previousDutyDependentRoot, currentDutyDependentRoot);
     validatorTimingChannel.onAttestationCreationDue(slot);
   }
 }

--- a/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/IndependentTimerEventChannelEventAdapter.java
+++ b/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/IndependentTimerEventChannelEventAdapter.java
@@ -73,7 +73,7 @@ public class IndependentTimerEventChannelEventAdapter
         reorgContext ->
             validatorTimingChannel.onChainReorg(slot, reorgContext.getCommonAncestorSlot()));
     validatorTimingChannel.onHeadUpdate(
-        slot, bestBlockRoot, previousDutyDependentRoot, currentDutyDependentRoot);
+        slot, previousDutyDependentRoot, currentDutyDependentRoot, bestBlockRoot);
     validatorTimingChannel.onAttestationCreationDue(slot);
   }
 }


### PR DESCRIPTION
## PR Description
Adds a hidden option to switch from using chain re-org events to the dependent root information to detect when duties need to be invalidated.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.