### PR TITLE
[Issue-3658] Rename "genesis" versions to "phase0"

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/BeaconState.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/BeaconState.java
@@ -31,7 +31,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis.BeaconStateGenesis;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStatePhase0;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 import tech.pegasys.teku.ssz.SSZTypes.SSZVector;
 import tech.pegasys.teku.ssz.backing.collections.SszBitvector;
@@ -167,10 +167,10 @@ public class BeaconState {
         new Checkpoint(beaconState.getCurrent_justified_checkpoint());
     this.finalized_checkpoint = new Checkpoint(beaconState.getFinalized_checkpoint());
 
-    // Optionally set genesis-specific versioned fields
-    final Optional<BeaconStateGenesis> maybeGenesisState = beaconState.toGenesisVersion();
-    if (maybeGenesisState.isPresent()) {
-      final BeaconStateGenesis genesisState = maybeGenesisState.get();
+    // Optionally set phase0-specific versioned fields
+    final Optional<BeaconStatePhase0> maybePhase0State = beaconState.toVersionPhase0();
+    if (maybePhase0State.isPresent()) {
+      final BeaconStatePhase0 genesisState = maybePhase0State.get();
       this.previous_epoch_attestations =
           genesisState.getPrevious_epoch_attestations().stream()
               .map(PendingAttestation::new)
@@ -238,7 +238,7 @@ public class BeaconState {
               state.setFinalized_checkpoint(finalized_checkpoint.asInternalCheckpoint());
 
               state
-                  .toGenesisVersionMutable()
+                  .toMutableVersionPhase0()
                   .ifPresent(
                       genesisState -> {
                         genesisState

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -75,12 +75,12 @@ public class Spec {
   }
 
   public static Spec create(final SpecConfiguration config) {
-    final SpecVersion initialSpec = SpecVersion.createGenesis(config.constants());
+    final SpecVersion initialSpec = SpecVersion.createPhase0(config.constants());
     return new Spec(initialSpec);
   }
 
   public static Spec create(final SpecConfiguration config, final ForkManifest forkManifest) {
-    final SpecVersion initialSpec = SpecVersion.createGenesis(config.constants());
+    final SpecVersion initialSpec = SpecVersion.createPhase0(config.constants());
     return new Spec(initialSpec, forkManifest);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecVersion.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecVersion.java
@@ -16,9 +16,9 @@ package tech.pegasys.teku.spec;
 import tech.pegasys.teku.spec.constants.SpecConstants;
 import tech.pegasys.teku.spec.logic.DelegatingSpecLogic;
 import tech.pegasys.teku.spec.logic.SpecLogic;
-import tech.pegasys.teku.spec.logic.versions.genesis.SpecLogicGenesis;
+import tech.pegasys.teku.spec.logic.versions.phase0.SpecLogicPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGenesis;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsPhase0;
 
 public class SpecVersion extends DelegatingSpecLogic {
   private final SpecConstants constants;
@@ -33,9 +33,9 @@ public class SpecVersion extends DelegatingSpecLogic {
     this.schemaDefinitions = schemaDefinitions;
   }
 
-  public static SpecVersion createGenesis(final SpecConstants specConstants) {
-    final SchemaDefinitions schemaDefinitions = new SchemaDefinitionsGenesis(specConstants);
-    final SpecLogic specLogic = new SpecLogicGenesis(specConstants, schemaDefinitions);
+  public static SpecVersion createPhase0(final SpecConstants specConstants) {
+    final SchemaDefinitions schemaDefinitions = new SchemaDefinitionsPhase0(specConstants);
+    final SpecLogic specLogic = new SpecLogicPhase0(specConstants, schemaDefinitions);
     return new SpecVersion(specConstants, schemaDefinitions, specLogic);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconState.java
@@ -25,7 +25,7 @@ import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.analysis.ValidatorStats;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis.BeaconStateGenesis;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStatePhase0;
 import tech.pegasys.teku.ssz.SSZTypes.SSZBackingList;
 import tech.pegasys.teku.ssz.SSZTypes.SSZBackingVector;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
@@ -171,7 +171,7 @@ public interface BeaconState extends SszContainer, ValidatorStats {
     void mutate(TState state) throws E1, E2, E3;
   }
 
-  default Optional<BeaconStateGenesis> toGenesisVersion() {
+  default Optional<BeaconStatePhase0> toVersionPhase0() {
     return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/MutableBeaconState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/MutableBeaconState.java
@@ -22,7 +22,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis.MutableBeaconStateGenesis;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.MutableBeaconStatePhase0;
 import tech.pegasys.teku.ssz.SSZTypes.SSZBackingList;
 import tech.pegasys.teku.ssz.SSZTypes.SSZBackingVector;
 import tech.pegasys.teku.ssz.SSZTypes.SSZMutableList;
@@ -137,7 +137,7 @@ public interface MutableBeaconState extends BeaconState, SszMutableRefContainer 
   @Override
   BeaconState commitChanges();
 
-  default Optional<MutableBeaconStateGenesis> toGenesisVersionMutable() {
+  default Optional<MutableBeaconStatePhase0> toMutableVersionPhase0() {
     return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis;
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -21,15 +21,15 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStat
 import tech.pegasys.teku.ssz.SSZTypes.SSZBackingList;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 
-public interface BeaconStateGenesis extends BeaconState {
+public interface BeaconStatePhase0 extends BeaconState {
 
-  static BeaconStateGenesis requireGenesisState(final BeaconState state) {
+  static BeaconStatePhase0 required(final BeaconState state) {
     return state
-        .toGenesisVersion()
+        .toVersionPhase0()
         .orElseThrow(
             () ->
                 new IllegalArgumentException(
-                    "Expected a genesis state but got: " + state.getClass().getSimpleName()));
+                    "Expected a phase0 state but got: " + state.getClass().getSimpleName()));
   }
 
   // Attestations
@@ -48,11 +48,11 @@ public interface BeaconStateGenesis extends BeaconState {
   }
 
   @Override
-  default Optional<BeaconStateGenesis> toGenesisVersion() {
+  default Optional<BeaconStatePhase0> toVersionPhase0() {
     return Optional.of(this);
   }
 
   <E1 extends Exception, E2 extends Exception, E3 extends Exception>
-      BeaconStateGenesis updatedGenesis(Mutator<MutableBeaconStateGenesis, E1, E2, E3> mutator)
+      BeaconStatePhase0 updatedPhase0(Mutator<MutableBeaconStatePhase0, E1, E2, E3> mutator)
           throws E1, E2, E3;
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0Impl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0Impl.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis;
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0;
 
 import com.google.common.base.MoreObjects.ToStringHelper;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
@@ -25,15 +25,15 @@ import tech.pegasys.teku.ssz.backing.schema.AbstractSszContainerSchema;
 import tech.pegasys.teku.ssz.backing.schema.SszCompositeSchema;
 import tech.pegasys.teku.ssz.backing.tree.TreeNode;
 
-class BeaconStateGenesisImpl extends AbstractBeaconState<MutableBeaconStateGenesis>
-    implements BeaconStateGenesis, BeaconStateCache, AttestationBasedValidatorStats {
+class BeaconStatePhase0Impl extends AbstractBeaconState<MutableBeaconStatePhase0>
+    implements BeaconStatePhase0, BeaconStateCache, ValidatorStatsPhase0 {
 
-  BeaconStateGenesisImpl(
-      final BeaconStateSchema<BeaconStateGenesis, MutableBeaconStateGenesis> schema) {
+  BeaconStatePhase0Impl(
+      final BeaconStateSchema<BeaconStatePhase0, MutableBeaconStatePhase0> schema) {
     super(schema);
   }
 
-  BeaconStateGenesisImpl(
+  BeaconStatePhase0Impl(
       SszCompositeSchema<?> type,
       TreeNode backingNode,
       IntCache<SszData> cache,
@@ -41,23 +41,23 @@ class BeaconStateGenesisImpl extends AbstractBeaconState<MutableBeaconStateGenes
     super(type, backingNode, cache, transitionCaches);
   }
 
-  BeaconStateGenesisImpl(
+  BeaconStatePhase0Impl(
       AbstractSszContainerSchema<? extends SszContainer> type, TreeNode backingNode) {
     super(type, backingNode);
   }
 
   @Override
   public <E1 extends Exception, E2 extends Exception, E3 extends Exception>
-      BeaconStateGenesis updatedGenesis(Mutator<MutableBeaconStateGenesis, E1, E2, E3> mutator)
+      BeaconStatePhase0 updatedPhase0(Mutator<MutableBeaconStatePhase0, E1, E2, E3> mutator)
           throws E1, E2, E3 {
-    MutableBeaconStateGenesis writableCopy = createWritableCopyPriv();
+    MutableBeaconStatePhase0 writableCopy = createWritableCopyPriv();
     mutator.mutate(writableCopy);
     return writableCopy.commitChanges();
   }
 
   @Override
-  protected MutableBeaconStateGenesis createWritableCopyPriv() {
-    return new MutableBeaconStateGenesisImpl(this);
+  protected MutableBeaconStatePhase0 createWritableCopyPriv() {
+    return new MutableBeaconStatePhase0Impl(this);
   }
 
   @Override
@@ -65,7 +65,7 @@ class BeaconStateGenesisImpl extends AbstractBeaconState<MutableBeaconStateGenes
     describeCustomFields(stringBuilder, this);
   }
 
-  static void describeCustomFields(ToStringHelper stringBuilder, final BeaconStateGenesis state) {
+  static void describeCustomFields(ToStringHelper stringBuilder, final BeaconStatePhase0 state) {
     stringBuilder
         .add("previous_epoch_attestations", state.getPrevious_epoch_attestations())
         .add("current_epoch_attestations", state.getCurrent_epoch_attestations());

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStateSchemaPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStateSchemaPhase0.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis;
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
@@ -24,17 +24,17 @@ import tech.pegasys.teku.ssz.backing.schema.SszListSchema;
 import tech.pegasys.teku.ssz.backing.tree.TreeNode;
 import tech.pegasys.teku.ssz.sos.SszField;
 
-public class BeaconStateSchemaGenesis
-    extends AbstractBeaconStateSchema<BeaconStateGenesis, MutableBeaconStateGenesis> {
+public class BeaconStateSchemaPhase0
+    extends AbstractBeaconStateSchema<BeaconStatePhase0, MutableBeaconStatePhase0> {
 
   @VisibleForTesting
-  BeaconStateSchemaGenesis(final SpecConstants specConstants) {
+  BeaconStateSchemaPhase0(final SpecConstants specConstants) {
     super("BeaconStateGenesis", getUniqueFields(specConstants), specConstants);
   }
 
-  public static BeaconStateSchema<BeaconStateGenesis, MutableBeaconStateGenesis> create(
+  public static BeaconStateSchema<BeaconStatePhase0, MutableBeaconStatePhase0> create(
       final SpecConstants specConstants) {
-    return new BeaconStateSchemaGenesis(specConstants);
+    return new BeaconStateSchemaPhase0(specConstants);
   }
 
   private static List<SszField> getUniqueFields(final SpecConstants specConstants) {
@@ -59,21 +59,21 @@ public class BeaconStateSchemaGenesis
   }
 
   @Override
-  public BeaconStateGenesis createFromBackingNode(TreeNode node) {
-    return new BeaconStateGenesisImpl(this, node);
+  public BeaconStatePhase0 createFromBackingNode(TreeNode node) {
+    return new BeaconStatePhase0Impl(this, node);
   }
 
   @Override
-  public MutableBeaconStateGenesis createBuilder() {
-    return new MutableBeaconStateGenesisImpl(createEmptyBeaconStateImpl(), true);
+  public MutableBeaconStatePhase0 createBuilder() {
+    return new MutableBeaconStatePhase0Impl(createEmptyBeaconStateImpl(), true);
   }
 
   @Override
-  public BeaconStateGenesis createEmpty() {
+  public BeaconStatePhase0 createEmpty() {
     return createEmptyBeaconStateImpl();
   }
 
-  private BeaconStateGenesisImpl createEmptyBeaconStateImpl() {
-    return new BeaconStateGenesisImpl(this);
+  private BeaconStatePhase0Impl createEmptyBeaconStateImpl() {
+    return new BeaconStatePhase0Impl(this);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/MutableBeaconStatePhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/MutableBeaconStatePhase0.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis;
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -20,15 +20,15 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconStat
 import tech.pegasys.teku.ssz.SSZTypes.SSZBackingList;
 import tech.pegasys.teku.ssz.SSZTypes.SSZMutableList;
 
-public interface MutableBeaconStateGenesis extends MutableBeaconState, BeaconStateGenesis {
+public interface MutableBeaconStatePhase0 extends MutableBeaconState, BeaconStatePhase0 {
 
-  static MutableBeaconStateGenesis requireGenesisStateMutable(final MutableBeaconState state) {
+  static MutableBeaconStatePhase0 required(final MutableBeaconState state) {
     return state
-        .toGenesisVersionMutable()
+        .toMutableVersionPhase0()
         .orElseThrow(
             () ->
                 new IllegalArgumentException(
-                    "Expected a genesis state but got: " + state.getClass().getSimpleName()));
+                    "Expected a phase0 state but got: " + state.getClass().getSimpleName()));
   }
 
   // Attestations
@@ -45,10 +45,10 @@ public interface MutableBeaconStateGenesis extends MutableBeaconState, BeaconSta
   }
 
   @Override
-  BeaconStateGenesis commitChanges();
+  BeaconStatePhase0 commitChanges();
 
   @Override
-  default Optional<MutableBeaconStateGenesis> toGenesisVersionMutable() {
+  default Optional<MutableBeaconStatePhase0> toMutableVersionPhase0() {
     return Optional.of(this);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/MutableBeaconStatePhase0Impl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/MutableBeaconStatePhase0Impl.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis;
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0;
 
 import com.google.common.base.MoreObjects.ToStringHelper;
 import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
@@ -25,29 +25,29 @@ import tech.pegasys.teku.ssz.backing.SszData;
 import tech.pegasys.teku.ssz.backing.cache.IntCache;
 import tech.pegasys.teku.ssz.backing.tree.TreeNode;
 
-class MutableBeaconStateGenesisImpl extends AbstractMutableBeaconState<BeaconStateGenesisImpl>
-    implements MutableBeaconStateGenesis, BeaconStateCache, AttestationBasedValidatorStats {
+class MutableBeaconStatePhase0Impl extends AbstractMutableBeaconState<BeaconStatePhase0Impl>
+    implements MutableBeaconStatePhase0, BeaconStateCache, ValidatorStatsPhase0 {
 
   private SSZMutableList<PendingAttestation> previousEpochAttestations;
   private SSZMutableList<PendingAttestation> currentEpochAttestations;
 
-  MutableBeaconStateGenesisImpl(BeaconStateGenesisImpl backingImmutableView) {
+  MutableBeaconStatePhase0Impl(BeaconStatePhase0Impl backingImmutableView) {
     super(backingImmutableView);
   }
 
-  MutableBeaconStateGenesisImpl(BeaconStateGenesisImpl backingImmutableView, boolean builder) {
+  MutableBeaconStatePhase0Impl(BeaconStatePhase0Impl backingImmutableView, boolean builder) {
     super(backingImmutableView, builder);
   }
 
   @Override
-  protected BeaconStateGenesisImpl createImmutableBeaconState(
+  protected BeaconStatePhase0Impl createImmutableBeaconState(
       TreeNode backingNode, IntCache<SszData> viewCache, TransitionCaches transitionCache) {
-    return new BeaconStateGenesisImpl(getSchema(), backingNode, viewCache, transitionCache);
+    return new BeaconStatePhase0Impl(getSchema(), backingNode, viewCache, transitionCache);
   }
 
   @Override
-  public BeaconStateGenesis commitChanges() {
-    return (BeaconStateGenesis) super.commitChanges();
+  public BeaconStatePhase0 commitChanges() {
+    return (BeaconStatePhase0) super.commitChanges();
   }
 
   @Override
@@ -55,7 +55,7 @@ class MutableBeaconStateGenesisImpl extends AbstractMutableBeaconState<BeaconSta
     return previousEpochAttestations != null
         ? previousEpochAttestations
         : (previousEpochAttestations =
-            MutableBeaconStateGenesis.super.getPrevious_epoch_attestations());
+            MutableBeaconStatePhase0.super.getPrevious_epoch_attestations());
   }
 
   @Override
@@ -63,7 +63,7 @@ class MutableBeaconStateGenesisImpl extends AbstractMutableBeaconState<BeaconSta
     return currentEpochAttestations != null
         ? currentEpochAttestations
         : (currentEpochAttestations =
-            MutableBeaconStateGenesis.super.getCurrent_epoch_attestations());
+            MutableBeaconStatePhase0.super.getCurrent_epoch_attestations());
   }
 
   @Override
@@ -74,13 +74,13 @@ class MutableBeaconStateGenesisImpl extends AbstractMutableBeaconState<BeaconSta
 
   @Override
   public <E1 extends Exception, E2 extends Exception, E3 extends Exception>
-      BeaconStateGenesis updatedGenesis(Mutator<MutableBeaconStateGenesis, E1, E2, E3> mutator)
+      BeaconStatePhase0 updatedPhase0(Mutator<MutableBeaconStatePhase0, E1, E2, E3> mutator)
           throws E1, E2, E3 {
     throw new UnsupportedOperationException();
   }
 
   @Override
   protected void addCustomFields(ToStringHelper stringBuilder) {
-    BeaconStateGenesisImpl.describeCustomFields(stringBuilder, this);
+    BeaconStatePhase0Impl.describeCustomFields(stringBuilder, this);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/ValidatorStatsPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/ValidatorStatsPhase0.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis;
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,7 +21,7 @@ import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 import tech.pegasys.teku.ssz.backing.collections.SszBitlist;
 
-interface AttestationBasedValidatorStats extends BeaconStateGenesis {
+interface ValidatorStatsPhase0 extends BeaconStatePhase0 {
   @Override
   default CorrectAndLiveValidators getValidatorStatsPreviousEpoch(final Bytes32 correctTargetRoot) {
     return getValidatorStats(getPrevious_epoch_attestations(), correctTargetRoot);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.logic.versions.genesis;
+package tech.pegasys.teku.spec.logic.versions.phase0;
 
 import tech.pegasys.teku.spec.constants.SpecConstants;
 import tech.pegasys.teku.spec.logic.SpecLogic;
@@ -25,12 +25,12 @@ import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.CommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
-import tech.pegasys.teku.spec.logic.versions.genesis.statetransition.epoch.EpochProcessorGenesis;
-import tech.pegasys.teku.spec.logic.versions.genesis.statetransition.epoch.ValidatorStatusFactoryGenesis;
-import tech.pegasys.teku.spec.logic.versions.genesis.util.BlockProcessorGenesis;
+import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.EpochProcessorPhase0;
+import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.ValidatorStatusFactoryPhase0;
+import tech.pegasys.teku.spec.logic.versions.phase0.util.BlockProcessorPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
-public class SpecLogicGenesis implements SpecLogic {
+public class SpecLogicPhase0 implements SpecLogic {
   private final CommitteeUtil committeeUtil;
   private final ValidatorsUtil validatorsUtil;
   private final AttestationUtil attestationUtil;
@@ -40,22 +40,21 @@ public class SpecLogicGenesis implements SpecLogic {
   private final StateTransition stateTransition;
   private final ForkChoiceUtil forkChoiceUtil;
   private final BlockProposalUtil blockProposalUtil;
-  private final ValidatorStatusFactoryGenesis validatorStatusFactory;
+  private final ValidatorStatusFactoryPhase0 validatorStatusFactory;
 
-  public SpecLogicGenesis(
-      final SpecConstants constants, final SchemaDefinitions schemaDefinitions) {
+  public SpecLogicPhase0(final SpecConstants constants, final SchemaDefinitions schemaDefinitions) {
     this.committeeUtil = new CommitteeUtil(constants);
     this.validatorsUtil = new ValidatorsUtil(constants);
     this.beaconStateUtil =
         new BeaconStateUtil(constants, schemaDefinitions, validatorsUtil, this.committeeUtil);
     this.attestationUtil = new AttestationUtil(constants, beaconStateUtil, validatorsUtil);
     this.validatorStatusFactory =
-        new ValidatorStatusFactoryGenesis(beaconStateUtil, attestationUtil, validatorsUtil);
+        new ValidatorStatusFactoryPhase0(beaconStateUtil, attestationUtil, validatorsUtil);
     this.epochProcessor =
-        new EpochProcessorGenesis(
+        new EpochProcessorPhase0(
             constants, validatorsUtil, this.beaconStateUtil, validatorStatusFactory);
     this.blockProcessorUtil =
-        new BlockProcessorGenesis(constants, beaconStateUtil, attestationUtil, validatorsUtil);
+        new BlockProcessorPhase0(constants, beaconStateUtil, attestationUtil, validatorsUtil);
     this.stateTransition =
         StateTransition.create(
             constants, blockProcessorUtil, epochProcessor, beaconStateUtil, validatorsUtil);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/EpochProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/EpochProcessorPhase0.java
@@ -11,21 +11,21 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.logic.versions.genesis.statetransition.epoch;
+package tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch;
 
 import tech.pegasys.teku.spec.constants.SpecConstants;
 import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis.MutableBeaconStateGenesis;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.MutableBeaconStatePhase0;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.AbstractEpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatusFactory;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 
-public class EpochProcessorGenesis extends AbstractEpochProcessor {
+public class EpochProcessorPhase0 extends AbstractEpochProcessor {
 
-  public EpochProcessorGenesis(
+  public EpochProcessorPhase0(
       final SpecConstants specConstants,
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
@@ -36,8 +36,7 @@ public class EpochProcessorGenesis extends AbstractEpochProcessor {
   @Override
   public void processParticipationUpdates(MutableBeaconState genericState) {
     // Rotate current/previous epoch attestations
-    final MutableBeaconStateGenesis state =
-        MutableBeaconStateGenesis.requireGenesisStateMutable(genericState);
+    final MutableBeaconStatePhase0 state = MutableBeaconStatePhase0.required(genericState);
     state.getPrevious_epoch_attestations().setAll(state.getCurrent_epoch_attestations());
     state
         .getCurrent_epoch_attestations()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/ValidatorStatusFactoryPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/ValidatorStatusFactoryPhase0.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.logic.versions.genesis.statetransition.epoch;
+package tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch;
 
 import java.util.List;
 import java.util.Optional;
@@ -20,7 +20,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis.BeaconStateGenesis;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStatePhase0;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.AbstractValidatorStatusFactory;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.InclusionInfo;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatus;
@@ -28,9 +28,9 @@ import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 
-public class ValidatorStatusFactoryGenesis extends AbstractValidatorStatusFactory {
+public class ValidatorStatusFactoryPhase0 extends AbstractValidatorStatusFactory {
 
-  public ValidatorStatusFactoryGenesis(
+  public ValidatorStatusFactoryPhase0(
       final BeaconStateUtil beaconStateUtil,
       final AttestationUtil attestationUtil,
       final ValidatorsUtil validatorsUtil) {
@@ -44,7 +44,7 @@ public class ValidatorStatusFactoryGenesis extends AbstractValidatorStatusFactor
       final UInt64 previousEpoch,
       final UInt64 currentEpoch) {
 
-    final BeaconStateGenesis state = BeaconStateGenesis.requireGenesisState(genericState);
+    final BeaconStatePhase0 state = BeaconStatePhase0.required(genericState);
 
     Stream.concat(
             state.getPrevious_epoch_attestations().stream(),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProcessorPhase0.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.logic.versions.genesis.util;
+package tech.pegasys.teku.spec.logic.versions.phase0.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -25,7 +25,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis.MutableBeaconStateGenesis;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.MutableBeaconStatePhase0;
 import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataStateTransitionValidator;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
@@ -35,10 +35,10 @@ import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 
-public final class BlockProcessorGenesis extends AbstractBlockProcessor {
+public final class BlockProcessorPhase0 extends AbstractBlockProcessor {
   private static final Logger LOG = LogManager.getLogger();
 
-  public BlockProcessorGenesis(
+  public BlockProcessorPhase0(
       final SpecConstants specConstants,
       final BeaconStateUtil beaconStateUtil,
       final AttestationUtil attestationUtil,
@@ -50,8 +50,7 @@ public final class BlockProcessorGenesis extends AbstractBlockProcessor {
   public void processAttestationsNoValidation(
       MutableBeaconState genericState, SSZList<Attestation> attestations)
       throws BlockProcessingException {
-    final MutableBeaconStateGenesis state =
-        MutableBeaconStateGenesis.requireGenesisStateMutable(genericState);
+    final MutableBeaconStatePhase0 state = MutableBeaconStatePhase0.required(genericState);
 
     try {
       final AttestationDataStateTransitionValidator validator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
@@ -15,17 +15,17 @@ package tech.pegasys.teku.spec.schemas;
 
 import tech.pegasys.teku.spec.constants.SpecConstants;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis.BeaconStateSchemaGenesis;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
 
-public class SchemaDefinitionsGenesis implements SchemaDefinitions {
+public class SchemaDefinitionsPhase0 implements SchemaDefinitions {
   private final SpecConstants specConstants;
 
-  public SchemaDefinitionsGenesis(final SpecConstants specConstants) {
+  public SchemaDefinitionsPhase0(final SpecConstants specConstants) {
     this.specConstants = specConstants;
   }
 
   @Override
   public BeaconStateSchema<?, ?> getBeaconStateSchema() {
-    return BeaconStateSchemaGenesis.create(specConstants);
+    return BeaconStateSchemaPhase0.create(specConstants);
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateInvariantsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateInvariantsTest.java
@@ -47,7 +47,7 @@ public class BeaconStateInvariantsTest {
 
   @Test
   public void extractSlot_zero() {
-    final BeaconState state = dataStructureUtil.stateBuilderGenesis().slot(UInt64.ZERO).build();
+    final BeaconState state = dataStructureUtil.stateBuilderPhase0().slot(UInt64.ZERO).build();
     final Bytes stateBytes = state.sszSerialize();
 
     final UInt64 result = BeaconStateInvariants.extractSlot(stateBytes);
@@ -56,8 +56,7 @@ public class BeaconStateInvariantsTest {
 
   @Test
   public void extractSlot_maxValue() {
-    final BeaconState state =
-        dataStructureUtil.stateBuilderGenesis().slot(UInt64.MAX_VALUE).build();
+    final BeaconState state = dataStructureUtil.stateBuilderPhase0().slot(UInt64.MAX_VALUE).build();
     final Bytes stateBytes = state.sszSerialize();
 
     final UInt64 result = BeaconStateInvariants.extractSlot(stateBytes);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0Test.java
@@ -11,23 +11,23 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis;
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0;
 
 import tech.pegasys.teku.spec.constants.SpecConstants;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconStateTest;
 
-public class BeaconStateGenesisTest
-    extends AbstractBeaconStateTest<BeaconStateGenesis, MutableBeaconStateGenesis> {
+public class BeaconStatePhase0Test
+    extends AbstractBeaconStateTest<BeaconStatePhase0, MutableBeaconStatePhase0> {
 
   @Override
-  protected BeaconStateSchema<BeaconStateGenesis, MutableBeaconStateGenesis> getSchema(
+  protected BeaconStateSchema<BeaconStatePhase0, MutableBeaconStatePhase0> getSchema(
       final SpecConstants specConstants) {
-    return BeaconStateSchemaGenesis.create(specConstants);
+    return BeaconStateSchemaPhase0.create(specConstants);
   }
 
   @Override
-  protected BeaconStateGenesis randomState() {
-    return dataStructureUtil.stateBuilderGenesis().build();
+  protected BeaconStatePhase0 randomState() {
+    return dataStructureUtil.stateBuilderPhase0().build();
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStateSchemaPhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStateSchemaPhase0Test.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis;
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,13 +23,13 @@ import tech.pegasys.teku.spec.constants.TestConstantsLoader;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconStateSchemaTest;
 
-public class BeaconStateSchemaGenesisTest
-    extends AbstractBeaconStateSchemaTest<BeaconStateGenesis, MutableBeaconStateGenesis> {
+public class BeaconStateSchemaPhase0Test
+    extends AbstractBeaconStateSchemaTest<BeaconStatePhase0, MutableBeaconStatePhase0> {
 
   @Override
-  protected BeaconStateSchema<BeaconStateGenesis, MutableBeaconStateGenesis> getSchema(
+  protected BeaconStateSchema<BeaconStatePhase0, MutableBeaconStatePhase0> getSchema(
       final SpecConstants specConstants) {
-    return BeaconStateSchemaGenesis.create(specConstants);
+    return BeaconStateSchemaPhase0.create(specConstants);
   }
 
   @Test
@@ -38,8 +38,8 @@ public class BeaconStateSchemaGenesisTest
     final SpecConstants modifiedConstants =
         TestConstantsLoader.loadConstantsBuilder("minimal").maxAttestations(123).build();
 
-    BeaconStateGenesis s1 = getSchema(modifiedConstants).createEmpty();
-    BeaconStateGenesis s2 = getSchema(standardSpec.getGenesisSpecConstants()).createEmpty();
+    BeaconStatePhase0 s1 = getSchema(modifiedConstants).createEmpty();
+    BeaconStatePhase0 s2 = getSchema(standardSpec.getGenesisSpecConstants()).createEmpty();
 
     assertThat(s1.getPrevious_epoch_attestations().getMaxSize())
         .isNotEqualTo(s2.getPrevious_epoch_attestations().getMaxSize());

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/ValidatorStatusFactoryPhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/ValidatorStatusFactoryPhase0Test.java
@@ -11,17 +11,17 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.logic.versions.genesis.statetransition.epoch;
+package tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch;
 
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.AbstractValidatorStatusFactory;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.AbstractValidatorStatusFactoryTest;
 
-class ValidatorStatusFactoryGenesisTest extends AbstractValidatorStatusFactoryTest {
+class ValidatorStatusFactoryPhase0Test extends AbstractValidatorStatusFactoryTest {
 
   @Override
   protected AbstractValidatorStatusFactory createFactory() {
     final SpecVersion genesisSpec = spec.getGenesisSpec();
-    return (ValidatorStatusFactoryGenesis) genesisSpec.getValidatorStatusFactory();
+    return (ValidatorStatusFactoryPhase0) genesisSpec.getValidatorStatusFactory();
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderPhase0.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderPhase0.java
@@ -17,19 +17,19 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis.BeaconStateGenesis;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis.BeaconStateSchemaGenesis;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis.MutableBeaconStateGenesis;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStatePhase0;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.MutableBeaconStatePhase0;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 
-public class BeaconStateBuilderGenesis
+public class BeaconStateBuilderPhase0
     extends AbstractBeaconStateBuilder<
-        BeaconStateGenesis, MutableBeaconStateGenesis, BeaconStateBuilderGenesis> {
+        BeaconStatePhase0, MutableBeaconStatePhase0, BeaconStateBuilderPhase0> {
 
   private SSZList<PendingAttestation> previousEpochAttestations;
   private SSZList<PendingAttestation> currentEpochAttestations;
 
-  private BeaconStateBuilderGenesis(
+  private BeaconStateBuilderPhase0(
       final Spec spec,
       final DataStructureUtil dataStructureUtil,
       final int defaultValidatorCount,
@@ -38,22 +38,22 @@ public class BeaconStateBuilderGenesis
   }
 
   @Override
-  protected BeaconStateGenesis getEmptyState() {
-    return BeaconStateSchemaGenesis.create(spec.getGenesisSpecConstants()).createEmpty();
+  protected BeaconStatePhase0 getEmptyState() {
+    return BeaconStateSchemaPhase0.create(spec.getGenesisSpecConstants()).createEmpty();
   }
 
   @Override
-  protected void setUniqueFields(final MutableBeaconStateGenesis state) {
+  protected void setUniqueFields(final MutableBeaconStatePhase0 state) {
     state.getPrevious_epoch_attestations().setAll(previousEpochAttestations);
     state.getCurrent_epoch_attestations().setAll(currentEpochAttestations);
   }
 
-  public static BeaconStateBuilderGenesis create(
+  public static BeaconStateBuilderPhase0 create(
       final DataStructureUtil dataStructureUtil,
       final Spec spec,
       final int defaultValidatorCount,
       final int defaultItemsInSSZLists) {
-    return new BeaconStateBuilderGenesis(
+    return new BeaconStateBuilderPhase0(
         spec, dataStructureUtil, defaultValidatorCount, defaultItemsInSSZLists);
   }
 
@@ -75,14 +75,14 @@ public class BeaconStateBuilderGenesis
             dataStructureUtil::randomPendingAttestation);
   }
 
-  public BeaconStateBuilderGenesis previousEpochAttestations(
+  public BeaconStateBuilderPhase0 previousEpochAttestations(
       final SSZList<PendingAttestation> previousEpochAttestations) {
     checkNotNull(previousEpochAttestations);
     this.previousEpochAttestations = previousEpochAttestations;
     return this;
   }
 
-  public BeaconStateBuilderGenesis currentEpochAttestations(
+  public BeaconStateBuilderPhase0 currentEpochAttestations(
       final SSZList<PendingAttestation> currentEpochAttestations) {
     checkNotNull(currentEpochAttestations);
     this.currentEpochAttestations = currentEpochAttestations;

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -628,16 +628,16 @@ public final class DataStructureUtil {
   }
 
   public BeaconState randomBeaconState(final int validatorCount, final int numItemsInSSZLists) {
-    return BeaconStateBuilderGenesis.create(this, spec, validatorCount, numItemsInSSZLists).build();
+    return BeaconStateBuilderPhase0.create(this, spec, validatorCount, numItemsInSSZLists).build();
   }
 
-  public BeaconStateBuilderGenesis stateBuilderGenesis() {
-    return BeaconStateBuilderGenesis.create(this, spec, 10, 10);
+  public BeaconStateBuilderPhase0 stateBuilderPhase0() {
+    return BeaconStateBuilderPhase0.create(this, spec, 10, 10);
   }
 
-  public BeaconStateBuilderGenesis stateBuilderGenesis(
+  public BeaconStateBuilderPhase0 stateBuilderPhase0(
       final int validatorCount, final int numItemsInSSZLists) {
-    return BeaconStateBuilderGenesis.create(this, spec, validatorCount, numItemsInSSZLists);
+    return BeaconStateBuilderPhase0.create(this, spec, validatorCount, numItemsInSSZLists);
   }
 
   public BeaconState randomBeaconState(UInt64 slot) {

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/ForkChoiceStrategyTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/ForkChoiceStrategyTest.java
@@ -120,7 +120,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     final UInt64 initialEpoch = UInt64.valueOf(100);
     final BeaconState anchorState =
         dataStructureUtil
-            .stateBuilderGenesis()
+            .stateBuilderPhase0()
             .setJustifiedCheckpointsToEpoch(initialEpoch.minus(2))
             .setFinalizedCheckpointToEpoch(initialEpoch.minus(3))
             .setSlotToStartOfEpoch(initialEpoch)

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -44,7 +44,7 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.genesis.BeaconStateGenesis;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStatePhase0;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 import tech.pegasys.teku.ssz.SSZTypes.SSZMutableList;
@@ -67,8 +67,8 @@ class BeaconChainMetricsTest {
       Bytes32.fromHexString("0x760aa80a2c5cc1452a5301ecb176b366372d5f2218e0c24eFFFFFFFFFFFFFF7F");
   private final Bytes32 root3 =
       Bytes32.fromHexString("0x760aa80a2c5cc1452a5301ecb176b366372d5f2218e0c24e0000000000000080");
-  private BeaconStateGenesis state =
-      dataStructureUtil.stateBuilderGenesis().slot(NODE_SLOT_VALUE).build();
+  private BeaconStatePhase0 state =
+      dataStructureUtil.stateBuilderPhase0().slot(NODE_SLOT_VALUE).build();
   private StateAndBlockSummary chainHead;
 
   private final NodeSlot nodeSlot = new NodeSlot(NODE_SLOT_VALUE);
@@ -107,7 +107,7 @@ class BeaconChainMetricsTest {
                   s.setPrevious_justified_checkpoint(previousJustifiedCheckpoint);
                   setBlockRoots(s, blockRootsList);
                 })
-            .toGenesisVersion()
+            .toVersionPhase0()
             .orElseThrow();
   }
 
@@ -118,7 +118,7 @@ class BeaconChainMetricsTest {
                 s -> {
                   setBlockRoots(s, newBlockRoots);
                 })
-            .toGenesisVersion()
+            .toVersionPhase0()
             .orElseThrow();
   }
 
@@ -481,7 +481,7 @@ class BeaconChainMetricsTest {
       final int slotAsInt, final List<PendingAttestation> attestations) {
     state =
         state
-            .updatedGenesis(
+            .updatedPhase0(
                 s -> {
                   final SSZMutableList<PendingAttestation> previousAtts =
                       s.getPrevious_epoch_attestations();
@@ -493,7 +493,7 @@ class BeaconChainMetricsTest {
                   s.getCurrent_epoch_attestations().clear();
                   s.setSlot(UInt64.valueOf(slotAsInt));
                 })
-            .toGenesisVersion()
+            .toVersionPhase0()
             .orElseThrow();
   }
 
@@ -503,7 +503,7 @@ class BeaconChainMetricsTest {
       final List<Validator> validatorsList) {
     state =
         state
-            .updatedGenesis(
+            .updatedPhase0(
                 s -> {
                   final SSZMutableList<PendingAttestation> currentAtts =
                       s.getCurrent_epoch_attestations();
@@ -523,7 +523,7 @@ class BeaconChainMetricsTest {
                     validators.setAll(SSZList.createMutable(validatorsList, 100, Validator.class));
                   }
                 })
-            .toGenesisVersion()
+            .toVersionPhase0()
             .orElseThrow();
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Rename "genesis" versions to "phase0".  The term "genesis" is a bit ambiguous - use "phase0" to refer to the spec version at the phase0 beacon chain launch. 

## Fixed Issue(s)
Part of #3658 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
