### PR TITLE
Add support for loading new validators in ValidatorLoader

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -223,13 +223,15 @@ public class VoluntaryExitCommand implements Runnable {
 
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
-            new RejectingSlashingProtector(), new PublicKeyLoader(), asyncRunner, metricsSystem);
+            config.validatorClient().getValidatorConfig(),
+            config.validatorClient().getInteropConfig(),
+            new RejectingSlashingProtector(),
+            new PublicKeyLoader(),
+            asyncRunner,
+            metricsSystem);
 
     try {
-      validators =
-          validatorLoader.initializeValidators(
-              config.validatorClient().getValidatorConfig(),
-              config.validatorClient().getInteropConfig());
+      validators = validatorLoader.loadValidators();
     } catch (InvalidConfigurationException ex) {
       SUB_COMMAND_LOG.error(ex.getMessage());
       System.exit(1);

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -231,7 +231,8 @@ public class VoluntaryExitCommand implements Runnable {
             metricsSystem);
 
     try {
-      validators = validatorLoader.loadValidators();
+      validatorLoader.loadValidators();
+      validators = validatorLoader.getOwnedValidators();
     } catch (InvalidConfigurationException ex) {
       SUB_COMMAND_LOG.error(ex.getMessage());
       System.exit(1);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -112,10 +112,13 @@ public class ValidatorClientService extends Service {
         new LocalSlashingProtector(new SyncDataAccessor(), slashingProtectionPath);
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
-            slashingProtector, new PublicKeyLoader(), asyncRunner, metricsSystem);
-    final OwnedValidators validators =
-        validatorLoader.initializeValidators(
-            config.getValidatorConfig(), config.getInteropConfig());
+            config.getValidatorConfig(),
+            config.getInteropConfig(),
+            slashingProtector,
+            new PublicKeyLoader(),
+            asyncRunner,
+            metricsSystem);
+    final OwnedValidators validators = validatorLoader.loadValidators();
     this.validatorIndexProvider = new ValidatorIndexProvider(validators, validatorApiChannel);
     final ValidatorDutyFactory validatorDutyFactory =
         new ValidatorDutyFactory(forkProvider, validatorApiChannel);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -118,7 +118,8 @@ public class ValidatorClientService extends Service {
             new PublicKeyLoader(),
             asyncRunner,
             metricsSystem);
-    final OwnedValidators validators = validatorLoader.loadValidators();
+    validatorLoader.loadValidators();
+    final OwnedValidators validators = validatorLoader.getOwnedValidators();
     this.validatorIndexProvider = new ValidatorIndexProvider(validators, validatorApiChannel);
     final ValidatorDutyFactory validatorDutyFactory =
         new ValidatorDutyFactory(forkProvider, validatorApiChannel);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/OwnedValidatorsTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/OwnedValidatorsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.loader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.core.signatures.NoOpSigner.NO_OP_SIGNER;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.networks.SpecProviderFactory;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.client.Validator;
+
+class OwnedValidatorsTest {
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(SpecProviderFactory.createMinimal());
+  private final OwnedValidators validators = new OwnedValidators();
+
+  @Test
+  void shouldAddNewValidator() {
+    final Validator validator =
+        new Validator(dataStructureUtil.randomPublicKey(), NO_OP_SIGNER, Optional::empty);
+    assertThat(validators.getValidatorCount()).isZero();
+    validators.addValidator(validator);
+
+    assertThat(validators.getValidatorCount()).isEqualTo(1);
+    assertThat(validators.getValidator(validator.getPublicKey())).contains(validator);
+  }
+
+  @Test
+  void shouldRejectReplacingAnExistingValidator() {
+    final BLSPublicKey publicKey = dataStructureUtil.randomPublicKey();
+    final Validator validator = new Validator(publicKey, NO_OP_SIGNER, Optional::empty);
+    final Validator validator2 = new Validator(publicKey, NO_OP_SIGNER, Optional::empty);
+    // Sanity check - if we ever add an equals method we'll have to find a new way to differentiate
+    assertThat(validator2).isNotEqualTo(validator);
+    validators.addValidator(validator);
+
+    assertThatThrownBy(() -> validators.addValidator(validator2))
+        .isInstanceOf(IllegalStateException.class);
+    assertThat(validators.getValidator(publicKey)).contains(validator);
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +46,7 @@ import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.networks.SpecProviderFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.InteropConfig;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
@@ -71,7 +73,8 @@ class ValidatorLoaderTest {
     }
   }
 
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(SpecProviderFactory.createMinimal());
 
   private final SlashingProtector slashingProtector = mock(SlashingProtector.class);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
@@ -82,8 +85,7 @@ class ValidatorLoaderTest {
   @SuppressWarnings("unchecked")
   private final HttpResponse<Void> upcheckResponse = mock(HttpResponse.class);
 
-  private final ValidatorLoader validatorLoader =
-      ValidatorLoader.create(slashingProtector, publicKeyLoader, asyncRunner, metricsSystem);
+  private final Supplier<HttpClient> httpClientFactory = () -> httpClient;
 
   @BeforeEach
   void initUpcheckMockResponse() throws IOException, InterruptedException {
@@ -97,8 +99,6 @@ class ValidatorLoaderTest {
     final List<BLSPublicKey> expectedKeys = List.of(PUBLIC_KEY1, PUBLIC_KEY2);
     final String publicKeysUrl = "http://example.com";
     when(publicKeyLoader.getPublicKeys(List.of(publicKeysUrl))).thenReturn(expectedKeys);
-    final ValidatorLoader validatorLoader =
-        ValidatorLoader.create(slashingProtector, publicKeyLoader, asyncRunner, metricsSystem);
 
     final InteropConfig interopConfig = InteropConfig.builder().build();
     final ValidatorConfig config =
@@ -108,8 +108,17 @@ class ValidatorLoaderTest {
             .validatorExternalSignerSlashingProtectionEnabled(true)
             .build();
 
-    final OwnedValidators validators =
-        validatorLoader.initializeValidators(config, interopConfig, () -> httpClient);
+    final ValidatorLoader validatorLoader =
+        ValidatorLoader.create(
+            config,
+            interopConfig,
+            httpClientFactory,
+            slashingProtector,
+            publicKeyLoader,
+            asyncRunner,
+            metricsSystem);
+
+    final OwnedValidators validators = validatorLoader.loadValidators();
 
     assertThat(validators.getValidatorCount()).isEqualTo(2);
 
@@ -125,7 +134,7 @@ class ValidatorLoaderTest {
   }
 
   @Test
-  void initializeValidatorsWithExternalSignerAndSlashingProtection() throws Exception {
+  void initializeValidatorsWithExternalSignerAndSlashingProtection() {
     final InteropConfig interopConfig = InteropConfig.builder().build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
@@ -134,9 +143,17 @@ class ValidatorLoaderTest {
                 Collections.singletonList(PUBLIC_KEY1.toString()))
             .validatorExternalSignerSlashingProtectionEnabled(true)
             .build();
+    final ValidatorLoader validatorLoader =
+        ValidatorLoader.create(
+            config,
+            interopConfig,
+            httpClientFactory,
+            slashingProtector,
+            publicKeyLoader,
+            asyncRunner,
+            metricsSystem);
 
-    final OwnedValidators validators =
-        validatorLoader.initializeValidators(config, interopConfig, () -> httpClient);
+    final OwnedValidators validators = validatorLoader.loadValidators();
 
     assertThat(validators.getValidatorCount()).isEqualTo(1);
     final Validator validator = validators.getValidator(PUBLIC_KEY1).orElseThrow();
@@ -157,7 +174,7 @@ class ValidatorLoaderTest {
   }
 
   @Test
-  void initializeValidatorsWithExternalSignerAndNoSlashingProtection() throws Exception {
+  void initializeValidatorsWithExternalSignerAndNoSlashingProtection() {
     final InteropConfig interopConfig = InteropConfig.builder().build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
@@ -166,9 +183,17 @@ class ValidatorLoaderTest {
                 Collections.singletonList(PUBLIC_KEY1.toString()))
             .validatorExternalSignerSlashingProtectionEnabled(false)
             .build();
+    final ValidatorLoader validatorLoader =
+        ValidatorLoader.create(
+            config,
+            interopConfig,
+            httpClientFactory,
+            slashingProtector,
+            publicKeyLoader,
+            asyncRunner,
+            metricsSystem);
 
-    final OwnedValidators validators =
-        validatorLoader.initializeValidators(config, interopConfig, () -> httpClient);
+    final OwnedValidators validators = validatorLoader.loadValidators();
 
     assertThat(validators.getValidatorCount()).isEqualTo(1);
     final Validator validator = validators.getValidator(PUBLIC_KEY1).orElseThrow();
@@ -205,9 +230,17 @@ class ValidatorLoaderTest {
                         + File.pathSeparator
                         + tempDir.toAbsolutePath().toString()))
             .build();
+    final ValidatorLoader validatorLoader =
+        ValidatorLoader.create(
+            config,
+            interopConfig,
+            httpClientFactory,
+            slashingProtector,
+            publicKeyLoader,
+            asyncRunner,
+            metricsSystem);
 
-    final OwnedValidators validators =
-        validatorLoader.initializeValidators(config, interopConfig, () -> httpClient);
+    final OwnedValidators validators = validatorLoader.loadValidators();
 
     assertThat(validators.getValidatorCount()).isEqualTo(2);
 
@@ -239,9 +272,17 @@ class ValidatorLoaderTest {
                         + File.pathSeparator
                         + tempDir.toAbsolutePath().toString()))
             .build();
+    final ValidatorLoader validatorLoader =
+        ValidatorLoader.create(
+            config,
+            interopConfig,
+            httpClientFactory,
+            slashingProtector,
+            publicKeyLoader,
+            asyncRunner,
+            metricsSystem);
 
-    final OwnedValidators validators =
-        validatorLoader.initializeValidators(config, interopConfig, () -> httpClient);
+    final OwnedValidators validators = validatorLoader.loadValidators();
 
     // Both local and external validators get loaded.
     assertThat(validators.getValidatorCount()).isEqualTo(1);
@@ -266,9 +307,17 @@ class ValidatorLoaderTest {
                         + File.pathSeparator
                         + tempDir.toAbsolutePath().toString()))
             .build();
+    final ValidatorLoader validatorLoader =
+        ValidatorLoader.create(
+            config,
+            interopConfig,
+            httpClientFactory,
+            slashingProtector,
+            publicKeyLoader,
+            asyncRunner,
+            metricsSystem);
 
-    final OwnedValidators validators =
-        validatorLoader.initializeValidators(config, interopConfig, () -> httpClient);
+    final OwnedValidators validators = validatorLoader.loadValidators();
 
     assertThat(validators.getValidatorCount()).isEqualTo(1);
 
@@ -280,6 +329,73 @@ class ValidatorLoaderTest {
     verify(slashingProtector)
         .maySignBlock(
             validator.getPublicKey(), forkInfo.getGenesisValidatorsRoot(), block.getSlot());
+  }
+
+  @Test
+  void shouldLoadAdditionalExternalValidatorsOnReload() {
+    final PublicKeyLoader publicKeyLoader = mock(PublicKeyLoader.class);
+    final List<BLSPublicKey> initialKeys = List.of(PUBLIC_KEY1);
+    final String publicKeysUrl = "http://example.com";
+    when(publicKeyLoader.getPublicKeys(List.of(publicKeysUrl))).thenReturn(initialKeys);
+
+    final InteropConfig interopConfig = InteropConfig.builder().build();
+    final ValidatorConfig config =
+        ValidatorConfig.builder()
+            .validatorExternalSignerUrl(SIGNER_URL)
+            .validatorExternalSignerPublicKeySources(Collections.singletonList(publicKeysUrl))
+            .validatorExternalSignerSlashingProtectionEnabled(true)
+            .build();
+    final ValidatorLoader validatorLoader =
+        ValidatorLoader.create(
+            config,
+            interopConfig,
+            httpClientFactory,
+            slashingProtector,
+            publicKeyLoader,
+            asyncRunner,
+            metricsSystem);
+
+    final OwnedValidators validators = validatorLoader.loadValidators();
+    assertThat(validators.getPublicKeys()).containsOnly(PUBLIC_KEY1);
+
+    final List<BLSPublicKey> reconfiguredKeys = List.of(PUBLIC_KEY1, PUBLIC_KEY2);
+    when(publicKeyLoader.getPublicKeys(List.of(publicKeysUrl))).thenReturn(reconfiguredKeys);
+
+    validatorLoader.loadValidators();
+    assertThat(validators.getPublicKeys()).containsExactlyInAnyOrder(PUBLIC_KEY1, PUBLIC_KEY2);
+  }
+
+  @Test
+  void shouldLoadAdditionalLocalValidatorsOnReload(final @TempDir Path tempDir) throws Exception {
+    final InteropConfig interopConfig = InteropConfig.builder().build();
+    final ValidatorConfig config =
+        ValidatorConfig.builder()
+            .validatorKeys(
+                List.of(
+                    tempDir.toAbsolutePath().toString()
+                        + File.pathSeparator
+                        + tempDir.toAbsolutePath().toString()))
+            .build();
+
+    final ValidatorLoader validatorLoader =
+        ValidatorLoader.create(
+            config,
+            interopConfig,
+            httpClientFactory,
+            slashingProtector,
+            publicKeyLoader,
+            asyncRunner,
+            metricsSystem);
+
+    // No validators initially
+    final OwnedValidators validators = validatorLoader.loadValidators();
+    assertThat(validators.getPublicKeys()).isEmpty();
+
+    // Then we add one and reload
+    writeKeystore(tempDir);
+    validatorLoader.loadValidators();
+
+    assertThat(validators.getPublicKeys()).containsExactlyInAnyOrder(PUBLIC_KEY1);
   }
 
   private void writeKeystore(final Path tempDir) throws Exception {
@@ -297,8 +413,16 @@ class ValidatorLoaderTest {
             .interopOwnedValidatorCount(ownedValidatorCount)
             .build();
     final ValidatorConfig config = ValidatorConfig.builder().build();
-    final OwnedValidators validators =
-        validatorLoader.initializeValidators(config, interopConfig, () -> httpClient);
+    final ValidatorLoader validatorLoader =
+        ValidatorLoader.create(
+            config,
+            interopConfig,
+            httpClientFactory,
+            slashingProtector,
+            publicKeyLoader,
+            asyncRunner,
+            metricsSystem);
+    final OwnedValidators validators = validatorLoader.loadValidators();
 
     assertThat(validators.getValidatorCount()).isEqualTo(ownedValidatorCount);
   }
@@ -312,8 +436,16 @@ class ValidatorLoaderTest {
             .interopOwnedValidatorCount(ownedValidatorCount)
             .build();
     final ValidatorConfig config = ValidatorConfig.builder().build();
-    final OwnedValidators validators =
-        validatorLoader.initializeValidators(config, interopConfig, () -> httpClient);
+    final ValidatorLoader validatorLoader =
+        ValidatorLoader.create(
+            config,
+            interopConfig,
+            httpClientFactory,
+            slashingProtector,
+            publicKeyLoader,
+            asyncRunner,
+            metricsSystem);
+    final OwnedValidators validators = validatorLoader.loadValidators();
 
     assertThat(validators.hasNoValidators()).isTrue();
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -118,7 +118,8 @@ class ValidatorLoaderTest {
             asyncRunner,
             metricsSystem);
 
-    final OwnedValidators validators = validatorLoader.loadValidators();
+    validatorLoader.loadValidators();
+    final OwnedValidators validators = validatorLoader.getOwnedValidators();
 
     assertThat(validators.getValidatorCount()).isEqualTo(2);
 
@@ -153,7 +154,8 @@ class ValidatorLoaderTest {
             asyncRunner,
             metricsSystem);
 
-    final OwnedValidators validators = validatorLoader.loadValidators();
+    validatorLoader.loadValidators();
+    final OwnedValidators validators = validatorLoader.getOwnedValidators();
 
     assertThat(validators.getValidatorCount()).isEqualTo(1);
     final Validator validator = validators.getValidator(PUBLIC_KEY1).orElseThrow();
@@ -193,7 +195,8 @@ class ValidatorLoaderTest {
             asyncRunner,
             metricsSystem);
 
-    final OwnedValidators validators = validatorLoader.loadValidators();
+    validatorLoader.loadValidators();
+    final OwnedValidators validators = validatorLoader.getOwnedValidators();
 
     assertThat(validators.getValidatorCount()).isEqualTo(1);
     final Validator validator = validators.getValidator(PUBLIC_KEY1).orElseThrow();
@@ -240,7 +243,8 @@ class ValidatorLoaderTest {
             asyncRunner,
             metricsSystem);
 
-    final OwnedValidators validators = validatorLoader.loadValidators();
+    validatorLoader.loadValidators();
+    final OwnedValidators validators = validatorLoader.getOwnedValidators();
 
     assertThat(validators.getValidatorCount()).isEqualTo(2);
 
@@ -282,7 +286,8 @@ class ValidatorLoaderTest {
             asyncRunner,
             metricsSystem);
 
-    final OwnedValidators validators = validatorLoader.loadValidators();
+    validatorLoader.loadValidators();
+    final OwnedValidators validators = validatorLoader.getOwnedValidators();
 
     // Both local and external validators get loaded.
     assertThat(validators.getValidatorCount()).isEqualTo(1);
@@ -317,7 +322,8 @@ class ValidatorLoaderTest {
             asyncRunner,
             metricsSystem);
 
-    final OwnedValidators validators = validatorLoader.loadValidators();
+    validatorLoader.loadValidators();
+    final OwnedValidators validators = validatorLoader.getOwnedValidators();
 
     assertThat(validators.getValidatorCount()).isEqualTo(1);
 
@@ -355,7 +361,8 @@ class ValidatorLoaderTest {
             asyncRunner,
             metricsSystem);
 
-    final OwnedValidators validators = validatorLoader.loadValidators();
+    validatorLoader.loadValidators();
+    final OwnedValidators validators = validatorLoader.getOwnedValidators();
     assertThat(validators.getPublicKeys()).containsOnly(PUBLIC_KEY1);
 
     final List<BLSPublicKey> reconfiguredKeys = List.of(PUBLIC_KEY1, PUBLIC_KEY2);
@@ -388,7 +395,8 @@ class ValidatorLoaderTest {
             metricsSystem);
 
     // No validators initially
-    final OwnedValidators validators = validatorLoader.loadValidators();
+    validatorLoader.loadValidators();
+    final OwnedValidators validators = validatorLoader.getOwnedValidators();
     assertThat(validators.getPublicKeys()).isEmpty();
 
     // Then we add one and reload
@@ -422,7 +430,8 @@ class ValidatorLoaderTest {
             publicKeyLoader,
             asyncRunner,
             metricsSystem);
-    final OwnedValidators validators = validatorLoader.loadValidators();
+    validatorLoader.loadValidators();
+    final OwnedValidators validators = validatorLoader.getOwnedValidators();
 
     assertThat(validators.getValidatorCount()).isEqualTo(ownedValidatorCount);
   }
@@ -445,7 +454,8 @@ class ValidatorLoaderTest {
             publicKeyLoader,
             asyncRunner,
             metricsSystem);
-    final OwnedValidators validators = validatorLoader.loadValidators();
+    validatorLoader.loadValidators();
+    final OwnedValidators validators = validatorLoader.getOwnedValidators();
 
     assertThat(validators.hasNoValidators()).isTrue();
   }


### PR DESCRIPTION
## PR Description
Rejig `ValidatorLoader` to support having `loadValidators` called multiple times and adding n ewvalidators to the same `OwnedValidators` instance each time.

## Fixed Issue(s)
#3494 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
