### PR TITLE
Add getSyncCommitteeIndex to BeaconStateAccessorsAltair

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ShuffleBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ShuffleBenchmark.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecConfiguration;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.util.CommitteeUtil;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.util.config.Constants;
 
 @Fork(3)
@@ -45,8 +46,7 @@ public class ShuffleBenchmark {
   private final SpecConfiguration specConfiguration =
       SpecConfiguration.builder().config(specConfig).build();
   private final Spec spec = Spec.create(specConfiguration);
-  private final tech.pegasys.teku.spec.logic.common.util.CommitteeUtil committeeUtil =
-      spec.atSlot(UInt64.ZERO).getCommitteeUtil();
+  private final MiscHelpers miscHelpers = spec.atSlot(UInt64.ZERO).miscHelpers();
 
   public ShuffleBenchmark() {
     Constants.setConstants("mainnet");
@@ -57,7 +57,7 @@ public class ShuffleBenchmark {
   @Measurement(iterations = 5)
   public void shuffledIndexBench(Blackhole bh) {
     for (int i = 0; i < indexCount; i++) {
-      int index = committeeUtil.computeShuffledIndex(i, indexCount, seed);
+      int index = miscHelpers.computeShuffledIndex(i, indexCount, seed);
       bh.consume(index);
     }
   }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/shuffling/ShufflingTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/shuffling/ShufflingTestExecutor.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableMap;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.reference.phase0.TestExecutor;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/shuffling/ShufflingTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/shuffling/ShufflingTestExecutor.java
@@ -24,7 +24,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.reference.phase0.TestExecutor;
-import tech.pegasys.teku.spec.logic.common.util.CommitteeUtil;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 
 public class ShufflingTestExecutor implements TestExecutor {
   public static final ImmutableMap<String, TestExecutor> SHUFFLING_TEST_TYPES =
@@ -34,14 +34,12 @@ public class ShufflingTestExecutor implements TestExecutor {
   public void runTest(final TestDefinition testDefinition) throws Exception {
     final ShufflingData shufflingData =
         loadYaml(testDefinition, "mapping.yaml", ShufflingData.class);
-    final CommitteeUtil committeeUtil =
-        testDefinition.getSpec().atSlot(UInt64.ZERO).getCommitteeUtil();
+    final MiscHelpers miscHelpers = testDefinition.getSpec().atSlot(UInt64.ZERO).miscHelpers();
     final Bytes32 seed = Bytes32.fromHexString(shufflingData.getSeed());
     IntStream.range(0, shufflingData.getCount())
         .forEach(
             index ->
-                assertThat(
-                        committeeUtil.computeShuffledIndex(index, shufflingData.getCount(), seed))
+                assertThat(miscHelpers.computeShuffledIndex(index, shufflingData.getCount(), seed))
                     .isEqualTo(shufflingData.getMapping(index)));
 
     final int[] inputs = IntStream.range(0, shufflingData.getCount()).toArray();

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/shuffling/ShufflingTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/shuffling/ShufflingTestExecutor.java
@@ -34,7 +34,7 @@ public class ShufflingTestExecutor implements TestExecutor {
   public void runTest(final TestDefinition testDefinition) throws Exception {
     final ShufflingData shufflingData =
         loadYaml(testDefinition, "mapping.yaml", ShufflingData.class);
-    final MiscHelpers miscHelpers = testDefinition.getSpec().atSlot(UInt64.ZERO).miscHelpers();
+    final MiscHelpers miscHelpers = testDefinition.getSpec().getGenesisSpec().miscHelpers();
     final Bytes32 seed = Bytes32.fromHexString(shufflingData.getSeed());
     IntStream.range(0, shufflingData.getCount())
         .forEach(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -13,6 +13,13 @@
 
 package tech.pegasys.teku.spec.logic.common.helpers;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.bytesToUInt64;
+import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uintToBytes;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 
@@ -26,5 +33,37 @@ public class MiscHelpers {
   public UInt64 computeEpochAtSlot(UInt64 slot) {
     // TODO this should take into account hard forks
     return slot.dividedBy(specConfig.getSlotsPerEpoch());
+  }
+
+  public int computeShuffledIndex(int index, int index_count, Bytes32 seed) {
+    checkArgument(index < index_count, "CommitteeUtil.computeShuffledIndex1");
+
+    int indexRet = index;
+    final int shuffleRoundCount = specConfig.getShuffleRoundCount();
+
+    for (int round = 0; round < shuffleRoundCount; round++) {
+
+      Bytes roundAsByte = Bytes.of((byte) round);
+
+      // This needs to be unsigned modulo.
+      int pivot =
+          bytesToUInt64(Hash.sha2_256(Bytes.wrap(seed, roundAsByte)).slice(0, 8))
+              .mod(index_count)
+              .intValue();
+      int flip = Math.floorMod(pivot + index_count - indexRet, index_count);
+      int position = Math.max(indexRet, flip);
+
+      Bytes positionDiv256 = uintToBytes(Math.floorDiv(position, 256), 4);
+      Bytes hashBytes = Hash.sha2_256(Bytes.wrap(seed, roundAsByte, positionDiv256));
+
+      int bitIndex = position & 0xff;
+      int theByte = hashBytes.get(bitIndex / 8);
+      int theBit = (theByte >> (bitIndex & 0x07)) & 1;
+      if (theBit != 0) {
+        indexRet = flip;
+      }
+    }
+
+    return indexRet;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -367,7 +367,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
     final int randaoIndex = nextEpoch.mod(specConfig.getEpochsPerHistoricalVector()).intValue();
     state
         .getRandao_mixes()
-        .setElement(randaoIndex, beaconStateUtil.getRandaoMix(state, currentEpoch));
+        .setElement(randaoIndex, beaconStateAccessors.getRandaoMix(state, currentEpoch));
 
     // Set historical root accumulator
     if (nextEpoch

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AbstractBlockProcessor.java
@@ -133,7 +133,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessorUtil {
       UInt64 epoch = beaconStateAccessors.getCurrentEpoch(state);
 
       Bytes32 mix =
-          beaconStateUtil
+          beaconStateAccessors
               .getRandaoMix(state, epoch)
               .xor(Hash.sha2_256(body.getRandao_reveal().toSSZBytes()));
       int index = epoch.mod(specConfig.getEpochsPerHistoricalVector()).intValue();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
@@ -137,21 +137,6 @@ public class BeaconStateUtil {
     return epoch.times(specConfig.getSlotsPerEpoch());
   }
 
-  public Bytes32 getSeed(BeaconState state, UInt64 epoch, Bytes4 domain_type)
-      throws IllegalArgumentException {
-    UInt64 randaoIndex =
-        epoch.plus(
-            specConfig.getEpochsPerHistoricalVector() - specConfig.getMinSeedLookahead() - 1);
-    Bytes32 mix = getRandaoMix(state, randaoIndex);
-    Bytes epochBytes = uintToBytes(epoch.longValue(), 8);
-    return Hash.sha2_256(Bytes.concatenate(domain_type.getWrappedBytes(), epochBytes, mix));
-  }
-
-  public Bytes32 getRandaoMix(BeaconState state, UInt64 epoch) {
-    int index = epoch.mod(specConfig.getEpochsPerHistoricalVector()).intValue();
-    return state.getRandao_mixes().getElement(index);
-  }
-
   public int getBeaconProposerIndex(BeaconState state) {
     return getBeaconProposerIndex(state, state.getSlot());
   }
@@ -167,7 +152,8 @@ public class BeaconStateUtil {
               Bytes32 seed =
                   Hash.sha2_256(
                       Bytes.concatenate(
-                          getSeed(state, epoch, specConfig.getDomainBeaconProposer()),
+                          beaconStateAccessors.getSeed(
+                              state, epoch, specConfig.getDomainBeaconProposer()),
                           uintToBytes(slot.longValue(), 8)));
               List<Integer> indices = beaconStateAccessors.getActiveValidatorIndices(state, epoch);
               return committeeUtil.computeProposerIndex(state, indices, seed);
@@ -369,7 +355,7 @@ public class BeaconStateUtil {
               return committeeUtil.computeCommittee(
                   state,
                   beaconStateAccessors.getActiveValidatorIndices(state, epoch),
-                  getSeed(state, epoch, specConfig.getDomainBeaconAttester()),
+                  beaconStateAccessors.getSeed(state, epoch, specConfig.getDomainBeaconAttester()),
                   committeeIndex,
                   count);
             });

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -70,7 +70,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
         new BeaconStateAccessorsAltair(config, predicates, miscHelpers);
 
     // Util
-    final CommitteeUtil committeeUtil = new CommitteeUtil(config);
+    final CommitteeUtil committeeUtil = new CommitteeUtil(config, miscHelpers);
     final ValidatorsUtil validatorsUtil = new ValidatorsUtil();
     final BeaconStateUtil beaconStateUtil =
         new BeaconStateUtil(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
@@ -14,20 +14,32 @@
 package tech.pegasys.teku.spec.logic.versions.altair.helpers;
 
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.integerSquareRoot;
+import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uintToBytes32;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.ssz.SszList;
 
 public class BeaconStateAccessorsAltair extends BeaconStateAccessors {
+
+  private static final int MAX_RANDOM_BYTE = 255; // 2**8 - 1
+  private final SpecConfigAltair altairConfig;
 
   public BeaconStateAccessorsAltair(
       final SpecConfigAltair config,
       final Predicates predicates,
       final MiscHelpersAltair miscHelpers) {
     super(config, predicates, miscHelpers);
+    this.altairConfig = config;
   }
 
   public UInt64 getBaseRewardPerIncrement(final BeaconState state) {
@@ -45,5 +57,44 @@ public class BeaconStateAccessorsAltair extends BeaconStateAccessors {
             .getEffective_balance()
             .dividedBy(config.getEffectiveBalanceIncrement());
     return increments.times(getBaseRewardPerIncrement(state));
+  }
+
+  /**
+   * Return the sequence of sync committee indices (which may include uplicate indices) for a given
+   * state and epoch.
+   *
+   * @param state the state to calculate committees from
+   * @param epoch the epoch to calcualte committees for
+   * @return the sequence of sync committee indices
+   */
+  public List<Integer> getSyncCommitteeIndices(final BeaconState state, final UInt64 epoch) {
+    final int epochsPerSyncCommitteePeriod = altairConfig.getEpochsPerSyncCommitteePeriod();
+    final UInt64 baseEpoch =
+        epoch
+            .dividedBy(epochsPerSyncCommitteePeriod)
+            .minusMinZero(1)
+            .times(epochsPerSyncCommitteePeriod);
+    final List<Integer> activeValidatorIndices = getActiveValidatorIndices(state, baseEpoch);
+    final int activeValidatorCount = activeValidatorIndices.size();
+    final Bytes32 seed = getSeed(state, baseEpoch, altairConfig.getDomainSyncCommittee());
+    int i = 0;
+    final SszList<Validator> validators = state.getValidators();
+    final List<Integer> syncCommitteeIndices = new ArrayList<>();
+    while (syncCommitteeIndices.size() < altairConfig.getSyncCommitteeSize()) {
+      final int shuffledIndex =
+          miscHelpers.computeShuffledIndex(i % activeValidatorCount, activeValidatorCount, seed);
+      final Integer candidateIndex = activeValidatorIndices.get(shuffledIndex);
+      final int randomByte = Hash.sha2_256(Bytes.wrap(seed, uintToBytes32(i / 32))).get(i % 32);
+      final UInt64 effectiveBalance = validators.get(candidateIndex).getEffective_balance();
+      // Sample with replacement
+      if (effectiveBalance
+          .times(MAX_RANDOM_BYTE)
+          .isGreaterThanOrEqualTo(config.getMaxEffectiveBalance().times(randomByte))) {
+        syncCommitteeIndices.add(candidateIndex);
+      }
+      i++;
+    }
+
+    return syncCommitteeIndices;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -71,7 +71,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
         new BeaconStateAccessors(config, predicates, miscHelpers);
 
     // Util
-    final CommitteeUtil committeeUtil = new CommitteeUtil(config);
+    final CommitteeUtil committeeUtil = new CommitteeUtil(config, miscHelpers);
     final ValidatorsUtil validatorsUtil = new ValidatorsUtil();
     final BeaconStateUtil beaconStateUtil =
         new BeaconStateUtil(

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpersTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpersTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.config.SpecConfig;
+
+class MiscHelpersTest {
+  private final SpecConfig specConfig = mock(SpecConfig.class);
+  private final MiscHelpers miscHelpers = new MiscHelpers(specConfig);
+
+  @Test
+  void computeShuffledIndex_boundaryTest() {
+    assertThatThrownBy(() -> miscHelpers.computeShuffledIndex(2, 1, Bytes32.ZERO))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void computeShuffledIndex_samples() {
+    when(specConfig.getShuffleRoundCount()).thenReturn(90);
+    assertThat(miscHelpers.computeShuffledIndex(320, 2048, Bytes32.ZERO)).isEqualTo(0);
+    assertThat(miscHelpers.computeShuffledIndex(1291, 2048, Bytes32.ZERO)).isEqualTo(1);
+    assertThat(miscHelpers.computeShuffledIndex(933, 2048, Bytes32.ZERO)).isEqualTo(2047);
+  }
+
+  @Test
+  void computeShuffledIndex_testListShuffleAndShuffledIndexCompatibility() {
+    when(specConfig.getShuffleRoundCount()).thenReturn(10);
+    Bytes32 seed = Bytes32.ZERO;
+    int index_count = 3333;
+    int[] indexes = IntStream.range(0, index_count).toArray();
+
+    tech.pegasys.teku.spec.datastructures.util.CommitteeUtil.shuffle_list(indexes, seed);
+    assertThat(indexes)
+        .isEqualTo(
+            IntStream.range(0, index_count)
+                .map(i -> miscHelpers.computeShuffledIndex(i, indexes.length, seed))
+                .toArray());
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/CommitteeUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/CommitteeUtilTest.java
@@ -14,11 +14,9 @@
 package tech.pegasys.teku.spec.logic.common.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.Bytes48;
@@ -34,7 +32,7 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 public class CommitteeUtilTest {
   final SpecConfig specConfig = mock(SpecConfig.class);
   private final Spec spec = SpecFactory.createMinimal();
-  CommitteeUtil committeeUtil = new CommitteeUtil(specConfig);
+  CommitteeUtil committeeUtil = new CommitteeUtil(specConfig, spec.getGenesisSpec().miscHelpers());
 
   @Test
   void aggregatorModulo_boundaryTest() {
@@ -59,35 +57,6 @@ public class CommitteeUtilTest {
     assertThat(committeeUtil.getAggregatorModulo(300)).isEqualTo(3);
     assertThat(committeeUtil.getAggregatorModulo(1000)).isEqualTo(10);
     assertThat(committeeUtil.getAggregatorModulo(100000)).isEqualTo(1000);
-  }
-
-  @Test
-  void computeShuffledIndex_boundaryTest() {
-    assertThatThrownBy(() -> committeeUtil.computeShuffledIndex(2, 1, Bytes32.ZERO))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  void computeShuffledIndex_samples() {
-    when(specConfig.getShuffleRoundCount()).thenReturn(90);
-    assertThat(committeeUtil.computeShuffledIndex(320, 2048, Bytes32.ZERO)).isEqualTo(0);
-    assertThat(committeeUtil.computeShuffledIndex(1291, 2048, Bytes32.ZERO)).isEqualTo(1);
-    assertThat(committeeUtil.computeShuffledIndex(933, 2048, Bytes32.ZERO)).isEqualTo(2047);
-  }
-
-  @Test
-  void computeShuffledIndex_testListShuffleAndShuffledIndexCompatibility() {
-    when(specConfig.getShuffleRoundCount()).thenReturn(10);
-    Bytes32 seed = Bytes32.ZERO;
-    int index_count = 3333;
-    int[] indexes = IntStream.range(0, index_count).toArray();
-
-    tech.pegasys.teku.spec.datastructures.util.CommitteeUtil.shuffle_list(indexes, seed);
-    assertThat(indexes)
-        .isEqualTo(
-            IntStream.range(0, index_count)
-                .map(i -> committeeUtil.computeShuffledIndex(i, indexes.length, seed))
-                .toArray());
   }
 
   @Test

--- a/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
+++ b/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
@@ -233,7 +233,7 @@ public class FuzzUtil {
       // no risk of inconsistency for this particular fuzzing as we only count <= 100
       // inconsistencies would require a validator count > MAX_INT32
       result_bb.putLong(
-          spec.atSlot(UInt64.ZERO).getCommitteeUtil().computeShuffledIndex(i, count, seed));
+          spec.atSlot(UInt64.ZERO).miscHelpers().computeShuffledIndex(i, count, seed));
     }
     return Optional.of(result_bb.array());
   }


### PR DESCRIPTION
## PR Description
Add the new `getSyncCommitteeIndex` function to `BeaconStateAccessorsAltair`.  Move a few existing methods out of utils to `MiscHelpers` so they're accessible and match their actual location in the spec.

## Fixed Issue(s)
#3648 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
