### PR TITLE
[Issue 3658] Finish migrating BeaconStateSchema

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/VoteTrackerSerialize.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/VoteTrackerSerialize.java
@@ -21,13 +21,13 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Warmup;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.storage.server.rocksdb.serialization.VoteTrackerSerializer;
+import tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer;
 
 public class VoteTrackerSerialize {
 
   private static VoteTracker votes = new DataStructureUtil().randomVoteTracker();
   private static Bytes votesSerialized = votes.sszSerialize();
-  private static VoteTrackerSerializer serializer = new VoteTrackerSerializer();
+  private static RocksDbSerializer<VoteTracker> serializer = RocksDbSerializer.VOTES_SERIALIZER;
 
   @Benchmark
   @Warmup(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/ForkManifest.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/ForkManifest.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.NavigableMap;
+import java.util.Objects;
 import java.util.TreeMap;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.constants.SpecConstants;
@@ -81,5 +82,18 @@ public class ForkManifest {
 
   public List<Fork> getForkSchedule() {
     return new ArrayList<>(forkSchedule.values());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final ForkManifest that = (ForkManifest) o;
+    return Objects.equals(forkSchedule, that.forkSchedule);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(forkSchedule);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -17,6 +17,7 @@ import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.NavigableMap;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
@@ -40,6 +41,7 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
@@ -158,6 +160,15 @@ public class Spec {
 
   public UInt64 getSecondsPerEth1Block(final UInt64 slot) {
     return atSlot(slot).getConstants().getSecondsPerEth1Block();
+  }
+
+  // Serialization
+  public BeaconState deserializeBeaconState(final Bytes serializedState) {
+    final UInt64 slot = BeaconStateSchema.extractSlot(serializedState);
+    return atSlot(slot)
+        .getSchemaDefinitions()
+        .getBeaconStateSchema()
+        .sszDeserialize(serializedState);
   }
 
   // BeaconState

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.NavigableMap;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -460,5 +461,18 @@ public class Spec {
   private SpecVersion getLatestSpec() {
     // When fork manifest is non-empty, we should pull the newest spec here
     return genesisSpec;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final Spec spec = (Spec) o;
+    return Objects.equals(forkManifest, spec.forkManifest);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(forkManifest);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconState.java
@@ -33,17 +33,8 @@ import tech.pegasys.teku.ssz.backing.collections.SszBitvector;
 import tech.pegasys.teku.ssz.backing.view.AbstractSszPrimitive;
 import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszBytes32;
 import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszUInt64;
-import tech.pegasys.teku.util.config.SpecDependent;
 
 public interface BeaconState extends SszContainer {
-
-  @Deprecated
-  SpecDependent<BeaconStateSchema> SSZ_SCHEMA = SpecDependent.of(BeaconStateSchema::create);
-
-  @Deprecated
-  static BeaconStateSchema getSszSchema() {
-    return SSZ_SCHEMA.get();
-  }
 
   // Versioning
   default UInt64 getGenesis_time() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateInvariants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateInvariants.java
@@ -23,13 +23,15 @@ import tech.pegasys.teku.ssz.backing.schema.SszSchema;
 import tech.pegasys.teku.ssz.backing.view.SszPrimitives;
 import tech.pegasys.teku.ssz.sos.SszField;
 
-class BeaconStateSchemaInvariants {
+class BeaconStateInvariants {
+  // Schemas
   static final SszSchema<SszPrimitives.SszUInt64> GENESIS_TIME_SCHEMA =
       SszPrimitiveSchemas.UINT64_SCHEMA;
   static final SszSchema<SszPrimitives.SszBytes32> GENESIS_VALIDATORS_ROOT_SCHEMA =
       SszPrimitiveSchemas.BYTES32_SCHEMA;
   static final SszSchema<SszPrimitives.SszUInt64> SLOT_SCHEMA = SszPrimitiveSchemas.UINT64_SCHEMA;
 
+  // Fields
   static SszField GENESIS_TIME_FIELD =
       new SszField(0, BeaconStateFields.GENESIS_TIME.name(), GENESIS_TIME_SCHEMA);
   static SszField GENESIS_VALIDATORS_ROOT_FIELD =
@@ -37,6 +39,7 @@ class BeaconStateSchemaInvariants {
           1, BeaconStateFields.GENESIS_VALIDATORS_ROOT.name(), GENESIS_VALIDATORS_ROOT_SCHEMA);
   static SszField SLOT_FIELD = new SszField(2, BeaconStateFields.SLOT.name(), SLOT_SCHEMA);
 
+  // Return list of invariant fields
   public static List<SszField> getInvariantFields() {
     return List.of(GENESIS_TIME_FIELD, GENESIS_VALIDATORS_ROOT_FIELD, SLOT_FIELD);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchema.java
@@ -14,9 +14,9 @@
 package tech.pegasys.teku.spec.datastructures.state.beaconstate;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.GENESIS_TIME_FIELD;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.GENESIS_VALIDATORS_ROOT_FIELD;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.SLOT_FIELD;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateInvariants.GENESIS_TIME_FIELD;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateInvariants.GENESIS_VALIDATORS_ROOT_FIELD;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateInvariants.SLOT_FIELD;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
@@ -79,7 +79,7 @@ public class BeaconStateSchema extends AbstractSszContainerSchema<BeaconState> {
           () ->
               SszListSchema.create(
                   Eth1Data.SSZ_SCHEMA,
-                  Constants.EPOCHS_PER_ETH1_VOTING_PERIOD * Constants.SLOTS_PER_EPOCH));
+                  (long) Constants.EPOCHS_PER_ETH1_VOTING_PERIOD * Constants.SLOTS_PER_EPOCH));
   private static final SszField ETH1_DEPOSIT_INDEX_FIELD =
       new SszField(
           10, BeaconStateFields.ETH1_DEPOSIT_INDEX.name(), SszPrimitiveSchemas.UINT64_SCHEMA);
@@ -120,7 +120,7 @@ public class BeaconStateSchema extends AbstractSszContainerSchema<BeaconState> {
           () ->
               SszListSchema.create(
                   PendingAttestation.SSZ_SCHEMA,
-                  Constants.MAX_ATTESTATIONS * Constants.SLOTS_PER_EPOCH));
+                  (long) Constants.MAX_ATTESTATIONS * Constants.SLOTS_PER_EPOCH));
   private static final SszField CURRENT_EPOCH_ATTESTATIONS_FIELD =
       new SszField(
           16,
@@ -128,7 +128,7 @@ public class BeaconStateSchema extends AbstractSszContainerSchema<BeaconState> {
           () ->
               SszListSchema.create(
                   PendingAttestation.SSZ_SCHEMA,
-                  Constants.MAX_ATTESTATIONS * Constants.SLOTS_PER_EPOCH));
+                  (long) Constants.MAX_ATTESTATIONS * Constants.SLOTS_PER_EPOCH));
   private static final SszField JUSTIFICATION_BITS_FIELD =
       new SszField(
           17,
@@ -164,7 +164,7 @@ public class BeaconStateSchema extends AbstractSszContainerSchema<BeaconState> {
           i);
     }
 
-    final List<SszField> invariantFields = BeaconStateSchemaInvariants.getInvariantFields();
+    final List<SszField> invariantFields = BeaconStateInvariants.getInvariantFields();
     checkArgument(
         fields.size() >= invariantFields.size(),
         "Must provide at least %s fields",

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchema.java
@@ -42,107 +42,8 @@ import tech.pegasys.teku.ssz.backing.schema.SszVectorSchema;
 import tech.pegasys.teku.ssz.backing.schema.collections.SszBitvectorSchema;
 import tech.pegasys.teku.ssz.backing.tree.TreeNode;
 import tech.pegasys.teku.ssz.sos.SszField;
-import tech.pegasys.teku.util.config.Constants;
 
 public class BeaconStateSchema extends AbstractSszContainerSchema<BeaconState> {
-
-  private static final SszField FORK_FIELD =
-      new SszField(3, BeaconStateFields.FORK.name(), Fork.SSZ_SCHEMA);
-  private static final SszField LATEST_BLOCK_HEADER_FIELD =
-      new SszField(4, BeaconStateFields.LATEST_BLOCK_HEADER.name(), BeaconBlockHeader.SSZ_SCHEMA);
-  private static final SszField BLOCK_ROOTS_FIELD =
-      new SszField(
-          5,
-          BeaconStateFields.BLOCK_ROOTS.name(),
-          () ->
-              SszVectorSchema.create(
-                  SszPrimitiveSchemas.BYTES32_SCHEMA, Constants.SLOTS_PER_HISTORICAL_ROOT));
-  private static final SszField STATE_ROOTS_FIELD =
-      new SszField(
-          6,
-          BeaconStateFields.STATE_ROOTS.name(),
-          () ->
-              SszVectorSchema.create(
-                  SszPrimitiveSchemas.BYTES32_SCHEMA, Constants.SLOTS_PER_HISTORICAL_ROOT));
-  private static final SszField HISTORICAL_ROOTS_FIELD =
-      new SszField(
-          7,
-          BeaconStateFields.HISTORICAL_ROOTS.name(),
-          () ->
-              SszListSchema.create(
-                  SszPrimitiveSchemas.BYTES32_SCHEMA, Constants.HISTORICAL_ROOTS_LIMIT));
-  private static final SszField ETH1_DATA_FIELD =
-      new SszField(8, BeaconStateFields.ETH1_DATA.name(), Eth1Data.SSZ_SCHEMA);
-  private static final SszField ETH1_DATA_VOTES_FIELD =
-      new SszField(
-          9,
-          BeaconStateFields.ETH1_DATA_VOTES.name(),
-          () ->
-              SszListSchema.create(
-                  Eth1Data.SSZ_SCHEMA,
-                  (long) Constants.EPOCHS_PER_ETH1_VOTING_PERIOD * Constants.SLOTS_PER_EPOCH));
-  private static final SszField ETH1_DEPOSIT_INDEX_FIELD =
-      new SszField(
-          10, BeaconStateFields.ETH1_DEPOSIT_INDEX.name(), SszPrimitiveSchemas.UINT64_SCHEMA);
-  private static final SszField VALIDATORS_FIELD =
-      new SszField(
-          11,
-          BeaconStateFields.VALIDATORS.name(),
-          () ->
-              SszListSchema.create(
-                  Validator.SSZ_SCHEMA,
-                  Constants.VALIDATOR_REGISTRY_LIMIT,
-                  SszSchemaHints.sszSuperNode(8)));
-  private static final SszField BALANCES_FIELD =
-      new SszField(
-          12,
-          BeaconStateFields.BALANCES.name(),
-          () ->
-              SszListSchema.create(
-                  SszPrimitiveSchemas.UINT64_SCHEMA, Constants.VALIDATOR_REGISTRY_LIMIT));
-  private static final SszField RANDAO_MIXES_FIELD =
-      new SszField(
-          13,
-          BeaconStateFields.RANDAO_MIXES.name(),
-          () ->
-              SszVectorSchema.create(
-                  SszPrimitiveSchemas.BYTES32_SCHEMA, Constants.EPOCHS_PER_HISTORICAL_VECTOR));
-  private static final SszField SLASHINGS_FIELD =
-      new SszField(
-          14,
-          BeaconStateFields.SLASHINGS.name(),
-          () ->
-              SszVectorSchema.create(
-                  SszPrimitiveSchemas.UINT64_SCHEMA, Constants.EPOCHS_PER_SLASHINGS_VECTOR));
-  private static final SszField PREVIOUS_EPOCH_ATTESTATIONS_FIELD =
-      new SszField(
-          15,
-          BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS.name(),
-          () ->
-              SszListSchema.create(
-                  PendingAttestation.SSZ_SCHEMA,
-                  (long) Constants.MAX_ATTESTATIONS * Constants.SLOTS_PER_EPOCH));
-  private static final SszField CURRENT_EPOCH_ATTESTATIONS_FIELD =
-      new SszField(
-          16,
-          BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS.name(),
-          () ->
-              SszListSchema.create(
-                  PendingAttestation.SSZ_SCHEMA,
-                  (long) Constants.MAX_ATTESTATIONS * Constants.SLOTS_PER_EPOCH));
-  private static final SszField JUSTIFICATION_BITS_FIELD =
-      new SszField(
-          17,
-          BeaconStateFields.JUSTIFICATION_BITS.name(),
-          () -> SszBitvectorSchema.create(Constants.JUSTIFICATION_BITS_LENGTH));
-  private static final SszField PREVIOUS_JUSTIFIED_CHECKPOINT_FIELD =
-      new SszField(
-          18, BeaconStateFields.PREVIOUS_JUSTIFIED_CHECKPOINT.name(), Checkpoint.SSZ_SCHEMA);
-  private static final SszField CURRENT_JUSTIFIED_CHECKPOINT_FIELD =
-      new SszField(
-          19, BeaconStateFields.CURRENT_JUSTIFIED_CHECKPOINT.name(), Checkpoint.SSZ_SCHEMA);
-  private static final SszField FINALIZED_CHECKPOINT_FIELD =
-      new SszField(20, BeaconStateFields.FINALIZED_CHECKPOINT.name(), Checkpoint.SSZ_SCHEMA);
 
   @VisibleForTesting
   BeaconStateSchema(final List<SszField> fields) {
@@ -194,34 +95,6 @@ public class BeaconStateSchema extends AbstractSszContainerSchema<BeaconState> {
 
   public static BeaconStateSchema create(final SpecConstants specConstants) {
     return new BeaconStateSchema(getFields(specConstants));
-  }
-
-  @Deprecated
-  public static BeaconStateSchema create() {
-    final List<SszField> fields =
-        List.of(
-            GENESIS_TIME_FIELD,
-            GENESIS_VALIDATORS_ROOT_FIELD,
-            SLOT_FIELD,
-            FORK_FIELD,
-            LATEST_BLOCK_HEADER_FIELD,
-            BLOCK_ROOTS_FIELD,
-            STATE_ROOTS_FIELD,
-            HISTORICAL_ROOTS_FIELD,
-            ETH1_DATA_FIELD,
-            ETH1_DATA_VOTES_FIELD,
-            ETH1_DEPOSIT_INDEX_FIELD,
-            VALIDATORS_FIELD,
-            BALANCES_FIELD,
-            RANDAO_MIXES_FIELD,
-            SLASHINGS_FIELD,
-            PREVIOUS_EPOCH_ATTESTATIONS_FIELD,
-            CURRENT_EPOCH_ATTESTATIONS_FIELD,
-            JUSTIFICATION_BITS_FIELD,
-            PREVIOUS_JUSTIFIED_CHECKPOINT_FIELD,
-            CURRENT_JUSTIFIED_CHECKPOINT_FIELD,
-            FINALIZED_CHECKPOINT_FIELD);
-    return new BeaconStateSchema(fields);
   }
 
   private static List<SszField> getFields(final SpecConstants specConstants) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchema.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStat
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.constants.SpecConstants;
@@ -179,6 +180,16 @@ public class BeaconStateSchema extends AbstractSszContainerSchema<BeaconState> {
           invariantIndex,
           actualField.getName());
     }
+  }
+
+  /**
+   * Extract the slot value from any serialized state
+   *
+   * @param bytes A serialized state
+   * @return The slot of the state
+   */
+  public static UInt64 extractSlot(final Bytes bytes) {
+    return BeaconStateInvariants.extractSlot(bytes);
   }
 
   public static BeaconStateSchema create(final SpecConstants specConstants) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchemaInvariants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchemaInvariants.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.state.beaconstate;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.ssz.backing.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.ssz.backing.schema.SszSchema;
+import tech.pegasys.teku.ssz.backing.view.SszPrimitives;
+import tech.pegasys.teku.ssz.sos.SszField;
+
+class BeaconStateSchemaInvariants {
+  static final SszSchema<SszPrimitives.SszUInt64> GENESIS_TIME_SCHEMA =
+      SszPrimitiveSchemas.UINT64_SCHEMA;
+  static final SszSchema<SszPrimitives.SszBytes32> GENESIS_VALIDATORS_ROOT_SCHEMA =
+      SszPrimitiveSchemas.BYTES32_SCHEMA;
+  static final SszSchema<SszPrimitives.SszUInt64> SLOT_SCHEMA = SszPrimitiveSchemas.UINT64_SCHEMA;
+
+  static SszField GENESIS_TIME_FIELD =
+      new SszField(0, BeaconStateFields.GENESIS_TIME.name(), GENESIS_TIME_SCHEMA);
+  static SszField GENESIS_VALIDATORS_ROOT_FIELD =
+      new SszField(
+          1, BeaconStateFields.GENESIS_VALIDATORS_ROOT.name(), GENESIS_VALIDATORS_ROOT_SCHEMA);
+  static SszField SLOT_FIELD = new SszField(2, BeaconStateFields.SLOT.name(), SLOT_SCHEMA);
+
+  public static List<SszField> getInvariantFields() {
+    return List.of(GENESIS_TIME_FIELD, GENESIS_VALIDATORS_ROOT_FIELD, SLOT_FIELD);
+  }
+
+  public static UInt64 extractSlot(final Bytes bytes) {
+    // Check assumptions
+    checkState(GENESIS_TIME_SCHEMA.isFixedSize(), "Expected genesisTime field to be a fixed size");
+    checkState(
+        GENESIS_VALIDATORS_ROOT_SCHEMA.isFixedSize(),
+        "Expected genesisValidatorsRoot field to be a fixed size");
+    checkState(SLOT_SCHEMA.isFixedSize(), "Expected slot field to be a fixed size");
+
+    final int offset =
+        GENESIS_TIME_SCHEMA.getFixedPartSize() + GENESIS_VALIDATORS_ROOT_SCHEMA.getFixedPartSize();
+    final int size = SLOT_SCHEMA.getFixedPartSize();
+
+    // Extract slot data
+    final Bytes slotData = bytes.slice(offset, size);
+    return SLOT_SCHEMA.sszDeserialize(slotData).get();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/ChainDataLoader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/ChainDataLoader.java
@@ -16,24 +16,14 @@ package tech.pegasys.teku.spec.datastructures.util;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import tech.pegasys.teku.infrastructure.io.resource.ResourceLoader;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class ChainDataLoader {
-  public static BeaconState loadState(final String source) throws IOException {
-    return BeaconState.getSszSchema()
-        .sszDeserialize(
-            ResourceLoader.urlOrFile()
-                .loadBytes(source)
-                .orElseThrow(() -> new FileNotFoundException("Could not find " + source)));
-  }
-
-  public static SignedBeaconBlock loadBlock(final String source) throws IOException {
-    return SignedBeaconBlock.SSZ_SCHEMA
-        .get()
-        .sszDeserialize(
-            ResourceLoader.urlOrFile()
-                .loadBytes(source)
-                .orElseThrow(() -> new FileNotFoundException("Could not find " + source)));
+  public static BeaconState loadState(final Spec spec, final String source) throws IOException {
+    return spec.deserializeBeaconState(
+        ResourceLoader.urlOrFile()
+            .loadBytes(source)
+            .orElseThrow(() -> new FileNotFoundException("Could not find " + source)));
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateInvariantsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateInvariantsTest.java
@@ -14,12 +14,12 @@
 package tech.pegasys.teku.spec.datastructures.state.beaconstate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.GENESIS_TIME_FIELD;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.GENESIS_TIME_SCHEMA;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.GENESIS_VALIDATORS_ROOT_FIELD;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.GENESIS_VALIDATORS_ROOT_SCHEMA;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.SLOT_FIELD;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.SLOT_SCHEMA;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateInvariants.GENESIS_TIME_FIELD;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateInvariants.GENESIS_TIME_SCHEMA;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateInvariants.GENESIS_VALIDATORS_ROOT_FIELD;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateInvariants.GENESIS_VALIDATORS_ROOT_SCHEMA;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateInvariants.SLOT_FIELD;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateInvariants.SLOT_SCHEMA;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
@@ -28,7 +28,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class BeaconStateSchemaInvariantsTest {
+public class BeaconStateInvariantsTest {
   private final Spec spec = SpecFactory.createMinimal();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
@@ -39,7 +39,7 @@ public class BeaconStateSchemaInvariantsTest {
       final Bytes stateBytes = state.sszSerialize();
 
       final UInt64 expectedSlot = state.getSlot();
-      final UInt64 result = BeaconStateSchemaInvariants.extractSlot(stateBytes);
+      final UInt64 result = BeaconStateInvariants.extractSlot(stateBytes);
       assertThat(result).isEqualTo(expectedSlot);
     }
   }
@@ -49,7 +49,7 @@ public class BeaconStateSchemaInvariantsTest {
     final BeaconState state = dataStructureUtil.stateBuilder().slot(UInt64.ZERO).build();
     final Bytes stateBytes = state.sszSerialize();
 
-    final UInt64 result = BeaconStateSchemaInvariants.extractSlot(stateBytes);
+    final UInt64 result = BeaconStateInvariants.extractSlot(stateBytes);
     assertThat(result).isEqualTo(UInt64.ZERO);
   }
 
@@ -58,7 +58,7 @@ public class BeaconStateSchemaInvariantsTest {
     final BeaconState state = dataStructureUtil.stateBuilder().slot(UInt64.MAX_VALUE).build();
     final Bytes stateBytes = state.sszSerialize();
 
-    final UInt64 result = BeaconStateSchemaInvariants.extractSlot(stateBytes);
+    final UInt64 result = BeaconStateInvariants.extractSlot(stateBytes);
     assertThat(result).isEqualTo(UInt64.MAX_VALUE);
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchemaInvariantsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchemaInvariantsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.state.beaconstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.GENESIS_TIME_FIELD;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.GENESIS_TIME_SCHEMA;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.GENESIS_VALIDATORS_ROOT_FIELD;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.GENESIS_VALIDATORS_ROOT_SCHEMA;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.SLOT_FIELD;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.SLOT_SCHEMA;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecFactory;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class BeaconStateSchemaInvariantsTest {
+  private final Spec spec = SpecFactory.createMinimal();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  @Test
+  public void extractSlot_randomValues() {
+    for (int i = 0; i < 50; i++) {
+      final BeaconState state = dataStructureUtil.randomBeaconState();
+      final Bytes stateBytes = state.sszSerialize();
+
+      final UInt64 expectedSlot = state.getSlot();
+      final UInt64 result = BeaconStateSchemaInvariants.extractSlot(stateBytes);
+      assertThat(result).isEqualTo(expectedSlot);
+    }
+  }
+
+  @Test
+  public void extractSlot_zero() {
+    final BeaconState state = dataStructureUtil.stateBuilder().slot(UInt64.ZERO).build();
+    final Bytes stateBytes = state.sszSerialize();
+
+    final UInt64 result = BeaconStateSchemaInvariants.extractSlot(stateBytes);
+    assertThat(result).isEqualTo(UInt64.ZERO);
+  }
+
+  @Test
+  public void extractSlot_maxValue() {
+    final BeaconState state = dataStructureUtil.stateBuilder().slot(UInt64.MAX_VALUE).build();
+    final Bytes stateBytes = state.sszSerialize();
+
+    final UInt64 result = BeaconStateSchemaInvariants.extractSlot(stateBytes);
+    assertThat(result).isEqualTo(UInt64.MAX_VALUE);
+  }
+
+  @Test
+  public void genesisTimeSchemaShouldMatchField() {
+    assertThat(GENESIS_TIME_SCHEMA).isEqualTo(GENESIS_TIME_FIELD.getSchema().get());
+  }
+
+  @Test
+  public void genesisValidatorsRootSchemaShouldMatchField() {
+    assertThat(GENESIS_VALIDATORS_ROOT_SCHEMA)
+        .isEqualTo(GENESIS_VALIDATORS_ROOT_FIELD.getSchema().get());
+  }
+
+  @Test
+  public void slotSchemaShouldMatchField() {
+    assertThat(SLOT_SCHEMA).isEqualTo(SLOT_FIELD.getSchema().get());
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchemaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchemaTest.java
@@ -21,37 +21,21 @@ import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStat
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecFactory;
 import tech.pegasys.teku.ssz.backing.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.ssz.backing.schema.SszVectorSchema;
 import tech.pegasys.teku.ssz.sos.SszField;
-import tech.pegasys.teku.util.config.Constants;
-import tech.pegasys.teku.util.config.SpecDependent;
 
 public class BeaconStateSchemaTest {
 
-  public void tearDown() {
-    Constants.setConstants("minimal");
-    SpecDependent.resetAll();
-  }
-
   @Test
-  public void create_minimal() {
-    final Spec spec = setupMinimalSpec();
-    final BeaconStateSchema specA = BeaconStateSchema.create(spec.getGenesisSpecConstants());
-    final BeaconStateSchema specB = BeaconStateSchema.create();
+  public void create_compareDifferentSpecs() {
+    final BeaconStateSchema minimalState =
+        BeaconStateSchema.create(SpecFactory.createMinimal().getGenesisSpecConstants());
+    final BeaconStateSchema mainnetState =
+        BeaconStateSchema.create(SpecFactory.createMainnet().getGenesisSpecConstants());
 
-    assertThat(specA).isEqualTo(specB);
-  }
-
-  @Test
-  public void create_mainnet() {
-    final Spec spec = setupMainnetSpec();
-    final BeaconStateSchema specA = BeaconStateSchema.create(spec.getGenesisSpecConstants());
-    final BeaconStateSchema specB = BeaconStateSchema.create();
-
-    assertThat(specA).isEqualTo(specB);
+    assertThat(minimalState).isNotEqualTo(mainnetState);
   }
 
   @Test
@@ -84,17 +68,5 @@ public class BeaconStateSchemaTest {
                     List.of(GENESIS_TIME_FIELD, GENESIS_VALIDATORS_ROOT_FIELD, randomField)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Expected invariant field 'SLOT' at index 2, but got 'random'");
-  }
-
-  private Spec setupMinimalSpec() {
-    Constants.setConstants("minimal");
-    SpecDependent.resetAll();
-    return SpecFactory.createMinimal();
-  }
-
-  private Spec setupMainnetSpec() {
-    Constants.setConstants("mainnet");
-    SpecDependent.resetAll();
-    return SpecFactory.createMainnet();
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchemaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchemaTest.java
@@ -15,9 +15,9 @@ package tech.pegasys.teku.spec.datastructures.state.beaconstate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.GENESIS_TIME_FIELD;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.GENESIS_VALIDATORS_ROOT_FIELD;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchemaInvariants.SLOT_FIELD;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateInvariants.GENESIS_TIME_FIELD;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateInvariants.GENESIS_VALIDATORS_ROOT_FIELD;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateInvariants.SLOT_FIELD;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -687,7 +687,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   private void setupInitialState(final RecentChainData client) {
     final Optional<AnchorPoint> initialAnchor =
-        wsInitializer.loadInitialAnchorPoint(beaconConfig.eth2NetworkConfig().getInitialState());
+        wsInitializer.loadInitialAnchorPoint(
+            spec, beaconConfig.eth2NetworkConfig().getInitialState());
     // Validate
     initialAnchor.ifPresent(
         anchor -> {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/WeakSubjectivityInitializer.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/WeakSubjectivityInitializer.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -38,12 +39,13 @@ class WeakSubjectivityInitializer {
 
   private static final Logger LOG = LogManager.getLogger();
 
-  public Optional<AnchorPoint> loadInitialAnchorPoint(final Optional<String> initialStateResource) {
+  public Optional<AnchorPoint> loadInitialAnchorPoint(
+      final Spec spec, final Optional<String> initialStateResource) {
     return initialStateResource.map(
         stateResource -> {
           try {
             STATUS_LOG.loadingInitialStateResource(stateResource);
-            final BeaconState state = ChainDataLoader.loadState(stateResource);
+            final BeaconState state = ChainDataLoader.loadState(spec, stateResource);
             final AnchorPoint anchor = AnchorPoint.fromInitialState(state);
             STATUS_LOG.loadedInitialStateResource(
                 state.hashTreeRoot(),

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -283,8 +283,8 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
           metricsSystem,
           hotOrSingleDBConfiguration.withDatabaseDir(dbDirectory.toPath()),
           finalizedConfiguration,
-          V4SchemaHot.INSTANCE,
-          V6SchemaFinalized.INSTANCE,
+          V4SchemaHot.create(spec),
+          V6SchemaFinalized.create(spec),
           stateStorageMode,
           stateStorageFrequency,
           spec);
@@ -356,8 +356,8 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
           metricsSystem,
           hotOrSingleDBConfiguration.withDatabaseDir(dbDirectory.toPath()),
           finalizedConfiguration,
-          V4SchemaHot.INSTANCE,
-          V6SchemaFinalized.INSTANCE,
+          V4SchemaHot.create(spec),
+          V6SchemaFinalized.create(spec),
           stateStorageMode,
           stateStorageFrequency,
           spec);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabase.java
@@ -119,13 +119,16 @@ public class RocksDbDatabase implements Database {
       final Spec spec) {
     final RocksDbAccessor hotDb =
         RocksDbInstanceFactory.create(
-            metricsSystem, STORAGE_HOT_DB, hotConfiguration, V4SchemaHot.INSTANCE.getAllColumns());
+            metricsSystem,
+            STORAGE_HOT_DB,
+            hotConfiguration,
+            V4SchemaHot.create(spec).getAllColumns());
     final RocksDbAccessor finalizedDb =
         RocksDbInstanceFactory.create(
             metricsSystem,
             STORAGE_FINALIZED_DB,
             finalizedConfiguration,
-            V4SchemaFinalized.INSTANCE.getAllColumns());
+            V4SchemaFinalized.create(spec).getAllColumns());
     return createV4(
         metricsSystem, hotDb, finalizedDb, stateStorageMode, stateStorageFrequency, spec);
   }
@@ -178,18 +181,14 @@ public class RocksDbDatabase implements Database {
       final StateStorageMode stateStorageMode,
       final long stateStorageFrequency,
       final Spec spec) {
+    final List<RocksDbColumn<?, ?>> v4FinalizedColumns =
+        V4SchemaFinalized.create(spec).getAllColumns();
     final RocksDbAccessor hotDb =
         LevelDbInstanceFactory.create(
-            metricsSystem,
-            STORAGE_HOT_DB,
-            hotConfiguration,
-            V4SchemaFinalized.INSTANCE.getAllColumns());
+            metricsSystem, STORAGE_HOT_DB, hotConfiguration, v4FinalizedColumns);
     final RocksDbAccessor finalizedDb =
         LevelDbInstanceFactory.create(
-            metricsSystem,
-            STORAGE_FINALIZED_DB,
-            finalizedConfiguration,
-            V4SchemaFinalized.INSTANCE.getAllColumns());
+            metricsSystem, STORAGE_FINALIZED_DB, finalizedConfiguration, v4FinalizedColumns);
     return createV4(
         metricsSystem, hotDb, finalizedDb, stateStorageMode, stateStorageFrequency, spec);
   }
@@ -242,9 +241,10 @@ public class RocksDbDatabase implements Database {
       final StateStorageMode stateStorageMode,
       final long stateStorageFrequency,
       final Spec spec) {
-    final V4HotRocksDbDao dao = new V4HotRocksDbDao(hotDb, V4SchemaHot.INSTANCE);
+    final V4HotRocksDbDao dao = new V4HotRocksDbDao(hotDb, V4SchemaHot.create(spec));
     final V4FinalizedRocksDbDao finalizedDbDao =
-        new V4FinalizedRocksDbDao(finalizedDb, V4SchemaFinalized.INSTANCE, stateStorageFrequency);
+        new V4FinalizedRocksDbDao(
+            finalizedDb, V4SchemaFinalized.create(spec), stateStorageFrequency);
     return new RocksDbDatabase(
         metricsSystem, dao, finalizedDbDao, dao, dao, stateStorageMode, spec);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/RocksDbColumn.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/RocksDbColumn.java
@@ -18,6 +18,8 @@ import static tech.pegasys.teku.infrastructure.unsigned.ByteUtil.toByteExact;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer;
 
+import java.util.Objects;
+
 public class RocksDbColumn<TKey, TValue> {
   private final Bytes id;
   private final RocksDbSerializer<TKey> keySerializer;
@@ -50,5 +52,18 @@ public class RocksDbColumn<TKey, TValue> {
 
   public RocksDbSerializer<TValue> getValueSerializer() {
     return valueSerializer;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final RocksDbColumn<?, ?> that = (RocksDbColumn<?, ?>) o;
+    return Objects.equals(id, that.id) && Objects.equals(keySerializer, that.keySerializer) && Objects.equals(valueSerializer, that.valueSerializer);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, keySerializer, valueSerializer);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/RocksDbColumn.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/RocksDbColumn.java
@@ -15,10 +15,9 @@ package tech.pegasys.teku.storage.server.rocksdb.schema;
 
 import static tech.pegasys.teku.infrastructure.unsigned.ByteUtil.toByteExact;
 
+import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer;
-
-import java.util.Objects;
 
 public class RocksDbColumn<TKey, TValue> {
   private final Bytes id;
@@ -59,7 +58,9 @@ public class RocksDbColumn<TKey, TValue> {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     final RocksDbColumn<?, ?> that = (RocksDbColumn<?, ?>) o;
-    return Objects.equals(id, that.id) && Objects.equals(keySerializer, that.keySerializer) && Objects.equals(valueSerializer, that.valueSerializer);
+    return Objects.equals(id, that.id)
+        && Objects.equals(keySerializer, that.keySerializer)
+        && Objects.equals(valueSerializer, that.valueSerializer);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/RocksDbVariable.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/RocksDbVariable.java
@@ -15,10 +15,9 @@ package tech.pegasys.teku.storage.server.rocksdb.schema;
 
 import static tech.pegasys.teku.infrastructure.unsigned.ByteUtil.toByteExact;
 
+import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer;
-
-import java.util.Objects;
 
 public class RocksDbVariable<TValue> {
   private final Bytes id;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/RocksDbVariable.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/RocksDbVariable.java
@@ -18,6 +18,8 @@ import static tech.pegasys.teku.infrastructure.unsigned.ByteUtil.toByteExact;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer;
 
+import java.util.Objects;
+
 public class RocksDbVariable<TValue> {
   private final Bytes id;
   private final RocksDbSerializer<TValue> serializer;
@@ -38,5 +40,18 @@ public class RocksDbVariable<TValue> {
 
   public RocksDbSerializer<TValue> getSerializer() {
     return serializer;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final RocksDbVariable<?> that = (RocksDbVariable<?>) o;
+    return Objects.equals(id, that.id) && Objects.equals(serializer, that.serializer);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, serializer);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/V4SchemaFinalized.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/V4SchemaFinalized.java
@@ -15,35 +15,34 @@ package tech.pegasys.teku.storage.server.rocksdb.schema;
 
 import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.BYTES32_SERIALIZER;
 import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.SIGNED_BLOCK_SERIALIZER;
-import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.STATE_SERIALIZER;
 import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.UINT64_SERIALIZER;
 
 import java.util.Collections;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer;
 
 public class V4SchemaFinalized implements SchemaFinalized {
-  public static final SchemaFinalized INSTANCE = new V4SchemaFinalized();
-
   private static final RocksDbColumn<Bytes32, UInt64> SLOTS_BY_FINALIZED_ROOT =
       RocksDbColumn.create(1, BYTES32_SERIALIZER, UINT64_SERIALIZER);
   private static final RocksDbColumn<UInt64, SignedBeaconBlock> FINALIZED_BLOCKS_BY_SLOT =
       RocksDbColumn.create(2, UINT64_SERIALIZER, SIGNED_BLOCK_SERIALIZER);
-  private static final RocksDbColumn<UInt64, BeaconState> FINALIZED_STATES_BY_SLOT =
-      RocksDbColumn.create(3, UINT64_SERIALIZER, STATE_SERIALIZER);
+  private final RocksDbColumn<UInt64, BeaconState> finalizedStatesBySlot;
   private static final RocksDbColumn<Bytes32, UInt64> SLOTS_BY_FINALIZED_STATE_ROOT =
       RocksDbColumn.create(4, BYTES32_SERIALIZER, UINT64_SERIALIZER);
-  private static final List<RocksDbColumn<?, ?>> ALL_COLUMNS =
-      List.of(
-          SLOTS_BY_FINALIZED_ROOT,
-          FINALIZED_BLOCKS_BY_SLOT,
-          FINALIZED_STATES_BY_SLOT,
-          SLOTS_BY_FINALIZED_STATE_ROOT);
 
-  private V4SchemaFinalized() {}
+  private V4SchemaFinalized(final Spec spec) {
+    this.finalizedStatesBySlot =
+        RocksDbColumn.create(3, UINT64_SERIALIZER, RocksDbSerializer.createStateSerializer(spec));
+  }
+
+  public static SchemaFinalized create(final Spec spec) {
+    return new V4SchemaFinalized(spec);
+  }
 
   @Override
   public RocksDbColumn<Bytes32, UInt64> getColumnSlotsByFinalizedRoot() {
@@ -57,7 +56,7 @@ public class V4SchemaFinalized implements SchemaFinalized {
 
   @Override
   public RocksDbColumn<UInt64, BeaconState> getColumnFinalizedStatesBySlot() {
-    return FINALIZED_STATES_BY_SLOT;
+    return finalizedStatesBySlot;
   }
 
   @Override
@@ -67,7 +66,11 @@ public class V4SchemaFinalized implements SchemaFinalized {
 
   @Override
   public List<RocksDbColumn<?, ?>> getAllColumns() {
-    return ALL_COLUMNS;
+    return List.of(
+        SLOTS_BY_FINALIZED_ROOT,
+        FINALIZED_BLOCKS_BY_SLOT,
+        finalizedStatesBySlot,
+        SLOTS_BY_FINALIZED_STATE_ROOT);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/V4SchemaHot.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/V4SchemaHot.java
@@ -21,7 +21,6 @@ import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSeri
 import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.PROTO_ARRAY_SNAPSHOT_SERIALIZER;
 import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.SIGNED_BLOCK_SERIALIZER;
 import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.SLOT_AND_BLOCK_ROOT_SERIALIZER;
-import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.STATE_SERIALIZER;
 import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.UINT64_SERIALIZER;
 import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.VOTES_SERIALIZER;
 
@@ -31,29 +30,27 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.protoarray.ProtoArraySnapshot;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.CheckpointEpochs;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer;
 
 public class V4SchemaHot implements SchemaHot {
-  public static final V4SchemaHot INSTANCE = new V4SchemaHot();
-
   private static final RocksDbColumn<Bytes32, SignedBeaconBlock> HOT_BLOCKS_BY_ROOT =
       RocksDbColumn.create(1, BYTES32_SERIALIZER, SIGNED_BLOCK_SERIALIZER);
   // Checkpoint states are no longer stored, keeping only for backwards compatibility.
-  private static final RocksDbColumn<Checkpoint, BeaconState> CHECKPOINT_STATES =
-      RocksDbColumn.create(2, CHECKPOINT_SERIALIZER, STATE_SERIALIZER);
+  private final RocksDbColumn<Checkpoint, BeaconState> checkpointStates;
   private static final RocksDbColumn<UInt64, VoteTracker> VOTES =
       RocksDbColumn.create(3, UINT64_SERIALIZER, VOTES_SERIALIZER);
   private static final RocksDbColumn<UInt64, DepositsFromBlockEvent> DEPOSITS_FROM_BLOCK_EVENTS =
       RocksDbColumn.create(4, UINT64_SERIALIZER, DEPOSITS_FROM_BLOCK_EVENT_SERIALIZER);
   private static final RocksDbColumn<Bytes32, SlotAndBlockRoot> STATE_ROOT_TO_SLOT_AND_BLOCK_ROOT =
       RocksDbColumn.create(5, BYTES32_SERIALIZER, SLOT_AND_BLOCK_ROOT_SERIALIZER);
-  private static final RocksDbColumn<Bytes32, BeaconState> HOT_STATES_BY_ROOT =
-      RocksDbColumn.create(6, BYTES32_SERIALIZER, STATE_SERIALIZER);
+  private final RocksDbColumn<Bytes32, BeaconState> hotStatesByRoot;
   private static final RocksDbColumn<Bytes32, CheckpointEpochs>
       HOT_BLOCK_CHECKPOINT_EPOCHS_BY_ROOT =
           RocksDbColumn.create(7, BYTES32_SERIALIZER, CHECKPOINT_EPOCHS_SERIALIZER);
@@ -67,8 +64,7 @@ public class V4SchemaHot implements SchemaHot {
       RocksDbVariable.create(3, CHECKPOINT_SERIALIZER);
   private static final RocksDbVariable<Checkpoint> FINALIZED_CHECKPOINT =
       RocksDbVariable.create(4, CHECKPOINT_SERIALIZER);
-  private static final RocksDbVariable<BeaconState> LATEST_FINALIZED_STATE =
-      RocksDbVariable.create(5, STATE_SERIALIZER);
+  private final RocksDbVariable<BeaconState> latestFinalizedState;
   private static final RocksDbVariable<MinGenesisTimeBlockEvent> MIN_GENESIS_TIME_BLOCK =
       RocksDbVariable.create(6, MIN_GENESIS_TIME_BLOCK_EVENT_SERIALIZER);
   private static final RocksDbVariable<ProtoArraySnapshot> PROTO_ARRAY_SNAPSHOT =
@@ -78,29 +74,17 @@ public class V4SchemaHot implements SchemaHot {
   private static final RocksDbVariable<Checkpoint> ANCHOR_CHECKPOINT =
       RocksDbVariable.create(9, CHECKPOINT_SERIALIZER);
 
-  private static final List<RocksDbColumn<?, ?>> ALL_COLUMNS =
-      List.of(
-          HOT_BLOCKS_BY_ROOT,
-          CHECKPOINT_STATES,
-          VOTES,
-          DEPOSITS_FROM_BLOCK_EVENTS,
-          STATE_ROOT_TO_SLOT_AND_BLOCK_ROOT,
-          HOT_STATES_BY_ROOT,
-          HOT_BLOCK_CHECKPOINT_EPOCHS_BY_ROOT);
+  private V4SchemaHot(final Spec spec) {
+    final RocksDbSerializer<BeaconState> stateSerializer =
+        RocksDbSerializer.createStateSerializer(spec);
+    checkpointStates = RocksDbColumn.create(2, CHECKPOINT_SERIALIZER, stateSerializer);
+    hotStatesByRoot = RocksDbColumn.create(6, BYTES32_SERIALIZER, stateSerializer);
+    latestFinalizedState = RocksDbVariable.create(5, stateSerializer);
+  }
 
-  private static final List<RocksDbVariable<?>> ALL_VARIABLES =
-      List.of(
-          GENESIS_TIME,
-          JUSTIFIED_CHECKPOINT,
-          BEST_JUSTIFIED_CHECKPOINT,
-          FINALIZED_CHECKPOINT,
-          LATEST_FINALIZED_STATE,
-          MIN_GENESIS_TIME_BLOCK,
-          PROTO_ARRAY_SNAPSHOT,
-          WEAK_SUBJECTIVITY_CHECKPOINT,
-          ANCHOR_CHECKPOINT);
-
-  private V4SchemaHot() {}
+  public static V4SchemaHot create(final Spec spec) {
+    return new V4SchemaHot(spec);
+  }
 
   @Override
   public RocksDbColumn<Bytes32, SignedBeaconBlock> getColumnHotBlocksByRoot() {
@@ -114,7 +98,7 @@ public class V4SchemaHot implements SchemaHot {
 
   @Override
   public RocksDbColumn<Checkpoint, BeaconState> getColumnCheckpointStates() {
-    return CHECKPOINT_STATES;
+    return checkpointStates;
   }
 
   @Override
@@ -134,7 +118,7 @@ public class V4SchemaHot implements SchemaHot {
 
   @Override
   public RocksDbColumn<Bytes32, BeaconState> getColumnHotStatesByRoot() {
-    return HOT_STATES_BY_ROOT;
+    return hotStatesByRoot;
   }
 
   @Override
@@ -159,7 +143,7 @@ public class V4SchemaHot implements SchemaHot {
 
   @Override
   public RocksDbVariable<BeaconState> getVariableLatestFinalizedState() {
-    return LATEST_FINALIZED_STATE;
+    return latestFinalizedState;
   }
 
   @Override
@@ -184,11 +168,27 @@ public class V4SchemaHot implements SchemaHot {
 
   @Override
   public List<RocksDbColumn<?, ?>> getAllColumns() {
-    return ALL_COLUMNS;
+    return List.of(
+        HOT_BLOCKS_BY_ROOT,
+        checkpointStates,
+        VOTES,
+        DEPOSITS_FROM_BLOCK_EVENTS,
+        STATE_ROOT_TO_SLOT_AND_BLOCK_ROOT,
+        hotStatesByRoot,
+        HOT_BLOCK_CHECKPOINT_EPOCHS_BY_ROOT);
   }
 
   @Override
   public List<RocksDbVariable<?>> getAllVariables() {
-    return ALL_VARIABLES;
+    return List.of(
+        GENESIS_TIME,
+        JUSTIFIED_CHECKPOINT,
+        BEST_JUSTIFIED_CHECKPOINT,
+        FINALIZED_CHECKPOINT,
+        latestFinalizedState,
+        MIN_GENESIS_TIME_BLOCK,
+        PROTO_ARRAY_SNAPSHOT,
+        WEAK_SUBJECTIVITY_CHECKPOINT,
+        ANCHOR_CHECKPOINT);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/V6SchemaFinalized.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/V6SchemaFinalized.java
@@ -15,23 +15,22 @@ package tech.pegasys.teku.storage.server.rocksdb.schema;
 
 import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.BYTES32_SERIALIZER;
 import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.SIGNED_BLOCK_SERIALIZER;
-import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.STATE_SERIALIZER;
 import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.UINT64_SERIALIZER;
 
 import java.util.Collections;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer;
 
 /**
  * The same as {@link V4SchemaFinalized} but with other column ids which are distinct from {@link
  * V4SchemaHot}
  */
 public class V6SchemaFinalized implements SchemaFinalized {
-  public static final SchemaFinalized INSTANCE = new V6SchemaFinalized();
-
   // column ids should be distinct across different DAOs to make possible using
   // schemes both for a single and separated DBs
   private static final int ID_OFFSET = 128;
@@ -40,18 +39,19 @@ public class V6SchemaFinalized implements SchemaFinalized {
       RocksDbColumn.create(ID_OFFSET + 1, BYTES32_SERIALIZER, UINT64_SERIALIZER);
   private static final RocksDbColumn<UInt64, SignedBeaconBlock> FINALIZED_BLOCKS_BY_SLOT =
       RocksDbColumn.create(ID_OFFSET + 2, UINT64_SERIALIZER, SIGNED_BLOCK_SERIALIZER);
-  private static final RocksDbColumn<UInt64, BeaconState> FINALIZED_STATES_BY_SLOT =
-      RocksDbColumn.create(ID_OFFSET + 3, UINT64_SERIALIZER, STATE_SERIALIZER);
+  private final RocksDbColumn<UInt64, BeaconState> finalizedStatesBySlot;
   private static final RocksDbColumn<Bytes32, UInt64> SLOTS_BY_FINALIZED_STATE_ROOT =
       RocksDbColumn.create(ID_OFFSET + 4, BYTES32_SERIALIZER, UINT64_SERIALIZER);
-  private static final List<RocksDbColumn<?, ?>> ALL_COLUMNS =
-      List.of(
-          SLOTS_BY_FINALIZED_ROOT,
-          FINALIZED_BLOCKS_BY_SLOT,
-          FINALIZED_STATES_BY_SLOT,
-          SLOTS_BY_FINALIZED_STATE_ROOT);
 
-  private V6SchemaFinalized() {}
+  private V6SchemaFinalized(final Spec spec) {
+    finalizedStatesBySlot =
+        RocksDbColumn.create(
+            ID_OFFSET + 3, UINT64_SERIALIZER, RocksDbSerializer.createStateSerializer(spec));
+  }
+
+  public static SchemaFinalized create(final Spec spec) {
+    return new V6SchemaFinalized(spec);
+  }
 
   @Override
   public RocksDbColumn<Bytes32, UInt64> getColumnSlotsByFinalizedRoot() {
@@ -65,7 +65,7 @@ public class V6SchemaFinalized implements SchemaFinalized {
 
   @Override
   public RocksDbColumn<UInt64, BeaconState> getColumnFinalizedStatesBySlot() {
-    return FINALIZED_STATES_BY_SLOT;
+    return finalizedStatesBySlot;
   }
 
   @Override
@@ -75,7 +75,11 @@ public class V6SchemaFinalized implements SchemaFinalized {
 
   @Override
   public List<RocksDbColumn<?, ?>> getAllColumns() {
-    return ALL_COLUMNS;
+    return List.of(
+        SLOTS_BY_FINALIZED_ROOT,
+        FINALIZED_BLOCKS_BY_SLOT,
+        finalizedStatesBySlot,
+        SLOTS_BY_FINALIZED_STATE_ROOT);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/BeaconStateSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/BeaconStateSerializer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.rocksdb.serialization;
+
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+import java.util.Objects;
+
+class BeaconStateSerializer implements RocksDbSerializer<BeaconState> {
+
+  private final Spec spec;
+
+  BeaconStateSerializer(final Spec spec) {
+    this.spec = spec;
+  }
+
+  @Override
+  public BeaconState deserialize(final byte[] data) {
+    return spec.deserializeBeaconState(Bytes.wrap(data));
+  }
+
+  @Override
+  public byte[] serialize(final BeaconState value) {
+    return value.sszSerialize().toArrayUnsafe();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final BeaconStateSerializer that = (BeaconStateSerializer) o;
+    return Objects.equals(spec, that.spec);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(spec);
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/BeaconStateSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/BeaconStateSerializer.java
@@ -13,11 +13,10 @@
 
 package tech.pegasys.teku.storage.server.rocksdb.serialization;
 
+import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-
-import java.util.Objects;
 
 class BeaconStateSerializer implements RocksDbSerializer<BeaconState> {
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/BytesSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/BytesSerializer.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.storage.server.rocksdb.serialization;
 
 import org.apache.tuweni.bytes.Bytes;
 
-public class BytesSerializer<T extends Bytes> implements RocksDbSerializer<T> {
+class BytesSerializer<T extends Bytes> implements RocksDbSerializer<T> {
 
   private final BytesFactory<T> bytesFactory;
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/CheckpointEpochsSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/CheckpointEpochsSerializer.java
@@ -18,7 +18,7 @@ import org.apache.tuweni.ssz.SSZ;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.CheckpointEpochs;
 
-public class CheckpointEpochsSerializer implements RocksDbSerializer<CheckpointEpochs> {
+class CheckpointEpochsSerializer implements RocksDbSerializer<CheckpointEpochs> {
 
   @Override
   public CheckpointEpochs deserialize(final byte[] data) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/DepositsFromBlockEventSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/DepositsFromBlockEventSerializer.java
@@ -25,7 +25,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.event.Deposit;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 
-public class DepositsFromBlockEventSerializer implements RocksDbSerializer<DepositsFromBlockEvent> {
+class DepositsFromBlockEventSerializer implements RocksDbSerializer<DepositsFromBlockEvent> {
 
   @Override
   public DepositsFromBlockEvent deserialize(final byte[] data) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/MinGenesisTimeBlockEventSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/MinGenesisTimeBlockEventSerializer.java
@@ -19,8 +19,7 @@ import org.apache.tuweni.ssz.SSZ;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 
-public class MinGenesisTimeBlockEventSerializer
-    implements RocksDbSerializer<MinGenesisTimeBlockEvent> {
+class MinGenesisTimeBlockEventSerializer implements RocksDbSerializer<MinGenesisTimeBlockEvent> {
   @Override
   public MinGenesisTimeBlockEvent deserialize(final byte[] data) {
     return SSZ.decode(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/ProtoArraySnapshotSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/ProtoArraySnapshotSerializer.java
@@ -23,7 +23,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.protoarray.BlockInformation;
 import tech.pegasys.teku.protoarray.ProtoArraySnapshot;
 
-public class ProtoArraySnapshotSerializer implements RocksDbSerializer<ProtoArraySnapshot> {
+class ProtoArraySnapshotSerializer implements RocksDbSerializer<ProtoArraySnapshot> {
   @Override
   public ProtoArraySnapshot deserialize(final byte[] data) {
     return SSZ.decode(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/RocksDbSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/RocksDbSerializer.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
 import tech.pegasys.teku.pow.event.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.protoarray.ProtoArraySnapshot;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.CheckpointEpochs;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -30,7 +31,6 @@ public interface RocksDbSerializer<T> {
   RocksDbSerializer<Bytes32> BYTES32_SERIALIZER = new BytesSerializer<>(Bytes32::wrap);
   RocksDbSerializer<SignedBeaconBlock> SIGNED_BLOCK_SERIALIZER =
       new SszSerializer<>(SignedBeaconBlock.getSszSchema());
-  RocksDbSerializer<BeaconState> STATE_SERIALIZER = new SszSerializer<>(BeaconState.getSszSchema());
   RocksDbSerializer<Checkpoint> CHECKPOINT_SERIALIZER = new SszSerializer<>(Checkpoint.SSZ_SCHEMA);
   RocksDbSerializer<VoteTracker> VOTES_SERIALIZER = new VoteTrackerSerializer();
   RocksDbSerializer<DepositsFromBlockEvent> DEPOSITS_FROM_BLOCK_EVENT_SERIALIZER =
@@ -43,6 +43,10 @@ public interface RocksDbSerializer<T> {
       new SlotAndBlockRootSerializer();
   RocksDbSerializer<CheckpointEpochs> CHECKPOINT_EPOCHS_SERIALIZER =
       new CheckpointEpochsSerializer();
+
+  static RocksDbSerializer<BeaconState> createStateSerializer(final Spec spec) {
+    return new BeaconStateSerializer(spec);
+  }
 
   T deserialize(final byte[] data);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/SlotAndBlockRootSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/SlotAndBlockRootSerializer.java
@@ -19,7 +19,7 @@ import org.apache.tuweni.ssz.SSZ;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 
-public class SlotAndBlockRootSerializer implements RocksDbSerializer<SlotAndBlockRoot> {
+class SlotAndBlockRootSerializer implements RocksDbSerializer<SlotAndBlockRoot> {
   @Override
   public SlotAndBlockRoot deserialize(final byte[] data) {
     return SSZ.decode(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/SszSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/SszSerializer.java
@@ -17,7 +17,7 @@ import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.ssz.backing.SszData;
 import tech.pegasys.teku.ssz.backing.schema.SszSchema;
 
-public class SszSerializer<T extends SszData> implements RocksDbSerializer<T> {
+class SszSerializer<T extends SszData> implements RocksDbSerializer<T> {
 
   private final SszSchema<T> type;
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/UInt64Serializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/UInt64Serializer.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.storage.server.rocksdb.serialization;
 import com.google.common.primitives.Longs;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class UInt64Serializer implements RocksDbSerializer<UInt64> {
+class UInt64Serializer implements RocksDbSerializer<UInt64> {
 
   @Override
   public UInt64 deserialize(final byte[] data) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/VoteTrackerSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/VoteTrackerSerializer.java
@@ -19,7 +19,7 @@ import org.apache.tuweni.ssz.SSZ;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 
-public class VoteTrackerSerializer implements RocksDbSerializer<VoteTracker> {
+class VoteTrackerSerializer implements RocksDbSerializer<VoteTracker> {
   @Override
   public VoteTracker deserialize(final byte[] data) {
     return SSZ.decode(

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/serialization/BeaconStateSerializerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/serialization/BeaconStateSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ConsenSys AG.
+ * Copyright 2021 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -18,33 +18,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecFactory;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class SszSerializerTest {
-
+public class BeaconStateSerializerTest {
   private final Spec spec = SpecFactory.createMinimal();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
-  private final SszSerializer<SignedBeaconBlock> blockSerializer =
-      new SszSerializer<>(SignedBeaconBlock.getSszSchema());
-  private final SszSerializer<Checkpoint> checkpointSerializer =
-      new SszSerializer<>(Checkpoint.SSZ_SCHEMA);
+  private final RocksDbSerializer<BeaconState> stateSerializer = new BeaconStateSerializer(spec);
 
   @Test
-  public void roundTrip_block() {
-    final SignedBeaconBlock value = dataStructureUtil.randomSignedBeaconBlock(11);
-    final byte[] bytes = blockSerializer.serialize(value);
-    final SignedBeaconBlock deserialized = blockSerializer.deserialize(bytes);
-    assertThat(deserialized).isEqualTo(value);
-  }
-
-  @Test
-  public void roundTrip_checkpoint() {
-    final Checkpoint value = dataStructureUtil.randomCheckpoint();
-    final byte[] bytes = checkpointSerializer.serialize(value);
-    final Checkpoint deserialized = checkpointSerializer.deserialize(bytes);
+  public void roundTrip_state() {
+    final BeaconState value = dataStructureUtil.randomBeaconState(11);
+    final byte[] bytes = stateSerializer.serialize(value);
+    final BeaconState deserialized = stateSerializer.deserialize(bytes);
     assertThat(deserialized).isEqualTo(value);
   }
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/rocksdb/InMemoryRocksDbDatabaseFactory.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/rocksdb/InMemoryRocksDbDatabaseFactory.java
@@ -43,8 +43,8 @@ public class InMemoryRocksDbDatabaseFactory {
         new StubMetricsSystem(),
         hotDb,
         coldDb,
-        V4SchemaHot.INSTANCE,
-        V6SchemaFinalized.INSTANCE,
+        V4SchemaHot.create(spec),
+        V6SchemaFinalized.create(spec),
         storageMode,
         stateStorageFrequency,
         spec);

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/FileBackedStorageSystemBuilder.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/FileBackedStorageSystemBuilder.java
@@ -163,8 +163,8 @@ public class FileBackedStorageSystemBuilder {
         new StubMetricsSystem(),
         hotConfigDefault.withDatabaseDir(hotDir),
         coldConfig,
-        V4SchemaHot.INSTANCE,
-        V6SchemaFinalized.INSTANCE,
+        V4SchemaHot.create(spec),
+        V6SchemaFinalized.create(spec),
         storageMode,
         stateStorageFrequency,
         spec);
@@ -182,8 +182,8 @@ public class FileBackedStorageSystemBuilder {
         new StubMetricsSystem(),
         hotConfigDefault.withDatabaseDir(hotDir),
         coldConfig,
-        V4SchemaHot.INSTANCE,
-        V6SchemaFinalized.INSTANCE,
+        V4SchemaHot.create(spec),
+        V6SchemaFinalized.create(spec),
         storageMode,
         stateStorageFrequency,
         spec);

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/InMemoryStorageSystemBuilder.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/InMemoryStorageSystemBuilder.java
@@ -140,10 +140,11 @@ public class InMemoryStorageSystemBuilder {
       hotDb =
           MockRocksDbInstance.createEmpty(
               concat(
-                  V4SchemaHot.INSTANCE.getAllColumns(), V6SchemaFinalized.INSTANCE.getAllColumns()),
+                  V4SchemaHot.create(spec).getAllColumns(),
+                  V6SchemaFinalized.create(spec).getAllColumns()),
               concat(
-                  V4SchemaHot.INSTANCE.getAllVariables(),
-                  V6SchemaFinalized.INSTANCE.getAllVariables()));
+                  V4SchemaHot.create(spec).getAllVariables(),
+                  V6SchemaFinalized.create(spec).getAllVariables()));
       coldDb = hotDb;
     }
     return InMemoryRocksDbDatabaseFactory.createV6(
@@ -159,13 +160,13 @@ public class InMemoryStorageSystemBuilder {
     if (hotDb == null) {
       hotDb =
           MockRocksDbInstance.createEmpty(
-              V4SchemaHot.INSTANCE.getAllColumns(), V4SchemaHot.INSTANCE.getAllVariables());
+              V4SchemaHot.create(spec).getAllColumns(), V4SchemaHot.create(spec).getAllVariables());
     }
     if (coldDb == null) {
       coldDb =
           MockRocksDbInstance.createEmpty(
-              V4SchemaFinalized.INSTANCE.getAllColumns(),
-              V4SchemaFinalized.INSTANCE.getAllVariables());
+              V4SchemaFinalized.create(spec).getAllColumns(),
+              V4SchemaFinalized.create(spec).getAllVariables());
     }
     return InMemoryRocksDbDatabaseFactory.createV4(
         hotDb, coldDb, storageMode, stateStorageFrequency, spec);

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
@@ -38,7 +38,6 @@ public class StoreAssertions {
             "checkpointStateRequestRegenerateCounter",
             "checkpointStateRequestMissCounter",
             "metricsSystem",
-            "spec",
             "states",
             "stateProvider",
             "checkpointStates",

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/TransitionCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/TransitionCommand.java
@@ -124,7 +124,7 @@ public class TransitionCommand implements Runnable {
     try (final InputStream in = selectInputStream(params);
         final OutputStream out = selectOutputStream(params)) {
       final Bytes inData = Bytes.wrap(ByteStreams.toByteArray(in));
-      BeaconState state = readState(inData);
+      BeaconState state = readState(spec, inData);
 
       try {
         BeaconState result = transition.applyTransition(spec, state);
@@ -161,8 +161,12 @@ public class TransitionCommand implements Runnable {
     }
   }
 
-  private BeaconState readState(final Bytes inData) {
-    return deserialize(inData, BeaconState.getSszSchema(), "pre state");
+  private BeaconState readState(final Spec spec, final Bytes inData) {
+    try {
+      return spec.deserializeBeaconState(inData);
+    } catch (final IllegalArgumentException e) {
+      throw new SSZException("Failed to parse SSZ (pre state): " + e.getMessage(), e);
+    }
   }
 
   private SignedBeaconBlock readBlock(final String path) throws IOException {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This is a follow-up to #3684.  Finish migrating calls to retrieve `BeaconStateSchema` instances: we now always go through `Spec` rather than using static accessors.  To enable this migration, a utility has been added that extracts the "slot" field from a serialized beacon state.  This allows us to grab the correct `BeaconStateSchema` for deserialization.  

**Note**: this PR updates our database schema and serialization logic. 

## Fixed Issue(s)
Part of #3658 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
