### PR TITLE
Enable dependent roots by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,22 @@
 ## Upcoming Breaking Changes
 
 - The default docker image will be updated to Java 15. Java 15 based images are available now for testing with the `-jdk15` suffix (e.g `consensys/teku:develop-jdk15`)
-- Teku currently publishes a `head` event on the REST API 4 seconds into a slot even if a block has not been received. In a future release this will be changed so `head` event is only published when a new
-  chain head block is imported. The `--Xvalidators-dependent-root-enabled` option can be used to switch to the new behaviour now for testing. 
-  Note: this should be applied to both the beacon node and validator client if running separately.
 - The `/teku/v1/beacon/states/:state_id` endpoint has been deprecated in favor of the standard API `/eth/v1/debug/beacon/states/:state_id` which now returns the state as SSZ when the `Accept: application/octet-stream` header is specified on the request.
 - Docker images are now being published to `consensys/teku`. The `pegasys/teku` images will continue to be updated for the next few releases but please update your configuration to use `consensys/teku`.
 - `--validators-key-files` and `--validators-key-password-files` have been replaced by `--validator-keys`. The old arguments will be removed in a future release.
 
 ## Next Release
 
+### Breaking Changes
+- Teku no longer publishes a `head` event on the REST API 4 seconds into a slot even if a block has not been received. The `head` event is only published when a new
+  chain head block is imported. The `--Xvalidators-dependent-root-enabled=false` option can be used to revert to the old behaviour.
+  Note: this should be applied to both the beacon node and validator client if running separately.
+
 ### Additions and Improvements
-- Enabled the new sync algorithm by default. This improves sync behaviour when there are multiple forks and distributes requests for blocks across available peers. The old sync algorithm can still be used by setting `--Xp2p-multipeer-sync-enabled=false`.
 - `--p2p-nat-method upnp` has been added to allow users to use upnp to configure firewalls to allow incoming connection requests.
+- Enabled the new sync algorithm by default. This improves sync behaviour when there are multiple forks and distributes requests for blocks across available peers. The old sync algorithm can still be used by setting `--Xp2p-multipeer-sync-enabled=false`.
+- The validator client now uses an independent timer to trigger attestation creation instead of depending on the beacon node publishing a `head` event 4 seconds into the slot. By default the beacon node no longer publishes a `head` event for empty slots. 
+  The previous behaviour can be restored with `--Xvalidators-dependent-root-enabled=false`. Note: this should be applied to both the beacon node and validator client if running separately.
 
 ### Bug Fixes
 - Ensured shutdown operations have fully completed prior to exiting the process.

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -85,7 +85,7 @@ public class ValidatorOptions {
       hidden = true,
       fallbackValue = "true",
       arity = "0..1")
-  private boolean useDependentRoots = false;
+  private boolean useDependentRoots = true;
 
   public void configure(TekuConfiguration.Builder builder) {
     if (validatorPerformanceTrackingEnabled != null) {

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -409,7 +409,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                 b.eth1Endpoint("http://localhost:8545")
                     .depositContract(address)
                     .eth1LogsMaxBlockRange(10_000))
-        .store(b -> b.hotStatePersistenceFrequencyInEpochs(2))
+        .store(b -> b.hotStatePersistenceFrequencyInEpochs(2).updateHeadForEmptySlots(false))
         .storageConfiguration(
             b ->
                 b.eth1DepositContract(Optional.of(address))
@@ -444,6 +444,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                     .validatorExternalSignerConcurrentRequestLimit(32)
                     .validatorKeystoreLockingEnabled(true)
                     .validatorPerformanceTrackingMode(ValidatorPerformanceTrackingMode.ALL)
+                    .useDependentRoots(true)
                     .graffitiProvider(new FileBackedGraffitiProvider()))
         .logging(
             b ->


### PR DESCRIPTION
## PR Description
Switch to using dependent roots by default and not publishing `head` events for empty slots.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
