### PR TITLE
Revert "Fix NoSuchElementException in batch sync (#3578)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
 - Ensured shutdown operations have fully completed prior to exiting the process.
-- Fixed `NoSuchElementException` that occurred during syncing.
 - Avoid marking the node as in sync incorrectly if an error occurs while syncing. Now selects a new target chain and continues syncing.
 - Reject validator related REST API requests when syncing, even if the head block is close to the current slot.  `head` and `chain_reorg` events do not fire while sync is active so the validator client is unable to detect when it should invalidate duties.
 - Increase the default limit for the queue for delivering events to REST API subscribers. When subscribing to attestations, they are often received in bursts which would exceed the previous limit even when the client was keeping up.

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -412,10 +412,6 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     return Optional.ofNullable(store).map(s -> s.containsBlock(root)).orElse(false);
   }
 
-  public Optional<UInt64> getSlotForBlockRoot(final Bytes32 root) {
-    return getForkChoiceStrategy().flatMap(forkChoice -> forkChoice.blockSlot(root));
-  }
-
   public SafeFuture<Optional<BeaconBlock>> retrieveBlockByRoot(final Bytes32 root) {
     if (store == null) {
       return EmptyStoreResults.EMPTY_BLOCK_FUTURE;

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -43,7 +43,6 @@ import tech.pegasys.teku.core.ChainBuilder;
 import tech.pegasys.teku.core.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.core.ChainProperties;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.datastructures.state.AnchorPoint;
@@ -66,7 +65,6 @@ import tech.pegasys.teku.util.EventSink;
 import tech.pegasys.teku.util.config.Constants;
 
 class RecentChainDataTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private StorageSystem storageSystem;
 
   private ChainBuilder chainBuilder;
@@ -736,6 +734,7 @@ class RecentChainDataTest {
   @Test
   public void getBlockRootBySlotWithHeadRoot_forUnknownHeadRoot() {
     initPostGenesis();
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil();
     final Bytes32 headRoot = dataStructureUtil.randomBytes32();
     final SignedBlockAndState bestBlock = advanceBestBlock(recentChainData);
 
@@ -772,21 +771,6 @@ class RecentChainDataTest {
       assertThat(recentChainData.getBlockRootBySlot(targetSlot, headRoot))
           .contains(expectedBlock.getRoot());
     }
-  }
-
-  @Test
-  void getSlotForBlockRoot_shouldReturnEmptyForUnknownBlock() {
-    initPostGenesis();
-
-    assertThat(recentChainData.getSlotForBlockRoot(dataStructureUtil.randomBytes32())).isEmpty();
-  }
-
-  @Test
-  void getSlotForBlockRoot_shouldReturnSlotForKnownBlock() {
-    initPostGenesis();
-
-    final SignedBeaconBlock block = storageSystem.chainUpdater().advanceChain().getBlock();
-    assertThat(recentChainData.getSlotForBlockRoot(block.getRoot())).contains(block.getSlot());
   }
 
   @Test

--- a/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/BatchSync.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/BatchSync.java
@@ -224,10 +224,6 @@ public class BatchSync implements Sync {
       final Batch batch, final SignedBeaconBlock firstBlock) {
     final NavigableSet<Batch> previousBatches = activeBatches.batchesBeforeExclusive(batch);
     if (isChildOfStartingPoint(firstBlock)) {
-      LOG.debug(
-          "Marking {} batches complete because block at slot {} connects to our chain",
-          previousBatches.size(),
-          firstBlock.getSlot());
       // We found where this chain connects to ours so all prior empty batches are
       // complete and our first block is valid.
       batch.markFirstBlockConfirmed();
@@ -248,22 +244,8 @@ public class BatchSync implements Sync {
     }
   }
 
-  /**
-   * Returns true if firstBlock is the first block in the chain we're trying to download.
-   *
-   * <p>Specifically, it's parent block must exist in our Store and be from the same slot as the
-   * common ancestor. If we accept the child of any block we have, we may incorrectly mark batches
-   * between the common ancestor and this block as empty, then later contest that when we received
-   * blocks from those batches.
-   *
-   * @param firstBlock the block to check if it's the start of the chain to sync
-   * @return true if and only if the block is a suitable start of the chain to sync
-   */
   private boolean isChildOfStartingPoint(final SignedBeaconBlock firstBlock) {
-    return recentChainData
-        .getSlotForBlockRoot(firstBlock.getParentRoot())
-        .map(parentSlot -> commonAncestorSlot.join().equals(parentSlot))
-        .orElse(false);
+    return recentChainData.containsBlock(firstBlock.getParentRoot());
   }
 
   private void checkBatchesFormChain(final Batch firstBatch, final Batch secondBatch) {

--- a/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/batches/NaiveConflictResolutionStrategy.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/batches/NaiveConflictResolutionStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.sync.forward.multipeer.batches;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.networking.eth2.peers.SyncSource;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
+
+public class NaiveConflictResolutionStrategy implements ConflictResolutionStrategy {
+  private static final Logger LOG = LogManager.getLogger();
+
+  @Override
+  public void verifyBatch(final Batch batch, final SyncSource source) {
+    LOG.debug("Invalidating batch {}", batch);
+    // Re-download all contested batches, but no penalties are applied to peers
+    // Just hope it works out better next time.
+    batch.markAsInvalid();
+  }
+
+  @Override
+  public void reportInvalidBatch(final Batch batch, final SyncSource source) {
+    LOG.debug("Disconnecting peer {} for providing invalid batch data {}", source, batch);
+    // Disconnect any peer that gives us clearly invalid data.
+    // This assumes malice where a simple chain reorg may have explained it
+    source.disconnectCleanly(DisconnectReason.REMOTE_FAULT).reportExceptions();
+  }
+
+  @Override
+  public void reportConfirmedBatch(final Batch batch, final SyncSource source) {}
+}

--- a/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/BatchSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/BatchSyncTest.java
@@ -581,36 +581,6 @@ class BatchSyncTest {
   }
 
   @Test
-  void shouldHandleBatchWithNoSyncSourceMarkedCompleteBecauseOfLaterBatch() {
-    final SafeFuture<SyncResult> syncFuture = sync.syncToChain(targetChain);
-    assertThat(syncFuture).isNotDone();
-
-    final Batch batch0 = batches.get(0);
-    final Batch batch1 = batches.get(1);
-    final Batch batch2 = batches.get(2);
-    final Batch batch3 = batches.get(3);
-    final Batch batch4 = batches.get(4);
-
-    // Found an old common ancestor so we already have blocks up to the start of batch 2
-    final SignedBlockAndState bestBlock =
-        storageSystem.chainUpdater().advanceChainUntil(batch4.getFirstSlot().longValue());
-    storageSystem.chainUpdater().updateBestBlock(bestBlock);
-
-    // We receive a block from in batch4 which is a child of an existing block
-    // but it's not the common ancestor sync started from
-    final SignedBeaconBlock batch4Block = chainBuilder.getBlockAtSlot(batch4.getFirstSlot());
-    assertThat(recentChainData.containsBlock(batch4Block.getParentRoot())).isTrue();
-    batches.receiveBlocks(batch4, batch4Block);
-
-    // None of the batches should be complete
-    assertThatBatch(batch0).isNotComplete();
-    assertThatBatch(batch1).isNotComplete();
-    assertThatBatch(batch2).isNotComplete();
-    assertThatBatch(batch3).isNotComplete();
-    assertThatBatch(batch4).isNotComplete();
-  }
-
-  @Test
   void shouldRemoveBatchFromActiveSetWhenImportCompletesSuccessfully() {
     assertThat(sync.syncToChain(targetChain)).isNotDone();
 


### PR DESCRIPTION
## PR Description
Common ancestor turns out to sometimes be an empty slot which causes problems. Not entirely sure how that happens but go back to having `NoSuchElementException` for now rather than not being able to sync.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
