### PR TITLE
Move metrics options out of GlobalConfiguration

### DIFF
--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
@@ -13,16 +13,94 @@
 
 package tech.pegasys.teku.infrastructure.metrics;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 
-public interface MetricsConfig {
-  boolean isMetricsEnabled();
+public class MetricsConfig {
 
-  int getMetricsPort();
+  private final boolean metricsEnabled;
+  private final int metricsPort;
+  private final String metricsInterface;
+  private final Set<MetricCategory> metricsCategories;
+  private final List<String> metricsHostAllowlist;
 
-  String getMetricsInterface();
+  private MetricsConfig(
+      final boolean metricsEnabled,
+      final int metricsPort,
+      final String metricsInterface,
+      final Set<MetricCategory> metricsCategories,
+      final List<String> metricsHostAllowlist) {
+    this.metricsEnabled = metricsEnabled;
+    this.metricsPort = metricsPort;
+    this.metricsInterface = metricsInterface;
+    this.metricsCategories = metricsCategories;
+    this.metricsHostAllowlist = metricsHostAllowlist;
+  }
 
-  List<String> getMetricsCategories();
+  public static MetricsConfigBuilder builder() {
+    return new MetricsConfigBuilder();
+  }
 
-  List<String> getMetricsHostAllowlist();
+  public boolean isMetricsEnabled() {
+    return metricsEnabled;
+  }
+
+  public int getMetricsPort() {
+    return metricsPort;
+  }
+
+  public String getMetricsInterface() {
+    return metricsInterface;
+  }
+
+  public Set<MetricCategory> getMetricsCategories() {
+    return metricsCategories;
+  }
+
+  public List<String> getMetricsHostAllowlist() {
+    return metricsHostAllowlist;
+  }
+
+  public static final class MetricsConfigBuilder {
+
+    private boolean metricsEnabled;
+    private int metricsPort;
+    private String metricsInterface;
+    private Set<MetricCategory> metricsCategories = new HashSet<>();
+    private List<String> metricsHostAllowlist;
+
+    private MetricsConfigBuilder() {}
+
+    public MetricsConfigBuilder metricsEnabled(boolean metricsEnabled) {
+      this.metricsEnabled = metricsEnabled;
+      return this;
+    }
+
+    public MetricsConfigBuilder metricsPort(int metricsPort) {
+      this.metricsPort = metricsPort;
+      return this;
+    }
+
+    public MetricsConfigBuilder metricsInterface(String metricsInterface) {
+      this.metricsInterface = metricsInterface;
+      return this;
+    }
+
+    public MetricsConfigBuilder metricsCategories(Set<MetricCategory> metricsCategories) {
+      this.metricsCategories = metricsCategories;
+      return this;
+    }
+
+    public MetricsConfigBuilder metricsHostAllowlist(List<String> metricsHostAllowlist) {
+      this.metricsHostAllowlist = metricsHostAllowlist;
+      return this;
+    }
+
+    public MetricsConfig build() {
+      return new MetricsConfig(
+          metricsEnabled, metricsPort, metricsInterface, metricsCategories, metricsHostAllowlist);
+    }
+  }
 }

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsEndpoint.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsEndpoint.java
@@ -13,35 +13,18 @@
 
 package tech.pegasys.teku.infrastructure.metrics;
 
-import static java.util.stream.Collectors.toSet;
-
-import com.google.common.collect.ImmutableMap;
 import io.vertx.core.Vertx;
-import java.util.EnumSet;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import org.hyperledger.besu.metrics.StandardMetricCategory;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.metrics.prometheus.MetricsService;
 import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 
 public class MetricsEndpoint {
 
   private final Optional<MetricsService> metricsService;
   private final MetricsSystem metricsSystem;
-  private static final Map<String, MetricCategory> SUPPORTED_CATEGORIES;
-
-  static {
-    final ImmutableMap.Builder<String, MetricCategory> builder = ImmutableMap.builder();
-    addCategories(builder, StandardMetricCategory.class);
-    addCategories(builder, TekuMetricCategory.class);
-    SUPPORTED_CATEGORIES = builder.build();
-  }
 
   public MetricsEndpoint(final MetricsConfig config, final Vertx vertx) {
     final MetricsConfiguration metricsConfig = createMetricsConfiguration(config);
@@ -72,20 +55,8 @@ public class MetricsEndpoint {
         .enabled(config.isMetricsEnabled())
         .port(config.getMetricsPort())
         .host(config.getMetricsInterface())
-        .metricCategories(getEnabledMetricCategories(config))
-        .hostsWhitelist(config.getMetricsHostAllowlist())
+        .metricCategories(config.getMetricsCategories())
+        .hostsAllowlist(config.getMetricsHostAllowlist())
         .build();
-  }
-
-  private Set<MetricCategory> getEnabledMetricCategories(final MetricsConfig config) {
-    return config.getMetricsCategories().stream()
-        .map(SUPPORTED_CATEGORIES::get)
-        .filter(Objects::nonNull)
-        .collect(toSet());
-  }
-
-  private static <T extends Enum<T> & MetricCategory> void addCategories(
-      ImmutableMap.Builder<String, MetricCategory> builder, Class<T> categoryEnum) {
-    EnumSet.allOf(categoryEnum).forEach(category -> builder.put(category.name(), category));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/BeaconNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/BeaconNode.java
@@ -56,7 +56,7 @@ public class BeaconNode implements Node {
     LoggingConfigurator.update(tekuConfig.loggingConfig());
 
     STATUS_LOG.onStartup(VersionProvider.VERSION);
-    this.metricsEndpoint = new MetricsEndpoint(globalConfig, vertx);
+    this.metricsEndpoint = new MetricsEndpoint(tekuConfig.metricsConfig(), vertx);
     final MetricsSystem metricsSystem = metricsEndpoint.getMetricsSystem();
     final TekuDefaultExceptionHandler subscriberExceptionHandler =
         new TekuDefaultExceptionHandler();

--- a/teku/src/main/java/tech/pegasys/teku/ValidatorNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/ValidatorNode.java
@@ -55,7 +55,7 @@ public class ValidatorNode implements Node {
     LoggingConfigurator.update(tekuConfig.loggingConfig());
 
     STATUS_LOG.onStartup(VersionProvider.VERSION);
-    this.metricsEndpoint = new MetricsEndpoint(globalConfig, vertx);
+    this.metricsEndpoint = new MetricsEndpoint(tekuConfig.metricsConfig(), vertx);
     final MetricsSystem metricsSystem = metricsEndpoint.getMetricsSystem();
     final TekuDefaultExceptionHandler subscriberExceptionHandler =
         new TekuDefaultExceptionHandler();

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -334,6 +334,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
       loggingOptions.configure(builder, dataOptions.getDataBasePath(), LOG_FILE, LOG_PATTERN);
       interopOptions.configure(builder);
       dataStorageOptions.configure(builder);
+      metricsOptions.configure(builder);
 
       return builder.build();
     } catch (IllegalArgumentException | NullPointerException e) {
@@ -346,11 +347,6 @@ public class BeaconNodeCommand implements Callable<Integer> {
         .setPeerRateLimit(eth2NetworkOptions.getPeerRateLimit())
         .setPeerRequestLimit(eth2NetworkOptions.getPeerRequestLimit())
         .setEth1LogsMaxBlockRange(depositOptions.getEth1LogsMaxBlockRange())
-        .setMetricsEnabled(metricsOptions.isMetricsEnabled())
-        .setMetricsPort(metricsOptions.getMetricsPort())
-        .setMetricsInterface(metricsOptions.getMetricsInterface())
-        .setMetricsCategories(metricsOptions.getMetricsCategories())
-        .setMetricsHostAllowlist(metricsOptions.getMetricsHostAllowlist())
         .setHotStatePersistenceFrequencyInEpochs(
             storeOptions.getHotStatePersistenceFrequencyInEpochs());
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/converter/MetricCategoryConverter.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/converter/MetricCategoryConverter.java
@@ -13,9 +13,11 @@
 
 package tech.pegasys.teku.cli.converter;
 
-import com.google.common.annotations.VisibleForTesting;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 import picocli.CommandLine;
@@ -26,7 +28,8 @@ public class MetricCategoryConverter implements CommandLine.ITypeConverter<Metri
 
   @Override
   public MetricCategory convert(final String value) {
-    final MetricCategory category = metricCategories.get(value);
+    checkNotNull(value, "Value to convert must not be null");
+    final MetricCategory category = metricCategories.get(value.toUpperCase(Locale.ROOT));
     if (category == null) {
       throw new IllegalArgumentException("Unknown category: " + value);
     }
@@ -35,15 +38,7 @@ public class MetricCategoryConverter implements CommandLine.ITypeConverter<Metri
 
   public <T extends Enum<T> & MetricCategory> void addCategories(final Class<T> categoryEnum) {
     EnumSet.allOf(categoryEnum)
-        .forEach(category -> metricCategories.put(category.name(), category));
-  }
-
-  public void addRegistryCategory(final MetricCategory metricCategory) {
-    metricCategories.put(metricCategory.getName().toUpperCase(), metricCategory);
-  }
-
-  @VisibleForTesting
-  Map<String, MetricCategory> getMetricCategories() {
-    return metricCategories;
+        .forEach(
+            category -> metricCategories.put(category.name().toUpperCase(Locale.ROOT), category));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -18,10 +18,10 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.hyperledger.besu.metrics.StandardMetricCategory;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 import picocli.CommandLine.Option;
+import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 
 public class MetricsOptions {
@@ -70,23 +70,13 @@ public class MetricsOptions {
       arity = "0..*")
   private final List<String> metricsHostAllowlist = Arrays.asList("127.0.0.1", "localhost");
 
-  public boolean isMetricsEnabled() {
-    return metricsEnabled;
-  }
-
-  public int getMetricsPort() {
-    return metricsPort;
-  }
-
-  public String getMetricsInterface() {
-    return metricsInterface;
-  }
-
-  public List<String> getMetricsCategories() {
-    return metricsCategories.stream().map(Object::toString).collect(Collectors.toList());
-  }
-
-  public List<String> getMetricsHostAllowlist() {
-    return metricsHostAllowlist;
+  public void configure(TekuConfiguration.Builder builder) {
+    builder.metrics(
+        b ->
+            b.metricsEnabled(metricsEnabled)
+                .metricsPort(metricsPort)
+                .metricsInterface(metricsInterface)
+                .metricsCategories(metricsCategories)
+                .metricsHostAllowlist(metricsHostAllowlist));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
@@ -30,7 +30,6 @@ import tech.pegasys.teku.cli.options.ValidatorClientOptions;
 import tech.pegasys.teku.cli.options.ValidatorOptions;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.storage.server.DatabaseStorageException;
-import tech.pegasys.teku.util.config.GlobalConfigurationBuilder;
 import tech.pegasys.teku.util.config.InvalidConfigurationException;
 
 @Command(
@@ -97,22 +96,13 @@ public class ValidatorClientCommand implements Callable<Integer> {
 
   private TekuConfiguration tekuConfiguration() {
     final TekuConfiguration.Builder builder = TekuConfiguration.builder();
-    builder.globalConfig(this::buildGlobalConfiguration);
     eth2NetworkOptions.configure(builder);
     validatorOptions.configure(builder);
     validatorClientOptions.configure(builder);
     dataOptions.configure(builder);
     loggingOptions.configure(builder, dataOptions.getDataBasePath(), LOG_FILE, LOG_PATTERN);
     interopOptions.configure(builder);
+    metricsOptions.configure(builder);
     return builder.build();
-  }
-
-  private void buildGlobalConfiguration(final GlobalConfigurationBuilder builder) {
-    builder
-        .setMetricsEnabled(metricsOptions.isMetricsEnabled())
-        .setMetricsPort(metricsOptions.getMetricsPort())
-        .setMetricsInterface(metricsOptions.getMetricsInterface())
-        .setMetricsCategories(metricsOptions.getMetricsCategories())
-        .setMetricsHostAllowlist(metricsOptions.getMetricsHostAllowlist());
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -50,7 +50,6 @@ import tech.pegasys.teku.infrastructure.async.MetricTrackingExecutorFactory;
 import tech.pegasys.teku.infrastructure.logging.SubCommandLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.util.config.Constants;
-import tech.pegasys.teku.util.config.GlobalConfigurationBuilder;
 import tech.pegasys.teku.util.config.InvalidConfigurationException;
 import tech.pegasys.teku.validator.client.Validator;
 import tech.pegasys.teku.validator.client.loader.ValidatorLoader;
@@ -259,8 +258,8 @@ public class VoluntaryExitCommand implements Runnable {
   }
 
   private TekuConfiguration tekuConfiguration() {
-    final TekuConfiguration.Builder builder = TekuConfiguration.builder();
-    builder.globalConfig(this::buildGlobalConfiguration);
+    final TekuConfiguration.Builder builder =
+        TekuConfiguration.builder().metrics(b -> b.metricsEnabled(false));
     validatorKeysOptions.configure(builder);
 
     validatorClientOptions.configure(builder);
@@ -279,9 +278,5 @@ public class VoluntaryExitCommand implements Runnable {
             .getBeaconNodeApiEndpoint()
             .orElse(URI.create("http://127.0.0.1:5051"))
             .toString());
-  }
-
-  private void buildGlobalConfiguration(final GlobalConfigurationBuilder builder) {
-    builder.setMetricsEnabled(false);
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -17,6 +17,8 @@ import java.util.function.Consumer;
 import tech.pegasys.teku.beaconrestapi.BeaconRestApiConfig;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfig;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfig.LoggingConfigBuilder;
+import tech.pegasys.teku.infrastructure.metrics.MetricsConfig;
+import tech.pegasys.teku.infrastructure.metrics.MetricsConfig.MetricsConfigBuilder;
 import tech.pegasys.teku.networking.eth2.P2PConfig;
 import tech.pegasys.teku.networking.eth2.P2PConfig.P2PConfigBuilder;
 import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
@@ -39,6 +41,7 @@ public class TekuConfiguration {
   private final WeakSubjectivityConfig weakSubjectivityConfig;
   private final DataConfig dataConfig;
   private final LoggingConfig loggingConfig;
+  private final MetricsConfig metricsConfig;
   private final BeaconChainConfiguration beaconChainConfig;
   private final ValidatorClientConfiguration validatorClientConfig;
   private final PowchainConfiguration powchainConfiguration;
@@ -54,7 +57,8 @@ public class TekuConfiguration {
       final DataConfig dataConfig,
       final P2PConfig p2pConfig,
       final BeaconRestApiConfig beaconRestApiConfig,
-      final LoggingConfig loggingConfig) {
+      final LoggingConfig loggingConfig,
+      final MetricsConfig metricsConfig) {
     this.globalConfiguration = globalConfiguration;
     this.eth2NetworkConfiguration = eth2NetworkConfiguration;
     this.storageConfiguration = storageConfiguration;
@@ -62,6 +66,7 @@ public class TekuConfiguration {
     this.powchainConfiguration = powchainConfiguration;
     this.dataConfig = dataConfig;
     this.loggingConfig = loggingConfig;
+    this.metricsConfig = metricsConfig;
     this.beaconChainConfig =
         new BeaconChainConfiguration(
             eth2NetworkConfiguration,
@@ -116,6 +121,10 @@ public class TekuConfiguration {
     return loggingConfig;
   }
 
+  public MetricsConfig metricsConfig() {
+    return metricsConfig;
+  }
+
   public static class Builder {
     private final GlobalConfigurationBuilder globalConfigurationBuilder =
         new GlobalConfigurationBuilder();
@@ -134,6 +143,7 @@ public class TekuConfiguration {
     private final BeaconRestApiConfig.BeaconRestApiConfigBuilder restApiBuilder =
         BeaconRestApiConfig.builder();
     private final LoggingConfig.LoggingConfigBuilder loggingConfigBuilder = LoggingConfig.builder();
+    private final MetricsConfig.MetricsConfigBuilder metricsConfigBuilder = MetricsConfig.builder();
 
     private Builder() {}
 
@@ -149,7 +159,8 @@ public class TekuConfiguration {
           dataConfigBuilder.build(),
           p2pConfigBuilder.build(),
           restApiBuilder.build(),
-          loggingConfigBuilder.build());
+          loggingConfigBuilder.build(),
+          metricsConfigBuilder.build());
     }
 
     public Builder globalConfig(final Consumer<GlobalConfigurationBuilder> globalConfigConsumer) {
@@ -207,6 +218,11 @@ public class TekuConfiguration {
 
     public Builder logging(final Consumer<LoggingConfigBuilder> loggingConfigBuilderConsumer) {
       loggingConfigBuilderConsumer.accept(loggingConfigBuilder);
+      return this;
+    }
+
+    public Builder metrics(final Consumer<MetricsConfigBuilder> metricsConfigBuilderConsumer) {
+      metricsConfigBuilderConsumer.accept(metricsConfigBuilder);
       return this;
     }
   }

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -15,12 +15,18 @@ package tech.pegasys.teku.cli;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.metrics.StandardMetricCategory.JVM;
+import static org.hyperledger.besu.metrics.StandardMetricCategory.PROCESS;
 import static tech.pegasys.teku.cli.BeaconNodeCommand.CONFIG_FILE_OPTION_NAME;
 import static tech.pegasys.teku.cli.BeaconNodeCommand.LOG_FILE;
 import static tech.pegasys.teku.cli.BeaconNodeCommand.LOG_PATTERN;
 import static tech.pegasys.teku.cli.options.MetricsOptions.DEFAULT_METRICS_CATEGORIES;
 import static tech.pegasys.teku.infrastructure.logging.LoggingDestination.BOTH;
 import static tech.pegasys.teku.infrastructure.logging.LoggingDestination.DEFAULT_BOTH;
+import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.BEACON;
+import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.EVENTBUS;
+import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.LIBP2P;
+import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.NETWORK;
 import static tech.pegasys.teku.util.config.StateStorageMode.PRUNE;
 
 import com.google.common.io.Resources;
@@ -29,13 +35,12 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.stream.Collectors;
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -360,14 +365,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         Eth2NetworkConfiguration.builder("mainnet").build();
 
     return expectedConfigurationBuilder()
-        .globalConfig(
-            b ->
-                b.setMetricsCategories(
-                        DEFAULT_METRICS_CATEGORIES.stream()
-                            .map(Object::toString)
-                            .collect(Collectors.toList()))
-                    .setPeerRateLimit(500)
-                    .setPeerRequestLimit(50))
+        .globalConfig(b -> b.setPeerRateLimit(500).setPeerRequestLimit(50))
         .eth2NetworkConfig(b -> b.applyNetworkDefaults("mainnet"))
         .powchain(
             b -> {
@@ -383,6 +381,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                     .logFile(StringUtils.joinWith("/", dataPath.toString(), "logs", LOG_FILE))
                     .logFileNamePattern(
                         StringUtils.joinWith("/", dataPath.toString(), "logs", LOG_PATTERN)))
+        .metrics(b -> b.metricsCategories(DEFAULT_METRICS_CATEGORIES))
         .restApi(b -> b.eth1DepositContractAddress(networkConfig.getEth1DepositContractAddress()))
         .p2p(
             b ->
@@ -461,6 +460,13 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                         StringUtils.joinWith("/", dataPath.toString(), "logs", LOG_PATTERN))
                     .includeEventsEnabled(true)
                     .includeValidatorDutiesEnabled(true))
+        .metrics(
+            b ->
+                b.metricsEnabled(false)
+                    .metricsPort(8008)
+                    .metricsInterface("127.0.0.1")
+                    .metricsCategories(Set.of(BEACON, LIBP2P, NETWORK, EVENTBUS, JVM, PROCESS))
+                    .metricsHostAllowlist(List.of("127.0.0.1", "localhost")))
         .interop(
             b ->
                 b.interopGenesisTime(1)
@@ -475,12 +481,6 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .setPeerRateLimit(500)
         .setPeerRequestLimit(50)
         .setEth1LogsMaxBlockRange(10_000)
-        .setMetricsEnabled(false)
-        .setMetricsPort(8008)
-        .setMetricsInterface("127.0.0.1")
-        .setMetricsCategories(
-            Arrays.asList("BEACON", "LIBP2P", "NETWORK", "EVENTBUS", "JVM", "PROCESS"))
-        .setMetricsHostAllowlist(List.of("127.0.0.1", "localhost"))
         .setHotStatePersistenceFrequencyInEpochs(2);
   }
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/MetricsOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/MetricsOptionsTest.java
@@ -69,6 +69,14 @@ public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  public void metricsCategories_shouldNotBeCaseSensitive() {
+    final MetricsConfig config =
+        getTekuConfigurationFromArguments("--metrics-categories", "LibP2P,network,EventBUS,PROCESS")
+            .metricsConfig();
+    assertThat(config.getMetricsCategories()).isEqualTo(Set.of(LIBP2P, NETWORK, EVENTBUS, PROCESS));
+  }
+
+  @Test
   public void metricsEnabled_shouldNotRequireAValue() {
     final MetricsConfig config =
         getTekuConfigurationFromArguments("--metrics-enabled").metricsConfig();

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfiguration.java
@@ -13,25 +13,15 @@
 
 package tech.pegasys.teku.util.config;
 
-import java.util.List;
-import tech.pegasys.teku.infrastructure.metrics.MetricsConfig;
-
 /** @deprecated - Use TekuConfiguration where possible. Global application configuration. */
 @Deprecated
-public class GlobalConfiguration implements MetricsConfig {
+public class GlobalConfiguration {
   // Network
   private final Integer peerRateLimit;
   private final Integer peerRequestLimit;
 
   // Deposit
   private final int eth1LogsMaxBlockRange;
-
-  // Metrics
-  private final boolean metricsEnabled;
-  private final int metricsPort;
-  private final String metricsInterface;
-  private final List<String> metricsCategories;
-  private final List<String> metricsHostAllowlist;
 
   // Store
   private final int hotStatePersistenceFrequencyInEpochs;
@@ -44,20 +34,10 @@ public class GlobalConfiguration implements MetricsConfig {
       final Integer peerRateLimit,
       final Integer peerRequestLimit,
       final int eth1LogsMaxBlockRange,
-      final boolean metricsEnabled,
-      final int metricsPort,
-      final String metricsInterface,
-      final List<String> metricsCategories,
-      final List<String> metricsHostAllowlist,
       final int hotStatePersistenceFrequencyInEpochs) {
     this.peerRateLimit = peerRateLimit;
     this.peerRequestLimit = peerRequestLimit;
     this.eth1LogsMaxBlockRange = eth1LogsMaxBlockRange;
-    this.metricsEnabled = metricsEnabled;
-    this.metricsPort = metricsPort;
-    this.metricsInterface = metricsInterface;
-    this.metricsCategories = metricsCategories;
-    this.metricsHostAllowlist = metricsHostAllowlist;
     this.hotStatePersistenceFrequencyInEpochs = hotStatePersistenceFrequencyInEpochs;
   }
 
@@ -71,31 +51,6 @@ public class GlobalConfiguration implements MetricsConfig {
 
   public int getEth1LogsMaxBlockRange() {
     return eth1LogsMaxBlockRange;
-  }
-
-  @Override
-  public boolean isMetricsEnabled() {
-    return metricsEnabled;
-  }
-
-  @Override
-  public int getMetricsPort() {
-    return metricsPort;
-  }
-
-  @Override
-  public String getMetricsInterface() {
-    return metricsInterface;
-  }
-
-  @Override
-  public List<String> getMetricsCategories() {
-    return metricsCategories;
-  }
-
-  @Override
-  public List<String> getMetricsHostAllowlist() {
-    return metricsHostAllowlist;
   }
 
   public int getHotStatePersistenceFrequencyInEpochs() {

--- a/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/GlobalConfigurationBuilder.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.util.config;
 
-import java.util.List;
-
 /**
  * @deprecated - Use TekuConfigurationBuilder where possible. Global application configuration
  *     builder.
@@ -25,11 +23,6 @@ public class GlobalConfigurationBuilder {
   private Integer peerRateLimit;
   private Integer peerRequestLimit;
   private int eth1LogsMaxBlockRange;
-  private boolean metricsEnabled;
-  private int metricsPort;
-  private String metricsInterface;
-  private List<String> metricsCategories;
-  private List<String> metricsHostAllowlist;
   private int hotStatePersistenceFrequencyInEpochs;
 
   public GlobalConfigurationBuilder setPeerRateLimit(final Integer peerRateLimit) {
@@ -47,32 +40,6 @@ public class GlobalConfigurationBuilder {
     return this;
   }
 
-  public GlobalConfigurationBuilder setMetricsEnabled(final boolean metricsEnabled) {
-    this.metricsEnabled = metricsEnabled;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setMetricsPort(final int metricsPort) {
-    this.metricsPort = metricsPort;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setMetricsInterface(final String metricsInterface) {
-    this.metricsInterface = metricsInterface;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setMetricsCategories(final List<String> metricsCategories) {
-    this.metricsCategories = metricsCategories;
-    return this;
-  }
-
-  public GlobalConfigurationBuilder setMetricsHostAllowlist(
-      final List<String> metricsHostAllowlist) {
-    this.metricsHostAllowlist = metricsHostAllowlist;
-    return this;
-  }
-
   public GlobalConfigurationBuilder setHotStatePersistenceFrequencyInEpochs(
       final int hotStatePersistenceFrequencyInEpochs) {
     this.hotStatePersistenceFrequencyInEpochs = hotStatePersistenceFrequencyInEpochs;
@@ -85,11 +52,6 @@ public class GlobalConfigurationBuilder {
         peerRateLimit,
         peerRequestLimit,
         eth1LogsMaxBlockRange,
-        metricsEnabled,
-        metricsPort,
-        metricsInterface,
-        metricsCategories,
-        metricsHostAllowlist,
         hotStatePersistenceFrequencyInEpochs);
   }
 }


### PR DESCRIPTION
## PR Description
Move metrics options out of `GlobalConfiguration`. Also fixes metric categories parsing on the command line to be case insensitive.

## Fixed Issue(s)
#2808

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.