### PR TITLE
Allow overwriting mutable child even if it was acquired by ref before

### DIFF
--- a/ssz/src/main/java/tech/pegasys/teku/ssz/impl/AbstractSszMutableComposite.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/impl/AbstractSszMutableComposite.java
@@ -81,12 +81,6 @@ public abstract class AbstractSszMutableComposite<
 
     ChildChangeRecord<SszChildT, SszMutableChildT> oldChangeRecord =
         childrenChanges.put(index, createChangeRecordByValue(value));
-    if (oldChangeRecord != null && oldChangeRecord.isByRef()) {
-      // restore old value to be consistent
-      childrenChanges.put(index, oldChangeRecord);
-      throw new IllegalStateException(
-          "A child couldn't be simultaneously modified by value and accessed by ref");
-    }
 
     sizeCache = index >= sizeCache ? index + 1 : sizeCache;
     invalidate();

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/impl/AbstractSszMutableComposite.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/impl/AbstractSszMutableComposite.java
@@ -87,8 +87,7 @@ public abstract class AbstractSszMutableComposite<
       immutableValue = value;
     }
 
-    ChildChangeRecord<SszChildT, SszMutableChildT> oldChangeRecord =
-        childrenChanges.put(index, createChangeRecordByValue(immutableValue));
+    childrenChanges.put(index, createChangeRecordByValue(immutableValue));
 
     sizeCache = index >= sizeCache ? index + 1 : sizeCache;
     invalidate();

--- a/ssz/src/test/java/tech/pegasys/teku/ssz/AbstractSszMutableCompositeTest.java
+++ b/ssz/src/test/java/tech/pegasys/teku/ssz/AbstractSszMutableCompositeTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ssz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ssz.collections.SszBytes32Vector;
+import tech.pegasys.teku.ssz.collections.SszMutableBytes32Vector;
+import tech.pegasys.teku.ssz.schema.SszVectorSchema;
+import tech.pegasys.teku.ssz.schema.collections.SszBytes32VectorSchema;
+
+public class AbstractSszMutableCompositeTest {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void setChildAfterAcquiringItByRefShouldWork() {
+    SszBytes32VectorSchema<SszBytes32Vector> childSchema = SszBytes32VectorSchema.create(3);
+    SszVectorSchema<SszBytes32Vector, ?> compositeSchema = SszVectorSchema.create(childSchema, 2);
+
+    SszMutableRefVector<SszBytes32Vector, SszMutableBytes32Vector> mutableComposite =
+        (SszMutableRefVector<SszBytes32Vector, SszMutableBytes32Vector>)
+            compositeSchema.getDefault().createWritableCopy();
+    SszMutableBytes32Vector mutableChild = mutableComposite.getByRef(0);
+    mutableChild.setElement(0, Bytes32.fromHexStringLenient("0x1111"));
+
+    SszBytes32Vector newChild =
+        childSchema.of(
+            Bytes32.fromHexStringLenient("0x2222"),
+            Bytes32.fromHexStringLenient("0x3333"),
+            Bytes32.fromHexStringLenient("0x4444"));
+    mutableComposite.set(0, newChild);
+
+    SszVector<SszBytes32Vector> changedComposite = mutableComposite.commitChanges();
+
+    assertThat(changedComposite.get(0).getElement(0))
+        .isEqualTo(Bytes32.fromHexStringLenient("0x2222"));
+    assertThat(changedComposite.get(0).getElement(1))
+        .isEqualTo(Bytes32.fromHexStringLenient("0x3333"));
+    assertThat(changedComposite.get(0).getElement(2))
+        .isEqualTo(Bytes32.fromHexStringLenient("0x4444"));
+    assertThat(changedComposite.get(1).getElement(0)).isEqualTo(Bytes32.ZERO);
+    assertThat(changedComposite.get(1).getElement(1)).isEqualTo(Bytes32.ZERO);
+    assertThat(changedComposite.get(1).getElement(2)).isEqualTo(Bytes32.ZERO);
+  }
+}

--- a/ssz/src/test/java/tech/pegasys/teku/ssz/SszMutableRefCompositeTestBase.java
+++ b/ssz/src/test/java/tech/pegasys/teku/ssz/SszMutableRefCompositeTestBase.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.ssz;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.ssz.SszDataAssert.assertThatSszData;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
@@ -58,7 +59,7 @@ public interface SszMutableRefCompositeTestBase extends SszMutableCompositeTestB
     SszMutableData mutableChild = data.getByRef(updateChildIndex);
     SszData newChildValue = updateSomething(mutableChild);
 
-    SszDataAssert.assertThatSszData(data.get(updateChildIndex))
+    assertThatSszData(data.get(updateChildIndex))
         .isEqualByGettersTo(newChildValue)
         .isEqualBySszTo(newChildValue);
     IntStream.range(0, data.size())
@@ -66,22 +67,20 @@ public interface SszMutableRefCompositeTestBase extends SszMutableCompositeTestB
         .forEach(
             i -> {
               if (i != updateChildIndex) {
-                SszDataAssert.assertThatSszData(data.get(i)).isEqualByAllMeansTo(origData.get(i));
+                assertThatSszData(data.get(i)).isEqualByAllMeansTo(origData.get(i));
               }
             });
 
     SszComposite<SszData> updatedData = data.commitChanges();
 
-    SszDataAssert.assertThatSszData(updatedData).isNotEqualByAllMeansTo(data);
-    SszDataAssert.assertThatSszData(updatedData.get(updateChildIndex))
-        .isEqualByAllMeansTo(newChildValue);
+    assertThatSszData(updatedData).isNotEqualByAllMeansTo(data);
+    assertThatSszData(updatedData.get(updateChildIndex)).isEqualByAllMeansTo(newChildValue);
     IntStream.range(0, data.size())
         .limit(32)
         .forEach(
             i -> {
               if (i != updateChildIndex) {
-                SszDataAssert.assertThatSszData(updatedData.get(i))
-                    .isEqualByAllMeansTo(origData.get(i));
+                assertThatSszData(updatedData.get(i)).isEqualByAllMeansTo(origData.get(i));
               }
             });
   }
@@ -108,15 +107,32 @@ public interface SszMutableRefCompositeTestBase extends SszMutableCompositeTestB
     SszData newChildValue = generator.randomData(childSchema);
     data.set(updateChildIndex, newChildValue);
 
-    SszDataAssert.assertThatSszData(data.get(updateChildIndex))
+    assertThatSszData(data.get(updateChildIndex))
         .isNotEqualByAllMeansTo(origData.get(updateChildIndex));
     SszMutableData byRef = data.getByRef(updateChildIndex);
     SszData newChildValueByRef = updateSomething(byRef);
 
-    SszDataAssert.assertThatSszData(data.get(updateChildIndex))
-        .isEqualByGettersTo(newChildValueByRef);
-    SszDataAssert.assertThatSszData(data.commitChanges().get(updateChildIndex))
+    assertThatSszData(data.get(updateChildIndex)).isEqualByGettersTo(newChildValueByRef);
+    assertThatSszData(data.commitChanges().get(updateChildIndex))
         .isEqualByAllMeansTo(newChildValueByRef);
+  }
+
+  @MethodSource("sszMutableByRefCompositeArguments")
+  @ParameterizedTest
+  default void getByRef_childUpdateByRefThenSetShouldWork(
+      SszMutableRefComposite<SszData, SszMutableData> data, int updateChildIndex) {
+    SszSchema<?> childSchema = data.getSchema().getChildSchema(updateChildIndex);
+
+    SszMutableData byRef = data.getByRef(updateChildIndex);
+    SszData newChildValueByRef = updateSomething(byRef);
+    assertThatSszData(data.get(updateChildIndex)).isEqualByGettersTo(newChildValueByRef);
+
+    SszData newChildValue = generator.randomData(childSchema);
+    data.set(updateChildIndex, newChildValue);
+
+    assertThatSszData(data.get(updateChildIndex)).isEqualByGettersTo(newChildValue);
+    assertThatSszData(data.commitChanges().get(updateChildIndex))
+        .isEqualByAllMeansTo(newChildValue);
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Allow overwriting mutable child even if it was acquired by ref before. The use case looks pretty legitimate don't see any reasons to restrict it.

## Fixed Issue(s)

Fixes #3680 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
