### PR TITLE
Add isInfinity() method to BLSSignature

### DIFF
--- a/bls/src/main/java/tech/pegasys/teku/bls/BLSPublicKey.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/BLSPublicKey.java
@@ -15,10 +15,10 @@ package tech.pegasys.teku.bls;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes48;
@@ -27,8 +27,6 @@ import tech.pegasys.teku.bls.impl.PublicKey;
 
 public final class BLSPublicKey {
 
-  // The number of SimpleSerialize basic types in this SSZ Container/POJO.
-  public static final int SSZ_FIELD_COUNT = 1;
   public static final int SSZ_BLS_PUBKEY_SIZE = BLSConstants.BLS_PUBKEY_SIZE;
 
   /**
@@ -129,10 +127,7 @@ public final class BLSPublicKey {
    * @return the serialization of the compressed form of the signature.
    */
   public Bytes toSSZBytes() {
-    return SSZ.encode(
-        writer -> {
-          writer.writeFixedBytes(toBytesCompressed());
-        });
+    return SSZ.encode(writer -> writer.writeFixedBytes(toBytesCompressed()));
   }
 
   public Bytes48 toBytesCompressed() {

--- a/bls/src/main/java/tech/pegasys/teku/bls/BLSSignature.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/BLSSignature.java
@@ -16,11 +16,12 @@ package tech.pegasys.teku.bls;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.isNull;
 
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import java.util.Objects;
+import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.ssz.SSZ;
+import tech.pegasys.teku.bls.impl.DeserializeException;
 import tech.pegasys.teku.bls.impl.Signature;
 
 public class BLSSignature {
@@ -108,6 +109,14 @@ public class BLSSignature {
 
   Signature getSignature() {
     return signature.get();
+  }
+
+  public boolean isInfinity() {
+    try {
+      return getSignature().isInfinity();
+    } catch (final DeserializeException e) {
+      return false;
+    }
   }
 
   @Override

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/Signature.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/Signature.java
@@ -71,6 +71,13 @@ public interface Signature {
    */
   boolean verify(PublicKey publicKey, Bytes message, Bytes dst);
 
+  /**
+   * Determine if this Signature is the `G2_POINT_AT_INFINITY`.
+   *
+   * @return true if this signature is the point at infinity, otherwise false.
+   */
+  boolean isInfinity();
+
   /** Implementation must override */
   @Override
   int hashCode();

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstSignature.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstSignature.java
@@ -196,7 +196,8 @@ public class BlstSignature implements Signature {
   }
 
   @SuppressWarnings("ReferenceEquality")
-  boolean isInfinity() {
+  @Override
+  public boolean isInfinity() {
     return this == INFINITY;
   }
 

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/G2Point.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/G2Point.java
@@ -223,6 +223,10 @@ public final class G2Point implements Group<G2Point> {
     return point;
   }
 
+  public boolean isInfinity() {
+    return point.is_infinity();
+  }
+
   @Override
   public String toString() {
     return point.toString();

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/MikuliSignature.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/mikuli/MikuliSignature.java
@@ -117,6 +117,11 @@ public class MikuliSignature implements Signature {
     return verify(MikuliPublicKey.fromPublicKey(publicKey), hashInGroup2);
   }
 
+  @Override
+  public boolean isInfinity() {
+    return point.isInfinity();
+  }
+
   /**
    * Verify that this signature is correct for the given public key and G2Point.
    *

--- a/bls/src/test/java/tech/pegasys/teku/bls/BLSSignatureTest.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/BLSSignatureTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.bls;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -126,5 +127,30 @@ abstract class BLSSignatureTest {
     final BLSSignature signature2 =
         BLSSignature.fromBytesCompressed(Bytes.fromHexString("22".repeat(96)));
     assertNotEquals(signature1, signature2);
+  }
+
+  @Test
+  void succeedsWhenInfiniteSignatureIsInfinite() {
+    final BLSSignature signature =
+        BLSSignature.fromBytesCompressed(
+            Bytes.fromHexString(
+                "0x"
+                    + "c000000000000000000000000000000000000000000000000000000000000000"
+                    + "0000000000000000000000000000000000000000000000000000000000000000"
+                    + "0000000000000000000000000000000000000000000000000000000000000000"));
+    assertThat(signature.isInfinity()).isTrue();
+  }
+
+  @Test
+  void succeedsWhenNonInfiniteSignatureIsNotInfinite() {
+    BLSSignature signature = BLSTestUtil.randomSignature(513);
+    assertThat(signature.isInfinity()).isFalse();
+  }
+
+  @Test
+  void succeedsWhenInvalidSignatureIsNotInfinite() {
+    final BLSSignature signature =
+        BLSSignature.fromBytesCompressed(Bytes.fromHexString("11".repeat(96)));
+    assertThat(signature.isInfinity()).isFalse();
   }
 }


### PR DESCRIPTION
## PR Description
Adds `isInfinite()` method to `BLSSignature` since the infinite signature is used in Altair when there are no sync committee members that signed (ie it indicates the absence of a signature).

Also fixed a few warnings by switching from Guava `Supplier` to the JDK `Supplier`. Interfaces are equivalent so may as well use the JDK version.

## Fixed Issue(s)
#3648 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
