### PR TITLE
Use SpecProvider for GetGenesis REST API data

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetGenesis.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetGenesis.java
@@ -33,9 +33,7 @@ import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.response.v1.beacon.GenesisData;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
-import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.provider.JsonProvider;
-import tech.pegasys.teku.util.config.Constants;
 
 public class GetGenesis extends AbstractHandler implements Handler {
   public static final String ROUTE = "/eth/v1/beacon/genesis";
@@ -80,11 +78,6 @@ public class GetGenesis extends AbstractHandler implements Handler {
     if (!chainDataProvider.isStoreAvailable()) {
       return Optional.empty();
     }
-    final ForkInfo forkInfo = chainDataProvider.getForkInfo().asInternalForkInfo();
-    return Optional.of(
-        new GenesisData(
-            chainDataProvider.getGenesisTime(),
-            forkInfo.getGenesisValidatorsRoot(),
-            Constants.GENESIS_FORK_VERSION));
+    return Optional.of(chainDataProvider.getGenesisData());
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetGenesisTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetGenesisTest.java
@@ -18,14 +18,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.api.response.GetForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GenesisData;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
-import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.util.config.Constants;
 
 public class GetGenesisTest extends AbstractBeaconHandlerTest {
   final DataStructureUtil dataStructureUtil = new DataStructureUtil();
@@ -42,17 +38,16 @@ public class GetGenesisTest extends AbstractBeaconHandlerTest {
   @Test
   public void shouldReturnGenesisInformation() throws Exception {
     final GetGenesis handler = new GetGenesis(chainDataProvider, jsonProvider);
-    final UInt64 genesisTime = dataStructureUtil.randomUInt64();
-    final ForkInfo forkInfo = dataStructureUtil.randomForkInfo();
+    final GenesisData expectedGenesisData =
+        new GenesisData(
+            dataStructureUtil.randomUInt64(),
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomBytes4());
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
-    when(chainDataProvider.getGenesisTime()).thenReturn(genesisTime);
-    when(chainDataProvider.getForkInfo()).thenReturn(new GetForkResponse(forkInfo));
+    when(chainDataProvider.getGenesisData()).thenReturn(expectedGenesisData);
 
     handler.handle(context);
     final GetGenesisResponse response = getResponseObject(GetGenesisResponse.class);
-    assertThat(response.data)
-        .isEqualTo(
-            new GenesisData(
-                genesisTime, forkInfo.getGenesisValidatorsRoot(), Constants.GENESIS_FORK_VERSION));
+    assertThat(response.data).isEqualTo(expectedGenesisData);
   }
 }

--- a/data/provider/build.gradle
+++ b/data/provider/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
     testImplementation testFixtures(project(':ethereum:core'))
     testImplementation testFixtures(project(':ethereum:datastructures'))
+    testImplementation testFixtures(project(':ethereum:spec'))
     testImplementation testFixtures(project(':infrastructure:async'))
     testImplementation testFixtures(project(':storage'))
     testImplementation testFixtures(project(':bls'))

--- a/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
@@ -58,7 +58,8 @@ public class DataProvider {
             voluntaryExitPool,
             blockManager,
             attestationManager);
-    chainDataProvider = new ChainDataProvider(recentChainData, combinedChainDataClient);
+    chainDataProvider =
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     syncDataProvider = new SyncDataProvider(syncService);
     this.validatorDataProvider =
         new ValidatorDataProvider(validatorApiChannel, combinedChainDataClient);

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -71,13 +71,11 @@ public class ChainDataProviderTest {
   private tech.pegasys.teku.datastructures.state.BeaconState beaconStateInternal;
 
   private SignedBlockAndState bestBlock;
-  private BeaconState beaconState;
   private Bytes32 blockRoot;
   private UInt64 slot;
   private RecentChainData recentChainData;
   private final CombinedChainDataClient mockCombinedChainDataClient =
       mock(CombinedChainDataClient.class);
-  private final RecentChainData mockRecentChainData = mock(RecentChainData.class);
   private UInt64 actualBalance;
   private final DataStructureUtil data = new DataStructureUtil();
   private final SpecProvider specProvider = StubSpecProvider.create();
@@ -93,7 +91,6 @@ public class ChainDataProviderTest {
     recentChainData = storageSystem.recentChainData();
     beaconStateInternal = bestBlock.getState();
 
-    beaconState = new BeaconState(beaconStateInternal);
     combinedChainDataClient = storageSystem.combinedChainDataClient();
     blockRoot = bestBlock.getRoot();
   }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -34,9 +34,9 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
-import tech.pegasys.teku.api.response.GetForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.BlockHeader;
 import tech.pegasys.teku.api.response.v1.beacon.FinalityCheckpointsResponse;
+import tech.pegasys.teku.api.response.v1.beacon.GenesisData;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.api.response.v1.debug.ChainHead;
 import tech.pegasys.teku.api.schema.Attestation;
@@ -53,6 +53,8 @@ import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecProvider;
+import tech.pegasys.teku.spec.StubSpecProvider;
 import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
 import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -78,6 +80,7 @@ public class ChainDataProviderTest {
   private final RecentChainData mockRecentChainData = mock(RecentChainData.class);
   private UInt64 actualBalance;
   private final DataStructureUtil data = new DataStructureUtil();
+  private final SpecProvider specProvider = StubSpecProvider.create();
 
   @BeforeEach
   public void setup() {
@@ -99,7 +102,7 @@ public class ChainDataProviderTest {
   public void getChainHeads_shouldReturnChainHeads()
       throws ExecutionException, InterruptedException {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     final SafeFuture<Optional<List<ChainHead>>> future = provider.getChainHeads();
     final Optional<List<ChainHead>> maybeResult = future.get();
     assertThat(maybeResult.orElse(emptyList()))
@@ -108,7 +111,8 @@ public class ChainDataProviderTest {
 
   @Test
   public void getGenesisTime_shouldThrowIfStoreNotAvailable() {
-    final ChainDataProvider provider = new ChainDataProvider(null, mockCombinedChainDataClient);
+    final ChainDataProvider provider =
+        new ChainDataProvider(specProvider, null, mockCombinedChainDataClient);
     when(mockCombinedChainDataClient.isStoreAvailable()).thenReturn(false);
     assertThatThrownBy(provider::getGenesisTime).isInstanceOf(ChainDataUnavailableException.class);
   }
@@ -117,17 +121,39 @@ public class ChainDataProviderTest {
   public void getGenesisTime_shouldReturnValueIfStoreAvailable() {
     final UInt64 genesis = beaconStateInternal.getGenesis_time();
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
 
     final UInt64 result = provider.getGenesisTime();
     assertEquals(genesis, result);
   }
 
   @Test
+  public void getGenesisData_shouldThrowIfStoreNotAvailable() {
+    final ChainDataProvider provider =
+        new ChainDataProvider(specProvider, null, mockCombinedChainDataClient);
+    when(mockCombinedChainDataClient.isStoreAvailable()).thenReturn(false);
+    assertThatThrownBy(provider::getGenesisData).isInstanceOf(ChainDataUnavailableException.class);
+  }
+
+  @Test
+  public void getGenesisData_shouldReturnValueIfStoreAvailable() {
+    final UInt64 genesisTime = beaconStateInternal.getGenesis_time();
+    final Bytes32 genesisValidatorsRoot = beaconStateInternal.getGenesis_validators_root();
+    final Bytes4 genesisForkVersion = specProvider.get(ZERO).getConstants().getGenesisForkVersion();
+
+    final ChainDataProvider provider =
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
+
+    final GenesisData result = provider.getGenesisData();
+    assertThat(result)
+        .isEqualTo(new GenesisData(genesisTime, genesisValidatorsRoot, genesisForkVersion));
+  }
+
+  @Test
   public void getBeaconState_shouldReturnEmptyWhenRootNotFound()
       throws ExecutionException, InterruptedException {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     SafeFuture<Optional<BeaconState>> future =
         provider.getBeaconState(data.randomBytes32().toHexString());
     final Optional<BeaconState> maybeState = future.get();
@@ -137,7 +163,7 @@ public class ChainDataProviderTest {
   @Test
   public void getBeaconState_shouldFindHeadState() throws ExecutionException, InterruptedException {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     SafeFuture<Optional<BeaconState>> future = provider.getBeaconState("head");
     final Optional<BeaconState> maybeState = future.get();
     assertThat(maybeState.get().asInternalBeaconState().hashTreeRoot())
@@ -146,39 +172,16 @@ public class ChainDataProviderTest {
 
   @Test
   public void validatorParameterToIndex_shouldThrowWhenStoreNotFound() {
-    final ChainDataProvider provider = new ChainDataProvider(null, mockCombinedChainDataClient);
+    final ChainDataProvider provider =
+        new ChainDataProvider(specProvider, null, mockCombinedChainDataClient);
     assertThrows(
         ChainDataUnavailableException.class, () -> provider.validatorParameterToIndex("1"));
   }
 
   @Test
-  public void getForkInfo_shouldThrowIfNoBlockRoot() {
-    ChainDataProvider provider =
-        new ChainDataProvider(mockRecentChainData, mockCombinedChainDataClient);
-    when(mockCombinedChainDataClient.isStoreAvailable()).thenReturn(true);
-    when(mockRecentChainData.getBestState()).thenReturn(Optional.empty());
-    assertThatThrownBy(provider::getForkInfo).isInstanceOf(ChainDataUnavailableException.class);
-  }
-
-  @Test
-  public void getForkInfo_shouldHaveForkIfBlockRootNotEmpty() {
-    final ChainDataProvider provider =
-        new ChainDataProvider(mockRecentChainData, mockCombinedChainDataClient);
-    when(mockCombinedChainDataClient.isStoreAvailable()).thenReturn(true);
-    when(mockRecentChainData.getBestState()).thenReturn(Optional.of(beaconStateInternal));
-    final GetForkResponse result = provider.getForkInfo();
-    verify(mockCombinedChainDataClient).isStoreAvailable();
-
-    assertThat(result.previous_version).isEqualTo(beaconState.fork.previous_version);
-    assertThat(result.current_version).isEqualTo(beaconState.fork.current_version);
-    assertThat(result.epoch).isEqualTo(beaconState.fork.epoch);
-    assertThat(result.genesis_validators_root).isEqualTo(beaconState.genesis_validators_root);
-  }
-
-  @Test
   public void validatorParameterToIndex_shouldAcceptValidatorRoot() {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
 
     Validator validator =
         new Validator(recentChainData.getBestState().get().getValidators().get(1));
@@ -190,7 +193,7 @@ public class ChainDataProviderTest {
   @Test
   public void validatorParameterToIndex_shouldAcceptValidatorId() {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
 
     assertThat(provider.validatorParameterToIndex("2")).isEqualTo(Optional.of(2));
   }
@@ -198,7 +201,7 @@ public class ChainDataProviderTest {
   @Test
   public void validatorParameterToIndex_shouldThrowException() {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
 
     assertThrows(BadRequestException.class, () -> provider.validatorParameterToIndex("2a"));
   }
@@ -206,7 +209,7 @@ public class ChainDataProviderTest {
   @Test
   public void validatorParameterToIndex_shouldDetectAboveMaxInt() {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
 
     assertThrows(
         BadRequestException.class,
@@ -218,7 +221,7 @@ public class ChainDataProviderTest {
   @Test
   public void validatorParameterToIndex_shouldThrowExceptionWithInvalidPublicKey() {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
 
     assertThrows(
         BadRequestException.class,
@@ -229,7 +232,7 @@ public class ChainDataProviderTest {
   public void getBlockHeaderByBlockId_shouldGetHeadBlock()
       throws ExecutionException, InterruptedException {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     final tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock block =
         combinedChainDataClient.getBestBlock().get();
     BlockHeader result = provider.getBlockHeader("head").get().get();
@@ -253,7 +256,7 @@ public class ChainDataProviderTest {
   public void getStateRoot_shouldGetRootAtGenesis()
       throws ExecutionException, InterruptedException {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
 
     final Optional<tech.pegasys.teku.datastructures.state.BeaconState> state =
         combinedChainDataClient.getStateAtSlotExact(ZERO).get();
@@ -266,7 +269,7 @@ public class ChainDataProviderTest {
   public void getBlockHeaders_shouldGetHeadBlockIfNoParameters()
       throws ExecutionException, InterruptedException {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     final tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock block =
         combinedChainDataClient.getBestBlock().get();
     List<BlockHeader> results = provider.getBlockHeaders(Optional.empty(), Optional.empty()).get();
@@ -277,7 +280,7 @@ public class ChainDataProviderTest {
   public void getBlockHeaders_shouldGetBlockGivenSlot()
       throws ExecutionException, InterruptedException {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     final UInt64 slot = combinedChainDataClient.getCurrentSlot();
     List<BlockHeader> results = provider.getBlockHeaders(Optional.empty(), Optional.of(slot)).get();
     assertThat(results.get(0).header.message.slot).isEqualTo(slot);
@@ -286,7 +289,7 @@ public class ChainDataProviderTest {
   @Test
   public void shouldGetBlockHeadersOnEmptyChainHeadSlot() {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
 
     final UInt64 headSlot = recentChainData.getHeadSlot();
     storageSystem.chainUpdater().advanceChain(headSlot.plus(1));
@@ -303,7 +306,7 @@ public class ChainDataProviderTest {
     final tech.pegasys.teku.datastructures.state.BeaconState internalState =
         data.randomBeaconState(1024);
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     List<Integer> indexes =
         provider.getFilteredValidatorList(internalState, List.of("1", "33"), emptySet()).stream()
             .map(v -> v.index.intValue())
@@ -316,7 +319,7 @@ public class ChainDataProviderTest {
     final tech.pegasys.teku.datastructures.state.BeaconState internalState =
         data.randomBeaconState(1024);
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     final String key = internalState.getValidators().get(12).getPubkey().toString();
     final String missingKey = data.randomPublicKey().toString();
     List<String> pubkeys =
@@ -330,21 +333,21 @@ public class ChainDataProviderTest {
   @Test
   public void validatorParameterToIndex_shouldThrowBadRequestExceptionWhenIndexInvalid() {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     assertThrows(BadRequestException.class, () -> provider.validatorParameterToIndex("a"));
   }
 
   @Test
   public void validatorParameterToIndex_shouldReturnEmptyIfIndexOutOfBounds() {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     assertThat(provider.validatorParameterToIndex("1024000")).isEmpty();
   }
 
   @Test
   public void validatorParameterToIndex_shouldThrowBadRequestExceptionWhenKeyNotFound() {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     assertThrows(
         BadRequestException.class,
         () -> provider.validatorParameterToIndex(Bytes32.fromHexString("0x00").toHexString()));
@@ -355,7 +358,7 @@ public class ChainDataProviderTest {
     final tech.pegasys.teku.datastructures.state.BeaconState internalState =
         data.randomBeaconState(11);
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
 
     assertThat(
             provider.getFilteredValidatorList(
@@ -371,7 +374,7 @@ public class ChainDataProviderTest {
   public void getStateCommittees_shouldReturnEmptyIfStateNotFound()
       throws ExecutionException, InterruptedException {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     assertThat(
             provider
                 .getStateCommittees(
@@ -388,7 +391,7 @@ public class ChainDataProviderTest {
     final tech.pegasys.teku.datastructures.state.BeaconState internalState =
         data.randomBeaconState(64);
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
 
     assertThat(
             provider
@@ -403,7 +406,7 @@ public class ChainDataProviderTest {
     final tech.pegasys.teku.datastructures.state.BeaconState internalState =
         data.randomBeaconState(64);
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
 
     assertThat(
             provider
@@ -420,7 +423,7 @@ public class ChainDataProviderTest {
   public void getStateFinalityCheckpoints_shouldGetEmptyCheckpointsBeforeFinalized()
       throws ExecutionException, InterruptedException {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
 
     assertThat(provider.getStateFinalityCheckpoints("genesis").get().get())
         .isEqualTo(
@@ -434,7 +437,7 @@ public class ChainDataProviderTest {
   public void getStateFinalityCheckpoints_shouldGetCheckpointsAfterFinalized()
       throws ExecutionException, InterruptedException {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, mockCombinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, mockCombinedChainDataClient);
     final tech.pegasys.teku.datastructures.state.BeaconState internalState =
         data.randomBeaconState(UInt64.valueOf(42));
     final FinalityCheckpointsResponse expected =
@@ -454,7 +457,7 @@ public class ChainDataProviderTest {
   public void getStateFork_shouldGetForkAtGenesis()
       throws ExecutionException, InterruptedException {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
 
     final Bytes4 bytes4 = Bytes4.fromHexString("0x00000001");
     final Optional<Fork> response = provider.getStateFork("genesis").get();
@@ -465,7 +468,7 @@ public class ChainDataProviderTest {
   @Test
   public void getValidatorBalancesFromState_shouldGetBalances() {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     final tech.pegasys.teku.datastructures.state.BeaconState internalState =
         data.randomBeaconState(1024);
     assertThat(provider.getValidatorBalancesFromState(internalState, emptyList())).hasSize(1024);
@@ -479,7 +482,7 @@ public class ChainDataProviderTest {
   @Test
   public void getForkSchedule() {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     assertThat(provider.getForkSchedule())
         .containsExactly(
             new Fork(recentChainData.getForkInfoAtCurrentTime().orElseThrow().getFork()));
@@ -488,7 +491,7 @@ public class ChainDataProviderTest {
   @Test
   public void getBlockRoot_shouldReturnRootOfBlock() throws Exception {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     final Optional<Root> response = provider.getBlockRoot("head").get();
     assertThat(response).isPresent();
     assertThat(response.get()).isEqualTo(new Root(bestBlock.getRoot()));
@@ -497,7 +500,7 @@ public class ChainDataProviderTest {
   @Test
   public void getBlockAttestations_shouldReturnAttestationsOfBlock() throws Exception {
     final ChainDataProvider provider =
-        new ChainDataProvider(recentChainData, combinedChainDataClient);
+        new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient);
     ChainBuilder chainBuilder = storageSystem.chainBuilder();
 
     ChainBuilder.BlockOptions blockOptions = ChainBuilder.BlockOptions.create();

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/GetForkResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/GetForkResponse.java
@@ -59,9 +59,4 @@ public class GetForkResponse {
     }
     genesis_validators_root = forkInfo.getGenesisValidatorsRoot();
   }
-
-  public tech.pegasys.teku.datastructures.state.ForkInfo asInternalForkInfo() {
-    return new tech.pegasys.teku.datastructures.state.ForkInfo(
-        new Fork(previous_version, current_version, epoch), genesis_validators_root);
-  }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -463,7 +463,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
         eventChannels.getPublisher(BlockImportChannel.class, beaconAsyncRunner);
     final ValidatorApiHandler validatorApiHandler =
         new ValidatorApiHandler(
-            new ChainDataProvider(recentChainData, combinedChainDataClient),
+            new ChainDataProvider(specProvider, recentChainData, combinedChainDataClient),
             combinedChainDataClient,
             syncService,
             blockFactory,


### PR DESCRIPTION
## PR Description
Eliminate a use of `Constants` in `GetGenesis` API handler.

## Fixed Issue(s)
#3394 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
