### PR TITLE
Unsubscribe from attestation subnets correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Additions and Improvements
 
 ### Bug Fixes
+- Fixed issue where attestation subnets were not unsubscribed from leading to unnecessary CPU load when running small numbers of validators.

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManager.java
@@ -71,10 +71,12 @@ public class AttestationGossipManager implements GossipManager {
   }
 
   public void subscribeToSubnetId(final int subnetId) {
+    LOG.trace("Subscribing to subnet ID {}", subnetId);
     subnetSubscriptions.subscribeToSubnetId(subnetId);
   }
 
   public void unsubscribeFromSubnetId(final int subnetId) {
+    LOG.trace("Unsubscribing to subnet ID {}", subnetId);
     subnetSubscriptions.unsubscribeFromSubnetId(subnetId);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
@@ -188,6 +188,6 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
 
   @Override
   public void unsubscribeFromAttestationSubnetId(final int subnetId) {
-    attestationGossipManager.subscribeToSubnetId(subnetId);
+    attestationGossipManager.unsubscribeFromSubnetId(subnetId);
   }
 }


### PR DESCRIPTION
## PR Description
Fix issue where attestation subnets were not unsubscribed from once the slot they were required at was reached.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
