### PR TITLE
Avoid exception when importing block that updates justified checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
 - Fixed issue in discv5 where nonce was incorrectly reused.
 - Block events now only return the slot and root, rather than the entire signed block.
+- Fixed `ProtoArray: Best node is not viable for head` error.

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -247,9 +247,6 @@ public class ForkChoice {
       return new SlotAndBlockRoot(block.getSlot(), block.getRoot());
     }
 
-    // TODO: Can we optimise and avoid running findHead if the justified checkpoint changes?
-    // This can be the only block we have with the new justified checkpoint so must be the head
-
     // Otherwise, use fork choice to find the new chain head as if this block is on time the
     // proposer weighting may cause us to reorg.
     // During sync, this may be noticeably slower than just comparing the chain head due to the way

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -247,11 +247,16 @@ public class ForkChoice {
       return new SlotAndBlockRoot(block.getSlot(), block.getRoot());
     }
 
+    // TODO: Can we optimise and avoid running findHead if the justified checkpoint changes?
+    // This can be the only block we have with the new justified checkpoint so must be the head
+
     // Otherwise, use fork choice to find the new chain head as if this block is on time the
     // proposer weighting may cause us to reorg.
     // During sync, this may be noticeably slower than just comparing the chain head due to the way
     // ProtoArray skips updating all ancestors when adding a new block but it's cheap when in sync.
-    return forkChoiceStrategy.findHead(recentChainData.getJustifiedCheckpoint().orElseThrow());
+    final Checkpoint justifiedCheckpoint = recentChainData.getJustifiedCheckpoint().orElseThrow();
+    final Checkpoint finalizedCheckpoint = recentChainData.getFinalizedCheckpoint().orElseThrow();
+    return forkChoiceStrategy.findHead(justifiedCheckpoint, finalizedCheckpoint);
   }
 
   public SafeFuture<AttestationProcessingResult> onAttestation(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -286,7 +286,7 @@ class ForkChoiceTest {
 
     // Update ProtoArray to avoid the special case of considering the anchor
     // epoch as allowing all nodes to be a valid head.
-    forkChoice.processHead(epoch4StartSlot);
+    processHead(epoch4StartSlot);
 
     prepEpochForJustification(chainUpdater, epoch4StartSlot);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.api.TrackingChainHeadChannel.ReorgEvent;
+import tech.pegasys.teku.storage.client.ChainUpdater;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.server.StateStorageMode;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -264,6 +265,81 @@ class ForkChoiceTest {
     // And we should be able to apply the new weightings without making the fork block's weight
     // negative
     assertDoesNotThrow(() -> forkChoice.processHead(updatedAttestationSlot));
+  }
+
+  @Test
+  void onBlock_shouldHandleNonCanonicalBlockThatUpdatesJustifiedCheckpoint() {
+    // If the new block is not the child of the current head block we use `ProtoArray.findHead`
+    // to check if it should become the new head.  If importing that block caused the justified
+    // checkpoint to be updated, then the justified epoch in ProtoArray won't match the justified
+    // epoch of the new head so it considers the head invalid.  Normally that update is done when
+    // applying pending votes.
+
+    final ChainUpdater chainUpdater = storageSystem.chainUpdater();
+    final UInt64 epoch4StartSlot = spec.computeStartSlotAtEpoch(UInt64.valueOf(4));
+
+    // Set the time to be the start of epoch 3 so all the blocks we need are valid
+    chainUpdater.setTime(
+        spec.getSlotStartTime(epoch4StartSlot, genesis.getState().getGenesis_time()));
+
+    justifyEpoch(chainUpdater, 2);
+
+    // Update ProtoArray to avoid the special case of considering the anchor
+    // epoch as allowing all nodes to be a valid head.
+    forkChoice.processHead(epoch4StartSlot);
+
+    prepEpochForJustification(chainUpdater, epoch4StartSlot);
+
+    // Switch head to a different fork so the next block has to use findHead
+    chainUpdater.updateBestBlock(chainBuilder.fork().generateNextBlock());
+
+    final SignedBlockAndState epoch4Block = chainBuilder.generateBlockAtSlot(epoch4StartSlot);
+    importBlock(epoch4Block);
+
+    // Should now have justified epoch 3
+    assertThat(recentChainData.getJustifiedCheckpoint())
+        .map(Checkpoint::getEpoch)
+        .contains(UInt64.valueOf(3));
+
+    // The only block with the newly justified checkpoint is epoch4Block so it should become head
+    assertThat(recentChainData.getBestBlockRoot()).contains(epoch4Block.getRoot());
+  }
+
+  private void justifyEpoch(final ChainUpdater chainUpdater, final long epoch) {
+    final UInt64 nextEpochStartSlot = spec.computeStartSlotAtEpoch(UInt64.valueOf(epoch + 1));
+    // Advance chain to an epoch we can actually justify
+    prepEpochForJustification(chainUpdater, nextEpochStartSlot);
+
+    // Trigger epoch transition into next epoch.
+    importBlock(chainBuilder.generateBlockAtSlot(nextEpochStartSlot));
+
+    // Should now have justified epoch
+    assertThat(recentChainData.getJustifiedCheckpoint())
+        .map(Checkpoint::getEpoch)
+        .contains(UInt64.valueOf(epoch));
+  }
+
+  private void prepEpochForJustification(
+      final ChainUpdater chainUpdater, final UInt64 nextEpochStartSlot) {
+    UInt64 headSlot = chainUpdater.getHeadSlot();
+    final UInt64 targetHeadSlot = nextEpochStartSlot.minus(2);
+    while (headSlot.isLessThan(targetHeadSlot)) {
+      SignedBlockAndState headBlock = chainBuilder.generateBlockAtSlot(headSlot.plus(1));
+      importBlock(headBlock);
+      assertThat(recentChainData.getBestBlockRoot()).contains(headBlock.getRoot());
+      headSlot = headBlock.getSlot();
+    }
+
+    // Add a block with enough attestations to justify the epoch.
+    final BlockOptions epoch2BlockOptions = BlockOptions.create();
+    final UInt64 newBlockSlot = headSlot.increment();
+    chainBuilder
+        .streamValidAttestationsForBlockAtSlot(newBlockSlot)
+        .forEach(epoch2BlockOptions::addAttestation);
+    final SignedBlockAndState epoch2Block =
+        chainBuilder.generateBlockAtSlot(newBlockSlot, epoch2BlockOptions);
+
+    importBlock(epoch2Block);
   }
 
   @Test

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ForkChoiceStrategy.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ForkChoiceStrategy.java
@@ -88,10 +88,15 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     return new ForkChoiceStrategy(protoArray, new ArrayList<>());
   }
 
-  public SlotAndBlockRoot findHead(final Checkpoint justifiedCheckpoint) {
+  public SlotAndBlockRoot findHead(
+      final Checkpoint justifiedCheckpoint, final Checkpoint finalizedCheckpoint) {
     protoArrayLock.readLock().lock();
     try {
-      final ProtoNode bestNode = protoArray.findHead(justifiedCheckpoint.getRoot());
+      final ProtoNode bestNode =
+          protoArray.findHead(
+              justifiedCheckpoint.getRoot(),
+              justifiedCheckpoint.getEpoch(),
+              finalizedCheckpoint.getEpoch());
       return new SlotAndBlockRoot(bestNode.getBlockSlot(), bestNode.getBlockRoot());
     } finally {
       protoArrayLock.readLock().unlock();
@@ -231,7 +236,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       protoArray.applyScoreChanges(deltas, justifiedEpoch, finalizedEpoch);
       balances = justifiedStateBalances;
 
-      return protoArray.findHead(justifiedRoot).getBlockRoot();
+      return protoArray.findHead(justifiedRoot, justifiedEpoch, finalizedEpoch).getBlockRoot();
     } finally {
       protoArrayLock.writeLock().unlock();
       votesLock.writeLock().unlock();

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
@@ -144,7 +144,14 @@ public class ProtoArray {
    * @param justifiedRoot the root of the justified checkpoint
    * @return the best node according to fork choice
    */
-  public ProtoNode findHead(Bytes32 justifiedRoot) {
+  public ProtoNode findHead(Bytes32 justifiedRoot, UInt64 justifiedEpoch, UInt64 finalizedEpoch) {
+    if (!this.justifiedEpoch.equals(justifiedEpoch)
+        || !this.finalizedEpoch.equals(finalizedEpoch)) {
+      this.justifiedEpoch = justifiedEpoch;
+      this.finalizedEpoch = finalizedEpoch;
+      // Justified or finalized epoch changed we we have to re-evaluate all best descendants.
+      applyToNodes(this::updateBestDescendantOfParent);
+    }
     int justifiedIndex =
         indices
             .get(justifiedRoot)

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayTest.java
@@ -90,11 +90,23 @@ class ProtoArrayTest {
     addBlock(1, blockRootB, Bytes32.ZERO);
 
     protoArray.applyProposerWeighting(proposerWeightingB);
-    assertThat(protoArray.findHead(GENESIS_CHECKPOINT.getRoot()).getBlockRoot())
+    assertThat(
+            protoArray
+                .findHead(
+                    GENESIS_CHECKPOINT.getRoot(),
+                    GENESIS_CHECKPOINT.getEpoch(),
+                    GENESIS_CHECKPOINT.getEpoch())
+                .getBlockRoot())
         .isEqualTo(blockRootB);
 
     protoArray.applyProposerWeighting(proposerWeightingA);
-    assertThat(protoArray.findHead(GENESIS_CHECKPOINT.getRoot()).getBlockRoot())
+    assertThat(
+            protoArray
+                .findHead(
+                    GENESIS_CHECKPOINT.getRoot(),
+                    GENESIS_CHECKPOINT.getEpoch(),
+                    GENESIS_CHECKPOINT.getEpoch())
+                .getBlockRoot())
         .isEqualTo(blockRootA);
   }
 


### PR DESCRIPTION
## PR Description
Avoid an exception that the best head is not valid when importing a block that causes the justified checkpoint to change and is not the child of the current head block.

In that case `ForkChoice` can't automatically make the new block head, so has to use `ProtoArray.findHead` but `ProtoArray.findHead` doesn't yet know about the updated justified epoch because that would normally be updated by running `applyScoreChanges` first, but we don't want to apply all pending votes as part of importing each block.

The fix is to update the justified and finalized epoch in ProtoArray if necessary as part of running `findHead`. While such an update is somewhat expensive, it's very unusual for it to be required and we do want to switch to the new block because if it caused a new justified checkpoint to be adopted then it must be the new head block (as all others have an earlier justified checkpoint so are not valid heads).

In terms of performance impact this extra update to checkpoints can only happen at most once per epoch. Further, during sync we'd be following a single chain so once the update is done once (if necessary at all), the rest of the block will build on the current head and not need any further updated.

## Fixed Issue(s)
fixes #3793 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
