### PR TITLE
Alternative version metrics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ For information on changes in released versions of Teku, see the [releases page]
   
 ### Additions and Improvements
 - Optimised fork choice to avoid unnecessary copying, reducing CPU and memory usage.
-- Added a labelled counter to metrics to display teku version, under `beacon_teku_version`. On startup the version being run will report as the label name, with a value of '1'.
+- Added a labelled counter to metrics to display teku version and release, under `beacon_teku_version`. On startup the version being run will report as the label 'version' and the full release as the label 'release', each with a value of '1'.
 
 ### Bug Fixes
 - Reduced verbosity of warning message when SIGHUP can't be intercepted (e.g. on Windows)

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
@@ -181,17 +181,16 @@ public class BeaconChainMetrics implements SlotEventsChannel {
             "previous_epoch_total_weight",
             "Total effective balance of all active validators in the previous epoch");
 
-    final String versionLabel =
-        VersionProvider.IMPLEMENTATION_VERSION
-            .replaceAll("[\\.\\+]", "_")
-            .replaceAll("[^0-9A-Za-z_]", "");
+    final String version =
+        VersionProvider.IMPLEMENTATION_VERSION.replaceAll("^v", "").replaceAll("\\+.*$", "");
     final LabelledMetric<Counter> versionCounter =
         metricsSystem.createLabelledCounter(
             TekuMetricCategory.BEACON,
             VersionProvider.CLIENT_IDENTITY + "_version",
             "Teku version in use",
-            versionLabel);
-    versionCounter.labels(versionLabel).inc();
+            "version",
+            "release");
+    versionCounter.labels(version, VersionProvider.IMPLEMENTATION_VERSION).inc();
   }
 
   @Override


### PR DESCRIPTION
## PR Description

This patch changes the version metrics supplied in beacon_teku_version in two ways.  Firstly, it provides both version and release labels using standard names 'version' and 'release' rather than using the variable release name as the label.  Secondly, it provides unmunged strings for the label values, making them easier to parse.


## Fixed Issue(s)

This provides an alternative solution to #3664 than that applied in #3717.  Using constant label names makes it much easier to obtain these values for inclusion in monitoring and alerting.  This also fits more closely with the format provided by other beacon chain clients.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
