### PR TITLE
Improve handling of multiple long forks when syncing

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/blocks/PendingBlockListener.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/blocks/PendingBlockListener.java
@@ -13,6 +13,6 @@
 
 package tech.pegasys.teku.datastructures.blocks;
 
-public interface ReceivedBlockListener {
+public interface PendingBlockListener {
   void accept(SignedBeaconBlock blockRoot);
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/PendingPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/PendingPoolTest.java
@@ -34,14 +34,15 @@ public class PendingPoolTest {
   private final PendingPool<SignedBeaconBlock> pendingPool =
       PendingPool.createForBlocks(historicalTolerance, futureTolerance, maxItems);
   private UInt64 currentSlot = historicalTolerance.times(2);
-  private List<Bytes32> requiredRootEvents = new ArrayList<>();
-  private List<Bytes32> requiredRootDroppedEvents = new ArrayList<>();
+  private final List<Bytes32> requiredRootEvents = new ArrayList<>();
+  private final List<Bytes32> requiredRootDroppedEvents = new ArrayList<>();
 
   @BeforeEach
   public void setup() {
     // Set up slot
-    pendingPool.subscribeRequiredBlockRoot(requiredRootEvents::add);
-    pendingPool.subscribeRequiredBlockRootDropped(requiredRootDroppedEvents::add);
+    pendingPool.subscribePendingItemAdded(item -> requiredRootEvents.add(item.getParentRoot()));
+    pendingPool.subscribePendingItemDropped(
+        item -> requiredRootDroppedEvents.add(item.getParentRoot()));
     setSlot(currentSlot);
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -228,7 +228,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
                     .importBlock(block)
                     .finish(err -> LOG.error("Failed to process recently fetched block.", err)));
     blockManager.subscribeToReceivedBlocks(
-        (root) -> syncService.getRecentBlockFetcher().cancelRecentBlockRequest(root));
+        (root) -> syncService.getRecentBlockFetcher().notifyBlockReceived(root));
     SafeFuture.allOfFailFast(
             attestationManager.start(),
             p2pNetwork.start(),
@@ -754,6 +754,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             beaconConfig.eth2NetworkConfig().getStartupTargetPeerCount(),
             Duration.ofSeconds(beaconConfig.eth2NetworkConfig().getStartupTimeoutSeconds()));
 
+    blockManager.subscribeToPendingBlocks(syncService.getRecentBlockFetcher()::fetchAncestors);
     syncService.getForwardSync().subscribeToSyncChanges(coalescingChainHeadChannel);
   }
 

--- a/sync/src/main/java/tech/pegasys/teku/sync/NoopSyncService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/NoopSyncService.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.sync;
 
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
-import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.sync.events.SyncState;
 import tech.pegasys.teku.sync.events.SyncingStatus;
@@ -64,17 +64,15 @@ public class NoopSyncService implements ForwardSync, RecentBlockFetcher, SyncSer
   public void unsubscribeFromSyncChanges(final long subscriberId) {}
 
   @Override
-  public long subscribeBlockFetched(final FetchRecentBlocksService.BlockSubscriber subscriber) {
-    return 0;
-  }
-
-  @Override
-  public void requestRecentBlock(final Bytes32 blockRoot) {
+  public void fetchAncestors(final SignedBeaconBlock block) {
     // No-op
   }
 
   @Override
-  public void cancelRecentBlockRequest(final Bytes32 blockRoot) {
+  public void subscribeBlockFetched(final FetchRecentBlocksService.BlockSubscriber subscriber) {}
+
+  @Override
+  public void notifyBlockReceived(final SignedBeaconBlock block) {
     // No-op
   }
 

--- a/sync/src/main/java/tech/pegasys/teku/sync/SyncServiceFactory.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/SyncServiceFactory.java
@@ -118,7 +118,7 @@ public class SyncServiceFactory {
 
     final ForwardSyncService forwardSyncService = createForwardSyncService();
     final FetchRecentBlocksService recentBlockFetcher =
-        FetchRecentBlocksService.create(asyncRunner, p2pNetwork, pendingBlocks);
+        FetchRecentBlocksService.create(asyncRunner, p2pNetwork, pendingBlocks, recentChainData);
     final SyncStateTracker syncStateTracker = createSyncStateTracker(forwardSyncService);
     final HistoricalBlockSyncService historicalBlockSyncService =
         createHistoricalSyncService(syncStateTracker);

--- a/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/MultipeerSyncService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/MultipeerSyncService.java
@@ -110,7 +110,7 @@ public class MultipeerSyncService extends Service implements ForwardSyncService 
         () -> {
           eventThread.start();
           peerChainTracker.start();
-          syncStallDetector.start();
+          syncStallDetector.start().reportExceptions();
         });
     return SafeFuture.COMPLETE;
   }
@@ -119,8 +119,7 @@ public class MultipeerSyncService extends Service implements ForwardSyncService 
   protected SafeFuture<?> doStop() {
     peerChainTracker.stop();
     eventThread.stop();
-    syncStallDetector.stop();
-    return SafeFuture.COMPLETE;
+    return syncStallDetector.stop();
   }
 
   @Override

--- a/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/SyncStallDetector.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/SyncStallDetector.java
@@ -36,8 +36,10 @@ public class SyncStallDetector extends Service {
   private static final Logger LOG = LogManager.getLogger();
 
   static final int STALL_CHECK_INTERVAL_SECONDS = 15;
-  static final int MAX_SECONDS_BETWEEN_IMPORTS = 60;
-  static final int MAX_SECONDS_BETWEEN_IMPORT_PROGRESS = 60;
+  // Time periods are fairly long because sync stalls should be rare and we might be rate limited
+  // if we have to request blocks from a small number of peers.
+  static final int MAX_SECONDS_BETWEEN_IMPORTS = 180;
+  static final int MAX_SECONDS_BETWEEN_IMPORT_PROGRESS = 180;
 
   private final EventThread eventThread;
   private final AsyncRunner asyncRunner;

--- a/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/SyncStallDetector.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/SyncStallDetector.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.sync.forward.multipeer;
+
+import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
+
+import com.google.common.base.MoreObjects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.Cancellable;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.service.serviceutils.Service;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.sync.forward.multipeer.batches.Batch;
+
+public class SyncStallDetector extends Service {
+  private static final Logger LOG = LogManager.getLogger();
+
+  static final int STALL_CHECK_INTERVAL_SECONDS = 15;
+  static final int MAX_SECONDS_BETWEEN_IMPORTS = 60;
+  static final int MAX_SECONDS_BETWEEN_IMPORT_PROGRESS = 60;
+
+  private final EventThread eventThread;
+  private final AsyncRunner asyncRunner;
+  private final TimeProvider timeProvider;
+  private final SyncController syncController;
+  private final BatchSync sync;
+  private Cancellable cancellable;
+
+  private Optional<BatchImportData> currentBatchImport = Optional.empty();
+  private final RecentChainData recentChainData;
+
+  public SyncStallDetector(
+      final EventThread eventThread,
+      final AsyncRunner asyncRunner,
+      final TimeProvider timeProvider,
+      final SyncController syncController,
+      final BatchSync sync,
+      final RecentChainData recentChainData) {
+    this.eventThread = eventThread;
+    this.asyncRunner = asyncRunner;
+    this.timeProvider = timeProvider;
+    this.syncController = syncController;
+    this.sync = sync;
+    this.recentChainData = recentChainData;
+  }
+
+  /**
+   * We consider a sync stalled if it has not made progress in X seconds. Progress is tracked based
+   * on getting new blocks onto the chain.
+   */
+  private void performStallCheck() {
+    eventThread.checkOnEventThread();
+    if (!syncController.isSyncActive()) {
+      LOG.debug("Not performing sync stall check as sync is not active");
+      return;
+    }
+    // Check if a new batch has started importing since the last stall check
+    final Optional<Batch> newImportingBatch = sync.getImportingBatch();
+    if (!currentBatchImport.map(d -> d.importingBatch).equals(newImportingBatch)) {
+      LOG.debug("Detected new batch being imported, sync is not stalled.");
+      // New batch being imported so we must be making progress
+      currentBatchImport = newImportingBatch.map(BatchImportData::new);
+      return;
+    }
+
+    // Stall case 1 - no import started more than X seconds after last one completed
+    final UInt64 secondsSinceLastCompletedImport =
+        timeProvider.getTimeInSeconds().minusMinZero(sync.getLastImportTimerStartPointSeconds());
+    if (currentBatchImport.isEmpty()
+        && secondsSinceLastCompletedImport.isGreaterThan(MAX_SECONDS_BETWEEN_IMPORTS)) {
+      LOG.warn(
+          "Sync has not started a batch importing for {} seconds after the previous batch import completed. Considering it stalled and restarting sync.",
+          secondsSinceLastCompletedImport);
+      sync.abort();
+      return;
+    }
+
+    // Stall case 2 - an import was started but hasn't imported a new block for more than X seconds
+    currentBatchImport.ifPresent(
+        currentImport -> {
+          final UInt64 timeSinceLastProgress = currentImport.calculateSecondsSinceLastProgress();
+          if (timeSinceLastProgress.isGreaterThan(MAX_SECONDS_BETWEEN_IMPORT_PROGRESS)) {
+            LOG.warn(
+                "Sync has not made progress importing batch {} for {} seconds after the previous batch import completed. Considering it stalled and restarting sync.",
+                currentImport,
+                secondsSinceLastCompletedImport);
+            sync.abort();
+          }
+        });
+  }
+
+  @Override
+  protected SafeFuture<?> doStart() {
+    cancellable =
+        asyncRunner.runWithFixedDelay(
+            () -> eventThread.execute(this::performStallCheck),
+            STALL_CHECK_INTERVAL_SECONDS,
+            TimeUnit.SECONDS,
+            error -> LOG.error("Failed to check for sync stalls", error));
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
+  protected SafeFuture<?> doStop() {
+    cancellable.cancel();
+    return SafeFuture.COMPLETE;
+  }
+
+  private class BatchImportData {
+    private final Batch importingBatch;
+    private Optional<Bytes32> lastImportedBlockRoot = Optional.empty();
+    private UInt64 lastProgressSeconds;
+
+    private BatchImportData(final Batch importingBatch) {
+      this.importingBatch = importingBatch;
+      this.lastProgressSeconds = timeProvider.getTimeInSeconds();
+    }
+
+    public UInt64 calculateSecondsSinceLastProgress() {
+      final Optional<Bytes32> newLastImportedBlockRoot = findLastImportedBlock();
+      if (
+      // No blocks imported from this batch at all
+      (lastImportedBlockRoot.isEmpty() && newLastImportedBlockRoot.isEmpty())
+          // No new blocks imported from this batch
+          || lastImportedBlockRoot.equals(newLastImportedBlockRoot)) {
+        return timeProvider.getTimeInSeconds().minusMinZero(lastProgressSeconds);
+      } else {
+        lastImportedBlockRoot = newLastImportedBlockRoot;
+        lastProgressSeconds = timeProvider.getTimeInSeconds();
+        return UInt64.ZERO;
+      }
+    }
+
+    private Optional<Bytes32> findLastImportedBlock() {
+      Optional<Bytes32> lastImportedBlock = Optional.empty();
+      for (SignedBeaconBlock block : importingBatch.getBlocks()) {
+        if (!recentChainData.containsBlock(block.getRoot())
+            && !recentChainData
+                .getFinalizedEpoch()
+                .isGreaterThanOrEqualTo(compute_epoch_at_slot(block.getSlot()))) {
+          return lastImportedBlock;
+        }
+        lastImportedBlock = Optional.of(block.getRoot());
+      }
+      return lastImportedBlock;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("importingBatch", importingBatch)
+          .add("lastImportedBlockRoot", lastImportedBlockRoot)
+          .add("lastProgressSeconds", lastProgressSeconds)
+          .toString();
+    }
+  }
+}

--- a/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchBlockTask.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchBlockTask.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
@@ -37,14 +38,19 @@ class FetchBlockTask {
       Comparator.comparing(p -> Math.random());
 
   private final P2PNetwork<Eth2Peer> eth2Network;
+  private final SlotAndBlockRoot targetChain;
   private final Bytes32 blockRoot;
   private final Set<NodeId> queriedPeers = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
   private final AtomicInteger numberOfRuns = new AtomicInteger(0);
   private final AtomicBoolean cancelled = new AtomicBoolean(false);
 
-  FetchBlockTask(final P2PNetwork<Eth2Peer> eth2Network, final Bytes32 blockRoot) {
+  FetchBlockTask(
+      final P2PNetwork<Eth2Peer> eth2Network,
+      final SlotAndBlockRoot targetChain,
+      final Bytes32 blockRoot) {
     this.eth2Network = eth2Network;
+    this.targetChain = targetChain;
     this.blockRoot = blockRoot;
   }
 
@@ -53,8 +59,14 @@ class FetchBlockTask {
   }
 
   public static FetchBlockTask create(
-      final P2PNetwork<Eth2Peer> eth2Network, final Bytes32 blockRoot) {
-    return new FetchBlockTask(eth2Network, blockRoot);
+      final P2PNetwork<Eth2Peer> eth2Network,
+      final SlotAndBlockRoot targetChain,
+      final Bytes32 blockRoot) {
+    return new FetchBlockTask(eth2Network, targetChain, blockRoot);
+  }
+
+  public SlotAndBlockRoot getTargetChain() {
+    return targetChain;
   }
 
   public Bytes32 getBlockRoot() {

--- a/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchRecentBlocksService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchRecentBlocksService.java
@@ -109,8 +109,8 @@ public class FetchRecentBlocksService extends Service implements RecentBlockFetc
   }
 
   public void fetchAncestors(final SignedBeaconBlock block, final SlotAndBlockRoot targetChain) {
-    if (pendingBlocksPool.contains(block.getParentRoot())) {
-      // We've already got this block
+    if (pendingBlocksPool.contains(block.getRoot())) {
+      // Already got this block, no need to do anything
       return;
     }
     // TODO: If the block is too far from current chain head, or too far from the target chain head,
@@ -122,6 +122,10 @@ public class FetchRecentBlocksService extends Service implements RecentBlockFetc
     if (recentChainData.containsBlock(block.getParentRoot())) {
       pendingBlocksPool.remove(block);
       blockSubscribers.deliver(BlockSubscriber::onBlock, block);
+      return;
+    }
+    if (pendingBlocksPool.contains(block.getParentRoot())) {
+      // We've already got this block's parent, no need to request it
       return;
     }
     requestBlockParent(block, targetChain);

--- a/sync/src/main/java/tech/pegasys/teku/sync/gossip/RecentBlockFetcher.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/gossip/RecentBlockFetcher.java
@@ -13,14 +13,13 @@
 
 package tech.pegasys.teku.sync.gossip;
 
-import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.sync.gossip.FetchRecentBlocksService.BlockSubscriber;
 
 public interface RecentBlockFetcher {
+  void fetchAncestors(final SignedBeaconBlock block);
 
-  long subscribeBlockFetched(BlockSubscriber subscriber);
+  void subscribeBlockFetched(BlockSubscriber subscriber);
 
-  void requestRecentBlock(Bytes32 blockRoot);
-
-  void cancelRecentBlockRequest(Bytes32 blockRoot);
+  void notifyBlockReceived(SignedBeaconBlock block);
 }

--- a/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/SyncStallDetectorTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/SyncStallDetectorTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.sync.forward.multipeer;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -52,7 +53,7 @@ class SyncStallDetectorTest {
 
   @BeforeEach
   void setUp() {
-    detector.start();
+    assertThat(detector.start()).isDone();
     when(syncController.isSyncActive()).thenReturn(true);
     when(recentChainData.getFinalizedEpoch()).thenReturn(UInt64.ONE);
   }

--- a/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/SyncStallDetectorTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/SyncStallDetectorTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.sync.forward.multipeer;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.sync.forward.multipeer.SyncStallDetector.MAX_SECONDS_BETWEEN_IMPORTS;
+import static tech.pegasys.teku.sync.forward.multipeer.SyncStallDetector.MAX_SECONDS_BETWEEN_IMPORT_PROGRESS;
+import static tech.pegasys.teku.sync.forward.multipeer.SyncStallDetector.STALL_CHECK_INTERVAL_SECONDS;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.sync.forward.multipeer.batches.Batch;
+import tech.pegasys.teku.sync.forward.multipeer.batches.SyncSourceBatch;
+
+class SyncStallDetectorTest {
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+
+  private final InlineEventThread eventThread = new InlineEventThread();
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(1000);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
+
+  private final SyncController syncController = mock(SyncController.class);
+  private final BatchSync sync = mock(BatchSync.class);
+  private final RecentChainData recentChainData = mock(RecentChainData.class);
+
+  private final SyncStallDetector detector =
+      new SyncStallDetector(
+          eventThread, asyncRunner, timeProvider, syncController, sync, recentChainData);
+
+  @BeforeEach
+  void setUp() {
+    detector.start();
+    when(syncController.isSyncActive()).thenReturn(true);
+    when(recentChainData.getFinalizedEpoch()).thenReturn(UInt64.ONE);
+  }
+
+  @Test
+  void shouldNotAbortSyncWhenNoSyncIsInProgress() {
+    // No sync in progress
+    when(syncController.isSyncActive()).thenReturn(false);
+
+    // Sync started long enough ago that it should have started importing something by now
+    when(sync.getLastImportTimerStartPointSeconds())
+        .thenReturn(timeProvider.getTimeInSeconds().minus(MAX_SECONDS_BETWEEN_IMPORTS));
+
+    triggerStallCheck();
+
+    verify(sync, never()).abort();
+  }
+
+  @Test
+  void shouldAbortSyncWhenNoImportStartedInTime() {
+    // Sync started long enough ago that it should have started importing something by now
+    when(sync.getLastImportTimerStartPointSeconds())
+        .thenReturn(timeProvider.getTimeInSeconds().minus(MAX_SECONDS_BETWEEN_IMPORTS));
+
+    triggerStallCheck();
+
+    verify(sync).abort();
+  }
+
+  @Test
+  void shouldAbortSyncWhenImportStartedByNotMakingProgress() {
+    // First import started in time
+    when(sync.getLastImportTimerStartPointSeconds()).thenReturn(timeProvider.getTimeInSeconds());
+    final Batch importingBatch = batchWithBlocks();
+    when(sync.getImportingBatch()).thenReturn(Optional.of(importingBatch));
+    withBlockNotImported(importingBatch, 0);
+
+    // First check records that the sync started and which block it is up to
+    triggerStallCheck();
+    verify(sync, never()).abort();
+
+    // Enough time passes before the first block is imported
+    timeProvider.advanceTimeBySeconds(MAX_SECONDS_BETWEEN_IMPORT_PROGRESS);
+
+    triggerStallCheck();
+    verify(sync).abort();
+  }
+
+  @Test
+  void shouldNotAbortSyncWhenBatchTakesALongTimeToImportButIsMakingProgress() {
+    // First import started in time
+    when(sync.getLastImportTimerStartPointSeconds()).thenReturn(timeProvider.getTimeInSeconds());
+    final Batch importingBatch = batchWithBlocks();
+    when(sync.getImportingBatch()).thenReturn(Optional.of(importingBatch));
+    withBlockNotImported(importingBatch, 0);
+
+    // First check records that the sync started and which block it is up to
+    triggerStallCheck();
+    verify(sync, never()).abort();
+
+    // Enough time passes to trigger the stall but the first block has now been imported
+    timeProvider.advanceTimeBySeconds(MAX_SECONDS_BETWEEN_IMPORT_PROGRESS);
+    withBlockImported(importingBatch, 0);
+    withBlockNotImported(importingBatch, 1);
+
+    triggerStallCheck();
+    verify(sync, never()).abort();
+  }
+
+  @Test
+  void shouldAbortSyncWhenFirstBlockOfSecondImportedBatchNotImported() {
+    // First import started in time
+    when(sync.getLastImportTimerStartPointSeconds()).thenReturn(timeProvider.getTimeInSeconds());
+    final Batch importingBatch = batchWithBlocks();
+    when(sync.getImportingBatch()).thenReturn(Optional.of(importingBatch));
+    withBlockNotImported(importingBatch, 0);
+
+    // First check records that the sync started and which block it is up to
+    triggerStallCheck();
+    verify(sync, never()).abort();
+
+    // Enough time passes to trigger the stall but the import completed and a new batch started
+    timeProvider.advanceTimeBySeconds(MAX_SECONDS_BETWEEN_IMPORT_PROGRESS);
+    withAllBlocksImported(importingBatch);
+    final Batch secondImportingBatch = batchWithBlocks();
+    when(sync.getImportingBatch()).thenReturn(Optional.of(secondImportingBatch));
+    withBlockNotImported(secondImportingBatch, 0);
+    triggerStallCheck();
+    verify(sync, never()).abort();
+
+    // Then time passes and no further progress is made
+    timeProvider.advanceTimeBySeconds(MAX_SECONDS_BETWEEN_IMPORT_PROGRESS);
+
+    // So the sync should be considered stalled
+    triggerStallCheck();
+    verify(sync).abort();
+  }
+
+  private void withBlockNotImported(final Batch importingBatch, final int blockIndex) {
+    mockBlockImported(importingBatch, blockIndex, false);
+  }
+
+  private void withBlockImported(final Batch importingBatch, final int blockIndex) {
+    mockBlockImported(importingBatch, blockIndex, true);
+  }
+
+  private void withAllBlocksImported(final Batch importingBatch) {
+    importingBatch.getBlocks().forEach(block -> withBlockImported(block, true));
+  }
+
+  private void mockBlockImported(
+      final Batch importingBatch, final int blockIndex, final boolean b) {
+    final SignedBeaconBlock block = importingBatch.getBlocks().get(blockIndex);
+    withBlockImported(block, b);
+  }
+
+  private void withBlockImported(final SignedBeaconBlock block, final boolean imported) {
+    when(recentChainData.containsBlock(block.getRoot())).thenReturn(imported);
+  }
+
+  private void triggerStallCheck() {
+    timeProvider.advanceTimeBySeconds(STALL_CHECK_INTERVAL_SECONDS);
+    asyncRunner.executeDueActions();
+  }
+
+  private Batch batchWithBlocks() {
+    final SyncSourceBatch batch = mock(SyncSourceBatch.class);
+    when(batch.getBlocks())
+        .thenReturn(
+            List.of(
+                dataStructureUtil.randomSignedBeaconBlock(100),
+                dataStructureUtil.randomSignedBeaconBlock(101),
+                dataStructureUtil.randomSignedBeaconBlock(104),
+                dataStructureUtil.randomSignedBeaconBlock(105)));
+    return batch;
+  }
+}

--- a/sync/src/test/java/tech/pegasys/teku/sync/gossip/FetchBlockTaskTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/gossip/FetchBlockTaskTest.java
@@ -24,6 +24,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.Eth2Network;
@@ -35,6 +36,7 @@ import tech.pegasys.teku.sync.gossip.FetchBlockTask.FetchBlockResult.Status;
 public class FetchBlockTaskTest {
 
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final SlotAndBlockRoot target = dataStructureUtil.randomSlotAndBlockRoot();
   final Eth2Network eth2Network = mock(Eth2Network.class);
   final List<Eth2Peer> peers = new ArrayList<>();
 
@@ -47,7 +49,7 @@ public class FetchBlockTaskTest {
   public void run_successful() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(10);
     final Bytes32 blockRoot = block.getMessage().hash_tree_root();
-    FetchBlockTask task = FetchBlockTask.create(eth2Network, blockRoot);
+    FetchBlockTask task = FetchBlockTask.create(eth2Network, target, blockRoot);
     assertThat(task.getBlockRoot()).isEqualTo(blockRoot);
 
     final Eth2Peer peer = registerNewPeer(1);
@@ -65,7 +67,7 @@ public class FetchBlockTaskTest {
   public void run_noPeers() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(10);
     final Bytes32 blockRoot = block.getMessage().hash_tree_root();
-    FetchBlockTask task = FetchBlockTask.create(eth2Network, blockRoot);
+    FetchBlockTask task = FetchBlockTask.create(eth2Network, target, blockRoot);
 
     final SafeFuture<FetchBlockResult> result = task.run();
     assertThat(result).isDone();
@@ -78,7 +80,7 @@ public class FetchBlockTaskTest {
   public void run_failAndRetryWithNoNewPeers() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(10);
     final Bytes32 blockRoot = block.getMessage().hash_tree_root();
-    FetchBlockTask task = FetchBlockTask.create(eth2Network, blockRoot);
+    FetchBlockTask task = FetchBlockTask.create(eth2Network, target, blockRoot);
 
     final Eth2Peer peer = registerNewPeer(1);
     when(peer.requestBlockByRoot(blockRoot))
@@ -104,7 +106,7 @@ public class FetchBlockTaskTest {
   public void run_failAndRetryWithNewPeer() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(10);
     final Bytes32 blockRoot = block.getMessage().hash_tree_root();
-    FetchBlockTask task = FetchBlockTask.create(eth2Network, blockRoot);
+    FetchBlockTask task = FetchBlockTask.create(eth2Network, target, blockRoot);
 
     final Eth2Peer peer = registerNewPeer(1);
     when(peer.requestBlockByRoot(blockRoot))
@@ -135,7 +137,7 @@ public class FetchBlockTaskTest {
   public void run_withMultiplesPeersAvailable() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(10);
     final Bytes32 blockRoot = block.getMessage().hash_tree_root();
-    FetchBlockTask task = FetchBlockTask.create(eth2Network, blockRoot);
+    FetchBlockTask task = FetchBlockTask.create(eth2Network, target, blockRoot);
 
     final Eth2Peer peer = registerNewPeer(1);
     when(peer.requestBlockByRoot(blockRoot))
@@ -159,7 +161,7 @@ public class FetchBlockTaskTest {
   public void cancel() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(10);
     final Bytes32 blockRoot = block.getMessage().hash_tree_root();
-    FetchBlockTask task = FetchBlockTask.create(eth2Network, blockRoot);
+    FetchBlockTask task = FetchBlockTask.create(eth2Network, target, blockRoot);
 
     final Eth2Peer peer = registerNewPeer(1);
     when(peer.requestBlockByRoot(blockRoot))

--- a/sync/src/test/java/tech/pegasys/teku/sync/gossip/FetchRecentBlocksServiceTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/gossip/FetchRecentBlocksServiceTest.java
@@ -111,6 +111,17 @@ public class FetchRecentBlocksServiceTest {
   }
 
   @Test
+  void immediatelyProcessBlockWhereParentBecomesAvailable() {
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(5);
+    // Block is available by the time we get to processing it
+    when(recentChainData.containsBlock(block.getParentRoot())).thenReturn(true);
+    recentBlockFetcher.fetchAncestors(block);
+
+    assertThat(importedBlocks).containsExactly(block);
+    assertTaskCounts(0, 0, 0);
+  }
+
+  @Test
   public void handleDuplicateRequiredBlocks() {
     final SignedBeaconBlock childBlock1 = dataStructureUtil.randomSignedBeaconBlock(5);
     final SignedBeaconBlock childBlock2 =

--- a/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
+++ b/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
@@ -127,9 +127,10 @@ public class SyncingNodeManager {
     final Eth2Network eth2Network = networkBuilder.startNetwork();
 
     final FetchRecentBlocksService recentBlockFetcher =
-        FetchRecentBlocksService.create(asyncRunner, eth2Network, pendingBlocks);
+        FetchRecentBlocksService.create(asyncRunner, eth2Network, pendingBlocks, recentChainData);
     recentBlockFetcher.subscribeBlockFetched(blockManager::importBlock);
-    blockManager.subscribeToReceivedBlocks(recentBlockFetcher::cancelRecentBlockRequest);
+    blockManager.subscribeToPendingBlocks(recentBlockFetcher::fetchAncestors);
+    blockManager.subscribeToReceivedBlocks(recentBlockFetcher::notifyBlockReceived);
 
     SyncManager syncManager =
         SyncManager.create(


### PR DESCRIPTION
## PR Description
Update the recent block fetcher to be able to request blocks either individually by hash or by range so it can better sync long forks.

## Fixed Issue(s)
#1890 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
