### PR TITLE
Reset SpecDependent in Constants.setConstants

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/Eth2ReferenceTestCase.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.reference.phase0;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
-import tech.pegasys.teku.datastructures.util.SpecDependent;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.reference.phase0.bls.BlsTests;
 import tech.pegasys.teku.reference.phase0.epoch_processing.EpochProcessingTestExecutor;
@@ -26,6 +25,7 @@ import tech.pegasys.teku.reference.phase0.sanity.SanityTests;
 import tech.pegasys.teku.reference.phase0.shuffling.ShufflingTestExecutor;
 import tech.pegasys.teku.reference.phase0.ssz_static.SszTestExecutor;
 import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.util.config.SpecDependent;
 
 public abstract class Eth2ReferenceTestCase {
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
@@ -48,12 +48,12 @@ import tech.pegasys.teku.datastructures.state.HistoricalBatch;
 import tech.pegasys.teku.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.datastructures.state.SigningData;
 import tech.pegasys.teku.datastructures.state.Validator;
-import tech.pegasys.teku.datastructures.util.SpecDependent;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.reference.phase0.TestDataUtils;
 import tech.pegasys.teku.reference.phase0.TestExecutor;
 import tech.pegasys.teku.ssz.backing.SszData;
 import tech.pegasys.teku.ssz.backing.schema.SszSchema;
+import tech.pegasys.teku.util.config.SpecDependent;
 
 public class SszTestExecutor<T extends SszData> implements TestExecutor {
   private final Supplier<SszSchema<T>> sszType;

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/blocks/BeaconBlock.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/blocks/BeaconBlock.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.datastructures.blocks;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.state.BeaconState;
-import tech.pegasys.teku.datastructures.util.SpecDependent;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.backing.containers.Container5;
 import tech.pegasys.teku.ssz.backing.containers.ContainerSchema5;
@@ -24,6 +23,7 @@ import tech.pegasys.teku.ssz.backing.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.ssz.backing.tree.TreeNode;
 import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszBytes32;
 import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszUInt64;
+import tech.pegasys.teku.util.config.SpecDependent;
 
 public final class BeaconBlock
     extends Container5<BeaconBlock, SszUInt64, SszUInt64, SszBytes32, SszBytes32, BeaconBlockBody>

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/blocks/BeaconBlockBody.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/blocks/BeaconBlockBody.java
@@ -21,7 +21,6 @@ import tech.pegasys.teku.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.datastructures.operations.Deposit;
 import tech.pegasys.teku.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.datastructures.operations.SignedVoluntaryExit;
-import tech.pegasys.teku.datastructures.util.SpecDependent;
 import tech.pegasys.teku.ssz.SSZTypes.SSZBackingList;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 import tech.pegasys.teku.ssz.backing.SszList;
@@ -36,6 +35,7 @@ import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszByte;
 import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszBytes32;
 import tech.pegasys.teku.ssz.backing.view.SszUtils;
 import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.util.config.SpecDependent;
 
 /** A Beacon block body */
 public class BeaconBlockBody

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/blocks/SignedBeaconBlock.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/blocks/SignedBeaconBlock.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.datastructures.blocks;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.datastructures.util.SpecDependent;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.backing.SszVector;
 import tech.pegasys.teku.ssz.backing.containers.Container2;
@@ -25,6 +24,7 @@ import tech.pegasys.teku.ssz.backing.schema.SszComplexSchemas;
 import tech.pegasys.teku.ssz.backing.tree.TreeNode;
 import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszByte;
 import tech.pegasys.teku.ssz.backing.view.SszUtils;
+import tech.pegasys.teku.util.config.SpecDependent;
 
 public class SignedBeaconBlock
     extends Container2<SignedBeaconBlock, BeaconBlock, SszVector<SszByte>>

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/BeaconState.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/BeaconState.java
@@ -19,7 +19,6 @@ import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.datastructures.blocks.Eth1Data;
-import tech.pegasys.teku.datastructures.util.SpecDependent;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.SSZTypes.Bitvector;
 import tech.pegasys.teku.ssz.SSZTypes.SSZBackingList;
@@ -41,6 +40,7 @@ import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszUInt64;
 import tech.pegasys.teku.ssz.backing.view.SszUtils;
 import tech.pegasys.teku.ssz.sos.SszField;
 import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.util.config.SpecDependent;
 
 public interface BeaconState extends SszContainer {
 

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/HistoricalBatch.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/HistoricalBatch.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.datastructures.state;
 
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.datastructures.util.SpecDependent;
 import tech.pegasys.teku.ssz.SSZTypes.SSZBackingVector;
 import tech.pegasys.teku.ssz.SSZTypes.SSZVector;
 import tech.pegasys.teku.ssz.backing.SszVector;
@@ -27,6 +26,7 @@ import tech.pegasys.teku.ssz.backing.view.AbstractSszPrimitive;
 import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszBytes32;
 import tech.pegasys.teku.ssz.backing.view.SszUtils;
 import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.util.config.SpecDependent;
 
 public class HistoricalBatch
     extends Container2<HistoricalBatch, SszVector<SszBytes32>, SszVector<SszBytes32>> {

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/state/HistoricalBatchTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/state/HistoricalBatchTest.java
@@ -25,11 +25,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
-import tech.pegasys.teku.datastructures.util.SpecDependent;
 import tech.pegasys.teku.ssz.SSZTypes.SSZMutableVector;
 import tech.pegasys.teku.ssz.SSZTypes.SSZVector;
 import tech.pegasys.teku.ssz.backing.SszTestUtils;
 import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.util.config.SpecDependent;
 
 @ExtendWith(BouncyCastleExtension.class)
 public class HistoricalBatchTest {

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/LengthBoundsCalculatorTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/util/LengthBoundsCalculatorTest.java
@@ -53,6 +53,7 @@ import tech.pegasys.teku.datastructures.state.Validator;
 import tech.pegasys.teku.ssz.backing.schema.SszSchema;
 import tech.pegasys.teku.ssz.sos.SszLengthBounds;
 import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.util.config.SpecDependent;
 
 /**
  * This is in the wrong module but we want to be able to access the datastructure types to check

--- a/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
+++ b/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
@@ -26,7 +26,6 @@ import tech.pegasys.teku.core.exceptions.BlockProcessingException;
 import tech.pegasys.teku.core.lookup.IndexedAttestationProvider;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.util.BeaconStateUtil;
-import tech.pegasys.teku.datastructures.util.SpecDependent;
 import tech.pegasys.teku.fuzz.input.AttestationFuzzInput;
 import tech.pegasys.teku.fuzz.input.AttesterSlashingFuzzInput;
 import tech.pegasys.teku.fuzz.input.BlockFuzzInput;
@@ -43,6 +42,7 @@ import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 import tech.pegasys.teku.ssz.backing.SszData;
 import tech.pegasys.teku.ssz.backing.schema.SszSchema;
 import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.util.config.SpecDependent;
 
 public class FuzzUtil {
   // NOTE: alternatively could also have these all in separate classes, which implement a

--- a/fuzz/src/test/java/tech/pegasys/teku/fuzz/FuzzUtilTest.java
+++ b/fuzz/src/test/java/tech/pegasys/teku/fuzz/FuzzUtilTest.java
@@ -33,7 +33,6 @@ import tech.pegasys.teku.datastructures.operations.Deposit;
 import tech.pegasys.teku.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.datastructures.state.BeaconState;
-import tech.pegasys.teku.datastructures.util.SpecDependent;
 import tech.pegasys.teku.fuzz.input.AttestationFuzzInput;
 import tech.pegasys.teku.fuzz.input.AttesterSlashingFuzzInput;
 import tech.pegasys.teku.fuzz.input.BlockFuzzInput;
@@ -44,6 +43,7 @@ import tech.pegasys.teku.fuzz.input.VoluntaryExitFuzzInput;
 import tech.pegasys.teku.ssz.backing.SszData;
 import tech.pegasys.teku.ssz.backing.schema.SszSchema;
 import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.util.config.SpecDependent;
 
 @ExtendWith(BouncyCastleExtension.class)
 class FuzzUtilTest {

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -189,6 +189,7 @@ public class Constants {
     } catch (IOException e) {
       throw new InvalidConfigurationException("Failed to load constants from " + source, e);
     }
+    SpecDependent.resetAll();
   }
 
   public static InputStream createInputStream(final String source) throws IOException {

--- a/util/src/main/java/tech/pegasys/teku/util/config/SpecDependent.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/SpecDependent.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.datastructures.util;
+package tech.pegasys.teku.util.config;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;


### PR DESCRIPTION
## PR Description
Ensure that SSZ schemas are in sync with the network constants by automatically resetting `SpecDependent` in `Constants.setConstants`.

## Fixed Issue(s)
fixes #3555 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
