### PR TITLE
Set accept header when requesting initial state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - The events api `/eth/v1/events` - `block` event now returns the slot and root as detailed in the standard API specification, instead of the entire block.
 
 ### Additions and Improvements
+- When downloading the `--initial-state` from a URL, the `Accept: application/octet-stream` header is now set. This provides compatibility with the standard API `/eth/v1/debug/beacon/states/:state_id` endpoint.
 - `--ws-checkpoint` CLI now accepts a URL optionally, and will load the `ws_checkpoint` field from that URL.
 
 ### Bug Fixes

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/ChainDataLoader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/ChainDataLoader.java
@@ -22,7 +22,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 public class ChainDataLoader {
   public static BeaconState loadState(final Spec spec, final String source) throws IOException {
     return spec.deserializeBeaconState(
-        ResourceLoader.urlOrFile()
+        ResourceLoader.urlOrFile("application/octet-stream")
             .loadBytes(source)
             .orElseThrow(() -> new FileNotFoundException("Could not find " + source)));
   }

--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/resource/ResourceLoader.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/resource/ResourceLoader.java
@@ -30,12 +30,19 @@ public abstract class ResourceLoader {
   }
 
   public static ResourceLoader urlOrFile() {
-    return urlOrFile(__ -> true);
+    return urlOrFile(Optional.empty(), __ -> true);
   }
 
-  public static ResourceLoader urlOrFile(final Predicate<String> sourceFilter) {
+  public static ResourceLoader urlOrFile(final String acceptHeader) {
+    return urlOrFile(Optional.of(acceptHeader), __ -> true);
+  }
+
+  public static ResourceLoader urlOrFile(
+      final Optional<String> acceptHeader, final Predicate<String> sourceFilter) {
     return new FallbackResourceLoader(
-        sourceFilter, new URLResourceLoader(sourceFilter), new FileResourceLoader(sourceFilter));
+        sourceFilter,
+        new URLResourceLoader(acceptHeader, sourceFilter),
+        new FileResourceLoader(sourceFilter));
   }
 
   public static ResourceLoader classpathUrlOrFile(
@@ -45,7 +52,7 @@ public abstract class ResourceLoader {
     return new FallbackResourceLoader(
         sourceFilter,
         new ClasspathResourceLoader(referenceClass, availableResources, sourceFilter),
-        new URLResourceLoader(sourceFilter),
+        new URLResourceLoader(Optional.empty(), sourceFilter),
         new FileResourceLoader(sourceFilter));
   }
 

--- a/infrastructure/io/src/test/java/tech/pegasys/teku/infrastructure/io/resource/URLResourceLoaderTest.java
+++ b/infrastructure/io/src/test/java/tech/pegasys/teku/infrastructure/io/resource/URLResourceLoaderTest.java
@@ -16,10 +16,11 @@ package tech.pegasys.teku.infrastructure.io.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URL;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class URLResourceLoaderTest {
-  private final ResourceLoader loader = new URLResourceLoader(__ -> true);
+  private final ResourceLoader loader = new URLResourceLoader(Optional.empty(), __ -> true);
 
   @Test
   public void shouldLoadContentFromURL() throws Exception {


### PR DESCRIPTION
## PR Description
Set `Accept: application/octet-stream` header when requesting the initial state so that it works with the standard API.

## Fixed Issue(s)
fixes #3529 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
