### PR TITLE
Make error less noisy when SIGHUP listener can't be registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Additions and Improvements
 
 ### Bug Fixes
+- Reduced verbosity of warning message when SIGHUP can't be interecepted (e.g. on Windows)

--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/SystemSignalListener.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/SystemSignalListener.java
@@ -55,8 +55,8 @@ public class SystemSignalListener {
       handleMethod.invoke(null, hupSignal, handler);
     } catch (Throwable e) {
       LOG.warn(
-          "Unable to register listener for SIGHUP events. Dynamic config reloading will not be supported.",
-          e);
+          "Unable to register listener for SIGHUP events. Dynamic config reloading will not be supported.");
+      LOG.debug("Failed to register listener for SIGHUP events.", e);
     }
   }
 }


### PR DESCRIPTION
## PR Description
Make the error message less noisy when the SIGHUP listener can't be registered as this will always happen on Windows.

Still prints a `WARN` level message but without the stack trace. Full stack trace is printed at debug level in case it's required.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
