### PR TITLE
refactor the index accessor to be a function of protoArray

### DIFF
--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
@@ -52,6 +52,10 @@ public class ProtoArray {
    */
   private final ProtoArrayIndices indices = new ProtoArrayIndices();
 
+  public Optional<Integer> getIndexByRoot(final Bytes32 root) {
+    return indices.get(root);
+  }
+
   ProtoArray(
       int pruneThreshold, UInt64 justifiedEpoch, UInt64 finalizedEpoch, UInt64 initialEpoch) {
     this.pruneThreshold = pruneThreshold;

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategy.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayForkChoiceStrategy.java
@@ -199,7 +199,7 @@ public class ProtoArrayForkChoiceStrategy implements ForkChoiceStrategy, BlockMe
           ProtoArrayScoreCalculator.computeDeltas(
               voteUpdater,
               getTotalTrackedNodeCount(),
-              protoArray.getRootIndices(),
+              protoArray::getIndexByRoot,
               balances,
               justifiedStateBalances);
 

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayScoreCalculatorTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayScoreCalculatorTest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,10 @@ public class ProtoArrayScoreCalculatorTest {
   private List<UInt64> oldBalances;
   private List<UInt64> newBalances;
   private VoteUpdater store;
+
+  private Optional<Integer> getIndex(final Bytes32 root) {
+    return Optional.ofNullable(indices.get(root));
+  }
 
   @BeforeEach
   void setUp() {
@@ -57,7 +62,8 @@ public class ProtoArrayScoreCalculatorTest {
       newBalances.add(ZERO);
     }
 
-    List<Long> deltas = computeDeltas(store, indices.size(), indices, oldBalances, newBalances);
+    List<Long> deltas =
+        computeDeltas(store, indices.size(), this::getIndex, oldBalances, newBalances);
     assertThat(deltas).hasSize(validatorCount);
 
     // Deltas should all be zero
@@ -78,7 +84,8 @@ public class ProtoArrayScoreCalculatorTest {
       newBalances.add(BALANCE);
     }
 
-    List<Long> deltas = computeDeltas(store, indices.size(), indices, oldBalances, newBalances);
+    List<Long> deltas =
+        computeDeltas(store, indices.size(), this::getIndex, oldBalances, newBalances);
     assertThat(deltas).hasSize(validatorCount);
 
     for (int i = 0; i < deltas.size(); i++) {
@@ -109,7 +116,8 @@ public class ProtoArrayScoreCalculatorTest {
       newBalances.add(BALANCE);
     }
 
-    List<Long> deltas = computeDeltas(store, indices.size(), indices, oldBalances, newBalances);
+    List<Long> deltas =
+        computeDeltas(store, indices.size(), this::getIndex, oldBalances, newBalances);
     assertThat(deltas).hasSize(validatorCount);
 
     // Each root should have the same delta
@@ -132,7 +140,8 @@ public class ProtoArrayScoreCalculatorTest {
       newBalances.add(BALANCE);
     }
 
-    List<Long> deltas = computeDeltas(store, indices.size(), indices, oldBalances, newBalances);
+    List<Long> deltas =
+        computeDeltas(store, indices.size(), this::getIndex, oldBalances, newBalances);
 
     assertThat(deltas).hasSize(validatorCount);
     long totalDelta = BALANCE.longValue() * Integer.toUnsignedLong(validatorCount);
@@ -176,7 +185,8 @@ public class ProtoArrayScoreCalculatorTest {
         new VoteTracker(getHash(1), getHash(1337), validator2vote.getNextEpoch());
     store.putVote(UInt64.valueOf(1), newVote2);
 
-    List<Long> deltas = computeDeltas(store, indices.size(), indices, oldBalances, newBalances);
+    List<Long> deltas =
+        computeDeltas(store, indices.size(), this::getIndex, oldBalances, newBalances);
     assertThat(deltas).hasSize(1);
 
     // The block should have lost both balances
@@ -202,7 +212,8 @@ public class ProtoArrayScoreCalculatorTest {
       newBalances.add(NEW_BALANCE);
     }
 
-    List<Long> deltas = computeDeltas(store, indices.size(), indices, oldBalances, newBalances);
+    List<Long> deltas =
+        computeDeltas(store, indices.size(), this::getIndex, oldBalances, newBalances);
     assertThat(deltas).hasSize(validatorCount);
 
     for (int i = 0; i < deltas.size(); i++) {
@@ -243,7 +254,8 @@ public class ProtoArrayScoreCalculatorTest {
       store.putVote(UInt64.valueOf(i), newVote);
     }
 
-    List<Long> deltas = computeDeltas(store, indices.size(), indices, oldBalances, newBalances);
+    List<Long> deltas =
+        computeDeltas(store, indices.size(), this::getIndex, oldBalances, newBalances);
     assertThat(deltas).hasSize(2);
 
     // Block 1 should have only lost one balance
@@ -276,7 +288,8 @@ public class ProtoArrayScoreCalculatorTest {
       store.putVote(UInt64.valueOf(i), newVote);
     }
 
-    List<Long> deltas = computeDeltas(store, indices.size(), indices, oldBalances, newBalances);
+    List<Long> deltas =
+        computeDeltas(store, indices.size(), this::getIndex, oldBalances, newBalances);
     assertThat(deltas).hasSize(2);
 
     // Block 1 should have lost both balances


### PR DESCRIPTION
removes the need to directly expose the ProtoArrayIndexes structure, which will be helpful if it needs to be refactored to handle different voting options.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
