### PR TITLE
Upgrade to latest metrics library from Besu

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -144,8 +144,8 @@ dependencyManagement {
 
     dependency 'io.prometheus:simpleclient:0.9.0'
 
-    dependency 'org.hyperledger.besu.internal:metrics-core:1.5.4'
-    dependency 'org.hyperledger.besu:plugin-api:1.5.4'
+    dependency 'org.hyperledger.besu.internal:metrics-core:20.10.4'
+    dependency 'org.hyperledger.besu:plugin-api:20.10.4'
 
     dependency "org.testcontainers:testcontainers:1.15.0-rc2"
     dependency "org.testcontainers:junit-jupiter:1.15.0-rc2"

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsEndpoint.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsEndpoint.java
@@ -16,24 +16,21 @@ package tech.pegasys.teku.infrastructure.metrics;
 import io.vertx.core.Vertx;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import org.hyperledger.besu.metrics.MetricsService;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
-import org.hyperledger.besu.metrics.prometheus.MetricsService;
 import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 public class MetricsEndpoint {
 
   private final Optional<MetricsService> metricsService;
-  private final MetricsSystem metricsSystem;
+  private final PrometheusMetricsSystem metricsSystem;
 
   public MetricsEndpoint(final MetricsConfig config, final Vertx vertx) {
     final MetricsConfiguration metricsConfig = createMetricsConfiguration(config);
-    metricsSystem = PrometheusMetricsSystem.init(metricsConfig);
-    if (metricsConfig.isEnabled()) {
-      metricsService = Optional.of(MetricsService.create(vertx, metricsConfig, metricsSystem));
-    } else {
-      metricsService = Optional.empty();
-    }
+    metricsSystem = new PrometheusMetricsSystem(config.getMetricsCategories(), true);
+    metricsSystem.init();
+    metricsService = MetricsService.create(vertx, metricsConfig, metricsSystem);
   }
 
   public CompletableFuture<?> start() {

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsHistogram.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsHistogram.java
@@ -102,7 +102,7 @@ public class MetricsHistogram {
     final MetricsHistogram histogram = new MetricsHistogram(histogram1);
     if (metricsSystem instanceof PrometheusMetricsSystem) {
       ((PrometheusMetricsSystem) metricsSystem)
-          .addCollector(category, histogram.histogramToCollector(category, name, help));
+          .addCollector(category, () -> histogram.histogramToCollector(category, name, help));
     }
     return histogram;
   }

--- a/infrastructure/metrics/src/test/java/tech/pegasys/teku/infrastructure/metrics/MetricsHistogramTest.java
+++ b/infrastructure/metrics/src/test/java/tech/pegasys/teku/infrastructure/metrics/MetricsHistogramTest.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.metrics.Observation;
-import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
 import org.junit.jupiter.api.Test;
 
@@ -31,8 +30,7 @@ class MetricsHistogramTest {
 
   private static final TekuMetricCategory CATEGORY = TekuMetricCategory.BEACON;
   private final ObservableMetricsSystem metricsSystem =
-      PrometheusMetricsSystem.init(
-          MetricsConfiguration.builder().enabled(true).metricCategories(Set.of(CATEGORY)).build());
+      new PrometheusMetricsSystem(Set.of(CATEGORY), true);
 
   @Test
   void shouldReportValuesWithNoSpecifiedUpperLimit() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbStats.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbStats.java
@@ -214,7 +214,7 @@ public class RocksDbStats implements AutoCloseable {
     if (metricsSystem instanceof PrometheusMetricsSystem) {
       for (final HistogramType histogram : HISTOGRAMS) {
         ((PrometheusMetricsSystem) metricsSystem)
-            .addCollector(category, histogramToCollector(category, stats, histogram));
+            .addCollector(category, () -> histogramToCollector(category, stats, histogram));
       }
     }
   }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbStatsTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbStatsTest.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.metrics.Observation;
-import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
 import org.junit.jupiter.api.Test;
 import org.rocksdb.RocksDB;
@@ -36,12 +35,7 @@ class RocksDbStatsTest {
   @Test
   void shouldNotCrashIfMetricsRequestedAfterClose() throws Exception {
     final ObservableMetricsSystem metricsSystem =
-        PrometheusMetricsSystem.init(
-            MetricsConfiguration.builder()
-                .enabled(true)
-                .metricCategories(Set.of(TekuMetricCategory.STORAGE_HOT_DB))
-                .timersEnabled(true)
-                .build());
+        new PrometheusMetricsSystem(Set.of(TekuMetricCategory.STORAGE_HOT_DB), true);
 
     try (RocksDbStats stats = new RocksDbStats(metricsSystem, TekuMetricCategory.STORAGE_HOT_DB)) {
       stats.registerMetrics(database);

--- a/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
@@ -99,7 +99,7 @@ public abstract class AbstractNode implements Node {
         .handleException(error -> LOG.error("Failed to stop services", error))
         .thenCompose(__ -> metricsEndpoint.stop())
         .orTimeout(5, TimeUnit.SECONDS)
-        .handleException(error -> LOG.error("Failed to stop metrics", error))
+        .handleException(error -> LOG.debug("Failed to stop metrics", error))
         .thenRun(vertx::close)
         .join();
   }


### PR DESCRIPTION
## PR Description
Upgrades to the latest metrics from Besu so we don't fall too far behind.  Changes shutdown to log failures to stop metrics at debug level instead of error - it's a long standing bug in Vertx that it doesn't always call the callback when stopping a http server and there's no downside to metrics being stopped unexpectedly anyway.

## Fixed Issue(s)
fixes #3517 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
Not adding a changelog as we previously ignored metrics shutdown entirely.