### PR TITLE
Implement getSyncCommittee method

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -426,7 +426,7 @@ public class Spec {
 
   public Optional<BLSPublicKey> getValidatorPubKey(
       final BeaconState state, final UInt64 proposerIndex) {
-    return atState(state).getValidatorsUtil().getValidatorPubKey(state, proposerIndex);
+    return atState(state).beaconStateAccessors().getValidatorPubKey(state, proposerIndex);
   }
 
   public Optional<Integer> getValidatorIndex(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/SyncCommittee.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/SyncCommittee.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.state;
 
+import java.util.List;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKeySchema;
@@ -46,6 +47,13 @@ public class SyncCommittee
     @Override
     public SyncCommittee createFromBackingNode(TreeNode node) {
       return new SyncCommittee(this, node);
+    }
+
+    public SyncCommittee create(
+        final List<SszPublicKey> pubkeys, final List<SszPublicKey> pubkeyAggregates) {
+      return create(
+          getPubkeysSchema().createFromElements(pubkeys),
+          getPubkeyAggregatesSchema().createFromElements(pubkeyAggregates));
     }
 
     public SyncCommittee create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Validator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Validator.java
@@ -132,8 +132,12 @@ public class Validator
     return getField0().getBytes();
   }
 
+  public SszPublicKey getSszPublicKey() {
+    return getField0();
+  }
+
   public BLSPublicKey getPublicKey() {
-    return getField0().getBLSPublicKey();
+    return getSszPublicKey().getBLSPublicKey();
   }
 
   public Bytes32 getWithdrawal_credentials() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Validator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Validator.java
@@ -132,12 +132,8 @@ public class Validator
     return getField0().getBytes();
   }
 
-  public SszPublicKey getSszPublicKey() {
-    return getField0();
-  }
-
   public BLSPublicKey getPublicKey() {
-    return getSszPublicKey().getBLSPublicKey();
+    return getField0().getBLSPublicKey();
   }
 
   public Bytes32 getWithdrawal_credentials() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/StateTransition.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/StateTransition.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BlockValidationResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BlockValidator;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
@@ -34,7 +35,6 @@ import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProces
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProcessorUtil;
-import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 
 public class StateTransition {
 
@@ -62,9 +62,10 @@ public class StateTransition {
       final BlockProcessorUtil blockProcessorUtil,
       final EpochProcessor epochProcessor,
       final BeaconStateUtil beaconStateUtil,
-      final ValidatorsUtil validatorsUtil) {
+      final BeaconStateAccessors beaconStateAccessors) {
     final BlockValidator blockValidator =
-        BlockValidator.standard(specConfig, beaconStateUtil, blockProcessorUtil, validatorsUtil);
+        BlockValidator.standard(
+            specConfig, beaconStateUtil, blockProcessorUtil, beaconStateAccessors);
     return new StateTransition(specConfig, blockProcessorUtil, epochProcessor, blockValidator);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BatchBlockValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BatchBlockValidator.java
@@ -17,9 +17,9 @@ import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProcessorUtil;
-import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 
 /**
  * Advanced block validator which uses {@link BatchSignatureVerifier} to verify all the BLS
@@ -29,20 +29,21 @@ class BatchBlockValidator implements BlockValidator {
   private final SpecConfig specConfig;
   private final BeaconStateUtil beaconStateUtil;
   private final BlockProcessorUtil blockProcessorUtil;
-  private final ValidatorsUtil validatorsUtil;
+  private final BeaconStateAccessors beaconStateAccessors;
   private final BlockValidator simpleValidator;
 
   BatchBlockValidator(
       final SpecConfig specConfig,
       final BeaconStateUtil beaconStateUtil,
       final BlockProcessorUtil blockProcessorUtil,
-      final ValidatorsUtil validatorsUtil) {
+      final BeaconStateAccessors beaconStateAccessors) {
     this.specConfig = specConfig;
     this.beaconStateUtil = beaconStateUtil;
     this.blockProcessorUtil = blockProcessorUtil;
-    this.validatorsUtil = validatorsUtil;
+    this.beaconStateAccessors = beaconStateAccessors;
     this.simpleValidator =
-        new SimpleBlockValidator(specConfig, beaconStateUtil, blockProcessorUtil, validatorsUtil);
+        new SimpleBlockValidator(
+            specConfig, beaconStateUtil, blockProcessorUtil, beaconStateAccessors);
   }
 
   @Override
@@ -53,7 +54,11 @@ class BatchBlockValidator implements BlockValidator {
     BatchSignatureVerifier signatureVerifier = new BatchSignatureVerifier();
     SimpleBlockValidator blockValidator =
         new SimpleBlockValidator(
-            specConfig, beaconStateUtil, blockProcessorUtil, validatorsUtil, signatureVerifier);
+            specConfig,
+            beaconStateUtil,
+            blockProcessorUtil,
+            beaconStateAccessors,
+            signatureVerifier);
     BlockValidationResult noBLSValidationResult =
         blockValidator.validatePreState(preState, block, indexedAttestationCache);
     // during the above validatePreState() call BatchSignatureVerifier just collected

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BlockValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BlockValidator.java
@@ -17,9 +17,9 @@ import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProcessorUtil;
-import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 
 /**
  * Dedicated class which performs block validation (apart from {@link BlockProcessorUtil} The
@@ -35,8 +35,9 @@ public interface BlockValidator {
       final SpecConfig specConfig,
       final BeaconStateUtil beaconStateUtil,
       final BlockProcessorUtil blockProcessorUtil,
-      final ValidatorsUtil validatorsUtil) {
-    return new BatchBlockValidator(specConfig, beaconStateUtil, blockProcessorUtil, validatorsUtil);
+      final BeaconStateAccessors beaconStateAccessors) {
+    return new BatchBlockValidator(
+        specConfig, beaconStateUtil, blockProcessorUtil, beaconStateAccessors);
   }
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/SimpleBlockValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/SimpleBlockValidator.java
@@ -24,11 +24,11 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProcessorUtil;
-import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 
 /**
  * Base logic of a block validation
@@ -41,19 +41,19 @@ class SimpleBlockValidator implements BlockValidator {
   private final SpecConfig specConfig;
   private final BeaconStateUtil beaconStateUtil;
   private final BlockProcessorUtil blockProcessorUtil;
-  private final ValidatorsUtil validatorsUtil;
+  private final BeaconStateAccessors beaconStateAccessors;
   private final BLSSignatureVerifier signatureVerifier;
 
   SimpleBlockValidator(
       final SpecConfig specConfig,
       final BeaconStateUtil beaconStateUtil,
       final BlockProcessorUtil blockProcessorUtil,
-      final ValidatorsUtil validatorsUtil,
+      final BeaconStateAccessors beaconStateAccessors,
       final BLSSignatureVerifier signatureVerifier) {
     this.specConfig = specConfig;
     this.beaconStateUtil = beaconStateUtil;
     this.blockProcessorUtil = blockProcessorUtil;
-    this.validatorsUtil = validatorsUtil;
+    this.beaconStateAccessors = beaconStateAccessors;
     this.signatureVerifier = signatureVerifier;
   }
 
@@ -61,12 +61,12 @@ class SimpleBlockValidator implements BlockValidator {
       final SpecConfig specConfig,
       final BeaconStateUtil beaconStateUtil,
       final BlockProcessorUtil blockProcessorUtil,
-      final ValidatorsUtil validatorsUtil) {
+      final BeaconStateAccessors beaconStateAccessors) {
     this(
         specConfig,
         beaconStateUtil,
         blockProcessorUtil,
-        validatorsUtil,
+        beaconStateAccessors,
         BLSSignatureVerifier.SIMPLE);
   }
 
@@ -120,7 +120,7 @@ class SimpleBlockValidator implements BlockValidator {
       throws BlockProcessingException {
     final int proposerIndex = beaconStateUtil.getBeaconProposerIndex(state, signed_block.getSlot());
     final BLSPublicKey proposerPublicKey =
-        validatorsUtil
+        beaconStateAccessors
             .getValidatorPubKey(state, UInt64.valueOf(proposerIndex))
             .orElseThrow(
                 () ->

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AbstractBlockProcessor.java
@@ -150,7 +150,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessorUtil {
     UInt64 epoch = miscHelpers.computeEpochAtSlot(block.getSlot());
     // Verify RANDAO reveal
     final BLSPublicKey proposerPublicKey =
-        validatorsUtil.getValidatorPubKey(state, block.getProposerIndex()).orElseThrow();
+        beaconStateAccessors.getValidatorPubKey(state, block.getProposerIndex()).orElseThrow();
     final Bytes32 domain = beaconStateUtil.getDomain(state, specConfig.getDomainRandao());
     final Bytes signing_root = beaconStateUtil.computeSigningRoot(epoch, domain);
     bls.verifyAndThrow(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.ssz.collections.SszBitlist;
 import tech.pegasys.teku.ssz.collections.SszUInt64List;
@@ -47,17 +48,17 @@ public class AttestationUtil {
 
   private final SpecConfig specConfig;
   private final BeaconStateUtil beaconStateUtil;
-  private final ValidatorsUtil validatorsUtil;
+  private final BeaconStateAccessors beaconStateAccessors;
   private final MiscHelpers miscHelpers;
 
   public AttestationUtil(
       final SpecConfig specConfig,
       final BeaconStateUtil beaconStateUtil,
-      final ValidatorsUtil validatorsUtil,
+      final BeaconStateAccessors beaconStateAccessors,
       final MiscHelpers miscHelpers) {
     this.specConfig = specConfig;
     this.beaconStateUtil = beaconStateUtil;
-    this.validatorsUtil = validatorsUtil;
+    this.beaconStateAccessors = beaconStateAccessors;
     this.miscHelpers = miscHelpers;
   }
 
@@ -178,7 +179,7 @@ public class AttestationUtil {
     List<BLSPublicKey> pubkeys =
         indices
             .streamUnboxed()
-            .flatMap(i -> validatorsUtil.getValidatorPubKey(state, i).stream())
+            .flatMap(i -> beaconStateAccessors.getValidatorPubKey(state, i).stream())
             .collect(toList());
     if (pubkeys.size() < indices.size()) {
       return AttestationProcessingResult.invalid(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
@@ -507,7 +507,8 @@ public class BeaconStateUtil {
       SszList<Validator> validators = state.getValidators();
 
       Function<Integer, BLSPublicKey> validatorPubkey =
-          index -> validatorsUtil.getValidatorPubKey(state, UInt64.valueOf(index)).orElse(null);
+          index ->
+              beaconStateAccessors.getValidatorPubKey(state, UInt64.valueOf(index)).orElse(null);
 
       existingIndex =
           IntStream.range(0, validators.size())

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
@@ -39,27 +39,6 @@ public class ValidatorsUtil {
         && validator.getActivation_epoch().equals(SpecConfig.FAR_FUTURE_EPOCH);
   }
 
-  public Optional<BLSPublicKey> getValidatorPubKey(BeaconState state, UInt64 validatorIndex) {
-    if (state.getValidators().size() <= validatorIndex.longValue()
-        || validatorIndex.longValue() < 0) {
-      return Optional.empty();
-    }
-    return Optional.of(
-        BeaconStateCache.getTransitionCaches(state)
-            .getValidatorsPubKeys()
-            .get(
-                validatorIndex,
-                i -> {
-                  BLSPublicKey pubKey = state.getValidators().get(i.intValue()).getPublicKey();
-
-                  // eagerly pre-cache pubKey => validatorIndex mapping
-                  BeaconStateCache.getTransitionCaches(state)
-                      .getValidatorIndexCache()
-                      .invalidateWithNewValue(pubKey, i.intValue());
-                  return pubKey;
-                }));
-  }
-
   @SuppressWarnings("DoNotReturnNullOptionals")
   public Optional<Integer> getValidatorIndex(BeaconState state, BLSPublicKey publicKey) {
     return BeaconStateCache.getTransitionCaches(state)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -82,7 +82,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
             miscHelpers,
             beaconStateAccessors);
     final AttestationUtil attestationUtil =
-        new AttestationUtil(config, beaconStateUtil, validatorsUtil, miscHelpers);
+        new AttestationUtil(config, beaconStateUtil, beaconStateAccessors, miscHelpers);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(
             beaconStateUtil, attestationUtil, beaconStateAccessors, predicates);
@@ -99,7 +99,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
             miscHelpers);
     final StateTransition stateTransition =
         StateTransition.create(
-            config, blockProcessorUtil, epochProcessor, beaconStateUtil, validatorsUtil);
+            config, blockProcessorUtil, epochProcessor, beaconStateUtil, beaconStateAccessors);
     final ForkChoiceUtil forkChoiceUtil =
         new ForkChoiceUtil(config, beaconStateUtil, attestationUtil, stateTransition, miscHelpers);
     final BlockProposalUtil blockProposalUtil =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
@@ -16,15 +16,21 @@ package tech.pegasys.teku.spec.logic.versions.altair.helpers;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.integerSquareRoot;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uintToBytes32;
 
+import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.Hash;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
+import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateSchemaAltair;
+import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.ssz.SszList;
@@ -96,5 +102,46 @@ public class BeaconStateAccessorsAltair extends BeaconStateAccessors {
     }
 
     return syncCommitteeIndices;
+  }
+
+  /**
+   * Return the sync comittee for a given state and epoch.
+   *
+   * @param state the state to get the sync committee for
+   * @param epoch the epoch to get the sync committee for
+   * @return the SyncCommittee
+   */
+  public SyncCommittee getSyncCommittee(final BeaconState state, final UInt64 epoch) {
+    final SszList<Validator> validators = state.getValidators();
+    final List<Integer> indices = getSyncCommitteeIndices(state, epoch);
+    final List<SszPublicKey> pubkeys =
+        indices.stream()
+            .map(index -> validators.get(index).getSszPublicKey())
+            .collect(Collectors.toList());
+
+    final int syncSubcommitteeSize = altairConfig.getSyncSubcommitteeSize();
+    final List<SszPublicKey> pubkeyAggregates = new ArrayList<>();
+    Preconditions.checkState(
+        pubkeys.size() % syncSubcommitteeSize == 0,
+        "SYNC_COMMITTEE_SIZE must be a multiple of SYNC_SUBCOMMITTEE_SIZE");
+    for (int i = 0; i < indices.size(); i += syncSubcommitteeSize) {
+      // Get subcommittee keys from the cache since we need to aggregate them and this avoids
+      // parsing each key.
+      final List<Integer> subcommitteeIndices = indices.subList(i, i + syncSubcommitteeSize);
+      final List<BLSPublicKey> subcommitteePubkeys =
+          getValidatorPublicKeys(state, subcommitteeIndices);
+      pubkeyAggregates.add(new SszPublicKey(BLSPublicKey.aggregate(subcommitteePubkeys)));
+    }
+
+    return ((BeaconStateSchemaAltair) state.getSchema())
+        .getNextSyncCommitteeSchema()
+        .create(pubkeys, pubkeyAggregates);
+  }
+
+  private List<BLSPublicKey> getValidatorPublicKeys(
+      final BeaconState state, final List<Integer> subcommitteeIndices) {
+    return subcommitteeIndices.stream()
+        .map(index -> getValidatorPubKey(state, UInt64.valueOf(index)).orElseThrow())
+        .collect(Collectors.toList());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -83,7 +83,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
             miscHelpers,
             beaconStateAccessors);
     final AttestationUtil attestationUtil =
-        new AttestationUtil(config, beaconStateUtil, validatorsUtil, miscHelpers);
+        new AttestationUtil(config, beaconStateUtil, beaconStateAccessors, miscHelpers);
     final ValidatorStatusFactoryPhase0 validatorStatusFactory =
         new ValidatorStatusFactoryPhase0(
             beaconStateUtil, attestationUtil, beaconStateAccessors, predicates);
@@ -100,7 +100,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
             miscHelpers);
     final StateTransition stateTransition =
         StateTransition.create(
-            config, blockProcessorUtil, epochProcessor, beaconStateUtil, validatorsUtil);
+            config, blockProcessorUtil, epochProcessor, beaconStateUtil, beaconStateAccessors);
     final ForkChoiceUtil forkChoiceUtil =
         new ForkChoiceUtil(config, beaconStateUtil, attestationUtil, stateTransition, miscHelpers);
     final BlockProposalUtil blockProposalUtil =


### PR DESCRIPTION
## PR Description
Implements the `getSyncCommittee` method from Altair spec. https://github.com/ethereum/eth2.0-specs/blob/dev/specs/altair/beacon-chain.md#get_sync_committee

Moves getValidatorPubKey from ValidatorsUtil to BeaconStateAccessors since it's needed at the "helper" level instead of the "util" level and seems like it's just accessing beacon state.

## Fixed Issue(s)
#3648 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
