### PR TITLE
Update get-forkchoice-snapshot debug command to handle no snapshot

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -207,12 +207,9 @@ public class DebugDbCommand implements Runnable {
     try (final Database database =
         createDatabase(dataOptions, dataStorageOptions, eth2NetworkOptions)) {
       final Optional<ProtoArraySnapshot> snapshot = database.getProtoArraySnapshot();
-      if (snapshot.isEmpty()) {
-        System.err.println("No fork choice snapshot available.");
-        return 2;
-      }
+
       final Map<UInt64, VoteTracker> votes = database.getVotes();
-      final String report = ForkChoiceDataWriter.writeForkChoiceData(snapshot.get(), votes);
+      final String report = ForkChoiceDataWriter.writeForkChoiceData(snapshot, votes);
       if (outputFile != null) {
         Files.writeString(outputFile, report, StandardCharsets.UTF_8);
       } else {

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/ForkChoiceDataWriter.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/ForkChoiceDataWriter.java
@@ -18,7 +18,9 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import tech.pegasys.teku.data.yaml.YamlProvider;
 import tech.pegasys.teku.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -28,13 +30,17 @@ import tech.pegasys.teku.protoarray.ProtoArraySnapshot;
 public class ForkChoiceDataWriter {
 
   public static String writeForkChoiceData(
-      final ProtoArraySnapshot snapshot, final Map<UInt64, VoteTracker> votes) throws IOException {
+      final Optional<ProtoArraySnapshot> snapshot, final Map<UInt64, VoteTracker> votes)
+      throws IOException {
     final SimpleModule forkChoiceModule =
         new SimpleModule()
             .addSerializer(ProtoArraySnapshot.class, new ProtoArraySnapshotSerializer())
             .addSerializer(VoteTracker.class, new VoteSerializer());
     final YamlProvider mapper = new YamlProvider(forkChoiceModule);
-    return mapper.writeString(Map.of("snapshot", snapshot, "votes", votes));
+    final Map<String, Object> data = new HashMap<>();
+    data.put("votes", votes);
+    snapshot.ifPresent(value -> data.put("snapshot", value));
+    return mapper.writeString(data);
   }
 
   private static class VoteSerializer extends JsonSerializer<VoteTracker> {


### PR DESCRIPTION
## PR Description
We no longer store separate protoarray snapshots because we rebuild them from the block data.  So update the `get-forkchoice-snapshot` command to handle not having a snapshot and just reporting the votes if that's the case.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
