### PR TITLE
Wait for services to actually stop before exiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 - Docker images are now being published to `consensys/teku`. The `pegasys/teku` images will continue to be updated for the next few releases but please update your configuration to use `consensys/teku`.
 - `--validators-key-files` and `--validators-key-password-files` have been replaced by `--validator-keys`. The old arguments will be removed in a future release.
 
+## Next Release
+
+### Bug Fixes
+- Ensured shutdown operations have fully completed prior to exiting the process.
+
 ## 21.1.1
 
 ### Additions and Improvements

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -514,6 +514,26 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   }
 
   /**
+   * Returns a void future that completes successfully with null result. The consumer is invoked if
+   * this future completes exceptions and the returned future only completes once the consumer
+   * returns.
+   *
+   * <p>The returned future will only complete exceptionally if the consumer throws an exception.
+   *
+   * @param action the exception handler to invoke.
+   * @return a void future that completes successfully unless the consumer throws an exception.
+   */
+  public SafeFuture<Void> handleException(final Consumer<Throwable> action) {
+    return handle(
+        (__, error) -> {
+          if (error != null) {
+            action.accept(error);
+          }
+          return null;
+        });
+  }
+
+  /**
    * Returns the future which completes with the same result or exception as this one. The resulting
    * future becomes complete when `waitForStage` completes. If the `waitForStage` completes
    * exceptionally the resulting future also completes exceptionally with the same exception

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
@@ -130,7 +130,9 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
         .stop()
         .handleComposed(
             (__, err) -> {
-              LOG.warn("Error shutting down connection manager");
+              if (err != null) {
+                LOG.warn("Error shutting down connection manager", err);
+              }
               return SafeFuture.allOf(p2pNetwork.stop(), discoveryService.stop());
             });
   }

--- a/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku;
+
+import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
+
+import com.google.common.eventbus.AsyncEventBus;
+import com.google.common.eventbus.EventBus;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.vertx.core.Vertx;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.config.TekuConfiguration;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
+import tech.pegasys.teku.infrastructure.async.MetricTrackingExecutorFactory;
+import tech.pegasys.teku.infrastructure.events.EventChannels;
+import tech.pegasys.teku.infrastructure.logging.LoggingConfigurator;
+import tech.pegasys.teku.infrastructure.metrics.MetricsEndpoint;
+import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
+import tech.pegasys.teku.infrastructure.version.VersionProvider;
+import tech.pegasys.teku.service.serviceutils.ServiceConfig;
+import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
+import tech.pegasys.teku.services.ServiceController;
+import tech.pegasys.teku.util.config.Constants;
+
+public abstract class AbstractNode implements Node {
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Vertx vertx = Vertx.vertx();
+  private final ExecutorService threadPool =
+      Executors.newCachedThreadPool(
+          new ThreadFactoryBuilder().setDaemon(true).setNameFormat("events-%d").build());
+
+  private final AsyncRunnerFactory asyncRunnerFactory;
+  private final EventChannels eventChannels;
+  private final MetricsEndpoint metricsEndpoint;
+  protected final ServiceConfig serviceConfig;
+
+  protected AbstractNode(final TekuConfiguration tekuConfig) {
+    LoggingConfigurator.update(tekuConfig.loggingConfig());
+
+    STATUS_LOG.onStartup(VersionProvider.VERSION);
+    this.metricsEndpoint = new MetricsEndpoint(tekuConfig.metricsConfig(), vertx);
+    final MetricsSystem metricsSystem = metricsEndpoint.getMetricsSystem();
+    final TekuDefaultExceptionHandler subscriberExceptionHandler =
+        new TekuDefaultExceptionHandler();
+    this.eventChannels = new EventChannels(subscriberExceptionHandler, metricsSystem);
+    final EventBus eventBus = new AsyncEventBus(threadPool, subscriberExceptionHandler);
+
+    asyncRunnerFactory = new AsyncRunnerFactory(new MetricTrackingExecutorFactory(metricsSystem));
+    serviceConfig =
+        new ServiceConfig(
+            asyncRunnerFactory,
+            new SystemTimeProvider(),
+            eventBus,
+            eventChannels,
+            metricsSystem,
+            DataDirLayout.createFrom(tekuConfig.dataConfig()));
+    Constants.setConstants(tekuConfig.eth2NetworkConfiguration().getConstants());
+  }
+
+  protected abstract ServiceController getServiceController();
+
+  @Override
+  public void start() {
+    metricsEndpoint.start().join();
+    getServiceController().start().join();
+  }
+
+  @Override
+  public void stop() {
+    // Stop processing new events
+    eventChannels.stop();
+    threadPool.shutdownNow();
+
+    // Stop async actions
+    asyncRunnerFactory.getAsyncRunners().forEach(AsyncRunner::shutdown);
+
+    // Stop services. This includes closing the database.
+    getServiceController()
+        .stop()
+        .orTimeout(30, TimeUnit.SECONDS)
+        .exceptionally(error -> reportShutdownError("Failed to stop services", error))
+        .thenCompose(__ -> metricsEndpoint.stop())
+        .orTimeout(5, TimeUnit.SECONDS)
+        .exceptionally(error -> reportShutdownError("Failed to stop metrics", error))
+        .thenRun(vertx::close)
+        .join();
+  }
+
+  private <T> T reportShutdownError(final String message, final Throwable error) {
+    LOG.error(message, error);
+    return null;
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
@@ -96,16 +96,11 @@ public abstract class AbstractNode implements Node {
     getServiceController()
         .stop()
         .orTimeout(30, TimeUnit.SECONDS)
-        .exceptionally(error -> reportShutdownError("Failed to stop services", error))
+        .handleException(error -> LOG.error("Failed to stop services", error))
         .thenCompose(__ -> metricsEndpoint.stop())
         .orTimeout(5, TimeUnit.SECONDS)
-        .exceptionally(error -> reportShutdownError("Failed to stop metrics", error))
+        .handleException(error -> LOG.error("Failed to stop metrics", error))
         .thenRun(vertx::close)
         .join();
-  }
-
-  private <T> T reportShutdownError(final String message, final Throwable error) {
-    LOG.error(message, error);
-    return null;
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/BeaconNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/BeaconNode.java
@@ -15,84 +15,21 @@ package tech.pegasys.teku;
 
 import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 
-import com.google.common.eventbus.AsyncEventBus;
-import com.google.common.eventbus.EventBus;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.vertx.core.Vertx;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.config.TekuConfiguration;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
-import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
-import tech.pegasys.teku.infrastructure.async.MetricTrackingExecutorFactory;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.events.EventChannels;
-import tech.pegasys.teku.infrastructure.logging.LoggingConfigurator;
-import tech.pegasys.teku.infrastructure.metrics.MetricsEndpoint;
-import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
-import tech.pegasys.teku.infrastructure.version.VersionProvider;
-import tech.pegasys.teku.service.serviceutils.ServiceConfig;
-import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.services.BeaconNodeServiceController;
-import tech.pegasys.teku.util.config.Constants;
 
-public class BeaconNode implements Node {
-
-  private final Vertx vertx = Vertx.vertx();
-  private final ExecutorService threadPool =
-      Executors.newCachedThreadPool(
-          new ThreadFactoryBuilder().setDaemon(true).setNameFormat("events-%d").build());
-
-  private final AsyncRunnerFactory asyncRunnerFactory;
+public class BeaconNode extends AbstractNode {
   private final BeaconNodeServiceController serviceController;
-  private final EventChannels eventChannels;
-  private final MetricsEndpoint metricsEndpoint;
 
   public BeaconNode(final TekuConfiguration tekuConfig) {
-    LoggingConfigurator.update(tekuConfig.loggingConfig());
-
-    STATUS_LOG.onStartup(VersionProvider.VERSION);
-    this.metricsEndpoint = new MetricsEndpoint(tekuConfig.metricsConfig(), vertx);
-    final MetricsSystem metricsSystem = metricsEndpoint.getMetricsSystem();
-    final TekuDefaultExceptionHandler subscriberExceptionHandler =
-        new TekuDefaultExceptionHandler();
-    this.eventChannels = new EventChannels(subscriberExceptionHandler, metricsSystem);
-    final EventBus eventBus = new AsyncEventBus(threadPool, subscriberExceptionHandler);
-
-    asyncRunnerFactory = new AsyncRunnerFactory(new MetricTrackingExecutorFactory(metricsSystem));
-    final ServiceConfig serviceConfig =
-        new ServiceConfig(
-            asyncRunnerFactory,
-            new SystemTimeProvider(),
-            eventBus,
-            eventChannels,
-            metricsSystem,
-            DataDirLayout.createFrom(tekuConfig.dataConfig()));
-    Constants.setConstants(tekuConfig.eth2NetworkConfiguration().getConstants());
+    super(tekuConfig);
 
     this.serviceController = new BeaconNodeServiceController(tekuConfig, serviceConfig);
     STATUS_LOG.beaconDataPathSet(serviceConfig.getDataDirLayout().getBeaconDataDirectory());
   }
 
   @Override
-  public void start() {
-    metricsEndpoint.start().join();
-    serviceController.start().join();
-  }
-
-  @Override
-  public void stop() {
-    // Stop processing new events
-    eventChannels.stop();
-    threadPool.shutdownNow();
-
-    // Stop async actions
-    asyncRunnerFactory.getAsyncRunners().forEach(AsyncRunner::shutdown);
-
-    // Stop services. This includes closing the database.
-    serviceController.stop().reportExceptions();
-    SafeFuture.of(metricsEndpoint.stop()).reportExceptions();
-    vertx.close();
+  protected BeaconNodeServiceController getServiceController() {
+    return serviceController;
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/ValidatorNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/ValidatorNode.java
@@ -15,84 +15,20 @@ package tech.pegasys.teku;
 
 import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 
-import com.google.common.eventbus.AsyncEventBus;
-import com.google.common.eventbus.EventBus;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.vertx.core.Vertx;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.config.TekuConfiguration;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
-import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
-import tech.pegasys.teku.infrastructure.async.MetricTrackingExecutorFactory;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.events.EventChannels;
-import tech.pegasys.teku.infrastructure.logging.LoggingConfigurator;
-import tech.pegasys.teku.infrastructure.metrics.MetricsEndpoint;
-import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
-import tech.pegasys.teku.infrastructure.version.VersionProvider;
-import tech.pegasys.teku.service.serviceutils.ServiceConfig;
-import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.services.ValidatorNodeServiceController;
-import tech.pegasys.teku.util.config.Constants;
 
-public class ValidatorNode implements Node {
-
-  private final Vertx vertx = Vertx.vertx();
-  private final ExecutorService threadPool =
-      Executors.newCachedThreadPool(
-          new ThreadFactoryBuilder().setDaemon(true).setNameFormat("events-%d").build());
-
-  private final AsyncRunnerFactory asyncRunnerFactory;
+public class ValidatorNode extends AbstractNode {
   private final ValidatorNodeServiceController serviceController;
-  private final EventChannels eventChannels;
-  private final MetricsEndpoint metricsEndpoint;
 
   public ValidatorNode(final TekuConfiguration tekuConfig) {
-    LoggingConfigurator.update(tekuConfig.loggingConfig());
-
-    STATUS_LOG.onStartup(VersionProvider.VERSION);
-    this.metricsEndpoint = new MetricsEndpoint(tekuConfig.metricsConfig(), vertx);
-    final MetricsSystem metricsSystem = metricsEndpoint.getMetricsSystem();
-    final TekuDefaultExceptionHandler subscriberExceptionHandler =
-        new TekuDefaultExceptionHandler();
-    this.eventChannels = new EventChannels(subscriberExceptionHandler, metricsSystem);
-    final EventBus eventBus = new AsyncEventBus(threadPool, subscriberExceptionHandler);
-
-    asyncRunnerFactory = new AsyncRunnerFactory(new MetricTrackingExecutorFactory(metricsSystem));
-    final ServiceConfig serviceConfig =
-        new ServiceConfig(
-            asyncRunnerFactory,
-            new SystemTimeProvider(),
-            eventBus,
-            eventChannels,
-            metricsSystem,
-            DataDirLayout.createFrom(tekuConfig.dataConfig()));
-    Constants.setConstants(tekuConfig.eth2NetworkConfiguration().getConstants());
-
+    super(tekuConfig);
     this.serviceController = new ValidatorNodeServiceController(tekuConfig, serviceConfig);
     STATUS_LOG.validatorDataPathSet(serviceConfig.getDataDirLayout().getValidatorDataDirectory());
   }
 
   @Override
-  public void start() {
-    metricsEndpoint.start().join();
-    serviceController.start().join();
-  }
-
-  @Override
-  public void stop() {
-    // Stop processing new events
-    eventChannels.stop();
-    threadPool.shutdownNow();
-
-    // Stop async actions
-    asyncRunnerFactory.getAsyncRunners().forEach(AsyncRunner::shutdown);
-
-    // Stop services. This includes closing the database.
-    serviceController.stop().reportExceptions();
-    SafeFuture.of(metricsEndpoint.stop()).reportExceptions();
-    vertx.close();
+  protected ValidatorNodeServiceController getServiceController() {
+    return serviceController;
   }
 }


### PR DESCRIPTION
## PR Description
Previously services were told to shutdown but there was nothing that actually waited for the returned futures to complete.  Now the top level node waits for stop to complete (with a 30 second timeout).  Then metrics are shutdown (and we wait) and finally vertx is closed.

Also resolves duplication between BeaconNode and ValidatorNode.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
