### PR TITLE
Upgrade to signers version from cloudsmith

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -153,7 +153,7 @@ dependencyManagement {
 
     dependency 'tech.pegasys.discovery:discovery:0.4.3'
 
-    dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.13'
+    dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.15'
 
     dependency 'org.jupnp:org.jupnp.support:2.5.2'
     dependency 'org.jupnp:org.jupnp:2.5.2'


### PR DESCRIPTION
## PR Description
Upgrade the signers dependency to the latest version which is available from cloudsmith instead of bintray.

## Fixed Issue(s)
#3584 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
