### PR TITLE
Fix state cache size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 - Docker images are now being published to `consensys/teku`. The `pegasys/teku` images will continue to be updated for the next few releases but please update your configuration to use `consensys/teku`.
 - `--validators-key-files` and `--validators-key-password-files` have been replaced by `--validator-keys`. The old arguments will be removed in a future release.
 
+## Next Release
+
+### Bug Fixes
+- Restored the state cache size to 160 to improve performance during sync.
+
 ## 21.1.0
 
 ### Additions and Improvements

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreConfig.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreConfig.java
@@ -16,12 +16,11 @@ package tech.pegasys.teku.storage.store;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Objects;
-import tech.pegasys.teku.util.config.Constants;
 
 public class StoreConfig {
   public static int MAX_CACHE_SIZE = 10_000;
 
-  public static final int DEFAULT_STATE_CACHE_SIZE = Constants.SLOTS_PER_EPOCH * 5;
+  public static final int DEFAULT_STATE_CACHE_SIZE = 32 * 5;
   // Max block size is about 20x smaller than the minimum state size
   public static final int DEFAULT_BLOCK_CACHE_SIZE = DEFAULT_STATE_CACHE_SIZE * 2;
   public static final int DEFAULT_CHECKPOINT_STATE_CACHE_SIZE = 20;


### PR DESCRIPTION
## PR Description
The state cache should be sized as `5 * SLOTS_PER_EPOCH` but because it uses the `Constants.SLOTS_PER_EPOCH` field and is now being loaded prior to the constants actually being set, it's getting the minimal value so has a cache size of 40 instead of 160.  This doesn't have a significant impact when in sync because you don't need most of those states, but during sync we're constantly regenerating states which wastes CPU.

This sets the cache size without using constants to the mainnet size (160) to avoid the problem.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
