### PR TITLE
Enable multipeer sync by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ## Next Release
 
+### Additions and Improvements
+- Enabled the new sync algorithm by default. This improves sync behaviour when there are multiple forks and distributes requests for blocks across available peers. The old sync algorithm can still be used by setting `--Xp2p-multipeer-sync-enabled=false`.
+
 ### Bug Fixes
 - Ensured shutdown operations have fully completed prior to exiting the process.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Additions and Improvements
 - Enabled the new sync algorithm by default. This improves sync behaviour when there are multiple forks and distributes requests for blocks across available peers. The old sync algorithm can still be used by setting `--Xp2p-multipeer-sync-enabled=false`.
+- `--p2p-nat-method upnp` has been added to allow users to use upnp to configure firewalls to allow incoming connection requests.
 
 ### Bug Fixes
 - Ensured shutdown operations have fully completed prior to exiting the process.
@@ -24,7 +25,6 @@
 - `--validators-external-signer-public-keys` arguments can now include URLs to load the public keys from. The URL should provide a list of public keys as a JSON array.
 - Added support for `block`, `attestation` and `voluntary_exit` event streams from the standard REST API.
 - If an advertised IP is set via `--p2p-advertised-ip` it is always used, regardless of the external IP discovered via the discv5 process.
-- `--p2p-nat-method upnp` has been added to allow users to use upnp to configure firewalls to allow incoming connection requests.
 
 ### Bug Fixes
 - Restored the state cache size to 160 to improve performance during sync.

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -129,7 +129,7 @@ public class P2POptions {
       description = "Enables experimental multipeer sync",
       hidden = true,
       arity = "1")
-  private boolean multiPeerSyncEnabled = false;
+  private boolean multiPeerSyncEnabled = true;
 
   @Option(
       names = {"--p2p-subscribe-all-subnets-enabled"},

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -428,7 +428,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                     .advertisedPort(OptionalInt.of(9000))
                     .advertisedIp(Optional.empty())
                     .privateKeyFile("path/to/file"))
-        .sync(s -> s.isSyncEnabled(false).isMultiPeerSyncEnabled(false))
+        .sync(s -> s.isSyncEnabled(false).isMultiPeerSyncEnabled(true))
         .restApi(
             b ->
                 b.restApiPort(5051)


### PR DESCRIPTION
## PR Description
Enable the new multipeer sync by default.

## Fixed Issue(s)
fixes #1844 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
