### PR TITLE
Support loading validators without restarting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - New validators can now be loaded without restarting by sending a `SIGHUP` to Teku. 
   Teku will recheck directories of keys specified via `--validator-keys` and URLs specified via `--validators-external-signer-public-keys` for any new validators to run.
   
-  *Important*: Teku does not support removing validators via this method as there is no reliable mechanism to signal when they have actually ceased performing duties.
+  *Important*: Removing validators still requires a restart as there is no reliable mechanism to signal when they have actually ceased performing duties.
 - `--p2p-nat-method upnp` has been added to allow users to use upnp to configure firewalls to allow incoming connection requests.
 - `--initial-state` argument is now ignored if chain data is already initialised. Previously it would be downloaded on every restart and Teku would exit if the referenced state was ahead of the chain on disk.
 - Enabled the new sync algorithm by default. This improves sync behaviour when there are multiple forks and distributes requests for blocks across available peers. The old sync algorithm can still be used by setting `--Xp2p-multipeer-sync-enabled=false`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ For information on changes in released versions of Teku, see the [releases page]
 - Docker images are now being published to `consensys/teku`. The `pegasys/teku` images are no longer updated.
 
 ### Additions and Improvements
+- New validators can now be loaded without restarting by sending a `SIGHUP` to Teku. 
+  Teku will recheck directories of keys specified via `--validator-keys` and URLs specified via `--validators-external-signer-public-keys` for any new validators to run.
+  
+  *Important*: Teku does not support removing validators via this method as there is no reliable mechanism to signal when they have actually ceased performing duties.
 - `--p2p-nat-method upnp` has been added to allow users to use upnp to configure firewalls to allow incoming connection requests.
 - `--initial-state` argument is now ignored if chain data is already initialised. Previously it would be downloaded on every restart and Teku would exit if the referenced state was ahead of the chain on disk.
 - Enabled the new sync algorithm by default. This improves sync behaviour when there are multiple forks and distributes requests for blocks across available peers. The old sync algorithm can still be used by setting `--Xp2p-multipeer-sync-enabled=false`.

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/AddValidatorsAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/AddValidatorsAcceptanceTest.java
@@ -49,5 +49,11 @@ public class AddValidatorsAcceptanceTest extends AcceptanceTestBase {
 
     // If the added validators perform their duties properly, the network will finalize.
     node.waitForNewFinalization();
+
+    // Check loading new validators a second time still works and that they don't have to be active
+    final ValidatorKeystores evenMoreKeystores =
+        createTekuDepositSender().sendValidatorDeposits(eth1Node, 1);
+    node.addValidators(evenMoreKeystores);
+    node.waitForOwnedValidatorCount(5);
   }
 }

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/AddValidatorsAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/AddValidatorsAcceptanceTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.test.acceptance;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
+import tech.pegasys.teku.test.acceptance.dsl.BesuNode;
+import tech.pegasys.teku.test.acceptance.dsl.TekuNode;
+import tech.pegasys.teku.test.acceptance.dsl.tools.deposits.ValidatorKeystores;
+
+public class AddValidatorsAcceptanceTest extends AcceptanceTestBase {
+
+  @Test
+  void shouldLoadAdditionalValidatorsWithoutRestart() throws Exception {
+    final BesuNode eth1Node = createBesuNode();
+    eth1Node.start();
+
+    final ValidatorKeystores initialKeystores =
+        createTekuDepositSender().sendValidatorDeposits(eth1Node, 2);
+
+    final ValidatorKeystores additionalKeystores =
+        createTekuDepositSender().sendValidatorDeposits(eth1Node, 2);
+
+    final TekuNode node =
+        createTekuNode(
+            config ->
+                config
+                    .withNetwork("less-swift")
+                    .withDepositsFrom(eth1Node)
+                    .withValidatorKeystores(initialKeystores));
+    node.start();
+
+    node.waitForOwnedValidatorCount(2);
+    node.waitForGenesis();
+
+    node.addValidators(additionalKeystores);
+    node.waitForOwnedValidatorCount(4);
+
+    // If the added validators perform their duties properly, the network will finalize.
+    node.waitForNewFinalization();
+  }
+}

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
@@ -38,6 +38,7 @@ public abstract class Node {
   public static final String TEKU_DOCKER_IMAGE = "consensys/teku:develop";
 
   protected static final int REST_API_PORT = 9051;
+  protected static final int METRICS_PORT = 8008;
   protected static final String CONFIG_FILE_PATH = "/config.yaml";
   protected static final String WORKING_DIRECTORY = "/opt/teku/";
   protected static final String DATA_PATH = WORKING_DIRECTORY + "data/";
@@ -116,9 +117,8 @@ public abstract class Node {
    * Copies contents of the given directory into node's working directory.
    *
    * @param tarFile
-   * @throws IOException
    */
-  public void copyContentsToWorkingDirectory(File tarFile) throws IOException {
+  public void copyContentsToWorkingDirectory(File tarFile) {
     container.withExpandedTarballToContainer(tarFile, WORKING_DIRECTORY);
   }
 }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/NodeContainer.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/NodeContainer.java
@@ -49,6 +49,10 @@ public class NodeContainer extends GenericContainer<NodeContainer> {
     return this;
   }
 
+  public void expandTarballToContainer(final File tarball, final String targetPath) {
+    expandTarballToContainer(getContainerId(), tarball, targetPath);
+  }
+
   private void expandTarballToContainer(
       final String containerId, final File tarball, final String targetPath) {
     try {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -23,11 +23,13 @@ import io.libp2p.core.PeerId;
 import io.libp2p.core.crypto.KEY_TYPE;
 import io.libp2p.core.crypto.KeyKt;
 import io.libp2p.core.crypto.PrivKey;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.StringReader;
 import java.net.URI;
-import java.nio.file.Files;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -59,6 +61,7 @@ import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.spec.SpecProvider;
 import tech.pegasys.teku.test.acceptance.dsl.tools.GenesisStateConfig;
 import tech.pegasys.teku.test.acceptance.dsl.tools.GenesisStateGenerator;
+import tech.pegasys.teku.test.acceptance.dsl.tools.deposits.ValidatorKeystores;
 
 public class TekuNode extends Node {
   private static final Logger LOG = LogManager.getLogger();
@@ -79,7 +82,7 @@ public class TekuNode extends Node {
 
     container
         .withWorkingDirectory(WORKING_DIRECTORY)
-        .withExposedPorts(REST_API_PORT)
+        .withExposedPorts(REST_API_PORT, METRICS_PORT)
         .waitingFor(
             new HttpWaitStrategy()
                 .forPort(REST_API_PORT)
@@ -119,6 +122,7 @@ public class TekuNode extends Node {
         (localFile, targetPath) ->
             container.withCopyFileToContainer(
                 MountableFile.forHostPath(localFile.getAbsolutePath()), targetPath));
+    config.getTarballsToCopy().forEach(this::copyContentsToWorkingDirectory);
     container.start();
   }
 
@@ -306,6 +310,40 @@ public class TekuNode extends Node {
     return config;
   }
 
+  public void addValidators(final ValidatorKeystores additionalKeystores) {
+    LOG.debug("Adding {} validators", additionalKeystores.getValidatorCount());
+    container.expandTarballToContainer(additionalKeystores.getTarball(), WORKING_DIRECTORY);
+    container
+        .getDockerClient()
+        .killContainerCmd(container.getContainerId())
+        .withSignal("HUP")
+        .exec();
+  }
+
+  public void waitForOwnedValidatorCount(final int expectedValidatorCount) throws IOException {
+    LOG.debug("Waiting for validator count to be {}", expectedValidatorCount);
+    waitFor(
+        () -> {
+          final String validatorCount = getMetricValue("validator_local_validator_count");
+          LOG.debug("Current validator count {}", validatorCount);
+          assertThat(Double.parseDouble(validatorCount)).isEqualTo(expectedValidatorCount);
+        });
+  }
+
+  private String getMetricValue(final String metricName) throws IOException {
+    final String prefix = metricName + " ";
+    final String allMetrics = httpClient.get(getMetricsUrl(), "/metrics");
+    try (BufferedReader reader = new BufferedReader(new StringReader(allMetrics))) {
+      for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+        if (line.startsWith(prefix)) {
+          return line.substring(prefix.length());
+        }
+      }
+    }
+    throw new IllegalArgumentException(
+        "Did not find metric " + metricName + " in: \n" + allMetrics);
+  }
+
   /**
    * Copies data directory from node into a temporary directory.
    *
@@ -338,6 +376,10 @@ public class TekuNode extends Node {
     return URI.create("http://127.0.0.1:" + container.getMappedPort(REST_API_PORT));
   }
 
+  private URI getMetricsUrl() {
+    return URI.create("http://127.0.0.1:" + container.getMappedPort(METRICS_PORT));
+  }
+
   @Override
   public void stop() {
     if (!started) {
@@ -367,13 +409,12 @@ public class TekuNode extends Node {
 
     private final PrivKey privateKey = KeyKt.generateKeyPair(KEY_TYPE.SECP256K1).component1();
     private final PeerId peerId = PeerId.fromPubKey(privateKey.publicKey());
-    private static final String VALIDATORS_FILE_PATH = "/validators.yml";
     private static final int DEFAULT_VALIDATOR_COUNT = 64;
 
     private String networkName = "swift";
-    private Map<String, Object> configMap = new HashMap<>();
+    private final Map<String, Object> configMap = new HashMap<>();
+    private final List<File> tarballsToCopy = new ArrayList<>();
 
-    private Optional<String> validatorKeys = Optional.empty();
     private Optional<GenesisStateConfig> genesisStateConfig = Optional.empty();
 
     public Config() {
@@ -389,9 +430,14 @@ public class TekuNode extends Node {
       configMap.put("Xinterop-owned-validator-count", DEFAULT_VALIDATOR_COUNT);
       configMap.put("Xinterop-number-of-validators", DEFAULT_VALIDATOR_COUNT);
       configMap.put("Xinterop-enabled", true);
+      configMap.put("validators-keystore-locking-enabled", false);
       configMap.put("rest-api-enabled", true);
       configMap.put("rest-api-port", REST_API_PORT);
       configMap.put("rest-api-docs-enabled", false);
+      configMap.put("metrics-enabled", true);
+      configMap.put("metrics-port", METRICS_PORT);
+      configMap.put("metrics-interface", "0.0.0.0");
+      configMap.put("metrics-host-allowlist", "*");
       configMap.put("data-path", DATA_PATH);
       configMap.put("eth1-deposit-contract-address", "0xdddddddddddddddddddddddddddddddddddddddd");
       configMap.put("eth1-endpoint", "http://notvalid.com");
@@ -414,6 +460,18 @@ public class TekuNode extends Node {
 
     public Config withInteropNumberOfValidators(final int validatorCount) {
       configMap.put("Xinterop-number-of-validators", validatorCount);
+      return this;
+    }
+
+    public Config withValidatorKeystores(final ValidatorKeystores keystores) {
+      tarballsToCopy.add(keystores.getTarball());
+      configMap.put(
+          "validator-keys",
+          WORKING_DIRECTORY
+              + keystores.getKeysDirectoryName()
+              + ":"
+              + WORKING_DIRECTORY
+              + keystores.getPasswordsDirectoryName());
       return this;
     }
 
@@ -451,12 +509,6 @@ public class TekuNode extends Node {
 
     public Map<File, String> write() throws Exception {
       final Map<File, String> configFiles = new HashMap<>();
-      if (validatorKeys.isPresent()) {
-        final File validatorsFile = Files.createTempFile("validators", ".yml").toFile();
-        validatorsFile.deleteOnExit();
-        Files.writeString(validatorsFile.toPath(), validatorKeys.get());
-        configFiles.put(validatorsFile, VALIDATORS_FILE_PATH);
-      }
 
       final File configFile = File.createTempFile("config", ".yaml");
       configFile.deleteOnExit();
@@ -471,6 +523,10 @@ public class TekuNode extends Node {
 
     private void writeTo(final File configFile) throws Exception {
       YAML_MAPPER.writeValue(configFile, configMap);
+    }
+
+    private List<File> getTarballsToCopy() {
+      return tarballsToCopy;
     }
   }
 }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
@@ -16,10 +16,8 @@ package tech.pegasys.teku.test.acceptance.dsl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
@@ -96,12 +94,9 @@ public class TekuValidatorNode extends Node {
   }
 
   public static class Config {
-    private static final String VALIDATORS_FILE_PATH = "/validators.yml";
     private static final int DEFAULT_VALIDATOR_COUNT = 64;
 
     private Map<String, Object> configMap = new HashMap<>();
-
-    private Optional<String> validatorKeys = Optional.empty();
 
     public Config() {
       configMap.put("validators-keystore-locking-enabled", false);
@@ -143,12 +138,6 @@ public class TekuValidatorNode extends Node {
 
     public Map<File, String> write() throws Exception {
       final Map<File, String> configFiles = new HashMap<>();
-      if (validatorKeys.isPresent()) {
-        final File validatorsFile = Files.createTempFile("validators", ".yml").toFile();
-        validatorsFile.deleteOnExit();
-        Files.writeString(validatorsFile.toPath(), validatorKeys.get());
-        configFiles.put(validatorsFile, VALIDATORS_FILE_PATH);
-      }
 
       final File configFile = File.createTempFile("config", ".yaml");
       configFile.deleteOnExit();

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/tools/deposits/ValidatorKeystores.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/tools/deposits/ValidatorKeystores.java
@@ -42,7 +42,7 @@ public class ValidatorKeystores {
     this.validatorKeys = validatorKeys;
   }
 
-  public File getTarball() throws Exception {
+  public File getTarball() {
     return maybeTarball.orElseGet(
         () -> {
           try {
@@ -52,6 +52,10 @@ public class ValidatorKeystores {
             throw new IllegalStateException("Unable to create validator tarball");
           }
         });
+  }
+
+  public int getValidatorCount() {
+    return validatorKeys.size();
   }
 
   public String getKeysDirectoryName() {

--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/SystemSignalListener.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/SystemSignalListener.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.io;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class SystemSignalListener {
+  private static final Logger LOG = LogManager.getLogger();
+
+  /**
+   * Registers an action to execute when a system specific signal to reload configuration is
+   * received. Currently this only supports listening for SIGHUP events.
+   *
+   * <p>Note that reflection is used to access these classes as they are not a standard part of the
+   * Java API and may not be available on all JVMs. A warning is logged if the listener cannot be
+   * added.
+   *
+   * @param action the action to run when a reconfigure signal is received.
+   */
+  @SuppressWarnings("JavaReflectionInvocation")
+  public static void registerReloadConfigListener(final Runnable action) {
+    try {
+      final Class<?> signalClass = Class.forName("sun.misc.Signal");
+      final Class<?> signalHandlerClass = Class.forName("sun.misc.SignalHandler");
+      final Constructor<?> constructor = signalClass.getConstructor(String.class);
+      final Object hupSignal = constructor.newInstance("HUP");
+      final Method handleMethod = signalClass.getMethod("handle", signalClass, signalHandlerClass);
+      final Object handler =
+          Proxy.newProxyInstance(
+              SystemSignalListener.class.getClassLoader(),
+              new Class<?>[] {signalHandlerClass},
+              (proxy, method, args) -> {
+                if (method.getName().equals("handle")) {
+                  action.run();
+                  return null;
+                } else {
+                  return method.invoke(action);
+                }
+              });
+      handleMethod.invoke(null, hupSignal, handler);
+    } catch (Throwable e) {
+      LOG.warn(
+          "Unable to register listener for SIGHUP events. Dynamic config reloading will not be supported.",
+          e);
+    }
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorLoader.java
@@ -122,7 +122,8 @@ public class ValidatorLoader {
     }
   }
 
-  public void loadValidators() {
+  // synchronized to ensure that only one load is active at a time
+  public synchronized void loadValidators() {
     final Map<BLSPublicKey, ValidatorProvider> validatorProviders = new HashMap<>();
     validatorSources.forEach(source -> addValidatorsFromSource(validatorProviders, source));
     MultithreadedValidatorLoader.loadValidators(


### PR DESCRIPTION
## PR Description
Add a listener for `SIGHUP` that triggers loading any new validator keys. This gets us to the minimum viable support for loading new validators without restarting.  It doesn't reload the config but does rescan directories for new local keys and re-downloads URLs for external public keys.

Add an acceptance test to verify that the whole process actually works and the new validators begin performing their duties.

## Fixed Issue(s)
#3494 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
