### PR TITLE
Fix Altair fork choice tests

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -37,6 +37,7 @@ public abstract class Eth2ReferenceTestCase {
   private final ImmutableMap<String, TestExecutor> COMMON_TEST_TYPES =
       ImmutableMap.<String, TestExecutor>builder()
           .putAll(BlsTests.BLS_TEST_TYPES)
+          .putAll(ForkChoiceTestExecutor.FORK_CHOICE_TEST_TYPES)
           .putAll(GenesisTests.GENESIS_TEST_TYPES)
           .putAll(ShufflingTestExecutor.SHUFFLING_TEST_TYPES)
           .putAll(EpochProcessingTestExecutor.EPOCH_PROCESSING_TEST_TYPES)
@@ -48,7 +49,6 @@ public abstract class Eth2ReferenceTestCase {
 
   private final ImmutableMap<String, TestExecutor> PHASE_0_TEST_TYPES =
       ImmutableMap.<String, TestExecutor>builder()
-          .putAll(ForkChoiceTestExecutor.FORK_CHOICE_TEST_TYPES)
           .putAll(RewardsTestExecutorPhase0.REWARDS_TEST_TYPES)
           .build();
 
@@ -56,7 +56,6 @@ public abstract class Eth2ReferenceTestCase {
       ImmutableMap.<String, TestExecutor>builder()
           .putAll(ForkUpgradeTestExecutor.FORK_UPGRADE_TEST_TYPES)
           .putAll(RewardsTestExecutorAltair.REWARDS_TEST_TYPES)
-          .put("fork_choice/get_head", TestExecutor.IGNORE_TESTS)
           .build();
 
   protected void runReferenceTest(final TestDefinition testDefinition) throws Throwable {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -49,7 +49,6 @@ public class ForkChoiceTestExecutor implements TestExecutor {
 
   @Override
   public void runTest(final TestDefinition testDefinition) throws Throwable {
-
     // Note: The fork choice spec says there may be settings in a meta.yaml file but currently no
     // tests actually have one, so we currently don't bother trying to load it.
     final BeaconState anchorState =

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.reference.TestDataUtils;
 import tech.pegasys.teku.reference.TestExecutor;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecFactory;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -48,27 +49,40 @@ public class ForkChoiceTestExecutor implements TestExecutor {
 
   @Override
   public void runTest(final TestDefinition testDefinition) throws Throwable {
+
     // Note: The fork choice spec says there may be settings in a meta.yaml file but currently no
     // tests actually have one, so we currently don't bother trying to load it.
     final BeaconState anchorState =
         TestDataUtils.loadStateFromSsz(testDefinition, "anchor_state.ssz_snappy");
     final Spec spec = testDefinition.getSpec();
-    final BeaconBlock anchorBlock =
-        TestDataUtils.loadSsz(
-            testDefinition, "anchor_block.ssz_snappy", spec::deserializeBeaconBlock);
+    final SignedBeaconBlock anchorBlock = loadAnchorBlock(testDefinition);
 
-    final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault();
+    final StorageSystem storageSystem =
+        InMemoryStorageSystemBuilder.create().specProvider(spec).build();
     final RecentChainData recentChainData = storageSystem.recentChainData();
     recentChainData.initializeFromAnchorPoint(
-        AnchorPoint.fromInitialBlockAndState(
-            new SignedBlockAndState(
-                SignedBeaconBlock.create(spec, anchorBlock, BLSSignature.empty()), anchorState)),
+        AnchorPoint.fromInitialBlockAndState(new SignedBlockAndState(anchorBlock, anchorState)),
         spec.getSlotStartTime(anchorBlock.getSlot(), anchorState.getGenesis_time()));
 
     final ForkChoice forkChoice =
         ForkChoice.create(spec, new InlineEventThread(), recentChainData, false);
 
     runSteps(testDefinition, spec, recentChainData, forkChoice);
+  }
+
+  /**
+   * The anchor block is currently always a Phase 0 block because of the way the specs repo are
+   * doing Altair genesis. See https://github.com/ethereum/eth2.0-specs/pull/2323
+   *
+   * @param testDefinition the test definition
+   * @return the anchor block for the test
+   */
+  private SignedBeaconBlock loadAnchorBlock(final TestDefinition testDefinition) {
+    final Spec phase0Spec = SpecFactory.create(testDefinition.getConfigName());
+    final BeaconBlock anchorBlock =
+        TestDataUtils.loadSsz(
+            testDefinition, "anchor_block.ssz_snappy", phase0Spec::deserializeBeaconBlock);
+    return SignedBeaconBlock.create(phase0Spec, anchorBlock, BLSSignature.empty());
   }
 
   private void runSteps(


### PR DESCRIPTION
## PR Description
Altair fork choice tests have a phase 0 block as the anchor block because of the way the reference tests are doing genesis.  So always load the anchor block using the phase 0 spec.

## Fixed Issue(s)
fixes #3799 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
