### PR TITLE
Avoid basic authentication credentials from being leaked to log files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,4 @@ For information on changes in released versions of Teku, see the [releases page]
 - Increase the default limit for the queue for delivering events to REST API subscribers. When subscribing to attestations, they are often received in bursts which would exceed the previous limit even when the client was keeping up.
   The default limit is now 250 and can now be configured with `--Xrest-api-max-pending-events`.
 - Fixed `ProtoNode: Delta to be subtracted is greater than node weight` exception which may occur after an issue writing data to disk storage.
+- Fix issue where basic authentication credentials included in the `--beacon-node-api-endpoint` URL were included in `DEBUG` level logs.

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 import okhttp3.Credentials;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
-import okhttp3.OkHttpClient.Builder;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.timed.RepeatingTaskScheduler;
@@ -90,7 +89,8 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
     return new RemoteBeaconNodeApi(beaconChainEventAdapter, validatorApiChannel);
   }
 
-  private static void addAuthenticator(final HttpUrl apiEndpoint, final Builder httpClientBuilder) {
+  private static void addAuthenticator(
+      final HttpUrl apiEndpoint, final OkHttpClient.Builder httpClientBuilder) {
     final String username = apiEndpoint.username();
     final String password = apiEndpoint.password();
     if (!Strings.isNullOrEmpty(apiEndpoint.password())) {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -15,10 +15,13 @@ package tech.pegasys.teku.validator.remote;
 
 import static tech.pegasys.teku.util.config.Constants.GENESIS_EPOCH;
 
+import com.google.common.base.Strings;
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
+import okhttp3.Credentials;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import okhttp3.OkHttpClient.Builder;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.timed.RepeatingTaskScheduler;
@@ -55,9 +58,13 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
 
     final int readTimeoutInSeconds =
         getReadTimeoutInSeconds(specProvider, useIndependentAttestationTiming);
-    final OkHttpClient okHttpClient =
-        new OkHttpClient.Builder().readTimeout(readTimeoutInSeconds, TimeUnit.SECONDS).build();
-    final HttpUrl apiEndpoint = HttpUrl.get(beaconNodeApiEndpoint);
+    final OkHttpClient.Builder httpClientBuilder =
+        new OkHttpClient.Builder().readTimeout(readTimeoutInSeconds, TimeUnit.SECONDS);
+    HttpUrl apiEndpoint = HttpUrl.get(beaconNodeApiEndpoint);
+    addAuthenticator(apiEndpoint, httpClientBuilder);
+    // Strip any authentication info from the URL to ensure it doesn't get logged.
+    apiEndpoint = apiEndpoint.newBuilder().username("").password("").build();
+    final OkHttpClient okHttpClient = httpClientBuilder.build();
     final OkHttpValidatorRestApiClient apiClient =
         new OkHttpValidatorRestApiClient(apiEndpoint, okHttpClient);
 
@@ -81,6 +88,18 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
             validatorTimingChannel);
 
     return new RemoteBeaconNodeApi(beaconChainEventAdapter, validatorApiChannel);
+  }
+
+  private static void addAuthenticator(final HttpUrl apiEndpoint, final Builder httpClientBuilder) {
+    final String username = apiEndpoint.username();
+    final String password = apiEndpoint.password();
+    if (!Strings.isNullOrEmpty(apiEndpoint.password())) {
+      final String credentials = Credentials.basic(username, password);
+      httpClientBuilder.addInterceptor(
+          chain ->
+              chain.proceed(
+                  chain.request().newBuilder().header("Authorization", credentials).build()));
+    }
   }
 
   private static int getReadTimeoutInSeconds(


### PR DESCRIPTION
## PR Description
Remove the credentials from the URL and apply the authorisation header manually to ensure that the credentials don't leak when URLs are logged.

## Fixed Issue(s)
fixes #3609 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
