### PR TITLE
Add SyncCommitteeUtil

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -61,6 +61,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProces
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
+import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.ssz.SszList;
 import tech.pegasys.teku.ssz.collections.SszBitlist;
@@ -106,6 +107,10 @@ public class Spec {
 
   public BeaconStateUtil getBeaconStateUtil(final UInt64 slot) {
     return atSlot(slot).getBeaconStateUtil();
+  }
+
+  public Optional<SyncCommitteeUtil> getSyncCommitteeUtil(final UInt64 slot) {
+    return atSlot(slot).getSyncCommitteeUtil();
   }
 
   public SpecVersion getGenesisSpec() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecVersion.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecVersion.java
@@ -57,7 +57,7 @@ public class SpecVersion extends DelegatingSpecLogic {
   }
 
   public static SpecVersion createAltair(final SpecConfigAltair specConfig) {
-    final SchemaDefinitions schemaDefinitions = new SchemaDefinitionsAltair(specConfig);
+    final SchemaDefinitionsAltair schemaDefinitions = new SchemaDefinitionsAltair(specConfig);
     final SpecLogic specLogic = SpecLogicAltair.create(specConfig, schemaDefinitions);
     return new SpecVersion(specConfig, schemaDefinitions, specLogic);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeSigningData.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeSigningData.java
@@ -26,6 +26,13 @@ public class SyncCommitteeSigningData
     super(schema, backingNode);
   }
 
+  protected SyncCommitteeSigningData(
+      final SyncCommitteeSigningDataSchema schema,
+      final SszUInt64 slot,
+      final SszUInt64 subcommitteeIndex) {
+    super(schema, slot, subcommitteeIndex);
+  }
+
   public UInt64 getSlot() {
     return getField0().get();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeSigningDataSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeSigningDataSchema.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations.versions.altair;
 
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.containers.ContainerSchema2;
 import tech.pegasys.teku.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.ssz.schema.SszPrimitiveSchemas;
@@ -34,5 +35,9 @@ public class SyncCommitteeSigningDataSchema
   @Override
   public SyncCommitteeSigningData createFromBackingNode(final TreeNode node) {
     return new SyncCommitteeSigningData(this, node);
+  }
+
+  public SyncCommitteeSigningData create(final UInt64 slot, final UInt64 subcommitteeIndex) {
+    return new SyncCommitteeSigningData(this, SszUInt64.of(slot), SszUInt64.of(subcommitteeIndex));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.logic;
 
+import java.util.Optional;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
@@ -26,6 +27,7 @@ import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.CommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
+import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 
 public class DelegatingSpecLogic implements SpecLogic {
@@ -78,6 +80,11 @@ public class DelegatingSpecLogic implements SpecLogic {
   @Override
   public BlockProposalUtil getBlockProposalUtil() {
     return specLogic.getBlockProposalUtil();
+  }
+
+  @Override
+  public Optional<SyncCommitteeUtil> getSyncCommitteeUtil() {
+    return specLogic.getSyncCommitteeUtil();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.logic;
 
+import java.util.Optional;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
@@ -26,6 +27,7 @@ import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.CommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
+import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 
 public interface SpecLogic {
@@ -46,6 +48,8 @@ public interface SpecLogic {
   ForkChoiceUtil getForkChoiceUtil();
 
   BlockProposalUtil getBlockProposalUtil();
+
+  Optional<SyncCommitteeUtil> getSyncCommitteeUtil();
 
   ValidatorStatusFactory getValidatorStatusFactory();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/AbstractSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/AbstractSpecLogic.java
@@ -47,7 +47,7 @@ public abstract class AbstractSpecLogic implements SpecLogic {
   protected final ForkChoiceUtil forkChoiceUtil;
   protected final BlockProposalUtil blockProposalUtil;
 
-  public AbstractSpecLogic(
+  protected AbstractSpecLogic(
       final Predicates predicates,
       final MiscHelpers miscHelpers,
       final BeaconStateAccessors beaconStateAccessors,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/AbstractSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/AbstractSpecLogic.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.spec.logic.common.util.CommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 
-public class AbstractSpecLogic implements SpecLogic {
+public abstract class AbstractSpecLogic implements SpecLogic {
   // Helpers
   protected final Predicates predicates;
   protected final MiscHelpers miscHelpers;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.util;
+
+import static tech.pegasys.teku.spec.constants.NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT;
+import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.bytesToUInt64;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfigAltair;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSigningData;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
+import tech.pegasys.teku.ssz.type.Bytes4;
+
+public class SyncCommitteeUtil {
+
+  // TODO: Should this be in the constants file?
+  private static final int TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE = 4;
+
+  private final BeaconStateAccessors beaconStateAccessors;
+  private final BeaconStateUtil beaconStateUtil;
+  private final SpecConfigAltair specConfig;
+  private final MiscHelpers miscHelpers;
+  private final SchemaDefinitionsAltair schemaDefinitionsAltair;
+
+  public SyncCommitteeUtil(
+      final BeaconStateAccessors beaconStateAccessors,
+      final BeaconStateUtil beaconStateUtil,
+      final SpecConfigAltair specConfig,
+      final MiscHelpers miscHelpers,
+      final SchemaDefinitionsAltair schemaDefinitionsAltair) {
+    this.beaconStateAccessors = beaconStateAccessors;
+    this.beaconStateUtil = beaconStateUtil;
+    this.specConfig = specConfig;
+    this.miscHelpers = miscHelpers;
+    this.schemaDefinitionsAltair = schemaDefinitionsAltair;
+  }
+
+  public Bytes getSyncCommitteeSignatureSigningRoot(
+      final BeaconState state, final SyncCommitteeContribution contribution) {
+    final UInt64 epoch = beaconStateAccessors.getCurrentEpoch(state);
+    final Bytes32 domain =
+        beaconStateUtil.getDomain(state, specConfig.getDomainSyncCommittee(), epoch);
+    return beaconStateUtil.computeSigningRoot(contribution.getBeaconBlockRoot(), domain);
+  }
+
+  public Bytes getContributionAndProofSigningRoot(
+      final BeaconState state, final ContributionAndProof contributionAndProof) {
+    final SyncCommitteeContribution contribution = contributionAndProof.getContribution();
+    final Bytes32 domain =
+        beaconStateUtil.getDomain(
+            state,
+            specConfig.getDomainContributionAndProof(),
+            miscHelpers.computeEpochAtSlot(contribution.getSlot()));
+    return beaconStateUtil.computeSigningRoot(contributionAndProof, domain);
+  }
+
+  public boolean isSyncCommitteeAggregator(final BLSSignature signature) {
+    final int modulo =
+        Math.max(
+            1,
+            specConfig.getSyncCommitteeSize()
+                / SYNC_COMMITTEE_SUBNET_COUNT
+                / TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE);
+    return bytesToUInt64(Hash.sha2_256(signature.toSSZBytes().slice(0, 8))).mod(modulo).isZero();
+  }
+
+  public Bytes getSyncCommitteeSigningDataSigningRoot(
+      final BeaconState state, final UInt64 slot, final UInt64 subcommitteeIndex) {
+    final Bytes4 domainSyncCommitteeSelectionProof =
+        specConfig.getDomainSyncCommitteeSelectionProof();
+    final Bytes32 domain =
+        beaconStateUtil.getDomain(
+            state, domainSyncCommitteeSelectionProof, miscHelpers.computeEpochAtSlot(slot));
+    final SyncCommitteeSigningData signingData =
+        schemaDefinitionsAltair.getSyncCommitteeSigningDataSchema().create(slot, subcommitteeIndex);
+    return beaconStateUtil.computeSigningRoot(signingData, domain);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -33,7 +33,7 @@ import tech.pegasys.teku.ssz.type.Bytes4;
 
 public class SyncCommitteeUtil {
 
-  // TODO: Should this be in the constants file?
+  // TODO: Should this be in constants file? https://github.com/ethereum/eth2.0-specs/issues/2317
   private static final int TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE = 4;
 
   private final BeaconStateAccessors beaconStateAccessors;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.logic.versions.phase0;
 
+import java.util.Optional;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
@@ -26,6 +27,7 @@ import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.CommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
+import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.versions.phase0.block.BlockProcessorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.EpochProcessorPhase0;
@@ -140,5 +142,10 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
         stateTransition,
         forkChoiceUtil,
         blockProposalUtil);
+  }
+
+  @Override
+  public Optional<SyncCommitteeUtil> getSyncCommitteeUtil() {
+    return Optional.empty();
   }
 }


### PR DESCRIPTION
## PR Description
Add the sync committee methods from honest validator specs (also required as part of gossip validation) to a new `SyncCommitteeUtil` which is available from the spec.

Went with returning an optional as its not supported in phase0 and the optional makes it easy to reject all gossip received for forks that don't support it.  The other option is throwing `UnsupportedOperationException` for phase0 but that would then need to be handled specifically in gossip validation.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
