### PR TITLE
finish copying functions from BeaconStateUtil and CommitteeUtil

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/BeaconStateUtil.java
@@ -207,10 +207,12 @@ public class BeaconStateUtil {
         && isThereEnoughNumberOfValidators(activeValidatorCount);
   }
 
+  @Deprecated
   private static boolean isThereEnoughNumberOfValidators(int activeValidatorCount) {
     return activeValidatorCount >= MIN_GENESIS_ACTIVE_VALIDATOR_COUNT;
   }
 
+  @Deprecated
   private static boolean isItMinGenesisTimeYet(final UInt64 genesisTime) {
     return genesisTime.compareTo(MIN_GENESIS_TIME) >= 0;
   }
@@ -289,6 +291,7 @@ public class BeaconStateUtil {
    * @see
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#get_total_active_balance</a>
    */
+  @Deprecated
   public static UInt64 get_total_active_balance(BeaconState state) {
     return BeaconStateCache.getTransitionCaches(state)
         .getTotalActiveBalance()
@@ -478,6 +481,7 @@ public class BeaconStateUtil {
    * @see
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#initiate_validator_exit</a>
    */
+  @Deprecated
   public static void initiate_validator_exit(MutableBeaconState state, int index) {
     Validator validator = state.getValidators().get(index);
     // Return if validator already initiated exit
@@ -524,7 +528,8 @@ public class BeaconStateUtil {
    * @see
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#slash_validator/a>
    */
-  public static void slash_validator(
+  @Deprecated
+  private static void slash_validator(
       MutableBeaconState state, int slashed_index, int whistleblower_index) {
     UInt64 epoch = get_current_epoch(state);
     initiate_validator_exit(state, slashed_index);
@@ -564,6 +569,7 @@ public class BeaconStateUtil {
     increase_balance(state, whistleblower_index, whistleblower_reward.minus(proposer_reward));
   }
 
+  @Deprecated
   public static void slash_validator(MutableBeaconState state, int slashed_index) {
     slash_validator(state, slashed_index, -1);
   }
@@ -596,6 +602,7 @@ public class BeaconStateUtil {
     return get_committee_count_per_slot(active_validator_indices.size());
   }
 
+  @Deprecated
   public static UInt64 get_committee_count_per_slot(final int activeValidatorCount) {
     return UInt64.valueOf(
         Math.max(
@@ -809,10 +816,12 @@ public class BeaconStateUtil {
     }
   }
 
+  @Deprecated
   public static Bytes32 uint_to_bytes32(long value) {
     return Bytes32.wrap(uint_to_bytes(value, 32));
   }
 
+  @Deprecated
   public static Bytes32 uint_to_bytes32(UInt64 value) {
     return uint_to_bytes32(value.longValue());
   }
@@ -823,10 +832,12 @@ public class BeaconStateUtil {
    * @see
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#bytes_to_int</a>
    */
+  @Deprecated
   public static UInt64 bytes_to_int64(Bytes data) {
     return UInt64.fromLongBits(data.toLong(ByteOrder.LITTLE_ENDIAN));
   }
 
+  @Deprecated
   public static Bytes32 getCurrentDutyDependentRoot(BeaconState state) {
     final UInt64 slot = compute_start_slot_at_epoch(get_current_epoch(state)).minusMinZero(1);
     // No previous block, use algorithm for calculating the genesis block root

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/CommitteeUtil.java
@@ -87,6 +87,7 @@ public class CommitteeUtil {
     return indexRet;
   }
 
+  @Deprecated
   private static List<Integer> shuffle_list(List<Integer> input, Bytes32 seed) {
     int[] indexes = input.stream().mapToInt(i -> i).toArray();
     shuffle_list(indexes, seed);
@@ -106,6 +107,7 @@ public class CommitteeUtil {
    * @param input The list to be shuffled.
    * @param seed Initial seed value used for randomization.
    */
+  @Deprecated
   public static void shuffle_list(int[] input, Bytes32 seed) {
 
     int listSize = input.length;
@@ -162,6 +164,7 @@ public class CommitteeUtil {
    * @param seed
    * @return
    */
+  @Deprecated
   public static int compute_proposer_index(BeaconState state, List<Integer> indices, Bytes32 seed) {
     checkArgument(!indices.isEmpty(), "compute_proposer_index indices must not be empty");
     UInt64 MAX_RANDOM_BYTE = UInt64.valueOf(255); // Math.pow(2, 8) - 1;
@@ -184,6 +187,7 @@ public class CommitteeUtil {
     }
   }
 
+  @Deprecated
   private static List<Integer> compute_committee_shuffle(
       BeaconState state, List<Integer> indices, Bytes32 seed, int fromIndex, int toIndex) {
     if (fromIndex < toIndex) {
@@ -208,7 +212,8 @@ public class CommitteeUtil {
    * @see
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#is_valid_merkle_branch</a>
    */
-  public static List<Integer> compute_committee(
+  @Deprecated
+  private static List<Integer> compute_committee(
       BeaconState state, List<Integer> indices, Bytes32 seed, int index, int count) {
     int start = Math.floorDiv(indices.size() * index, count);
     int end = Math.floorDiv(indices.size() * (index + 1), count);
@@ -223,6 +228,8 @@ public class CommitteeUtil {
    * @param index
    * @return
    */
+  /* note: now in BeaconStateUtil */
+  @Deprecated
   public static List<Integer> get_beacon_committee(BeaconState state, UInt64 slot, UInt64 index) {
     // Make sure state is within range of the slot being queried
     validateStateForCommitteeQuery(state, slot);
@@ -246,6 +253,8 @@ public class CommitteeUtil {
             });
   }
 
+  /* note: now in BeaconStateUtil */
+  @Deprecated
   private static void validateStateForCommitteeQuery(BeaconState state, UInt64 slot) {
     final UInt64 oldestQueryableSlot = getEarliestQueryableSlotForTargetSlot(slot);
     checkArgument(
@@ -261,6 +270,8 @@ public class CommitteeUtil {
    * @param slot The slot for which we want to retrieve committee information
    * @return The earliest slot from which we can query committee assignments
    */
+  /* note: now in BeaconStateUtil */
+  @Deprecated
   public static UInt64 getEarliestQueryableSlotForTargetSlot(final UInt64 slot) {
     final UInt64 epoch = compute_epoch_at_slot(slot);
     return getEarliestQueryableSlotForTargetEpoch(epoch);
@@ -272,6 +283,8 @@ public class CommitteeUtil {
    * @param epoch The epoch for which we want to retrieve committee information
    * @return The earliest slot from which we can query committee assignments
    */
+  /* note: now in BeaconStateUtil */
+  @Deprecated
   public static UInt64 getEarliestQueryableSlotForTargetEpoch(final UInt64 epoch) {
     final UInt64 previousEpoch = epoch.compareTo(UInt64.ZERO) > 0 ? epoch.minus(UInt64.ONE) : epoch;
     return compute_start_slot_at_epoch(previousEpoch);
@@ -288,6 +301,7 @@ public class CommitteeUtil {
         : Math.max(1, committeeSize / TARGET_AGGREGATORS_PER_COMMITTEE);
   }
 
+  @Deprecated
   public static boolean isAggregator(final BLSSignature slot_signature, final int modulo) {
     return bytes_to_int64(Hash.sha2_256(slot_signature.toSSZBytes()).slice(0, 8))
         .mod(modulo)
@@ -304,6 +318,8 @@ public class CommitteeUtil {
    * @param attestation
    * @return
    */
+  /* note: now in BeaconStateUtil */
+  @Deprecated
   public static int computeSubnetForAttestation(
       final BeaconState state, final Attestation attestation) {
     final UInt64 attestationSlot = attestation.getData().getSlot();
@@ -311,6 +327,8 @@ public class CommitteeUtil {
     return computeSubnetForCommittee(state, attestationSlot, committeeIndex);
   }
 
+  /* note: now in BeaconStateUtil */
+  @Deprecated
   public static int computeSubnetForCommittee(
       final BeaconState state, final UInt64 attestationSlot, final UInt64 committeeIndex) {
     return computeSubnetForCommittee(
@@ -319,6 +337,8 @@ public class CommitteeUtil {
         get_committee_count_per_slot(state, compute_epoch_at_slot(attestationSlot)));
   }
 
+  /* note: now in BeaconStateUtil */
+  @Deprecated
   public static int computeSubnetForCommittee(
       final UInt64 attestationSlot, final UInt64 committeeIndex, final UInt64 committeesPerSlot) {
     final UInt64 slotsSinceEpochStart = attestationSlot.mod(SLOTS_PER_EPOCH);

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/ValidatorsUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/ValidatorsUtil.java
@@ -52,6 +52,7 @@ public class ValidatorsUtil {
    * @param validator the validator
    * @return true if the validator is eligible for activation
    */
+  @Deprecated
   public static boolean is_eligible_for_activation(BeaconState state, Validator validator) {
     return validator
                 .getActivation_eligibility_epoch()
@@ -91,8 +92,13 @@ public class ValidatorsUtil {
    * @param epoch - The epoch under consideration.
    * @return A list of indices representing the active validators for the given epoch.
    * @see
+   * @deprecated moved to stateful BeaconStateUtil
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#get_active_validator_indices</a>
    */
+  /*
+   * note: moved to BeaconStateUtil
+   */
+  @Deprecated
   public static List<Integer> get_active_validator_indices(BeaconState state, UInt64 epoch) {
     final UInt64 stateEpoch = BeaconStateUtil.get_current_epoch(state);
     final UInt64 maxLookaheadEpoch = getMaxLookaheadEpoch(stateEpoch);
@@ -114,10 +120,18 @@ public class ValidatorsUtil {
             });
   }
 
+  /*
+   * note: moved to BeaconStateUtil
+   */
+  @Deprecated
   public static UInt64 getMaxLookaheadEpoch(final BeaconState state) {
     return getMaxLookaheadEpoch(BeaconStateUtil.get_current_epoch(state));
   }
 
+  /*
+   * note: moved to BeaconStateUtil
+   */
+  @Deprecated
   private static UInt64 getMaxLookaheadEpoch(final UInt64 stateEpoch) {
     return stateEpoch.plus(MAX_SEED_LOOKAHEAD);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/util/ByteUtils.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/util/ByteUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.util;
+
+import java.nio.ByteOrder;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class ByteUtils {
+  public static Bytes uintToBytes(long value, int numBytes) {
+    int longBytes = Long.SIZE / 8;
+    Bytes valueBytes = Bytes.ofUnsignedLong(value, ByteOrder.LITTLE_ENDIAN);
+    if (numBytes <= longBytes) {
+      return valueBytes.slice(0, numBytes);
+    } else {
+      return Bytes.wrap(valueBytes, Bytes.wrap(new byte[numBytes - longBytes]));
+    }
+  }
+
+  public static Bytes32 uintToBytes32(long value) {
+    return Bytes32.wrap(uintToBytes(value, 32));
+  }
+
+  static Bytes32 uintToBytes32(UInt64 value) {
+    return uintToBytes32(value.longValue());
+  }
+
+  public static UInt64 bytesToUInt64(Bytes data) {
+    return UInt64.fromLongBits(data.toLong(ByteOrder.LITTLE_ENDIAN));
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/util/CommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/util/CommitteeUtil.java
@@ -14,15 +14,19 @@
 package tech.pegasys.teku.spec.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.bytes_to_int64;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.uint_to_bytes;
+import static tech.pegasys.teku.spec.util.ByteUtils.bytesToUInt64;
+import static tech.pegasys.teku.spec.util.ByteUtils.uintToBytes;
 
 import com.google.common.primitives.UnsignedBytes;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.Hash;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.datastructures.state.BeaconStateCache;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.constants.SpecConstants;
 
@@ -45,13 +49,13 @@ public class CommitteeUtil {
 
       // This needs to be unsigned modulo.
       int pivot =
-          bytes_to_int64(Hash.sha2_256(Bytes.wrap(seed, roundAsByte)).slice(0, 8))
+          bytesToUInt64(Hash.sha2_256(Bytes.wrap(seed, roundAsByte)).slice(0, 8))
               .mod(index_count)
               .intValue();
       int flip = Math.floorMod(pivot + index_count - indexRet, index_count);
       int position = Math.max(indexRet, flip);
 
-      Bytes positionDiv256 = uint_to_bytes(Math.floorDiv(position, 256), 4);
+      Bytes positionDiv256 = uintToBytes(Math.floorDiv(position, 256), 4);
       Bytes hashBytes = Hash.sha2_256(Bytes.wrap(seed, roundAsByte, positionDiv256));
 
       int bitIndex = position & 0xff;
@@ -74,7 +78,7 @@ public class CommitteeUtil {
     while (true) {
       int candidate_index = indices.get(computeShuffledIndex(i % total, total, seed));
       if (i % 32 == 0) {
-        hash = Hash.sha2_256(Bytes.concatenate(seed, uint_to_bytes(Math.floorDiv(i, 32), 8)));
+        hash = Hash.sha2_256(Bytes.concatenate(seed, uintToBytes(Math.floorDiv(i, 32), 8)));
       }
       int random_byte = UnsignedBytes.toInt(hash.get(i % 32));
       UInt64 effective_balance = state.getValidators().get(candidate_index).getEffective_balance();
@@ -91,5 +95,85 @@ public class CommitteeUtil {
     return specConstants.getTargetAggregatorsPerCommittee() == 0
         ? 1
         : Math.max(1, committeeSize / specConstants.getTargetAggregatorsPerCommittee());
+  }
+
+  public void shuffleList(int[] input, Bytes32 seed) {
+
+    int listSize = input.length;
+    if (listSize == 0) {
+      return;
+    }
+
+    for (int round = specConstants.getShuffleRoundCount() - 1; round >= 0; round--) {
+
+      Bytes roundAsByte = Bytes.of((byte) round);
+
+      // This needs to be unsigned modulo.
+      int pivot =
+          bytesToUInt64(Hash.sha2_256(Bytes.wrap(seed, roundAsByte)).slice(0, 8))
+              .mod(listSize)
+              .intValue();
+
+      Bytes hashBytes = Bytes.EMPTY;
+      int mirror1 = (pivot + 2) / 2;
+      int mirror2 = (pivot + listSize) / 2;
+      for (int i = mirror1; i <= mirror2; i++) {
+
+        int flip, bitIndex;
+        if (i <= pivot) {
+          flip = pivot - i;
+          bitIndex = i & 0xff;
+          if (bitIndex == 0 || i == mirror1) {
+            hashBytes = Hash.sha2_256(Bytes.wrap(seed, roundAsByte, uintToBytes(i / 256, 4)));
+          }
+        } else {
+          flip = pivot + listSize - i;
+          bitIndex = flip & 0xff;
+          if (bitIndex == 0xff || i == pivot + 1) {
+            hashBytes = Hash.sha2_256(Bytes.wrap(seed, roundAsByte, uintToBytes(flip / 256, 4)));
+          }
+        }
+
+        int theByte = hashBytes.get(bitIndex / 8);
+        int theBit = (theByte >> (bitIndex & 0x07)) & 1;
+        if (theBit != 0) {
+          int tmp = input[i];
+          input[i] = input[flip];
+          input[flip] = tmp;
+        }
+      }
+    }
+  }
+
+  public static boolean isAggregator(final BLSSignature slot_signature, final int modulo) {
+    return bytesToUInt64(Hash.sha2_256(slot_signature.toSSZBytes()).slice(0, 8))
+        .mod(modulo)
+        .isZero();
+  }
+
+  List<Integer> computeCommittee(
+      BeaconState state, List<Integer> indices, Bytes32 seed, int index, int count) {
+    int start = Math.floorDiv(indices.size() * index, count);
+    int end = Math.floorDiv(indices.size() * (index + 1), count);
+    return computeCommitteeShuffle(state, indices, seed, start, end);
+  }
+
+  private List<Integer> shuffleList(List<Integer> input, Bytes32 seed) {
+    int[] indexes = input.stream().mapToInt(i -> i).toArray();
+    shuffleList(indexes, seed);
+    return Arrays.stream(indexes).boxed().collect(Collectors.toList());
+  }
+
+  List<Integer> computeCommitteeShuffle(
+      BeaconState state, List<Integer> indices, Bytes32 seed, int fromIndex, int toIndex) {
+    if (fromIndex < toIndex) {
+      int indexCount = indices.size();
+      checkArgument(fromIndex < indexCount, "CommitteeUtil.getShuffledIndex1");
+      checkArgument(toIndex <= indexCount, "CommitteeUtil.getShuffledIndex1");
+    }
+    return BeaconStateCache.getTransitionCaches(state)
+        .getCommitteeShuffle()
+        .get(seed, s -> shuffleList(indices, s))
+        .subList(fromIndex, toIndex);
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/util/ByteUtilsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/util/ByteUtilsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class ByteUtilsTest {
+
+  @Test
+  void intToBytes32UInt64() {
+    assertEquals(
+        Bytes32.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000"),
+        ByteUtils.uintToBytes32(UInt64.ZERO));
+    assertEquals(
+        Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000"),
+        ByteUtils.uintToBytes32(UInt64.ONE));
+    assertEquals(
+        Bytes32.fromHexString("0xffffffffffffffff000000000000000000000000000000000000000000000000"),
+        ByteUtils.uintToBytes32(UInt64.MAX_VALUE));
+    assertEquals(
+        Bytes32.fromHexString("0xefcdab8967452301000000000000000000000000000000000000000000000000"),
+        ByteUtils.uintToBytes32(UInt64.valueOf(0x0123456789abcdefL)));
+  }
+
+  @Test
+  void bytesToInt() {
+    assertEquals(UInt64.valueOf(0), ByteUtils.bytesToUInt64(Bytes.fromHexString("0x00")));
+    assertEquals(UInt64.valueOf(1), ByteUtils.bytesToUInt64(Bytes.fromHexString("0x01")));
+    assertEquals(
+        UInt64.valueOf(1), ByteUtils.bytesToUInt64(Bytes.fromHexString("0x0100000000000000")));
+    assertEquals(
+        UInt64.valueOf(0x123456789abcdef0L),
+        ByteUtils.bytesToUInt64(Bytes.fromHexString("0xf0debc9a78563412")));
+    assertEquals(
+        UInt64.fromLongBits(0xffffffffffffffffL),
+        ByteUtils.bytesToUInt64(Bytes.fromHexString("0xffffffffffffffff")));
+    assertEquals(
+        UInt64.fromLongBits(0x0000000000000080L),
+        ByteUtils.bytesToUInt64(Bytes.fromHexString("0x8000000000000000")));
+    assertEquals(
+        UInt64.fromLongBits(0xffffffffffffff7fL),
+        ByteUtils.bytesToUInt64(Bytes.fromHexString("0x7fffffffffffffff")));
+  }
+}


### PR DESCRIPTION
Some CommitteeUtils relied on BeaconStateUtil, and to make sure there wasn't a cyclic dependency, i've moved them to live in BeaconStateUtil.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
