### PR TITLE
Add TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE to Altair config

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigAltair.java
@@ -46,6 +46,9 @@ public class SpecConfigAltair extends DelegatingSpecConfig {
   private final int maxValidLightClientUpdates;
   private final int lightClientUpdateTimeout;
 
+  // Validator
+  private final int targetAggregatorsPerSyncSubcommittee;
+
   public SpecConfigAltair(
       final SpecConfig specConfig,
       final UInt64 inactivityPenaltyQuotientAltair,
@@ -62,7 +65,8 @@ public class SpecConfigAltair extends DelegatingSpecConfig {
       final UInt64 altairForkSlot,
       final int minSyncCommitteeParticipants,
       final int maxValidLightClientUpdates,
-      final int lightClientUpdateTimeout) {
+      final int lightClientUpdateTimeout,
+      final int targetAggregatorsPerSyncSubcommittee) {
     super(specConfig);
     this.inactivityPenaltyQuotientAltair = inactivityPenaltyQuotientAltair;
     this.minSlashingPenaltyQuotientAltair = altairMinSlashingPenaltyQuotient;
@@ -79,6 +83,7 @@ public class SpecConfigAltair extends DelegatingSpecConfig {
     this.minSyncCommitteeParticipants = minSyncCommitteeParticipants;
     this.maxValidLightClientUpdates = maxValidLightClientUpdates;
     this.lightClientUpdateTimeout = lightClientUpdateTimeout;
+    this.targetAggregatorsPerSyncSubcommittee = targetAggregatorsPerSyncSubcommittee;
   }
 
   public static SpecConfigAltair required(final SpecConfig specConfig) {
@@ -139,6 +144,10 @@ public class SpecConfigAltair extends DelegatingSpecConfig {
     return domainContributionAndProof;
   }
 
+  public int getTargetAggregatorsPerSyncSubcommittee() {
+    return targetAggregatorsPerSyncSubcommittee;
+  }
+
   @Override
   public Optional<SpecConfigAltair> toVersionAltair() {
     return Optional.of(this);
@@ -164,7 +173,9 @@ public class SpecConfigAltair extends DelegatingSpecConfig {
         && Objects.equals(domainSyncCommitteeSelectionProof, that.domainSyncCommitteeSelectionProof)
         && Objects.equals(domainContributionAndProof, that.domainContributionAndProof)
         && Objects.equals(altairForkVersion, that.altairForkVersion)
-        && Objects.equals(altairForkSlot, that.altairForkSlot);
+        && Objects.equals(altairForkSlot, that.altairForkSlot)
+        && Objects.equals(
+            targetAggregatorsPerSyncSubcommittee, that.targetAggregatorsPerSyncSubcommittee);
   }
 
   @Override
@@ -185,6 +196,7 @@ public class SpecConfigAltair extends DelegatingSpecConfig {
         altairForkSlot,
         minSyncCommitteeParticipants,
         maxValidLightClientUpdates,
-        lightClientUpdateTimeout);
+        lightClientUpdateTimeout,
+        targetAggregatorsPerSyncSubcommittee);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
@@ -675,6 +675,9 @@ public class SpecConfigBuilder {
     private Integer maxValidLightClientUpdates;
     private Integer lightClientUpdateTimeout;
 
+    // Validator
+    private Integer targetAggregatorsPerSyncSubcommittee;
+
     private AltairBuilder() {}
 
     SpecConfigAltair build(final SpecConfig specConfig) {
@@ -694,7 +697,8 @@ public class SpecConfigBuilder {
           altairForkSlot,
           minSyncCommitteeParticipants,
           maxValidLightClientUpdates,
-          lightClientUpdateTimeout);
+          lightClientUpdateTimeout,
+          targetAggregatorsPerSyncSubcommittee);
     }
 
     void validate() {
@@ -714,6 +718,8 @@ public class SpecConfigBuilder {
       validateConstant("minSyncCommitteeParticipants", minSyncCommitteeParticipants);
       validateConstant("maxValidLightClientUpdates", maxValidLightClientUpdates);
       validateConstant("lightClientUpdateTimeout", lightClientUpdateTimeout);
+      validateConstant(
+          "targetAggregatorsPerSyncSubcommittee", targetAggregatorsPerSyncSubcommittee);
     }
 
     public AltairBuilder inactivityPenaltyQuotientAltair(
@@ -807,6 +813,13 @@ public class SpecConfigBuilder {
     public AltairBuilder lightClientUpdateTimeout(final Integer lightClientUpdateTimeout) {
       checkNotNull(lightClientUpdateTimeout);
       this.lightClientUpdateTimeout = lightClientUpdateTimeout;
+      return this;
+    }
+
+    public AltairBuilder targetAggregatorsPerSyncSubcommittee(
+        final Integer targetAggregatorsPerSyncSubcommittee) {
+      checkNotNull(targetAggregatorsPerSyncSubcommittee);
+      this.targetAggregatorsPerSyncSubcommittee = targetAggregatorsPerSyncSubcommittee;
       return this;
     }
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -56,9 +56,6 @@ import tech.pegasys.teku.ssz.type.Bytes4;
 
 public class SyncCommitteeUtil {
 
-  // TODO: Should this be in constants file? https://github.com/ethereum/eth2.0-specs/issues/2317
-  private static final int TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE = 4;
-
   private final BeaconStateAccessors beaconStateAccessors;
   private final BeaconStateUtil beaconStateUtil;
   private final ValidatorsUtil validatorsUtil;
@@ -163,7 +160,7 @@ public class SyncCommitteeUtil {
             1,
             specConfig.getSyncCommitteeSize()
                 / SYNC_COMMITTEE_SUBNET_COUNT
-                / TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE);
+                / specConfig.getTargetAggregatorsPerSyncSubcommittee());
     return bytesToUInt64(Hash.sha2_256(signature.toSSZBytes()).slice(0, 8)).mod(modulo).isZero();
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigAltairTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigAltairTest.java
@@ -85,6 +85,7 @@ public class SpecConfigAltairTest {
         dataStructureUtil.randomUInt64(),
         dataStructureUtil.randomPositiveInt(),
         dataStructureUtil.randomPositiveInt(),
+        dataStructureUtil.randomPositiveInt(),
         dataStructureUtil.randomPositiveInt());
   }
 }

--- a/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/invalid/missingAltairField.yaml
+++ b/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/invalid/missingAltairField.yaml
@@ -47,6 +47,12 @@ MAX_VALID_LIGHT_CLIENT_UPDATES: 8192
 LIGHT_CLIENT_UPDATE_TIMEOUT: 8192
 
 
+# Validator
+# ---------------------------------------------------------------
+# 2**2 (= 4)
+TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE: 4
+
+
 #Phase 0
 
 # Misc

--- a/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/invalid/multifile_dupFields/altair.yaml
+++ b/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/invalid/multifile_dupFields/altair.yaml
@@ -52,3 +52,9 @@ MIN_SYNC_COMMITTEE_PARTICIPANTS: 1
 MAX_VALID_LIGHT_CLIENT_UPDATES: 8192
 # 2**13 (=8192)
 LIGHT_CLIENT_UPDATE_TIMEOUT: 8192
+
+
+# Validator
+# ---------------------------------------------------------------
+# 2**2 (= 4)
+TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE: 4

--- a/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/standard/mainnetAltair.yaml
+++ b/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/standard/mainnetAltair.yaml
@@ -202,3 +202,9 @@ MIN_SYNC_COMMITTEE_PARTICIPANTS: 1
 MAX_VALID_LIGHT_CLIENT_UPDATES: 8192
 # 2**13 (=8192)
 LIGHT_CLIENT_UPDATE_TIMEOUT: 8192
+
+
+# Validator
+# ---------------------------------------------------------------
+# 2**2 (= 4)
+TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE: 4

--- a/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/standard/multifile/altair.yaml
+++ b/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/standard/multifile/altair.yaml
@@ -49,3 +49,9 @@ MIN_SYNC_COMMITTEE_PARTICIPANTS: 1
 MAX_VALID_LIGHT_CLIENT_UPDATES: 8192
 # 2**13 (=8192)
 LIGHT_CLIENT_UPDATE_TIMEOUT: 8192
+
+
+# Validator
+# ---------------------------------------------------------------
+# 2**2 (= 4)
+TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE: 4

--- a/util/src/main/resources/tech/pegasys/teku/util/config/mainnet/altair.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/mainnet/altair.yaml
@@ -51,3 +51,9 @@ MIN_SYNC_COMMITTEE_PARTICIPANTS: 1
 MAX_VALID_LIGHT_CLIENT_UPDATES: 8192
 # 2**13 (=8192)
 LIGHT_CLIENT_UPDATE_TIMEOUT: 8192
+
+
+# Validator
+# ---------------------------------------------------------------
+# 2**2 (= 4)
+TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE: 4

--- a/util/src/main/resources/tech/pegasys/teku/util/config/minimal/altair.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/minimal/altair.yaml
@@ -51,3 +51,9 @@ MIN_SYNC_COMMITTEE_PARTICIPANTS: 1
 MAX_VALID_LIGHT_CLIENT_UPDATES: 32
 # [customized]
 LIGHT_CLIENT_UPDATE_TIMEOUT: 32
+
+
+# Validator
+# ---------------------------------------------------------------
+# 2**2 (= 4)
+TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE: 4


### PR DESCRIPTION
## PR Description
`TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE` has been added to the spec constants so update Teku to match.

Spec change: https://github.com/ethereum/eth2.0-specs/pull/2327/

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
