### PR TITLE
Fix option in help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 - Restored the state cache size to 160 to improve performance during sync.
+- Fixed help text for `--validators-graffiti-file` to refer to `--validators-graffiti` as the fallback not `--graffiti`.
 
 ## 21.1.0
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -41,7 +41,7 @@ public class ValidatorOptions {
       names = {"--validators-graffiti-file"},
       paramLabel = "<GRAFFITI FILE>",
       description =
-          "File to load graffiti value to include during block creation. Value gets converted to bytes and padded to Bytes32.  If file reading fails during block creation, teku will fall back to any value supplied via --graffiti.",
+          "File to load graffiti value to include during block creation. Value gets converted to bytes and padded to Bytes32.  If file reading fails during block creation, teku will fall back to any value supplied via --validators-graffiti.",
       arity = "1")
   private Path graffitiFile;
 


### PR DESCRIPTION
## PR Description
Option is actually `--validators-graffiti` not just `--graffiti`.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
