### PR TITLE
Remove feature toggle for disabling eth1 storage

### DIFF
--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -61,9 +61,7 @@ public class StorageService extends Service {
           chainStorage = ChainStorage.create(serviceConfig.getEventBus(), database);
           final DepositStorage depositStorage =
               DepositStorage.create(
-                  serviceConfig.getEventChannels().getPublisher(Eth1EventsChannel.class),
-                  database,
-                  serviceConfig.getConfig().isEth1DepositsFromStorageEnabled());
+                  serviceConfig.getEventChannels().getPublisher(Eth1EventsChannel.class), database);
           protoArrayStorage = new ProtoArrayStorage(database);
 
           serviceConfig

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/DepositStorageTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/DepositStorageTest.java
@@ -66,7 +66,7 @@ public class DepositStorageTest {
     eventsChannel = storageSystem.eth1EventsChannel();
 
     storageSystem.chainUpdater().initializeGenesis();
-    depositStorage = storageSystem.createDepositStorage(true);
+    depositStorage = storageSystem.createDepositStorage();
   }
 
   @AfterEach
@@ -117,25 +117,6 @@ public class DepositStorageTest {
     assertThat(future.get().getLastProcessedDepositIndex())
         .hasValue(postGenesisDeposits.getLastDepositIndex().bigIntegerValue());
     assertThat(future.get().isPastMinGenesisBlock()).isTrue();
-  }
-
-  @ParameterizedTest(name = "{0}")
-  @ArgumentsSource(StorageSystemArgumentsProvider.class)
-  public void shouldNotLoadFromStorageIfDisabled(
-      final String storageType,
-      final StorageSystemArgumentsProvider.StorageSystemSupplier storageSystemSupplier)
-      throws ExecutionException, InterruptedException {
-    setup(storageSystemSupplier);
-    depositStorage = DepositStorage.create(eventsChannel, database, false);
-
-    database.addMinGenesisTimeBlock(genesis_100);
-    database.addDepositsFromBlockEvent(block_101);
-    SafeFuture<ReplayDepositsResult> future = depositStorage.replayDepositEvents();
-    assertThat(future).isCompleted();
-
-    assertThat(eventsChannel.getOrderedList()).isEmpty();
-    assertThat(future.get().getFirstUnprocessedBlockNumber()).isEqualTo(BigInteger.ZERO);
-    assertThat(future.get().isPastMinGenesisBlock()).isFalse();
   }
 
   @ParameterizedTest(name = "{0}")

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
@@ -133,8 +133,8 @@ public class StorageSystem implements AutoCloseable {
     return chainUpdater;
   }
 
-  public DepositStorage createDepositStorage(final boolean eth1DepositsFromStorageEnabled) {
-    return DepositStorage.create(eth1EventsChannel, database, eth1DepositsFromStorageEnabled);
+  public DepositStorage createDepositStorage() {
+    return DepositStorage.create(eth1EventsChannel, database);
   }
 
   public ProtoArrayStorage createProtoArrayStorage() {

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -349,7 +349,6 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setPeerRateLimit(eth2NetworkOptions.getPeerRateLimit())
         .setPeerRequestLimit(eth2NetworkOptions.getPeerRequestLimit())
         .setEth1LogsMaxBlockRange(depositOptions.getEth1LogsMaxBlockRange())
-        .setEth1DepositsFromStorageEnabled(depositOptions.isEth1DepositsFromStorageEnabled())
         .setTransitionRecordDirectory(outputOptions.getTransitionRecordDirectory())
         .setMetricsEnabled(metricsOptions.isMetricsEnabled())
         .setMetricsPort(metricsOptions.getMetricsPort())

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
@@ -27,17 +27,6 @@ public class DepositOptions {
   private String eth1Endpoint = null;
 
   @Option(
-      hidden = true,
-      names = {"--Xeth1-deposits-from-storage-enabled"},
-      defaultValue = "true",
-      paramLabel = "<BOOLEAN>",
-      fallbackValue = "true",
-      description =
-          "On startup, use Eth1 deposits from storage before loading from the remote endpoint.",
-      arity = "0..1")
-  private boolean eth1DepositsFromStorageEnabled = true;
-
-  @Option(
       names = {"--eth1-deposit-contract-max-request-size"},
       paramLabel = "<INTEGER>",
       description =
@@ -47,10 +36,6 @@ public class DepositOptions {
 
   public int getEth1LogsMaxBlockRange() {
     return eth1LogsMaxBlockRange;
-  }
-
-  public boolean isEth1DepositsFromStorageEnabled() {
-    return eth1DepositsFromStorageEnabled;
   }
 
   public void configure(final TekuConfiguration.Builder builder) {

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -85,8 +85,7 @@ public class DebugDbCommand implements Runnable {
     try (final YamlEth1EventsChannel eth1EventsChannel = new YamlEth1EventsChannel(System.out);
         final Database database =
             createDatabase(dataOptions, dataStorageOptions, eth2NetworkOptions)) {
-      final DepositStorage depositStorage =
-          DepositStorage.create(eth1EventsChannel, database, true);
+      final DepositStorage depositStorage = DepositStorage.create(eth1EventsChannel, database);
       depositStorage.replayDepositEvents().join();
     }
     return 0;

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -470,7 +470,6 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setPeerRateLimit(500)
         .setPeerRequestLimit(50)
         .setEth1LogsMaxBlockRange(10_000)
-        .setEth1DepositsFromStorageEnabled(true)
         .setMetricsEnabled(false)
         .setMetricsPort(8008)
         .setMetricsInterface("127.0.0.1")

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
@@ -18,7 +18,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.teku.config.TekuConfiguration;
-import tech.pegasys.teku.util.config.GlobalConfiguration;
 
 public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
 
@@ -28,7 +27,6 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
 
     assertThat(config.powchain().isEnabled()).isTrue();
     assertThat(config.powchain().getEth1Endpoint()).isEqualTo("http://example.com:1234/path/");
-    assertThat(config.global().isEth1DepositsFromStorageEnabled()).isFalse();
   }
 
   @Test
@@ -49,13 +47,6 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
     final String[] args = {"--eth1-endpoint", "   "};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(config.powchain().isEnabled()).isFalse();
-  }
-
-  @Test
-  public void shouldDisableLoadFromStorageByDefault() {
-    final GlobalConfiguration globalConfigurationFromArguments =
-        getGlobalConfigurationFromArguments();
-    assertThat(globalConfigurationFromArguments.isEth1DepositsFromStorageEnabled()).isTrue();
   }
 
   @Test

--- a/teku/src/test/resources/depositOptions_config.yaml
+++ b/teku/src/test/resources/depositOptions_config.yaml
@@ -1,3 +1,2 @@
 # eth1
-Xeth1-deposits-from-storage-enabled: False
 eth1-endpoint: "http://example.com:1234/path/"

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
@@ -24,7 +24,6 @@ public class GlobalConfiguration implements MetricsConfig {
   private final Integer peerRequestLimit;
 
   // Deposit
-  private final boolean eth1DepositsFromStorageEnabled;
   private final int eth1LogsMaxBlockRange;
 
   // Output
@@ -53,7 +52,6 @@ public class GlobalConfiguration implements MetricsConfig {
       final Integer peerRateLimit,
       final Integer peerRequestLimit,
       final int eth1LogsMaxBlockRange,
-      final boolean eth1DepositsFromStorageEnabled,
       final String transitionRecordDirectory,
       final boolean metricsEnabled,
       final int metricsPort,
@@ -67,7 +65,6 @@ public class GlobalConfiguration implements MetricsConfig {
     this.peerRateLimit = peerRateLimit;
     this.peerRequestLimit = peerRequestLimit;
     this.eth1LogsMaxBlockRange = eth1LogsMaxBlockRange;
-    this.eth1DepositsFromStorageEnabled = eth1DepositsFromStorageEnabled;
     this.transitionRecordDirectory = transitionRecordDirectory;
     this.metricsEnabled = metricsEnabled;
     this.metricsPort = metricsPort;
@@ -90,10 +87,6 @@ public class GlobalConfiguration implements MetricsConfig {
 
   public int getEth1LogsMaxBlockRange() {
     return eth1LogsMaxBlockRange;
-  }
-
-  public boolean isEth1DepositsFromStorageEnabled() {
-    return eth1DepositsFromStorageEnabled;
   }
 
   public String getTransitionRecordDirectory() {

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
@@ -25,7 +25,6 @@ public class GlobalConfigurationBuilder {
   private Integer peerRateLimit;
   private Integer peerRequestLimit;
   private int eth1LogsMaxBlockRange;
-  private boolean eth1DepositsFromStorageEnabled;
   private String transitionRecordDirectory;
   private boolean metricsEnabled;
   private int metricsPort;
@@ -49,12 +48,6 @@ public class GlobalConfigurationBuilder {
 
   public GlobalConfigurationBuilder setEth1LogsMaxBlockRange(final int eth1LogsMaxBlockRange) {
     this.eth1LogsMaxBlockRange = eth1LogsMaxBlockRange;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setEth1DepositsFromStorageEnabled(
-      final boolean eth1DepositsFromStorageEnabled) {
-    this.eth1DepositsFromStorageEnabled = eth1DepositsFromStorageEnabled;
     return this;
   }
 
@@ -118,7 +111,6 @@ public class GlobalConfigurationBuilder {
         peerRateLimit,
         peerRequestLimit,
         eth1LogsMaxBlockRange,
-        eth1DepositsFromStorageEnabled,
         transitionRecordDirectory,
         metricsEnabled,
         metricsPort,


### PR DESCRIPTION
## PR Description
Remove feature toggle for disabling replaying eth1 deposits from storage.  Been enabled by default for ages and working well.  CLI option is `--X` so no requirement to maintain backwards compatibility.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.