### PR TITLE
Add check to ensure maven artefacts have unique names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ jobs:
       - run:
           name: Spotless
           command: |
-            ./gradlew --no-daemon --parallel spotlessCheck
+            ./gradlew --no-daemon --parallel spotlessCheck checkMavenCoordinateCollisions
 
   unitTests:
     parallelism: 2

--- a/build.gradle
+++ b/build.gradle
@@ -256,6 +256,25 @@ task cleanRefTests(dependsOn: [cleanRefTestsGeneral, cleanRefTestsMainnet, clean
 
 task deploy() {}
 
+task checkMavenCoordinateCollisions {
+  doLast {
+    def coordinates = [:]
+    getAllprojects().forEach {
+      if (it.properties.containsKey('publishing') && it.jar?.enabled) {
+        def coordinate = it.publishing?.publications[0].coordinates
+        if (coordinates.containsKey(coordinate)) {
+          throw new GradleException("Duplicate maven coordinates detected, ${coordinate} is used by " +
+              "both ${coordinates[coordinate]} and ${it.path}.\n" +
+              "Please add a `publishing` script block to one or both subprojects.")
+        }
+        coordinates[coordinate] = it.path
+      }
+    }
+  }
+}
+
+check.dependsOn('checkMavenCoordinateCollisions')
+
 application {
   applicationName = "teku"
   mainClassName = "tech.pegasys.teku.Teku"

--- a/storage/api/build.gradle
+++ b/storage/api/build.gradle
@@ -4,3 +4,9 @@ dependencies {
 
     implementation 'org.apache.tuweni:tuweni-bytes'
 }
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) { artifactId 'storage-api' }
+    }
+}

--- a/validator/api/build.gradle
+++ b/validator/api/build.gradle
@@ -9,3 +9,9 @@ dependencies {
 
   testImplementation testFixtures(project(':bls'))
 }
+
+publishing {
+  publications {
+    mavenJava(MavenPublication) { artifactId 'validator-api' }
+  }
+}


### PR DESCRIPTION
## PR Description
The `storage:api` and `validator:api` modules were both being published to maven as just `api`.  This would sometimes result in cloudsmith rejecting the uploads because of the duplicate artefacts.

Adds an explicit check that all maven artefacts have unique names and configures the `api` modules to use unique names.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
