### PR TITLE
Avoid warning that initial state will be ignored for prater testnet

### DIFF
--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -173,9 +173,15 @@ public class Eth2NetworkConfiguration {
       return this;
     }
 
-    public Builder initialState(final String initialState) {
+    public Builder customInitialState(final String initialState) {
       this.initialState = Optional.of(initialState);
       this.usingCustomInitialState = true;
+      return this;
+    }
+
+    public Builder defaultInitialState(final String initialState) {
+      this.initialState = Optional.of(initialState);
+      this.usingCustomInitialState = false;
       return this;
     }
 
@@ -305,7 +311,7 @@ public class Eth2NetworkConfiguration {
           .constants(PRATER.configName())
           .startupTimeoutSeconds(120)
           .eth1DepositContractDeployBlock(4367322)
-          .initialState(
+          .defaultInitialState(
               "https://github.com/eth2-clients/eth2-testnets/raw/192c1b48ea5ff4adb4e6ef7d2a9e5f82fb5ffd72/shared/prater/genesis.ssz")
           .discoveryBootnodes(
               // q9f Bootnodes

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -129,7 +129,7 @@ public class Eth2NetworkOptions {
       builder.eth1DepositContractAddress(eth1DepositContractAddress);
     }
     if (StringUtils.isNotBlank(initialState)) {
-      builder.initialState(initialState);
+      builder.customInitialState(initialState);
     }
     if (forkChoiceBalanceAttackMitigationEnabled != null) {
       builder.balanceAttackMitigationEnabled(forkChoiceBalanceAttackMitigationEnabled);


### PR DESCRIPTION
## PR Description
Avoid logging a warning on Prater that the initial state will be ignored.  It's the first network where the default doesn't come from the class path so the custom state flag got set incorrectly.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
