### PR TITLE
Use getTotalBalance instead of reimplementing in processSyncCommittee

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/util/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/util/BlockProcessorAltair.java
@@ -223,10 +223,7 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
     // Compute the participant and proposer sync rewards
     final SszMutableList<Validator> validators = state.getValidators();
     final UInt64 committeeEffectiveBalance =
-        includedIndices.stream()
-            .map(includedIndex -> validators.get(includedIndex).getEffective_balance())
-            .reduce(UInt64.ZERO, UInt64::plus)
-            .max(specConfig.getEffectiveBalanceIncrement());
+        beaconStateAccessorsAltair.getTotalBalance(state, includedIndices);
 
     UInt64 proposerReward = UInt64.ZERO;
     final int beaconProposerIndex = beaconStateUtil.getBeaconProposerIndex(state);


### PR DESCRIPTION
## PR Description
Use existing `getTotalBalance` method instead of reimplementing it.  As per: https://github.com/ethereum/eth2.0-specs/pull/2294

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
