### PR TITLE
Avoid dropping out of sync mode early if a sync fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
 - Ensured shutdown operations have fully completed prior to exiting the process.
 - Fixed `NoSuchElementException` that occurred during syncing.
+- Avoid marking the node as in sync incorrectly if an error occurs while syncing. Now selects a new target chain and continues syncing.

--- a/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/SyncController.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/SyncController.java
@@ -133,7 +133,9 @@ public class SyncController {
   private InProgressSync startSync(final SyncTarget syncTarget) {
     eventThread.checkOnEventThread();
     final TargetChain chain = syncTarget.getTargetChain();
-    if (currentSync.map(current -> current.hasSameTarget(chain)).orElse(false)) {
+    if (currentSync
+        .map(current -> !current.isFailed() && current.hasSameTarget(chain))
+        .orElse(false)) {
       LOG.trace("Not starting new sync because it has the same target as current sync");
       return currentSync.get();
     }
@@ -176,7 +178,11 @@ public class SyncController {
     }
 
     public boolean isActiveOrFailed() {
-      return isActive() || result.join() == SyncResult.FAILED;
+      return isActive() || isFailed();
+    }
+
+    public boolean isFailed() {
+      return result.isDone() && result.join() == SyncResult.FAILED;
     }
 
     public boolean isActivePrimarySync() {

--- a/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/SyncController.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/SyncController.java
@@ -82,7 +82,7 @@ public class SyncController {
   private Optional<InProgressSync> selectNewSyncTarget() {
     return syncTargetSelector
         .selectSyncTarget(
-            currentSync.filter(InProgressSync::isActive).map(InProgressSync::getSyncTarget))
+            currentSync.filter(InProgressSync::isActiveOrFailed).map(InProgressSync::getSyncTarget))
         .map(this::startSync);
   }
 
@@ -173,6 +173,10 @@ public class SyncController {
 
     public boolean isActive() {
       return !result.isDone();
+    }
+
+    public boolean isActiveOrFailed() {
+      return isActive() || result.join() == SyncResult.FAILED;
     }
 
     public boolean isActivePrimarySync() {

--- a/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/SyncControllerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/SyncControllerTest.java
@@ -117,6 +117,22 @@ class SyncControllerTest {
   }
 
   @Test
+  void shouldPassFailedSyncsToSyncTargetSelector() {
+    // When a sync fails, we want to stay in sync mode and switch to another target chain even
+    // if it's not much ahead of our current head.
+
+    final SafeFuture<SyncResult> syncFuture = startFinalizedSync();
+
+    // First selection has no current sync
+    verify(syncTargetSelector).selectSyncTarget(Optional.empty());
+
+    syncFuture.complete(SyncResult.FAILED);
+
+    verify(syncTargetSelector)
+        .selectSyncTarget(Optional.of(SyncTarget.finalizedTarget(targetChain)));
+  }
+
+  @Test
   void shouldRemainSyncingWhenNoTargetChainSelectedButPreviousSyncStillActive() {
     final SafeFuture<SyncResult> previousSync = startFinalizedSync();
 

--- a/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/SyncControllerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/SyncControllerTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -126,10 +127,13 @@ class SyncControllerTest {
     // First selection has no current sync
     verify(syncTargetSelector).selectSyncTarget(Optional.empty());
 
+    when(sync.syncToChain(targetChain)).thenReturn(new SafeFuture<>());
     syncFuture.complete(SyncResult.FAILED);
 
     verify(syncTargetSelector)
         .selectSyncTarget(Optional.of(SyncTarget.finalizedTarget(targetChain)));
+    // Should restart sync to the chain even though it has the same target
+    verify(sync, times(2)).syncToChain(targetChain);
   }
 
   @Test


### PR DESCRIPTION
## PR Description
When selecting a new target chain after a sync failure, don't require the new target to be significantly ahead. Just apply the same thresholds as when selecting a better target chain to ensure we sync all the way up to head before stopping even if there's a failure.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
