### PR TITLE
[Issue-3563] Simplify AsyncRunner API

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/FutureUtil.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/FutureUtil.java
@@ -13,8 +13,8 @@
 
 package tech.pegasys.teku.infrastructure.async;
 
+import java.time.Duration;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -28,8 +28,7 @@ public class FutureUtil {
       AsyncRunner runner,
       ExceptionThrowingRunnable runnable,
       Cancellable task,
-      long delayAmount,
-      TimeUnit delayUnit,
+      final Duration duration,
       Consumer<Throwable> exceptionHandler) {
 
     runner
@@ -45,13 +44,11 @@ public class FutureUtil {
                     LOG.warn("Exception in exception handler", e);
                   }
                 } finally {
-                  runWithFixedDelay(
-                      runner, runnable, task, delayAmount, delayUnit, exceptionHandler);
+                  runWithFixedDelay(runner, runnable, task, duration, exceptionHandler);
                 }
               }
             },
-            delayAmount,
-            delayUnit)
+            duration)
         .finish(() -> {}, exceptionHandler);
   }
 

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.infrastructure.async;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -492,6 +493,10 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   @Override
   public SafeFuture<T> whenComplete(final BiConsumer<? super T, ? super Throwable> action) {
     return (SafeFuture<T>) super.whenComplete(action);
+  }
+
+  public SafeFuture<T> orTimeout(final Duration timeout) {
+    return orTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.infrastructure.async;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -74,9 +75,7 @@ public class ScheduledExecutorAsyncRunner implements AsyncRunner {
   @Override
   @SuppressWarnings("FutureReturnValueIgnored")
   public <U> SafeFuture<U> runAfterDelay(
-      final ExceptionThrowingFutureSupplier<U> action,
-      final long delayAmount,
-      final TimeUnit delayUnit) {
+      final ExceptionThrowingFutureSupplier<U> action, final Duration delay) {
     if (shutdown.get()) {
       LOG.debug("Ignoring async task because shutdown is in progress");
       return new SafeFuture<>();
@@ -91,8 +90,8 @@ public class ScheduledExecutorAsyncRunner implements AsyncRunner {
               handleExecutorError(result, t);
             }
           },
-          delayAmount,
-          delayUnit);
+          delay.toMillis(),
+          TimeUnit.MILLISECONDS);
     } catch (final Throwable t) {
       handleExecutorError(result, t);
     }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/timed/RepeatingTaskScheduler.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/timed/RepeatingTaskScheduler.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.infrastructure.async.timed;
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.infrastructure.time.TimeProvider.MILLIS_PER_SECOND;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -69,7 +69,7 @@ public class RepeatingTaskScheduler {
     }
     asyncRunner
         .runAfterDelay(
-            () -> scheduleEvent(event), dueMs.minus(nowMs).longValue(), TimeUnit.MILLISECONDS)
+            () -> scheduleEvent(event), Duration.ofMillis(dueMs.minus(nowMs).longValue()))
         .finish(
             error -> {
               LOG.error("Failed to schedule next repeat of event. Skipping", error);

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/DelayedExecutorAsyncRunnerTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/DelayedExecutorAsyncRunnerTest.java
@@ -24,8 +24,8 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 import static tech.pegasys.teku.infrastructure.async.Waiter.waitFor;
 
+import java.time.Duration;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
@@ -133,8 +133,7 @@ public class DelayedExecutorAsyncRunnerTest {
   public void testRecurrentTaskCancel() throws Exception {
     AtomicInteger counter = new AtomicInteger();
     Cancellable task =
-        asyncRunner.runWithFixedDelay(
-            counter::incrementAndGet, 100, TimeUnit.MILLISECONDS, t -> {});
+        asyncRunner.runWithFixedDelay(counter::incrementAndGet, Duration.ofMillis(100), t -> {});
     waitFor(() -> assertThat(counter).hasValueGreaterThan(3));
     task.cancel();
     int cnt1 = counter.get();
@@ -154,8 +153,7 @@ public class DelayedExecutorAsyncRunnerTest {
                 throw new RuntimeException("Ups");
               }
             },
-            100,
-            TimeUnit.MILLISECONDS,
+            Duration.ofMillis(100),
             exception::set);
     waitFor(() -> assertThat(counter).hasValueGreaterThan(3));
     assertThat(exception.get()).hasMessageContaining("Ups");

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunnerTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunnerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -142,8 +143,7 @@ class ScheduledExecutorAsyncRunnerTest {
             });
     AtomicInteger counter = new AtomicInteger();
     Cancellable task =
-        asyncRunner.runWithFixedDelay(
-            counter::incrementAndGet, 100, TimeUnit.MILLISECONDS, t -> {});
+        asyncRunner.runWithFixedDelay(counter::incrementAndGet, Duration.ofMillis(100), t -> {});
     assertThat(scheduledActions).hasSize(1);
     scheduledActions.get(0).run();
     assertThat(counter).hasValue(1);
@@ -175,8 +175,7 @@ class ScheduledExecutorAsyncRunnerTest {
             throw new RuntimeException("Ups");
           }
         },
-        100,
-        TimeUnit.MILLISECONDS,
+        Duration.ofMillis(100),
         exception::set);
     assertThat(scheduledActions).hasSize(1);
     scheduledActions.get(0).run();
@@ -192,7 +191,7 @@ class ScheduledExecutorAsyncRunnerTest {
     final RejectedExecutionException exception = new RejectedExecutionException("Too lazy");
     doThrow(exception).when(workerPool).execute(any());
 
-    final SafeFuture<Void> result = asyncRunner.runAfterDelay(() -> {}, 100, TimeUnit.MILLISECONDS);
+    final SafeFuture<Void> result = asyncRunner.runAfterDelay(() -> {}, Duration.ofMillis(100));
 
     final ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
     verify(scheduler).schedule(taskCaptor.capture(), eq(100L), eq(TimeUnit.MILLISECONDS));

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/DelayedExecutorAsyncRunner.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/DelayedExecutorAsyncRunner.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.infrastructure.async;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
@@ -45,8 +46,8 @@ public class DelayedExecutorAsyncRunner implements AsyncRunner {
 
   @Override
   public <U> SafeFuture<U> runAfterDelay(
-      ExceptionThrowingFutureSupplier<U> action, long delayAmount, TimeUnit delayUnit) {
-    final Executor executor = getDelayedExecutor(delayAmount, delayUnit);
+      ExceptionThrowingFutureSupplier<U> action, Duration delay) {
+    final Executor executor = getDelayedExecutor(delay.toMillis(), TimeUnit.MILLISECONDS);
     return runAsync(action, executor);
   }
 

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/StubAsyncRunner.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/StubAsyncRunner.java
@@ -16,11 +16,11 @@ package tech.pegasys.teku.infrastructure.async;
 import static com.google.common.base.Preconditions.checkState;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.propagateResult;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
-import java.util.concurrent.TimeUnit;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
@@ -62,9 +62,8 @@ public class StubAsyncRunner implements AsyncRunner {
 
   @Override
   public <U> SafeFuture<U> runAfterDelay(
-      ExceptionThrowingFutureSupplier<U> action, long delayAmount, TimeUnit delayUnit) {
-    return schedule(
-        action, timeProvider.getTimeInMillis().longValue() + delayUnit.toMillis(delayAmount));
+      ExceptionThrowingFutureSupplier<U> action, Duration delay) {
+    return schedule(action, timeProvider.getTimeInMillis().longValue() + delay.toMillis());
   }
 
   @Override

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/SyncAsyncRunner.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/SyncAsyncRunner.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.infrastructure.async;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 public class SyncAsyncRunner implements AsyncRunner {
   public static final SyncAsyncRunner SYNC_RUNNER = new SyncAsyncRunner();
@@ -27,9 +27,7 @@ public class SyncAsyncRunner implements AsyncRunner {
 
   @Override
   public <U> SafeFuture<U> runAfterDelay(
-      final ExceptionThrowingFutureSupplier<U> action,
-      final long delayAmount,
-      final TimeUnit delayUnit) {
+      final ExceptionThrowingFutureSupplier<U> action, final Duration delay) {
     throw new UnsupportedOperationException(
         "Delayed execution not possible using " + SyncAsyncRunner.class.getName());
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -17,7 +17,6 @@ import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -36,6 +35,7 @@ import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.MetadataMessagesFactory;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
+import tech.pegasys.teku.networking.eth2.rpc.core.RpcTimeouts;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.networking.p2p.network.PeerHandler;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
@@ -45,7 +45,6 @@ import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
-import tech.pegasys.teku.util.config.Constants;
 
 public class Eth2PeerManager implements PeerLookup, PeerHandler {
   private static final Logger LOG = LogManager.getLogger();
@@ -158,16 +157,14 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
                 .finish(
                     () -> LOG.trace("Updated status for peer {}", peer),
                     err -> LOG.debug("Exception updating status for peer {}", peer, err)),
-        eth2StatusUpdateInterval.getSeconds(),
-        TimeUnit.SECONDS,
+        eth2StatusUpdateInterval,
         err -> LOG.debug("Exception calling runnable for updating peer status.", err));
   }
 
   Cancellable periodicallyPingPeer(Eth2Peer peer) {
     return asyncRunner.runWithFixedDelay(
         () -> sendPeriodicPing(peer),
-        eth2RpcPingInterval.toMillis(),
-        TimeUnit.MILLISECONDS,
+        eth2RpcPingInterval,
         err -> LOG.debug("Exception calling runnable for pinging peer", err));
   }
 
@@ -220,8 +217,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
                 peer.disconnectCleanly(DisconnectReason.REMOTE_FAULT).reportExceptions();
               }
             },
-            Constants.RESP_TIMEOUT,
-            TimeUnit.SECONDS)
+            RpcTimeouts.RESP_TIMEOUT)
         .finish(
             () -> {},
             error -> {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
@@ -17,7 +17,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -115,7 +114,7 @@ public class Eth2IncomingRequestHandler<
   private void ensureRequestReceivedWithinTimeLimit(final RpcStream stream) {
     final Duration timeout = RpcTimeouts.RESP_TIMEOUT;
     asyncRunner
-        .getDelayedFuture(timeout.toMillis(), TimeUnit.MILLISECONDS)
+        .getDelayedFuture(timeout)
         .thenAccept(
             (__) -> {
               if (!requestHandled.get()) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcTimeouts.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcTimeouts.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.networking.eth2.rpc.core;
 
 import java.time.Duration;
 import tech.pegasys.teku.networking.p2p.rpc.StreamTimeoutException;
-import tech.pegasys.teku.util.config.Constants;
 
 /**
  * This class holds constants related to handling rpc request timeouts. See:
@@ -24,9 +23,9 @@ import tech.pegasys.teku.util.config.Constants;
 public abstract class RpcTimeouts {
 
   // The maximum time to wait for first byte of request response (time-to-first-byte).
-  static final Duration TTFB_TIMEOUT = Duration.ofSeconds(Constants.TTFB_TIMEOUT);
+  static final Duration TTFB_TIMEOUT = Duration.ofSeconds(5);
   // The maximum time for complete response transfer.
-  static final Duration RESP_TIMEOUT = Duration.ofSeconds(Constants.RESP_TIMEOUT);
+  public static final Duration RESP_TIMEOUT = Duration.ofSeconds(10);
 
   public static class RpcTimeoutException extends StreamTimeoutException {
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManager.java
@@ -92,8 +92,7 @@ public class ConnectionManager extends Service {
     periodicPeerSearch =
         asyncRunner.runWithFixedDelay(
             this::searchForPeers,
-            DISCOVERY_INTERVAL.toMillis(),
-            TimeUnit.MILLISECONDS,
+            DISCOVERY_INTERVAL,
             error -> LOG.error("Error while searching for peers", error));
     connectToKnownPeers();
     searchForPeers();
@@ -197,9 +196,7 @@ public class ConnectionManager extends Service {
                         RECONNECT_TIMEOUT.toSeconds());
                     asyncRunner
                         .runAfterDelay(
-                            () -> maintainPersistentConnection(peerAddress),
-                            RECONNECT_TIMEOUT.toMillis(),
-                            TimeUnit.MILLISECONDS)
+                            () -> maintainPersistentConnection(peerAddress), RECONNECT_TIMEOUT)
                         .reportExceptions();
                   });
               return peer;
@@ -213,9 +210,7 @@ public class ConnectionManager extends Service {
                   RECONNECT_TIMEOUT.toSeconds());
               failedConnectionCounter.inc();
               return asyncRunner.runAfterDelay(
-                  () -> maintainPersistentConnection(peerAddress),
-                  RECONNECT_TIMEOUT.toMillis(),
-                  TimeUnit.MILLISECONDS);
+                  () -> maintainPersistentConnection(peerAddress), RECONNECT_TIMEOUT);
             });
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandler.java
@@ -29,7 +29,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -68,7 +67,7 @@ public class RpcHandler implements ProtocolBinding<Controller> {
         SafeFuture.createInterruptor(connection.closeFuture(), PeerDisconnectedException::new);
     Interruptor timeoutInterruptor =
         SafeFuture.createInterruptor(
-            asyncRunner.getDelayedFuture(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS),
+            asyncRunner.getDelayedFuture(TIMEOUT),
             () ->
                 new StreamTimeoutException(
                     "Timed out waiting to initialize stream for method " + rpcMethod.getId()));

--- a/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
@@ -28,7 +28,6 @@ import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -109,8 +108,7 @@ public class DepositFetcher {
 
               return asyncRunner.runAfterDelay(
                   () -> sendNextBatchRequest(fetchState),
-                  Constants.ETH1_DEPOSIT_REQUEST_RETRY_TIMEOUT,
-                  TimeUnit.SECONDS);
+                  Constants.ETH1_DEPOSIT_REQUEST_RETRY_TIMEOUT);
             })
         .thenCompose(
             __ -> {

--- a/pow/src/main/java/tech/pegasys/teku/pow/DepositProcessingController.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/DepositProcessingController.java
@@ -18,7 +18,6 @@ import static tech.pegasys.teku.pow.MinimumGenesisTimeBlockFinder.notifyMinGenes
 
 import com.google.common.base.Throwables;
 import java.math.BigInteger;
-import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -182,7 +181,7 @@ public class DepositProcessingController {
         err);
 
     asyncRunner
-        .getDelayedFuture(Constants.ETH1_DEPOSIT_REQUEST_RETRY_TIMEOUT, TimeUnit.SECONDS)
+        .getDelayedFuture(Constants.ETH1_DEPOSIT_REQUEST_RETRY_TIMEOUT)
         .finish(
             this::fetchLatestSubscriptionDeposits,
             (error) -> LOG.warn("Unable to execute delayed request. Dropping request", error));

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1DepositManager.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1DepositManager.java
@@ -20,7 +20,6 @@ import static tech.pegasys.teku.pow.MinimumGenesisTimeBlockFinder.notifyMinGenes
 import com.google.common.base.Preconditions;
 import java.math.BigInteger;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.web3j.protocol.core.methods.response.EthBlock;
@@ -175,11 +174,11 @@ public class Eth1DepositManager {
               LOG.debug(
                   "Eth1DepositManager failed to get the head of Eth1: {}. Retrying in {} seconds.",
                   err.getMessage(),
-                  Constants.ETH1_DEPOSIT_REQUEST_RETRY_TIMEOUT,
+                  Constants.ETH1_DEPOSIT_REQUEST_RETRY_TIMEOUT.toSeconds(),
                   err);
 
               return asyncRunner
-                  .getDelayedFuture(Constants.ETH1_DEPOSIT_REQUEST_RETRY_TIMEOUT, TimeUnit.SECONDS)
+                  .getDelayedFuture(Constants.ETH1_DEPOSIT_REQUEST_RETRY_TIMEOUT)
                   .thenCompose((__) -> getHead());
             });
   }
@@ -194,8 +193,7 @@ public class Eth1DepositManager {
   private SafeFuture<UInt64> waitForEth1ChainToReachFollowDistanceIfNecessary(UInt64 number) {
     if (number.isLessThan(Constants.ETH1_FOLLOW_DISTANCE)) {
       return asyncRunner
-          .getDelayedFuture(
-              Constants.ETH1_LOCAL_CHAIN_BEHIND_FOLLOW_DISTANCE_WAIT, TimeUnit.SECONDS)
+          .getDelayedFuture(Constants.ETH1_LOCAL_CHAIN_BEHIND_FOLLOW_DISTANCE_WAIT)
           .thenCompose(__ -> getLatestEth1BlockNumber())
           .thenCompose(this::waitForEth1ChainToReachFollowDistanceIfNecessary);
     } else {

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1HeadTracker.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1HeadTracker.java
@@ -15,8 +15,8 @@ package tech.pegasys.teku.pow;
 
 import static tech.pegasys.teku.util.config.Constants.ETH1_FOLLOW_DISTANCE;
 
+import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -65,8 +65,7 @@ public class Eth1HeadTracker {
                 asyncRunner
                     .runAfterDelay(
                         this::pollLatestHead,
-                        Constants.SECONDS_PER_ETH1_BLOCK.longValue(),
-                        TimeUnit.SECONDS)
+                        Duration.ofSeconds(Constants.SECONDS_PER_ETH1_BLOCK.longValue()))
                     .finish(
                         () -> {},
                         error ->

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1StatusLogger.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1StatusLogger.java
@@ -15,8 +15,8 @@ package tech.pegasys.teku.pow;
 
 import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 
+import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -26,7 +26,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class Eth1StatusLogger {
   private static final Logger LOG = LogManager.getLogger();
-  private static final int LOG_INTERVAL = 30000;
+  private static final Duration LOG_INTERVAL = Duration.ofSeconds(30);
 
   private final AsyncRunner asyncRunner;
   private final TimeProvider timeProvider;
@@ -53,7 +53,6 @@ public class Eth1StatusLogger {
           asyncRunner.runWithFixedDelay(
               () -> reportOutage(outageStartInSeconds),
               LOG_INTERVAL,
-              TimeUnit.MILLISECONDS,
               error -> LOG.error("Failed to check Eth1 status", error));
       activeReporter = Optional.of(reporter);
     }

--- a/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
@@ -17,7 +17,6 @@ import java.math.BigInteger;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.web3j.protocol.Web3j;
@@ -81,8 +80,7 @@ public class Web3jEth1Provider implements Eth1Provider {
             (err) -> {
               LOG.debug("Retrying Eth1 request for block: {}", blockHash, err);
               return asyncRunner
-                  .getDelayedFuture(
-                      Constants.ETH1_INDIVIDUAL_BLOCK_RETRY_TIMEOUT, TimeUnit.MILLISECONDS)
+                  .getDelayedFuture(Constants.ETH1_INDIVIDUAL_BLOCK_RETRY_TIMEOUT)
                   .thenCompose(__ -> getGuaranteedEth1Block(blockHash));
             });
   }
@@ -95,8 +93,7 @@ public class Web3jEth1Provider implements Eth1Provider {
             (err) -> {
               LOG.debug("Retrying Eth1 request for block: {}", blockNumber, err);
               return asyncRunner
-                  .getDelayedFuture(
-                      Constants.ETH1_INDIVIDUAL_BLOCK_RETRY_TIMEOUT, TimeUnit.MILLISECONDS)
+                  .getDelayedFuture(Constants.ETH1_INDIVIDUAL_BLOCK_RETRY_TIMEOUT)
                   .thenCompose(__ -> getGuaranteedEth1Block(blockNumber));
             });
   }

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/Eth1ChainIdValidator.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/Eth1ChainIdValidator.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.services.powchain;
 
 import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -61,7 +61,8 @@ public class Eth1ChainIdValidator {
                     Constants.DEPOSIT_CHAIN_ID, chainId.intValueExact());
               }
             })
-        .handleComposed((__, err) -> asyncRunner.runAfterDelay(this::validate, 1, TimeUnit.MINUTES))
+        .handleComposed(
+            (__, err) -> asyncRunner.runAfterDelay(this::validate, Duration.ofMinutes(1)))
         .reportExceptions();
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainData.java
@@ -19,7 +19,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.eventbus.EventBus;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -160,9 +159,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
   }
 
   private SafeFuture<Optional<StoreBuilder>> requestInitialStore() {
-    return storageQueryChannel
-        .onStoreRequest()
-        .orTimeout(Constants.STORAGE_REQUEST_TIMEOUT, TimeUnit.SECONDS);
+    return storageQueryChannel.onStoreRequest().orTimeout(Constants.STORAGE_REQUEST_TIMEOUT);
   }
 
   private SafeFuture<Optional<StoreBuilder>> requestInitialStoreWithRetry(
@@ -174,8 +171,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
                 LOG.trace("Storage initialization timed out, will retry.");
                 return asyncRunner.runAfterDelay(
                     () -> requestInitialStoreWithRetry(asyncRunner),
-                    Constants.STORAGE_REQUEST_TIMEOUT,
-                    TimeUnit.SECONDS);
+                    Constants.STORAGE_REQUEST_TIMEOUT);
               } else {
                 STATUS_LOG.fatalErrorInitialisingStorage(err);
                 return SafeFuture.failedFuture(err);

--- a/sync/src/main/java/tech/pegasys/teku/sync/events/SyncStateTracker.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/events/SyncStateTracker.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.sync.events;
 
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -100,9 +99,7 @@ public class SyncStateTracker extends Service implements SyncStateProvider {
         startupTargetPeerCount,
         startupTimeout);
     peerConnectedSubscriptionId = network.subscribeConnect(peer -> onPeerConnected());
-    asyncRunner
-        .runAfterDelay(this::onStartupTimeout, startupTimeout.toMillis(), TimeUnit.MILLISECONDS)
-        .reportExceptions();
+    asyncRunner.runAfterDelay(this::onStartupTimeout, startupTimeout).reportExceptions();
     syncSubscriptionId = syncService.subscribeToSyncChanges(this::onSyncingChanged);
     return SafeFuture.COMPLETE;
   }

--- a/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/SyncStallDetector.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/SyncStallDetector.java
@@ -16,8 +16,8 @@ package tech.pegasys.teku.sync.forward.multipeer;
 import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 
 import com.google.common.base.MoreObjects;
+import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -35,7 +35,7 @@ import tech.pegasys.teku.sync.forward.multipeer.batches.Batch;
 public class SyncStallDetector extends Service {
   private static final Logger LOG = LogManager.getLogger();
 
-  static final int STALL_CHECK_INTERVAL_SECONDS = 15;
+  static final Duration STALL_CHECK_INTERVAL = Duration.ofSeconds(15);
   // Time periods are fairly long because sync stalls should be rare and we might be rate limited
   // if we have to request blocks from a small number of peers.
   static final int MAX_SECONDS_BETWEEN_IMPORTS = 180;
@@ -116,8 +116,7 @@ public class SyncStallDetector extends Service {
     cancellable =
         asyncRunner.runWithFixedDelay(
             () -> eventThread.execute(this::performStallCheck),
-            STALL_CHECK_INTERVAL_SECONDS,
-            TimeUnit.SECONDS,
+            STALL_CHECK_INTERVAL,
             error -> LOG.error("Failed to check for sync stalls", error));
     return SafeFuture.COMPLETE;
   }

--- a/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/chains/ThrottlingSyncSource.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/chains/ThrottlingSyncSource.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.sync.forward.multipeer.chains;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
@@ -55,7 +55,7 @@ public class ThrottlingSyncSource implements SyncSource {
       return delegate.requestBlocksByRange(startSlot, count, step, listener);
     } else {
       return asyncRunner.runAfterDelay(
-          () -> requestBlocksByRange(startSlot, count, step, listener), 3, TimeUnit.SECONDS);
+          () -> requestBlocksByRange(startSlot, count, step, listener), Duration.ofSeconds(3));
     }
   }
 

--- a/sync/src/main/java/tech/pegasys/teku/sync/forward/singlepeer/PeerSync.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/forward/singlepeer/PeerSync.java
@@ -20,7 +20,6 @@ import com.google.common.base.Throwables;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
@@ -153,8 +152,7 @@ public class PeerSync {
                   ancestorStartSlot,
                   peer.getId());
               final SafeFuture<Void> readyForNextRequest =
-                  asyncRunner.getDelayedFuture(
-                      NEXT_REQUEST_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                  asyncRunner.getDelayedFuture(NEXT_REQUEST_TIMEOUT);
               final PeerSyncBlockRequest request =
                   new PeerSyncBlockRequest(
                       readyForNextRequest,

--- a/sync/src/main/java/tech/pegasys/teku/sync/forward/singlepeer/SyncManager.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/forward/singlepeer/SyncManager.java
@@ -24,7 +24,6 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -188,7 +187,7 @@ public class SyncManager extends Service {
             () -> {
               LOG.trace("No suitable peers (out of {}) found for sync.", network.getPeerCount());
               asyncRunner
-                  .getDelayedFuture(LONG_DELAY.toMillis(), TimeUnit.MILLISECONDS)
+                  .getDelayedFuture(LONG_DELAY)
                   .thenAccept((res) -> startOrScheduleSync())
                   .reportExceptions();
               return completedFuture(null);
@@ -209,8 +208,7 @@ public class SyncManager extends Service {
             result -> {
               if (result != PeerSyncResult.SUCCESSFUL_SYNC) {
                 LOG.trace("Sync to peer {} failed with {}.", syncPeer.getId(), result.name());
-                return asyncRunner.runAfterDelay(
-                    this::executeSync, SHORT_DELAY.toMillis(), TimeUnit.MILLISECONDS);
+                return asyncRunner.runAfterDelay(this::executeSync, SHORT_DELAY);
               } else {
                 LOG.trace("Successfully synced to peer {}.", syncPeer.getId());
                 return completedFuture(null);
@@ -228,7 +226,7 @@ public class SyncManager extends Service {
               peersWithSyncErrors.add(syncPeer.getId());
               // Wait a little bit, clear error and retry
               asyncRunner
-                  .getDelayedFuture(LONG_DELAY.toMillis(), TimeUnit.MILLISECONDS)
+                  .getDelayedFuture(LONG_DELAY)
                   .thenAccept(
                       (res) -> {
                         peersWithSyncErrors.remove(syncPeer.getId());

--- a/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchRecentBlocksService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/gossip/FetchRecentBlocksService.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -215,7 +214,7 @@ public class FetchRecentBlocksService extends Service implements RecentBlockFetc
 
   private void queueTaskWithDelay(FetchBlockTask task, Duration delay) {
     asyncRunner
-        .getDelayedFuture(delay.getSeconds(), TimeUnit.SECONDS)
+        .getDelayedFuture(delay)
         .finish(
             () -> queueTask(task),
             (err) -> {

--- a/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/SyncStallDetectorTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/SyncStallDetectorTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.sync.forward.multipeer.SyncStallDetector.MAX_SECONDS_BETWEEN_IMPORTS;
 import static tech.pegasys.teku.sync.forward.multipeer.SyncStallDetector.MAX_SECONDS_BETWEEN_IMPORT_PROGRESS;
-import static tech.pegasys.teku.sync.forward.multipeer.SyncStallDetector.STALL_CHECK_INTERVAL_SECONDS;
+import static tech.pegasys.teku.sync.forward.multipeer.SyncStallDetector.STALL_CHECK_INTERVAL;
 
 import java.util.List;
 import java.util.Optional;
@@ -175,7 +175,7 @@ class SyncStallDetectorTest {
   }
 
   private void triggerStallCheck() {
-    timeProvider.advanceTimeBySeconds(STALL_CHECK_INTERVAL_SECONDS);
+    timeProvider.advanceTimeBySeconds(STALL_CHECK_INTERVAL.toSeconds());
     asyncRunner.executeDueActions();
   }
 

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -17,7 +17,7 @@ import com.google.common.collect.ImmutableList;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.io.resource.ResourceLoader;
@@ -138,8 +138,6 @@ public class Constants {
   public static final int MAX_REQUEST_BLOCKS = 1024;
   public static final int MAX_CHUNK_SIZE = 1048576; // bytes
   public static final int ATTESTATION_SUBNET_COUNT = 64;
-  public static final int TTFB_TIMEOUT = 5; // in sec
-  public static final int RESP_TIMEOUT = 10; // in sec
   public static final UInt64 ATTESTATION_PROPAGATION_SLOT_RANGE = UInt64.valueOf(32);
   public static final int MAXIMUM_GOSSIP_CLOCK_DISPARITY = 500; // in ms
 
@@ -153,12 +151,12 @@ public class Constants {
   // Teku specific
   public static final Bytes32 ZERO_HASH = Bytes32.ZERO;
   public static final double TIME_TICKER_REFRESH_RATE = 2; // per sec
-  public static final long ETH1_INDIVIDUAL_BLOCK_RETRY_TIMEOUT = 500; // in milli sec
-  public static final long ETH1_DEPOSIT_REQUEST_RETRY_TIMEOUT = 2; // in sec
-  public static final long ETH1_LOCAL_CHAIN_BEHIND_FOLLOW_DISTANCE_WAIT = 3; // in sec
+  public static final Duration ETH1_INDIVIDUAL_BLOCK_RETRY_TIMEOUT = Duration.ofMillis(500);
+  public static final Duration ETH1_DEPOSIT_REQUEST_RETRY_TIMEOUT = Duration.ofSeconds(2);
+  public static final Duration ETH1_LOCAL_CHAIN_BEHIND_FOLLOW_DISTANCE_WAIT = Duration.ofSeconds(3);
   public static final int MAXIMUM_CONCURRENT_ETH1_REQUESTS = 5;
   public static final int REPUTATION_MANAGER_CAPACITY = 1024;
-  public static final long STORAGE_REQUEST_TIMEOUT = 60; // in sec
+  public static final Duration STORAGE_REQUEST_TIMEOUT = Duration.ofSeconds(60);
   public static final int STORAGE_QUERY_CHANNEL_PARALLELISM = 10; // # threads
   public static final int PROTOARRAY_FORKCHOICE_PRUNE_THRESHOLD = 256;
   public static final int ATTESTATION_RETENTION_EPOCHS = 2;
@@ -170,9 +168,9 @@ public class Constants {
   public static final int MAX_BLOCKS_PER_MINUTE = 500;
 
   // Teku Validator Client Specific
-  public static final long FORK_RETRY_DELAY_SECONDS = 10; // in sec
-  public static final long FORK_REFRESH_TIME_SECONDS = TimeUnit.MINUTES.toSeconds(5); // in sec
-  public static final long GENESIS_DATA_RETRY_DELAY_SECONDS = 10; // in sec
+  public static final Duration FORK_RETRY_DELAY_SECONDS = Duration.ofSeconds(10);
+  public static final Duration FORK_REFRESH_TIME_SECONDS = Duration.ofMinutes(5);
+  public static final Duration GENESIS_DATA_RETRY_DELAY_SECONDS = Duration.ofSeconds(10);
 
   static {
     setConstants("minimal");

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -168,9 +168,9 @@ public class Constants {
   public static final int MAX_BLOCKS_PER_MINUTE = 500;
 
   // Teku Validator Client Specific
-  public static final Duration FORK_RETRY_DELAY_SECONDS = Duration.ofSeconds(10);
-  public static final Duration FORK_REFRESH_TIME_SECONDS = Duration.ofMinutes(5);
-  public static final Duration GENESIS_DATA_RETRY_DELAY_SECONDS = Duration.ofSeconds(10);
+  public static final Duration FORK_RETRY_DELAY = Duration.ofSeconds(10);
+  public static final Duration FORK_REFRESH_TIME = Duration.ofMinutes(5);
+  public static final Duration GENESIS_DATA_RETRY_DELAY = Duration.ofSeconds(10);
 
   static {
     setConstants("minimal");

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/GenesisDataProvider.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/GenesisDataProvider.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.validator.beaconnode;
 import static tech.pegasys.teku.util.config.Constants.GENESIS_DATA_RETRY_DELAY_SECONDS;
 
 import com.google.common.base.Suppliers;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -58,7 +57,7 @@ public class GenesisDataProvider {
             error -> {
               LOG.error("Failed to retrieve genesis data. Retrying after delay", error);
               return asyncRunner.runAfterDelay(
-                  this::fetchGenesisData, GENESIS_DATA_RETRY_DELAY_SECONDS, TimeUnit.SECONDS);
+                  this::fetchGenesisData, GENESIS_DATA_RETRY_DELAY_SECONDS);
             });
   }
 
@@ -73,9 +72,7 @@ public class GenesisDataProvider {
                         () -> {
                           LOG.info("Waiting for genesis data to be known");
                           return asyncRunner.runAfterDelay(
-                              this::requestGenesisData,
-                              GENESIS_DATA_RETRY_DELAY_SECONDS,
-                              TimeUnit.SECONDS);
+                              this::requestGenesisData, GENESIS_DATA_RETRY_DELAY_SECONDS);
                         }));
   }
 }

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/GenesisDataProvider.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/GenesisDataProvider.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.validator.beaconnode;
 
-import static tech.pegasys.teku.util.config.Constants.GENESIS_DATA_RETRY_DELAY_SECONDS;
+import static tech.pegasys.teku.util.config.Constants.GENESIS_DATA_RETRY_DELAY;
 
 import com.google.common.base.Suppliers;
 import java.util.function.Supplier;
@@ -56,8 +56,7 @@ public class GenesisDataProvider {
         .exceptionallyCompose(
             error -> {
               LOG.error("Failed to retrieve genesis data. Retrying after delay", error);
-              return asyncRunner.runAfterDelay(
-                  this::fetchGenesisData, GENESIS_DATA_RETRY_DELAY_SECONDS);
+              return asyncRunner.runAfterDelay(this::fetchGenesisData, GENESIS_DATA_RETRY_DELAY);
             });
   }
 
@@ -72,7 +71,7 @@ public class GenesisDataProvider {
                         () -> {
                           LOG.info("Waiting for genesis data to be known");
                           return asyncRunner.runAfterDelay(
-                              this::requestGenesisData, GENESIS_DATA_RETRY_DELAY_SECONDS);
+                              this::requestGenesisData, GENESIS_DATA_RETRY_DELAY);
                         }));
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLogger.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLogger.java
@@ -16,11 +16,11 @@ package tech.pegasys.teku.validator.client;
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -33,7 +33,7 @@ import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 public class DefaultValidatorStatusLogger implements ValidatorStatusLogger {
 
   private static final int VALIDATOR_KEYS_PRINT_LIMIT = 20;
-  private static final long INITIAL_STATUS_CHECK_RETRY_PERIOD = 5; // seconds
+  private static final Duration INITIAL_STATUS_CHECK_RETRY_PERIOD = Duration.ofSeconds(5);
 
   final List<BLSPublicKey> validatorPublicKeys;
   final ValidatorApiChannel validatorApiChannel;
@@ -78,7 +78,7 @@ public class DefaultValidatorStatusLogger implements ValidatorStatusLogger {
 
   private SafeFuture<Void> retryInitialValidatorStatusCheck() {
     return asyncRunner.runAfterDelay(
-        this::printInitialValidatorStatuses, INITIAL_STATUS_CHECK_RETRY_PERIOD, TimeUnit.SECONDS);
+        this::printInitialValidatorStatuses, INITIAL_STATUS_CHECK_RETRY_PERIOD);
   }
 
   private void printValidatorStatusesOneByOne(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ForkProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ForkProvider.java
@@ -13,8 +13,8 @@
 
 package tech.pegasys.teku.validator.client;
 
-import static tech.pegasys.teku.util.config.Constants.FORK_REFRESH_TIME_SECONDS;
-import static tech.pegasys.teku.util.config.Constants.FORK_RETRY_DELAY_SECONDS;
+import static tech.pegasys.teku.util.config.Constants.FORK_REFRESH_TIME;
+import static tech.pegasys.teku.util.config.Constants.FORK_RETRY_DELAY;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -53,7 +53,7 @@ public class ForkProvider extends Service {
         .exceptionallyCompose(
             error -> {
               LOG.error("Failed to retrieve current fork info. Retrying after delay", error);
-              return asyncRunner.runAfterDelay(this::loadForkInfo, FORK_RETRY_DELAY_SECONDS);
+              return asyncRunner.runAfterDelay(this::loadForkInfo, FORK_RETRY_DELAY);
             });
   }
 
@@ -68,16 +68,14 @@ public class ForkProvider extends Service {
             maybeFork -> {
               if (maybeFork.isEmpty()) {
                 LOG.trace("Fork info not available, retrying");
-                return asyncRunner.runAfterDelay(this::requestForkInfo, FORK_RETRY_DELAY_SECONDS);
+                return asyncRunner.runAfterDelay(this::requestForkInfo, FORK_RETRY_DELAY);
               }
               final ForkInfo forkInfo =
                   new ForkInfo(maybeFork.orElseThrow(), genesisValidatorsRoot);
               currentFork.complete(forkInfo);
               currentFork = SafeFuture.completedFuture(forkInfo);
               // Periodically refresh the current fork info.
-              asyncRunner
-                  .runAfterDelay(this::loadForkInfo, FORK_REFRESH_TIME_SECONDS)
-                  .reportExceptions();
+              asyncRunner.runAfterDelay(this::loadForkInfo, FORK_REFRESH_TIME).reportExceptions();
               return SafeFuture.completedFuture(forkInfo);
             });
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ForkProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ForkProvider.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.validator.client;
 import static tech.pegasys.teku.util.config.Constants.FORK_REFRESH_TIME_SECONDS;
 import static tech.pegasys.teku.util.config.Constants.FORK_RETRY_DELAY_SECONDS;
 
-import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -54,8 +53,7 @@ public class ForkProvider extends Service {
         .exceptionallyCompose(
             error -> {
               LOG.error("Failed to retrieve current fork info. Retrying after delay", error);
-              return asyncRunner.runAfterDelay(
-                  this::loadForkInfo, FORK_RETRY_DELAY_SECONDS, TimeUnit.SECONDS);
+              return asyncRunner.runAfterDelay(this::loadForkInfo, FORK_RETRY_DELAY_SECONDS);
             });
   }
 
@@ -70,8 +68,7 @@ public class ForkProvider extends Service {
             maybeFork -> {
               if (maybeFork.isEmpty()) {
                 LOG.trace("Fork info not available, retrying");
-                return asyncRunner.runAfterDelay(
-                    this::requestForkInfo, FORK_RETRY_DELAY_SECONDS, TimeUnit.SECONDS);
+                return asyncRunner.runAfterDelay(this::requestForkInfo, FORK_RETRY_DELAY_SECONDS);
               }
               final ForkInfo forkInfo =
                   new ForkInfo(maybeFork.orElseThrow(), genesisValidatorsRoot);
@@ -79,7 +76,7 @@ public class ForkProvider extends Service {
               currentFork = SafeFuture.completedFuture(forkInfo);
               // Periodically refresh the current fork info.
               asyncRunner
-                  .runAfterDelay(this::loadForkInfo, FORK_REFRESH_TIME_SECONDS, TimeUnit.SECONDS)
+                  .runAfterDelay(this::loadForkInfo, FORK_REFRESH_TIME_SECONDS)
                   .reportExceptions();
               return SafeFuture.completedFuture(forkInfo);
             });

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/RetryingDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/RetryingDutyLoader.java
@@ -14,8 +14,8 @@
 package tech.pegasys.teku.validator.client;
 
 import com.google.common.base.Throwables;
+import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -71,7 +71,7 @@ public class RetryingDutyLoader implements DutyLoader {
               }
               // Short delay before retrying as loading duties is very time sensitive
               return asyncRunner.runAfterDelay(
-                  () -> requestDuties(epoch, cancellable), 1, TimeUnit.SECONDS);
+                  () -> requestDuties(epoch, cancellable), Duration.ofSeconds(1));
             });
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSignerStatusLogger.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSignerStatusLogger.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.validator.client.signer;
 
 import java.net.URL;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import org.apache.logging.log4j.LogManager;
@@ -24,7 +24,7 @@ import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 
 public class ExternalSignerStatusLogger {
   private static final Logger LOG = LogManager.getLogger();
-  private static final long DELAY_SECONDS = 30;
+  private static final Duration FIXED_DELAY = Duration.ofSeconds(30);
   private final StatusLogger statusLogger;
   private final BooleanSupplier upcheckSupplier;
   private final URL signingServiceUrl;
@@ -45,8 +45,7 @@ public class ExternalSignerStatusLogger {
   public void logWithFixedDelay() {
     asyncRunner.runWithFixedDelay(
         this::log,
-        DELAY_SECONDS,
-        TimeUnit.SECONDS,
+        FIXED_DELAY,
         err -> LOG.debug("Unexpected error calling external signer upcheck", err));
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -17,13 +17,13 @@ import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toMap;
 
 import com.google.common.base.Throwables;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
@@ -314,7 +314,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
                   && attempt < MAX_RATE_LIMITING_RETRIES) {
                 LOG.warn("Beacon node request rate limit has been exceeded. Retrying after delay.");
                 return asyncRunner.runAfterDelay(
-                    () -> sendRequest(requestExecutor, attempt + 1), 2, TimeUnit.SECONDS);
+                    () -> sendRequest(requestExecutor, attempt + 1), Duration.ofSeconds(2));
               } else {
                 return SafeFuture.failedFuture(error);
               }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Simplify `AsyncRunner` API:  just accept `Duration` arguments rather than split timeAmount / timeUnit arguments.

## Fixed Issue(s)
Fixes #3563

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
