### PR TITLE
Rename spec getter methods

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/epoch_processing/EpochProcessingTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/epoch_processing/EpochProcessingTestExecutor.java
@@ -65,7 +65,7 @@ public class EpochProcessingTestExecutor implements TestExecutor {
     final BeaconState expectedPostState = loadStateFromSsz(testDefinition, "post.ssz");
 
     final EpochProcessor epochProcessor =
-        testDefinition.getSpecProvider().getGenesisSpec().getEpochProcessor();
+        testDefinition.getSpec().getGenesisSpec().getEpochProcessor();
     final EpochProcessingExecutor processor = new DefaultEpochProcessingExecutor(epochProcessor);
     final BeaconState result = preState.updated(state -> executeOperation(processor, state));
     assertThat(result).isEqualTo(expectedPostState);

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/genesis/GenesisValidityTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/genesis/GenesisValidityTestExecutor.java
@@ -30,11 +30,11 @@ public class GenesisValidityTestExecutor implements TestExecutor {
   @Override
   public void runTest(final TestDefinition testDefinition) throws Exception {
     final BeaconState state = loadStateFromSsz(testDefinition, "genesis.ssz");
-    final Spec spec = testDefinition.getSpecProvider();
+    final Spec spec = testDefinition.getSpec();
     final BeaconStateUtil beaconStateUtil = spec.atEpoch(UInt64.ZERO).getBeaconStateUtil();
     final boolean expectedValidity = loadYaml(testDefinition, "is_valid.yaml", Boolean.class);
     final int activeValidatorCount =
-        testDefinition.getSpecProvider().countActiveValidators(state, SpecConstants.GENESIS_EPOCH);
+        testDefinition.getSpec().countActiveValidators(state, SpecConstants.GENESIS_EPOCH);
     final boolean result =
         beaconStateUtil.isValidGenesisState(state.getGenesis_time(), activeValidatorCount);
     assertThat(result).isEqualTo(expectedValidity);

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/operations/OperationsTestExecutor.java
@@ -82,7 +82,7 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
     final Path dataPath = testDefinition.getTestDirectory().resolve(dataFileName);
 
     final DefaultOperationProcessor standardProcessor =
-        new DefaultOperationProcessor(testDefinition.getSpecProvider());
+        new DefaultOperationProcessor(testDefinition.getSpec());
     runProcessor(standardProcessor, testDefinition, preState, dataPath);
   }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/rewards/RewardsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/rewards/RewardsTestExecutor.java
@@ -45,7 +45,7 @@ public class RewardsTestExecutor implements TestExecutor {
     final ValidatorStatuses validatorStatuses = ValidatorStatuses.create(preState);
     final RewardsAndPenaltiesCalculator calculator =
         testDefinition
-            .getSpecProvider()
+            .getSpec()
             .getGenesisSpec()
             .getEpochProcessor()
             .createRewardsAndPenaltiesCalculator(preState, validatorStatuses);

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityBlocksTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityBlocksTestExecutor.java
@@ -69,7 +69,7 @@ public class SanityBlocksTestExecutor implements TestExecutor {
       final BeaconState preState,
       final List<SignedBeaconBlock> blocks,
       final Optional<BeaconState> expectedState) {
-    final Spec spec = testDefinition.getSpecProvider();
+    final Spec spec = testDefinition.getSpec();
     expectedState.ifPresentOrElse(
         (state) ->
             assertThat(processor.processBlocks(spec, metaData, preState, blocks)).isEqualTo(state),

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanitySlotsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanitySlotsTestExecutor.java
@@ -35,7 +35,7 @@ public class SanitySlotsTestExecutor implements TestExecutor {
 
     final UInt64 endSlot = preState.getSlot().plus(numberOfSlots);
 
-    final BeaconState result = processSlots(testDefinition.getSpecProvider(), preState, endSlot);
+    final BeaconState result = processSlots(testDefinition.getSpec(), preState, endSlot);
     assertThat(result).isEqualTo(expectedState);
   }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/shuffling/ShufflingTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/shuffling/ShufflingTestExecutor.java
@@ -35,7 +35,7 @@ public class ShufflingTestExecutor implements TestExecutor {
     final ShufflingData shufflingData =
         loadYaml(testDefinition, "mapping.yaml", ShufflingData.class);
     final CommitteeUtil committeeUtil =
-        testDefinition.getSpecProvider().atSlot(UInt64.ZERO).getCommitteeUtil();
+        testDefinition.getSpec().atSlot(UInt64.ZERO).getCommitteeUtil();
     final Bytes32 seed = Bytes32.fromHexString(shufflingData.getSeed());
     IntStream.range(0, shufflingData.getCount())
         .forEach(

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -39,7 +39,7 @@ public class TestDefinition {
     return specName;
   }
 
-  public Spec getSpecProvider() {
+  public Spec getSpec() {
     if (spec == null) {
       spec = SpecFactory.create(specName);
     }

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -83,7 +83,7 @@ public class Eth2NetworkConfiguration {
     return new Builder();
   }
 
-  public Spec getSpecProvider() {
+  public Spec getSpec() {
     return spec;
   }
 

--- a/ethereum/networks/src/test/java/tech/pegasys/teku/networks/Eth2NetworkConfigurationTest.java
+++ b/ethereum/networks/src/test/java/tech/pegasys/teku/networks/Eth2NetworkConfigurationTest.java
@@ -48,7 +48,7 @@ public class Eth2NetworkConfigurationTest {
     final Eth2NetworkConfiguration config =
         Eth2NetworkConfiguration.builder(url.toString()).build();
     assertThat(config.getConstants()).isEqualTo(url.toString());
-    assertThat(config.getSpecProvider().getGenesisSpecConstants().getConfigName())
+    assertThat(config.getSpec().getGenesisSpecConstants().getConfigName())
         .isEqualTo("Custom Constants");
   }
 
@@ -59,7 +59,7 @@ public class Eth2NetworkConfigurationTest {
     final Eth2NetworkConfiguration config =
         Eth2NetworkConfiguration.builder().constants(url.toString()).build();
     assertThat(config.getConstants()).isEqualTo(url.toString());
-    assertThat(config.getSpecProvider().getGenesisSpecConstants().getConfigName())
+    assertThat(config.getSpec().getGenesisSpecConstants().getConfigName())
         .isEqualTo("Custom Constants");
   }
 

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
@@ -49,7 +49,7 @@ public class WeakSubjectivityCalculator {
 
   public static WeakSubjectivityCalculator create(final WeakSubjectivityConfig config) {
     return new WeakSubjectivityCalculator(
-        config.getSpecProvider(), config.getSafetyDecay(), StateCalculator.DEFAULT);
+        config.getSpec(), config.getSafetyDecay(), StateCalculator.DEFAULT);
   }
 
   /**

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
@@ -62,7 +62,7 @@ public class WeakSubjectivityValidator {
       WeakSubjectivityCalculator calculator,
       WeakSubjectivityViolationPolicy violationPolicy,
       final Optional<BeaconStateUtil> maybeBeaconStateUtil) {
-    this.spec = config.getSpecProvider();
+    this.spec = config.getSpec();
     this.calculator = calculator;
     this.violationPolicy = violationPolicy;
     this.config = config;

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/config/WeakSubjectivityConfig.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/config/WeakSubjectivityConfig.java
@@ -66,7 +66,7 @@ public class WeakSubjectivityConfig {
         .suppressWSPeriodChecksUntilEpoch(suppressWSPeriodChecksUntilEpoch);
   }
 
-  public Spec getSpecProvider() {
+  public Spec getSpec() {
     return spec;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -129,7 +129,7 @@ public class Eth2P2PNetworkBuilder {
     final DiscoveryNetwork<?> network = buildNetwork(gossipEncoding);
 
     return new ActiveEth2P2PNetwork(
-        config.getSpecProvider(),
+        config.getSpec(),
         asyncRunner,
         metricsSystem,
         network,
@@ -193,7 +193,7 @@ public class Eth2P2PNetworkBuilder {
             Collections::shuffle),
         discoConfig,
         networkConfig,
-        config.getSpecProvider());
+        config.getSpec());
   }
 
   private void validate() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -61,7 +61,7 @@ public class P2PConfig {
     return new Builder();
   }
 
-  public Spec getSpecProvider() {
+  public Spec getSpec() {
     return spec;
   }
 

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -235,7 +235,7 @@ public class Eth2P2PNetworkFactory {
                     Collections::shuffle),
                 config.getDiscoveryConfig(),
                 config.getNetworkConfig(),
-                config.getSpecProvider());
+                config.getSpec());
 
         return new ActiveEth2P2PNetwork(
             spec,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainConfiguration.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainConfiguration.java
@@ -63,7 +63,7 @@ public class BeaconChainConfiguration {
     this.spec = spec;
   }
 
-  public Spec getSpecProvider() {
+  public Spec getSpec() {
     return spec;
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -177,7 +177,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   public BeaconChainController(
       final ServiceConfig serviceConfig, final BeaconChainConfiguration beaconConfig) {
     this.beaconConfig = beaconConfig;
-    this.spec = beaconConfig.getSpecProvider();
+    this.spec = beaconConfig.getSpec();
     this.beaconDataDirectory = serviceConfig.getDataDirLayout().getBeaconDataDirectory();
     this.asyncRunnerFactory = serviceConfig.getAsyncRunnerFactory();
     this.beaconAsyncRunner = serviceConfig.createAsyncRunner("beaconchain");

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageConfiguration.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageConfiguration.java
@@ -60,7 +60,7 @@ public class StorageConfiguration {
     return dataStorageCreateDbVersion;
   }
 
-  public Spec getSpecProvider() {
+  public Spec getSpec() {
     return spec;
   }
 

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -57,11 +57,11 @@ public class StorageService extends Service {
                   config.getDataStorageCreateDbVersion(),
                   config.getDataStorageFrequency(),
                   config.getEth1DepositContract(),
-                  config.getSpecProvider());
+                  config.getSpec());
           database = dbFactory.createDatabase();
 
           chainStorage =
-              ChainStorage.create(serviceConfig.getEventBus(), database, config.getSpecProvider());
+              ChainStorage.create(serviceConfig.getEventBus(), database, config.getSpec());
           final DepositStorage depositStorage =
               DepositStorage.create(
                   serviceConfig.getEventChannels().getPublisher(Eth1EventsChannel.class), database);

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/TransitionCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/TransitionCommand.java
@@ -119,7 +119,7 @@ public class TransitionCommand implements Runnable {
 
   private int processStateTransition(
       final InAndOutParams params, final StateTransitionFunction transition) {
-    final Spec spec = params.eth2NetworkOptions.getNetworkConfiguration().getSpecProvider();
+    final Spec spec = params.eth2NetworkOptions.getNetworkConfiguration().getSpec();
     Constants.setConstants(params.eth2NetworkOptions.getNetworkConfiguration().getConstants());
     try (final InputStream in = selectInputStream(params);
         final OutputStream out = selectOutputStream(params)) {

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/admin/WeakSubjectivityCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/admin/WeakSubjectivityCommand.java
@@ -106,7 +106,7 @@ public class WeakSubjectivityCommand implements Runnable {
       final BeaconNodeDataOptions dataOptions,
       final DataStorageOptions dataStorageOptions,
       final Eth2NetworkOptions eth2NetworkOptions) {
-    final Spec spec = eth2NetworkOptions.getNetworkConfiguration().getSpecProvider();
+    final Spec spec = eth2NetworkOptions.getNetworkConfiguration().getSpec();
     final VersionedDatabaseFactory databaseFactory =
         new VersionedDatabaseFactory(
             new NoOpMetricsSystem(),

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -227,7 +227,7 @@ public class DebugDbCommand implements Runnable {
       final BeaconNodeDataOptions dataOptions,
       final DataStorageOptions dataStorageOptions,
       final Eth2NetworkOptions eth2NetworkOptions) {
-    final Spec spec = eth2NetworkOptions.getNetworkConfiguration().getSpecProvider();
+    final Spec spec = eth2NetworkOptions.getNetworkConfiguration().getSpec();
     final VersionedDatabaseFactory databaseFactory =
         new VersionedDatabaseFactory(
             new NoOpMetricsSystem(),

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -178,7 +178,7 @@ public class TekuConfiguration {
       // Create spec, and pass spec to other builders that require it
       final Eth2NetworkConfiguration eth2NetworkConfiguration =
           eth2NetworkConfigurationBuilder.build();
-      final Spec spec = eth2NetworkConfiguration.getSpecProvider();
+      final Spec spec = eth2NetworkConfiguration.getSpec();
 
       interopConfigBuilder.specProvider(spec);
       // Update storage config

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientConfiguration.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientConfiguration.java
@@ -37,7 +37,7 @@ public class ValidatorClientConfiguration {
     return interopConfig;
   }
 
-  public Spec getSpecProvider() {
+  public Spec getSpec() {
     return spec;
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -79,15 +79,11 @@ public class ValidatorClientService extends Service {
             .map(
                 endpoint ->
                     RemoteBeaconNodeApi.create(
-                        services,
-                        asyncRunner,
-                        endpoint,
-                        config.getSpecProvider(),
-                        useDependentRoots))
+                        services, asyncRunner, endpoint, config.getSpec(), useDependentRoots))
             .orElseGet(
                 () ->
                     InProcessBeaconNodeApi.create(
-                        services, asyncRunner, useDependentRoots, config.getSpecProvider()));
+                        services, asyncRunner, useDependentRoots, config.getSpec()));
     final ValidatorApiChannel validatorApiChannel = beaconNodeApi.getValidatorApi();
     final GenesisDataProvider genesisDataProvider =
         new GenesisDataProvider(asyncRunner, validatorApiChannel);
@@ -98,7 +94,7 @@ public class ValidatorClientService extends Service {
 
     ValidatorClientService validatorClientService =
         new ValidatorClientService(
-            eventChannels, validatorLoader, beaconNodeApi, forkProvider, config.getSpecProvider());
+            eventChannels, validatorLoader, beaconNodeApi, forkProvider, config.getSpec());
 
     asyncRunner
         .runAsync(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Follow-up to #3676: rename getters from `getSpecProvider()` to `getSpec()` to match recently updated class names.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
