### PR TITLE
Implement inactivity score updates

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -40,6 +40,7 @@ public abstract class Eth2ReferenceTestCase {
           .putAll(GenesisTests.GENESIS_TEST_TYPES)
           .putAll(ShufflingTestExecutor.SHUFFLING_TEST_TYPES)
           .putAll(EpochProcessingTestExecutor.EPOCH_PROCESSING_TEST_TYPES)
+          .putAll(SanityTests.SANITY_TEST_TYPES)
           .putAll(SszTestExecutor.SSZ_TEST_TYPES)
           .putAll(OperationsTestExecutor.OPERATIONS_TEST_TYPES)
           .putAll(SszTestExecutorDeprecated.SSZ_TEST_TYPES)
@@ -47,7 +48,6 @@ public abstract class Eth2ReferenceTestCase {
 
   private final ImmutableMap<String, TestExecutor> PHASE_0_TEST_TYPES =
       ImmutableMap.<String, TestExecutor>builder()
-          .putAll(SanityTests.SANITY_TEST_TYPES)
           .putAll(ForkChoiceTestExecutor.FORK_CHOICE_TEST_TYPES)
           .putAll(RewardsTestExecutorPhase0.REWARDS_TEST_TYPES)
           .build();

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -25,6 +25,8 @@ import tech.pegasys.teku.reference.phase0.bls.BlsTests;
 import tech.pegasys.teku.reference.phase0.forkchoice.ForkChoiceTestExecutor;
 import tech.pegasys.teku.reference.phase0.genesis.GenesisTests;
 import tech.pegasys.teku.reference.phase0.rewards.RewardsTestExecutorPhase0;
+import tech.pegasys.teku.reference.phase0.sanity.SanityBlocksTestExecutor;
+import tech.pegasys.teku.reference.phase0.sanity.SanitySlotsTestExecutor;
 import tech.pegasys.teku.reference.phase0.sanity.SanityTests;
 import tech.pegasys.teku.reference.phase0.shuffling.ShufflingTestExecutor;
 import tech.pegasys.teku.reference.phase0.ssz_static.SszTestExecutor;
@@ -40,7 +42,6 @@ public abstract class Eth2ReferenceTestCase {
           .putAll(GenesisTests.GENESIS_TEST_TYPES)
           .putAll(ShufflingTestExecutor.SHUFFLING_TEST_TYPES)
           .putAll(EpochProcessingTestExecutor.EPOCH_PROCESSING_TEST_TYPES)
-          .putAll(SanityTests.SANITY_TEST_TYPES)
           .putAll(SszTestExecutor.SSZ_TEST_TYPES)
           .putAll(OperationsTestExecutor.OPERATIONS_TEST_TYPES)
           .putAll(SszTestExecutorDeprecated.SSZ_TEST_TYPES)
@@ -50,12 +51,19 @@ public abstract class Eth2ReferenceTestCase {
       ImmutableMap.<String, TestExecutor>builder()
           .putAll(ForkChoiceTestExecutor.FORK_CHOICE_TEST_TYPES)
           .putAll(RewardsTestExecutorPhase0.REWARDS_TEST_TYPES)
+          .putAll(SanityTests.SANITY_TEST_TYPES)
           .build();
 
   private final ImmutableMap<String, TestExecutor> ALTAIR_TEST_TYPES =
       ImmutableMap.<String, TestExecutor>builder()
           .putAll(ForkUpgradeTestExecutor.FORK_UPGRADE_TEST_TYPES)
           .putAll(RewardsTestExecutorAltair.REWARDS_TEST_TYPES)
+          .put("fork_choice/get_head", TestExecutor.IGNORE_TESTS)
+
+          // Sanity tests include finality which aren't yet passing
+          .put("sanity/blocks", new SanityBlocksTestExecutor())
+          .put("sanity/slots", new SanitySlotsTestExecutor())
+          .put("finality/finality", TestExecutor.IGNORE_TESTS)
           .build();
 
   protected void runReferenceTest(final TestDefinition testDefinition) throws Throwable {
@@ -79,10 +87,6 @@ public abstract class Eth2ReferenceTestCase {
         testExecutor = PHASE_0_TEST_TYPES.get(testDefinition.getTestType());
       } else if (testDefinition.getFork().equals(TestFork.ALTAIR)) {
         testExecutor = ALTAIR_TEST_TYPES.get(testDefinition.getTestType());
-        if (testExecutor == null) {
-          // Ignore unhandled altair tests for now
-          testExecutor = TestExecutor.IGNORE_TESTS;
-        }
       }
     }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -39,7 +39,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    * <p>e.g. set to "ssz_static" to run only ssz static tests or "ssz_static/Attestation" for only
    * attestation ssz tests.
    */
-  private static final String TEST_TYPE = "operations";
+  private static final String TEST_TYPE = "sanity";
 
   /** Filter test to run to those from the specified spec. One of general, minimal or mainnet */
   private static final String SPEC = "";

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -39,7 +39,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    * <p>e.g. set to "ssz_static" to run only ssz static tests or "ssz_static/Attestation" for only
    * attestation ssz tests.
    */
-  private static final String TEST_TYPE = "sanity";
+  private static final String TEST_TYPE = "finality";
 
   /** Filter test to run to those from the specified spec. One of general, minimal or mainnet */
   private static final String SPEC = "";

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -176,6 +176,18 @@ public class BeaconStateAccessors {
             });
   }
 
+  public UInt64 getFinalityDelay(final BeaconState state) {
+    return getPreviousEpoch(state).minus(state.getFinalized_checkpoint().getEpoch());
+  }
+
+  public boolean isInactivityLeak(final UInt64 finalityDelay) {
+    return finalityDelay.isGreaterThan(config.getMinEpochsToInactivityPenalty());
+  }
+
+  public boolean isInactivityLeak(final BeaconState state) {
+    return isInactivityLeak(getFinalityDelay(state));
+  }
+
   private void validateStateCanCalculateProposerIndexAtSlot(
       final BeaconState state, final UInt64 requestedSlot) {
     final UInt64 epoch = miscHelpers.computeEpochAtSlot(requestedSlot);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -82,6 +82,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
     final ValidatorStatuses validatorStatuses =
         validatorStatusFactory.createValidatorStatuses(preState);
     processJustificationAndFinalization(state, validatorStatuses.getTotalBalances());
+    processInactivityUpdates(state, validatorStatuses);
     processRewardsAndPenalties(state, validatorStatuses);
     processRegistryUpdates(state, validatorStatuses.getStatuses());
     processSlashings(state, validatorStatuses.getTotalBalances().getCurrentEpochActiveValidators());
@@ -160,6 +161,12 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
     } catch (IllegalArgumentException e) {
       throw new EpochProcessingException(e);
     }
+  }
+
+  @Override
+  public void processInactivityUpdates(
+      final MutableBeaconState state, final ValidatorStatuses validatorStatuses) {
+    // Do nothing by default.
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/EpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/EpochProcessor.java
@@ -31,6 +31,8 @@ public interface EpochProcessor {
   void processJustificationAndFinalization(MutableBeaconState state, TotalBalances totalBalances)
       throws EpochProcessingException;
 
+  void processInactivityUpdates(MutableBeaconState state, ValidatorStatuses validatorStatuses);
+
   void processRewardsAndPenalties(MutableBeaconState state, ValidatorStatuses validatorStatuses)
       throws EpochProcessingException;
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/RewardsAndPenaltiesCalculator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/RewardsAndPenaltiesCalculator.java
@@ -44,16 +44,14 @@ public abstract class RewardsAndPenaltiesCalculator {
   public abstract RewardAndPenaltyDeltas getDeltas() throws IllegalArgumentException;
 
   protected UInt64 getFinalityDelay() {
-    return beaconStateAccessors
-        .getPreviousEpoch(state)
-        .minus(state.getFinalized_checkpoint().getEpoch());
+    return beaconStateAccessors.getFinalityDelay(state);
   }
 
   protected boolean isInactivityLeak(final UInt64 finalityDelay) {
-    return finalityDelay.isGreaterThan(specConfig.getMinEpochsToInactivityPenalty());
+    return beaconStateAccessors.isInactivityLeak(finalityDelay);
   }
 
   protected boolean isInactivityLeak() {
-    return getFinalityDelay().isGreaterThan(specConfig.getMinEpochsToInactivityPenalty());
+    return beaconStateAccessors.isInactivityLeak(state);
   }
 }


### PR DESCRIPTION
## PR Description
Implement inactivity score updates as part of epoch processing for Altair.

Enable sanity reference tests as they now pass. :tada: (but finality tests still aren't)
Move to explicitly ignoring Altair tests that aren't yet working instead of defaulting to ignore unrecognised Altair tests.

## Fixed Issue(s)
#3654 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
