### PR TITLE
Use specific fork digest for attestation subnets

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
@@ -117,7 +117,12 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
   protected void addGossipManagers(final ForkInfo forkInfo) {
     AttestationSubnetSubscriptions attestationSubnetSubscriptions =
         new AttestationSubnetSubscriptions(
-            asyncRunner, discoveryNetwork, gossipEncoding, recentChainData, attestationProcessor);
+            asyncRunner,
+            discoveryNetwork,
+            gossipEncoding,
+            recentChainData,
+            attestationProcessor,
+            forkInfo);
 
     blockGossipManager =
         new BlockGossipManager(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/CommitteeSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/CommitteeSubnetSubscriptions.java
@@ -1,0 +1,52 @@
+package tech.pegasys.teku.networking.eth2.gossip.subnets;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
+import tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers.Eth2TopicHandler;
+import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
+import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
+
+abstract class CommitteeSubnetSubscriptions implements AutoCloseable {
+
+  protected final GossipNetwork gossipNetwork;
+  protected final GossipEncoding gossipEncoding;
+
+  private final Map<Integer, TopicChannel> subnetIdToTopicChannel = new HashMap<>();
+
+  protected CommitteeSubnetSubscriptions(
+      final GossipNetwork gossipNetwork, final GossipEncoding gossipEncoding) {
+    this.gossipNetwork = gossipNetwork;
+    this.gossipEncoding = gossipEncoding;
+  }
+
+  protected synchronized Optional<TopicChannel> getChannelForSubnet(final int subnetId) {
+    return Optional.ofNullable(subnetIdToTopicChannel.get(subnetId));
+  }
+
+  public synchronized void subscribeToSubnetId(final int subnetId) {
+    subnetIdToTopicChannel.computeIfAbsent(subnetId, this::createChannelForSubnetId);
+  }
+
+  public synchronized void unsubscribeFromSubnetId(final int subnetId) {
+    final TopicChannel topicChannel = subnetIdToTopicChannel.remove(subnetId);
+    if (topicChannel != null) {
+      topicChannel.close();
+    }
+  }
+
+  private TopicChannel createChannelForSubnetId(final int subnetId) {
+    final Eth2TopicHandler<?> topicHandler = createTopicHandler(subnetId);
+    return gossipNetwork.subscribe(topicHandler.getTopic(), topicHandler);
+  }
+
+  protected abstract Eth2TopicHandler<?> createTopicHandler(final int subnetId);
+
+  @Override
+  public synchronized void close() {
+    // Close gossip channels
+    subnetIdToTopicChannel.values().forEach(TopicChannel::close);
+    subnetIdToTopicChannel.clear();
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/CommitteeSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/CommitteeSubnetSubscriptions.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.networking.eth2.gossip.subnets;
 
 import java.util.HashMap;

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
@@ -38,9 +38,9 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.util.CommitteeUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.ssz.type.Bytes4;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -61,19 +61,19 @@ public class AttestationGossipManagerTest {
   private AttestationGossipManager attestationGossipManager;
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+  private final ForkInfo forkInfo = dataStructureUtil.randomForkInfo();
   private final AttestationSubnetSubscriptions attestationSubnetSubscriptions =
       new AttestationSubnetSubscriptions(
           asyncRunner,
           gossipNetwork,
           gossipEncoding,
           recentChainData,
-          gossipedAttestationProcessor);
-  private Bytes4 forkDigest;
+          gossipedAttestationProcessor,
+          forkInfo);
 
   @BeforeEach
   public void setup() {
     BeaconChainUtil.create(spec, 0, recentChainData).initializeStorage();
-    forkDigest = recentChainData.getHeadForkInfo().orElseThrow().getForkDigest();
     attestationGossipManager =
         new AttestationGossipManager(metricsSystem, attestationSubnetSubscriptions);
   }
@@ -186,6 +186,6 @@ public class AttestationGossipManagerTest {
   }
 
   private String getSubnetTopic(final int subnetId) {
-    return TopicNames.getAttestationSubnetTopic(forkDigest, subnetId, gossipEncoding);
+    return TopicNames.getAttestationSubnetTopic(forkInfo.getForkDigest(), subnetId, gossipEncoding);
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetSubscriptionsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationSubnetSubscriptionsTest.java
@@ -62,7 +62,12 @@ public class AttestationSubnetSubscriptionsTest {
     BeaconChainUtil.create(spec, 0, recentChainData).initializeStorage();
     subnetSubscriptions =
         new AttestationSubnetSubscriptions(
-            asyncRunner, gossipNetwork, gossipEncoding, recentChainData, processor);
+            asyncRunner,
+            gossipNetwork,
+            gossipEncoding,
+            recentChainData,
+            processor,
+            recentChainData.getHeadForkInfo().orElseThrow());
 
     when(gossipNetwork.subscribe(any(), any())).thenReturn(mock(TopicChannel.class));
   }


### PR DESCRIPTION
## PR Description
Pass the fork info into `AttestationSubnetSubscriptions` so they always use the right topic for the fork.
Previously used the fork digest from the current head state which is potentially incorrect.  The `GossipForkManager` takes care of handling subscribing to different topics for different forks.

Also extract out a base class to be used for sync committee subnets.

## Fixed Issue(s)
#3803 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
