### PR TITLE
 The ValidateableAttestation received from the network should be created with aggregateFromNetwork()

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/AggregateAttestationTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/AggregateAttestationTopicHandler.java
@@ -33,7 +33,7 @@ public class AggregateAttestationTopicHandler {
     OperationProcessor<SignedAggregateAndProof> convertingProcessor =
         proofMessage ->
             operationProcessor.process(
-                ValidateableAttestation.aggregateFromValidator(proofMessage));
+                ValidateableAttestation.aggregateFromNetwork(proofMessage));
     return new Eth2TopicHandler<>(
         asyncRunner,
         convertingProcessor,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/AggregateAttestationTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/AggregateAttestationTopicHandler.java
@@ -32,8 +32,7 @@ public class AggregateAttestationTopicHandler {
 
     OperationProcessor<SignedAggregateAndProof> convertingProcessor =
         proofMessage ->
-            operationProcessor.process(
-                ValidateableAttestation.aggregateFromNetwork(proofMessage));
+            operationProcessor.process(ValidateableAttestation.aggregateFromNetwork(proofMessage));
     return new Eth2TopicHandler<>(
         asyncRunner,
         convertingProcessor,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Follow up to @mbaxter comment here https://github.com/ConsenSys/teku/pull/3512/files/a0ac6ea3652d064a4f4e3422eb75c0f028912e32#r570493081

The ValidateableAttestation received from the network should be created with aggregateFromNetwork()

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
