### PR TITLE
Fix stall in multipeer sync

### DIFF
--- a/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/BatchDataRequester.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/BatchDataRequester.java
@@ -70,7 +70,7 @@ public class BatchDataRequester {
     UInt64 nextBatchStart = getNextSlotToRequest(commonAncestorSlot);
     final UInt64 targetSlot = targetChain.getChainHead().getSlot();
     for (long i = pendingBatchesCount;
-        i < maxPendingBatches && nextBatchStart.isLessThan(targetSlot);
+        i < maxPendingBatches && nextBatchStart.isLessThanOrEqualTo(targetSlot);
         i++) {
       final UInt64 remainingSlots = targetSlot.minus(nextBatchStart).plus(1);
       final UInt64 count = remainingSlots.min(batchSize);


### PR DESCRIPTION
## PR Description
When a multipeer sync needed to fetch one more slot in the last batch, `BatchDataRequester` incorrectly thought it had created all the required batches and so the sync stalled with the second-to-last batch never being confirmed (because that last block was required to match the target chain block root).

## Fixed Issue(s)
#1844 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
Still an experimental feature so don't need to note every fix.