### PR TITLE
Add support for signing sync committee data structures

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalSigner.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalSigner.java
@@ -20,23 +20,30 @@ import static tech.pegasys.teku.core.signatures.SigningRootUtil.signingRootForSi
 import static tech.pegasys.teku.core.signatures.SigningRootUtil.signingRootForSignVoluntaryExit;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSigningData;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 
 public class LocalSigner implements Signer {
+
+  private final Spec spec;
   private final BLSKeyPair keypair;
   private final AsyncRunner asyncRunner;
 
-  public LocalSigner(final BLSKeyPair keypair, final AsyncRunner asyncRunner) {
+  public LocalSigner(final Spec spec, final BLSKeyPair keypair, final AsyncRunner asyncRunner) {
+    this.spec = spec;
     this.keypair = keypair;
     this.asyncRunner = asyncRunner;
   }
@@ -72,6 +79,40 @@ public class LocalSigner implements Signer {
   public SafeFuture<BLSSignature> signVoluntaryExit(
       final VoluntaryExit voluntaryExit, final ForkInfo forkInfo) {
     return sign(signingRootForSignVoluntaryExit(voluntaryExit, forkInfo));
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signSyncCommitteeSignature(
+      final UInt64 slot, final Bytes32 beaconBlockRoot, final ForkInfo forkInfo) {
+    return SafeFuture.of(
+            () ->
+                spec.getSyncCommitteeUtil(slot)
+                    .orElseThrow()
+                    .getSyncCommitteeSignatureSigningRoot(
+                        forkInfo, spec.computeEpochAtSlot(slot), beaconBlockRoot))
+        .thenCompose(this::sign);
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signSyncCommitteeSelectionProof(
+      final SyncCommitteeSigningData signingData, final ForkInfo forkInfo) {
+    return SafeFuture.of(
+            () ->
+                spec.getSyncCommitteeUtil(signingData.getSlot())
+                    .orElseThrow()
+                    .getSyncCommitteeSigningDataSigningRoot(signingData, forkInfo))
+        .thenCompose(this::sign);
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signContributionAndProof(
+      final ContributionAndProof contributionAndProof, final ForkInfo forkInfo) {
+    return SafeFuture.of(
+            () ->
+                spec.getSyncCommitteeUtil(contributionAndProof.getContribution().getSlot())
+                    .orElseThrow()
+                    .getContributionAndProofSigningRoot(contributionAndProof, forkInfo))
+        .thenCompose(this::sign);
   }
 
   @Override

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/Signer.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/Signer.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.core.signatures;
 
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -20,6 +21,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSigningData;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 
 public interface Signer {
@@ -36,6 +39,15 @@ public interface Signer {
       AggregateAndProof aggregateAndProof, ForkInfo forkInfo);
 
   SafeFuture<BLSSignature> signVoluntaryExit(VoluntaryExit voluntaryExit, ForkInfo forkInfo);
+
+  SafeFuture<BLSSignature> signSyncCommitteeSignature(
+      UInt64 slot, Bytes32 beaconBlockRoot, ForkInfo forkInfo);
+
+  SafeFuture<BLSSignature> signSyncCommitteeSelectionProof(
+      SyncCommitteeSigningData signingData, ForkInfo forkInfo);
+
+  SafeFuture<BLSSignature> signContributionAndProof(
+      ContributionAndProof contributionAndProof, ForkInfo forkInfo);
 
   boolean isLocal();
 }

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SlashingProtectedSigner.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SlashingProtectedSigner.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.core.signatures;
 
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -23,6 +24,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSigningData;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 
 /**
@@ -116,6 +119,24 @@ public class SlashingProtectedSigner implements Signer {
   public SafeFuture<BLSSignature> signVoluntaryExit(
       final VoluntaryExit voluntaryExit, final ForkInfo forkInfo) {
     return delegate.signVoluntaryExit(voluntaryExit, forkInfo);
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signSyncCommitteeSignature(
+      final UInt64 slot, final Bytes32 beaconBlockRoot, final ForkInfo forkInfo) {
+    return delegate.signSyncCommitteeSignature(slot, beaconBlockRoot, forkInfo);
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signSyncCommitteeSelectionProof(
+      final SyncCommitteeSigningData signingData, final ForkInfo forkInfo) {
+    return delegate.signSyncCommitteeSelectionProof(signingData, forkInfo);
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signContributionAndProof(
+      final ContributionAndProof contributionAndProof, final ForkInfo forkInfo) {
+    return delegate.signContributionAndProof(contributionAndProof, forkInfo);
   }
 
   @Override

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/LocalSignerTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/LocalSignerTest.java
@@ -23,6 +23,8 @@ import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -31,13 +33,14 @@ import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class LocalSignerTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Spec spec = SpecFactory.createMinimal();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final ForkInfo fork = dataStructureUtil.randomForkInfo();
 
   private static final BLSKeyPair KEYPAIR = BLSTestUtil.randomKeyPair(1234);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
 
-  private final LocalSigner signer = new LocalSigner(KEYPAIR, asyncRunner);
+  private final LocalSigner signer = new LocalSigner(spec, KEYPAIR, asyncRunner);
 
   @Test
   public void shouldSignBlock() {

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AggregateGenerator.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AggregateGenerator.java
@@ -63,7 +63,7 @@ public class AggregateGenerator {
   }
 
   private Signer getSignerForValidatorIndex(final int validatorIndex) {
-    return new LocalSigner(validatorKeys.get(validatorIndex), SYNC_RUNNER);
+    return new LocalSigner(spec, validatorKeys.get(validatorIndex), SYNC_RUNNER);
   }
 
   public class Generator {

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AttestationGenerator.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AttestationGenerator.java
@@ -322,7 +322,7 @@ public class AttestationGenerator {
       SszBitlist aggregationBitfield = getAggregationBits(committeSize, indexIntoCommittee);
 
       BLSSignature signature =
-          new LocalSigner(attesterKeyPair, SYNC_RUNNER)
+          new LocalSigner(spec, attesterKeyPair, SYNC_RUNNER)
               .signAttestationData(attestationData, state.getForkInfo())
               .join();
       return new Attestation(aggregationBitfield, attestationData, signature);

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -407,12 +407,12 @@ public class ChainBuilder {
   }
 
   private Signer getSigner(final int proposerIndex) {
-    return new LocalSigner(validatorKeys.get(proposerIndex), SYNC_RUNNER);
+    return new LocalSigner(spec, validatorKeys.get(proposerIndex), SYNC_RUNNER);
   }
 
   public static final class BlockOptions {
 
-    private List<Attestation> attestations = new ArrayList<>();
+    private final List<Attestation> attestations = new ArrayList<>();
     private Optional<Eth1Data> eth1Data = Optional.empty();
 
     private BlockOptions() {}

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/VoluntaryExitGenerator.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/VoluntaryExitGenerator.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.core.signatures.LocalSigner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
@@ -29,9 +30,12 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.util.config.Constants;
 
 public class VoluntaryExitGenerator {
+
+  private final Spec spec;
   private final List<BLSKeyPair> validatorKeys;
 
-  public VoluntaryExitGenerator(final List<BLSKeyPair> validatorKeys) {
+  public VoluntaryExitGenerator(final Spec spec, final List<BLSKeyPair> validatorKeys) {
+    this.spec = spec;
     this.validatorKeys = validatorKeys;
   }
 
@@ -40,7 +44,7 @@ public class VoluntaryExitGenerator {
     VoluntaryExit exit = new VoluntaryExit(epoch, UInt64.valueOf(validatorIndex));
 
     BLSSignature exitSignature =
-        new LocalSigner(getKeypair(validatorIndex, valid), SYNC_RUNNER)
+        new LocalSigner(spec, getKeypair(validatorIndex, valid), SYNC_RUNNER)
             .signVoluntaryExit(exit, forkInfo)
             .join();
 

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/signatures/NoOpSigner.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/signatures/NoOpSigner.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.core.signatures;
 
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -20,6 +21,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSigningData;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 
 public class NoOpSigner implements Signer {
@@ -57,6 +60,24 @@ public class NoOpSigner implements Signer {
   @Override
   public SafeFuture<BLSSignature> signVoluntaryExit(
       final VoluntaryExit voluntaryExit, final ForkInfo forkInfo) {
+    return new SafeFuture<>();
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signSyncCommitteeSignature(
+      final UInt64 slot, final Bytes32 beaconBlockRoot, final ForkInfo forkInfo) {
+    return new SafeFuture<>();
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signSyncCommitteeSelectionProof(
+      final SyncCommitteeSigningData signingData, final ForkInfo forkInfo) {
+    return new SafeFuture<>();
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signContributionAndProof(
+      final ContributionAndProof contributionAndProof, final ForkInfo forkInfo) {
     return new SafeFuture<>();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ContributionAndProof.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ContributionAndProof.java
@@ -27,6 +27,14 @@ public class ContributionAndProof
     super(schema, backingNode);
   }
 
+  ContributionAndProof(
+      final ContributionAndProofSchema schema,
+      final SszUInt64 aggregatorIndex,
+      final SyncCommitteeContribution contribution,
+      final SszSignature selectionProof) {
+    super(schema, aggregatorIndex, contribution, selectionProof);
+  }
+
   public UInt64 getAggregatorIndex() {
     return getField0().get();
   }
@@ -35,7 +43,7 @@ public class ContributionAndProof
     return getField1();
   }
 
-  public BLSSignature getSignature() {
+  public BLSSignature getSelectionProof() {
     return getField2().getSignature();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ContributionAndProofSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ContributionAndProofSchema.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.datastructures.operations.versions.altair;
 
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 import tech.pegasys.teku.ssz.containers.ContainerSchema3;
@@ -42,5 +44,13 @@ public class ContributionAndProofSchema
   @Override
   public ContributionAndProof createFromBackingNode(final TreeNode node) {
     return new ContributionAndProof(this, node);
+  }
+
+  public ContributionAndProof create(
+      final UInt64 aggregatorIndex,
+      final SyncCommitteeContribution contribution,
+      final BLSSignature selectionProof) {
+    return new ContributionAndProof(
+        this, SszUInt64.of(aggregatorIndex), contribution, new SszSignature(selectionProof));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SignedContributionAndProof.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SignedContributionAndProof.java
@@ -26,6 +26,13 @@ public class SignedContributionAndProof
     super(schema, backingNode);
   }
 
+  protected SignedContributionAndProof(
+      final SignedContributionAndProofSchema schema,
+      final ContributionAndProof message,
+      final SszSignature signature) {
+    super(schema, message, signature);
+  }
+
   public ContributionAndProof getMessage() {
     return getField0();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SignedContributionAndProofSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SignedContributionAndProofSchema.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations.versions.altair;
 
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 import tech.pegasys.teku.ssz.containers.ContainerSchema2;
@@ -23,8 +24,8 @@ public class SignedContributionAndProofSchema
 
   private SignedContributionAndProofSchema(
       final NamedSchema<ContributionAndProof> messageSchema,
-      final NamedSchema<SszSignature> signatureProof) {
-    super("SignedContributionAndProof", messageSchema, signatureProof);
+      final NamedSchema<SszSignature> signatureSchema) {
+    super("SignedContributionAndProof", messageSchema, signatureSchema);
   }
 
   public static SignedContributionAndProofSchema create(
@@ -37,5 +38,10 @@ public class SignedContributionAndProofSchema
   @Override
   public SignedContributionAndProof createFromBackingNode(final TreeNode node) {
     return new SignedContributionAndProof(this, node);
+  }
+
+  public SignedContributionAndProof create(
+      final ContributionAndProof message, final BLSSignature signature) {
+    return new SignedContributionAndProof(this, message, new SszSignature(signature));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeContribution.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeContribution.java
@@ -19,7 +19,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.ssz.collections.SszBitvector;
 import tech.pegasys.teku.ssz.containers.Container5;
-import tech.pegasys.teku.ssz.containers.ContainerSchema5;
 import tech.pegasys.teku.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.ssz.tree.TreeNode;
@@ -28,46 +27,23 @@ public class SyncCommitteeContribution
     extends Container5<
         SyncCommitteeContribution, SszUInt64, SszBytes32, SszUInt64, SszBitvector, SszSignature> {
 
-  protected SyncCommitteeContribution(
-      final ContainerSchema5<
-              SyncCommitteeContribution,
-              SszUInt64,
-              SszBytes32,
-              SszUInt64,
-              SszBitvector,
-              SszSignature>
-          schema) {
+  protected SyncCommitteeContribution(final SyncCommitteeContributionSchema schema) {
     super(schema);
   }
 
   protected SyncCommitteeContribution(
-      final ContainerSchema5<
-              SyncCommitteeContribution,
-              SszUInt64,
-              SszBytes32,
-              SszUInt64,
-              SszBitvector,
-              SszSignature>
-          schema,
-      final TreeNode backingNode) {
+      final SyncCommitteeContributionSchema schema, final TreeNode backingNode) {
     super(schema, backingNode);
   }
 
   protected SyncCommitteeContribution(
-      final ContainerSchema5<
-              SyncCommitteeContribution,
-              SszUInt64,
-              SszBytes32,
-              SszUInt64,
-              SszBitvector,
-              SszSignature>
-          schema,
-      final SszUInt64 arg0,
-      final SszBytes32 arg1,
-      final SszUInt64 arg2,
-      final SszBitvector arg3,
-      final SszSignature arg4) {
-    super(schema, arg0, arg1, arg2, arg3, arg4);
+      final SyncCommitteeContributionSchema schema,
+      final SszUInt64 slot,
+      final SszBytes32 beaconBlockRoot,
+      final SszUInt64 subcommitteeIndex,
+      final SszBitvector aggregationBits,
+      final SszSignature signature) {
+    super(schema, slot, beaconBlockRoot, subcommitteeIndex, aggregationBits, signature);
   }
 
   public UInt64 getSlot() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeContributionSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeContributionSchema.java
@@ -15,6 +15,9 @@ package tech.pegasys.teku.spec.datastructures.operations.versions.altair;
 
 import static tech.pegasys.teku.spec.constants.NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT;
 
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
@@ -57,8 +60,28 @@ public class SyncCommitteeContributionSchema
         namedSchema("signature", SszSignatureSchema.INSTANCE));
   }
 
+  public SyncCommitteeContribution create(
+      final UInt64 slot,
+      final Bytes32 beaconBlockRoot,
+      final UInt64 subcommitteeIndex,
+      final SszBitvector aggregationBits,
+      final BLSSignature signature) {
+    return new SyncCommitteeContribution(
+        this,
+        SszUInt64.of(slot),
+        SszBytes32.of(beaconBlockRoot),
+        SszUInt64.of(subcommitteeIndex),
+        aggregationBits,
+        new SszSignature(signature));
+  }
+
   @Override
   public SyncCommitteeContribution createFromBackingNode(final TreeNode node) {
     return new SyncCommitteeContribution(this, node);
+  }
+
+  @SuppressWarnings("unchecked")
+  public SszBitvectorSchema<SszBitvector> getAggregationBitsSchema() {
+    return (SszBitvectorSchema<SszBitvector>) getChildSchema(3);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -168,8 +168,4 @@ public class SyncCommitteeUtil {
       final ContributionAndProof message, final BLSSignature signature) {
     return schemaDefinitionsAltair.getSignedContributionAndProofSchema().create(message, signature);
   }
-
-  private UInt64 computeSyncCommitteePeriod(final UInt64 epoch) {
-    return epoch.dividedBy(specConfig.getEpochsPerSyncCommitteePeriod());
-  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -61,11 +61,11 @@ public class SyncCommitteeUtil {
   public Bytes32 getSyncCommitteeSignatureSigningRoot(
       final BeaconState state, final Bytes32 blockRoot) {
     return getSyncCommitteeSignatureSigningRoot(
-        state.getForkInfo(), beaconStateAccessors.getCurrentEpoch(state), blockRoot);
+        blockRoot, beaconStateAccessors.getCurrentEpoch(state), state.getForkInfo());
   }
 
   public Bytes32 getSyncCommitteeSignatureSigningRoot(
-      final ForkInfo forkInfo, final UInt64 epoch, final Bytes32 blockRoot) {
+      final Bytes32 blockRoot, final UInt64 epoch, final ForkInfo forkInfo) {
     final Bytes32 domain =
         beaconStateUtil.getDomain(
             specConfig.getDomainSyncCommittee(),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -23,8 +23,11 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContributionSchema;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSigningData;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
@@ -55,9 +58,26 @@ public class SyncCommitteeUtil {
     this.schemaDefinitionsAltair = schemaDefinitionsAltair;
   }
 
-  public Bytes getSyncCommitteeSignatureSigningRoot(
+  public Bytes32 getSyncCommitteeSignatureSigningRoot(
+      final BeaconState state, final Bytes32 blockRoot) {
+    return getSyncCommitteeSignatureSigningRoot(
+        state.getForkInfo(), beaconStateAccessors.getCurrentEpoch(state), blockRoot);
+  }
+
+  public Bytes32 getSyncCommitteeSignatureSigningRoot(
+      final ForkInfo forkInfo, final UInt64 epoch, final Bytes32 blockRoot) {
+    final Bytes32 domain =
+        beaconStateUtil.getDomain(
+            specConfig.getDomainSyncCommittee(),
+            epoch,
+            forkInfo.getFork(),
+            forkInfo.getGenesisValidatorsRoot());
+    return beaconStateUtil.computeSigningRoot(blockRoot, domain);
+  }
+
+  public Bytes getSyncCommitteeContributionSigningRoot(
       final BeaconState state, final SyncCommitteeContribution contribution) {
-    final UInt64 epoch = beaconStateAccessors.getCurrentEpoch(state);
+    final UInt64 epoch = miscHelpers.computeEpochAtSlot(contribution.getSlot());
     final Bytes32 domain =
         beaconStateUtil.getDomain(state, specConfig.getDomainSyncCommittee(), epoch);
     return beaconStateUtil.computeSigningRoot(contribution.getBeaconBlockRoot(), domain);
@@ -65,12 +85,19 @@ public class SyncCommitteeUtil {
 
   public Bytes getContributionAndProofSigningRoot(
       final BeaconState state, final ContributionAndProof contributionAndProof) {
+    final ForkInfo forkInfo = state.getForkInfo();
+    return getContributionAndProofSigningRoot(contributionAndProof, forkInfo);
+  }
+
+  public Bytes getContributionAndProofSigningRoot(
+      final ContributionAndProof contributionAndProof, final ForkInfo forkInfo) {
     final SyncCommitteeContribution contribution = contributionAndProof.getContribution();
     final Bytes32 domain =
         beaconStateUtil.getDomain(
-            state,
             specConfig.getDomainContributionAndProof(),
-            miscHelpers.computeEpochAtSlot(contribution.getSlot()));
+            miscHelpers.computeEpochAtSlot(contribution.getSlot()),
+            forkInfo.getFork(),
+            forkInfo.getGenesisValidatorsRoot());
     return beaconStateUtil.computeSigningRoot(contributionAndProof, domain);
   }
 
@@ -81,18 +108,68 @@ public class SyncCommitteeUtil {
             specConfig.getSyncCommitteeSize()
                 / SYNC_COMMITTEE_SUBNET_COUNT
                 / TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE);
-    return bytesToUInt64(Hash.sha2_256(signature.toSSZBytes().slice(0, 8))).mod(modulo).isZero();
+    return bytesToUInt64(Hash.sha2_256(signature.toSSZBytes()).slice(0, 8)).mod(modulo).isZero();
   }
 
   public Bytes getSyncCommitteeSigningDataSigningRoot(
       final BeaconState state, final UInt64 slot, final UInt64 subcommitteeIndex) {
+    final SyncCommitteeSigningData signingData =
+        createSyncCommitteeSigningData(slot, subcommitteeIndex);
+    final ForkInfo forkInfo = state.getForkInfo();
+    return getSyncCommitteeSigningDataSigningRoot(signingData, forkInfo);
+  }
+
+  public Bytes getSyncCommitteeSigningDataSigningRoot(
+      final SyncCommitteeSigningData signingData, final ForkInfo forkInfo) {
     final Bytes4 domainSyncCommitteeSelectionProof =
         specConfig.getDomainSyncCommitteeSelectionProof();
     final Bytes32 domain =
         beaconStateUtil.getDomain(
-            state, domainSyncCommitteeSelectionProof, miscHelpers.computeEpochAtSlot(slot));
-    final SyncCommitteeSigningData signingData =
-        schemaDefinitionsAltair.getSyncCommitteeSigningDataSchema().create(slot, subcommitteeIndex);
+            domainSyncCommitteeSelectionProof,
+            miscHelpers.computeEpochAtSlot(signingData.getSlot()),
+            forkInfo.getFork(),
+            forkInfo.getGenesisValidatorsRoot());
     return beaconStateUtil.computeSigningRoot(signingData, domain);
+  }
+
+  public SyncCommitteeSigningData createSyncCommitteeSigningData(
+      final UInt64 slot, final UInt64 subcommitteeIndex) {
+    return schemaDefinitionsAltair
+        .getSyncCommitteeSigningDataSchema()
+        .create(slot, subcommitteeIndex);
+  }
+
+  public SyncCommitteeContribution createSyncCommitteeContribution(
+      final UInt64 slot,
+      final Bytes32 beaconBlockRoot,
+      final UInt64 subcommitteeIndex,
+      final Iterable<Integer> setParticipationBits,
+      final BLSSignature signature) {
+    final SyncCommitteeContributionSchema schema =
+        schemaDefinitionsAltair.getSyncCommitteeContributionSchema();
+    return schema.create(
+        slot,
+        beaconBlockRoot,
+        subcommitteeIndex,
+        schema.getAggregationBitsSchema().ofBits(setParticipationBits),
+        signature);
+  }
+
+  public ContributionAndProof createContributionAndProof(
+      final UInt64 aggregatorIndex,
+      final SyncCommitteeContribution contribution,
+      final BLSSignature selectionProof) {
+    return schemaDefinitionsAltair
+        .getContributionAndProofSchema()
+        .create(aggregatorIndex, contribution, selectionProof);
+  }
+
+  public SignedContributionAndProof createSignedContributionAndProof(
+      final ContributionAndProof message, final BLSSignature signature) {
+    return schemaDefinitionsAltair.getSignedContributionAndProofSchema().create(message, signature);
+  }
+
+  private UInt64 computeSyncCommitteePeriod(final UInt64 epoch) {
+    return epoch.dividedBy(specConfig.getEpochsPerSyncCommitteePeriod());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
@@ -38,7 +38,6 @@ public class ValidatorsUtil {
         && validator.getActivation_epoch().equals(SpecConfig.FAR_FUTURE_EPOCH);
   }
 
-  @SuppressWarnings("DoNotReturnNullOptionals")
   public Optional<Integer> getValidatorIndex(BeaconState state, BLSPublicKey publicKey) {
     return BeaconStateCache.getTransitionCaches(state)
         .getValidatorIndexCache()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
@@ -67,11 +67,11 @@ public class BeaconStateAccessorsAltair extends BeaconStateAccessors {
   }
 
   /**
-   * Return the sequence of sync committee indices (which may include uplicate indices) for a given
+   * Return the sequence of sync committee indices (which may include duplicate indices) for a given
    * state and epoch.
    *
    * @param state the state to calculate committees from
-   * @param epoch the epoch to calcualte committees for
+   * @param epoch the epoch to calculate committees for
    * @return the sequence of sync committee indices
    */
   public List<Integer> getSyncCommitteeIndices(final BeaconState state, final UInt64 epoch) {

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -334,7 +334,7 @@ public class BeaconChainUtil {
   }
 
   public Signer getSigner(final int proposerIndex) {
-    return new LocalSigner(validatorKeys.get(proposerIndex), SYNC_RUNNER);
+    return new LocalSigner(spec, validatorKeys.get(proposerIndex), SYNC_RUNNER);
   }
 
   public static class Builder {

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/VoluntaryExitGossipIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/VoluntaryExitGossipIntegrationTest.java
@@ -99,7 +99,7 @@ public class VoluntaryExitGossipIntegrationTest {
     assertThat(stateFuture).isCompleted();
     final BeaconState state = stateFuture.join().orElseThrow();
     final VoluntaryExitGenerator exitGenerator =
-        new VoluntaryExitGenerator(node1.chainUtil().getValidatorKeys());
+        new VoluntaryExitGenerator(spec, node1.chainUtil().getValidatorKeys());
     final SignedVoluntaryExit voluntaryExit = exitGenerator.valid(state, 0);
 
     // Publish voluntary exit

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/VoluntaryExitTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/VoluntaryExitTopicHandlerTest.java
@@ -52,7 +52,7 @@ public class VoluntaryExitTopicHandlerTest {
 
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final VoluntaryExitGenerator exitGenerator =
-      new VoluntaryExitGenerator(beaconChainUtil.getValidatorKeys());
+      new VoluntaryExitGenerator(spec, beaconChainUtil.getValidatorKeys());
 
   private final Eth2TopicHandler<SignedVoluntaryExit> topicHandler =
       new Eth2TopicHandler<>(

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -221,6 +221,7 @@ public class VoluntaryExitCommand implements Runnable {
 
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
+            config.validatorClient().getSpec(),
             config.validatorClient().getValidatorConfig(),
             config.validatorClient().getInteropConfig(),
             new RejectingSlashingProtector(),

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerIntegrationTest.java
@@ -57,6 +57,8 @@ import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -70,7 +72,8 @@ import tech.pegasys.teku.validator.client.loader.HttpClientExternalSignerFactory
 public class ExternalSignerIntegrationTest {
   private static final Duration TIMEOUT = Duration.ofMillis(500);
   private static final BLSKeyPair KEYPAIR = BLSTestUtil.randomKeyPair(1234);
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Spec spec = SpecFactory.createMinimal();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final ForkInfo fork = dataStructureUtil.randomForkInfo();
   private final JsonProvider jsonProvider = new JsonProvider();
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
@@ -94,6 +97,7 @@ public class ExternalSignerIntegrationTest {
 
     externalSigner =
         new ExternalSigner(
+            spec,
             httpClientExternalSignerFactory.get(),
             config.getValidatorExternalSignerUrl(),
             KEYPAIR.getPublicKey(),

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -122,6 +122,7 @@ public class ValidatorClientService extends Service {
     final SlashingProtector slashingProtector =
         new LocalSlashingProtector(new SyncDataAccessor(), slashingProtectionPath);
     return ValidatorLoader.create(
+        config.getSpec(),
         config.getValidatorConfig(),
         config.getInteropConfig(),
         slashingProtector,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/MockStartValidatorSource.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/MockStartValidatorSource.java
@@ -24,15 +24,19 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.core.signatures.LocalSigner;
 import tech.pegasys.teku.core.signatures.Signer;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.interop.MockStartValidatorKeyPairFactory;
 import tech.pegasys.teku.validator.api.InteropConfig;
 
 public class MockStartValidatorSource implements ValidatorSource {
   private static final Logger LOG = LogManager.getLogger();
+  private final Spec spec;
   private final InteropConfig config;
   private final AsyncRunner asyncRunner;
 
-  public MockStartValidatorSource(final InteropConfig config, final AsyncRunner asyncRunner) {
+  public MockStartValidatorSource(
+      final Spec spec, final InteropConfig config, final AsyncRunner asyncRunner) {
+    this.spec = spec;
     this.config = config;
     this.asyncRunner = asyncRunner;
   }
@@ -62,7 +66,7 @@ public class MockStartValidatorSource implements ValidatorSource {
 
     @Override
     public Signer createSigner() {
-      return new LocalSigner(keyPair, asyncRunner);
+      return new LocalSigner(spec, keyPair, asyncRunner);
     }
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -35,6 +35,7 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -58,6 +59,7 @@ import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSigningData;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 
 public class ExternalSigner implements Signer {
   public static final String EXTERNAL_SIGNER_ENDPOINT = "/api/v1/eth2/sign";
@@ -190,12 +192,11 @@ public class ExternalSigner implements Signer {
   @Override
   public SafeFuture<BLSSignature> signSyncCommitteeSignature(
       final UInt64 slot, final Bytes32 beaconBlockRoot, final ForkInfo forkInfo) {
-    return SafeFuture.of(
-            () ->
-                spec.getSyncCommitteeUtil(slot)
-                    .orElseThrow()
-                    .getSyncCommitteeSignatureSigningRoot(
-                        forkInfo, spec.computeEpochAtSlot(slot), beaconBlockRoot))
+    return signingRootFromSyncCommitteeUtils(
+            slot,
+            utils ->
+                utils.getSyncCommitteeSignatureSigningRoot(
+                    beaconBlockRoot, spec.computeEpochAtSlot(slot), forkInfo))
         .thenCompose(
             signingRoot ->
                 sign(
@@ -208,11 +209,9 @@ public class ExternalSigner implements Signer {
   @Override
   public SafeFuture<BLSSignature> signSyncCommitteeSelectionProof(
       final SyncCommitteeSigningData signingData, final ForkInfo forkInfo) {
-    return SafeFuture.of(
-            () ->
-                spec.getSyncCommitteeUtil(signingData.getSlot())
-                    .orElseThrow()
-                    .getSyncCommitteeSigningDataSigningRoot(signingData, forkInfo))
+    return signingRootFromSyncCommitteeUtils(
+            signingData.getSlot(),
+            utils -> utils.getSyncCommitteeSigningDataSigningRoot(signingData, forkInfo))
         .thenCompose(
             signingRoot ->
                 sign(
@@ -231,11 +230,9 @@ public class ExternalSigner implements Signer {
   @Override
   public SafeFuture<BLSSignature> signContributionAndProof(
       final ContributionAndProof contributionAndProof, final ForkInfo forkInfo) {
-    return SafeFuture.of(
-            () ->
-                spec.getSyncCommitteeUtil(contributionAndProof.getContribution().getSlot())
-                    .orElseThrow()
-                    .getContributionAndProofSigningRoot(contributionAndProof, forkInfo))
+    return signingRootFromSyncCommitteeUtils(
+            contributionAndProof.getContribution().getSlot(),
+            utils -> utils.getContributionAndProofSigningRoot(contributionAndProof, forkInfo))
         .thenCompose(
             signingRoot ->
                 sign(
@@ -248,6 +245,12 @@ public class ExternalSigner implements Signer {
   @Override
   public boolean isLocal() {
     return false;
+  }
+
+  private SafeFuture<Bytes> signingRootFromSyncCommitteeUtils(
+      final UInt64 slot, final Function<SyncCommitteeUtil, Bytes> createSigningRoot) {
+    return SafeFuture.of(
+        () -> createSigningRoot.apply(spec.getSyncCommitteeUtil(slot).orElseThrow()));
   }
 
   private Map<String, Object> forkInfo(final ForkInfo forkInfo) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/SignType.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/SignType.java
@@ -27,5 +27,11 @@ public enum SignType {
   @JsonProperty("aggregate_and_proof")
   AGGREGATE_AND_PROOF,
   @JsonProperty("voluntary_exit")
-  VOLUNTARY_EXIT
+  VOLUNTARY_EXIT,
+  @JsonProperty("sync_committee_signature")
+  SYNC_COMMITTEE_SIGNATURE,
+  @JsonProperty("sync_committee_selection_proof")
+  SYNC_COMMITTEE_SELECTION_PROOF,
+  @JsonProperty("sync_committee_contribution_and_proof")
+  SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/LocalValidatorSourceTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/LocalValidatorSourceTest.java
@@ -38,6 +38,8 @@ import tech.pegasys.teku.core.signatures.SigningRootUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.ssz.type.Bytes4;
@@ -54,11 +56,12 @@ class LocalValidatorSourceTest {
       new BLSKeyPair(BLSSecretKey.fromBytes(BLS_PRIVATE_KEY));
 
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+  private final Spec spec = SpecFactory.createMinimal();
   private final ValidatorConfig config = mock(ValidatorConfig.class);
   private final KeystoreLocker keystoreLocker = mock(KeystoreLocker.class);
 
   private final LocalValidatorSource validatorSource =
-      new LocalValidatorSource(config, keystoreLocker, asyncRunner);
+      new LocalValidatorSource(spec, config, keystoreLocker, asyncRunner);
 
   @Test
   void shouldLoadKeysFromKeyStores(@TempDir final Path tempDir) throws Exception {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -112,6 +112,7 @@ class ValidatorLoaderTest {
 
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
+            spec,
             config,
             disabledInteropConfig,
             httpClientFactory,
@@ -147,6 +148,7 @@ class ValidatorLoaderTest {
             .build();
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
+            spec,
             config,
             disabledInteropConfig,
             httpClientFactory,
@@ -187,6 +189,7 @@ class ValidatorLoaderTest {
             .build();
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
+            spec,
             config,
             disabledInteropConfig,
             httpClientFactory,
@@ -233,6 +236,7 @@ class ValidatorLoaderTest {
             .build();
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
+            spec,
             config,
             disabledInteropConfig,
             httpClientFactory,
@@ -274,6 +278,7 @@ class ValidatorLoaderTest {
             .build();
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
+            spec,
             config,
             disabledInteropConfig,
             httpClientFactory,
@@ -309,6 +314,7 @@ class ValidatorLoaderTest {
             .build();
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
+            spec,
             config,
             disabledInteropConfig,
             httpClientFactory,
@@ -347,6 +353,7 @@ class ValidatorLoaderTest {
             .build();
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
+            spec,
             config,
             disabledInteropConfig,
             httpClientFactory,
@@ -381,6 +388,7 @@ class ValidatorLoaderTest {
             .build();
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
+            spec,
             config,
             disabledInteropConfig,
             httpClientFactory,
@@ -413,6 +421,7 @@ class ValidatorLoaderTest {
 
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
+            spec,
             config,
             disabledInteropConfig,
             httpClientFactory,
@@ -451,6 +460,7 @@ class ValidatorLoaderTest {
     final ValidatorConfig config = ValidatorConfig.builder().build();
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
+            spec,
             config,
             interopConfig,
             httpClientFactory,
@@ -476,6 +486,7 @@ class ValidatorLoaderTest {
     final ValidatorConfig config = ValidatorConfig.builder().build();
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
+            spec,
             config,
             interopConfig,
             httpClientFactory,


### PR DESCRIPTION
## PR Description
Add support to `Signer` to sign the various sync committee gossip messages and to `SyncCommitteUtil` to create them without having to do a heap of messing about with SszSchemas etc.

Note the `ExternalSigner` will need further updates to send the full data structure over to Web3Signer and Web3Signer will need to be updated to support them.  Logged a separate ticket for Web3Signer to cover that work (https://github.com/ConsenSys/web3signer/issues/391)

## Fixed Issue(s)
#3803 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
