### PR TITLE
Avoid sharing mutable instance

### DIFF
--- a/ssz/src/main/java/tech/pegasys/teku/ssz/impl/AbstractSszMutableComposite.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/impl/AbstractSszMutableComposite.java
@@ -74,13 +74,21 @@ public abstract class AbstractSszMutableComposite<
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public void set(int index, SszChildT value) {
     checkIndex(index, true);
     checkNotNull(value);
     validateChildSchema(index, value);
 
+    final SszChildT immutableValue;
+    if (value instanceof SszMutableData) {
+      immutableValue = (SszChildT) ((SszMutableData) value).commitChanges();
+    } else {
+      immutableValue = value;
+    }
+
     ChildChangeRecord<SszChildT, SszMutableChildT> oldChangeRecord =
-        childrenChanges.put(index, createChangeRecordByValue(value));
+        childrenChanges.put(index, createChangeRecordByValue(immutableValue));
     if (oldChangeRecord != null && oldChangeRecord.isByRef()) {
       // restore old value to be consistent
       childrenChanges.put(index, oldChangeRecord);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

As described in #3679 we would like to avoid unintentionally sharing the same mutable instance as different structure members. Seems like this situation is not too exceptional. 

The solution could be just to make an immutable copy of a new value if it is mutable.

## Fixed Issue(s)

Fixes #3679

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
