### PR TITLE
[Issue 3807] Override Altair penalty configuration

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -218,7 +218,7 @@ public class Spec {
   }
 
   public int getBeaconProposerIndex(final BeaconState state, final UInt64 slot) {
-    return atState(state).getBeaconStateUtil().getBeaconProposerIndex(state, slot);
+    return atState(state).beaconStateAccessors().getBeaconProposerIndex(state, slot);
   }
 
   public UInt64 getCommitteeCountPerSlot(final BeaconState state, final UInt64 epoch) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigAltair.java
@@ -86,6 +86,7 @@ public class SpecConfigAltair extends DelegatingSpecConfig {
     return altairForkVersion;
   }
 
+  // Updated penalty values
   public UInt64 getInactivityPenaltyQuotientAltair() {
     return inactivityPenaltyQuotientAltair;
   }
@@ -95,6 +96,22 @@ public class SpecConfigAltair extends DelegatingSpecConfig {
   }
 
   public int getProportionalSlashingMultiplierAltair() {
+    return proportionalSlashingMultiplierAltair;
+  }
+
+  // Override original penalty values
+  @Override
+  public UInt64 getInactivityPenaltyQuotient() {
+    return inactivityPenaltyQuotientAltair;
+  }
+
+  @Override
+  public int getMinSlashingPenaltyQuotient() {
+    return minSlashingPenaltyQuotientAltair;
+  }
+
+  @Override
+  public int getProportionalSlashingMultiplier() {
     return proportionalSlashingMultiplierAltair;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.logic;
 
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.statetransition.StateTransition;
@@ -97,5 +98,10 @@ public class DelegatingSpecLogic implements SpecLogic {
   @Override
   public BeaconStateAccessors beaconStateAccessors() {
     return specLogic.beaconStateAccessors();
+  }
+
+  @Override
+  public BeaconStateMutators beaconStateMutators() {
+    return specLogic.beaconStateMutators();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.logic;
 
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.statetransition.StateTransition;
@@ -53,4 +54,6 @@ public interface SpecLogic {
   MiscHelpers miscHelpers();
 
   BeaconStateAccessors beaconStateAccessors();
+
+  BeaconStateMutators beaconStateMutators();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/AbstractSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/AbstractSpecLogic.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.logic.common;
 import tech.pegasys.teku.spec.logic.SpecLogic;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.statetransition.StateTransition;
@@ -33,6 +34,7 @@ public class AbstractSpecLogic implements SpecLogic {
   protected final Predicates predicates;
   protected final MiscHelpers miscHelpers;
   protected final BeaconStateAccessors beaconStateAccessors;
+  protected final BeaconStateMutators beaconStateMutators;
   // Utils
   protected final CommitteeUtil committeeUtil;
   protected final ValidatorsUtil validatorsUtil;
@@ -49,6 +51,7 @@ public class AbstractSpecLogic implements SpecLogic {
       final Predicates predicates,
       final MiscHelpers miscHelpers,
       final BeaconStateAccessors beaconStateAccessors,
+      final BeaconStateMutators beaconStateMutators,
       final CommitteeUtil committeeUtil,
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
@@ -62,6 +65,7 @@ public class AbstractSpecLogic implements SpecLogic {
     this.predicates = predicates;
     this.miscHelpers = miscHelpers;
     this.beaconStateAccessors = beaconStateAccessors;
+    this.beaconStateMutators = beaconStateMutators;
     this.committeeUtil = committeeUtil;
     this.validatorsUtil = validatorsUtil;
     this.beaconStateUtil = beaconStateUtil;
@@ -137,5 +141,10 @@ public class AbstractSpecLogic implements SpecLogic {
   @Override
   public BeaconStateAccessors beaconStateAccessors() {
     return beaconStateAccessors;
+  }
+
+  @Override
+  public BeaconStateMutators beaconStateMutators() {
+    return beaconStateMutators;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -55,6 +55,17 @@ public class BeaconStateAccessors {
     return currentEpoch.equals(GENESIS_EPOCH) ? GENESIS_EPOCH : currentEpoch.minus(UInt64.ONE);
   }
 
+  public UInt64 getValidatorChurnLimit(BeaconState state) {
+    final int activeValidatorCount =
+        getActiveValidatorIndices(state, getCurrentEpoch(state)).size();
+    return getValidatorChurnLimit(activeValidatorCount);
+  }
+
+  public UInt64 getValidatorChurnLimit(final int activeValidatorCount) {
+    return UInt64.valueOf(config.getMinPerEpochChurnLimit())
+        .max(UInt64.valueOf(activeValidatorCount / config.getChurnLimitQuotient()));
+  }
+
   public Optional<BLSPublicKey> getValidatorPubKey(BeaconState state, UInt64 validatorIndex) {
     if (state.getValidators().size() <= validatorIndex.longValue()
         || validatorIndex.longValue() < 0) {
@@ -141,5 +152,40 @@ public class BeaconStateAccessors {
   public Bytes32 getRandaoMix(BeaconState state, UInt64 epoch) {
     int index = epoch.mod(config.getEpochsPerHistoricalVector()).intValue();
     return state.getRandao_mixes().getElement(index);
+  }
+
+  public int getBeaconProposerIndex(BeaconState state) {
+    return getBeaconProposerIndex(state, state.getSlot());
+  }
+
+  public int getBeaconProposerIndex(BeaconState state, UInt64 requestedSlot) {
+    validateStateCanCalculateProposerIndexAtSlot(state, requestedSlot);
+    return BeaconStateCache.getTransitionCaches(state)
+        .getBeaconProposerIndex()
+        .get(
+            requestedSlot,
+            slot -> {
+              UInt64 epoch = miscHelpers.computeEpochAtSlot(slot);
+              Bytes32 seed =
+                  Hash.sha2_256(
+                      Bytes.concatenate(
+                          getSeed(state, epoch, config.getDomainBeaconProposer()),
+                          uintToBytes(slot.longValue(), 8)));
+              List<Integer> indices = getActiveValidatorIndices(state, epoch);
+              return miscHelpers.computeProposerIndex(state, indices, seed);
+            });
+  }
+
+  private void validateStateCanCalculateProposerIndexAtSlot(
+      final BeaconState state, final UInt64 requestedSlot) {
+    UInt64 epoch = miscHelpers.computeEpochAtSlot(requestedSlot);
+    final UInt64 stateEpoch = getCurrentEpoch(state);
+    checkArgument(
+        epoch.equals(stateEpoch),
+        "Cannot calculate proposer index for a slot outside the current epoch. Requested slot %s (in epoch %s), state slot %s (in epoch %s)",
+        requestedSlot,
+        epoch,
+        state.getSlot(),
+        stateEpoch);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.helpers;
+
+import static java.util.stream.Collectors.toList;
+import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
+
+import java.util.Collections;
+import java.util.List;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+
+public class BeaconStateMutators {
+  private final SpecConfig specConfig;
+  private final MiscHelpers miscHelpers;
+  private final BeaconStateAccessors beaconStateAccessors;
+
+  public BeaconStateMutators(
+      final SpecConfig specConfig,
+      final MiscHelpers miscHelpers,
+      final BeaconStateAccessors beaconStateAccessors) {
+    this.specConfig = specConfig;
+    this.miscHelpers = miscHelpers;
+    this.beaconStateAccessors = beaconStateAccessors;
+  }
+
+  /**
+   * Increase validator balance by ``delta``.
+   *
+   * @param state
+   * @param index
+   * @param delta
+   * @see
+   *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#increase_balance</a>
+   */
+  public void increaseBalance(MutableBeaconState state, int index, UInt64 delta) {
+    state.getBalances().setElement(index, state.getBalances().getElement(index).plus(delta));
+  }
+
+  /**
+   * Decrease validator balance by ``delta`` with underflow protection.
+   *
+   * @param state
+   * @param index
+   * @param delta
+   * @see
+   *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#decrease_balance</a>
+   */
+  public void decreaseBalance(MutableBeaconState state, int index, UInt64 delta) {
+    state
+        .getBalances()
+        .setElement(index, state.getBalances().getElement(index).minusMinZero(delta));
+  }
+
+  public void initiateValidatorExit(MutableBeaconState state, int index) {
+    Validator validator = state.getValidators().get(index);
+    // Return if validator already initiated exit
+    if (!validator.getExit_epoch().equals(FAR_FUTURE_EPOCH)) {
+      return;
+    }
+
+    // Compute exit queue epoch
+    List<UInt64> exit_epochs =
+        state.getValidators().stream()
+            .map(Validator::getExit_epoch)
+            .filter(exitEpoch -> !exitEpoch.equals(FAR_FUTURE_EPOCH))
+            .collect(toList());
+    exit_epochs.add(
+        miscHelpers.computeActivationExitEpoch(beaconStateAccessors.getCurrentEpoch(state)));
+    UInt64 exit_queue_epoch = Collections.max(exit_epochs);
+    final UInt64 final_exit_queue_epoch = exit_queue_epoch;
+    UInt64 exit_queue_churn =
+        UInt64.valueOf(
+            state.getValidators().stream()
+                .filter(v -> v.getExit_epoch().equals(final_exit_queue_epoch))
+                .count());
+
+    if (exit_queue_churn.compareTo(beaconStateAccessors.getValidatorChurnLimit(state)) >= 0) {
+      exit_queue_epoch = exit_queue_epoch.plus(UInt64.ONE);
+    }
+
+    // Set validator exit epoch and withdrawable epoch
+    state
+        .getValidators()
+        .set(
+            index,
+            validator
+                .withExit_epoch(exit_queue_epoch)
+                .withWithdrawable_epoch(
+                    exit_queue_epoch.plus(specConfig.getMinValidatorWithdrawabilityDelay())));
+  }
+
+  public void slashValidator(MutableBeaconState state, int slashed_index) {
+    slashValidator(state, slashed_index, -1);
+  }
+
+  private void slashValidator(MutableBeaconState state, int slashedIndex, int whistleblowerIndex) {
+    UInt64 epoch = beaconStateAccessors.getCurrentEpoch(state);
+    initiateValidatorExit(state, slashedIndex);
+
+    Validator validator = state.getValidators().get(slashedIndex);
+
+    state
+        .getValidators()
+        .set(
+            slashedIndex,
+            validator
+                .withSlashed(true)
+                .withWithdrawable_epoch(
+                    validator
+                        .getWithdrawable_epoch()
+                        .max(epoch.plus(specConfig.getEpochsPerSlashingsVector()))));
+
+    int index = epoch.mod(specConfig.getEpochsPerSlashingsVector()).intValue();
+    state
+        .getSlashings()
+        .setElement(
+            index, state.getSlashings().getElement(index).plus(validator.getEffective_balance()));
+    decreaseBalance(
+        state,
+        slashedIndex,
+        validator.getEffective_balance().dividedBy(specConfig.getMinSlashingPenaltyQuotient()));
+
+    // Apply proposer and whistleblower rewards
+    int proposer_index = beaconStateAccessors.getBeaconProposerIndex(state);
+    if (whistleblowerIndex == -1) {
+      whistleblowerIndex = proposer_index;
+    }
+
+    UInt64 whistleblower_reward =
+        validator.getEffective_balance().dividedBy(specConfig.getWhistleblowerRewardQuotient());
+    UInt64 proposer_reward = whistleblower_reward.dividedBy(specConfig.getProposerRewardQuotient());
+    increaseBalance(state, proposer_index, proposer_reward);
+    increaseBalance(state, whistleblowerIndex, whistleblower_reward.minus(proposer_reward));
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -17,22 +17,20 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.bytesToUInt64;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uintToBytes;
 
+import com.google.common.primitives.UnsignedBytes;
+import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.Hash;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class MiscHelpers {
   protected final SpecConfig specConfig;
 
   public MiscHelpers(final SpecConfig specConfig) {
     this.specConfig = specConfig;
-  }
-
-  public UInt64 computeEpochAtSlot(UInt64 slot) {
-    // TODO this should take into account hard forks
-    return slot.dividedBy(specConfig.getSlotsPerEpoch());
   }
 
   public int computeShuffledIndex(int index, int index_count, Bytes32 seed) {
@@ -65,5 +63,36 @@ public class MiscHelpers {
     }
 
     return indexRet;
+  }
+
+  public int computeProposerIndex(BeaconState state, List<Integer> indices, Bytes32 seed) {
+    checkArgument(!indices.isEmpty(), "compute_proposer_index indices must not be empty");
+    UInt64 MAX_RANDOM_BYTE = UInt64.valueOf(255); // Math.pow(2, 8) - 1;
+    int i = 0;
+    final int total = indices.size();
+    Bytes32 hash = null;
+    while (true) {
+      int candidate_index = indices.get(computeShuffledIndex(i % total, total, seed));
+      if (i % 32 == 0) {
+        hash = Hash.sha2_256(Bytes.concatenate(seed, uintToBytes(Math.floorDiv(i, 32), 8)));
+      }
+      int random_byte = UnsignedBytes.toInt(hash.get(i % 32));
+      UInt64 effective_balance = state.getValidators().get(candidate_index).getEffective_balance();
+      if (effective_balance
+          .times(MAX_RANDOM_BYTE)
+          .isGreaterThanOrEqualTo(specConfig.getMaxEffectiveBalance().times(random_byte))) {
+        return candidate_index;
+      }
+      i++;
+    }
+  }
+
+  public UInt64 computeEpochAtSlot(UInt64 slot) {
+    // TODO this should take into account hard forks
+    return slot.dividedBy(specConfig.getSlotsPerEpoch());
+  }
+
+  public UInt64 computeActivationExitEpoch(UInt64 epoch) {
+    return epoch.plus(UInt64.ONE).plus(specConfig.getMaxSeedLookahead());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/SimpleBlockValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/SimpleBlockValidator.java
@@ -118,7 +118,8 @@ class SimpleBlockValidator implements BlockValidator {
 
   private void verifyBlockSignature(final BeaconState state, SignedBeaconBlock signed_block)
       throws BlockProcessingException {
-    final int proposerIndex = beaconStateUtil.getBeaconProposerIndex(state, signed_block.getSlot());
+    final int proposerIndex =
+        beaconStateAccessors.getBeaconProposerIndex(state, signed_block.getSlot());
     final BLSPublicKey proposerPublicKey =
         beaconStateAccessors
             .getValidatorPubKey(state, UInt64.valueOf(proposerIndex))

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenaltyDeltas.RewardAndPenalty;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.TotalBalances;
@@ -46,20 +47,23 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
   protected final BeaconStateUtil beaconStateUtil;
   protected final ValidatorStatusFactory validatorStatusFactory;
   protected final BeaconStateAccessors beaconStateAccessors;
+  protected final BeaconStateMutators beaconStateMutators;
 
   protected AbstractEpochProcessor(
       final SpecConfig specConfig,
       final MiscHelpers miscHelpers,
+      final BeaconStateAccessors beaconStateAccessors,
+      final BeaconStateMutators beaconStateMutators,
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
-      final ValidatorStatusFactory validatorStatusFactory,
-      final BeaconStateAccessors beaconStateAccessors) {
+      final ValidatorStatusFactory validatorStatusFactory) {
     this.specConfig = specConfig;
     this.miscHelpers = miscHelpers;
+    this.beaconStateAccessors = beaconStateAccessors;
+    this.beaconStateMutators = beaconStateMutators;
     this.validatorsUtil = validatorsUtil;
     this.beaconStateUtil = beaconStateUtil;
     this.validatorStatusFactory = validatorStatusFactory;
-    this.beaconStateAccessors = beaconStateAccessors;
   }
 
   /**
@@ -218,7 +222,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
             && status
                 .getCurrentEpochEffectiveBalance()
                 .isLessThanOrEqualTo(specConfig.getEjectionBalance())) {
-          beaconStateUtil.initiateValidatorExit(state, index);
+          beaconStateMutators.initiateValidatorExit(state, index);
         }
       }
 
@@ -254,7 +258,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
               .collect(Collectors.toList());
 
       // Dequeued validators for activation up to churn limit (without resetting activation epoch)
-      int churnLimit = beaconStateUtil.getValidatorChurnLimit(state).intValue();
+      int churnLimit = beaconStateAccessors.getValidatorChurnLimit(state).intValue();
       int sublistSize = Math.min(churnLimit, activationQueue.size());
       for (Integer index : activationQueue.subList(0, sublistSize)) {
         state
@@ -263,7 +267,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
                 index,
                 validator ->
                     validator.withActivation_epoch(
-                        beaconStateUtil.computeActivationExitEpoch(currentEpoch)));
+                        miscHelpers.computeActivationExitEpoch(currentEpoch)));
       }
     } catch (IllegalArgumentException e) {
       throw new EpochProcessingException(e);
@@ -296,7 +300,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
                 .dividedBy(increment)
                 .times(adjustedTotalSlashingBalance);
         UInt64 penalty = penaltyNumerator.dividedBy(totalBalance).times(increment);
-        validatorsUtil.decreaseBalance(state, index, penalty);
+        beaconStateMutators.decreaseBalance(state, index, penalty);
       }
     }
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/CommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/CommitteeUtil.java
@@ -17,7 +17,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.bytesToUInt64;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uintToBytes;
 
-import com.google.common.primitives.UnsignedBytes;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,41 +24,15 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.Hash;
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
-import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 
 public class CommitteeUtil {
   private final SpecConfig specConfig;
-  private final MiscHelpers miscHelpers;
 
-  public CommitteeUtil(final SpecConfig specConfig, final MiscHelpers miscHelpers) {
+  public CommitteeUtil(final SpecConfig specConfig) {
     this.specConfig = specConfig;
-    this.miscHelpers = miscHelpers;
-  }
-
-  public int computeProposerIndex(BeaconState state, List<Integer> indices, Bytes32 seed) {
-    checkArgument(!indices.isEmpty(), "compute_proposer_index indices must not be empty");
-    UInt64 MAX_RANDOM_BYTE = UInt64.valueOf(255); // Math.pow(2, 8) - 1;
-    int i = 0;
-    final int total = indices.size();
-    Bytes32 hash = null;
-    while (true) {
-      int candidate_index = indices.get(miscHelpers.computeShuffledIndex(i % total, total, seed));
-      if (i % 32 == 0) {
-        hash = Hash.sha2_256(Bytes.concatenate(seed, uintToBytes(Math.floorDiv(i, 32), 8)));
-      }
-      int random_byte = UnsignedBytes.toInt(hash.get(i % 32));
-      UInt64 effective_balance = state.getValidators().get(candidate_index).getEffective_balance();
-      if (effective_balance
-          .times(MAX_RANDOM_BYTE)
-          .isGreaterThanOrEqualTo(specConfig.getMaxEffectiveBalance().times(random_byte))) {
-        return candidate_index;
-      }
-      i++;
-    }
   }
 
   public int getAggregatorModulo(final int committeeSize) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
@@ -20,7 +20,6 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 
 public class ValidatorsUtil {
 
@@ -44,34 +43,6 @@ public class ValidatorsUtil {
     return BeaconStateCache.getTransitionCaches(state)
         .getValidatorIndexCache()
         .getValidatorIndex(state, publicKey);
-  }
-
-  /**
-   * Decrease validator balance by ``delta`` with underflow protection.
-   *
-   * @param state
-   * @param index
-   * @param delta
-   * @see
-   *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#decrease_balance</a>
-   */
-  public void decreaseBalance(MutableBeaconState state, int index, UInt64 delta) {
-    state
-        .getBalances()
-        .setElement(index, state.getBalances().getElement(index).minusMinZero(delta));
-  }
-
-  /**
-   * Increase validator balance by ``delta``.
-   *
-   * @param state
-   * @param index
-   * @param delta
-   * @see
-   *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#increase_balance</a>
-   */
-  public void increaseBalance(MutableBeaconState state, int index, UInt64 delta) {
-    state.getBalances().setElement(index, state.getBalances().getElement(index).plus(delta));
   }
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.logic.versions.altair;
 
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataStateTransitionValidator;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
@@ -36,6 +37,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
       final Predicates predicates,
       final MiscHelpersAltair miscHelpers,
       final BeaconStateAccessorsAltair beaconStateAccessors,
+      final BeaconStateMutators beaconStateMutators,
       final CommitteeUtil committeeUtil,
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
@@ -50,6 +52,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
         predicates,
         miscHelpers,
         beaconStateAccessors,
+        beaconStateMutators,
         committeeUtil,
         validatorsUtil,
         beaconStateUtil,
@@ -69,13 +72,15 @@ public class SpecLogicAltair extends AbstractSpecLogic {
     final MiscHelpersAltair miscHelpers = new MiscHelpersAltair(config);
     final BeaconStateAccessorsAltair beaconStateAccessors =
         new BeaconStateAccessorsAltair(config, predicates, miscHelpers);
+    final BeaconStateMutators beaconStateMutators =
+        new BeaconStateMutators(config, miscHelpers, beaconStateAccessors);
 
     // Operation validaton
     final AttestationDataStateTransitionValidator attestationValidator =
         new AttestationDataStateTransitionValidator();
 
     // Util
-    final CommitteeUtil committeeUtil = new CommitteeUtil(config, miscHelpers);
+    final CommitteeUtil committeeUtil = new CommitteeUtil(config);
     final ValidatorsUtil validatorsUtil = new ValidatorsUtil();
     final BeaconStateUtil beaconStateUtil =
         new BeaconStateUtil(
@@ -100,16 +105,18 @@ public class SpecLogicAltair extends AbstractSpecLogic {
         new EpochProcessorAltair(
             config,
             miscHelpers,
+            beaconStateAccessors,
+            beaconStateMutators,
             validatorsUtil,
             beaconStateUtil,
-            validatorStatusFactory,
-            beaconStateAccessors);
+            validatorStatusFactory);
     final BlockProcessorAltair blockProcessor =
         new BlockProcessorAltair(
             config,
             predicates,
             miscHelpers,
             beaconStateAccessors,
+            beaconStateMutators,
             beaconStateUtil,
             attestationUtil,
             validatorsUtil,
@@ -126,6 +133,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
         predicates,
         miscHelpers,
         beaconStateAccessors,
+        beaconStateMutators,
         committeeUtil,
         validatorsUtil,
         beaconStateUtil,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -24,12 +24,12 @@ import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.CommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
+import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.StateTransitionAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.EpochProcessorAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.ValidatorStatusFactoryAltair;
-import tech.pegasys.teku.spec.logic.versions.altair.util.BlockProcessorAltair;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class SpecLogicAltair extends AbstractSpecLogic {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.logic.versions.altair.util;
+package tech.pegasys.teku.spec.logic.versions.altair.block;
 
 import static tech.pegasys.teku.spec.constants.IncentivizationWeights.WEIGHT_DENOMINATOR;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.integerSquareRoot;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/StateTransitionAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/StateTransitionAltair.java
@@ -23,8 +23,8 @@ import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BlockV
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
+import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
-import tech.pegasys.teku.spec.logic.versions.altair.util.BlockProcessorAltair;
 
 public class StateTransitionAltair extends StateTransition {
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.MutableBeaconStateAltair;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.AbstractEpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenaltyDeltas;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatusFactory;
@@ -39,17 +40,19 @@ public class EpochProcessorAltair extends AbstractEpochProcessor {
   public EpochProcessorAltair(
       final SpecConfigAltair specConfig,
       final MiscHelpersAltair miscHelpers,
+      final BeaconStateAccessorsAltair beaconStateAccessors,
+      final BeaconStateMutators beaconStateMutators,
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
-      final ValidatorStatusFactory validatorStatusFactory,
-      final BeaconStateAccessorsAltair beaconStateAccessors) {
+      final ValidatorStatusFactory validatorStatusFactory) {
     super(
         specConfig,
         miscHelpers,
+        beaconStateAccessors,
+        beaconStateMutators,
         validatorsUtil,
         beaconStateUtil,
-        validatorStatusFactory,
-        beaconStateAccessors);
+        validatorStatusFactory);
     this.specConfigAltair = specConfig;
     this.miscHelpersAltair = miscHelpers;
     this.beaconStateAccessorsAltair = beaconStateAccessors;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/util/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/util/BlockProcessorAltair.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconStat
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.MutableBeaconStateAltair;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataStateTransitionValidator;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
@@ -61,6 +62,7 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
       final Predicates predicates,
       final MiscHelpersAltair miscHelpers,
       final BeaconStateAccessorsAltair beaconStateAccessors,
+      final BeaconStateMutators beaconStateMutators,
       final BeaconStateUtil beaconStateUtil,
       final AttestationUtil attestationUtil,
       final ValidatorsUtil validatorsUtil,
@@ -70,6 +72,7 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
         predicates,
         miscHelpers,
         beaconStateAccessors,
+        beaconStateMutators,
         beaconStateUtil,
         attestationUtil,
         validatorsUtil,
@@ -152,11 +155,11 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
       if (shouldUpdate) {
         epochParticipation.set(index, SszByte.of(participationFlags));
 
-        final int proposerIndex = beaconStateUtil.getBeaconProposerIndex(state);
+        final int proposerIndex = beaconStateAccessors.getBeaconProposerIndex(state);
         final UInt64 proposerReward =
             proposerRewardNumerator.dividedBy(
                 specConfig.getProposerRewardQuotient().times(WEIGHT_DENOMINATOR));
-        validatorsUtil.increaseBalance(state, proposerIndex, proposerReward);
+        beaconStateMutators.increaseBalance(state, proposerIndex, proposerReward);
       }
     }
   }
@@ -229,16 +232,17 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
             .max(specConfig.getEffectiveBalanceIncrement());
 
     UInt64 proposerReward = UInt64.ZERO;
-    final int beaconProposerIndex = beaconStateUtil.getBeaconProposerIndex(state);
+    final int beaconProposerIndex = beaconStateAccessors.getBeaconProposerIndex(state);
     for (Integer includedIndex : includedIndices) {
       final UInt64 effectiveBalance = validators.get(includedIndex).getEffective_balance();
       final UInt64 inclusionReward =
           maxSlotRewards.times(effectiveBalance).dividedBy(committeeEffectiveBalance);
       UInt64 proposerShare = inclusionReward.dividedBy(specConfig.getProposerRewardQuotient());
       proposerReward = proposerReward.plus(proposerShare);
-      validatorsUtil.increaseBalance(state, includedIndex, inclusionReward.minus(proposerShare));
+      beaconStateMutators.increaseBalance(
+          state, includedIndex, inclusionReward.minus(proposerShare));
     }
-    validatorsUtil.increaseBalance(state, beaconProposerIndex, proposerReward);
+    beaconStateMutators.increaseBalance(state, beaconProposerIndex, proposerReward);
   }
 
   private boolean eth2FastAggregateVerify(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.logic.versions.phase0;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataStateTransitionValidator;
@@ -37,6 +38,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
       final Predicates predicates,
       final MiscHelpers miscHelpers,
       final BeaconStateAccessors beaconStateAccessors,
+      final BeaconStateMutators beaconStateMutators,
       final CommitteeUtil committeeUtil,
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
@@ -51,6 +53,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
         predicates,
         miscHelpers,
         beaconStateAccessors,
+        beaconStateMutators,
         committeeUtil,
         validatorsUtil,
         beaconStateUtil,
@@ -70,13 +73,15 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
     final MiscHelpers miscHelpers = new MiscHelpers(config);
     final BeaconStateAccessors beaconStateAccessors =
         new BeaconStateAccessors(config, predicates, miscHelpers);
+    final BeaconStateMutators beaconStateMutators =
+        new BeaconStateMutators(config, miscHelpers, beaconStateAccessors);
 
     // Operation validaton
     final AttestationDataStateTransitionValidator attestationValidator =
         new AttestationDataStateTransitionValidator();
 
     // Util
-    final CommitteeUtil committeeUtil = new CommitteeUtil(config, miscHelpers);
+    final CommitteeUtil committeeUtil = new CommitteeUtil(config);
     final ValidatorsUtil validatorsUtil = new ValidatorsUtil();
     final BeaconStateUtil beaconStateUtil =
         new BeaconStateUtil(
@@ -96,16 +101,18 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
         new EpochProcessorPhase0(
             config,
             miscHelpers,
+            beaconStateAccessors,
+            beaconStateMutators,
             validatorsUtil,
             beaconStateUtil,
-            validatorStatusFactory,
-            beaconStateAccessors);
+            validatorStatusFactory);
     final BlockProcessorPhase0 blockProcessor =
         new BlockProcessorPhase0(
             config,
             predicates,
             miscHelpers,
             beaconStateAccessors,
+            beaconStateMutators,
             beaconStateUtil,
             attestationUtil,
             validatorsUtil,
@@ -122,6 +129,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
         predicates,
         miscHelpers,
         beaconStateAccessors,
+        beaconStateMutators,
         committeeUtil,
         validatorsUtil,
         beaconStateUtil,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -27,9 +27,9 @@ import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.CommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
+import tech.pegasys.teku.spec.logic.versions.phase0.block.BlockProcessorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.EpochProcessorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.ValidatorStatusFactoryPhase0;
-import tech.pegasys.teku.spec.logic.versions.phase0.util.BlockProcessorPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class SpecLogicPhase0 extends AbstractSpecLogic {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.logic.versions.phase0.util;
+package tech.pegasys.teku.spec.logic.versions.phase0.block;
 
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/EpochProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/EpochProcessorPhase0.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.MutableBeaconStatePhase0;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.AbstractEpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenaltyDeltas;
@@ -31,17 +32,19 @@ public class EpochProcessorPhase0 extends AbstractEpochProcessor {
   public EpochProcessorPhase0(
       final SpecConfig specConfig,
       final MiscHelpers miscHelpers,
+      final BeaconStateAccessors beaconStateAccessors,
+      final BeaconStateMutators beaconStateMutators,
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
-      final ValidatorStatusFactory validatorStatusFactory,
-      final BeaconStateAccessors beaconStateAccessors) {
+      final ValidatorStatusFactory validatorStatusFactory) {
     super(
         specConfig,
         miscHelpers,
+        beaconStateAccessors,
+        beaconStateMutators,
         validatorsUtil,
         beaconStateUtil,
-        validatorStatusFactory,
-        beaconStateAccessors);
+        validatorStatusFactory);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProcessorPhase0.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconStat
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.MutableBeaconStatePhase0;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataStateTransitionValidator;
@@ -36,6 +37,7 @@ public final class BlockProcessorPhase0 extends AbstractBlockProcessor {
       final Predicates predicates,
       final MiscHelpers miscHelpers,
       final BeaconStateAccessors beaconStateAccessors,
+      final BeaconStateMutators beaconStateMutators,
       final BeaconStateUtil beaconStateUtil,
       final AttestationUtil attestationUtil,
       final ValidatorsUtil validatorsUtil,
@@ -45,6 +47,7 @@ public final class BlockProcessorPhase0 extends AbstractBlockProcessor {
         predicates,
         miscHelpers,
         beaconStateAccessors,
+        beaconStateMutators,
         beaconStateUtil,
         attestationUtil,
         validatorsUtil,
@@ -64,7 +67,7 @@ public final class BlockProcessorPhase0 extends AbstractBlockProcessor {
             attestation.getAggregation_bits(),
             data,
             state.getSlot().minus(data.getSlot()),
-            UInt64.valueOf(beaconStateUtil.getBeaconProposerIndex(state)));
+            UInt64.valueOf(beaconStateAccessors.getBeaconProposerIndex(state)));
 
     if (data.getTarget().getEpoch().equals(beaconStateAccessors.getCurrentEpoch(state))) {
       state.getCurrent_epoch_attestations().append(pendingAttestation);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/CommitteeUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/CommitteeUtilTest.java
@@ -32,7 +32,7 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 public class CommitteeUtilTest {
   final SpecConfig specConfig = mock(SpecConfig.class);
   private final Spec spec = SpecFactory.createMinimal();
-  CommitteeUtil committeeUtil = new CommitteeUtil(specConfig, spec.getGenesisSpec().miscHelpers());
+  CommitteeUtil committeeUtil = new CommitteeUtil(specConfig);
 
   @Test
   void aggregatorModulo_boundaryTest() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Use the new Altair penalty configuration values.  This is implemented by simply overriding the old penalty `SpecConfig` getters to return the new Altair values.  An alternative approach would be to [explicitly override the logic](https://github.com/ConsenSys/teku/compare/master...mbaxter:issue-3807/altair/use-updated-penalty-config) that accesses these values.  

Also, move `slash_validator` method to `BeaconStateMutators`, moving supporting logic to spec `helpers` to enable this reorganization.

## Fixed Issue(s)
Fixes #3807 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
