### PR TITLE
Switch default docker to use jdk15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Upcoming Breaking Changes
 
-- The default docker image will be updated to Java 15. Java 15 based images are available now for testing with the `-jdk15` suffix (e.g `consensys/teku:develop-jdk15`)
 - The `/teku/v1/beacon/states/:state_id` endpoint has been deprecated in favor of the standard API `/eth/v1/debug/beacon/states/:state_id` which now returns the state as SSZ when the `Accept: application/octet-stream` header is specified on the request.
 - Docker images are now being published to `consensys/teku`. The `pegasys/teku` images will continue to be updated for the next few releases but please update your configuration to use `consensys/teku`.
 - `--validators-key-files` and `--validators-key-password-files` have been replaced by `--validator-keys`. The old arguments will be removed in a future release.
@@ -13,12 +12,14 @@
 - Teku no longer publishes a `head` event on the REST API 4 seconds into a slot even if a block has not been received. The `head` event is only published when a new
   chain head block is imported. The `--Xvalidators-dependent-root-enabled=false` option can be used to revert to the old behaviour.
   Note: this should be applied to both the beacon node and validator client if running separately.
+- The default docker image now uses Java 15. Java 14 based images are available with the `-jdk14` suffix if required (e.g `consensys/teku:develop-jdk14`)
 
 ### Additions and Improvements
 - `--p2p-nat-method upnp` has been added to allow users to use upnp to configure firewalls to allow incoming connection requests.
 - Enabled the new sync algorithm by default. This improves sync behaviour when there are multiple forks and distributes requests for blocks across available peers. The old sync algorithm can still be used by setting `--Xp2p-multipeer-sync-enabled=false`.
 - The validator client now uses an independent timer to trigger attestation creation instead of depending on the beacon node publishing a `head` event 4 seconds into the slot. By default the beacon node no longer publishes a `head` event for empty slots. 
   The previous behaviour can be restored with `--Xvalidators-dependent-root-enabled=false`. Note: this should be applied to both the beacon node and validator client if running separately.
+- The default docker image has been upgraded to use Java 15.
 
 ### Bug Fixes
 - Ensured shutdown operations have fully completed prior to exiting the process.

--- a/build.gradle
+++ b/build.gradle
@@ -358,8 +358,8 @@ tasks.register("dockerDistUntar") {
 }
 
 def dockerVariants = [
+  "jdk15",
   "jdk14",
-  "jdk15"
 ]
 
 task distDocker  {


### PR DESCRIPTION
## PR Description
Switch the default docker image to use jdk15 instead of 14.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
