### PR TITLE
Exit when unrecoverable database errors are encountered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For information on changes in released versions of Teku, see the [releases page]
   The previous behaviour can be restored with `--Xvalidators-dependent-root-enabled=false`. Note: this should be applied to both the beacon node and validator client if running separately.
 - The default docker image has been upgraded to use Java 15.
 - Updated the ENRs for MainNet bootnodes run by the Nimbus team.
+- Teku will now exit when database writes fail (e.g. due to disk failure) to enable systems like kubernetes to better identify and respond to the failure.
 
 ### Bug Fixes
 - Ensured shutdown operations have fully completed prior to exiting the process.

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseStorageException.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseStorageException.java
@@ -14,11 +14,28 @@
 package tech.pegasys.teku.storage.server;
 
 public class DatabaseStorageException extends RuntimeException {
-  public DatabaseStorageException(final String s) {
-    super(s);
+  private final boolean unrecoverable;
+
+  private DatabaseStorageException(
+      final String message, final boolean unrecoverable, final Throwable cause) {
+    super(message, cause);
+    this.unrecoverable = unrecoverable;
   }
 
-  public DatabaseStorageException(final String s, final Throwable cause) {
-    super(s, cause);
+  public static DatabaseStorageException recoverable(final String message, final Throwable cause) {
+    return new DatabaseStorageException(message, false, cause);
+  }
+
+  public static DatabaseStorageException unrecoverable(
+      final String message, final Throwable cause) {
+    return new DatabaseStorageException(message, true, cause);
+  }
+
+  public static DatabaseStorageException unrecoverable(final String message) {
+    return new DatabaseStorageException(message, true, null);
+  }
+
+  public boolean isUnrecoverable() {
+    return unrecoverable;
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -187,7 +187,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
           stateStorageFrequency,
           specProvider);
     } catch (final IOException e) {
-      throw new DatabaseStorageException("Failed to read configuration file", e);
+      throw DatabaseStorageException.unrecoverable("Failed to read configuration file", e);
     }
   }
 
@@ -209,7 +209,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
           stateStorageFrequency,
           specProvider);
     } catch (final IOException e) {
-      throw new DatabaseStorageException("Failed to read metadata", e);
+      throw DatabaseStorageException.unrecoverable("Failed to read metadata", e);
     }
   }
 
@@ -225,7 +225,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
       final V6DatabaseMetadata metaData =
           V6DatabaseMetadata.init(getMetadataFile(), defaultMetaData);
       if (defaultMetaData.isSingleDB() != metaData.isSingleDB()) {
-        throw new DatabaseStorageException(
+        throw DatabaseStorageException.unrecoverable(
             "The database was originally created as "
                 + (metaData.isSingleDB() ? "Single" : "Separate")
                 + " but now accessed as "
@@ -258,7 +258,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
           stateStorageFrequency,
           specProvider);
     } catch (final IOException e) {
-      throw new DatabaseStorageException("Failed to read metadata", e);
+      throw DatabaseStorageException.unrecoverable("Failed to read metadata", e);
     }
   }
 
@@ -272,7 +272,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
 
   private void validateDataPaths() {
     if (dbDirectory.exists() && !dbVersionFile.exists()) {
-      throw new DatabaseStorageException(
+      throw DatabaseStorageException.unrecoverable(
           String.format(
               "No database version file was found, and the database path %s exists.",
               dataDirectory.getAbsolutePath()));
@@ -281,7 +281,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
 
   private void createDirectories(DatabaseVersion dbVersion) {
     if (!dbDirectory.mkdirs() && !dbDirectory.isDirectory()) {
-      throw new DatabaseStorageException(
+      throw DatabaseStorageException.unrecoverable(
           String.format(
               "Unable to create the path to store database files at %s",
               dbDirectory.getAbsolutePath()));
@@ -291,7 +291,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
       case V4:
       case V5:
         if (!v5ArchiveDirectory.mkdirs() && !v5ArchiveDirectory.isDirectory()) {
-          throw new DatabaseStorageException(
+          throw DatabaseStorageException.unrecoverable(
               String.format(
                   "Unable to create the path to store archive files at %s",
                   v5ArchiveDirectory.getAbsolutePath()));
@@ -301,7 +301,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
         v6ArchiveDirectory.ifPresent(
             archiveDirectory -> {
               if (!archiveDirectory.mkdirs() && !archiveDirectory.isDirectory()) {
-                throw new DatabaseStorageException(
+                throw DatabaseStorageException.unrecoverable(
                     "Unable to create the path to store archive files at "
                         + archiveDirectory.getAbsolutePath());
               }
@@ -320,9 +320,10 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
         return DatabaseVersion.fromString(versionValue)
             .orElseThrow(
                 () ->
-                    new DatabaseStorageException("Unrecognized database version: " + versionValue));
+                    DatabaseStorageException.unrecoverable(
+                        "Unrecognized database version: " + versionValue));
       } catch (IOException e) {
-        throw new DatabaseStorageException(
+        throw DatabaseStorageException.unrecoverable(
             String.format(
                 "Unable to read database version from file %s", dbVersionFile.getAbsolutePath()),
             e);
@@ -336,7 +337,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
       try {
         Files.writeString(dbVersionFile.toPath(), version.getValue(), StandardOpenOption.CREATE);
       } catch (IOException e) {
-        throw new DatabaseStorageException(
+        throw DatabaseStorageException.unrecoverable(
             "Failed to write database version to file " + dbVersionFile.getAbsolutePath(), e);
       }
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/network/DatabaseNetwork.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/network/DatabaseNetwork.java
@@ -60,12 +60,12 @@ public class DatabaseNetwork {
           objectMapper.readerFor(DatabaseNetwork.class).readValue(source);
 
       if (!forkVersionString.equals(databaseNetwork.forkVersion)) {
-        throw new DatabaseStorageException(
+        throw DatabaseStorageException.unrecoverable(
             formatMessage("fork version", forkVersionString, databaseNetwork.forkVersion));
       }
       if (databaseNetwork.depositContract != null
           && !databaseNetwork.depositContract.equals(depositContractString)) {
-        throw new DatabaseStorageException(
+        throw DatabaseStorageException.unrecoverable(
             formatMessage(
                 "deposit contract", depositContractString, databaseNetwork.depositContract));
       }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbExceptionUtil.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbExceptionUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.rocksdb;
+
+import org.rocksdb.RocksDBException;
+import tech.pegasys.teku.storage.server.DatabaseStorageException;
+
+public class RocksDbExceptionUtil {
+  public static DatabaseStorageException wrapException(
+      final String message, final RocksDBException cause) {
+    return isUnrecoverable(cause)
+        ? DatabaseStorageException.unrecoverable(message, cause)
+        : DatabaseStorageException.recoverable(message, cause);
+  }
+
+  private static boolean isUnrecoverable(final RocksDBException cause) {
+    if (cause.getStatus() == null) {
+      return true;
+    }
+    switch (cause.getStatus().getCode()) {
+      case TimedOut:
+      case TryAgain:
+      case MergeInProgress:
+      case Incomplete:
+      case Busy:
+      case Expired:
+        return false;
+      default:
+        return true;
+    }
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstance.java
@@ -32,8 +32,8 @@ import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.TransactionDB;
 import org.rocksdb.WriteOptions;
-import tech.pegasys.teku.storage.server.DatabaseStorageException;
 import tech.pegasys.teku.storage.server.ShuttingDownException;
+import tech.pegasys.teku.storage.server.rocksdb.RocksDbExceptionUtil;
 import tech.pegasys.teku.storage.server.rocksdb.schema.RocksDbColumn;
 import tech.pegasys.teku.storage.server.rocksdb.schema.RocksDbVariable;
 
@@ -65,7 +65,7 @@ public class RocksDbInstance implements RocksDbAccessor {
       return Optional.ofNullable(db.get(defaultHandle, variable.getId().toArrayUnsafe()))
           .map(data -> variable.getSerializer().deserialize(data));
     } catch (RocksDBException e) {
-      throw new DatabaseStorageException("Failed to get value", e);
+      throw RocksDbExceptionUtil.wrapException("Failed to get value", e);
     }
   }
 
@@ -78,7 +78,7 @@ public class RocksDbInstance implements RocksDbAccessor {
       return Optional.ofNullable(db.get(handle, keyBytes))
           .map(data -> column.getValueSerializer().deserialize(data));
     } catch (RocksDBException e) {
-      throw new DatabaseStorageException("Failed to get value", e);
+      throw RocksDbExceptionUtil.wrapException("Failed to get value", e);
     }
   }
 
@@ -225,7 +225,7 @@ public class RocksDbInstance implements RocksDbAccessor {
             try {
               rocksDbTx.put(defaultHandle, variable.getId().toArrayUnsafe(), serialized);
             } catch (RocksDBException e) {
-              throw new DatabaseStorageException("Failed to put variable", e);
+              throw RocksDbExceptionUtil.wrapException("Failed to put variable", e);
             }
           });
     }
@@ -240,7 +240,7 @@ public class RocksDbInstance implements RocksDbAccessor {
             try {
               rocksDbTx.put(handle, keyBytes, valueBytes);
             } catch (RocksDBException e) {
-              throw new DatabaseStorageException("Failed to put column data", e);
+              throw RocksDbExceptionUtil.wrapException("Failed to put column data", e);
             }
           });
     }
@@ -256,7 +256,7 @@ public class RocksDbInstance implements RocksDbAccessor {
               try {
                 rocksDbTx.put(handle, key, value);
               } catch (RocksDBException e) {
-                throw new DatabaseStorageException("Failed to put column data", e);
+                throw RocksDbExceptionUtil.wrapException("Failed to put column data", e);
               }
             }
           });
@@ -270,7 +270,7 @@ public class RocksDbInstance implements RocksDbAccessor {
             try {
               rocksDbTx.delete(handle, column.getKeySerializer().serialize(key));
             } catch (RocksDBException e) {
-              throw new DatabaseStorageException("Failed to delete key", e);
+              throw RocksDbExceptionUtil.wrapException("Failed to delete key", e);
             }
           });
     }
@@ -282,7 +282,7 @@ public class RocksDbInstance implements RocksDbAccessor {
             try {
               rocksDbTx.delete(defaultHandle, variable.getId().toArrayUnsafe());
             } catch (RocksDBException e) {
-              throw new DatabaseStorageException("Failed to delete variable", e);
+              throw RocksDbExceptionUtil.wrapException("Failed to delete variable", e);
             }
           });
     }
@@ -294,7 +294,7 @@ public class RocksDbInstance implements RocksDbAccessor {
             try {
               this.rocksDbTx.commit();
             } catch (RocksDBException e) {
-              throw new DatabaseStorageException("Failed to commit transaction", e);
+              throw RocksDbExceptionUtil.wrapException("Failed to commit transaction", e);
             } finally {
               close();
             }
@@ -308,7 +308,7 @@ public class RocksDbInstance implements RocksDbAccessor {
             try {
               this.rocksDbTx.commit();
             } catch (RocksDBException e) {
-              throw new DatabaseStorageException("Failed to commit transaction", e);
+              throw RocksDbExceptionUtil.wrapException("Failed to commit transaction", e);
             } finally {
               close();
             }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstanceFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstanceFactory.java
@@ -39,6 +39,7 @@ import org.rocksdb.TransactionDB;
 import org.rocksdb.TransactionDBOptions;
 import tech.pegasys.teku.storage.server.DatabaseStorageException;
 import tech.pegasys.teku.storage.server.rocksdb.RocksDbConfiguration;
+import tech.pegasys.teku.storage.server.rocksdb.RocksDbExceptionUtil;
 import tech.pegasys.teku.storage.server.rocksdb.schema.RocksDbColumn;
 import tech.pegasys.teku.storage.server.rocksdb.schema.Schema;
 
@@ -106,7 +107,7 @@ public class RocksDbInstanceFactory {
 
       return new RocksDbInstance(db, defaultHandle, columnHandlesMap, resources);
     } catch (RocksDBException e) {
-      throw new DatabaseStorageException(
+      throw RocksDbExceptionUtil.wrapException(
           "Failed to open database at path: " + configuration.getDatabaseDir(), e);
     }
   }
@@ -118,11 +119,12 @@ public class RocksDbInstanceFactory {
               try {
                 return Bytes.wrap(handle.getName()).equals(Schema.DEFAULT_COLUMN_ID);
               } catch (RocksDBException e) {
-                throw new DatabaseStorageException("Unable to retrieve default column handle", e);
+                throw RocksDbExceptionUtil.wrapException(
+                    "Unable to retrieve default column handle", e);
               }
             })
         .findFirst()
-        .orElseThrow(() -> new DatabaseStorageException("No default column defined"));
+        .orElseThrow(() -> DatabaseStorageException.unrecoverable("No default column defined"));
   }
 
   private static DBOptions createDBOptions(

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbExceptionUtilTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbExceptionUtilTest.java
@@ -28,16 +28,6 @@ import tech.pegasys.teku.storage.server.DatabaseStorageException;
 
 class RocksDbExceptionUtilTest {
 
-  private static Stream<Arguments> recoverableErrorCodes() {
-    return Stream.of(
-        Arguments.of(Code.TimedOut),
-        Arguments.of(Code.TryAgain),
-        Arguments.of(Code.MergeInProgress),
-        Arguments.of(Code.Incomplete),
-        Arguments.of(Code.Busy),
-        Arguments.of(Code.Expired));
-  }
-
   @ParameterizedTest
   @MethodSource("recoverableErrorCodes")
   void shouldIdentifyRecoverableExceptions(final Code code) {
@@ -60,5 +50,15 @@ class RocksDbExceptionUtilTest {
         new RocksDBException(new Status(Code.IOError, SubCode.None, null));
     final DatabaseStorageException result = RocksDbExceptionUtil.wrapException("Test", exception);
     assertThat(result.isUnrecoverable()).isTrue();
+  }
+
+  static Stream<Arguments> recoverableErrorCodes() {
+    return Stream.of(
+        Arguments.of(Code.TimedOut),
+        Arguments.of(Code.TryAgain),
+        Arguments.of(Code.MergeInProgress),
+        Arguments.of(Code.Incomplete),
+        Arguments.of(Code.Busy),
+        Arguments.of(Code.Expired));
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbExceptionUtilTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbExceptionUtilTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.rocksdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.Status;
+import org.rocksdb.Status.Code;
+import org.rocksdb.Status.SubCode;
+import tech.pegasys.teku.storage.server.DatabaseStorageException;
+
+class RocksDbExceptionUtilTest {
+
+  private static Stream<Arguments> recoverableErrorCodes() {
+    return Stream.of(
+        Arguments.of(Code.TimedOut),
+        Arguments.of(Code.TryAgain),
+        Arguments.of(Code.MergeInProgress),
+        Arguments.of(Code.Incomplete),
+        Arguments.of(Code.Busy),
+        Arguments.of(Code.Expired));
+  }
+
+  @ParameterizedTest
+  @MethodSource("recoverableErrorCodes")
+  void shouldIdentifyRecoverableExceptions(final Code code) {
+    final RocksDBException exception = new RocksDBException(new Status(code, SubCode.None, null));
+    final DatabaseStorageException result = RocksDbExceptionUtil.wrapException("Test", exception);
+    assertThat(result).hasMessage("Test");
+    assertThat(result.isUnrecoverable()).isFalse();
+  }
+
+  @Test
+  void shouldBeUnrecoverableWhenNoStatusIsSet() {
+    final RocksDBException exception = new RocksDBException("Oh dear");
+    final DatabaseStorageException result = RocksDbExceptionUtil.wrapException("Test", exception);
+    assertThat(result.isUnrecoverable()).isTrue();
+  }
+
+  @Test
+  void shouldBeUnrecoverableWhenCodeIsNotRecoverable() {
+    final RocksDBException exception =
+        new RocksDBException(new Status(Code.IOError, SubCode.None, null));
+    final DatabaseStorageException result = RocksDbExceptionUtil.wrapException("Test", exception);
+    assertThat(result.isUnrecoverable()).isTrue();
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
+++ b/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 import tech.pegasys.teku.pow.exception.InvalidDepositEventsException;
 import tech.pegasys.teku.service.serviceutils.FatalServiceFailureException;
+import tech.pegasys.teku.storage.server.DatabaseStorageException;
 import tech.pegasys.teku.storage.server.ShuttingDownException;
 
 public final class TekuDefaultExceptionHandler
@@ -90,6 +91,11 @@ public final class TekuDefaultExceptionHandler
     if (fatalServiceError.isPresent()) {
       final String failedService = fatalServiceError.get().getService().getSimpleName();
       statusLog.fatalError(failedService, exception);
+      System.exit(2);
+    } else if (ExceptionUtil.getCause(exception, DatabaseStorageException.class)
+        .filter(DatabaseStorageException::isUnrecoverable)
+        .isPresent()) {
+      statusLog.fatalError(subscriberDescription, exception);
       System.exit(2);
     } else if (exception instanceof OutOfMemoryError) {
       statusLog.fatalError(subscriberDescription, exception);


### PR DESCRIPTION
## PR Description
Exit teku when an unhandled `DatabaseStorageException` is encountered unless the `RocksDbException` status clearly indicates it is a temporary error.

## Fixed Issue(s)
fixes #3489 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
