### PR TITLE
Weak subjectivity failure will now report to console

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
@@ -22,6 +22,7 @@ import javax.annotation.CheckReturnValue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.logging.LogFormatter;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -79,6 +80,7 @@ public class BlockImporter {
     }
 
     if (!weakSubjectivityValidator.isBlockValid(block, getForkChoiceStrategy())) {
+      EventLogger.EVENT_LOG.weakSubjectivityFailedEvent(block.getRoot(), block.getSlot());
       return SafeFuture.completedFuture(BlockImportResult.FAILED_WEAK_SUBJECTIVITY_CHECKS);
     }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -88,7 +88,7 @@ public class EventLogger {
         String.format(
             "Sync Event  *** Weak subjectivity check failed block: %s, slot: %s",
             LogFormatter.formatHashRoot(blockRoot), slot.toString());
-    info(weakSubjectivityFailedEventLog, Color.RED);
+    warn(weakSubjectivityFailedEventLog, Color.RED);
   }
 
   public void slotEvent(
@@ -117,5 +117,9 @@ public class EventLogger {
 
   private void info(final String message, final Color color) {
     log.info(print(message, color));
+  }
+
+  private void warn(final String message, final Color color) {
+    log.warn(print(message, color));
   }
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -83,6 +83,14 @@ public class EventLogger {
     info(syncEventLog, Color.WHITE);
   }
 
+  public void weakSubjectivityFailedEvent(final Bytes32 blockRoot, final UInt64 slot) {
+    final String weakSubjectivityFailedEventLog =
+        String.format(
+            "Sync Event  *** Weak subjectivity check failed block: %s, slot: %s",
+            LogFormatter.formatHashRoot(blockRoot), slot.toString());
+    info(weakSubjectivityFailedEventLog, Color.RED);
+  }
+
   public void slotEvent(
       final UInt64 nodeSlot,
       final UInt64 headSlot,


### PR DESCRIPTION
Previously weak subjectivity failures would report to file, but not console and it was difficult to see that sync was having trouble matching because of weak subjectivity.

fixes #3753

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
