### PR TITLE
 use SpecProvider in validator client

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
@@ -21,6 +21,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecProvider;
 
 public class AttestationDutyScheduler extends AbstractDutyScheduler {
   private UInt64 lastAttestationCreationSlot;
@@ -30,8 +31,9 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
   public AttestationDutyScheduler(
       final MetricsSystem metricsSystem,
       final DutyLoader epochDutiesScheduler,
-      final boolean useDependentRoots) {
-    super(epochDutiesScheduler, LOOKAHEAD_EPOCHS, useDependentRoots);
+      final boolean useDependentRoots,
+      final SpecProvider specProvider) {
+    super(epochDutiesScheduler, LOOKAHEAD_EPOCHS, useDependentRoots, specProvider);
 
     metricsSystem.createIntegerGauge(
         TekuMetricCategory.VALIDATOR,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -21,6 +21,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecProvider;
 
 public class BlockDutyScheduler extends AbstractDutyScheduler {
   private static final Logger LOG = LogManager.getLogger();
@@ -29,8 +30,9 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
   public BlockDutyScheduler(
       final MetricsSystem metricsSystem,
       final DutyLoader epochDutiesScheduler,
-      final boolean useDependentRoots) {
-    super(epochDutiesScheduler, LOOKAHEAD_EPOCHS, useDependentRoots);
+      final boolean useDependentRoots,
+      final SpecProvider specProvider) {
+    super(epochDutiesScheduler, LOOKAHEAD_EPOCHS, useDependentRoots, specProvider);
 
     metricsSystem.createIntegerGauge(
         TekuMetricCategory.VALIDATOR,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -122,7 +122,7 @@ public class ValidatorClientService extends Service {
     final OwnedValidators validators = validatorLoader.getOwnedValidators();
     this.validatorIndexProvider = new ValidatorIndexProvider(validators, validatorApiChannel);
     final ValidatorDutyFactory validatorDutyFactory =
-        new ValidatorDutyFactory(forkProvider, validatorApiChannel);
+        new ValidatorDutyFactory(forkProvider, validatorApiChannel, specProvider);
     final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions =
         new BeaconCommitteeSubscriptions(validatorApiChannel);
     final DutyLoader attestationDutyLoader =
@@ -146,9 +146,10 @@ public class ValidatorClientService extends Service {
                 validatorIndexProvider));
     final boolean useDependentRoots = config.getValidatorConfig().useDependentRoots();
     this.attestationTimingChannel =
-        new AttestationDutyScheduler(metricsSystem, attestationDutyLoader, useDependentRoots);
+        new AttestationDutyScheduler(
+            metricsSystem, attestationDutyLoader, useDependentRoots, specProvider);
     this.blockProductionTimingChannel =
-        new BlockDutyScheduler(metricsSystem, blockDutyLoader, useDependentRoots);
+        new BlockDutyScheduler(metricsSystem, blockDutyLoader, useDependentRoots, specProvider);
     addValidatorCountMetric(metricsSystem, validators);
     this.validatorStatusLogger =
         new DefaultValidatorStatusLogger(validators, validatorApiChannel, asyncRunner);
@@ -179,7 +180,8 @@ public class ValidatorClientService extends Service {
                   validatorStatusLogger,
                   validatorIndexProvider,
                   blockProductionTimingChannel,
-                  attestationTimingChannel));
+                  attestationTimingChannel,
+                  specProvider));
           validatorStatusLogger.printInitialValidatorStatuses().reportExceptions();
           return beaconNodeApi.subscribeToEvents();
         });

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.client;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecProvider;
+import tech.pegasys.teku.spec.util.BeaconStateUtil;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 
 public class ValidatorTimingActions implements ValidatorTimingChannel {
@@ -43,9 +44,10 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
     validatorIndexProvider.lookupValidators();
     blockDuties.onSlot(slot);
     attestationDuties.onSlot(slot);
-    final BeaconStateUtil beaconStateUtil = specProvider.atSlot(slot);
-    final UInt64 firstSlotOfEpoch = beaconStateUtil.computeStartSlotAtEpoch(beaconStateUtil.computeEpochAtSlot(slot));
-    if (slot.equals(firstSlotOfEpoch.plus(1)) {
+    final BeaconStateUtil beaconStateUtil = specProvider.atSlot(slot).getBeaconStateUtil();
+    final UInt64 firstSlotOfEpoch =
+        beaconStateUtil.computeStartSlotAtEpoch(beaconStateUtil.computeEpochAtSlot(slot));
+    if (slot.equals(firstSlotOfEpoch.plus(1))) {
       statusLogger.checkValidatorStatusChanges();
     }
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -13,10 +13,9 @@
 
 package tech.pegasys.teku.validator.client;
 
-import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_EPOCH;
-
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecProvider;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 
 public class ValidatorTimingActions implements ValidatorTimingChannel {
@@ -24,16 +23,19 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
   private final ValidatorTimingChannel blockDuties;
   private final ValidatorTimingChannel attestationDuties;
   private final ValidatorStatusLogger statusLogger;
+  private final SpecProvider specProvider;
 
   public ValidatorTimingActions(
       final ValidatorStatusLogger statusLogger,
       final ValidatorIndexProvider validatorIndexProvider,
       final ValidatorTimingChannel blockDuties,
-      final ValidatorTimingChannel attestationDuties) {
+      final ValidatorTimingChannel attestationDuties,
+      final SpecProvider specProvider) {
     this.statusLogger = statusLogger;
     this.validatorIndexProvider = validatorIndexProvider;
     this.blockDuties = blockDuties;
     this.attestationDuties = attestationDuties;
+    this.specProvider = specProvider;
   }
 
   @Override
@@ -41,7 +43,7 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
     validatorIndexProvider.lookupValidators();
     blockDuties.onSlot(slot);
     attestationDuties.onSlot(slot);
-    if (slot.mod(SLOTS_PER_EPOCH).equals(UInt64.ONE)) {
+    if (slot.mod(specProvider.getSlotsPerEpoch(slot)).equals(UInt64.ONE)) {
       statusLogger.checkValidatorStatusChanges();
     }
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -43,7 +43,9 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
     validatorIndexProvider.lookupValidators();
     blockDuties.onSlot(slot);
     attestationDuties.onSlot(slot);
-    if (slot.mod(specProvider.getSlotsPerEpoch(slot)).equals(UInt64.ONE)) {
+    final BeaconStateUtil beaconStateUtil = specProvider.atSlot(slot);
+    final UInt64 firstSlotOfEpoch = beaconStateUtil.computeStartSlotAtEpoch(beaconStateUtil.computeEpochAtSlot(slot));
+    if (slot.equals(firstSlotOfEpoch.plus(1)) {
       statusLogger.checkValidatorStatusChanges();
     }
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.validator.client.duties;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
@@ -26,6 +25,7 @@ import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecProvider;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.ForkProvider;
 import tech.pegasys.teku.validator.client.Validator;
@@ -36,16 +36,19 @@ public class BlockProductionDuty implements Duty {
   private final UInt64 slot;
   private final ForkProvider forkProvider;
   private final ValidatorApiChannel validatorApiChannel;
+  private final SpecProvider specProvider;
 
   public BlockProductionDuty(
       final Validator validator,
       final UInt64 slot,
       final ForkProvider forkProvider,
-      final ValidatorApiChannel validatorApiChannel) {
+      final ValidatorApiChannel validatorApiChannel,
+      final SpecProvider specProvider) {
     this.validator = validator;
     this.slot = slot;
     this.forkProvider = forkProvider;
     this.validatorApiChannel = validatorApiChannel;
+    this.specProvider = specProvider;
   }
 
   @Override
@@ -92,7 +95,9 @@ public class BlockProductionDuty implements Duty {
   }
 
   public SafeFuture<BLSSignature> createRandaoReveal(final ForkInfo forkInfo) {
-    return validator.getSigner().createRandaoReveal(compute_epoch_at_slot(slot), forkInfo);
+    return validator
+        .getSigner()
+        .createRandaoReveal(specProvider.computeEpochAtSlot(slot), forkInfo);
   }
 
   public SafeFuture<SignedBeaconBlock> signBlock(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ValidatorDutyFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ValidatorDutyFactory.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.client.duties;
 import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
 
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecProvider;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.ForkProvider;
 import tech.pegasys.teku.validator.client.Validator;
@@ -23,16 +24,21 @@ import tech.pegasys.teku.validator.client.Validator;
 public class ValidatorDutyFactory {
   private final ForkProvider forkProvider;
   private final ValidatorApiChannel validatorApiChannel;
+  private final SpecProvider specProvider;
 
   public ValidatorDutyFactory(
-      final ForkProvider forkProvider, final ValidatorApiChannel validatorApiChannel) {
+      final ForkProvider forkProvider,
+      final ValidatorApiChannel validatorApiChannel,
+      final SpecProvider specProvider) {
     this.forkProvider = forkProvider;
     this.validatorApiChannel = validatorApiChannel;
+    this.specProvider = specProvider;
   }
 
   public BlockProductionDuty createBlockProductionDuty(
       final UInt64 slot, final Validator validator) {
-    return new BlockProductionDuty(validator, slot, forkProvider, validatorApiChannel);
+    return new BlockProductionDuty(
+        validator, slot, forkProvider, validatorApiChannel, specProvider);
   }
 
   public AttestationProductionDuty createAttestationProductionDuty(final UInt64 slot) {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
@@ -76,7 +75,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             completedFuture(
                 Optional.of(new AttesterDuties(dataStructureUtil.randomBytes32(), emptyList()))));
 
-    dutyScheduler.onSlot(compute_start_slot_at_epoch(UInt64.ONE));
+    dutyScheduler.onSlot(specProvider.computeStartSlotAtEpoch(UInt64.ONE));
 
     verify(validatorApiChannel).getAttestationDuties(UInt64.ONE, VALIDATOR_INDICES);
     verify(validatorApiChannel).getAttestationDuties(UInt64.valueOf(2), VALIDATOR_INDICES);
@@ -91,7 +90,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     verify(validatorApiChannel).getAttestationDuties(UInt64.ONE, VALIDATOR_INDICES);
 
     // Process each slot up to the start of epoch 1
-    final UInt64 epoch1Start = compute_start_slot_at_epoch(UInt64.ONE);
+    final UInt64 epoch1Start = specProvider.computeStartSlotAtEpoch(UInt64.ONE);
     for (int slot = 0; slot <= epoch1Start.intValue(); slot++) {
       dutyScheduler.onSlot(UInt64.valueOf(slot));
     }
@@ -102,12 +101,12 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   public void shouldNotRefetchDutiesWhichHaveAlreadyBeenRetrieved() {
     createDutySchedulerWithRealDuties(false);
     when(validatorApiChannel.getAttestationDuties(any(), any())).thenReturn(new SafeFuture<>());
-    dutyScheduler.onSlot(compute_start_slot_at_epoch(UInt64.ONE));
+    dutyScheduler.onSlot(specProvider.computeStartSlotAtEpoch(UInt64.ONE));
 
     verify(validatorApiChannel).getAttestationDuties(UInt64.ONE, VALIDATOR_INDICES);
     verify(validatorApiChannel).getAttestationDuties(UInt64.valueOf(2), VALIDATOR_INDICES);
 
-    dutyScheduler.onSlot(compute_start_slot_at_epoch(UInt64.valueOf(2)));
+    dutyScheduler.onSlot(specProvider.computeStartSlotAtEpoch(UInt64.valueOf(2)));
 
     // Requests the next epoch, but not the current one because we already have that
     verify(validatorApiChannel).getAttestationDuties(UInt64.valueOf(3), VALIDATOR_INDICES);
@@ -139,7 +138,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
         .thenReturn(request1)
         .thenReturn(request2);
 
-    dutyScheduler.onSlot(compute_start_slot_at_epoch(UInt64.ONE));
+    dutyScheduler.onSlot(specProvider.computeStartSlotAtEpoch(UInt64.ONE));
     verify(validatorApiChannel, times(1)).getAttestationDuties(UInt64.ONE, VALIDATOR_INDICES);
 
     request1.completeExceptionally(new RuntimeException("Nope"));
@@ -157,10 +156,10 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   public void shouldRefetchDutiesForMultipleEpochsAfterReorg() {
     createDutySchedulerWithRealDuties(false);
     final UInt64 currentEpoch = UInt64.valueOf(5);
-    final UInt64 currentSlot = compute_start_slot_at_epoch(currentEpoch);
+    final UInt64 currentSlot = specProvider.computeStartSlotAtEpoch(currentEpoch);
     final UInt64 nextEpoch = currentEpoch.plus(1);
     final UInt64 commonAncestorEpoch = currentEpoch.minus(2);
-    final UInt64 commonAncestorSlot = compute_start_slot_at_epoch(commonAncestorEpoch);
+    final UInt64 commonAncestorSlot = specProvider.computeStartSlotAtEpoch(commonAncestorEpoch);
     when(validatorApiChannel.getAttestationDuties(any(), any())).thenReturn(new SafeFuture<>());
     dutyScheduler.onSlot(currentSlot);
 
@@ -178,10 +177,10 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   public void shouldRefetchDutiesForNextEpochAfterReorg() {
     createDutySchedulerWithRealDuties(false);
     final UInt64 currentEpoch = UInt64.valueOf(5);
-    final UInt64 currentSlot = compute_start_slot_at_epoch(currentEpoch);
+    final UInt64 currentSlot = specProvider.computeStartSlotAtEpoch(currentEpoch);
     final UInt64 nextEpoch = currentEpoch.plus(1);
     final UInt64 commonAncestorEpoch = currentEpoch.minus(1);
-    final UInt64 commonAncestorSlot = compute_start_slot_at_epoch(commonAncestorEpoch);
+    final UInt64 commonAncestorSlot = specProvider.computeStartSlotAtEpoch(commonAncestorEpoch);
     when(validatorApiChannel.getAttestationDuties(any(), any())).thenReturn(new SafeFuture<>());
     dutyScheduler.onSlot(currentSlot);
 
@@ -198,9 +197,9 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   public void shouldNotRefetchDutiesWhenCommonAncestorInCurrentEpoch() {
     createDutySchedulerWithRealDuties(false);
     final UInt64 currentEpoch = UInt64.valueOf(5);
-    final UInt64 currentSlot = compute_start_slot_at_epoch(currentEpoch);
+    final UInt64 currentSlot = specProvider.computeStartSlotAtEpoch(currentEpoch);
     final UInt64 nextEpoch = currentEpoch.plus(1);
-    final UInt64 commonAncestorSlot = compute_start_slot_at_epoch(currentEpoch);
+    final UInt64 commonAncestorSlot = specProvider.computeStartSlotAtEpoch(currentEpoch);
     when(validatorApiChannel.getAttestationDuties(any(), any())).thenReturn(new SafeFuture<>());
     dutyScheduler.onSlot(currentSlot);
 
@@ -216,7 +215,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   public void shouldRefetchDutiesForMultipleEpochsWhenCurrentAndPreviousDependentRootChanges() {
     createDutySchedulerWithRealDuties(true);
     final UInt64 currentEpoch = UInt64.valueOf(5);
-    final UInt64 currentSlot = compute_start_slot_at_epoch(currentEpoch);
+    final UInt64 currentSlot = specProvider.computeStartSlotAtEpoch(currentEpoch);
     final UInt64 nextEpoch = currentEpoch.plus(1);
     final Bytes32 previousDutyDependentRoot = dataStructureUtil.randomBytes32();
     final Bytes32 currentDutyDependentRoot = dataStructureUtil.randomBytes32();
@@ -248,7 +247,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   public void shouldRefetchDutiesForNextEpochWhenHeadUpdateHasNewCurrentDependentRoot() {
     createDutySchedulerWithRealDuties(true);
     final UInt64 currentEpoch = UInt64.valueOf(5);
-    final UInt64 currentSlot = compute_start_slot_at_epoch(currentEpoch);
+    final UInt64 currentSlot = specProvider.computeStartSlotAtEpoch(currentEpoch);
     final UInt64 nextEpoch = currentEpoch.plus(1);
     final Bytes32 previousDutyDependentRoot = dataStructureUtil.randomBytes32();
     final Bytes32 currentDutyDependentRoot = dataStructureUtil.randomBytes32();
@@ -279,7 +278,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   public void shouldNotRefetchDutiesWhenHeadUpdateReceivedWithNoChangeInDependentRoots() {
     createDutySchedulerWithRealDuties(true);
     final UInt64 currentEpoch = UInt64.valueOf(5);
-    final UInt64 currentSlot = compute_start_slot_at_epoch(currentEpoch);
+    final UInt64 currentSlot = specProvider.computeStartSlotAtEpoch(currentEpoch);
     final UInt64 nextEpoch = currentEpoch.plus(1);
     final Bytes32 previousDutyDependentRoot = dataStructureUtil.randomBytes32();
     final Bytes32 currentDutyDependentRoot = dataStructureUtil.randomBytes32();
@@ -309,7 +308,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   void shouldRefetchAllDutiesOnMissedEvents() {
     createDutySchedulerWithRealDuties(false);
     final UInt64 currentEpoch = UInt64.valueOf(5);
-    final UInt64 currentSlot = compute_start_slot_at_epoch(currentEpoch);
+    final UInt64 currentSlot = specProvider.computeStartSlotAtEpoch(currentEpoch);
     final UInt64 nextEpoch = currentEpoch.plus(1);
     when(validatorApiChannel.getAttestationDuties(any(), any())).thenReturn(new SafeFuture<>());
     dutyScheduler.onSlot(currentSlot);
@@ -329,7 +328,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   void shouldRefetchAllDutiesOnMissedEventsWhenUsingDependentRoots() {
     createDutySchedulerWithRealDuties(true);
     final UInt64 currentEpoch = UInt64.valueOf(5);
-    final UInt64 currentSlot = compute_start_slot_at_epoch(currentEpoch);
+    final UInt64 currentSlot = specProvider.computeStartSlotAtEpoch(currentEpoch);
     final UInt64 nextEpoch = currentEpoch.plus(1);
     when(validatorApiChannel.getAttestationDuties(any(), any())).thenReturn(new SafeFuture<>());
     dutyScheduler.onSlot(currentSlot);
@@ -372,7 +371,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   public void shouldNotProcessAggregationIfCurrentEpochIsTooFarBeforeSlotEpoch() {
     createDutySchedulerWithMockDuties();
     // first slot of epoch 2
-    final UInt64 slot = compute_start_slot_at_epoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1));
+    final UInt64 slot = specProvider.computeStartSlotAtEpoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1));
     dutyScheduler.onSlot(ONE); // epoch 0
     dutyScheduler.onAttestationAggregationDue(slot);
     verify(scheduledDuties, never()).performAggregation(slot);
@@ -382,7 +381,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   public void shouldNotProcessAttestationIfCurrentEpochIsTooFarBeforeSlotEpoch() {
     createDutySchedulerWithMockDuties();
     // first slot of epoch 2
-    final UInt64 slot = compute_start_slot_at_epoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1));
+    final UInt64 slot = specProvider.computeStartSlotAtEpoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1));
     dutyScheduler.onSlot(ONE); // epoch 0
     dutyScheduler.onAttestationCreationDue(slot);
     verify(scheduledDuties, never()).produceAttestations(slot);
@@ -393,7 +392,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     createDutySchedulerWithMockDuties();
     // last slot of epoch 1
     final UInt64 slot =
-        compute_start_slot_at_epoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1)).decrement();
+        specProvider.computeStartSlotAtEpoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1)).decrement();
     dutyScheduler.onSlot(ONE); // epoch 0
     dutyScheduler.onAttestationAggregationDue(slot);
     verify(scheduledDuties).performAggregation(slot);
@@ -404,7 +403,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     createDutySchedulerWithMockDuties();
     // last slot of epoch 1
     final UInt64 slot =
-        compute_start_slot_at_epoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1)).decrement();
+        specProvider.computeStartSlotAtEpoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1)).decrement();
     dutyScheduler.onSlot(ONE); // epoch 0
     dutyScheduler.onAttestationCreationDue(slot);
     verify(scheduledDuties).produceAttestations(slot);
@@ -455,7 +454,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
         .thenReturn(attestationDuty);
 
     // Load duties
-    dutyScheduler.onSlot(compute_start_slot_at_epoch(ZERO));
+    dutyScheduler.onSlot(specProvider.computeStartSlotAtEpoch(ZERO));
     verify(attestationDuty).addValidator(validator1, 3, 6, 5, 10);
 
     // Execute
@@ -512,7 +511,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     when(dutyFactory.createAttestationProductionDuty(attestationSlot)).thenReturn(attestationDuty);
 
     // Load duties
-    dutyScheduler.onSlot(compute_start_slot_at_epoch(ZERO));
+    dutyScheduler.onSlot(specProvider.computeStartSlotAtEpoch(ZERO));
 
     // Both validators should be scheduled to create an attestation in the same slot
     verify(attestationDuty)
@@ -579,7 +578,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     when(dutyFactory.createAttestationProductionDuty(attestationSlot)).thenReturn(attestationDuty);
 
     // Load duties
-    dutyScheduler.onSlot(compute_start_slot_at_epoch(ZERO));
+    dutyScheduler.onSlot(specProvider.computeStartSlotAtEpoch(ZERO));
 
     // Both validators should be scheduled to create an attestation in the same slot
     verify(attestationDuty)
@@ -646,7 +645,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     when(dutyFactory.createAttestationProductionDuty(attestationSlot)).thenReturn(attestationDuty);
 
     // Load duties
-    dutyScheduler.onSlot(compute_start_slot_at_epoch(ZERO));
+    dutyScheduler.onSlot(specProvider.computeStartSlotAtEpoch(ZERO));
 
     // Both validators should be scheduled to create an attestation in the same slot
     verify(attestationDuty)
@@ -733,7 +732,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
         .thenReturn(unsignedAttestationFuture);
 
     // Load duties
-    final UInt64 epochStartSlot = compute_start_slot_at_epoch(ONE);
+    final UInt64 epochStartSlot = specProvider.computeStartSlotAtEpoch(ONE);
     dutyScheduler.onSlot(epochStartSlot);
 
     // Only validator1 should have had an aggregation duty created for it
@@ -799,38 +798,38 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   }
 
   private void createDutySchedulerWithRealDuties(final boolean useDependentRoots) {
+    final AttestationDutyLoader attestationDutyLoader =
+        new AttestationDutyLoader(
+            validatorApiChannel,
+            forkProvider,
+            dependentRoot -> new ScheduledDuties(dutyFactory, dependentRoot),
+            new OwnedValidators(Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2)),
+            validatorIndexProvider,
+            beaconCommitteeSubscriptions,
+            specProvider);
     dutyScheduler =
         new AttestationDutyScheduler(
             metricsSystem,
-            new RetryingDutyLoader(
-                asyncRunner,
-                new AttestationDutyLoader(
-                    validatorApiChannel,
-                    forkProvider,
-                    dependentRoot -> new ScheduledDuties(dutyFactory, dependentRoot),
-                    new OwnedValidators(
-                        Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2)),
-                    validatorIndexProvider,
-                    beaconCommitteeSubscriptions,
-                    specProvider)),
-            useDependentRoots);
+            new RetryingDutyLoader(asyncRunner, attestationDutyLoader),
+            useDependentRoots,
+            specProvider);
   }
 
   private void createDutySchedulerWithMockDuties() {
+    final AttestationDutyLoader attestationDutyLoader =
+        new AttestationDutyLoader(
+            validatorApiChannel,
+            forkProvider,
+            dependentRoot -> scheduledDuties,
+            new OwnedValidators(Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2)),
+            validatorIndexProvider,
+            beaconCommitteeSubscriptions,
+            specProvider);
     dutyScheduler =
         new AttestationDutyScheduler(
             metricsSystem2,
-            new RetryingDutyLoader(
-                asyncRunner,
-                new AttestationDutyLoader(
-                    validatorApiChannel,
-                    forkProvider,
-                    dependentRoot -> scheduledDuties,
-                    new OwnedValidators(
-                        Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2)),
-                    validatorIndexProvider,
-                    beaconCommitteeSubscriptions,
-                    specProvider)),
-            false);
+            new RetryingDutyLoader(asyncRunner, attestationDutyLoader),
+            false,
+            specProvider);
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
 
@@ -37,6 +36,8 @@ import tech.pegasys.teku.datastructures.state.ForkInfo;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networks.SpecProviderFactory;
+import tech.pegasys.teku.spec.SpecProvider;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.FileBackedGraffitiProvider;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
@@ -46,8 +47,8 @@ import tech.pegasys.teku.validator.client.Validator;
 
 class BlockProductionDutyTest {
   private static final UInt64 SLOT = UInt64.valueOf(498294);
-
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final SpecProvider specProvider = SpecProviderFactory.createMinimal();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(specProvider);
   private final ForkProvider forkProvider = mock(ForkProvider.class);
   private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
   private final Signer signer = mock(Signer.class);
@@ -61,7 +62,7 @@ class BlockProductionDutyTest {
   private final ValidatorLogger validatorLogger = mock(ValidatorLogger.class);
 
   private final BlockProductionDuty duty =
-      new BlockProductionDuty(validator, SLOT, forkProvider, validatorApiChannel);
+      new BlockProductionDuty(validator, SLOT, forkProvider, validatorApiChannel, specProvider);
 
   @BeforeEach
   public void setUp() {
@@ -78,7 +79,7 @@ class BlockProductionDutyTest {
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
     final BLSSignature blockSignature = dataStructureUtil.randomSignature();
     final BeaconBlock unsignedBlock = dataStructureUtil.randomBeaconBlock(SLOT.longValue());
-    when(signer.createRandaoReveal(compute_epoch_at_slot(SLOT), fork))
+    when(signer.createRandaoReveal(specProvider.computeEpochAtSlot(SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(SLOT, randaoReveal, Optional.of(graffiti)))
         .thenReturn(completedFuture(Optional.of(unsignedBlock)));
@@ -98,7 +99,7 @@ class BlockProductionDutyTest {
   @Test
   public void shouldFailWhenCreateRandaoFails() {
     final RuntimeException error = new RuntimeException("Sorry!");
-    when(signer.createRandaoReveal(compute_epoch_at_slot(SLOT), fork))
+    when(signer.createRandaoReveal(specProvider.computeEpochAtSlot(SLOT), fork))
         .thenReturn(failedFuture(error));
 
     assertDutyFails(error);
@@ -108,7 +109,7 @@ class BlockProductionDutyTest {
   public void shouldFailWhenCreateUnsignedBlockFails() {
     final RuntimeException error = new RuntimeException("Sorry!");
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
-    when(signer.createRandaoReveal(compute_epoch_at_slot(SLOT), fork))
+    when(signer.createRandaoReveal(specProvider.computeEpochAtSlot(SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(SLOT, randaoReveal, Optional.of(graffiti)))
         .thenReturn(failedFuture(error));
@@ -119,7 +120,7 @@ class BlockProductionDutyTest {
   @Test
   public void shouldFailWhenCreateUnsignedBlockReturnsEmpty() {
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
-    when(signer.createRandaoReveal(compute_epoch_at_slot(SLOT), fork))
+    when(signer.createRandaoReveal(specProvider.computeEpochAtSlot(SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(SLOT, randaoReveal, Optional.of(graffiti)))
         .thenReturn(completedFuture(Optional.empty()));
@@ -140,7 +141,7 @@ class BlockProductionDutyTest {
     final RuntimeException error = new RuntimeException("Sorry!");
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
     final BeaconBlock unsignedBlock = dataStructureUtil.randomBeaconBlock(SLOT.longValue());
-    when(signer.createRandaoReveal(compute_epoch_at_slot(SLOT), fork))
+    when(signer.createRandaoReveal(specProvider.computeEpochAtSlot(SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(SLOT, randaoReveal, Optional.of(graffiti)))
         .thenReturn(completedFuture(Optional.of(unsignedBlock)));


### PR DESCRIPTION
  - removed deprecated static constants from validator client module.

  - removed any calls to the static BeaconStateUtil functions.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
