### PR TITLE
remove static constants from validator module

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -450,7 +450,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
         beaconConfig.p2pConfig().isSubscribeAllSubnetsEnabled()
             ? AllSubnetsSubscriber.create(attestationTopicSubscriber)
             : new ValidatorBasedStableSubnetSubscriber(attestationTopicSubscriber, new Random());
-    this.activeValidatorTracker = new ActiveValidatorTracker(stableSubnetSubscriber);
+    this.activeValidatorTracker = new ActiveValidatorTracker(stableSubnetSubscriber, specProvider);
   }
 
   public void initValidatorApiHandler() {
@@ -465,7 +465,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             voluntaryExitPool,
             depositProvider,
             eth1DataCache,
-            VersionProvider.getDefaultGraffiti());
+            VersionProvider.getDefaultGraffiti(),
+            specProvider);
     final BlockImportChannel blockImportChannel =
         eventChannels.getPublisher(BlockImportChannel.class, beaconAsyncRunner);
     final ValidatorApiHandler validatorApiHandler =

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -179,6 +179,8 @@ public class TekuConfiguration {
       final Eth2NetworkConfiguration eth2NetworkConfiguration =
           eth2NetworkConfigurationBuilder.build();
       final SpecProvider specProvider = eth2NetworkConfiguration.getSpecProvider();
+
+      interopConfigBuilder.specProvider(specProvider);
       // Update storage config
       storageConfigurationBuilder.specProvider(specProvider);
       // Update weak subjectivity

--- a/validator/api/build.gradle
+++ b/validator/api/build.gradle
@@ -2,6 +2,7 @@ dependencies {
   implementation project(':bls')
   implementation project(':infrastructure:async')
   implementation project(':ethereum:core')
+  implementation project(':ethereum:spec')
   implementation project(':ethereum:datastructures')
   implementation project(':data:serializer')
   implementation project(':util')

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/InteropConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/InteropConfig.java
@@ -13,7 +13,10 @@
 
 package tech.pegasys.teku.validator.api;
 
-import tech.pegasys.teku.util.config.Constants;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import tech.pegasys.teku.spec.SpecProvider;
+import tech.pegasys.teku.spec.constants.SpecConstants;
 import tech.pegasys.teku.util.config.InvalidConfigurationException;
 
 public class InteropConfig {
@@ -72,11 +75,17 @@ public class InteropConfig {
     private int interopOwnedValidatorCount;
     private int interopNumberOfValidators = 64;
     private boolean interopEnabled;
+    private SpecProvider specProvider;
 
     private InteropConfigBuilder() {}
 
     public InteropConfigBuilder interopGenesisTime(Integer interopGenesisTime) {
       this.interopGenesisTime = interopGenesisTime;
+      return this;
+    }
+
+    public InteropConfigBuilder specProvider(SpecProvider specProvider) {
+      this.specProvider = specProvider;
       return this;
     }
 
@@ -112,11 +121,13 @@ public class InteropConfig {
     }
 
     private void validate() throws IllegalArgumentException {
-      if (interopNumberOfValidators < Constants.SLOTS_PER_EPOCH) {
+      checkNotNull(specProvider);
+      final SpecConstants genesisSpecConstants = specProvider.getGenesisSpecConstants();
+      if (interopNumberOfValidators < genesisSpecConstants.getSlotsPerEpoch()) {
         throw new InvalidConfigurationException(
             String.format(
                 "Invalid configuration. Interop number of validators [%d] must be greater than or equal to [%d]",
-                interopNumberOfValidators, Constants.SLOTS_PER_EPOCH));
+                interopNumberOfValidators, genesisSpecConstants.getSlotsPerEpoch()));
       }
     }
   }

--- a/validator/beaconnode/build.gradle
+++ b/validator/beaconnode/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
   implementation project(':ethereum:core')
   implementation project(':ethereum:datastructures')
+  implementation project(':ethereum:spec')
   implementation project(':infrastructure:async')
   implementation project(':infrastructure:events')
   implementation project(':infrastructure:metrics')
@@ -15,6 +16,7 @@ dependencies {
   implementation 'org.apache.commons:commons-lang3'
 
   testImplementation 'org.mockito:mockito-core'
+  testImplementation project(':ethereum:networks')
   testImplementation testFixtures(project(':ethereum:datastructures'))
   testImplementation testFixtures(project(':infrastructure:async'))
   testImplementation testFixtures(project(':infrastructure:metrics'))

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.validator.beaconnode;
 
 import static tech.pegasys.teku.core.ForkChoiceUtil.getCurrentSlot;
 import static tech.pegasys.teku.core.ForkChoiceUtil.getSlotStartTime;
-import static tech.pegasys.teku.util.config.Constants.SECONDS_PER_SLOT;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -23,17 +22,17 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.timed.RepeatingTaskScheduler;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecProvider;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 
 public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
   private static final Logger LOG = LogManager.getLogger();
-  private final long oneThirdSlotSeconds = SECONDS_PER_SLOT / 3;
-  private final long twoThirdSlotSeconds = oneThirdSlotSeconds * 2;
 
   private final GenesisDataProvider genesisDataProvider;
   private final RepeatingTaskScheduler taskScheduler;
   private final TimeProvider timeProvider;
   private final ValidatorTimingChannel validatorTimingChannel;
+  private final SpecProvider specProvider;
   private final boolean useIndependentAttestationTiming;
   private UInt64 genesisTime;
 
@@ -42,30 +41,36 @@ public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
       final RepeatingTaskScheduler taskScheduler,
       final TimeProvider timeProvider,
       final ValidatorTimingChannel validatorTimingChannel,
-      final boolean useIndependentAttestationTiming) {
+      final boolean useIndependentAttestationTiming,
+      final SpecProvider specProvider) {
     this.genesisDataProvider = genesisDataProvider;
     this.taskScheduler = taskScheduler;
     this.timeProvider = timeProvider;
     this.validatorTimingChannel = validatorTimingChannel;
     this.useIndependentAttestationTiming = useIndependentAttestationTiming;
+    this.specProvider = specProvider;
   }
 
   void start(final UInt64 genesisTime) {
     this.genesisTime = genesisTime;
     final UInt64 currentSlot = getCurrentSlot(timeProvider.getTimeInSeconds(), genesisTime);
     final UInt64 nextSlotStartTime = getSlotStartTime(currentSlot.plus(1), genesisTime);
-    taskScheduler.scheduleRepeatingEvent(
-        nextSlotStartTime, UInt64.valueOf(SECONDS_PER_SLOT), this::onStartSlot);
+    final UInt64 secondsPerSlot = UInt64.valueOf(specProvider.getSecondsPerSlot(currentSlot));
+
+    // NOTE: seconds_per_slot currently based on genesis slot, and timings set up based on this
+    //       if seconds_per_slot ever changes, timers would have to be updated, which isn't
+    //       currently implemented.
+    final long oneThirdSlotSeconds = specProvider.getSecondsPerSlot(currentSlot) / 3;
+    final long twoThirdSlotSeconds = oneThirdSlotSeconds * 2;
+    taskScheduler.scheduleRepeatingEvent(nextSlotStartTime, secondsPerSlot, this::onStartSlot);
     if (useIndependentAttestationTiming) {
       taskScheduler.scheduleRepeatingEvent(
           nextSlotStartTime.plus(oneThirdSlotSeconds),
-          UInt64.valueOf(SECONDS_PER_SLOT),
+          secondsPerSlot,
           this::onAttestationCreationDue);
     }
     taskScheduler.scheduleRepeatingEvent(
-        nextSlotStartTime.plus(twoThirdSlotSeconds),
-        UInt64.valueOf(SECONDS_PER_SLOT),
-        this::onAggregationDue);
+        nextSlotStartTime.plus(twoThirdSlotSeconds), secondsPerSlot, this::onAggregationDue);
   }
 
   private void onStartSlot(final UInt64 scheduledTime, final UInt64 actualTime) {
@@ -98,7 +103,9 @@ public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
   }
 
   private boolean isTooLate(final UInt64 scheduledTime, final UInt64 actualTime) {
-    return scheduledTime.plus(SECONDS_PER_SLOT).isLessThan(actualTime);
+    final UInt64 currentSlot = getCurrentSlot(timeProvider.getTimeInSeconds(), genesisTime);
+    final UInt64 secondsPerSlot = UInt64.valueOf(specProvider.getSecondsPerSlot(currentSlot));
+    return scheduledTime.plus(secondsPerSlot).isLessThan(actualTime);
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -81,7 +81,9 @@ public class ValidatorClientService extends Service {
                         config.getSpecProvider(),
                         useDependentRoots))
             .orElseGet(
-                () -> InProcessBeaconNodeApi.create(services, asyncRunner, useDependentRoots));
+                () ->
+                    InProcessBeaconNodeApi.create(
+                        services, asyncRunner, useDependentRoots, config.getSpecProvider()));
     final ValidatorApiChannel validatorApiChannel = beaconNodeApi.getValidatorApi();
     final GenesisDataProvider genesisDataProvider =
         new GenesisDataProvider(asyncRunner, validatorApiChannel);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -76,6 +76,8 @@ class ValidatorLoaderTest {
 
   private final SpecProvider specProvider = SpecProviderFactory.createMinimal();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(specProvider);
+  private final InteropConfig disabledInteropConfig =
+      InteropConfig.builder().specProvider(specProvider).build();
 
   private final SlashingProtector slashingProtector = mock(SlashingProtector.class);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
@@ -101,7 +103,6 @@ class ValidatorLoaderTest {
     final String publicKeysUrl = "http://example.com";
     when(publicKeyLoader.getPublicKeys(List.of(publicKeysUrl))).thenReturn(expectedKeys);
 
-    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -112,7 +113,7 @@ class ValidatorLoaderTest {
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
             config,
-            interopConfig,
+            disabledInteropConfig,
             httpClientFactory,
             slashingProtector,
             publicKeyLoader,
@@ -137,7 +138,6 @@ class ValidatorLoaderTest {
 
   @Test
   void initializeValidatorsWithExternalSignerAndSlashingProtection() {
-    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -148,7 +148,7 @@ class ValidatorLoaderTest {
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
             config,
-            interopConfig,
+            disabledInteropConfig,
             httpClientFactory,
             slashingProtector,
             publicKeyLoader,
@@ -178,7 +178,6 @@ class ValidatorLoaderTest {
 
   @Test
   void initializeValidatorsWithExternalSignerAndNoSlashingProtection() {
-    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -189,7 +188,7 @@ class ValidatorLoaderTest {
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
             config,
-            interopConfig,
+            disabledInteropConfig,
             httpClientFactory,
             slashingProtector,
             publicKeyLoader,
@@ -221,8 +220,6 @@ class ValidatorLoaderTest {
   @Test
   void initializeValidatorsWithBothLocalAndExternalSigners(@TempDir Path tempDir) throws Exception {
     writeKeystore(tempDir);
-
-    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -237,7 +234,7 @@ class ValidatorLoaderTest {
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
             config,
-            interopConfig,
+            disabledInteropConfig,
             httpClientFactory,
             slashingProtector,
             publicKeyLoader,
@@ -264,8 +261,6 @@ class ValidatorLoaderTest {
   void initializeValidatorsWithDuplicateKeysInLocalAndExternalSignersTakesExternalAsPriority(
       @TempDir Path tempDir) throws Exception {
     writeKeystore(tempDir);
-
-    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -280,7 +275,7 @@ class ValidatorLoaderTest {
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
             config,
-            interopConfig,
+            disabledInteropConfig,
             httpClientFactory,
             slashingProtector,
             publicKeyLoader,
@@ -304,7 +299,6 @@ class ValidatorLoaderTest {
   void shouldEnableSlashingProtectionForLocalValidators(@TempDir Path tempDir) throws Exception {
     writeKeystore(tempDir);
 
-    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorKeys(
@@ -316,7 +310,7 @@ class ValidatorLoaderTest {
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
             config,
-            interopConfig,
+            disabledInteropConfig,
             httpClientFactory,
             slashingProtector,
             publicKeyLoader,
@@ -345,7 +339,6 @@ class ValidatorLoaderTest {
     final String publicKeysUrl = "http://example.com";
     when(publicKeyLoader.getPublicKeys(List.of(publicKeysUrl))).thenReturn(initialKeys);
 
-    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -355,7 +348,7 @@ class ValidatorLoaderTest {
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
             config,
-            interopConfig,
+            disabledInteropConfig,
             httpClientFactory,
             slashingProtector,
             publicKeyLoader,
@@ -380,7 +373,6 @@ class ValidatorLoaderTest {
     final String publicKeysUrl = "http://example.com";
     when(publicKeyLoader.getPublicKeys(List.of(publicKeysUrl))).thenReturn(initialKeys);
 
-    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -390,7 +382,7 @@ class ValidatorLoaderTest {
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
             config,
-            interopConfig,
+            disabledInteropConfig,
             httpClientFactory,
             slashingProtector,
             publicKeyLoader,
@@ -410,7 +402,6 @@ class ValidatorLoaderTest {
 
   @Test
   void shouldLoadAdditionalLocalValidatorsOnReload(final @TempDir Path tempDir) throws Exception {
-    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorKeys(
@@ -423,7 +414,7 @@ class ValidatorLoaderTest {
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
             config,
-            interopConfig,
+            disabledInteropConfig,
             httpClientFactory,
             slashingProtector,
             publicKeyLoader,

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -47,6 +47,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.networks.SpecProviderFactory;
+import tech.pegasys.teku.spec.SpecProvider;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.InteropConfig;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
@@ -73,8 +74,8 @@ class ValidatorLoaderTest {
     }
   }
 
-  private final DataStructureUtil dataStructureUtil =
-      new DataStructureUtil(SpecProviderFactory.createMinimal());
+  private final SpecProvider specProvider = SpecProviderFactory.createMinimal();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(specProvider);
 
   private final SlashingProtector slashingProtector = mock(SlashingProtector.class);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
@@ -100,7 +101,7 @@ class ValidatorLoaderTest {
     final String publicKeysUrl = "http://example.com";
     when(publicKeyLoader.getPublicKeys(List.of(publicKeysUrl))).thenReturn(expectedKeys);
 
-    final InteropConfig interopConfig = InteropConfig.builder().build();
+    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -136,7 +137,7 @@ class ValidatorLoaderTest {
 
   @Test
   void initializeValidatorsWithExternalSignerAndSlashingProtection() {
-    final InteropConfig interopConfig = InteropConfig.builder().build();
+    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -177,7 +178,7 @@ class ValidatorLoaderTest {
 
   @Test
   void initializeValidatorsWithExternalSignerAndNoSlashingProtection() {
-    final InteropConfig interopConfig = InteropConfig.builder().build();
+    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -221,7 +222,7 @@ class ValidatorLoaderTest {
   void initializeValidatorsWithBothLocalAndExternalSigners(@TempDir Path tempDir) throws Exception {
     writeKeystore(tempDir);
 
-    final InteropConfig interopConfig = InteropConfig.builder().build();
+    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -264,7 +265,7 @@ class ValidatorLoaderTest {
       @TempDir Path tempDir) throws Exception {
     writeKeystore(tempDir);
 
-    final InteropConfig interopConfig = InteropConfig.builder().build();
+    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -303,7 +304,7 @@ class ValidatorLoaderTest {
   void shouldEnableSlashingProtectionForLocalValidators(@TempDir Path tempDir) throws Exception {
     writeKeystore(tempDir);
 
-    final InteropConfig interopConfig = InteropConfig.builder().build();
+    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorKeys(
@@ -344,7 +345,7 @@ class ValidatorLoaderTest {
     final String publicKeysUrl = "http://example.com";
     when(publicKeyLoader.getPublicKeys(List.of(publicKeysUrl))).thenReturn(initialKeys);
 
-    final InteropConfig interopConfig = InteropConfig.builder().build();
+    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -379,7 +380,7 @@ class ValidatorLoaderTest {
     final String publicKeysUrl = "http://example.com";
     when(publicKeyLoader.getPublicKeys(List.of(publicKeysUrl))).thenReturn(initialKeys);
 
-    final InteropConfig interopConfig = InteropConfig.builder().build();
+    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorExternalSignerUrl(SIGNER_URL)
@@ -409,7 +410,7 @@ class ValidatorLoaderTest {
 
   @Test
   void shouldLoadAdditionalLocalValidatorsOnReload(final @TempDir Path tempDir) throws Exception {
-    final InteropConfig interopConfig = InteropConfig.builder().build();
+    final InteropConfig interopConfig = InteropConfig.builder().specProvider(specProvider).build();
     final ValidatorConfig config =
         ValidatorConfig.builder()
             .validatorKeys(
@@ -452,6 +453,7 @@ class ValidatorLoaderTest {
     final int ownedValidatorCount = 10;
     final InteropConfig interopConfig =
         InteropConfig.builder()
+            .specProvider(specProvider)
             .interopEnabled(true)
             .interopOwnedValidatorCount(ownedValidatorCount)
             .build();
@@ -476,6 +478,7 @@ class ValidatorLoaderTest {
     final int ownedValidatorCount = 10;
     final InteropConfig interopConfig =
         InteropConfig.builder()
+            .specProvider(specProvider)
             .interopEnabled(false)
             .interopOwnedValidatorCount(ownedValidatorCount)
             .build();

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
@@ -88,7 +88,8 @@ class BlockFactoryTest {
           voluntaryExitPool,
           depositProvider,
           eth1DataCache,
-          graffiti);
+          graffiti,
+          specProvider);
 
   @BeforeEach
   void setUp() {

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
@@ -19,7 +19,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.datastructures.util.BeaconStateUtil.is_valid_merkle_branch;
 
 import java.util.List;
 import java.util.Optional;
@@ -43,8 +42,10 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networks.SpecProviderFactory;
 import tech.pegasys.teku.networks.TestConstantsLoader;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecProvider;
 import tech.pegasys.teku.spec.constants.SpecConstants;
+import tech.pegasys.teku.spec.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 import tech.pegasys.teku.ssz.SSZTypes.SSZMutableList;
@@ -249,13 +250,14 @@ public class DepositProviderTest {
   }
 
   private void checkThatDepositProofIsValid(SSZList<Deposit> deposits) {
+    final Spec genesisSpec = specProvider.getGenesisSpec();
     deposits.forEach(
         deposit ->
             assertThat(
-                    is_valid_merkle_branch(
+                    BeaconStateUtil.isValidMerkleBranch(
                         deposit.getData().hashTreeRoot(),
                         deposit.getProof(),
-                        specProvider.getGenesisSpecConstants().getDepositContractTreeDepth() + 1,
+                        genesisSpec.getConstants().getDepositContractTreeDepth() + 1,
                         ((DepositWithIndex) deposit).getIndex().intValue(),
                         depositMerkleTree.getRoot()))
                 .isTrue());

--- a/validator/eventadapter/build.gradle
+++ b/validator/eventadapter/build.gradle
@@ -2,6 +2,7 @@ dependencies {
   api 'org.bouncycastle:bcprov-jdk15on'
   implementation project(':bls')
   implementation project(':ethereum:datastructures')
+  implementation project(':ethereum:spec')
   implementation project(':ethereum:statetransition')
   implementation project(':infrastructure:events')
   implementation project(':infrastructure:async')

--- a/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/InProcessBeaconNodeApi.java
+++ b/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/InProcessBeaconNodeApi.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.timed.RepeatingTaskScheduler;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
+import tech.pegasys.teku.spec.SpecProvider;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.beaconnode.BeaconChainEventAdapter;
@@ -42,7 +43,8 @@ public class InProcessBeaconNodeApi implements BeaconNodeApi {
   public static BeaconNodeApi create(
       final ServiceConfig services,
       final AsyncRunner asyncRunner,
-      final boolean useIndependentAttestationTiming) {
+      final boolean useIndependentAttestationTiming,
+      final SpecProvider specProvider) {
     final MetricsSystem metricsSystem = services.getMetricsSystem();
     final EventChannels eventChannels = services.getEventChannels();
     final ValidatorApiChannel validatorApiChannel =
@@ -56,7 +58,8 @@ public class InProcessBeaconNodeApi implements BeaconNodeApi {
             new RepeatingTaskScheduler(asyncRunner, services.getTimeProvider()),
             services.getTimeProvider(),
             validatorTimingChannel,
-            useIndependentAttestationTiming);
+            useIndependentAttestationTiming,
+            specProvider);
     final BeaconChainEventAdapter beaconChainEventAdapter =
         new IndependentTimerEventChannelEventAdapter(
             eventChannels, timeBasedEventAdapter, validatorTimingChannel);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -81,7 +81,8 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
                 new RepeatingTaskScheduler(asyncRunner, serviceConfig.getTimeProvider()),
                 serviceConfig.getTimeProvider(),
                 validatorTimingChannel,
-                useIndependentAttestationTiming),
+                useIndependentAttestationTiming,
+                specProvider),
             validatorTimingChannel);
 
     return new RemoteBeaconNodeApi(beaconChainEventAdapter, validatorApiChannel);


### PR DESCRIPTION
 - removed calls to BeaconStateUtil also.

  - it should be noted that the SECONDS_PER_SLOT use where timers are configured was not updated to handle timing changes that would need refreshing of the timers. The timers are set at startup based on the seconds per slot at the calculated slot-time. Seconds_per_slot are not changing in the first fork, so this problem is limited risk to defer for now.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
