### PR TITLE
detect eth1 nodes that are not fully synced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
 - Upgraded to use BLS implementation BLST version 0.3.3.
+- Teku now waits for Eth1 nodes to finish syncing before requesting data from them. Thanks to Enrico Del Fante.
 - Added new metrics to Validators
   - `validator_external_signer_requests` with labels `success`, `failed`, `timeout`.
   - `validator_duties_performed` with labels `type` and `result`.

--- a/pow/src/main/java/tech/pegasys/teku/pow/ErrorTrackingEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/ErrorTrackingEth1Provider.java
@@ -82,6 +82,11 @@ public class ErrorTrackingEth1Provider implements Eth1Provider {
     return logStatus(delegate.getChainId());
   }
 
+  @Override
+  public SafeFuture<Boolean> ethSyncing() {
+    return logStatus(delegate.ethSyncing());
+  }
+
   private <T> SafeFuture<T> logStatus(final SafeFuture<T> action) {
     return action
         .thenPeek((t) -> eth1StatusLogger.success())

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1DepositManager.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1DepositManager.java
@@ -166,7 +166,7 @@ public class Eth1DepositManager {
 
   private SafeFuture<EthBlock.Block> getHead() {
     return waitForEth1ProviderToBeInSync()
-        .thenCompose((__) -> getLatestEth1BlockNumber())
+        .thenCompose(__ -> getLatestEth1BlockNumber())
         .thenCompose(this::waitForEth1ChainToReachFollowDistanceIfNecessary)
         .thenApply(number -> number.minus(Constants.ETH1_FOLLOW_DISTANCE))
         .thenCompose(eth1Provider::getGuaranteedEth1Block)
@@ -193,10 +193,11 @@ public class Eth1DepositManager {
                 LOG.info(
                     "Eth1DepositManager failed to get the head of Eth1: still syncing. Retrying in {} seconds.",
                     Constants.ETH1_SYNCING_RETRY_TIMEOUT.toSeconds());
-                return asyncRunner
-                    .getDelayedFuture(Constants.ETH1_SYNCING_RETRY_TIMEOUT)
-                    .thenCompose(__ -> waitForEth1ProviderToBeInSync());
-              } else return SafeFuture.COMPLETE;
+                return asyncRunner.runAfterDelay(
+                    this::waitForEth1ProviderToBeInSync, Constants.ETH1_SYNCING_RETRY_TIMEOUT);
+              } else {
+                return SafeFuture.COMPLETE;
+              }
             });
   }
 

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1Provider.java
@@ -50,4 +50,6 @@ public interface Eth1Provider {
   SafeFuture<EthCall> ethCall(String from, String to, String data, UInt64 blockNumber);
 
   SafeFuture<BigInteger> getChainId();
+
+  SafeFuture<Boolean> ethSyncing();
 }

--- a/pow/src/main/java/tech/pegasys/teku/pow/ThrottlingEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/ThrottlingEth1Provider.java
@@ -90,4 +90,9 @@ public class ThrottlingEth1Provider implements Eth1Provider {
   public SafeFuture<BigInteger> getChainId() {
     return taskQueue.queueTask(delegate::getChainId);
   }
+
+  @Override
+  public SafeFuture<Boolean> ethSyncing() {
+    return taskQueue.queueTask(delegate::ethSyncing);
+  }
 }

--- a/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
@@ -28,6 +28,7 @@ import org.web3j.protocol.core.methods.request.Transaction;
 import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.EthCall;
 import org.web3j.protocol.core.methods.response.EthChainId;
+import org.web3j.protocol.core.methods.response.EthSyncing;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -133,5 +134,10 @@ public class Web3jEth1Provider implements Eth1Provider {
   @Override
   public SafeFuture<BigInteger> getChainId() {
     return sendAsync(web3j.ethChainId()).thenApply(EthChainId::getChainId);
+  }
+
+  @Override
+  public SafeFuture<Boolean> ethSyncing() {
+    return sendAsync(web3j.ethSyncing()).thenApply(EthSyncing::isSyncing);
   }
 }

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -155,6 +155,7 @@ public class Constants {
   public static final double TIME_TICKER_REFRESH_RATE = 2; // per sec
   public static final Duration ETH1_INDIVIDUAL_BLOCK_RETRY_TIMEOUT = Duration.ofMillis(500);
   public static final Duration ETH1_DEPOSIT_REQUEST_RETRY_TIMEOUT = Duration.ofSeconds(2);
+  public static final Duration ETH1_SYNCING_RETRY_TIMEOUT = Duration.ofSeconds(30);
   public static final Duration ETH1_LOCAL_CHAIN_BEHIND_FOLLOW_DISTANCE_WAIT = Duration.ofSeconds(3);
   public static final int MAXIMUM_CONCURRENT_ETH1_REQUESTS = 5;
   public static final int REPUTATION_MANAGER_CAPACITY = 1024;


### PR DESCRIPTION
## PR Description

Include `isSyncing` method in `Eth1Provider` interface and relative implementations.

When requesting eht1 head in  `tech.pegasys.teku.pow.Eth1DepositManager#getHead`, a new check is added to verify if eth1 node is still syncing. if yes introduces a 30s delay before trying again.

Associated tests have been updated. A new test case has been added to cover the retry code flow. 

new costant: Costants.ETH1_SYNCING_RETRY_TIMEOUT

## Fixed Issue(s)
fixes #3357
fixes #3337

