### PR TITLE
Upgrade to discovery release published on Cloudsmith

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ allprojects {
     mavenLocal()
     jcenter()
     mavenCentral()
+    maven { url "https://artifacts.consensys.net/public/maven/maven/" }
     maven { url "https://hyperledger-org.bintray.com/besu-repo/" }
     maven { url "https://consensys.bintray.com/pegasys-repo/" }
   }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -151,7 +151,7 @@ dependencyManagement {
     dependency "org.testcontainers:testcontainers:1.15.0-rc2"
     dependency "org.testcontainers:junit-jupiter:1.15.0-rc2"
 
-    dependency 'tech.pegasys.discovery:discovery:0.4.2-dev-c8f2d6d9'
+    dependency 'tech.pegasys.discovery:discovery:0.4.3'
 
     dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.13'
 


### PR DESCRIPTION
## PR Description
Upgrade to latest discovery release so we're using the version from cloudsmith instead of bintray.

## Fixed Issue(s)
#3584 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
