### PR TITLE
Fix SyncDataProvider to avoid an underflow error when the sync target is lower than current head

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/teku/api/SyncDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/SyncDataProvider.java
@@ -46,7 +46,7 @@ public class SyncDataProvider {
   private UInt64 getSlotsBehind(final tech.pegasys.teku.sync.events.SyncingStatus syncingStatus) {
     if (syncingStatus.isSyncing() && syncingStatus.getHighestSlot().isPresent()) {
       final UInt64 highestSlot = syncingStatus.getHighestSlot().get();
-      return highestSlot.minus(syncingStatus.getCurrentSlot());
+      return highestSlot.minusMinZero(syncingStatus.getCurrentSlot());
     }
     return UInt64.ZERO;
   }


### PR DESCRIPTION
## PR Description
Fix an underflow exception in `SyncDataProvider` when the current chain head is actually ahead of the sync target chain head.  This is unusual but can happen when there are multiple forks and the node is currently on a minority fork that happens to have published a block more recently.

Pretty sure this can't happen with our current single peer sync and extremely exotic anyway because normally you'd expect to reorg to the fork you're syncing but at least theoretically possible.  Not going to changelog it because of that though - mostly just making the change to be suitably defensive.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

