### PR TITLE
Move storage config options out of GlobalConfiguration

### DIFF
--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageConfiguration.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageConfiguration.java
@@ -13,16 +13,27 @@
 
 package tech.pegasys.teku.services.chainstorage;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Optional;
 import tech.pegasys.teku.datastructures.eth1.Eth1Address;
+import tech.pegasys.teku.storage.server.DatabaseVersion;
+import tech.pegasys.teku.util.config.StateStorageMode;
 
 public class StorageConfiguration {
   private final Optional<Eth1Address> eth1DepositContract;
 
-  private StorageConfiguration(final Optional<Eth1Address> eth1DepositContract) {
+  private final StateStorageMode dataStorageMode;
+  private final long dataStorageFrequency;
+  private final DatabaseVersion dataStorageCreateDbVersion;
+
+  private StorageConfiguration(
+      final Optional<Eth1Address> eth1DepositContract,
+      final StateStorageMode dataStorageMode,
+      final long dataStorageFrequency,
+      final DatabaseVersion dataStorageCreateDbVersion) {
     this.eth1DepositContract = eth1DepositContract;
+    this.dataStorageMode = dataStorageMode;
+    this.dataStorageFrequency = dataStorageFrequency;
+    this.dataStorageCreateDbVersion = dataStorageCreateDbVersion;
   }
 
   public static Builder builder() {
@@ -33,19 +44,50 @@ public class StorageConfiguration {
     return eth1DepositContract;
   }
 
-  public static class Builder {
-    private Optional<Eth1Address> eth1DepositContract = Optional.empty();
+  public StateStorageMode getDataStorageMode() {
+    return dataStorageMode;
+  }
+
+  public long getDataStorageFrequency() {
+    return dataStorageFrequency;
+  }
+
+  public DatabaseVersion getDataStorageCreateDbVersion() {
+    return dataStorageCreateDbVersion;
+  }
+
+  public static final class Builder {
+
+    private Optional<Eth1Address> eth1DepositContract;
+    private StateStorageMode dataStorageMode;
+    private long dataStorageFrequency;
+    private DatabaseVersion dataStorageCreateDbVersion;
 
     private Builder() {}
 
-    public StorageConfiguration build() {
-      return new StorageConfiguration(eth1DepositContract);
-    }
-
-    public Builder eth1DepositContract(final Optional<Eth1Address> eth1DepositContract) {
-      checkNotNull(eth1DepositContract);
+    public Builder eth1DepositContract(Optional<Eth1Address> eth1DepositContract) {
       this.eth1DepositContract = eth1DepositContract;
       return this;
+    }
+
+    public Builder dataStorageMode(StateStorageMode dataStorageMode) {
+      this.dataStorageMode = dataStorageMode;
+      return this;
+    }
+
+    public Builder dataStorageFrequency(long dataStorageFrequency) {
+      this.dataStorageFrequency = dataStorageFrequency;
+      return this;
+    }
+
+    public Builder dataStorageCreateDbVersion(DatabaseVersion dataStorageCreateDbVersion) {
+      this.dataStorageCreateDbVersion = dataStorageCreateDbVersion;
+      return this;
+    }
+
+    public StorageConfiguration build() {
+      return new StorageConfiguration(
+          eth1DepositContract, dataStorageMode, dataStorageFrequency, dataStorageCreateDbVersion);
     }
   }
 }

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -52,9 +52,9 @@ public class StorageService extends Service {
                   serviceConfig.getMetricsSystem(),
                   serviceConfig.getDataDirLayout().getBeaconDataDirectory(),
                   Optional.empty(),
-                  serviceConfig.getConfig().getDataStorageMode(),
-                  serviceConfig.getConfig().getDataStorageCreateDbVersion(),
-                  serviceConfig.getConfig().getDataStorageFrequency(),
+                  config.getDataStorageMode(),
+                  config.getDataStorageCreateDbVersion(),
+                  config.getDataStorageFrequency(),
                   config.getEth1DepositContract());
           database = dbFactory.createDatabase();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -66,7 +66,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
         dataPath,
         Optional.empty(),
         dataStorageMode,
-        DatabaseVersion.DEFAULT_VERSION.getValue(),
+        DatabaseVersion.DEFAULT_VERSION,
         DEFAULT_STORAGE_FREQUENCY,
         depositContractAddress);
   }
@@ -75,7 +75,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
       final MetricsSystem metricsSystem,
       final Path dataPath,
       final StateStorageMode dataStorageMode,
-      final String createDatabaseVersion,
+      final DatabaseVersion createDatabaseVersion,
       final long stateStorageFrequency,
       final Optional<Eth1Address> eth1Address) {
     this(
@@ -93,7 +93,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
       final Path dataPath,
       final Optional<Path> maybeArchiveDataPath,
       final StateStorageMode dataStorageMode,
-      final String createDatabaseVersion,
+      final DatabaseVersion createDatabaseVersion,
       final long stateStorageFrequency,
       final Optional<Eth1Address> eth1Address) {
     this.metricsSystem = metricsSystem;
@@ -106,8 +106,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
     this.stateStorageFrequency = stateStorageFrequency;
     this.eth1Address = eth1Address;
 
-    this.createDatabaseVersion =
-        DatabaseVersion.fromString(createDatabaseVersion).orElse(DatabaseVersion.DEFAULT_VERSION);
+    this.createDatabaseVersion = createDatabaseVersion;
   }
 
   @Override

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
@@ -66,7 +66,12 @@ public class VersionedDatabaseFactoryTest {
   public void createDatabase_asV4Database() throws Exception {
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, "4", 1L, eth1Address);
+            new StubMetricsSystem(),
+            dataDir,
+            DATA_STORAGE_MODE,
+            DatabaseVersion.V4,
+            1L,
+            eth1Address);
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
       assertDbVersionSaved(dataDir, DatabaseVersion.V4);
@@ -81,7 +86,12 @@ public class VersionedDatabaseFactoryTest {
   public void createDatabase_asV5Database() throws Exception {
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, "5", 1L, eth1Address);
+            new StubMetricsSystem(),
+            dataDir,
+            DATA_STORAGE_MODE,
+            DatabaseVersion.V5,
+            1L,
+            eth1Address);
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
       assertDbVersionSaved(dataDir, DatabaseVersion.V5);
@@ -99,7 +109,12 @@ public class VersionedDatabaseFactoryTest {
   public void createDatabase_asV6DatabaseSingle() throws Exception {
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, "6", 1L, eth1Address);
+            new StubMetricsSystem(),
+            dataDir,
+            DATA_STORAGE_MODE,
+            DatabaseVersion.V6,
+            1L,
+            eth1Address);
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
       assertDbVersionSaved(dataDir, DatabaseVersion.V6);
@@ -121,7 +136,7 @@ public class VersionedDatabaseFactoryTest {
             mainDataDir,
             Optional.of(coldDataDir),
             DATA_STORAGE_MODE,
-            "6",
+            DatabaseVersion.V6,
             1L,
             eth1Address);
 
@@ -169,7 +184,12 @@ public class VersionedDatabaseFactoryTest {
     createDbDirectory(dataDir);
     final VersionedDatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, "4", 1L, eth1Address);
+            new StubMetricsSystem(),
+            dataDir,
+            DATA_STORAGE_MODE,
+            DatabaseVersion.V4,
+            1L,
+            eth1Address);
     assertThat(dbFactory.getDatabaseVersion()).isEqualTo(DatabaseVersion.V4);
   }
 
@@ -178,7 +198,12 @@ public class VersionedDatabaseFactoryTest {
     createDbDirectory(dataDir);
     final VersionedDatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, "5", 1L, eth1Address);
+            new StubMetricsSystem(),
+            dataDir,
+            DATA_STORAGE_MODE,
+            DatabaseVersion.V5,
+            1L,
+            eth1Address);
     assertThat(dbFactory.getDatabaseVersion()).isEqualTo(DatabaseVersion.V5);
   }
 
@@ -190,7 +215,7 @@ public class VersionedDatabaseFactoryTest {
             dataDir,
             Optional.empty(),
             DATA_STORAGE_MODE,
-            "6",
+            DatabaseVersion.V6,
             1L,
             eth1Address);
     try (Database db = dbFactorySingle.createDatabase()) {}
@@ -201,7 +226,7 @@ public class VersionedDatabaseFactoryTest {
             dataDir,
             Optional.of(dataDir.resolve("cold")),
             DATA_STORAGE_MODE,
-            "6",
+            DatabaseVersion.V6,
             1L,
             eth1Address);
 
@@ -220,7 +245,7 @@ public class VersionedDatabaseFactoryTest {
             dataDir,
             Optional.of(dataDir.resolve("cold")),
             DATA_STORAGE_MODE,
-            "6",
+            DatabaseVersion.V6,
             1L,
             eth1Address);
     try (Database db = dbFactorySeparate.createDatabase()) {}
@@ -231,7 +256,7 @@ public class VersionedDatabaseFactoryTest {
             dataDir,
             Optional.empty(),
             DATA_STORAGE_MODE,
-            "6",
+            DatabaseVersion.V6,
             1L,
             eth1Address);
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -337,6 +337,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
       beaconRestApiOptions.configure(builder);
       loggingOptions.configure(builder, dataOptions.getDataBasePath(), LOG_FILE, LOG_PATTERN);
       interopOptions.configure(builder);
+      dataStorageOptions.configure(builder);
 
       return builder.build();
     } catch (IllegalArgumentException | NullPointerException e) {
@@ -355,9 +356,6 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setMetricsInterface(metricsOptions.getMetricsInterface())
         .setMetricsCategories(metricsOptions.getMetricsCategories())
         .setMetricsHostAllowlist(metricsOptions.getMetricsHostAllowlist())
-        .setDataStorageMode(dataStorageOptions.getDataStorageMode())
-        .setDataStorageFrequency(dataStorageOptions.getDataStorageFrequency())
-        .setDataStorageCreateDbVersion(dataStorageOptions.getCreateDbVersion())
         .setHotStatePersistenceFrequencyInEpochs(
             storeOptions.getHotStatePersistenceFrequencyInEpochs());
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DataStorageOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DataStorageOptions.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.cli.options;
 
 import picocli.CommandLine;
+import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.storage.server.DatabaseVersion;
 import tech.pegasys.teku.storage.server.VersionedDatabaseFactory;
 import tech.pegasys.teku.util.config.StateStorageMode;
@@ -46,11 +47,15 @@ public class DataStorageOptions {
     return dataStorageMode;
   }
 
-  public long getDataStorageFrequency() {
-    return dataStorageFrequency;
+  public void configure(final TekuConfiguration.Builder builder) {
+    builder.storageConfiguration(
+        b ->
+            b.dataStorageMode(dataStorageMode)
+                .dataStorageFrequency(dataStorageFrequency)
+                .dataStorageCreateDbVersion(parseDatabaseVersion()));
   }
 
-  public String getCreateDbVersion() {
-    return createDbVersion;
+  private DatabaseVersion parseDatabaseVersion() {
+    return DatabaseVersion.fromString(createDbVersion).orElse(DatabaseVersion.DEFAULT_VERSION);
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -415,7 +415,12 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .eth2NetworkConfig(
             b -> b.applyMinimalNetworkDefaults().eth1DepositContractAddress(Optional.of(address)))
         .powchain(b -> b.eth1Endpoint("http://localhost:8545").depositContract(address))
-        .storageConfiguration(b -> b.eth1DepositContract(Optional.of(address)))
+        .storageConfiguration(
+            b ->
+                b.eth1DepositContract(Optional.of(address))
+                    .dataStorageMode(PRUNE)
+                    .dataStorageFrequency(VersionedDatabaseFactory.DEFAULT_STORAGE_FREQUENCY)
+                    .dataStorageCreateDbVersion(DatabaseVersion.DEFAULT_VERSION))
         .data(b -> b.dataBasePath(dataPath))
         .p2p(
             b ->
@@ -476,9 +481,6 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setMetricsCategories(
             Arrays.asList("BEACON", "LIBP2P", "NETWORK", "EVENTBUS", "JVM", "PROCESS"))
         .setMetricsHostAllowlist(List.of("127.0.0.1", "localhost"))
-        .setDataStorageMode(PRUNE)
-        .setDataStorageFrequency(VersionedDatabaseFactory.DEFAULT_STORAGE_FREQUENCY)
-        .setDataStorageCreateDbVersion(DatabaseVersion.DEFAULT_VERSION.getValue())
         .setHotStatePersistenceFrequencyInEpochs(2);
   }
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DataOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DataOptionsTest.java
@@ -21,7 +21,8 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.teku.config.TekuConfiguration;
-import tech.pegasys.teku.util.config.GlobalConfiguration;
+import tech.pegasys.teku.services.chainstorage.StorageConfiguration;
+import tech.pegasys.teku.storage.server.DatabaseVersion;
 
 public class DataOptionsTest extends AbstractBeaconNodeCommandTest {
   private static final Path TEST_PATH = Path.of("/tmp/teku");
@@ -30,25 +31,25 @@ public class DataOptionsTest extends AbstractBeaconNodeCommandTest {
   public void dataPath_shouldReadFromConfigurationFile() {
     final TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromFile("dataOptions_config.yaml");
-    final GlobalConfiguration globalConfiguration = tekuConfiguration.global();
+    final StorageConfiguration config = tekuConfiguration.storageConfiguration();
     assertThat(tekuConfiguration.dataConfig().getDataBasePath()).isEqualTo(TEST_PATH);
-    assertThat(globalConfiguration.getDataStorageMode()).isEqualTo(ARCHIVE);
-    assertThat(globalConfiguration.getDataStorageCreateDbVersion()).isEqualTo("4");
-    assertThat(globalConfiguration.getDataStorageFrequency()).isEqualTo(128L);
+    assertThat(config.getDataStorageMode()).isEqualTo(ARCHIVE);
+    assertThat(config.getDataStorageCreateDbVersion()).isEqualTo(DatabaseVersion.V4);
+    assertThat(config.getDataStorageFrequency()).isEqualTo(128L);
   }
 
   @Test
   public void dataStorageMode_shouldAcceptPrune() {
-    final GlobalConfiguration globalConfiguration =
-        getGlobalConfigurationFromArguments("--data-storage-mode", "prune");
-    assertThat(globalConfiguration.getDataStorageMode()).isEqualTo(PRUNE);
+    final StorageConfiguration config =
+        getTekuConfigurationFromArguments("--data-storage-mode", "prune").storageConfiguration();
+    assertThat(config.getDataStorageMode()).isEqualTo(PRUNE);
   }
 
   @Test
   public void dataStorageMode_shouldAcceptArchive() {
-    final GlobalConfiguration globalConfiguration =
-        getGlobalConfigurationFromArguments("--data-storage-mode", "archive");
-    assertThat(globalConfiguration.getDataStorageMode()).isEqualTo(ARCHIVE);
+    final StorageConfiguration config =
+        getTekuConfigurationFromArguments("--data-storage-mode", "archive").storageConfiguration();
+    assertThat(config.getDataStorageMode()).isEqualTo(ARCHIVE);
   }
 
   @Test
@@ -60,27 +61,29 @@ public class DataOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
   public void dataStorageFrequency_shouldDefault() {
-    final GlobalConfiguration globalConfiguration = getGlobalConfigurationFromArguments();
-    assertThat(globalConfiguration.getDataStorageFrequency()).isEqualTo(2048L);
+    final StorageConfiguration config = getTekuConfigurationFromArguments().storageConfiguration();
+    assertThat(config.getDataStorageFrequency()).isEqualTo(2048L);
   }
 
   @Test
   public void dataStorageFrequency_shouldAcceptNonDefaultValues() {
-    final GlobalConfiguration globalConfiguration =
-        getGlobalConfigurationFromArguments("--data-storage-archive-frequency", "1024000");
-    assertThat(globalConfiguration.getDataStorageFrequency()).isEqualTo(1024000L);
+    final StorageConfiguration config =
+        getTekuConfigurationFromArguments("--data-storage-archive-frequency", "1024000")
+            .storageConfiguration();
+    assertThat(config.getDataStorageFrequency()).isEqualTo(1024000L);
   }
 
   @Test
   public void dataStorageCreateDbVersion_shouldDefault() {
-    final GlobalConfiguration globalConfiguration = getGlobalConfigurationFromArguments();
-    assertThat(globalConfiguration.getDataStorageCreateDbVersion()).isEqualTo("5");
+    final StorageConfiguration config = getTekuConfigurationFromArguments().storageConfiguration();
+    assertThat(config.getDataStorageCreateDbVersion()).isEqualTo(DatabaseVersion.V5);
   }
 
   @Test
   public void dataStorageCreateDbVersion_shouldAcceptNonDefaultValues() {
-    final GlobalConfiguration globalConfiguration =
-        getGlobalConfigurationFromArguments("--Xdata-storage-create-db-version", "3.0");
-    assertThat(globalConfiguration.getDataStorageCreateDbVersion()).isEqualTo("3.0");
+    final StorageConfiguration config =
+        getTekuConfigurationFromArguments("--Xdata-storage-create-db-version", "noop")
+            .storageConfiguration();
+    assertThat(config.getDataStorageCreateDbVersion()).isEqualTo(DatabaseVersion.NOOP);
   }
 }

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
@@ -36,11 +36,6 @@ public class GlobalConfiguration implements MetricsConfig {
   private final List<String> metricsCategories;
   private final List<String> metricsHostAllowlist;
 
-  // Database
-  private final StateStorageMode dataStorageMode;
-  private final long dataStorageFrequency;
-  private final String dataStorageCreateDbVersion;
-
   // Store
   private final int hotStatePersistenceFrequencyInEpochs;
 
@@ -58,9 +53,6 @@ public class GlobalConfiguration implements MetricsConfig {
       final String metricsInterface,
       final List<String> metricsCategories,
       final List<String> metricsHostAllowlist,
-      final StateStorageMode dataStorageMode,
-      final long dataStorageFrequency,
-      final String dataStorageCreateDbVersion,
       final int hotStatePersistenceFrequencyInEpochs) {
     this.peerRateLimit = peerRateLimit;
     this.peerRequestLimit = peerRequestLimit;
@@ -71,9 +63,6 @@ public class GlobalConfiguration implements MetricsConfig {
     this.metricsInterface = metricsInterface;
     this.metricsCategories = metricsCategories;
     this.metricsHostAllowlist = metricsHostAllowlist;
-    this.dataStorageMode = dataStorageMode;
-    this.dataStorageFrequency = dataStorageFrequency;
-    this.dataStorageCreateDbVersion = dataStorageCreateDbVersion;
     this.hotStatePersistenceFrequencyInEpochs = hotStatePersistenceFrequencyInEpochs;
   }
 
@@ -116,18 +105,6 @@ public class GlobalConfiguration implements MetricsConfig {
   @Override
   public List<String> getMetricsHostAllowlist() {
     return metricsHostAllowlist;
-  }
-
-  public StateStorageMode getDataStorageMode() {
-    return dataStorageMode;
-  }
-
-  public long getDataStorageFrequency() {
-    return dataStorageFrequency;
-  }
-
-  public String getDataStorageCreateDbVersion() {
-    return dataStorageCreateDbVersion;
   }
 
   public int getHotStatePersistenceFrequencyInEpochs() {

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
@@ -31,10 +31,7 @@ public class GlobalConfigurationBuilder {
   private String metricsInterface;
   private List<String> metricsCategories;
   private List<String> metricsHostAllowlist;
-  private StateStorageMode dataStorageMode;
-  private String dataStorageCreateDbVersion;
   private int hotStatePersistenceFrequencyInEpochs;
-  private long dataStorageFrequency;
 
   public GlobalConfigurationBuilder setPeerRateLimit(final Integer peerRateLimit) {
     this.peerRateLimit = peerRateLimit;
@@ -83,22 +80,6 @@ public class GlobalConfigurationBuilder {
     return this;
   }
 
-  public GlobalConfigurationBuilder setDataStorageMode(final StateStorageMode dataStorageMode) {
-    this.dataStorageMode = dataStorageMode;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setDataStorageFrequency(final long dataStorageFrequency) {
-    this.dataStorageFrequency = dataStorageFrequency;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setDataStorageCreateDbVersion(
-      final String dataStorageCreateDbVersion) {
-    this.dataStorageCreateDbVersion = dataStorageCreateDbVersion;
-    return this;
-  }
-
   public GlobalConfigurationBuilder setHotStatePersistenceFrequencyInEpochs(
       final int hotStatePersistenceFrequencyInEpochs) {
     this.hotStatePersistenceFrequencyInEpochs = hotStatePersistenceFrequencyInEpochs;
@@ -117,9 +98,6 @@ public class GlobalConfigurationBuilder {
         metricsInterface,
         metricsCategories,
         metricsHostAllowlist,
-        dataStorageMode,
-        dataStorageFrequency,
-        dataStorageCreateDbVersion,
         hotStatePersistenceFrequencyInEpochs);
   }
 }


### PR DESCRIPTION
## PR Description
Move database storage options out of `GlobalConfiguration` to `StorageConfiguration`.

## Fixed Issue(s)
#2808 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.