### PR TITLE
Reduce log level for message about starting a regeneration

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/stategenerator/StateGenerator.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/stategenerator/StateGenerator.java
@@ -82,7 +82,7 @@ public class StateGenerator {
 
   public SafeFuture<StateAndBlockSummary> regenerateStateForBlock(final Bytes32 blockRoot) {
     final int blockCount = blockTree.size() - 1;
-    LOG.info("Regenerate state for block {} by replaying {} blocks", blockRoot, blockCount);
+    LOG.debug("Regenerate state for block {} by replaying {} blocks", blockRoot, blockCount);
     final long startTime = System.currentTimeMillis();
 
     return chainStateGenerator


### PR DESCRIPTION
## PR Description
We log two INFO level messages when regenerating a state - one at the start and one at the end.  Reduce the one at the start to DEBUG level - it's potentially useful if things appear stalled but the end message contains the time taken which is the more generically useful message.

I think it is helpful to know when regenerations are happening - if they happen too often memory or cache size should be increased and without these messages it could be quite difficult to find the cause of performance degradation.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
