### PR TITLE
Upgrade reference tests to 1.1.0-alpha.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ allprojects {
 }
 
 // Note: v1.0.0 tests were republished to fix an initial error. This comment forces cache update
-def refTestVersion = 'v1.1.0-alpha.2'
+def refTestVersion = 'v1.1.0-alpha.3'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
 def refTestDownloadDir = "${buildDir}/refTests/${refTestVersion}"
 def refTestExpandDir = "${project.rootDir}/eth-reference-tests/src/referenceTest/resources/eth2.0-spec-tests/"

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -39,7 +39,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    * <p>e.g. set to "ssz_static" to run only ssz static tests or "ssz_static/Attestation" for only
    * attestation ssz tests.
    */
-  private static final String TEST_TYPE = "rewards";
+  private static final String TEST_TYPE = "operations";
 
   /** Filter test to run to those from the specified spec. One of general, minimal or mainnet */
   private static final String SPEC = "";

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -48,13 +48,6 @@ public class ForkChoiceTestExecutor implements TestExecutor {
 
   @Override
   public void runTest(final TestDefinition testDefinition) throws Throwable {
-    if (testDefinition.getTestName().equals("filtered_block_tree")) {
-      // filtered_block_tree test is broken.
-      // See https://github.com/ethereum/eth2.0-specs/issues/2269
-      TestExecutor.IGNORE_TESTS.runTest(testDefinition);
-      return;
-    }
-
     // Note: The fork choice spec says there may be settings in a meta.yaml file but currently no
     // tests actually have one, so we currently don't bother trying to load it.
     final BeaconState anchorState =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/IncentivizationWeights.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/IncentivizationWeights.java
@@ -20,5 +20,6 @@ public class IncentivizationWeights {
   public static final UInt64 TIMELY_SOURCE_WEIGHT = UInt64.valueOf(12);
   public static final UInt64 TIMELY_TARGET_WEIGHT = UInt64.valueOf(24);
   public static final UInt64 SYNC_REWARD_WEIGHT = UInt64.valueOf(8);
+  public static final UInt64 PROPOSER_WEIGHT = UInt64.valueOf(8);
   public static final UInt64 WEIGHT_DENOMINATOR = UInt64.valueOf(64);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
@@ -142,9 +142,13 @@ public class BeaconStateMutators {
 
     UInt64 whistleblower_reward =
         validator.getEffective_balance().dividedBy(specConfig.getWhistleblowerRewardQuotient());
-    UInt64 proposer_reward = whistleblower_reward.dividedBy(specConfig.getProposerRewardQuotient());
+    UInt64 proposer_reward = calculateProposerReward(whistleblower_reward);
     increaseBalance(state, proposer_index, proposer_reward);
     increaseBalance(state, whistleblowerIndex, whistleblower_reward.minus(proposer_reward));
+  }
+
+  protected UInt64 calculateProposerReward(final UInt64 whistleblower_reward) {
+    return whistleblower_reward.dividedBy(specConfig.getProposerRewardQuotient());
   }
 
   protected int getMinSlashingPenaltyQuotient() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -159,7 +159,8 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
     if (!proposerRewardNumerator.isZero()) {
       final int proposerIndex = beaconStateAccessors.getBeaconProposerIndex(state);
       final UInt64 proposerRewardDenominator =
-          (WEIGHT_DENOMINATOR.minus(PROPOSER_WEIGHT))
+          WEIGHT_DENOMINATOR
+              .minus(PROPOSER_WEIGHT)
               .times(WEIGHT_DENOMINATOR)
               .dividedBy(PROPOSER_WEIGHT);
       final UInt64 proposerReward = proposerRewardNumerator.dividedBy(proposerRewardDenominator);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateMutatorsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateMutatorsAltair.java
@@ -13,6 +13,10 @@
 
 package tech.pegasys.teku.spec.logic.versions.altair.helpers;
 
+import static tech.pegasys.teku.spec.constants.IncentivizationWeights.PROPOSER_WEIGHT;
+import static tech.pegasys.teku.spec.constants.IncentivizationWeights.WEIGHT_DENOMINATOR;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
@@ -27,6 +31,11 @@ public class BeaconStateMutatorsAltair extends BeaconStateMutators {
       final BeaconStateAccessors beaconStateAccessors) {
     super(specConfig, miscHelpers, beaconStateAccessors);
     this.specConfigAltair = specConfig;
+  }
+
+  @Override
+  protected UInt64 calculateProposerReward(final UInt64 whistleblower_reward) {
+    return whistleblower_reward.times(PROPOSER_WEIGHT).dividedBy(WEIGHT_DENOMINATOR);
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Upgrade ref tests to 1.1.0-alpha.3 and re-enable fork choice test that was broken in the previous alpha.

Couple of logic changes were also applied around the way proposer rewards are calculated that has changed since alpha.2.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
