### PR TITLE
allow validators-external-signer-public-keys to accept a url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - Restored the state cache size to 160 to improve performance during sync.
 - Fixed help text for `--validators-graffiti-file` to refer to `--validators-graffiti` as the fallback not `--graffiti`.
 
+### Additions and Improvements
+- `--validators-external-signer-public-keys` now accepts a URL to load public keys from.
+
 ## 21.1.0
 
 ### Additions and Improvements

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/PublicKeyLoader.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/PublicKeyLoader.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.options;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.util.config.InvalidConfigurationException;
+
+class PublicKeyLoader {
+  final ObjectMapper objectMapper;
+
+  public PublicKeyLoader() {
+    this(new ObjectMapper());
+  }
+
+  public PublicKeyLoader(final ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public List<BLSPublicKey> getPublicKeys(final List<String> publicKeys) {
+    if (publicKeys == null || publicKeys.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    try {
+      final Set<BLSPublicKey> blsPublicKeySet =
+          publicKeys.stream()
+              .flatMap(
+                  key ->
+                      key.contains(":")
+                          ? readKeysFromUrl(key)
+                          : Stream.of(BLSPublicKey.fromSSZBytes(Bytes.fromHexString(key))))
+              .collect(Collectors.toSet());
+
+      return List.copyOf(blsPublicKeySet);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidConfigurationException(
+          "Invalid configuration. Signer public key is invalid", e);
+    }
+  }
+
+  private Stream<BLSPublicKey> readKeysFromUrl(final String url) {
+    try {
+      final String[] keys = objectMapper.readValue(new URL(url), String[].class);
+      return Arrays.asList(keys).stream()
+          .map(key -> BLSPublicKey.fromSSZBytes(Bytes.fromHexString(key)));
+    } catch (IOException ex) {
+      throw new InvalidConfigurationException("Failed to load public keys from URL " + url, ex);
+    }
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
@@ -215,10 +215,5 @@ public class ValidatorKeysOptions {
         throw new IllegalArgumentException("Failed to load public keys from URL", ex);
       }
     }
-
-    static class PublicKeyRemoteList {
-      @JsonProperty("keys")
-      public List<String> keys;
-    }
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
@@ -68,7 +68,7 @@ public class ValidatorKeysOptions {
   @CommandLine.Option(
       names = {"--validators-external-signer-public-keys"},
       paramLabel = "<STRINGS>",
-      description = "The list of external signer public keys",
+      description = "The list of external signer public keys, or a URL to load the keys from",
       split = ",",
       arity = "0..*")
   private List<String> validatorExternalSignerPublicKeys = new ArrayList<>();

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -207,7 +208,8 @@ public class ValidatorKeysOptions {
 
     private Stream<BLSPublicKey> readKeysFromUrl(final String url) {
       try {
-        return objectMapper.readValue(url, PublicKeyRemoteList.class).keys.stream()
+        final String[] keys = objectMapper.readValue(new URL(url), String[].class);
+        return Arrays.asList(keys).stream()
             .map(key -> BLSPublicKey.fromSSZBytes(Bytes.fromHexString(key)));
       } catch (IOException ex) {
         throw new IllegalArgumentException("Failed to load public keys from URL", ex);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.cli.options;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import java.io.IOException;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
@@ -13,21 +13,13 @@
 
 package tech.pegasys.teku.cli.options;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.apache.tuweni.bytes.Bytes;
 import picocli.CommandLine;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.config.TekuConfiguration;
@@ -168,51 +160,5 @@ public class ValidatorKeysOptions {
       return null;
     }
     return Path.of(option);
-  }
-
-  static class PublicKeyLoader {
-    final ObjectMapper objectMapper;
-
-    public PublicKeyLoader() {
-      this(new ObjectMapper());
-    }
-
-    public PublicKeyLoader(final ObjectMapper objectMapper) {
-      this.objectMapper = objectMapper;
-    }
-
-    public List<BLSPublicKey> getPublicKeys(final List<String> publicKeys) {
-      if (publicKeys == null || publicKeys.isEmpty()) {
-        return Collections.emptyList();
-      }
-
-      try {
-        final Set<BLSPublicKey> blsPublicKeySet =
-            publicKeys.stream()
-                .filter(key -> !key.contains(":"))
-                .map(key -> BLSPublicKey.fromSSZBytes(Bytes.fromHexString(key)))
-                .collect(Collectors.toSet());
-        blsPublicKeySet.addAll(
-            publicKeys.stream()
-                .filter(key -> key.contains(":"))
-                .flatMap(this::readKeysFromUrl)
-                .collect(Collectors.toList()));
-
-        return List.copyOf(blsPublicKeySet);
-      } catch (IllegalArgumentException e) {
-        throw new InvalidConfigurationException(
-            "Invalid configuration. Signer public key is invalid", e);
-      }
-    }
-
-    private Stream<BLSPublicKey> readKeysFromUrl(final String url) {
-      try {
-        final String[] keys = objectMapper.readValue(new URL(url), String[].class);
-        return Arrays.asList(keys).stream()
-            .map(key -> BLSPublicKey.fromSSZBytes(Bytes.fromHexString(key)));
-      } catch (IOException ex) {
-        throw new IllegalArgumentException("Failed to load public keys from URL", ex);
-      }
-    }
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/PublicKeyLoaderTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/PublicKeyLoaderTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 
-public class ValidatorKeysOptionsTest {
+public class PublicKeyLoaderTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final String firstKeyStr =
       dataStructureUtil.randomPublicKey().toBytesCompressed().toHexString();
@@ -39,8 +39,7 @@ public class ValidatorKeysOptionsTest {
       BLSPublicKey.fromBytesCompressed(Bytes48.fromHexString(secondKeyStr));
 
   private final ObjectMapper mapper = mock(ObjectMapper.class);
-  private final ValidatorKeysOptions.PublicKeyLoader loader =
-      new ValidatorKeysOptions.PublicKeyLoader(mapper);
+  private final PublicKeyLoader loader = new PublicKeyLoader(mapper);
 
   @Test
   void shouldGetListOfLocallySpecifiedPubKeys() {

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorKeysOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorKeysOptionsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.options;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes48;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+
+public class ValidatorKeysOptionsTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final String firstKeyStr =
+      dataStructureUtil.randomPublicKey().toBytesCompressed().toHexString();
+  private final String secondKeyStr =
+      dataStructureUtil.randomPublicKey().toBytesCompressed().toHexString();
+  private final String urlSource = "http://my.host";
+  private final BLSPublicKey firstKey =
+      BLSPublicKey.fromBytesCompressed(Bytes48.fromHexString(firstKeyStr));
+  private final BLSPublicKey secondKey =
+      BLSPublicKey.fromBytesCompressed(Bytes48.fromHexString(secondKeyStr));
+
+  private final ObjectMapper mapper = mock(ObjectMapper.class);
+  private final ValidatorKeysOptions.PublicKeyLoader loader =
+      new ValidatorKeysOptions.PublicKeyLoader(mapper);
+
+  @Test
+  void shouldGetListOfLocallySpecifiedPubKeys() {
+    assertThat(loader.getPublicKeys(List.of(firstKeyStr, secondKeyStr)))
+        .containsExactly(firstKey, secondKey);
+  }
+
+  @Test
+  void shouldRemoveDuplicateKeysFromLocalList() {
+    assertThat(loader.getPublicKeys(List.of(firstKeyStr, secondKeyStr, firstKeyStr)))
+        .containsExactly(firstKey, secondKey);
+  }
+
+  @Test
+  void shouldReadFromUrl() throws IOException {
+    final String[] values = {firstKeyStr, secondKeyStr};
+    when(mapper.readValue(new URL(urlSource), String[].class)).thenReturn(values);
+    assertThat(loader.getPublicKeys(List.of(urlSource))).containsExactly(firstKey, secondKey);
+  }
+
+  @Test
+  void shouldHandleDuplicatesAcrossSources() throws IOException {
+    final String[] values = {firstKeyStr, secondKeyStr};
+    when(mapper.readValue(new URL(urlSource), String[].class)).thenReturn(values);
+    assertThat(loader.getPublicKeys(List.of(firstKeyStr, urlSource, secondKeyStr)))
+        .containsExactly(firstKey, secondKey);
+  }
+
+  @Test
+  void shouldHandleEmptyResponseFromUrl() throws IOException {
+    final String[] values = {};
+    when(mapper.readValue(new URL(urlSource), String[].class)).thenReturn(values);
+    assertThat(loader.getPublicKeys(List.of(urlSource, secondKeyStr))).containsExactly(secondKey);
+  }
+}

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -85,6 +86,15 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
             .validatorClient()
             .getValidatorConfig();
     assertThat(config.isValidatorExternalSignerSlashingProtectionEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldDisplayReasonableErrorMessageIfKeysUrlInvalid() {
+    assertThatThrownBy(
+            () ->
+                getTekuConfigurationFromArguments(
+                    "--validators-external-signer-public-keys=http://local.missing/"))
+        .hasMessageContaining("Failed to load public keys from URL http://local.missing/");
   }
 
   @Test


### PR DESCRIPTION
Accepts an array of public key strings to come back in json format
```
[
 "0x00", "0x11"
]
```

Adds keys to a set, which will de-duplicate any keys that are specified on both the command line and in the URL.

fixes #3378

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
