### PR TITLE
Update context used to retrieve CloudSmith api keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,7 +465,7 @@ workflows:
             - spotless
           context:
             - dockerhub-quorumengineering-ro
-            - quorum-gradle
+            - cloudsmith-protocols
       - publishDocker:
           filters:
             branches:


### PR DESCRIPTION
## PR Description
Updates the context used to access CloudSmith API keys for publishing.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
