### PR TITLE
Stop publishing builds to bintray

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,18 +283,6 @@ jobs:
           command: |
             ./gradlew --no-daemon --parallel distDocker
 
-  publish:
-    executor: medium_executor
-    steps:
-      - prepare
-      - attach_workspace:
-          at: ~/project
-      - run:
-          name: Publish
-          # binTray plugin doesn't publish pom artifacts if configure-on-demand is used
-          command: |
-            ./gradlew --no-daemon --parallel -no-configure-on-demand bintrayUpload
-
   publish-cloudsmith:
     executor: small_executor
     steps:
@@ -459,25 +447,6 @@ workflows:
             tags:
               <<: *filters-release-tags
           context: dockerhub-quorumengineering-ro
-      - publish:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release-.*/
-            tags:
-              <<: *filters-release-tags
-          requires:
-            - unitTests
-            - integrationTests
-            - acceptanceTests
-            - referenceTests
-            - docker
-            - extractAPISpec
-            - spotless
-          context:
-            - dockerhub-quorumengineering-ro
-            - quorum-gradle
       - publish-cloudsmith:
           filters:
             branches:

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ import java.text.SimpleDateFormat
 
 plugins {
   id 'com.diffplug.gradle.spotless' version '4.5.1'
-  id 'com.jfrog.bintray' version '1.8.5'
   id 'com.github.ben-manes.versions' version '0.28.0'
   id 'com.github.hierynomus.license' version '0.15.0'
   id 'io.spring.dependency-management' version '1.0.9.RELEASE'
@@ -50,29 +49,8 @@ gradle.startParameter.taskNames = expandedTaskList.flatten() as Iterable<String>
 
 def userHome = System.getProperty("user.home")
 
-apply plugin: 'com.jfrog.bintray'
-
-def bintrayUser = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
-def bintrayKey = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_KEY')
-
 def cloudsmithUser = project.hasProperty('cloudsmithUser') ? project.property('cloudsmithUser') : System.getenv('CLOUDSMITH_USER')
 def cloudsmithKey = project.hasProperty('cloudsmithApiKey') ? project.property('cloudsmithApiKey') : System.getenv('CLOUDSMITH_API_KEY')
-
-def bintrayPackage = bintray.pkg {
-  repo = 'pegasys-repo'
-  name = 'teku'
-  userOrg = 'consensys'
-  desc = 'Java Implementation of the Ethereum 2.0 Beacon Chain'
-  licenses = ['Apache-2.0']
-  websiteUrl = 'https://github.com/ConsenSys/teku'
-  issueTrackerUrl = 'https://github.com/ConsenSys/teku/issues'
-  vcsUrl = 'https://github.com/ConsenSys/teku.git'
-
-  version {
-    name = project.version
-    released = new Date()
-  }
-}
 
 allprojects {
   apply plugin: 'java-library'
@@ -471,7 +449,6 @@ subprojects {
   }
 
   if (sourceSetIsPopulated("main") || sourceSetIsPopulated("testFixtures")) {
-    apply plugin: 'com.jfrog.bintray'
     apply plugin: 'maven-publish'
 
     publishing {
@@ -517,18 +494,6 @@ subprojects {
           }
         }
       }
-    }
-
-    bintray {
-      user = bintrayUser
-      key = bintrayKey
-
-      publications = ['mavenJava']
-      override = isDevelopBuild
-
-      publish = true
-
-      pkg = bintrayPackage
     }
   }
 
@@ -748,25 +713,6 @@ task cloudsmithUpload {
     }
   }
 }
-
-bintray {
-  user = bintrayUser
-  key = bintrayKey
-
-  filesSpec {
-    from distTar.destinationDir.path
-    from distZip.destinationDir.path
-    into '.'
-  }
-
-  publish = true
-  override = isDevelopBuild
-
-  pkg = bintrayPackage
-}
-
-bintrayUpload.mustRunAfter(distTar)
-bintrayUpload.mustRunAfter(distZip)
 
 task dockerUpload {
   dependsOn([distDocker])


### PR DESCRIPTION
## PR Description
Stop publishing to bintray - artefacts are now only published to cloudsmith.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
