### PR TITLE
Enable Altair ssz_static reference tests for the types we've implemented

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -34,12 +34,13 @@ import tech.pegasys.teku.util.config.SpecDependent;
 public abstract class Eth2ReferenceTestCase {
 
   private final ImmutableMap<String, TestExecutor> COMMON_TEST_TYPES =
-      ImmutableMap.<String, TestExecutor>builder().build();
-
-  private final ImmutableMap<String, TestExecutor> PHASE_0_TEST_TYPES =
       ImmutableMap.<String, TestExecutor>builder()
           .putAll(SszTestExecutor.SSZ_TEST_TYPES)
           .putAll(SszTestExecutorDeprecated.SSZ_TEST_TYPES)
+          .build();
+
+  private final ImmutableMap<String, TestExecutor> PHASE_0_TEST_TYPES =
+      ImmutableMap.<String, TestExecutor>builder()
           .putAll(BlsTests.BLS_TEST_TYPES)
           .putAll(EpochProcessingTestExecutor.EPOCH_PROCESSING_TEST_TYPES)
           .putAll(OperationsTestExecutor.OPERATIONS_TEST_TYPES)

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -39,7 +39,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    * <p>e.g. set to "ssz_static" to run only ssz static tests or "ssz_static/Attestation" for only
    * attestation ssz tests.
    */
-  private static final String TEST_TYPE = "fork/fork";
+  private static final String TEST_TYPE = "ssz_static";
 
   /** Filter test to run to those from the specified spec. One of general, minimal or mainnet */
   private static final String SPEC = "";

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
@@ -21,6 +21,8 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.reference.TestDataUtils;
 import tech.pegasys.teku.reference.TestExecutor;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateSchemaAltair;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.ssz.SszData;
 import tech.pegasys.teku.ssz.schema.SszSchema;
@@ -43,6 +45,26 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
           .put(
               "ssz_static/BeaconBlockBody",
               new SszTestExecutor<>(SchemaDefinitions::getBeaconBlockBodySchema))
+          .put(
+              "ssz_static/SyncCommittee",
+              new SszTestExecutor<>(
+                  schemas ->
+                      BeaconStateSchemaAltair.required(schemas.getBeaconStateSchema())
+                          .getCurrentSyncCommitteeSchema()))
+          .put(
+              "ssz_static/SyncAggregate",
+              new SszTestExecutor<>(
+                  schemas ->
+                      BeaconBlockBodySchemaAltair.required(schemas.getBeaconBlockBodySchema())
+                          .getSyncAggregateSchema()))
+          .put("ssz_static/ContributionAndProof", IGNORE_TESTS)
+          .put("ssz_static/SignedContributionAndProof", IGNORE_TESTS)
+          .put("ssz_static/LightClientStore", IGNORE_TESTS)
+          .put("ssz_static/LightClientSnapshot", IGNORE_TESTS)
+          .put("ssz_static/LightClientUpdate", IGNORE_TESTS)
+          .put("ssz_static/SyncCommitteeContribution", IGNORE_TESTS)
+          .put("ssz_static/SyncCommitteeSignature", IGNORE_TESTS)
+          .put("ssz_static/SyncCommitteeSigningData", IGNORE_TESTS)
 
           // SSZ Generic
           .put("ssz_generic/basic_vector", IGNORE_TESTS)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltair.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.util.function.Consumer;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
@@ -107,6 +109,14 @@ public class BeaconBlockBodySchemaAltair
             SszListSchema.create(SignedVoluntaryExit.SSZ_SCHEMA, maxVoluntaryExits)),
         namedSchema(
             BlockBodyFields.SYNC_AGGREGATE.name(), SyncAggregateSchema.create(syncCommitteeSize)));
+  }
+
+  public static BeaconBlockBodySchemaAltair required(final BeaconBlockBodySchema<?> schema) {
+    checkArgument(
+        schema instanceof BeaconBlockBodySchemaAltair,
+        "Expected a BeaconBlockBodySchemaAltair but was %s",
+        schema.getClass());
+    return (BeaconBlockBodySchemaAltair) schema;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateSchemaAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateSchemaAltair.java
@@ -13,11 +13,14 @@
 
 package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.datastructures.state.SyncCommittee.SyncCommitteeSchema;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields;
 import tech.pegasys.teku.ssz.primitive.SszByte;
@@ -83,6 +86,14 @@ public class BeaconStateSchemaAltair
         inactivityScores,
         currentSyncCommitteeField,
         nextSyncCommitteeField);
+  }
+
+  public static BeaconStateSchemaAltair required(final BeaconStateSchema<?, ?> schema) {
+    checkArgument(
+        schema instanceof BeaconStateSchemaAltair,
+        "Expected a BeaconStateSchemaAltair but was %s",
+        schema.getClass());
+    return (BeaconStateSchemaAltair) schema;
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
## PR Description
Enable Altair ssz_static reference tests.  Ignore types we haven't yet implemented (including some we won't need to implement as they're used for light client implementations).

## Fixed Issue(s)
#3805 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
