### PR TITLE
Enable bls, genesis and shuffling Altair reference tests

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -35,6 +35,9 @@ public abstract class Eth2ReferenceTestCase {
 
   private final ImmutableMap<String, TestExecutor> COMMON_TEST_TYPES =
       ImmutableMap.<String, TestExecutor>builder()
+          .putAll(BlsTests.BLS_TEST_TYPES)
+          .putAll(GenesisTests.GENESIS_TEST_TYPES)
+          .putAll(ShufflingTestExecutor.SHUFFLING_TEST_TYPES)
           .putAll(EpochProcessingTestExecutor.EPOCH_PROCESSING_TEST_TYPES)
           .putAll(SszTestExecutor.SSZ_TEST_TYPES)
           .putAll(OperationsTestExecutor.OPERATIONS_TEST_TYPES)
@@ -43,9 +46,6 @@ public abstract class Eth2ReferenceTestCase {
 
   private final ImmutableMap<String, TestExecutor> PHASE_0_TEST_TYPES =
       ImmutableMap.<String, TestExecutor>builder()
-          .putAll(BlsTests.BLS_TEST_TYPES)
-          .putAll(ShufflingTestExecutor.SHUFFLING_TEST_TYPES)
-          .putAll(GenesisTests.GENESIS_TEST_TYPES)
           .putAll(SanityTests.SANITY_TEST_TYPES)
           .putAll(RewardsTestExecutor.REWARDS_TEST_TYPES)
           .putAll(ForkChoiceTestExecutor.FORK_CHOICE_TEST_TYPES)

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -18,12 +18,13 @@ import org.junit.jupiter.api.Assertions;
 import tech.pegasys.teku.ethtests.TestFork;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.reference.altair.fork.ForkUpgradeTestExecutor;
+import tech.pegasys.teku.reference.altair.rewards.RewardsTestExecutorAltair;
 import tech.pegasys.teku.reference.common.epoch_processing.EpochProcessingTestExecutor;
 import tech.pegasys.teku.reference.common.operations.OperationsTestExecutor;
 import tech.pegasys.teku.reference.phase0.bls.BlsTests;
 import tech.pegasys.teku.reference.phase0.forkchoice.ForkChoiceTestExecutor;
 import tech.pegasys.teku.reference.phase0.genesis.GenesisTests;
-import tech.pegasys.teku.reference.phase0.rewards.RewardsTestExecutor;
+import tech.pegasys.teku.reference.phase0.rewards.RewardsTestExecutorPhase0;
 import tech.pegasys.teku.reference.phase0.sanity.SanityTests;
 import tech.pegasys.teku.reference.phase0.shuffling.ShufflingTestExecutor;
 import tech.pegasys.teku.reference.phase0.ssz_static.SszTestExecutor;
@@ -47,13 +48,14 @@ public abstract class Eth2ReferenceTestCase {
   private final ImmutableMap<String, TestExecutor> PHASE_0_TEST_TYPES =
       ImmutableMap.<String, TestExecutor>builder()
           .putAll(SanityTests.SANITY_TEST_TYPES)
-          .putAll(RewardsTestExecutor.REWARDS_TEST_TYPES)
           .putAll(ForkChoiceTestExecutor.FORK_CHOICE_TEST_TYPES)
+          .putAll(RewardsTestExecutorPhase0.REWARDS_TEST_TYPES)
           .build();
 
   private final ImmutableMap<String, TestExecutor> ALTAIR_TEST_TYPES =
       ImmutableMap.<String, TestExecutor>builder()
           .putAll(ForkUpgradeTestExecutor.FORK_UPGRADE_TEST_TYPES)
+          .putAll(RewardsTestExecutorAltair.REWARDS_TEST_TYPES)
           .build();
 
   protected void runReferenceTest(final TestDefinition testDefinition) throws Throwable {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -39,7 +39,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    * <p>e.g. set to "ssz_static" to run only ssz static tests or "ssz_static/Attestation" for only
    * attestation ssz tests.
    */
-  private static final String TEST_TYPE = "genesis";
+  private static final String TEST_TYPE = "rewards";
 
   /** Filter test to run to those from the specified spec. One of general, minimal or mainnet */
   private static final String SPEC = "";

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -39,7 +39,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    * <p>e.g. set to "ssz_static" to run only ssz static tests or "ssz_static/Attestation" for only
    * attestation ssz tests.
    */
-  private static final String TEST_TYPE = "operations";
+  private static final String TEST_TYPE = "genesis";
 
   /** Filter test to run to those from the specified spec. One of general, minimal or mainnet */
   private static final String SPEC = "";

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/rewards/RewardsTestExecutorAltair.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/rewards/RewardsTestExecutorAltair.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.altair.rewards;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
+import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.reference.TestExecutor;
+import tech.pegasys.teku.reference.phase0.rewards.ExpectedDeltas;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.config.SpecConfigAltair;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenaltyDeltas;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatusFactory;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatuses;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair.FlagIndexAndWeight;
+import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.RewardsAndPenaltiesCalculatorAltair;
+
+public class RewardsTestExecutorAltair implements TestExecutor {
+
+  public static final ImmutableMap<String, TestExecutor> REWARDS_TEST_TYPES =
+      ImmutableMap.of(
+          "rewards/basic", new RewardsTestExecutorAltair(),
+          "rewards/leak", new RewardsTestExecutorAltair(),
+          "rewards/random", new RewardsTestExecutorAltair());
+
+  @Override
+  public void runTest(final TestDefinition testDefinition) throws Throwable {
+    final BeaconState preState = loadStateFromSsz(testDefinition, "pre.ssz_snappy");
+
+    final ValidatorStatusFactory statusFactory =
+        testDefinition.getSpec().getGenesisSpec().getValidatorStatusFactory();
+    final ValidatorStatuses validatorStatuses = statusFactory.createValidatorStatuses(preState);
+
+    final SpecVersion spec = testDefinition.getSpec().getGenesisSpec();
+    final RewardsAndPenaltiesCalculatorAltair calculator =
+        new RewardsAndPenaltiesCalculatorAltair(
+            SpecConfigAltair.required(spec.getConfig()),
+            BeaconStateAltair.required(preState),
+            validatorStatuses,
+            (MiscHelpersAltair) spec.miscHelpers(),
+            (BeaconStateAccessorsAltair) spec.beaconStateAccessors());
+    runTest(testDefinition, calculator, validatorStatuses);
+  }
+
+  private void runTest(
+      final TestDefinition testDefinition,
+      final RewardsAndPenaltiesCalculatorAltair calculator,
+      final ValidatorStatuses validatorStatuses) {
+    assertDeltas(
+        testDefinition,
+        "head_deltas.ssz_snappy",
+        applyFlagIndexDeltas(
+            calculator, validatorStatuses, MiscHelpersAltair.TIMELY_HEAD_FLAG_INDEX_AND_WEIGHT));
+    assertDeltas(
+        testDefinition,
+        "inactivity_penalty_deltas.ssz_snappy",
+        apply(calculator, validatorStatuses, calculator::processInactivityPenaltyDeltas));
+    assertDeltas(
+        testDefinition,
+        "source_deltas.ssz_snappy",
+        applyFlagIndexDeltas(
+            calculator, validatorStatuses, MiscHelpersAltair.TIMELY_SOURCE_FLAG_INDEX_AND_WEIGHT));
+    assertDeltas(
+        testDefinition,
+        "target_deltas.ssz_snappy",
+        applyFlagIndexDeltas(
+            calculator, validatorStatuses, MiscHelpersAltair.TIMELY_TARGET_FLAG_INDEX_AND_WEIGHT));
+  }
+
+  private Supplier<RewardAndPenaltyDeltas> applyFlagIndexDeltas(
+      final RewardsAndPenaltiesCalculatorAltair calculator,
+      final ValidatorStatuses validatorStatuses,
+      final FlagIndexAndWeight flagIndexAndWeight) {
+    return apply(
+        calculator,
+        validatorStatuses,
+        deltas -> calculator.processFlagIndexDeltas(deltas, flagIndexAndWeight));
+  }
+
+  private Supplier<RewardAndPenaltyDeltas> apply(
+      final RewardsAndPenaltiesCalculatorAltair calculator,
+      final ValidatorStatuses validatorStatuses,
+      final Consumer<RewardAndPenaltyDeltas> step) {
+    return () -> {
+      final RewardAndPenaltyDeltas deltas =
+          new RewardAndPenaltyDeltas(validatorStatuses.getValidatorCount());
+      step.accept(deltas);
+      return deltas;
+    };
+  }
+
+  private void assertDeltas(
+      final TestDefinition testDefinition,
+      final String expectedResultsFileName,
+      final Supplier<RewardAndPenaltyDeltas> function) {
+    final RewardAndPenaltyDeltas expectedDeltas =
+        loadSsz(testDefinition, expectedResultsFileName, ExpectedDeltas.SSZ_SCHEMA).getDeltas();
+    final RewardAndPenaltyDeltas actualDeltas = function.get();
+    assertThat(actualDeltas)
+        .describedAs(expectedResultsFileName)
+        .isEqualToComparingFieldByField(expectedDeltas);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/rewards/RewardsTestExecutorAltair.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/rewards/RewardsTestExecutorAltair.java
@@ -74,7 +74,7 @@ public class RewardsTestExecutorAltair implements TestExecutor {
     assertDeltas(
         testDefinition,
         "inactivity_penalty_deltas.ssz_snappy",
-        apply(calculator, validatorStatuses, calculator::processInactivityPenaltyDeltas));
+        apply(validatorStatuses, calculator::processInactivityPenaltyDeltas));
     assertDeltas(
         testDefinition,
         "source_deltas.ssz_snappy",
@@ -92,15 +92,11 @@ public class RewardsTestExecutorAltair implements TestExecutor {
       final ValidatorStatuses validatorStatuses,
       final FlagIndexAndWeight flagIndexAndWeight) {
     return apply(
-        calculator,
-        validatorStatuses,
-        deltas -> calculator.processFlagIndexDeltas(deltas, flagIndexAndWeight));
+        validatorStatuses, deltas -> calculator.processFlagIndexDeltas(deltas, flagIndexAndWeight));
   }
 
   private Supplier<RewardAndPenaltyDeltas> apply(
-      final RewardsAndPenaltiesCalculatorAltair calculator,
-      final ValidatorStatuses validatorStatuses,
-      final Consumer<RewardAndPenaltyDeltas> step) {
+      final ValidatorStatuses validatorStatuses, final Consumer<RewardAndPenaltyDeltas> step) {
     return () -> {
       final RewardAndPenaltyDeltas deltas =
           new RewardAndPenaltyDeltas(validatorStatuses.getValidatorCount());

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/genesis/GenesisInitializationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/genesis/GenesisInitializationTestExecutor.java
@@ -53,6 +53,9 @@ public class GenesisInitializationTestExecutor implements TestExecutor {
   }
 
   private static class GenesisMetaData {
+    @JsonProperty(value = "description", required = false)
+    private String description;
+    
     @JsonProperty(value = "deposits_count", required = true)
     private int depositsCount;
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/genesis/GenesisInitializationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/genesis/GenesisInitializationTestExecutor.java
@@ -55,7 +55,7 @@ public class GenesisInitializationTestExecutor implements TestExecutor {
   private static class GenesisMetaData {
     @JsonProperty(value = "description", required = false)
     private String description;
-    
+
     @JsonProperty(value = "deposits_count", required = true)
     private int depositsCount;
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/genesis/GenesisInitializationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/genesis/GenesisInitializationTestExecutor.java
@@ -53,6 +53,7 @@ public class GenesisInitializationTestExecutor implements TestExecutor {
   }
 
   private static class GenesisMetaData {
+    @SuppressWarnings("unused")
     @JsonProperty(value = "description", required = false)
     private String description;
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/rewards/RewardsTestExecutorPhase0.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/rewards/RewardsTestExecutorPhase0.java
@@ -29,13 +29,13 @@ import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.Validato
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.RewardsAndPenaltiesCalculatorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.RewardsAndPenaltiesCalculatorPhase0.Step;
 
-public class RewardsTestExecutor implements TestExecutor {
+public class RewardsTestExecutorPhase0 implements TestExecutor {
 
   public static final ImmutableMap<String, TestExecutor> REWARDS_TEST_TYPES =
       ImmutableMap.of(
-          "rewards/basic", new RewardsTestExecutor(),
-          "rewards/leak", new RewardsTestExecutor(),
-          "rewards/random", new RewardsTestExecutor());
+          "rewards/basic", new RewardsTestExecutorPhase0(),
+          "rewards/leak", new RewardsTestExecutorPhase0(),
+          "rewards/random", new RewardsTestExecutorPhase0());
 
   @Override
   public void runTest(final TestDefinition testDefinition) throws Throwable {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/MiscHelpersAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/MiscHelpersAltair.java
@@ -23,16 +23,21 @@ import tech.pegasys.teku.spec.constants.ParticipationFlags;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 
 public class MiscHelpersAltair extends MiscHelpers {
+
+  public static final FlagIndexAndWeight TIMELY_HEAD_FLAG_INDEX_AND_WEIGHT =
+      new FlagIndexAndWeight(
+          ParticipationFlags.TIMELY_HEAD_FLAG_INDEX, IncentivizationWeights.TIMELY_HEAD_WEIGHT);
+  public static final FlagIndexAndWeight TIMELY_SOURCE_FLAG_INDEX_AND_WEIGHT =
+      new FlagIndexAndWeight(
+          ParticipationFlags.TIMELY_SOURCE_FLAG_INDEX, IncentivizationWeights.TIMELY_SOURCE_WEIGHT);
+  public static final FlagIndexAndWeight TIMELY_TARGET_FLAG_INDEX_AND_WEIGHT =
+      new FlagIndexAndWeight(
+          ParticipationFlags.TIMELY_TARGET_FLAG_INDEX, IncentivizationWeights.TIMELY_TARGET_WEIGHT);
   private static final List<FlagIndexAndWeight> flagIndicesAndWeights =
       List.of(
-          new FlagIndexAndWeight(
-              ParticipationFlags.TIMELY_HEAD_FLAG_INDEX, IncentivizationWeights.TIMELY_HEAD_WEIGHT),
-          new FlagIndexAndWeight(
-              ParticipationFlags.TIMELY_SOURCE_FLAG_INDEX,
-              IncentivizationWeights.TIMELY_SOURCE_WEIGHT),
-          new FlagIndexAndWeight(
-              ParticipationFlags.TIMELY_TARGET_FLAG_INDEX,
-              IncentivizationWeights.TIMELY_TARGET_WEIGHT));
+          TIMELY_HEAD_FLAG_INDEX_AND_WEIGHT,
+          TIMELY_SOURCE_FLAG_INDEX_AND_WEIGHT,
+          TIMELY_TARGET_FLAG_INDEX_AND_WEIGHT);
 
   public MiscHelpersAltair(final SpecConfig specConfig) {
     super(specConfig);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/RewardsAndPenaltiesCalculatorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/RewardsAndPenaltiesCalculatorAltair.java
@@ -82,7 +82,7 @@ public class RewardsAndPenaltiesCalculatorAltair extends RewardsAndPenaltiesCalc
    * @param deltas The deltas accumulator (holding deltas for all validators) to be updated
    * @param flagIndexAndWeight The flagIndexAndWeight to process
    */
-  protected void processFlagIndexDeltas(
+  public void processFlagIndexDeltas(
       final RewardAndPenaltyDeltas deltas, final FlagIndexAndWeight flagIndexAndWeight) {
 
     final int flagIndex = flagIndexAndWeight.getIndex();
@@ -129,7 +129,7 @@ public class RewardsAndPenaltiesCalculatorAltair extends RewardsAndPenaltiesCalc
    *     beacon-chain.md</a>
    * @param deltas The deltas accumulator (holding deltas for all validators) to be updated
    */
-  protected void processInactivityPenaltyDeltas(final RewardAndPenaltyDeltas deltas) {
+  public void processInactivityPenaltyDeltas(final RewardAndPenaltyDeltas deltas) {
     if (isInactivityLeak()) {
       final List<ValidatorStatus> statusList = validatorStatuses.getStatuses();
       for (int i = 0; i < statusList.size(); i++) {


### PR DESCRIPTION
## PR Description
Enable the bls, genesis and shuffling reference tests for Altair.  The BLS tests are actually all in general anyway and the shuffling tests only exist for mainnet as they are completely unchanged in Altair but if they ever appear we'll now run them. That seems better than leaving them as phase0 specific.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
