### PR TITLE
Enable slashing protection for local validators

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorLoader.java
@@ -85,7 +85,8 @@ public class ValidatorLoader {
       final ValidatorConfig config, final Map<BLSPublicKey, ValidatorProvider> validatorProviders) {
     if (config.getValidatorKeystorePasswordFilePairs() != null) {
       addValidatorsFromSource(
-          validatorProviders, new LocalValidatorSource(config, new KeystoreLocker(), asyncRunner));
+          validatorProviders,
+          slashingProtected(new LocalValidatorSource(config, new KeystoreLocker(), asyncRunner)));
     }
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -253,6 +253,35 @@ class ValidatorLoaderTest {
     assertThat(validator.getSigner().isLocal()).isFalse();
   }
 
+  @Test
+  void shouldEnableSlashingProtectionForLocalValidators(@TempDir Path tempDir) throws Exception {
+    writeKeystore(tempDir);
+
+    final InteropConfig interopConfig = InteropConfig.builder().build();
+    final ValidatorConfig config =
+        ValidatorConfig.builder()
+            .validatorKeys(
+                List.of(
+                    tempDir.toAbsolutePath().toString()
+                        + File.pathSeparator
+                        + tempDir.toAbsolutePath().toString()))
+            .build();
+
+    final OwnedValidators validators =
+        validatorLoader.initializeValidators(config, interopConfig, () -> httpClient);
+
+    assertThat(validators.getValidatorCount()).isEqualTo(1);
+
+    final Validator validator = validators.getValidator(PUBLIC_KEY1).orElseThrow();
+    final BeaconBlock block = dataStructureUtil.randomBeaconBlock(1);
+    final ForkInfo forkInfo = dataStructureUtil.randomForkInfo();
+    when(slashingProtector.maySignBlock(any(), any(), any())).thenReturn(new SafeFuture<>());
+    validator.getSigner().signBlock(block, forkInfo);
+    verify(slashingProtector)
+        .maySignBlock(
+            validator.getPublicKey(), forkInfo.getGenesisValidatorsRoot(), block.getSlot());
+  }
+
   private void writeKeystore(final Path tempDir) throws Exception {
     final URL resource = Resources.getResource("pbkdf2TestVector.json");
     Files.copy(Path.of(resource.toURI()), tempDir.resolve("key.json"));

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -276,7 +276,7 @@ class ValidatorLoaderTest {
     final BeaconBlock block = dataStructureUtil.randomBeaconBlock(1);
     final ForkInfo forkInfo = dataStructureUtil.randomForkInfo();
     when(slashingProtector.maySignBlock(any(), any(), any())).thenReturn(new SafeFuture<>());
-    validator.getSigner().signBlock(block, forkInfo);
+    assertThat(validator.getSigner().signBlock(block, forkInfo)).isNotDone();
     verify(slashingProtector)
         .maySignBlock(
             validator.getPublicKey(), forkInfo.getGenesisValidatorsRoot(), block.getSlot());


### PR DESCRIPTION
## PR Description
Ensure slashing protection is applied to local validators when loading.  e632ef88270132eb8a60e680cafcf53685b8a4e8 introduced the regression earlier today.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
