### PR TITLE
Fix wrong ConnectionClosedException from RcpHandler.sendRequest()

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ExceptionThrowingConsumer.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ExceptionThrowingConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ConsenSys AG.
+ * Copyright 2021 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,13 +11,9 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.networking.p2p.peer;
+package tech.pegasys.teku.infrastructure.async;
 
-public class PeerDisconnectedException extends RuntimeException {
+public interface ExceptionThrowingConsumer<V> {
 
-  public PeerDisconnectedException() {}
-
-  public PeerDisconnectedException(Throwable cause) {
-    super(cause);
-  }
+  void accept(V value) throws Throwable;
 }

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
@@ -485,6 +485,26 @@ public class SafeFutureTest {
   }
 
   @Test
+  public void catchAndRethrow_shouldCompleteWithHandlersException() throws RuntimeException {
+    final AtomicReference<Throwable> receivedError = new AtomicReference<>();
+    final SafeFuture<String> safeFuture = new SafeFuture<>();
+
+    final RuntimeException originalException = new RuntimeException("Nope");
+    final RuntimeException consumerException = new RuntimeException("Yup");
+
+    final SafeFuture<String> result =
+        safeFuture.catchAndRethrow(
+            err -> {
+              receivedError.set(err);
+              throw consumerException;
+            });
+
+    safeFuture.completeExceptionally(originalException);
+    assertThatSafeFuture(result).isCompletedExceptionallyWith(consumerException);
+    assertThat(receivedError).hasValue(originalException);
+  }
+
+  @Test
   public void propagateTo_propagatesSuccessfulResult() {
     final SafeFuture<String> target = new SafeFuture<>();
     final SafeFuture<String> source = new SafeFuture<>();

--- a/networking/p2p/build.gradle
+++ b/networking/p2p/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   implementation project(':ethereum:statetransition')
   implementation project(':infrastructure:async')
   implementation project(':infrastructure:collections')
+  implementation project(':infrastructure:exceptions')
   implementation project(':infrastructure:io')
   implementation project(':infrastructure:logging')
   implementation project(':infrastructure:metrics')


### PR DESCRIPTION
## PR Description

#### Reason

https://github.com/ConsenSys/teku/blob/cc98b7230126985e92f3ed4136e6012a74e762a5/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandler.java#L75-L76

The exception is thrown from `createStream()` method.

The `createStream()` is called when the `Connection` was just closed but when passing `SafeFuture.notInterrupted(closeInterruptor)` right before the `Connection.closeFuture` was not yet complete

#### Fix

Add the `RcpHandler.sendRequest()` async chain with analog of 
```java
try {
  ...
} catch (ConnectionClosedException e) {
  throw new PeerDisconnectedException(e);
}
```

## Fixed Issue(s)

Fix #3548 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
