### PR TITLE
[Issue 3596] Migrate StateTransition

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityBlocksTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityBlocksTestExecutor.java
@@ -22,6 +22,7 @@ import static tech.pegasys.teku.reference.phase0.TestDataUtils.loadYaml;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import tech.pegasys.teku.core.StateTransition;
@@ -31,6 +32,7 @@ import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.reference.phase0.BlsSetting;
 import tech.pegasys.teku.reference.phase0.TestExecutor;
+import tech.pegasys.teku.spec.SpecProvider;
 
 public class SanityBlocksTestExecutor implements TestExecutor {
 
@@ -51,26 +53,70 @@ public class SanityBlocksTestExecutor implements TestExecutor {
                         SignedBeaconBlock.getSszSchema()))
             .collect(Collectors.toList());
 
+    final Optional<BeaconState> expectedState;
     if (testDefinition.getTestDirectory().resolve(EXPECTED_STATE_FILENAME).toFile().exists()) {
-      final BeaconState expectedState = loadStateFromSsz(testDefinition, EXPECTED_STATE_FILENAME);
-      assertThat(applyBlocks(metaData, preState, blocks)).isEqualTo(expectedState);
+      expectedState = Optional.of(loadStateFromSsz(testDefinition, EXPECTED_STATE_FILENAME));
     } else {
-      assertThatThrownBy(() -> applyBlocks(metaData, preState, blocks))
-          .isInstanceOf(StateTransitionException.class);
+      expectedState = Optional.empty();
+    }
+
+    runBlockProcessor(
+        this::applyBlocksStandard, testDefinition, metaData, preState, blocks, expectedState);
+    runBlockProcessor(
+        this::applyBlocksDeprecated, testDefinition, metaData, preState, blocks, expectedState);
+  }
+
+  private void runBlockProcessor(
+      final BlocksProcessor processor,
+      final TestDefinition testDefinition,
+      final SanityBlocksMetaData metaData,
+      final BeaconState preState,
+      final List<SignedBeaconBlock> blocks,
+      final Optional<BeaconState> expectedState) {
+    final SpecProvider specProvider = testDefinition.getSpecProvider();
+    expectedState.ifPresentOrElse(
+        (state) ->
+            assertThat(processor.processBlocks(specProvider, metaData, preState, blocks))
+                .isEqualTo(state),
+        () ->
+            assertThatThrownBy(
+                    () -> processor.processBlocks(specProvider, metaData, preState, blocks))
+                .hasCauseInstanceOf(StateTransitionException.class));
+  }
+
+  private BeaconState applyBlocksStandard(
+      final SpecProvider specProvider,
+      final SanityBlocksMetaData metaData,
+      final BeaconState preState,
+      final List<SignedBeaconBlock> blocks) {
+    try {
+      BeaconState result = preState;
+      for (SignedBeaconBlock block : blocks) {
+        result =
+            specProvider.initiateStateTransition(
+                result, block, metaData.getBlsSetting() != IGNORED);
+      }
+      return result;
+    } catch (StateTransitionException e) {
+      throw new RuntimeException(e);
     }
   }
 
-  private BeaconState applyBlocks(
+  private BeaconState applyBlocksDeprecated(
+      final SpecProvider specProvider,
       final SanityBlocksMetaData metaData,
       final BeaconState preState,
-      final List<SignedBeaconBlock> blocks)
-      throws StateTransitionException {
-    final StateTransition stateTransition = new StateTransition();
-    BeaconState result = preState;
-    for (SignedBeaconBlock block : blocks) {
-      result = stateTransition.initiate(result, block, metaData.getBlsSetting() != IGNORED);
+      final List<SignedBeaconBlock> blocks) {
+    try {
+      final StateTransition stateTransition = new StateTransition();
+      BeaconState result = preState;
+      for (SignedBeaconBlock block : blocks) {
+        result = stateTransition.initiate(result, block, metaData.getBlsSetting() != IGNORED);
+      }
+      return result;
+    } catch (StateTransitionException e) {
+      throw new RuntimeException(e);
     }
-    return result;
   }
 
   private static class SanityBlocksMetaData {
@@ -94,5 +140,13 @@ public class SanityBlocksTestExecutor implements TestExecutor {
     public int getRevealDeadlinesSetting() {
       return revealDeadlinesSetting;
     }
+  }
+
+  private interface BlocksProcessor {
+    BeaconState processBlocks(
+        final SpecProvider specProvider,
+        final SanityBlocksMetaData metaData,
+        final BeaconState preState,
+        final List<SignedBeaconBlock> blocks);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanitySlotsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanitySlotsTestExecutor.java
@@ -18,10 +18,13 @@ import static tech.pegasys.teku.reference.phase0.TestDataUtils.loadStateFromSsz;
 import static tech.pegasys.teku.reference.phase0.TestDataUtils.loadYaml;
 
 import tech.pegasys.teku.core.StateTransition;
+import tech.pegasys.teku.core.exceptions.EpochProcessingException;
+import tech.pegasys.teku.core.exceptions.SlotProcessingException;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.reference.phase0.TestExecutor;
+import tech.pegasys.teku.spec.SpecProvider;
 
 public class SanitySlotsTestExecutor implements TestExecutor {
 
@@ -30,10 +33,28 @@ public class SanitySlotsTestExecutor implements TestExecutor {
     final int numberOfSlots = loadYaml(testDefinition, "slots.yaml", Integer.class);
     final BeaconState preState = loadStateFromSsz(testDefinition, "pre.ssz");
     final BeaconState expectedState = loadStateFromSsz(testDefinition, "post.ssz");
-    final StateTransition stateTransition = new StateTransition();
+
     final UInt64 endSlot = preState.getSlot().plus(numberOfSlots);
 
-    final BeaconState result = stateTransition.process_slots(preState, endSlot);
+    // Standard test
+    final BeaconState result =
+        processSlotsStandard(testDefinition.getSpecProvider(), preState, endSlot);
     assertThat(result).isEqualTo(expectedState);
+
+    // Deprecated test
+    final BeaconState resultDeprecated = processSlotsDeprecated(preState, endSlot);
+    assertThat(resultDeprecated).isEqualTo(expectedState);
+  }
+
+  private BeaconState processSlotsStandard(
+      final SpecProvider specProvider, final BeaconState preState, final UInt64 endSlot)
+      throws EpochProcessingException, SlotProcessingException {
+    return specProvider.processSlots(preState, endSlot);
+  }
+
+  private BeaconState processSlotsDeprecated(final BeaconState preState, final UInt64 endSlot)
+      throws EpochProcessingException, SlotProcessingException {
+    final StateTransition stateTransition = new StateTransition();
+    return stateTransition.process_slots(preState, endSlot);
   }
 }

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceBlockTasks.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/ForkChoiceBlockTasks.java
@@ -68,7 +68,7 @@ public class ForkChoiceBlockTasks {
     try {
       state =
           st.processAndValidateBlock(
-              signed_block, indexedAttestationProvider, blockSlotState, true);
+              signed_block, blockSlotState, true, indexedAttestationProvider);
     } catch (StateTransitionException e) {
       return BlockImportResult.failedStateTransition(e);
     }

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/StateTransition.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/StateTransition.java
@@ -47,11 +47,7 @@ public class StateTransition {
   private final BlockValidator blockValidator;
 
   public StateTransition() {
-    this(createDefaultBlockValidator());
-  }
-
-  public StateTransition(BlockValidator blockValidator) {
-    this.blockValidator = blockValidator;
+    this.blockValidator = createDefaultBlockValidator();
   }
 
   public BeaconState initiate(BeaconState preState, SignedBeaconBlock signed_block)
@@ -93,7 +89,7 @@ public class StateTransition {
       BeaconState postSlotState = process_slots(preState, signedBlock.getMessage().getSlot());
 
       return processAndValidateBlock(
-          signedBlock, indexedAttestationProvider, postSlotState, validateStateRootAndSignatures);
+          signedBlock, postSlotState, validateStateRootAndSignatures, indexedAttestationProvider);
     } catch (SlotProcessingException | EpochProcessingException | IllegalArgumentException e) {
       LOG.warn("State Transition error", e);
       throw new StateTransitionException(e);
@@ -102,9 +98,9 @@ public class StateTransition {
 
   public BeaconState processAndValidateBlock(
       final SignedBeaconBlock signedBlock,
-      final IndexedAttestationProvider indexedAttestationProvider,
       final BeaconState blockSlotState,
-      final boolean validateStateRootAndSignatures)
+      final boolean validateStateRootAndSignatures,
+      final IndexedAttestationProvider indexedAttestationProvider)
       throws StateTransitionException {
     BlockValidator blockValidator =
         validateStateRootAndSignatures ? this.blockValidator : BlockValidator.NOOP;

--- a/ethereum/dataproviders/build.gradle
+++ b/ethereum/dataproviders/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     implementation project(':ethereum:core')
     implementation project(':ethereum:datastructures')
+    implementation project(':ethereum:spec')
     implementation project(':infrastructure:async')
     implementation project(':infrastructure:metrics')
 
@@ -9,6 +10,7 @@ dependencies {
     testImplementation testFixtures(project(':bls'))
     testImplementation testFixtures(project(':ethereum:core'))
     testImplementation testFixtures(project(':ethereum:datastructures'))
+    testImplementation testFixtures(project(':ethereum:networks'))
     testImplementation testFixtures(project(':infrastructure:async'))
     testImplementation testFixtures(project(':infrastructure:metrics'))
 }

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/AsyncChainStateGenerator.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/AsyncChainStateGenerator.java
@@ -29,21 +29,25 @@ import tech.pegasys.teku.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.datastructures.hashtree.HashTree;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.SpecProvider;
 
 class AsyncChainStateGenerator {
   private static final Logger LOG = LogManager.getLogger();
   public static final int DEFAULT_BLOCK_BATCH_SIZE = 250;
 
+  private final SpecProvider specProvider;
   private final HashTree blockTree;
   private final BlockProvider blockProvider;
   private final StateProvider stateProvider;
   private final int blockBatchSize;
 
   private AsyncChainStateGenerator(
+      final SpecProvider specProvider,
       final HashTree blockTree,
       final BlockProvider blockProvider,
       final StateProvider stateProvider,
       final int blockBatchSize) {
+    this.specProvider = specProvider;
     this.blockTree = blockTree;
     this.blockProvider = blockProvider;
     this.stateProvider = stateProvider;
@@ -51,11 +55,12 @@ class AsyncChainStateGenerator {
   }
 
   public static AsyncChainStateGenerator create(
+      final SpecProvider specProvider,
       final HashTree blockTree,
       final BlockProvider blockProvider,
       final StateProvider stateProvider) {
     return new AsyncChainStateGenerator(
-        blockTree, blockProvider, stateProvider, DEFAULT_BLOCK_BATCH_SIZE);
+        specProvider, blockTree, blockProvider, stateProvider, DEFAULT_BLOCK_BATCH_SIZE);
   }
 
   public SafeFuture<StateAndBlockSummary> generateTargetState(final Bytes32 targetRoot) {
@@ -166,7 +171,7 @@ class AsyncChainStateGenerator {
               }
 
               final ChainStateGenerator chainStateGenerator =
-                  ChainStateGenerator.create(chainBlocks, startState, true);
+                  ChainStateGenerator.create(specProvider, chainBlocks, startState, true);
               final AtomicReference<BeaconState> lastState = new AtomicReference<>(null);
               chainStateGenerator.generateStates(
                   stateAndBlock -> {

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/BlockProcessor.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/BlockProcessor.java
@@ -15,12 +15,12 @@ package tech.pegasys.teku.dataproviders.generators;
 
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.StateTransitionException;
-import tech.pegasys.teku.core.blockvalidator.NoOpBlockValidator;
+import tech.pegasys.teku.core.blockvalidator.BlockValidator;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 
 class BlockProcessor {
-  private final StateTransition stateTransition = new StateTransition(new NoOpBlockValidator());
+  private final StateTransition stateTransition = new StateTransition(BlockValidator.NOOP);
 
   public BeaconState process(final BeaconState preState, final SignedBeaconBlock block) {
 

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/BlockProcessor.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/BlockProcessor.java
@@ -13,18 +13,22 @@
 
 package tech.pegasys.teku.dataproviders.generators;
 
-import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.StateTransitionException;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.spec.SpecProvider;
 
 class BlockProcessor {
-  private final StateTransition stateTransition = new StateTransition();
+  private final SpecProvider specProvider;
+
+  BlockProcessor(final SpecProvider specProvider) {
+    this.specProvider = specProvider;
+  }
 
   public BeaconState process(final BeaconState preState, final SignedBeaconBlock block) {
 
     try {
-      final BeaconState postState = stateTransition.initiate(preState, block, false);
+      final BeaconState postState = specProvider.initiateStateTransition(preState, block, false);
       assertBlockAndStateMatch(block, postState);
       return postState;
     } catch (StateTransitionException e) {

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/BlockProcessor.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/BlockProcessor.java
@@ -15,17 +15,16 @@ package tech.pegasys.teku.dataproviders.generators;
 
 import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.StateTransitionException;
-import tech.pegasys.teku.core.blockvalidator.BlockValidator;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 
 class BlockProcessor {
-  private final StateTransition stateTransition = new StateTransition(BlockValidator.NOOP);
+  private final StateTransition stateTransition = new StateTransition();
 
   public BeaconState process(final BeaconState preState, final SignedBeaconBlock block) {
 
     try {
-      final BeaconState postState = stateTransition.initiate(preState, block);
+      final BeaconState postState = stateTransition.initiate(preState, block, false);
       assertBlockAndStateMatch(block, postState);
       return postState;
     } catch (StateTransitionException e) {

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/ChainStateGenerator.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/ChainStateGenerator.java
@@ -19,13 +19,15 @@ import java.util.List;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.spec.SpecProvider;
 
 class ChainStateGenerator {
-  private final BlockProcessor blockProcessor = new BlockProcessor();
+  private final BlockProcessor blockProcessor;
   private final List<SignedBeaconBlock> chain;
   private final BeaconState baseState;
 
   private ChainStateGenerator(
+      final SpecProvider specProvider,
       final List<SignedBeaconBlock> chain,
       final BeaconState baseState,
       final boolean skipValidation) {
@@ -39,6 +41,7 @@ class ChainStateGenerator {
 
     this.chain = chain;
     this.baseState = baseState;
+    this.blockProcessor = new BlockProcessor(specProvider);
   }
 
   /**
@@ -49,15 +52,18 @@ class ChainStateGenerator {
    * @return
    */
   public static ChainStateGenerator create(
-      final List<SignedBeaconBlock> chain, final BeaconState baseState) {
-    return create(chain, baseState, false);
+      final SpecProvider specProvider,
+      final List<SignedBeaconBlock> chain,
+      final BeaconState baseState) {
+    return create(specProvider, chain, baseState, false);
   }
 
   static ChainStateGenerator create(
+      final SpecProvider specProvider,
       final List<SignedBeaconBlock> chain,
       final BeaconState baseState,
       final boolean skipValidation) {
-    return new ChainStateGenerator(chain, baseState, skipValidation);
+    return new ChainStateGenerator(specProvider, chain, baseState, skipValidation);
   }
 
   public void generateStates(final StateHandler handler) {

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateGenerationTask.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateGenerationTask.java
@@ -23,19 +23,23 @@ import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.datastructures.hashtree.HashTree;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.SpecProvider;
 
 public class StateGenerationTask implements CacheableTask<Bytes32, StateAndBlockSummary> {
   private static final Logger LOG = LogManager.getLogger();
+  private final SpecProvider specProvider;
   private final HashTree tree;
   private final BlockProvider blockProvider;
   private final Bytes32 blockRoot;
   private final StateRegenerationBaseSelector baseSelector;
 
   public StateGenerationTask(
+      final SpecProvider specProvider,
       final Bytes32 blockRoot,
       final HashTree tree,
       final BlockProvider blockProvider,
       final StateRegenerationBaseSelector baseSelector) {
+    this.specProvider = specProvider;
     this.tree = tree;
     this.blockProvider = blockProvider;
     this.blockRoot = blockRoot;
@@ -71,6 +75,7 @@ public class StateGenerationTask implements CacheableTask<Bytes32, StateAndBlock
       return this;
     }
     return new StateGenerationTask(
+        specProvider,
         blockRoot,
         tree,
         blockProvider,
@@ -89,7 +94,7 @@ public class StateGenerationTask implements CacheableTask<Bytes32, StateAndBlock
     }
     final StateAndBlockSummary base = maybeBase.get();
     return StateGenerator.create(
-            tree.withRoot(base.getRoot()).block(base).build(), base, blockProvider)
+            specProvider, tree.withRoot(base.getRoot()).block(base).build(), base, blockProvider)
         .regenerateStateForBlock(blockRoot)
         .thenApply(Optional::of);
   }

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateGenerator.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateGenerator.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.datastructures.hashtree.HashTree;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.SpecProvider;
 
 public class StateGenerator {
   public static final int DEFAULT_STATE_CACHE_SIZE = 100;
@@ -46,22 +47,31 @@ public class StateGenerator {
   }
 
   public static StateGenerator create(
+      SpecProvider specProvider,
       final HashTree blockTree,
       final StateAndBlockSummary rootBlockAndState,
       final BlockProvider blockProvider) {
-    return create(blockTree, rootBlockAndState, blockProvider, Collections.emptyMap());
+    return create(
+        specProvider, blockTree, rootBlockAndState, blockProvider, Collections.emptyMap());
   }
 
   public static StateGenerator create(
+      final SpecProvider specProvider,
       final HashTree blockTree,
       final StateAndBlockSummary rootBlockAndState,
       final BlockProvider blockProvider,
       final Map<Bytes32, BeaconState> knownStates) {
     return create(
-        blockTree, rootBlockAndState, blockProvider, knownStates, DEFAULT_STATE_CACHE_SIZE);
+        specProvider,
+        blockTree,
+        rootBlockAndState,
+        blockProvider,
+        knownStates,
+        DEFAULT_STATE_CACHE_SIZE);
   }
 
   public static StateGenerator create(
+      final SpecProvider specProvider,
       final HashTree blockTree,
       final StateAndBlockSummary rootBlockAndState,
       final BlockProvider blockProvider,
@@ -76,7 +86,7 @@ public class StateGenerator {
     final StateCache stateCache = new StateCache(stateCacheSize, availableStates);
 
     final AsyncChainStateGenerator chainStateGenerator =
-        AsyncChainStateGenerator.create(blockTree, blockProvider, stateCache::get);
+        AsyncChainStateGenerator.create(specProvider, blockTree, blockProvider, stateCache::get);
     return new StateGenerator(blockTree, chainStateGenerator, stateCache);
   }
 

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StreamingStateRegenerator.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StreamingStateRegenerator.java
@@ -11,9 +11,11 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.core;
+package tech.pegasys.teku.dataproviders.generators;
 
 import java.util.stream.Stream;
+import tech.pegasys.teku.core.StateTransition;
+import tech.pegasys.teku.core.StateTransitionException;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StateGenerationTaskTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StateGenerationTaskTest.java
@@ -37,10 +37,13 @@ import tech.pegasys.teku.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.datastructures.hashtree.HashTree;
 import tech.pegasys.teku.datastructures.state.BlockRootAndState;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.networks.SpecProviderFactory;
+import tech.pegasys.teku.spec.SpecProvider;
 
 class StateGenerationTaskTest {
 
   private static final int REPLAY_TOLERANCE_TO_AVOID_LOADING_IN_EPOCHS = 0;
+  private final SpecProvider specProvider = SpecProviderFactory.createMinimal();
   private final ChainBuilder chainBuilder = ChainBuilder.createDefault();
   private TrackingBlockProvider blockProvider;
 
@@ -133,6 +136,7 @@ class StateGenerationTaskTest {
     }
     final HashTree tree = treeBuilder.build();
     return new StateGenerationTask(
+        specProvider,
         endBlock.getRoot(),
         tree,
         blockProvider,

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StateGeneratorTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StateGeneratorTest.java
@@ -35,9 +35,12 @@ import tech.pegasys.teku.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.datastructures.hashtree.HashTree;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networks.SpecProviderFactory;
+import tech.pegasys.teku.spec.SpecProvider;
 
 public class StateGeneratorTest {
   protected static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(3);
+  private final SpecProvider specProvider = SpecProviderFactory.createMinimal();
   private final ChainBuilder chainBuilder = ChainBuilder.create(VALIDATOR_KEYS);
 
   @Test
@@ -58,7 +61,8 @@ public class StateGeneratorTest {
     blockMap.remove(genesis.getRoot());
     final BlockProvider blockProvider = BlockProvider.fromMap(blockMap);
 
-    final StateGenerator generator = StateGenerator.create(tree, genesis, blockProvider);
+    final StateGenerator generator =
+        StateGenerator.create(specProvider, tree, genesis, blockProvider);
     final SafeFuture<StateAndBlockSummary> result =
         generator.regenerateStateForBlock(lastBlockAndState.getRoot());
     assertThat(result).isCompletedWithValue(lastBlockAndState);
@@ -81,7 +85,8 @@ public class StateGeneratorTest {
     blockMap.remove(genesis.getRoot());
     final BlockProvider blockProvider = BlockProvider.fromMap(blockMap);
 
-    final StateGenerator generator = StateGenerator.create(tree, genesis, blockProvider);
+    final StateGenerator generator =
+        StateGenerator.create(specProvider, tree, genesis, blockProvider);
     final SafeFuture<StateAndBlockSummary> result =
         generator.regenerateStateForBlock(genesis.getRoot());
     final StateAndBlockSummary expected = StateAndBlockSummary.create(genesis.getState());
@@ -132,7 +137,8 @@ public class StateGeneratorTest {
     blockMap.remove(missingBlock.getRoot());
     final BlockProvider blockProvider = BlockProvider.fromMap(blockMap);
 
-    final StateGenerator generator = StateGenerator.create(tree, genesis, blockProvider);
+    final StateGenerator generator =
+        StateGenerator.create(specProvider, tree, genesis, blockProvider);
     processor.accept(generator, missingBlock);
   }
 

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StreamingStateRegeneratorTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StreamingStateRegeneratorTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.core;
+package tech.pegasys.teku.dataproviders.generators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.core.ChainBuilder;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StreamingStateRegeneratorTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StreamingStateRegeneratorTest.java
@@ -24,10 +24,13 @@ import tech.pegasys.teku.core.ChainBuilder;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networks.SpecProviderFactory;
+import tech.pegasys.teku.spec.SpecProvider;
 
 class StreamingStateRegeneratorTest {
 
   private static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(3);
+  private final SpecProvider specProvider = SpecProviderFactory.createMinimal();
   private final ChainBuilder chainBuilder = ChainBuilder.create(VALIDATOR_KEYS);
 
   @Test
@@ -44,7 +47,9 @@ class StreamingStateRegeneratorTest {
         newBlocksAndStates.get(newBlocksAndStates.size() - 1);
     final BeaconState result =
         StreamingStateRegenerator.regenerate(
-            genesis.getState(), newBlocksAndStates.stream().map(SignedBlockAndState::getBlock));
+            specProvider,
+            genesis.getState(),
+            newBlocksAndStates.stream().map(SignedBlockAndState::getBlock));
     assertThat(result).isEqualTo(lastBlockAndState.getState());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec;
 
 import tech.pegasys.teku.spec.constants.SpecConstants;
+import tech.pegasys.teku.spec.statetransition.StateTransition;
 import tech.pegasys.teku.spec.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.util.AttestationUtil;
 import tech.pegasys.teku.spec.util.BeaconStateUtil;
@@ -29,6 +30,7 @@ public class Spec {
   private final BeaconStateUtil beaconStateUtil;
   private final EpochProcessor epochProcessor;
   private final BlockProcessorUtil blockProcessorUtil;
+  private final StateTransition stateTransition;
 
   Spec(final SpecConstants constants) {
     this.constants = constants;
@@ -39,6 +41,9 @@ public class Spec {
     this.epochProcessor = new EpochProcessor(this.constants, validatorsUtil, this.beaconStateUtil);
     this.blockProcessorUtil =
         new BlockProcessorUtil(this.constants, beaconStateUtil, attestationUtil, validatorsUtil);
+    this.stateTransition =
+        StateTransition.create(
+            constants, blockProcessorUtil, epochProcessor, beaconStateUtil, validatorsUtil);
   }
 
   public SpecConstants getConstants() {
@@ -67,5 +72,9 @@ public class Spec {
 
   public BlockProcessorUtil getBlockProcessorUtil() {
     return blockProcessorUtil;
+  }
+
+  public StateTransition getStateTransition() {
+    return stateTransition;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecProvider.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecProvider.java
@@ -31,9 +31,9 @@ import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.Fork;
 import tech.pegasys.teku.datastructures.state.MutableBeaconState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
 import tech.pegasys.teku.spec.constants.SpecConstants;
 import tech.pegasys.teku.spec.util.BeaconStateUtil;
-import tech.pegasys.teku.spec.util.BlockProcessorUtil;
 import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 import tech.pegasys.teku.ssz.backing.collections.SszBitlist;
@@ -161,7 +161,7 @@ public class SpecProvider {
   public void processAttestations(
       MutableBeaconState state,
       SSZList<Attestation> attestations,
-      BlockProcessorUtil.IndexedAttestationCache indexedAttestationCache)
+      IndexedAttestationCache indexedAttestationCache)
       throws BlockProcessingException {
     atState(state)
         .getBlockProcessorUtil()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/cache/CapturingIndexedAttestationCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/cache/CapturingIndexedAttestationCache.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.cache;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.operations.IndexedAttestation;
+
+class CapturingIndexedAttestationCache implements IndexedAttestationCache {
+  private final Map<Attestation, IndexedAttestation> indexedAttestations = new HashMap<>();
+
+  @Override
+  public IndexedAttestation computeIfAbsent(
+      final Attestation attestation, final Supplier<IndexedAttestation> attestationProvider) {
+    return indexedAttestations.computeIfAbsent(attestation, __ -> attestationProvider.get());
+  }
+
+  public Collection<IndexedAttestation> getIndexedAttestations() {
+    return indexedAttestations.values();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/cache/IndexedAttestationCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/cache/IndexedAttestationCache.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.cache;
+
+import java.util.function.Supplier;
+import tech.pegasys.teku.datastructures.operations.Attestation;
+import tech.pegasys.teku.datastructures.operations.IndexedAttestation;
+
+public interface IndexedAttestationCache {
+  IndexedAttestationCache NOOP = (att, supplier) -> supplier.get();
+
+  static IndexedAttestationCache noop() {
+    return NOOP;
+  }
+
+  static IndexedAttestationCache capturing() {
+    return new CapturingIndexedAttestationCache();
+  }
+
+  IndexedAttestation computeIfAbsent(
+      Attestation attestation, Supplier<IndexedAttestation> attestationProvider);
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/statetransition/blockvalidator/BatchBlockValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/statetransition/blockvalidator/BatchBlockValidator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.statetransition.blockvalidator;
+
+import tech.pegasys.teku.core.blockvalidator.BatchSignatureVerifier;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
+import tech.pegasys.teku.spec.constants.SpecConstants;
+import tech.pegasys.teku.spec.util.BeaconStateUtil;
+import tech.pegasys.teku.spec.util.BlockProcessorUtil;
+import tech.pegasys.teku.spec.util.ValidatorsUtil;
+
+/**
+ * Advanced block validator which uses {@link BatchSignatureVerifier} to verify all the BLS
+ * signatures inside a block in an optimized batched way.
+ */
+class BatchBlockValidator implements BlockValidator {
+  private final SpecConstants specConstants;
+  private final BeaconStateUtil beaconStateUtil;
+  private final BlockProcessorUtil blockProcessorUtil;
+  private final ValidatorsUtil validatorsUtil;
+  private final BlockValidator simpleValidator;
+
+  BatchBlockValidator(
+      final SpecConstants specConstants,
+      final BeaconStateUtil beaconStateUtil,
+      final BlockProcessorUtil blockProcessorUtil,
+      final ValidatorsUtil validatorsUtil) {
+    this.specConstants = specConstants;
+    this.beaconStateUtil = beaconStateUtil;
+    this.blockProcessorUtil = blockProcessorUtil;
+    this.validatorsUtil = validatorsUtil;
+    this.simpleValidator =
+        new SimpleBlockValidator(
+            specConstants, beaconStateUtil, blockProcessorUtil, validatorsUtil);
+  }
+
+  @Override
+  public BlockValidationResult validatePreState(
+      BeaconState preState,
+      SignedBeaconBlock block,
+      IndexedAttestationCache indexedAttestationCache) {
+    BatchSignatureVerifier signatureVerifier = new BatchSignatureVerifier();
+    SimpleBlockValidator blockValidator =
+        new SimpleBlockValidator(
+            specConstants, beaconStateUtil, blockProcessorUtil, validatorsUtil, signatureVerifier);
+    BlockValidationResult noBLSValidationResult =
+        blockValidator.validatePreState(preState, block, indexedAttestationCache);
+    // during the above validatePreState() call BatchSignatureVerifier just collected
+    // a bunch of signatures to be verified in optimized batched way on the following step
+    if (!noBLSValidationResult.isValid()) {
+      // something went wrong aside of signatures verification
+      return noBLSValidationResult;
+    } else {
+      boolean batchBLSResult = signatureVerifier.batchVerify();
+      if (!batchBLSResult) {
+        // validate again naively to get exact invalid signature
+        return simpleValidator.validatePreState(preState, block, indexedAttestationCache);
+      } else {
+        return BlockValidationResult.SUCCESSFUL;
+      }
+    }
+  }
+
+  @Override
+  public BlockValidationResult validatePostState(BeaconState postState, SignedBeaconBlock block) {
+    return simpleValidator.validatePostState(postState, block);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/statetransition/blockvalidator/BlockValidationResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/statetransition/blockvalidator/BlockValidationResult.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.statetransition.blockvalidator;
+
+/** Represents block validation result which may contain reason exception in case of a failure */
+public class BlockValidationResult {
+  public static BlockValidationResult SUCCESSFUL = new BlockValidationResult(true);
+  public static BlockValidationResult FAILED = new BlockValidationResult(false);
+
+  private final boolean isValid;
+  private final Exception reason;
+
+  private BlockValidationResult(Exception reason) {
+    this.isValid = false;
+    this.reason = reason;
+  }
+
+  private BlockValidationResult(boolean isValid) {
+    this.isValid = isValid;
+    reason = null;
+  }
+
+  public static BlockValidationResult failedExceptionally(final Exception reason) {
+    return new BlockValidationResult(reason);
+  }
+
+  public boolean isValid() {
+    return isValid;
+  }
+
+  public Exception getReason() {
+    return reason;
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/statetransition/blockvalidator/BlockValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/statetransition/blockvalidator/BlockValidator.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.statetransition.blockvalidator;
+
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
+import tech.pegasys.teku.spec.constants.SpecConstants;
+import tech.pegasys.teku.spec.util.BeaconStateUtil;
+import tech.pegasys.teku.spec.util.BlockProcessorUtil;
+import tech.pegasys.teku.spec.util.ValidatorsUtil;
+
+/**
+ * Dedicated class which performs block validation (apart from {@link
+ * tech.pegasys.teku.core.BlockProcessorUtil} The validation may be performed either synchronously
+ * (then the methods return completed futures) or asynchronously.
+ */
+public interface BlockValidator {
+
+  /** Block validator which just returns OK result without any validations */
+  BlockValidator NOOP = new NoOpBlockValidator();
+
+  static BlockValidator standard(
+      final SpecConstants specConstants,
+      final BeaconStateUtil beaconStateUtil,
+      final BlockProcessorUtil blockProcessorUtil,
+      final ValidatorsUtil validatorsUtil) {
+    return new BatchBlockValidator(
+        specConstants, beaconStateUtil, blockProcessorUtil, validatorsUtil);
+  }
+
+  /**
+   * Validates the block against the state prior to block processing
+   *
+   * <p>This normally includes validating all signatures, checking validity of attestations,
+   * slashings, etc.
+   *
+   * @param preState Normally the state with the slot equal to the block's slot However
+   *     implementations may allow to pass earlier or later state which has the necessary
+   *     information (randao history) to recover committees for the block slot, attestations slots,
+   *     etc
+   * @param block Block to be validated
+   * @param indexedAttestationCache
+   * @return Result promise
+   */
+  BlockValidationResult validatePreState(
+      BeaconState preState,
+      SignedBeaconBlock block,
+      IndexedAttestationCache indexedAttestationCache);
+
+  /**
+   * Validates the block against the state after block processing
+   *
+   * <p>This is normally calculating the state hash root and comparing it to the state root
+   * specified in the block
+   *
+   * @param postState beacon state right after applying block transition
+   * @param block Block to be validated
+   * @return Result promise
+   */
+  BlockValidationResult validatePostState(BeaconState postState, SignedBeaconBlock block);
+
+  /**
+   * Combines {@link #validatePreState(BeaconState, SignedBeaconBlock, IndexedAttestationCache)} and
+   * {@link #validatePostState(BeaconState, SignedBeaconBlock)}
+   *
+   * @return
+   */
+  default BlockValidationResult validate(
+      BeaconState preState,
+      SignedBeaconBlock block,
+      BeaconState postState,
+      IndexedAttestationCache indexedAttestationCache) {
+    BlockValidationResult preResult = validatePreState(preState, block, indexedAttestationCache);
+    if (!preResult.isValid()) {
+      return preResult;
+    }
+
+    return validatePostState(postState, block);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/statetransition/blockvalidator/NoOpBlockValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/statetransition/blockvalidator/NoOpBlockValidator.java
@@ -11,11 +11,11 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.core.blockvalidator;
+package tech.pegasys.teku.spec.statetransition.blockvalidator;
 
-import tech.pegasys.teku.core.lookup.IndexedAttestationProvider;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
 
 class NoOpBlockValidator implements BlockValidator {
 
@@ -23,7 +23,7 @@ class NoOpBlockValidator implements BlockValidator {
   public BlockValidationResult validatePreState(
       BeaconState preState,
       SignedBeaconBlock block,
-      IndexedAttestationProvider indexedAttestationProvider) {
+      IndexedAttestationCache indexedAttestationCache) {
     return BlockValidationResult.SUCCESSFUL;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/statetransition/blockvalidator/SimpleBlockValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/statetransition/blockvalidator/SimpleBlockValidator.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.statetransition.blockvalidator;
+
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.bls.BLSSignatureVerifier.InvalidSignatureException;
+import tech.pegasys.teku.core.StateTransitionException;
+import tech.pegasys.teku.core.exceptions.BlockProcessingException;
+import tech.pegasys.teku.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.datastructures.blocks.BeaconBlockBody;
+import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.datastructures.state.BeaconState;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
+import tech.pegasys.teku.spec.constants.SpecConstants;
+import tech.pegasys.teku.spec.util.BeaconStateUtil;
+import tech.pegasys.teku.spec.util.BlockProcessorUtil;
+import tech.pegasys.teku.spec.util.ValidatorsUtil;
+
+/**
+ * Base logic of a block validation
+ *
+ * <p>Delegates bls signature verifications to BLSSignatureVerifier instance Optionally may skip
+ * some validations.
+ */
+class SimpleBlockValidator implements BlockValidator {
+
+  private final SpecConstants specConstants;
+  private final BeaconStateUtil beaconStateUtil;
+  private final BlockProcessorUtil blockProcessorUtil;
+  private final ValidatorsUtil validatorsUtil;
+  private final BLSSignatureVerifier signatureVerifier;
+
+  SimpleBlockValidator(
+      final SpecConstants specConstants,
+      final BeaconStateUtil beaconStateUtil,
+      final BlockProcessorUtil blockProcessorUtil,
+      final ValidatorsUtil validatorsUtil,
+      final BLSSignatureVerifier signatureVerifier) {
+    this.specConstants = specConstants;
+    this.beaconStateUtil = beaconStateUtil;
+    this.blockProcessorUtil = blockProcessorUtil;
+    this.validatorsUtil = validatorsUtil;
+    this.signatureVerifier = signatureVerifier;
+  }
+
+  public SimpleBlockValidator(
+      final SpecConstants specConstants,
+      final BeaconStateUtil beaconStateUtil,
+      final BlockProcessorUtil blockProcessorUtil,
+      final ValidatorsUtil validatorsUtil) {
+    this(
+        specConstants,
+        beaconStateUtil,
+        blockProcessorUtil,
+        validatorsUtil,
+        BLSSignatureVerifier.SIMPLE);
+  }
+
+  @Override
+  public BlockValidationResult validatePreState(
+      BeaconState preState,
+      SignedBeaconBlock block,
+      IndexedAttestationCache indexedAttestationCache) {
+    try {
+      // Verify signature
+      verifyBlockSignature(preState, block);
+
+      // Verify body
+      BeaconBlock blockMessage = block.getMessage();
+      BeaconBlockBody blockBody = blockMessage.getBody();
+      blockProcessorUtil.verifyAttestations(
+          preState, blockBody.getAttestations(), signatureVerifier, indexedAttestationCache);
+      blockProcessorUtil.verifyRandao(preState, blockMessage, signatureVerifier);
+
+      if (!blockProcessorUtil.verifyProposerSlashings(
+          preState, blockBody.getProposer_slashings(), signatureVerifier)) {
+        return BlockValidationResult.FAILED;
+      }
+
+      if (!blockProcessorUtil.verifyVoluntaryExits(
+          preState, blockBody.getVoluntary_exits(), signatureVerifier)) {
+        return BlockValidationResult.FAILED;
+      }
+      return BlockValidationResult.SUCCESSFUL;
+    } catch (BlockProcessingException | InvalidSignatureException e) {
+      return BlockValidationResult.failedExceptionally(e);
+    }
+  }
+
+  @Override
+  public BlockValidationResult validatePostState(BeaconState postState, SignedBeaconBlock block) {
+    if (!block.getMessage().getStateRoot().equals(postState.hashTreeRoot())) {
+      return BlockValidationResult.failedExceptionally(
+          new StateTransitionException(
+              "Block state root does NOT match the calculated state root!\n"
+                  + "Block state root: "
+                  + block.getMessage().getStateRoot().toHexString()
+                  + "New state root: "
+                  + postState.hashTreeRoot().toHexString()));
+    } else {
+      return BlockValidationResult.SUCCESSFUL;
+    }
+  }
+
+  private void verifyBlockSignature(final BeaconState state, SignedBeaconBlock signed_block)
+      throws BlockProcessingException {
+    final int proposerIndex = beaconStateUtil.getBeaconProposerIndex(state, signed_block.getSlot());
+    final BLSPublicKey proposerPublicKey =
+        validatorsUtil
+            .getValidatorPubKey(state, UInt64.valueOf(proposerIndex))
+            .orElseThrow(
+                () ->
+                    new BlockProcessingException(
+                        "Public key not found for validator " + proposerIndex));
+    final Bytes signing_root =
+        beaconStateUtil.computeSigningRoot(
+            signed_block.getMessage(),
+            beaconStateUtil.getDomain(state, specConstants.getDomainBeaconProposer()));
+    try {
+      signatureVerifier.verifyAndThrow(
+          proposerPublicKey, signing_root, signed_block.getSignature());
+    } catch (InvalidSignatureException e) {
+      throw new BlockProcessingException("Invalid block signature: " + signed_block);
+    }
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/util/BlockProcessorUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/util/BlockProcessorUtil.java
@@ -17,12 +17,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Math.toIntExact;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -48,7 +44,6 @@ import tech.pegasys.teku.datastructures.operations.Attestation;
 import tech.pegasys.teku.datastructures.operations.AttestationData;
 import tech.pegasys.teku.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.datastructures.operations.Deposit;
-import tech.pegasys.teku.datastructures.operations.IndexedAttestation;
 import tech.pegasys.teku.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.datastructures.state.BeaconState;
@@ -57,6 +52,7 @@ import tech.pegasys.teku.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.datastructures.state.Validator;
 import tech.pegasys.teku.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
 import tech.pegasys.teku.spec.constants.SpecConstants;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 
@@ -497,34 +493,5 @@ public final class BlockProcessorUtil {
       }
     }
     return true;
-  }
-
-  public interface IndexedAttestationCache {
-    IndexedAttestationCache NOOP = (att, supplier) -> supplier.get();
-
-    static IndexedAttestationCache noop() {
-      return NOOP;
-    }
-
-    static IndexedAttestationCache capturing() {
-      return new CapturingIndexedAttestationCache();
-    }
-
-    IndexedAttestation computeIfAbsent(
-        Attestation attestation, Supplier<IndexedAttestation> attestationProvider);
-  }
-
-  public static class CapturingIndexedAttestationCache implements IndexedAttestationCache {
-    private final Map<Attestation, IndexedAttestation> indexedAttestations = new HashMap<>();
-
-    @Override
-    public IndexedAttestation computeIfAbsent(
-        final Attestation attestation, final Supplier<IndexedAttestation> attestationProvider) {
-      return indexedAttestations.computeIfAbsent(attestation, __ -> attestationProvider.get());
-    }
-
-    public Collection<IndexedAttestation> getIndexedAttestations() {
-      return indexedAttestations.values();
-    }
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -386,7 +386,6 @@ public class BeaconChainController extends Service implements TimeTickChannel {
         new CombinedChainDataClient(
             recentChainData,
             eventChannels.getPublisher(StorageQueryChannel.class, beaconAsyncRunner),
-            stateTransition,
             specProvider);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.core.exceptions.EpochProcessingException;
 import tech.pegasys.teku.core.exceptions.SlotProcessingException;
 import tech.pegasys.teku.datastructures.blocks.BeaconBlockAndState;
@@ -57,24 +56,14 @@ public class CombinedChainDataClient {
 
   private final RecentChainData recentChainData;
   private final StorageQueryChannel historicalChainData;
-  private final StateTransition stateTransition;
   private final SpecProvider specProvider;
 
   public CombinedChainDataClient(
       final RecentChainData recentChainData,
       final StorageQueryChannel historicalChainData,
       final SpecProvider specProvider) {
-    this(recentChainData, historicalChainData, new StateTransition(), specProvider);
-  }
-
-  public CombinedChainDataClient(
-      final RecentChainData recentChainData,
-      final StorageQueryChannel historicalChainData,
-      final StateTransition stateTransition,
-      final SpecProvider specProvider) {
     this.recentChainData = recentChainData;
     this.historicalChainData = historicalChainData;
-    this.stateTransition = stateTransition;
     this.specProvider = specProvider;
   }
 
@@ -333,7 +322,7 @@ public class CombinedChainDataClient {
       return Optional.empty();
     }
     try {
-      return Optional.of(stateTransition.process_slots(preState, slot));
+      return Optional.of(specProvider.processSlots(preState, slot));
     } catch (SlotProcessingException | EpochProcessingException | IllegalArgumentException e) {
       LOG.debug("State Transition error", e);
       return Optional.empty();

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -141,11 +141,11 @@ public abstract class RecentChainData implements StoreUpdateHandler {
         StoreBuilder.forkChoiceStoreBuilder(
                 asyncRunner,
                 metricsSystem,
+                specProvider,
                 blockProvider,
                 stateProvider,
                 anchorPoint,
-                currentTime,
-                specProvider)
+                currentTime)
             .storeConfig(storeConfig)
             .build();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -62,7 +62,9 @@ public class ChainStorage implements StorageUpdateChannel, StorageQueryChannel, 
     final int finalizedStateCacheSize =
         specProvider.getSlotsPerEpoch(SpecConstants.GENESIS_EPOCH) * 3;
     return new ChainStorage(
-        eventBus, database, new FinalizedStateCache(database, finalizedStateCacheSize, true));
+        eventBus,
+        database,
+        new FinalizedStateCache(specProvider, database, finalizedStateCacheSize, true));
   }
 
   public void start() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -486,6 +486,7 @@ public class RocksDbDatabase implements Database {
     return Optional.of(
         StoreBuilder.create()
             .metricsSystem(metricsSystem)
+            .specProvider(specProvider)
             .time(time)
             .anchor(maybeAnchor)
             .genesisTime(genesisTime)

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/state/FinalizedStateCache.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/state/FinalizedStateCache.java
@@ -26,7 +26,7 @@ import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.stream.Stream;
-import tech.pegasys.teku.core.StreamingStateRegenerator;
+import tech.pegasys.teku.dataproviders.generators.StreamingStateRegenerator;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/state/FinalizedStateCache.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/state/FinalizedStateCache.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.dataproviders.generators.StreamingStateRegenerator;
 import tech.pegasys.teku.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecProvider;
 import tech.pegasys.teku.storage.server.Database;
 
 public class FinalizedStateCache {
@@ -41,10 +42,15 @@ public class FinalizedStateCache {
   private final NavigableSet<UInt64> availableSlots = new ConcurrentSkipListSet<>();
 
   private final LoadingCache<UInt64, BeaconState> stateCache;
+  private final SpecProvider specProvider;
   private final Database database;
 
   public FinalizedStateCache(
-      final Database database, final int maximumCacheSize, final boolean useSoftReferences) {
+      final SpecProvider specProvider,
+      final Database database,
+      final int maximumCacheSize,
+      final boolean useSoftReferences) {
+    this.specProvider = specProvider;
     this.database = database;
     final CacheBuilder<UInt64, BeaconState> cacheBuilder =
         CacheBuilder.newBuilder()
@@ -104,7 +110,8 @@ public class FinalizedStateCache {
       }
       try (final Stream<SignedBeaconBlock> blocks =
           database.streamFinalizedBlocks(preState.getSlot().plus(ONE), slot)) {
-        final BeaconState state = StreamingStateRegenerator.regenerate(preState, blocks);
+        final BeaconState state =
+            StreamingStateRegenerator.regenerate(specProvider, preState, blocks);
         availableSlots.add(state.getSlot());
         return state;
       }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.spec.SpecProvider;
 public class StoreBuilder {
   private AsyncRunner asyncRunner;
   private MetricsSystem metricsSystem;
+  private SpecProvider specProvider;
   private BlockProvider blockProvider;
   private StateAndBlockSummaryProvider stateAndBlockProvider;
   private StoreConfig storeConfig = StoreConfig.createDefault();
@@ -59,11 +60,11 @@ public class StoreBuilder {
   public static StoreBuilder forkChoiceStoreBuilder(
       final AsyncRunner asyncRunner,
       final MetricsSystem metricsSystem,
+      final SpecProvider specProvider,
       final BlockProvider blockProvider,
       final StateAndBlockSummaryProvider stateAndBlockProvider,
       final AnchorPoint anchor,
-      final UInt64 currentTime,
-      final SpecProvider specProvider) {
+      final UInt64 currentTime) {
     final UInt64 genesisTime = anchor.getState().getGenesis_time();
     final UInt64 slot = anchor.getState().getSlot();
     final UInt64 time =
@@ -84,6 +85,7 @@ public class StoreBuilder {
     return create()
         .asyncRunner(asyncRunner)
         .metricsSystem(metricsSystem)
+        .specProvider(specProvider)
         .blockProvider(blockProvider)
         .stateProvider(stateAndBlockProvider)
         .anchor(anchor.getCheckpoint())
@@ -102,6 +104,7 @@ public class StoreBuilder {
     return Store.create(
         asyncRunner,
         metricsSystem,
+        specProvider,
         blockProvider,
         stateAndBlockProvider,
         anchor,
@@ -119,6 +122,7 @@ public class StoreBuilder {
   private void assertValid() {
     checkState(asyncRunner != null, "Async runner must be defined");
     checkState(metricsSystem != null, "Metrics system must be defined");
+    checkState(specProvider != null, "SpecProvider must be defined");
     checkState(blockProvider != null, "Block provider must be defined");
     checkState(stateAndBlockProvider != null, "StateAndBlockProvider must be defined");
     checkState(time != null, "Time must be defined");
@@ -138,6 +142,12 @@ public class StoreBuilder {
   public StoreBuilder metricsSystem(final MetricsSystem metricsSystem) {
     checkNotNull(metricsSystem);
     this.metricsSystem = metricsSystem;
+    return this;
+  }
+
+  public StoreBuilder specProvider(final SpecProvider specProvider) {
+    checkNotNull(specProvider);
+    this.specProvider = specProvider;
     return this;
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.core.StateTransition;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.datastructures.state.CommitteeAssignment;
 import tech.pegasys.teku.networks.SpecProviderFactory;
@@ -32,10 +31,8 @@ class CombinedChainDataClientTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(specProvider);
   private final RecentChainData recentChainData = mock(RecentChainData.class);
   private final StorageQueryChannel historicalChainData = mock(StorageQueryChannel.class);
-  private final StateTransition stateTransition = new StateTransition();
   private final CombinedChainDataClient client =
-      new CombinedChainDataClient(
-          recentChainData, historicalChainData, stateTransition, specProvider);
+      new CombinedChainDataClient(recentChainData, historicalChainData, specProvider);
 
   @Test
   public void getCommitteesFromStateWithCache_shouldReturnCommitteeAssignments() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
@@ -103,11 +103,11 @@ public class StorageBackedRecentChainDataTest {
         StoreBuilder.forkChoiceStoreBuilder(
             SYNC_RUNNER,
             new StubMetricsSystem(),
+            specProvider,
             BlockProvider.NOOP,
             StateAndBlockSummaryProvider.NOOP,
             AnchorPoint.fromGenesisState(INITIAL_STATE),
-            UInt64.ZERO,
-            specProvider);
+            UInt64.ZERO);
     storeRequestFuture.complete(Optional.of(genesisStoreBuilder));
     assertThat(client).isCompleted();
     assertStoreInitialized(client.get());
@@ -157,6 +157,7 @@ public class StorageBackedRecentChainDataTest {
 
     final StoreBuilder storeBuilder =
         StoreBuilder.create()
+            .specProvider(specProvider)
             .latestFinalized(anchorPoint)
             .justifiedCheckpoint(anchorPoint.getCheckpoint())
             .bestJustifiedCheckpoint(anchorPoint.getCheckpoint())
@@ -225,11 +226,11 @@ public class StorageBackedRecentChainDataTest {
         StoreBuilder.forkChoiceStoreBuilder(
                 SYNC_RUNNER,
                 new StubMetricsSystem(),
+                specProvider,
                 BlockProvider.NOOP,
                 StateAndBlockSummaryProvider.NOOP,
                 AnchorPoint.fromGenesisState(INITIAL_STATE),
-                UInt64.ZERO,
-                specProvider)
+                UInt64.ZERO)
             .storeConfig(storeConfig)
             .build();
     client.get().initializeFromGenesis(INITIAL_STATE, UInt64.ZERO);
@@ -274,11 +275,11 @@ public class StorageBackedRecentChainDataTest {
         StoreBuilder.forkChoiceStoreBuilder(
             SYNC_RUNNER,
             new StubMetricsSystem(),
+            specProvider,
             BlockProvider.NOOP,
             StateAndBlockSummaryProvider.NOOP,
             AnchorPoint.fromGenesisState(INITIAL_STATE),
-            UInt64.ZERO,
-            specProvider);
+            UInt64.ZERO);
     storeRequestFuture.complete(Optional.of(genesisStoreBuilder));
     assertThat(client).isCompleted();
     assertStoreInitialized(client.get());

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/state/FinalizedStateCacheTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/state/FinalizedStateCacheTest.java
@@ -32,16 +32,19 @@ import tech.pegasys.teku.core.ChainBuilder;
 import tech.pegasys.teku.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networks.SpecProviderFactory;
+import tech.pegasys.teku.spec.SpecProvider;
 import tech.pegasys.teku.storage.server.Database;
 
 class FinalizedStateCacheTest {
   private static final int MAXIMUM_CACHE_SIZE = 3;
   protected static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(3);
+  private final SpecProvider specProvider = SpecProviderFactory.createMinimal();
   private final ChainBuilder chainBuilder = ChainBuilder.create(VALIDATOR_KEYS);
   private final Database database = mock(Database.class);
   // We don't use soft references in unit tests to avoid intermittency
   private final FinalizedStateCache cache =
-      new FinalizedStateCache(database, MAXIMUM_CACHE_SIZE, false);
+      new FinalizedStateCache(specProvider, database, MAXIMUM_CACHE_SIZE, false);
 
   @BeforeEach
   public void setUp() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
@@ -135,6 +135,7 @@ public abstract class AbstractStoreTest {
     return StoreBuilder.create()
         .asyncRunner(SYNC_RUNNER)
         .metricsSystem(new StubMetricsSystem())
+        .specProvider(specProvider)
         .blockProvider(blockProviderFromChainBuilder())
         .stateProvider(StateAndBlockSummaryProvider.NOOP)
         .anchor(Optional.empty())

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -55,6 +55,7 @@ class StoreTest extends AbstractStoreTest {
                 Store.create(
                     SYNC_RUNNER,
                     new StubMetricsSystem(),
+                    specProvider,
                     blockProviderFromChainBuilder(),
                     StateAndBlockSummaryProvider.NOOP,
                     Optional.empty(),

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
@@ -38,6 +38,7 @@ public class StoreAssertions {
             "checkpointStateRequestRegenerateCounter",
             "checkpointStateRequestMissCounter",
             "metricsSystem",
+            "specProvider",
             "states",
             "stateProvider",
             "checkpointStates",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Copy `StateTransition` and `BlockValidator` into `spec` package.  Update production usages where possible:
* `BlockProcessor`
* `StreamingStateRegnerator`
* `CombinedChainDataClient`

Simplify some of the migrated logic as well:
* Cut booleans from `SimpleBlockValidator` that disable parts of the validation logic
* Always set up the standard validator in `StateTransition` - just use the existing boolean parameter to override validation (`validateStateRootAndSignatures`)

Update ref tests to run old and new `StateTransition` logic. 

## Fixed Issue(s)
Part of #3596

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
