### PR TITLE
Add validator_external_signer_requests metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - When downloading the `--initial-state` from a URL, the `Accept: application/octet-stream` header is now set. This provides compatibility with the standard API `/eth/v1/debug/beacon/states/:state_id` endpoint.
 - `--ws-checkpoint` CLI now accepts a URL optionally, and will load the `ws_checkpoint` field from that URL.
 - Reduced CPU usage by avoiding creation of REST API events when there are no subscribers.
+- Added a labelled counter to metrics for external signer requests, `validator_external_signer_requests`, with labels `success`, `failed`, `timeout`
 
 ### Bug Fixes
 - Fixed issue in discv5 where nonce was incorrectly reused.

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSource.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSource.java
@@ -36,16 +36,19 @@ public class ExternalValidatorSource implements ValidatorSource {
   private final Supplier<HttpClient> externalSignerHttpClientFactory;
   private final PublicKeyLoader publicKeyLoader;
   private final ThrottlingTaskQueue externalSignerTaskQueue;
+  private final MetricsSystem metricsSystem;
 
   private ExternalValidatorSource(
       final ValidatorConfig config,
       final Supplier<HttpClient> externalSignerHttpClientFactory,
       final PublicKeyLoader publicKeyLoader,
-      final ThrottlingTaskQueue externalSignerTaskQueue) {
+      final ThrottlingTaskQueue externalSignerTaskQueue,
+      final MetricsSystem metricsSystem) {
     this.config = config;
     this.externalSignerHttpClientFactory = externalSignerHttpClientFactory;
     this.publicKeyLoader = publicKeyLoader;
     this.externalSignerTaskQueue = externalSignerTaskQueue;
+    this.metricsSystem = metricsSystem;
   }
 
   public static ExternalValidatorSource create(
@@ -62,7 +65,11 @@ public class ExternalValidatorSource implements ValidatorSource {
             "external_signer_request_queue_size");
     setupExternalSignerStatusLogging(config, externalSignerHttpClientFactory, asyncRunner);
     return new ExternalValidatorSource(
-        config, externalSignerHttpClientFactory, publicKeyLoader, externalSignerTaskQueue);
+        config,
+        externalSignerHttpClientFactory,
+        publicKeyLoader,
+        externalSignerTaskQueue,
+        metricsSystem);
   }
 
   @Override
@@ -112,7 +119,8 @@ public class ExternalValidatorSource implements ValidatorSource {
           config.getValidatorExternalSignerUrl(),
           publicKey,
           config.getValidatorExternalSignerTimeout(),
-          externalSignerTaskQueue);
+          externalSignerTaskQueue,
+          metricsSystem);
     }
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -98,37 +98,37 @@ public class ExternalSigner implements Signer {
   @Override
   public SafeFuture<BLSSignature> createRandaoReveal(final UInt64 epoch, final ForkInfo forkInfo) {
     return sign(
-            signingRootForRandaoReveal(epoch, forkInfo),
-            SignType.RANDAO_REVEAL,
-            Map.of("randao_reveal", Map.of("epoch", epoch), FORK_INFO, forkInfo(forkInfo)),
-            slashableGenericMessage("randao reveal"));
+        signingRootForRandaoReveal(epoch, forkInfo),
+        SignType.RANDAO_REVEAL,
+        Map.of("randao_reveal", Map.of("epoch", epoch), FORK_INFO, forkInfo(forkInfo)),
+        slashableGenericMessage("randao reveal"));
   }
 
   @Override
   public SafeFuture<BLSSignature> signBlock(final BeaconBlock block, final ForkInfo forkInfo) {
     return sign(
-            signingRootForSignBlock(block, forkInfo),
-            SignType.BLOCK,
-            Map.of(
-                "block",
-                new tech.pegasys.teku.api.schema.BeaconBlock(block),
-                FORK_INFO,
-                forkInfo(forkInfo)),
-            slashableBlockMessage(block));
+        signingRootForSignBlock(block, forkInfo),
+        SignType.BLOCK,
+        Map.of(
+            "block",
+            new tech.pegasys.teku.api.schema.BeaconBlock(block),
+            FORK_INFO,
+            forkInfo(forkInfo)),
+        slashableBlockMessage(block));
   }
 
   @Override
   public SafeFuture<BLSSignature> signAttestationData(
       final AttestationData attestationData, final ForkInfo forkInfo) {
     return sign(
-            signingRootForSignAttestationData(attestationData, forkInfo),
-            SignType.ATTESTATION,
-            Map.of(
-                "attestation",
-                new tech.pegasys.teku.api.schema.AttestationData(attestationData),
-                FORK_INFO,
-                forkInfo(forkInfo)),
-            slashableAttestationMessage(attestationData));
+        signingRootForSignAttestationData(attestationData, forkInfo),
+        SignType.ATTESTATION,
+        Map.of(
+            "attestation",
+            new tech.pegasys.teku.api.schema.AttestationData(attestationData),
+            FORK_INFO,
+            forkInfo(forkInfo)),
+        slashableAttestationMessage(attestationData));
   }
 
   private void recordMetrics(final BLSSignature result, final Throwable error) {
@@ -148,38 +148,38 @@ public class ExternalSigner implements Signer {
     return taskQueue.queueTask(
         () ->
             sign(
-                    signingRootForSignAggregationSlot(slot, forkInfo),
-                    SignType.AGGREGATION_SLOT,
-                    Map.of("aggregation_slot", Map.of("slot", slot), FORK_INFO, forkInfo(forkInfo)),
-                    slashableGenericMessage("aggregation slot")));
+                signingRootForSignAggregationSlot(slot, forkInfo),
+                SignType.AGGREGATION_SLOT,
+                Map.of("aggregation_slot", Map.of("slot", slot), FORK_INFO, forkInfo(forkInfo)),
+                slashableGenericMessage("aggregation slot")));
   }
 
   @Override
   public SafeFuture<BLSSignature> signAggregateAndProof(
       final AggregateAndProof aggregateAndProof, final ForkInfo forkInfo) {
     return sign(
-            signingRootForSignAggregateAndProof(aggregateAndProof, forkInfo),
-            SignType.AGGREGATE_AND_PROOF,
-            Map.of(
-                "aggregate_and_proof",
-                new tech.pegasys.teku.api.schema.AggregateAndProof(aggregateAndProof),
-                FORK_INFO,
-                forkInfo(forkInfo)),
-            slashableGenericMessage("aggregate and proof"));
+        signingRootForSignAggregateAndProof(aggregateAndProof, forkInfo),
+        SignType.AGGREGATE_AND_PROOF,
+        Map.of(
+            "aggregate_and_proof",
+            new tech.pegasys.teku.api.schema.AggregateAndProof(aggregateAndProof),
+            FORK_INFO,
+            forkInfo(forkInfo)),
+        slashableGenericMessage("aggregate and proof"));
   }
 
   @Override
   public SafeFuture<BLSSignature> signVoluntaryExit(
       final VoluntaryExit voluntaryExit, final ForkInfo forkInfo) {
     return sign(
-            signingRootForSignVoluntaryExit(voluntaryExit, forkInfo),
-            SignType.VOLUNTARY_EXIT,
-            Map.of(
-                "voluntary_exit",
-                new tech.pegasys.teku.api.schema.VoluntaryExit(voluntaryExit),
-                FORK_INFO,
-                forkInfo(forkInfo)),
-            slashableGenericMessage("voluntary exit"));
+        signingRootForSignVoluntaryExit(voluntaryExit, forkInfo),
+        SignType.VOLUNTARY_EXIT,
+        Map.of(
+            "voluntary_exit",
+            new tech.pegasys.teku.api.schema.VoluntaryExit(voluntaryExit),
+            FORK_INFO,
+            forkInfo(forkInfo)),
+        slashableGenericMessage("voluntary exit"));
   }
 
   @Override
@@ -202,22 +202,22 @@ public class ExternalSigner implements Signer {
       final Supplier<String> slashableMessage) {
     final String publicKey = blsPublicKey.toBytesCompressed().toString();
     return SafeFuture.of(
-        () -> {
-          final String requestBody = createSigningRequestBody(signingRoot, type, metadata);
-          final URI uri =
-              signingServiceUrl.toURI().resolve(EXTERNAL_SIGNER_ENDPOINT + "/" + publicKey);
-          final HttpRequest request =
-              HttpRequest.newBuilder()
-                  .uri(uri)
-                  .timeout(timeout)
-                  .header("Content-Type", "application/json")
-                  .POST(BodyPublishers.ofString(requestBody))
-                  .build();
-          return httpClient
-              .sendAsync(request, BodyHandlers.ofString())
-              .handleAsync(
-                  (response, error) -> this.getBlsSignature(response, error, slashableMessage));
-        })
+            () -> {
+              final String requestBody = createSigningRequestBody(signingRoot, type, metadata);
+              final URI uri =
+                  signingServiceUrl.toURI().resolve(EXTERNAL_SIGNER_ENDPOINT + "/" + publicKey);
+              final HttpRequest request =
+                  HttpRequest.newBuilder()
+                      .uri(uri)
+                      .timeout(timeout)
+                      .header("Content-Type", "application/json")
+                      .POST(BodyPublishers.ofString(requestBody))
+                      .build();
+              return httpClient
+                  .sendAsync(request, BodyHandlers.ofString())
+                  .handleAsync(
+                      (response, error) -> this.getBlsSignature(response, error, slashableMessage));
+            })
         .whenComplete(this::recordMetrics);
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -101,8 +101,7 @@ public class ExternalSigner implements Signer {
             signingRootForRandaoReveal(epoch, forkInfo),
             SignType.RANDAO_REVEAL,
             Map.of("randao_reveal", Map.of("epoch", epoch), FORK_INFO, forkInfo(forkInfo)),
-            slashableGenericMessage("randao reveal"))
-        .whenComplete(this::recordMetrics);
+            slashableGenericMessage("randao reveal"));
   }
 
   @Override
@@ -115,8 +114,7 @@ public class ExternalSigner implements Signer {
                 new tech.pegasys.teku.api.schema.BeaconBlock(block),
                 FORK_INFO,
                 forkInfo(forkInfo)),
-            slashableBlockMessage(block))
-        .whenComplete(this::recordMetrics);
+            slashableBlockMessage(block));
   }
 
   @Override
@@ -130,8 +128,7 @@ public class ExternalSigner implements Signer {
                 new tech.pegasys.teku.api.schema.AttestationData(attestationData),
                 FORK_INFO,
                 forkInfo(forkInfo)),
-            slashableAttestationMessage(attestationData))
-        .whenComplete(this::recordMetrics);
+            slashableAttestationMessage(attestationData));
   }
 
   private void recordMetrics(final BLSSignature result, final Throwable error) {
@@ -154,8 +151,7 @@ public class ExternalSigner implements Signer {
                     signingRootForSignAggregationSlot(slot, forkInfo),
                     SignType.AGGREGATION_SLOT,
                     Map.of("aggregation_slot", Map.of("slot", slot), FORK_INFO, forkInfo(forkInfo)),
-                    slashableGenericMessage("aggregation slot"))
-                .whenComplete(this::recordMetrics));
+                    slashableGenericMessage("aggregation slot")));
   }
 
   @Override
@@ -169,8 +165,7 @@ public class ExternalSigner implements Signer {
                 new tech.pegasys.teku.api.schema.AggregateAndProof(aggregateAndProof),
                 FORK_INFO,
                 forkInfo(forkInfo)),
-            slashableGenericMessage("aggregate and proof"))
-        .whenComplete(this::recordMetrics);
+            slashableGenericMessage("aggregate and proof"));
   }
 
   @Override
@@ -184,8 +179,7 @@ public class ExternalSigner implements Signer {
                 new tech.pegasys.teku.api.schema.VoluntaryExit(voluntaryExit),
                 FORK_INFO,
                 forkInfo(forkInfo)),
-            slashableGenericMessage("voluntary exit"))
-        .whenComplete(this::recordMetrics);
+            slashableGenericMessage("voluntary exit"));
   }
 
   @Override
@@ -223,7 +217,8 @@ public class ExternalSigner implements Signer {
               .sendAsync(request, BodyHandlers.ofString())
               .handleAsync(
                   (response, error) -> this.getBlsSignature(response, error, slashableMessage));
-        });
+        })
+        .whenComplete(this::recordMetrics);
   }
 
   private String createSigningRequestBody(


### PR DESCRIPTION
Validator client now records success, failure, timeout of external signer requests

Partially addresses #3610

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
