### PR TITLE
Log fatal errors as well as printing to System.err

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed help text for `--validators-graffiti-file` to refer to `--validators-graffiti` as the fallback not `--graffiti`.
 - Fixed validator client timeout when reading from the event stream to avoid unnecessary reconnections.
 - Reduced bandwidth usage during a forward sync by skipping requesting parents of blocks received via gossip as they are likely to be retrieved via the forward sync more efficiently.
+- Error conditions which prevent Teku from starting, such as being unable to load validator keys, are now reported to both the log and system error to make them more likely to be seen.
 
 
 ## 21.1.0


### PR DESCRIPTION
## PR Description
When teku exits at startup (e.g because the validator keys can't be loaded), print the error message to both the log and to `System.err` to maximise the chance of it being seen by users. Note that the message sent to the log is only seen by a console user if `--log-destination CONSOLE` is set, so normally users still get nice clean console output.  Even with CONSOLE destination, the simple clear error is the last thing printed with the more verbose log output above it.

The one exception to this is when the parsing of CLI options fails because we are then unable to configure the logging system correctly. The error message in that case is only printed to System.err (previously it was incorrectly printed to System.out even though it's an error message).

## Fixed Issue(s)
fixes #3481 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
