### PR TITLE
Make max pending events configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,5 @@ For information on changes in released versions of Teku, see the [releases page]
 - Fixed `NoSuchElementException` that occurred during syncing.
 - Avoid marking the node as in sync incorrectly if an error occurs while syncing. Now selects a new target chain and continues syncing.
 - Reject validator related REST API requests when syncing, even if the head block is close to the current slot.  `head` and `chain_reorg` events do not fire while sync is active so the validator client is unable to detect when it should invalidate duties.
+- Increase the default limit for the queue for delivering events to REST API subscribers. When subscribing to attestations, they are often received in bursts which would exceed the previous limit even when the client was keeping up.
+  The default limit is now 250 and can now be configured with `--Xrest-api-max-pending-events`.

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -94,7 +94,6 @@ public class BeaconRestApi {
   private final Javalin app;
   private final JsonProvider jsonProvider = new JsonProvider();
   private static final Logger LOG = LogManager.getLogger();
-  public static final String FILE_NOT_FOUND_HTML = "404.html";
 
   private void initialize(
       final DataProvider dataProvider,
@@ -117,7 +116,7 @@ public class BeaconRestApi {
     addExceptionHandlers();
     // standard api endpoint inclusion
     addV1BeaconHandlers(dataProvider);
-    addEventHandler(dataProvider, eventChannels, asyncRunner);
+    addEventHandler(dataProvider, eventChannels, asyncRunner, configuration);
     addV1NodeHandlers(dataProvider);
     addV1ValidatorHandlers(dataProvider);
     addV1ConfigHandlers(dataProvider, configuration.getEth1DepositContractAddress());
@@ -335,8 +334,16 @@ public class BeaconRestApi {
   private void addEventHandler(
       final DataProvider dataProvider,
       final EventChannels eventChannels,
-      final AsyncRunner asyncRunner) {
-    app.get(GetEvents.ROUTE, new GetEvents(dataProvider, jsonProvider, eventChannels, asyncRunner));
+      final AsyncRunner asyncRunner,
+      final BeaconRestApiConfig configuration) {
+    app.get(
+        GetEvents.ROUTE,
+        new GetEvents(
+            dataProvider,
+            jsonProvider,
+            eventChannels,
+            asyncRunner,
+            configuration.getMaxPendingEvents()));
   }
 
   public void stop() {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiConfig.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiConfig.java
@@ -28,6 +28,7 @@ public class BeaconRestApiConfig {
   private final List<String> restApiHostAllowlist;
   private final List<String> restApiCorsAllowedOrigins;
   private final Optional<Eth1Address> eth1DepositContractAddress;
+  private final int maxPendingEvents;
 
   private BeaconRestApiConfig(
       final int restApiPort,
@@ -36,7 +37,8 @@ public class BeaconRestApiConfig {
       final String restApiInterface,
       final List<String> restApiHostAllowlist,
       final List<String> restApiCorsAllowedOrigins,
-      final Optional<Eth1Address> eth1DepositContractAddress) {
+      final Optional<Eth1Address> eth1DepositContractAddress,
+      final int maxPendingEvents) {
     this.restApiPort = restApiPort;
     this.restApiDocsEnabled = restApiDocsEnabled;
     this.restApiEnabled = restApiEnabled;
@@ -44,6 +46,7 @@ public class BeaconRestApiConfig {
     this.restApiHostAllowlist = restApiHostAllowlist;
     this.restApiCorsAllowedOrigins = restApiCorsAllowedOrigins;
     this.eth1DepositContractAddress = eth1DepositContractAddress;
+    this.maxPendingEvents = maxPendingEvents;
   }
 
   public int getRestApiPort() {
@@ -74,6 +77,10 @@ public class BeaconRestApiConfig {
     return eth1DepositContractAddress;
   }
 
+  public int getMaxPendingEvents() {
+    return maxPendingEvents;
+  }
+
   public static BeaconRestApiConfigBuilder builder() {
     return new BeaconRestApiConfigBuilder();
   }
@@ -87,6 +94,7 @@ public class BeaconRestApiConfig {
     private List<String> restApiHostAllowlist;
     private List<String> restApiCorsAllowedOrigins;
     private Optional<Eth1Address> eth1DepositContractAddress = Optional.empty();
+    private int maxPendingEvents;
 
     private BeaconRestApiConfigBuilder() {}
 
@@ -136,6 +144,11 @@ public class BeaconRestApiConfig {
       return this;
     }
 
+    public BeaconRestApiConfigBuilder maxPendingEvents(final int maxEventQueueSize) {
+      this.maxPendingEvents = maxEventQueueSize;
+      return this;
+    }
+
     public BeaconRestApiConfig build() {
       return new BeaconRestApiConfig(
           restApiPort,
@@ -144,7 +157,8 @@ public class BeaconRestApiConfig {
           restApiInterface,
           restApiHostAllowlist,
           restApiCorsAllowedOrigins,
-          eth1DepositContractAddress);
+          eth1DepositContractAddress,
+          maxPendingEvents);
     }
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -56,6 +56,7 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
   private final JsonProvider jsonProvider;
   private final ChainDataProvider provider;
   private final AsyncRunner asyncRunner;
+  private final int maxPendingEvents;
   // collection of subscribers
   private final Collection<EventSubscriber> eventSubscribers;
 
@@ -66,10 +67,12 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
       final SyncDataProvider syncDataProvider,
       final ConfigProvider configProvider,
       final AsyncRunner asyncRunner,
-      final EventChannels eventChannels) {
+      final EventChannels eventChannels,
+      final int maxPendingEvents) {
     this.provider = chainDataProvider;
     this.jsonProvider = jsonProvider;
     this.asyncRunner = asyncRunner;
+    this.maxPendingEvents = maxPendingEvents;
     this.eventSubscribers = new ConcurrentLinkedQueue<>();
     this.configProvider = configProvider;
     eventChannels.subscribe(ChainHeadChannel.class, this);
@@ -92,7 +95,8 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
               eventSubscribers.removeIf(sub -> sub.getSseClient().equals(sseClient));
               LOG.trace("disconnected " + sseClient.hashCode());
             },
-            asyncRunner);
+            asyncRunner,
+            maxPendingEvents);
     eventSubscribers.add(subscriber);
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/GetEvents.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/GetEvents.java
@@ -54,7 +54,8 @@ public class GetEvents implements Handler {
       final DataProvider dataProvider,
       final JsonProvider jsonProvider,
       final EventChannels eventChannels,
-      final AsyncRunner asyncRunner) {
+      final AsyncRunner asyncRunner,
+      final int maxPendingEvents) {
     this(
         dataProvider.getNodeDataProvider(),
         dataProvider.getChainDataProvider(),
@@ -62,7 +63,8 @@ public class GetEvents implements Handler {
         dataProvider.getSyncDataProvider(),
         dataProvider.getConfigProvider(),
         eventChannels,
-        asyncRunner);
+        asyncRunner,
+        maxPendingEvents);
   }
 
   GetEvents(
@@ -72,7 +74,8 @@ public class GetEvents implements Handler {
       final SyncDataProvider syncDataProvider,
       final ConfigProvider configProvider,
       final EventChannels eventChannels,
-      final AsyncRunner asyncRunner) {
+      final AsyncRunner asyncRunner,
+      final int maxPendingEvents) {
     this.jsonProvider = jsonProvider;
     eventSubscriptionManager =
         new EventSubscriptionManager(
@@ -82,7 +85,8 @@ public class GetEvents implements Handler {
             syncDataProvider,
             configProvider,
             asyncRunner,
-            eventChannels);
+            eventChannels,
+            maxPendingEvents);
   }
 
   @OpenApi(

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -128,7 +128,8 @@ public class EventSubscriptionManagerTest {
             syncDataProvider,
             configProvider,
             asyncRunner,
-            channels);
+            channels,
+            10);
     client1 = new SseClient(ctx);
   }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.config.TekuConfiguration;
 public class BeaconRestApiOptions {
 
   public static final int DEFAULT_REST_API_PORT = 5051;
+  public static final int DEFAULT_MAX_EVENT_QUEUE_SIZE = 250;
 
   @Option(
       names = {"--rest-api-port"},
@@ -69,29 +70,11 @@ public class BeaconRestApiOptions {
       arity = "0..*")
   private final List<String> restApiCorsAllowedOrigins = new ArrayList<>();
 
-  public int getRestApiPort() {
-    return restApiPort;
-  }
-
-  public boolean isRestApiDocsEnabled() {
-    return restApiDocsEnabled;
-  }
-
-  public boolean isRestApiEnabled() {
-    return restApiEnabled;
-  }
-
-  public String getRestApiInterface() {
-    return restApiInterface;
-  }
-
-  public List<String> getRestApiHostAllowlist() {
-    return restApiHostAllowlist;
-  }
-
-  public List<String> getRestApiCorsAllowedOrigins() {
-    return restApiCorsAllowedOrigins;
-  }
+  @Option(
+      names = {"--Xrest-api-max-pending-events"},
+      paramLabel = "<INTEGER>",
+      hidden = true)
+  private int maxPendingEvents = DEFAULT_MAX_EVENT_QUEUE_SIZE;
 
   public void configure(final TekuConfiguration.Builder builder) {
     builder.restApi(
@@ -102,6 +85,7 @@ public class BeaconRestApiOptions {
                 .restApiPort(restApiPort)
                 .restApiInterface(restApiInterface)
                 .restApiHostAllowlist(restApiHostAllowlist)
-                .restApiCorsAllowedOrigins(restApiCorsAllowedOrigins));
+                .restApiCorsAllowedOrigins(restApiCorsAllowedOrigins)
+                .maxPendingEvents(maxPendingEvents));
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -45,6 +45,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import tech.pegasys.teku.cli.options.BeaconRestApiOptions;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
@@ -437,7 +438,8 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                     .restApiInterface("127.0.0.1")
                     .restApiHostAllowlist(List.of("127.0.0.1", "localhost"))
                     .restApiCorsAllowedOrigins(new ArrayList<>())
-                    .eth1DepositContractAddress(Optional.of(address)))
+                    .eth1DepositContractAddress(Optional.of(address))
+                    .maxPendingEvents(BeaconRestApiOptions.DEFAULT_MAX_EVENT_QUEUE_SIZE))
         .validator(
             b ->
                 b.validatorExternalSignerTimeout(Duration.ofSeconds(5))


### PR DESCRIPTION
## PR Description
There are enough validators on Pyrmont that the `attestation` subscription would regularly hit the limit of 10 pending events even when just printing the event stream to the console.  Teku would correctly disconnect the connection because it was failing to keep up but would trigger an error in the logs because it still tried to publish the pending events.

To fix this:
* Increase default to 250 to handle bursts in receiving attestations.
* Add flag to stop publishing events when the connection has been closed rather than just triggering an `IllegalStateException`.

## Fixed Issue(s)
fixes #3579 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
