### PR TITLE
Add a validator_duties_performed metric by duty type and result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ For information on changes in released versions of Teku, see the [releases page]
 - `--ws-checkpoint` CLI now accepts a URL optionally, and will load the `ws_checkpoint` field from that URL.
 - validator-client now publishes `validator_current_epoch` which is the epoch based on slot events on the validator client.
 - Reduced CPU usage by avoiding creation of REST API events when there are no subscribers.
-- Added a labelled counter to metrics for external signer requests, `validator_external_signer_requests`, with labels `success`, `failed`, `timeout`
+- Added a labelled counter to metrics for external signer requests, `validator_external_signer_requests`, with a result label containing `success`, `failed`, `timeout`
+- Added a labelled counter to metrics for storing the results of duties, `validator_duties_performed`, with a `type` and `result`.
 
 ### Bug Fixes
 - Fixed issue in discv5 where nonce was incorrectly reused.

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -147,7 +147,8 @@ public class ValidatorClientService extends Service {
             new AttestationDutyLoader(
                 validatorApiChannel,
                 forkProvider,
-                dependentRoot -> new ScheduledDuties(validatorDutyFactory, dependentRoot),
+                dependentRoot ->
+                    new ScheduledDuties(validatorDutyFactory, dependentRoot, metricsSystem),
                 validators,
                 validatorIndexProvider,
                 beaconCommitteeSubscriptions,
@@ -157,7 +158,8 @@ public class ValidatorClientService extends Service {
             asyncRunner,
             new BlockProductionDutyLoader(
                 validatorApiChannel,
-                dependentRoot -> new ScheduledDuties(validatorDutyFactory, dependentRoot),
+                dependentRoot ->
+                    new ScheduledDuties(validatorDutyFactory, dependentRoot, metricsSystem),
                 validators,
                 validatorIndexProvider));
     final boolean useDependentRoots = config.getValidatorConfig().useDependentRoots();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -87,9 +87,7 @@ public class ExternalSigner implements Signer {
             TekuMetricCategory.VALIDATOR,
             "external_signer_requests",
             "Completed external signer counts",
-            "success",
-            "failed",
-            "timeout");
+            "result");
     successCounter = labelledCounter.labels("success");
     failedCounter = labelledCounter.labels("failed");
     timeoutCounter = labelledCounter.labels("timeout");

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -802,7 +802,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
         new AttestationDutyLoader(
             validatorApiChannel,
             forkProvider,
-            dependentRoot -> new ScheduledDuties(dutyFactory, dependentRoot),
+            dependentRoot -> new ScheduledDuties(dutyFactory, dependentRoot, metricsSystem),
             new OwnedValidators(Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2)),
             validatorIndexProvider,
             beaconCommitteeSubscriptions,

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
@@ -342,7 +342,7 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
                 asyncRunner,
                 new BlockProductionDutyLoader(
                     validatorApiChannel,
-                    dependentRoot -> new ScheduledDuties(dutyFactory, dependentRoot),
+                    dependentRoot -> new ScheduledDuties(dutyFactory, dependentRoot, metricsSystem),
                     new OwnedValidators(
                         Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2)),
                     validatorIndexProvider)),


### PR DESCRIPTION
 - also fixed the use of labels in `validator_external_signer_requests`

Partially Addresses #3610

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
