### PR TITLE
Fix intermittent LibP2PPrivateKeyLoaderTest.

### DIFF
--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPrivateKeyLoaderTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPrivateKeyLoaderTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.p2p.libp2p;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.libp2p.core.crypto.KeyKt;
 import io.libp2p.core.crypto.PrivKey;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -36,7 +37,7 @@ public class LibP2PPrivateKeyLoaderTest {
     // check that new key is generated
     final PrivKey generatedPK = loader.get();
     assertThat(generatedPK).isNotNull();
-    assertThat(generatedPK.raw().length).isGreaterThanOrEqualTo(32);
+    assertRoundTrip(generatedPK);
 
     // check the same key loaded next time
     PrivKey loadedPK = loader.get();
@@ -48,7 +49,7 @@ public class LibP2PPrivateKeyLoaderTest {
     // check that another key is generated after old key is deleted
     PrivKey generatedAnotherPK = loader.get();
     assertThat(generatedAnotherPK).isNotNull();
-    assertThat(generatedAnotherPK.raw().length).isGreaterThanOrEqualTo(32);
+    assertRoundTrip(generatedAnotherPK);
     assertThat(generatedAnotherPK).isNotEqualTo(generatedPK);
   }
 
@@ -63,5 +64,10 @@ public class LibP2PPrivateKeyLoaderTest {
     final LibP2PPrivateKeyLoader loader =
         new LibP2PPrivateKeyLoader(store, Optional.of(customPKFile.toAbsolutePath().toString()));
     assertThat(loader.get()).isEqualTo(privKey);
+  }
+
+  private void assertRoundTrip(final PrivKey generatedPK) {
+    final PrivKey reparsed = KeyKt.unmarshalPrivateKey(generatedPK.bytes());
+    assertThat(reparsed).isEqualTo(generatedPK);
   }
 }


### PR DESCRIPTION
## PR Description
Fix intermittency in `LibP2PPrivateKeyLoaderTest`.  The length of serialised form of the private keys is not guaranteed. Just check it can round trip instead.

## Fixed Issue(s)
fixes #3602

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
