### PR TITLE
Support building from shallow clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
 - Reduced verbosity of warning message when SIGHUP can't be interecepted (e.g. on Windows)
+- Fixed build failure when checked out as a shallow clone. Shallow clones are still not recommended as the version number cannot be determined correctly.

--- a/build.gradle
+++ b/build.gradle
@@ -657,6 +657,9 @@ def calculateVersion() {
     return 'UNKNOWN'
   }
   String version = grgit.describe(tags: true)
+  if (version == null) {
+    return "UNKNOWN+g${grgit.head().abbreviatedId}"
+  }
   def versionPattern = ~/^(?<lastVersion>.*)-(?<devVersion>[0-9]+-g[a-z0-9]+)$/
   def matcher = version =~ versionPattern
   if (matcher.find()) {


### PR DESCRIPTION
## PR Description
Support building Teku from a shallow git clone where `git describe` doesn't find any tags. The version will be reported as "UNKNOWN+g<commit hash>".

e.g.
```
git init
git fetch --depth 1 https://github.com/ajsutton/teku.git 3f3e260079046c38c2082f0c5ec265f99aa356a2
git checkout --detach "FETCH_HEAD"
./gradlew printVersion
```

Gives:
```
Specific version: UNKNOWN+g3f3e260  Publish version: develop
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
