### PR TITLE
Fix EpochCachePrimer to calculate committees in MIN_LOOKAHEAD epochs, not MAX_LOOKAHEAD

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/EpochCachePrimer.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/EpochCachePrimer.java
@@ -75,7 +75,9 @@ public class EpochCachePrimer {
 
     // Calculate committees for max lookahead epoch
     // (assume earlier epochs were already requested)
-    final UInt64 lookaheadEpoch = spec.getMaxLookaheadEpoch(state);
+    final UInt64 stateEpoch = spec.getCurrentEpoch(state);
+    final UInt64 lookaheadEpoch =
+        stateEpoch.plus(spec.getSpecConstants(stateEpoch).getMinSeedLookahead());
     final UInt64 lookAheadEpochStartSlot = spec.computeStartSlotAtEpoch(lookaheadEpoch);
     final UInt64 committeeCount = spec.getCommitteeCountPerSlot(state, lookaheadEpoch);
     UInt64.range(lookAheadEpochStartSlot, spec.computeStartSlotAtEpoch(lookaheadEpoch.plus(1)))

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/EpochCachePrimer.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/EpochCachePrimer.java
@@ -73,7 +73,7 @@ public class EpochCachePrimer {
               beaconStateUtil.getAttestersTotalEffectiveBalance(state, slot);
             });
 
-    // Calculate committees for max lookahead epoch
+    // Calculate committees for furthest future epoch that can be calculated from this state
     // (assume earlier epochs were already requested)
     final UInt64 stateEpoch = spec.getCurrentEpoch(state);
     final UInt64 lookaheadEpoch =


### PR DESCRIPTION
## PR Description
Fix `java.lang.IllegalArgumentException: Committee information must be derived from a state no older than the previous epoch. State at slot 803296 is older than cutoff slot 803392` errors from `EpochCachePrimer`.  It should calculate committees for `MIN_SEED_LOOKAHEAD` epochs ahead, not `MAX_SEED_LOOKAHEAD` epochs.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
