### PR TITLE
Avoid serializing events unless there are actually subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Additions and Improvements
 - When downloading the `--initial-state` from a URL, the `Accept: application/octet-stream` header is now set. This provides compatibility with the standard API `/eth/v1/debug/beacon/states/:state_id` endpoint.
 - `--ws-checkpoint` CLI now accepts a URL optionally, and will load the `ws_checkpoint` field from that URL.
+- Reduced CPU usage by avoiding creation of REST API events when there are no subscribers.
 
 ### Bug Fixes
 - Block events now only return the slot and root, rather than the entire signed block.

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.sse.SseClient;
 import java.util.List;
 import java.util.Queue;
@@ -21,6 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.api.response.v1.EventType;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.events.EventSubscriptionManager.EventSource;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 
 public class EventSubscriber {
@@ -50,12 +52,13 @@ public class EventSubscriber {
     this.sseClient.onClose(closeCallback);
   }
 
-  public void onEvent(final EventType eventType, final String message) {
+  public void onEvent(final EventType eventType, final EventSource message)
+      throws JsonProcessingException {
     if (!eventTypes.contains(eventType)) {
       return;
     }
     if (queuedEvents.size() < maxPendingEvents) {
-      queuedEvents.add(QueuedEvent.of(eventType, message));
+      queuedEvents.add(QueuedEvent.of(eventType, message.get()));
       processEventQueue();
     } else {
       LOG.debug("Closing event connection due to exceeding the pending message limit");


### PR DESCRIPTION
## PR Description
Avoid serializing REST API events unless there are actually subscribers listening for those events.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
