### PR TITLE
Remove bintray repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,6 @@ allprojects {
     maven { url "https://artifacts.consensys.net/public/maven/maven/" }
     maven { url "https://dl.cloudsmith.io/public/libp2p/jvm-libp2p/maven/" }
     maven { url "https://hyperledger.jfrog.io/artifactory/besu-maven/" }
-    maven { url "https://consensys.bintray.com/pegasys-repo/" }
   }
 
   dependencies {


### PR DESCRIPTION
## PR Description
As all dependencies have no migrated off of bintray we can remove the bintray repo.

Tested by doing a build in a brand new docker image with no existing gradle caches.

## Fixed Issue(s)
fixes #3584 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
