### PR TITLE
Ensure proposer duties are reported in slot order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,4 @@ For information on changes in released versions of Teku, see the [releases page]
   The default limit is now 250 and can now be configured with `--Xrest-api-max-pending-events`.
 - Fixed `ProtoNode: Delta to be subtracted is greater than node weight` exception which may occur after an issue writing data to disk storage.
 - Fix issue where basic authentication credentials included in the `--beacon-node-api-endpoint` URL were included in `DEBUG` level logs.
+- Proposer duties are now consistently reported in slot order in the REST API.

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -34,6 +34,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import com.google.common.eventbus.EventBus;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -75,6 +76,7 @@ import tech.pegasys.teku.validator.api.AttesterDuty;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.NodeSyncingException;
 import tech.pegasys.teku.validator.api.ProposerDuties;
+import tech.pegasys.teku.validator.api.ProposerDuty;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
 
@@ -302,6 +304,20 @@ class ValidatorApiHandlerTest {
         validatorApiHandler.getProposerDuties(EPOCH);
     final Optional<ProposerDuties> duties = assertCompletedSuccessfully(result);
     assertThat(duties.orElseThrow().getDuties().size()).isEqualTo(Constants.SLOTS_PER_EPOCH);
+  }
+
+  @Test
+  void getProposerDuties_shouldReturnDutiesInOrder() {
+    final BeaconState state = createStateWithActiveValidators(EPOCH_START_SLOT);
+    when(chainDataClient.getStateAtSlotExact(EPOCH_START_SLOT))
+        .thenReturn(completedFuture(Optional.of(state)));
+    when(chainDataClient.getCurrentEpoch()).thenReturn(EPOCH.minus(1));
+
+    final SafeFuture<Optional<ProposerDuties>> result =
+        validatorApiHandler.getProposerDuties(EPOCH);
+    final Optional<ProposerDuties> duties = assertCompletedSuccessfully(result);
+    final List<ProposerDuty> actual = duties.orElseThrow().getDuties();
+    assertThat(actual).isSortedAccordingTo(Comparator.comparing(ProposerDuty::getSlot));
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Ensures proposer duties are returned in slot order instead of the undefined order a `HashMap` gives us.

Conveniently also simplifies and slightly optimises the code.

## Fixed Issue(s)
fixes #3635 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
