### PR TITLE
Never create attestations while sync is in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ For information on changes in released versions of Teku, see the [releases page]
 - Ensured shutdown operations have fully completed prior to exiting the process.
 - Fixed `NoSuchElementException` that occurred during syncing.
 - Avoid marking the node as in sync incorrectly if an error occurs while syncing. Now selects a new target chain and continues syncing.
+- Reject validator related REST API requests when syncing, even if the head block is close to the current slot.  `head` and `chain_reorg` events do not fire while sync is active so the validator client is unable to detect when it should invalidate duties.

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -74,7 +74,6 @@ import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.events.block.ProposedBlockEvent;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
-import tech.pegasys.teku.sync.events.SyncState;
 import tech.pegasys.teku.sync.events.SyncStateProvider;
 import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.validator.api.AttesterDuties;
@@ -453,14 +452,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
 
   @VisibleForTesting
   boolean isSyncActive() {
-    final SyncState syncState = syncStateProvider.getCurrentSyncState();
-    return syncState.isStartingUp() || (syncState.isSyncing() && headBlockIsTooFarBehind());
-  }
-
-  private boolean headBlockIsTooFarBehind() {
-    final UInt64 currentEpoch = combinedChainDataClient.getCurrentEpoch();
-    final UInt64 headEpoch = combinedChainDataClient.getHeadEpoch();
-    return headEpoch.plus(1).isLessThan(currentEpoch);
+    return !syncStateProvider.getCurrentSyncState().isInSync();
   }
 
   private ProposerDuties getProposerDutiesFromIndexesAndState(

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -128,13 +128,13 @@ class ValidatorApiHandlerTest {
   @Test
   public void isSyncActive_syncIsActiveAndHeadALittleBehind() {
     setupSyncingState(SyncState.SYNCING, EPOCH, EPOCH.minus(1));
-    assertThat(validatorApiHandler.isSyncActive()).isFalse();
+    assertThat(validatorApiHandler.isSyncActive()).isTrue();
   }
 
   @Test
   public void isSyncActive_syncIsActiveAndHeadIsCaughtUp() {
     setupSyncingState(SyncState.SYNCING, EPOCH, EPOCH);
-    assertThat(validatorApiHandler.isSyncActive()).isFalse();
+    assertThat(validatorApiHandler.isSyncActive()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Even if the sync is close enough to head that duties could be calculated, reject requests to perform validator actions as `head` and `reorg` events are still not being fired so the validator client doesn't know if it needs to invalidate duties.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
