### PR TITLE
Remove unused RocksDbAccessor method getLastEntry

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbAccessor.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbAccessor.java
@@ -50,16 +50,6 @@ public interface RocksDbAccessor extends AutoCloseable {
   <K, V> Optional<ColumnEntry<K, V>> getFirstEntry(RocksDbColumn<K, V> column);
 
   /**
-   * Returns the last entry in the given column.
-   *
-   * @param column The column we want to query
-   * @param <K> The key type of the column
-   * @param <V> The value type of the column
-   * @return The last entry in this column - the entry with the greatest key value
-   */
-  <K, V> Optional<ColumnEntry<K, V>> getLastEntry(RocksDbColumn<K, V> column);
-
-  /**
    * Returns the last key in the given column without loading the associated value.
    *
    * @param column The column we want to query

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/core/RocksDbInstance.java
@@ -110,15 +110,6 @@ public class RocksDbInstance implements RocksDbAccessor {
   }
 
   @Override
-  public <K, V> Optional<ColumnEntry<K, V>> getLastEntry(RocksDbColumn<K, V> column) {
-    assertOpen();
-    try (final Stream<ColumnEntry<K, V>> stream =
-        createStream(column, AbstractRocksIterator::seekToLast)) {
-      return stream.findFirst();
-    }
-  }
-
-  @Override
   public <K, V> Optional<K> getLastKey(final RocksDbColumn<K, V> column) {
     assertOpen();
     final ColumnFamilyHandle handle = columnHandles.get(column);

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/rocksdb/core/MockRocksDbInstance.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/rocksdb/core/MockRocksDbInstance.java
@@ -117,13 +117,6 @@ public class MockRocksDbInstance implements RocksDbAccessor {
   }
 
   @Override
-  public <K, V> Optional<ColumnEntry<K, V>> getLastEntry(final RocksDbColumn<K, V> column) {
-    assertOpen();
-    assertValidColumn(column);
-    return Optional.ofNullable(columnData.get(column).lastEntry()).map(e -> columnEntry(column, e));
-  }
-
-  @Override
   public <K, V> Optional<K> getLastKey(final RocksDbColumn<K, V> column) {
     assertOpen();
     assertValidColumn(column);


### PR DESCRIPTION
## PR Description
The `getLastEntry` method is unused so remove it.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
