### PR TITLE
Make RecentChainData.getNextFork actually return the next fork

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/ForkManifest.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/ForkManifest.java
@@ -16,8 +16,8 @@ package tech.pegasys.teku.spec;
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_EPOCH;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.NavigableMap;
@@ -76,12 +76,16 @@ public class ForkManifest {
     return forkSchedule.floorEntry(epoch).getValue();
   }
 
+  public Fork next(final UInt64 epoch) {
+    return forkSchedule.ceilingEntry(epoch).getValue();
+  }
+
   public Fork getGenesisFork() {
     return forkSchedule.firstEntry().getValue();
   }
 
-  public List<Fork> getForkSchedule() {
-    return new ArrayList<>(forkSchedule.values());
+  public Collection<Fork> getForkSchedule() {
+    return Collections.unmodifiableCollection(forkSchedule.values());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/ForkManifest.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/ForkManifest.java
@@ -20,8 +20,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.TreeMap;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
@@ -76,8 +78,13 @@ public class ForkManifest {
     return forkSchedule.floorEntry(epoch).getValue();
   }
 
-  public Fork next(final UInt64 epoch) {
-    return forkSchedule.ceilingEntry(epoch).getValue();
+  public Optional<Fork> getNext(final UInt64 epoch) {
+    if (epoch.equals(UInt64.MAX_VALUE)) {
+      // Epoch MAX_VALUE is the end of time, there shall be no more forks.
+      return Optional.empty();
+    }
+    return Optional.ofNullable(forkSchedule.ceilingEntry(epoch.increment()))
+        .map(Map.Entry::getValue);
   }
 
   public Fork getGenesisFork() {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/ForkManifestTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/ForkManifestTest.java
@@ -106,4 +106,14 @@ class ForkManifestTest {
     assertThat(forkManifest.get(UInt64.valueOf(200L))).isEqualTo(thirdFork);
     assertThat(forkManifest.get(UInt64.MAX_VALUE)).isEqualTo(thirdFork);
   }
+
+  @Test
+  void shouldGetNextFork() {
+    assertThat(forkManifest.getNext(UInt64.ZERO)).contains(secondFork);
+    assertThat(forkManifest.getNext(UInt64.ONE)).contains(secondFork);
+    assertThat(forkManifest.getNext(secondFork.getEpoch().decrement())).contains(secondFork);
+    assertThat(forkManifest.getNext(secondFork.getEpoch())).contains(thirdFork);
+    assertThat(forkManifest.getNext(thirdFork.getEpoch())).isEmpty();
+    assertThat(forkManifest.getNext(UInt64.MAX_VALUE)).isEmpty();
+  }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -357,8 +357,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   }
 
   public Optional<Fork> getNextFork() {
-    // There is no future fork defined at this point.
-    return Optional.empty();
+    return getCurrentEpoch().map(spec.getForkManifest()::next);
   }
 
   /**

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -357,7 +357,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   }
 
   public Optional<Fork> getNextFork() {
-    return getCurrentEpoch().map(spec.getForkManifest()::next);
+    return getCurrentEpoch().flatMap(spec.getForkManifest()::getNext);
   }
 
   /**


### PR DESCRIPTION
## PR Description
Update `RecentChainData.getNextFork()` to actually get the next fork from the `ForkManifest` rather than always returning `empty`.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
