### PR TITLE
update jmh tests to use stateful utils and constants

### DIFF
--- a/eth-benchmark-tests/build.gradle
+++ b/eth-benchmark-tests/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 
   implementation testFixtures(project(':ethereum:core'))
   implementation testFixtures(project(':ethereum:datastructures'))
+  implementation testFixtures(project(':ethereum:spec'))
   implementation testFixtures(project(':ethereum:statetransition'))
   implementation testFixtures(project(':storage'))
 

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/BeaconBlockBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/BeaconBlockBenchmark.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.benchmarks;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.tuweni.bytes.Bytes32;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -26,25 +27,23 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
-import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.spec.SpecProvider;
+import tech.pegasys.teku.spec.StubSpecProvider;
 
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class BeaconBlockBenchmark {
-
+  private static SpecProvider specProvider = StubSpecProvider.createMainnet();
   private static final BLSPublicKey pubkey = BLSTestUtil.randomPublicKey(0);
   private static final DataStructureUtil dataStructureUtil =
-      new DataStructureUtil(0).withPubKeyGenerator(() -> pubkey);
+      new DataStructureUtil(0, Optional.of(specProvider.getGenesisSpec()))
+          .withPubKeyGenerator(() -> pubkey);
   private static final BeaconBlock fullBeaconBlock =
       dataStructureUtil.randomBeaconBlock(100, Bytes32.random(), true);
   private static final BeaconBlock sparseBeaconBlock =
       dataStructureUtil.randomBeaconBlock(100, Bytes32.random(), false);
-
-  public BeaconBlockBenchmark() {
-    Constants.setConstants("mainnet");
-  }
 
   @Benchmark
   public void hashFullBlocks(Blackhole bh) {

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ShuffleBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ShuffleBenchmark.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.benchmarks;
 
+import java.util.Optional;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -27,30 +28,21 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 import tech.pegasys.teku.datastructures.util.CommitteeUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.SpecConfiguration;
 import tech.pegasys.teku.spec.SpecProvider;
-import tech.pegasys.teku.spec.constants.SpecConstants;
-import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.spec.StubSpecProvider;
 
 @Fork(3)
 @BenchmarkMode(Mode.SingleShotTime)
 @State(Scope.Thread)
 public class ShuffleBenchmark {
+  private SpecProvider specProvider = StubSpecProvider.createMainnet();
 
   @Param({"16384", "32768"})
   int indexCount;
 
   Bytes32 seed = Bytes32.ZERO;
-  private final SpecConstants specConstants = SpecConstants.builder().configName("mainnet").build();
-  private final SpecConfiguration specConfiguration =
-      SpecConfiguration.builder().constants(specConstants).build();
-  private final SpecProvider specProvider = SpecProvider.create(specConfiguration);
   private final tech.pegasys.teku.spec.util.CommitteeUtil committeeUtil =
       specProvider.atSlot(UInt64.ZERO).getCommitteeUtil();
-
-  public ShuffleBenchmark() {
-    Constants.setConstants("mainnet");
-  }
 
   @Benchmark
   @Warmup(iterations = 2)

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
@@ -56,7 +56,7 @@ import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
 @Threads(1)
 public abstract class TransitionBenchmark {
 
-  private static SpecProvider specProvider = StubSpecProvider.createMainnet();
+  private static SpecProvider specProvider = StubSpecProvider.createMainnet( __ -> {}, false);
   WeakSubjectivityValidator wsValidator;
   RecentChainData recentChainData;
   BeaconChainUtil localChain;
@@ -84,7 +84,7 @@ public abstract class TransitionBenchmark {
         BlsKeyPairIO.createReaderForResource(keysFile).readAll(validatorsCount);
 
     EventBus localEventBus = mock(EventBus.class);
-    wsValidator = WeakSubjectivityFactory.lenientValidator();
+    wsValidator = WeakSubjectivityFactory.lenientValidator(Optional.of(specProvider.getGenesisSpec().getBeaconStateUtil()));
     recentChainData = MemoryOnlyRecentChainData.create(localEventBus);
     localChain = BeaconChainUtil.create(recentChainData, validatorKeys, false);
     localChain.initializeStorage();

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/SszAttestationBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/SszAttestationBenchmark.java
@@ -13,17 +13,21 @@
 
 package tech.pegasys.teku.benchmarks.ssz;
 
+import java.util.Optional;
 import org.openjdk.jmh.infra.Blackhole;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.spec.SpecProvider;
+import tech.pegasys.teku.spec.StubSpecProvider;
 import tech.pegasys.teku.ssz.SSZTypes.Bitlist;
 import tech.pegasys.teku.ssz.backing.schema.SszSchema;
 
 public class SszAttestationBenchmark extends SszAbstractContainerBenchmark<Attestation> {
-
-  private static final DataStructureUtil dataStructureUtil = new DataStructureUtil(1);
+  private static SpecProvider specProvider = StubSpecProvider.createMainnet();
+  private static final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(1, Optional.of(specProvider.getGenesisSpec()));
   private static final Attestation anAttestation = dataStructureUtil.randomAttestation();
 
   private static final Bitlist aggregation_bits = anAttestation.getAggregation_bits();

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/SszBeaconBlockBodyBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/SszBeaconBlockBodyBenchmark.java
@@ -13,14 +13,18 @@
 
 package tech.pegasys.teku.benchmarks.ssz;
 
+import java.util.Optional;
 import org.openjdk.jmh.infra.Blackhole;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlockBody;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
+import tech.pegasys.teku.spec.SpecProvider;
+import tech.pegasys.teku.spec.StubSpecProvider;
 import tech.pegasys.teku.ssz.backing.schema.SszSchema;
 
 public class SszBeaconBlockBodyBenchmark extends SszAbstractContainerBenchmark<BeaconBlockBody> {
-
-  private static final DataStructureUtil dataStructureUtil = new DataStructureUtil(1);
+  private static SpecProvider specProvider = StubSpecProvider.createMainnet();
+  private static final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(1, Optional.of(specProvider.getGenesisSpec()));
   private static final BeaconBlockBody beaconBlockBody = dataStructureUtil.randomBeaconBlockBody();
 
   @Override

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/SszPendingAttestationBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/SszPendingAttestationBenchmark.java
@@ -13,18 +13,22 @@
 
 package tech.pegasys.teku.benchmarks.ssz;
 
+import java.util.Optional;
 import org.openjdk.jmh.infra.Blackhole;
 import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecProvider;
+import tech.pegasys.teku.spec.StubSpecProvider;
 import tech.pegasys.teku.ssz.SSZTypes.Bitlist;
 import tech.pegasys.teku.ssz.backing.schema.SszSchema;
 
 public class SszPendingAttestationBenchmark
     extends SszAbstractContainerBenchmark<PendingAttestation> {
-
-  private static final DataStructureUtil dataStructureUtil = new DataStructureUtil(1);
+  private static SpecProvider specProvider = StubSpecProvider.createMainnet();
+  private static final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(1, Optional.of(specProvider.getGenesisSpec()));
   private static final PendingAttestation aPendingAttestation =
       dataStructureUtil.randomPendingAttestation();
 

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/util/backing/BeaconStateBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/util/backing/BeaconStateBenchmark.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.benchmarks.util.backing;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
@@ -26,19 +27,17 @@ import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Validator;
 import tech.pegasys.teku.datastructures.util.DataStructureUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.spec.SpecProvider;
+import tech.pegasys.teku.spec.StubSpecProvider;
 
 @State(Scope.Thread)
 public class BeaconStateBenchmark {
-
+  private static SpecProvider specProvider = StubSpecProvider.createMainnet();
   private static final BLSPublicKey pubkey = BLSTestUtil.randomPublicKey(0);
   private static final DataStructureUtil dataStructureUtil =
-      new DataStructureUtil(0).withPubKeyGenerator(() -> pubkey);
+      new DataStructureUtil(0, Optional.of(specProvider.getGenesisSpec()))
+          .withPubKeyGenerator(() -> pubkey);
   private static final BeaconState beaconState = dataStructureUtil.randomBeaconState(32 * 1024);
-
-  public BeaconStateBenchmark() {
-    Constants.setConstants("mainnet");
-  }
 
   @Benchmark
   @Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)

--- a/ethereum/datastructures/build.gradle
+++ b/ethereum/datastructures/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   testFixturesApi 'org.apache.tuweni:tuweni-bytes'
   testFixturesApi 'com.google.guava:guava'
   testFixturesApi project(':infrastructure:unsigned')
+  testFixturesApi project(':ethereum:spec')
 
   testFixturesImplementation project(':bls')
   testFixturesImplementation testFixtures(project(':bls'))

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -23,9 +23,13 @@ public class Spec {
   private final BeaconStateUtil beaconStateUtil;
 
   Spec(final SpecConstants constants) {
+    this(constants, true);
+  }
+
+  Spec(final SpecConstants constants, final boolean validateBlocks) {
     this.constants = constants;
     this.committeeUtil = new CommitteeUtil(this.constants);
-    this.beaconStateUtil = new BeaconStateUtil(this.constants, this.committeeUtil);
+    this.beaconStateUtil = new BeaconStateUtil(this.constants, this.committeeUtil, validateBlocks);
   }
 
   public SpecConstants getConstants() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecProvider.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecProvider.java
@@ -44,8 +44,10 @@ public class SpecProvider {
   }
 
   public static SpecProvider create(
-      final SpecConfiguration config, final ForkManifest forkManifest) {
-    final Spec initialSpec = new Spec(config.constants());
+      final SpecConfiguration config,
+      final ForkManifest forkManifest,
+      final boolean validateBlocks) {
+    final Spec initialSpec = new Spec(config.constants(), validateBlocks);
     return new SpecProvider(initialSpec, forkManifest);
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/StubSpecProvider.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/StubSpecProvider.java
@@ -38,26 +38,26 @@ public class StubSpecProvider {
   }
 
   public static SpecProvider createMinimal(Consumer<SpecConstantsBuilder> builderConsumer) {
-    return create("minimal", builderConsumer);
+    return create("minimal", builderConsumer, true);
   }
 
   public static SpecProvider createMainnet() {
-    return createMainnet(__ -> {});
+    return createMainnet(__ -> {}, true);
   }
 
-  public static SpecProvider createMainnet(Consumer<SpecConstantsBuilder> builderConsumer) {
-    return create("mainnet", builderConsumer);
+  public static SpecProvider createMainnet(Consumer<SpecConstantsBuilder> builderConsumer, final boolean validateBlocks) {
+    return create("mainnet", builderConsumer, validateBlocks);
   }
 
   private static SpecProvider create(
-      final String constants, final Consumer<SpecConstantsBuilder> builderConsumer) {
+      final String constants, final Consumer<SpecConstantsBuilder> builderConsumer, final boolean validateBlocks) {
     final Bytes4 genesisFork = Bytes4.fromHexString("0x00000000");
 
     final SpecConfiguration config =
         SpecConfiguration.builder().constants(loadConstants(constants, builderConsumer)).build();
     final ForkManifest forkManifest =
         ForkManifest.create(List.of(new Fork(genesisFork, genesisFork, UInt64.ZERO)));
-    return SpecProvider.create(config, forkManifest);
+    return SpecProvider.create(config, forkManifest, validateBlocks);
   }
 
   private static SpecConstants loadConstants(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -68,6 +68,8 @@ import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
 import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 
 public class BlockImporterTest {
+  private static SpecProvider specProvider = StubSpecProvider.createMainnet(
+      config -> config.slotsPerEpoch(6), false);
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(8);
   private final EventBus localEventBus = mock(EventBus.class);
   private final RecentChainData recentChainData = MemoryOnlyRecentChainData.create(localEventBus);
@@ -90,18 +92,6 @@ public class BlockImporterTest {
 
   private final BlockImporter blockImporter =
       new BlockImporter(recentChainData, forkChoice, weakSubjectivityValidator, localEventBus);
-
-  @BeforeAll
-  public static void init() {
-    Constants.SLOTS_PER_EPOCH = 6;
-    BeaconStateUtil.BLS_VERIFY_DEPOSIT = false;
-  }
-
-  @AfterAll
-  public static void dispose() {
-    BeaconStateUtil.BLS_VERIFY_DEPOSIT = true;
-    Constants.setConstants("minimal");
-  }
 
   @BeforeEach
   public void setup() {

--- a/ethereum/weaksubjectivity/src/testFixtures/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityFactory.java
+++ b/ethereum/weaksubjectivity/src/testFixtures/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityFactory.java
@@ -15,7 +15,10 @@ package tech.pegasys.teku.weaksubjectivity;
 
 import tech.pegasys.teku.spec.SpecProvider;
 import tech.pegasys.teku.spec.StubSpecProvider;
+import tech.pegasys.teku.spec.util.BeaconStateUtil;
 import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
+
+import java.util.Optional;
 
 public class WeakSubjectivityFactory {
 
@@ -25,5 +28,9 @@ public class WeakSubjectivityFactory {
 
   public static WeakSubjectivityValidator lenientValidator() {
     return WeakSubjectivityValidator.lenient(wsConfig);
+  }
+
+  public static WeakSubjectivityValidator lenientValidator(final Optional<BeaconStateUtil> beaconStateUtil) {
+    return WeakSubjectivityValidator.lenient(wsConfig, beaconStateUtil);
   }
 }

--- a/networking/eth2/build.gradle
+++ b/networking/eth2/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   testImplementation testFixtures(project(':infrastructure:metrics'))
   testImplementation testFixtures(project(':ethereum:core'))
   testImplementation testFixtures(project(':ethereum:datastructures'))
+  testImplementation testFixtures(project(':ethereum:spec'))
   testImplementation testFixtures(project(':ethereum:statetransition'))
   testImplementation testFixtures(project(':infrastructure:async'))
   testImplementation testFixtures(project(':infrastructure:time'))

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2TopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2TopicHandlerTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2.gossip.topics;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
 import io.libp2p.core.pubsub.ValidationResult;
+import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.RejectedExecutionException;
 import org.apache.tuweni.bytes.Bytes;
@@ -29,11 +30,16 @@ import tech.pegasys.teku.networking.eth2.gossip.encoding.DecodingException;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers.Eth2TopicHandler;
 import tech.pegasys.teku.networking.p2p.gossip.PreparedGossipMessage;
+import tech.pegasys.teku.spec.SpecProvider;
+import tech.pegasys.teku.spec.StubSpecProvider;
 import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class Eth2TopicHandlerTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(0);
+
+  private static SpecProvider specProvider = StubSpecProvider.createMainnet();
+  private static final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(0, Optional.of(specProvider.getGenesisSpec()));
   private final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
   private final Bytes blockBytes = GossipEncoding.SSZ_SNAPPY.encode(block);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -45,14 +45,19 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
+import tech.pegasys.teku.spec.SpecProvider;
+import tech.pegasys.teku.spec.StubSpecProvider;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 class BeaconBlocksByRangeMessageHandlerTest {
 
+  private static SpecProvider specProvider = StubSpecProvider.createMainnet();
+  private static final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(0, Optional.of(specProvider.getGenesisSpec()));
   private static final UInt64 MAX_REQUEST_SIZE = UInt64.valueOf(8);
   private static final List<StateAndBlockSummary> BLOCKS_W_STATE =
       IntStream.rangeClosed(0, 10)
-          .mapToObj(slot -> new DataStructureUtil(slot).randomSignedBlockAndState(slot))
+          .mapToObj(slot -> dataStructureUtil.randomSignedBlockAndState(slot))
           .collect(Collectors.toList());
   private static final List<SignedBeaconBlock> BLOCKS =
       BLOCKS_W_STATE.stream()

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
@@ -42,6 +42,8 @@ import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.protoarray.ProtoArrayStorageChannel;
 import tech.pegasys.teku.protoarray.StoredBlockMetadata;
+import tech.pegasys.teku.spec.SpecProvider;
+import tech.pegasys.teku.spec.StubSpecProvider;
 import tech.pegasys.teku.storage.api.ChainHeadChannel;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
@@ -55,8 +57,10 @@ import tech.pegasys.teku.storage.store.UpdatableStore;
 
 public class StorageBackedRecentChainDataTest {
 
-  private static final BeaconState INITIAL_STATE =
-      new DataStructureUtil(3).randomBeaconState(UInt64.ZERO);
+  private static SpecProvider specProvider = StubSpecProvider.createMainnet();
+  private static final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(3, Optional.of(specProvider.getGenesisSpec()));
+  private static final BeaconState INITIAL_STATE = dataStructureUtil.randomBeaconState(UInt64.ZERO);
 
   private final StorageQueryChannel storageQueryChannel = mock(StorageQueryChannel.class);
   private final StorageUpdateChannel storageUpdateChannel = mock(StorageUpdateChannel.class);


### PR DESCRIPTION
also remove the static constant from beaconStateUtil that allows toggling of verifyDeposits, as it's not really something we want to be able to toggle within an object like some tests do.

partially addresses #3394

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
