### PR TITLE
Publish to Cloudsmith

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,6 +282,11 @@ jobs:
     executor: small_executor
     steps:
       - prepare
+      - run:
+          name: Install Python3
+          command: |
+            sudo apt update
+            sudo apt install python3 python3-pip python3-venv
       - attach_workspace:
           at: ~/project
       - run:
@@ -375,82 +380,82 @@ workflows:
           filters:
             tags: &filters-release-tags
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?/
-      - spotless:
-          filters:
-            tags:
-              <<: *filters-release-tags
-          context:
-            - dockerhub-quorumengineering-ro
-      - referenceTests:
-          requires:
-            - assemble
-            - spotless
-          filters:
-            tags:
-              <<: *filters-release-tags
-          context:
-            - dockerhub-quorumengineering-ro
-      - unitTests:
-          requires:
-            - assemble
-            - spotless
-          filters:
-            tags:
-              <<: *filters-release-tags
-          context:
-            - dockerhub-quorumengineering-ro
-      - integrationTests:
-          requires:
-            - assemble
-            - spotless
-          filters:
-            tags:
-              <<: *filters-release-tags
-          context:
-            - dockerhub-quorumengineering-ro
-      - acceptanceTests:
-          requires:
-            - assemble
-            - spotless
-          filters:
-            tags:
-              <<: *filters-release-tags
-          context:
-            - dockerhub-quorumengineering-ro
-      - docker:
-          requires:
-            - assemble
-            - spotless
-          filters:
-            tags:
-              <<: *filters-release-tags
-          context:
-            - dockerhub-quorumengineering-ro
-      - extractAPISpec:
-          requires:
-            - assemble
-          filters:
-            tags:
-              <<: *filters-release-tags
-          context: dockerhub-quorumengineering-ro
-      - publish:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release-.*/
-            tags:
-              <<: *filters-release-tags
-          requires:
-            - unitTests
-            - integrationTests
-            - acceptanceTests
-            - referenceTests
-            - docker
-            - extractAPISpec
-          context:
-            - dockerhub-quorumengineering-ro
-            - quorum-gradle
+#      - spotless:
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#          context:
+#            - dockerhub-quorumengineering-ro
+#      - referenceTests:
+#          requires:
+#            - assemble
+#            - spotless
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#          context:
+#            - dockerhub-quorumengineering-ro
+#      - unitTests:
+#          requires:
+#            - assemble
+#            - spotless
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#          context:
+#            - dockerhub-quorumengineering-ro
+#      - integrationTests:
+#          requires:
+#            - assemble
+#            - spotless
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#          context:
+#            - dockerhub-quorumengineering-ro
+#      - acceptanceTests:
+#          requires:
+#            - assemble
+#            - spotless
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#          context:
+#            - dockerhub-quorumengineering-ro
+#      - docker:
+#          requires:
+#            - assemble
+#            - spotless
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#          context:
+#            - dockerhub-quorumengineering-ro
+#      - extractAPISpec:
+#          requires:
+#            - assemble
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#          context: dockerhub-quorumengineering-ro
+#      - publish:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - /^release-.*/
+#            tags:
+#              <<: *filters-release-tags
+#          requires:
+#            - unitTests
+#            - integrationTests
+#            - acceptanceTests
+#            - referenceTests
+#            - docker
+#            - extractAPISpec
+#          context:
+#            - dockerhub-quorumengineering-ro
+#            - quorum-gradle
       - publish-cloudsmith:
           filters:
             branches:
@@ -461,46 +466,47 @@ workflows:
             tags:
               <<: *filters-release-tags
           requires:
-            - unitTests
-            - integrationTests
-            - acceptanceTests
-            - referenceTests
-            - docker
-            - extractAPISpec
+            - assemble
+#            - unitTests
+#            - integrationTests
+#            - acceptanceTests
+#            - referenceTests
+#            - docker
+#            - extractAPISpec
           context:
             - dockerhub-quorumengineering-ro
             - quorum-gradle
-      - publishDocker:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release-.*/
-            tags:
-              <<: *filters-release-tags
-          requires:
-            - unitTests
-            - integrationTests
-            - acceptanceTests
-            - referenceTests
-            - docker
-            - extractAPISpec
-          context:
-            - dockerhub-quorumengineering-rw
-      - publishAPISpec:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release-.*/
-            tags: # stable doc is published only on tags to prevent confusion on the doc site.
-              <<: *filters-release-tags
-          requires:
-            - unitTests
-            - integrationTests
-            - acceptanceTests
-            - referenceTests
-            - docker
-            - extractAPISpec
-          context:
-            - dockerhub-quorumengineering-ro
+#      - publishDocker:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - /^release-.*/
+#            tags:
+#              <<: *filters-release-tags
+#          requires:
+#            - unitTests
+#            - integrationTests
+#            - acceptanceTests
+#            - referenceTests
+#            - docker
+#            - extractAPISpec
+#          context:
+#            - dockerhub-quorumengineering-rw
+#      - publishAPISpec:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - /^release-.*/
+#            tags: # stable doc is published only on tags to prevent confusion on the doc site.
+#              <<: *filters-release-tags
+#          requires:
+#            - unitTests
+#            - integrationTests
+#            - acceptanceTests
+#            - referenceTests
+#            - docker
+#            - extractAPISpec
+#          context:
+#            - dockerhub-quorumengineering-ro

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,6 +278,17 @@ jobs:
           command: |
             ./gradlew --no-daemon --parallel -no-configure-on-demand bintrayUpload
 
+  publish-cloudsmith:
+    executor: small_executor
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Publish to Cloudsmith
+          command: |
+            ./gradlew --no-daemon --parallel cloudsmithUpload publish
+
   publishDocker:
     executor: medium_executor
     steps:
@@ -428,6 +439,25 @@ workflows:
               only:
                 - master
                 - /^release-.*/
+            tags:
+              <<: *filters-release-tags
+          requires:
+            - unitTests
+            - integrationTests
+            - acceptanceTests
+            - referenceTests
+            - docker
+            - extractAPISpec
+          context:
+            - dockerhub-quorumengineering-ro
+            - quorum-gradle
+      - publish-cloudsmith:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+                - cloudsmith
             tags:
               <<: *filters-release-tags
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,133 +380,131 @@ workflows:
           filters:
             tags: &filters-release-tags
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?/
-#      - spotless:
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#          context:
-#            - dockerhub-quorumengineering-ro
-#      - referenceTests:
-#          requires:
-#            - assemble
-#            - spotless
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#          context:
-#            - dockerhub-quorumengineering-ro
-#      - unitTests:
-#          requires:
-#            - assemble
-#            - spotless
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#          context:
-#            - dockerhub-quorumengineering-ro
-#      - integrationTests:
-#          requires:
-#            - assemble
-#            - spotless
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#          context:
-#            - dockerhub-quorumengineering-ro
-#      - acceptanceTests:
-#          requires:
-#            - assemble
-#            - spotless
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#          context:
-#            - dockerhub-quorumengineering-ro
-#      - docker:
-#          requires:
-#            - assemble
-#            - spotless
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#          context:
-#            - dockerhub-quorumengineering-ro
-#      - extractAPISpec:
-#          requires:
-#            - assemble
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#          context: dockerhub-quorumengineering-ro
-#      - publish:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - /^release-.*/
-#            tags:
-#              <<: *filters-release-tags
-#          requires:
-#            - unitTests
-#            - integrationTests
-#            - acceptanceTests
-#            - referenceTests
-#            - docker
-#            - extractAPISpec
-#          context:
-#            - dockerhub-quorumengineering-ro
-#            - quorum-gradle
+      - spotless:
+          filters:
+            tags:
+              <<: *filters-release-tags
+          context:
+            - dockerhub-quorumengineering-ro
+      - referenceTests:
+          requires:
+            - assemble
+            - spotless
+          filters:
+            tags:
+              <<: *filters-release-tags
+          context:
+            - dockerhub-quorumengineering-ro
+      - unitTests:
+          requires:
+            - assemble
+            - spotless
+          filters:
+            tags:
+              <<: *filters-release-tags
+          context:
+            - dockerhub-quorumengineering-ro
+      - integrationTests:
+          requires:
+            - assemble
+            - spotless
+          filters:
+            tags:
+              <<: *filters-release-tags
+          context:
+            - dockerhub-quorumengineering-ro
+      - acceptanceTests:
+          requires:
+            - assemble
+            - spotless
+          filters:
+            tags:
+              <<: *filters-release-tags
+          context:
+            - dockerhub-quorumengineering-ro
+      - docker:
+          requires:
+            - assemble
+            - spotless
+          filters:
+            tags:
+              <<: *filters-release-tags
+          context:
+            - dockerhub-quorumengineering-ro
+      - extractAPISpec:
+          requires:
+            - assemble
+          filters:
+            tags:
+              <<: *filters-release-tags
+          context: dockerhub-quorumengineering-ro
+      - publish:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+            tags:
+              <<: *filters-release-tags
+          requires:
+            - unitTests
+            - integrationTests
+            - acceptanceTests
+            - referenceTests
+            - docker
+            - extractAPISpec
+          context:
+            - dockerhub-quorumengineering-ro
+            - quorum-gradle
       - publish-cloudsmith:
           filters:
             branches:
               only:
                 - master
                 - /^release-.*/
-                - cloudsmith
             tags:
               <<: *filters-release-tags
           requires:
-            - assemble
-#            - unitTests
-#            - integrationTests
-#            - acceptanceTests
-#            - referenceTests
-#            - docker
-#            - extractAPISpec
+            - unitTests
+            - integrationTests
+            - acceptanceTests
+            - referenceTests
+            - docker
+            - extractAPISpec
           context:
             - dockerhub-quorumengineering-ro
             - quorum-gradle
-#      - publishDocker:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - /^release-.*/
-#            tags:
-#              <<: *filters-release-tags
-#          requires:
-#            - unitTests
-#            - integrationTests
-#            - acceptanceTests
-#            - referenceTests
-#            - docker
-#            - extractAPISpec
-#          context:
-#            - dockerhub-quorumengineering-rw
-#      - publishAPISpec:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - /^release-.*/
-#            tags: # stable doc is published only on tags to prevent confusion on the doc site.
-#              <<: *filters-release-tags
-#          requires:
-#            - unitTests
-#            - integrationTests
-#            - acceptanceTests
-#            - referenceTests
-#            - docker
-#            - extractAPISpec
-#          context:
-#            - dockerhub-quorumengineering-ro
+      - publishDocker:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+            tags:
+              <<: *filters-release-tags
+          requires:
+            - unitTests
+            - integrationTests
+            - acceptanceTests
+            - referenceTests
+            - docker
+            - extractAPISpec
+          context:
+            - dockerhub-quorumengineering-rw
+      - publishAPISpec:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+            tags: # stable doc is published only on tags to prevent confusion on the doc site.
+              <<: *filters-release-tags
+          requires:
+            - unitTests
+            - integrationTests
+            - acceptanceTests
+            - referenceTests
+            - docker
+            - extractAPISpec
+          context:
+            - dockerhub-quorumengineering-ro

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Upcoming Breaking Changes
-
+- Binary downloads will be transitioned from Bintray to Cloudsmith.  Please ensure you use links in the documentation or release notes.
+  Ansible users should ensure they have the latest version of the ansible role.
+  To ensure a smooth migration, releases are currently published to both Cloudsmith and Bintray but support for Bintray will be dropped in the near future.
 - The `/teku/v1/beacon/states/:state_id` endpoint has been deprecated in favor of the standard API `/eth/v1/debug/beacon/states/:state_id` which now returns the state as SSZ when the `Accept: application/octet-stream` header is specified on the request.
 - Docker images are now being published to `consensys/teku`. The `pegasys/teku` images will continue to be updated for the next few releases but please update your configuration to use `consensys/teku`.
 - `--validators-key-files` and `--validators-key-password-files` have been replaced by `--validator-keys`. The old arguments will be removed in a future release.

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ apply plugin: 'com.jfrog.bintray'
 def bintrayUser = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
 def bintrayKey = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_KEY')
 
+def cloudsmithUser = project.hasProperty('cloudsmithUser') ? project.property('cloudsmithUser') : System.getenv('CLOUDSMITH_USER')
+def cloudsmithKey = project.hasProperty('cloudsmithApiKey') ? project.property('cloudsmithApiKey') : System.getenv('CLOUDSMITH_API_KEY')
+
 def bintrayPackage = bintray.pkg {
   repo = 'pegasys-repo'
   name = 'teku'
@@ -471,6 +474,16 @@ subprojects {
     apply plugin: 'maven-publish'
 
     publishing {
+      repositories {
+        maven {
+          name = "cloudsmith"
+          url = "https://api-g.cloudsmith.io/maven/consensys/teku/"
+          credentials {
+            username = cloudsmithUser
+            password = cloudsmithKey
+          }
+        }
+      }
       publications {
         mavenJava(MavenPublication) {
           groupId "tech.pegasys.teku.internal"
@@ -484,6 +497,8 @@ subprojects {
             usage('java-api') { fromResolutionOf('runtimeClasspath') }
             usage('java-runtime') { fromResolutionResult() }
           }
+          suppressPomMetadataWarningsFor('testFixturesApiElements')
+          suppressPomMetadataWarningsFor('testFixturesRuntimeElements')
           pom {
             name = "Teku - ${project.name}"
             url = 'https://github.com/ConsenSys/teku'
@@ -720,6 +735,16 @@ configure(subprojects.findAll {it.name != 'errorprone-checks'}) {
 
   tasks.withType(JavaCompile) {
     options.annotationProcessorPath = configurations.annotationProcessor
+  }
+}
+
+task cloudsmithUpload {
+  dependsOn([distTar, distZip])
+  doLast {
+    exec {
+      executable project.file("scripts/cloudsmith-upload.sh")
+      args rootProject.version, distTar.archiveFile.get(), distZip.archiveFile.get()
+    }
   }
 }
 

--- a/scripts/cloudsmith-upload.sh
+++ b/scripts/cloudsmith-upload.sh
@@ -15,5 +15,5 @@ fi
 
 python3 -m pip install --upgrade cloudsmith-cli
 
-cloudsmith push raw consensys/teku $TAR_DIST --version "${TEKU_VERSION}" --summary "Teku ${TEKU_VERSION} binary distribution" --description "Binary distribution of Teku ${TEKU_VERSION}."
-cloudsmith push raw consensys/teku $ZIP_DIST --version "${TEKU_VERSION}" --summary "Teku ${TEKU_VERSION} binary distribution" --description "Binary distribution of Teku ${TEKU_VERSION}."
+cloudsmith push raw consensys/teku $TAR_DIST --version "${TEKU_VERSION}" --summary "Teku ${TEKU_VERSION} binary distribution" --description "Binary distribution of Teku ${TEKU_VERSION}." --content-type 'application/tar+gzip'
+cloudsmith push raw consensys/teku $ZIP_DIST --version "${TEKU_VERSION}" --summary "Teku ${TEKU_VERSION} binary distribution" --description "Binary distribution of Teku ${TEKU_VERSION}." --content-type 'application/zip'

--- a/scripts/cloudsmith-upload.sh
+++ b/scripts/cloudsmith-upload.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+TEKU_VERSION=${1:?Must specify teku version}
+TAR_DIST=${2:?Must specify path to tar distribution}
+ZIP_DIST=${3:?Must specify path to zip distribution}
+
+ENV_DIR=./build/tmp/cloudsmith-env
+if [[ -d ${ENV_DIR} ]] ; then
+    source ${ENV_DIR}/bin/activate
+else
+    python3 -m venv ${ENV_DIR}
+    source ${ENV_DIR}/bin/activate
+fi
+
+python3 -m pip install --upgrade cloudsmith-cli
+
+cloudsmith push raw consensys/teku $TAR_DIST --version "${TEKU_VERSION}" --summary "Teku ${TEKU_VERSION} binary distribution" --description "Binary distribution of Teku ${TEKU_VERSION}."
+cloudsmith push raw consensys/teku $ZIP_DIST --version "${TEKU_VERSION}" --summary "Teku ${TEKU_VERSION} binary distribution" --description "Binary distribution of Teku ${TEKU_VERSION}."

--- a/scripts/cloudsmith-upload.sh
+++ b/scripts/cloudsmith-upload.sh
@@ -15,5 +15,5 @@ fi
 
 python3 -m pip install --upgrade cloudsmith-cli
 
-cloudsmith push raw consensys/teku $TAR_DIST --version "${TEKU_VERSION}" --summary "Teku ${TEKU_VERSION} binary distribution" --description "Binary distribution of Teku ${TEKU_VERSION}." --content-type 'application/tar+gzip'
-cloudsmith push raw consensys/teku $ZIP_DIST --version "${TEKU_VERSION}" --summary "Teku ${TEKU_VERSION} binary distribution" --description "Binary distribution of Teku ${TEKU_VERSION}." --content-type 'application/zip'
+cloudsmith push raw consensys/teku $TAR_DIST --name 'teku.tar.gz' --version "${TEKU_VERSION}" --summary "Teku ${TEKU_VERSION} binary distribution" --description "Binary distribution of Teku ${TEKU_VERSION}." --content-type 'application/tar+gzip'
+cloudsmith push raw consensys/teku $ZIP_DIST --name 'teku.zip' --version "${TEKU_VERSION}" --summary "Teku ${TEKU_VERSION} binary distribution" --description "Binary distribution of Teku ${TEKU_VERSION}." --content-type 'application/zip'


### PR DESCRIPTION
## PR Description
Add publishing of jar and release artefacts to Cloudsmith. Still publishing to bintray as well for backwards compatibility.

## Fixed Issue(s)
#3475 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
