### PR TITLE
Support basic authentication with --initial-state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
 - Early access: Support for automatic fail-over of eth1-endpoints.  Multiple endpoints can be specified with the new `--eth1-endpoints` CLI option. Thanks to Enrico Del Fante.
+- Basic authentication is now supported for `--initial-state`. Infura can now be used as the source of initial states with `--initial-state https://{projectid}:{secret}@eth2-beacon-mainnet.infura.io/eth/v1/debug/beacon/states/finalized`
 - Implement standard rest api `/eth/v2/beacon/blocks/:block_id` which supports altair blocks. Documented under 'Experimental' endpoints until more widely implemented.
 
 ### Bug Fixes

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/ChainDataLoader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/ChainDataLoader.java
@@ -24,6 +24,6 @@ public class ChainDataLoader {
     return spec.deserializeBeaconState(
         ResourceLoader.urlOrFile("application/octet-stream")
             .loadBytes(source)
-            .orElseThrow(() -> new FileNotFoundException("Could not find " + source)));
+            .orElseThrow(() -> new FileNotFoundException("Not found")));
   }
 }

--- a/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/UrlSanitizer.java
+++ b/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/UrlSanitizer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.http;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class UrlSanitizer {
+  public static String sanitizePotentialUrl(final String possibleUrl) {
+    try {
+      final URI uri = new URI(possibleUrl);
+      return new URI(
+              uri.getScheme(),
+              null,
+              uri.getHost(),
+              uri.getPort(),
+              uri.getPath(),
+              uri.getQuery(),
+              uri.getFragment())
+          .toASCIIString();
+    } catch (URISyntaxException e) {
+      // Not actually a URI so no need to sanitize
+      return possibleUrl;
+    }
+  }
+}

--- a/infrastructure/http/src/test/java/tech/pegasys/teku/infrastructure/http/UrlSanitizerTest.java
+++ b/infrastructure/http/src/test/java/tech/pegasys/teku/infrastructure/http/UrlSanitizerTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.infrastructure.http;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/infrastructure/http/src/test/java/tech/pegasys/teku/infrastructure/http/UrlSanitizerTest.java
+++ b/infrastructure/http/src/test/java/tech/pegasys/teku/infrastructure/http/UrlSanitizerTest.java
@@ -1,0 +1,35 @@
+package tech.pegasys.teku.infrastructure.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UrlSanitizerTest {
+  @Test
+  void shouldRemoveBasicCredentialsFromUrl() {
+    final String input = "http://user:pass@localhost:2993/some%20path/b/c/?foo=bar#1234";
+    final String result = UrlSanitizer.sanitizePotentialUrl(input);
+    assertThat(result).isEqualTo("http://localhost:2993/some%20path/b/c/?foo=bar#1234");
+  }
+
+  @Test
+  void shouldRemoveBasicCredentialsFromUrlWithUnusualScheme() {
+    final String input = "yasf://user:pass@localhost:2993/some%20path/b/c/?foo=bar#1234";
+    final String result = UrlSanitizer.sanitizePotentialUrl(input);
+    assertThat(result).isEqualTo("yasf://localhost:2993/some%20path/b/c/?foo=bar#1234");
+  }
+
+  @Test
+  void shouldNotModifyUrlWithNoCredentials() {
+    final String input = "http://localhost:2993/some%20path/b/c/?foo=bar#1234";
+    final String result = UrlSanitizer.sanitizePotentialUrl(input);
+    assertThat(result).isEqualTo("http://localhost:2993/some%20path/b/c/?foo=bar#1234");
+  }
+
+  @Test
+  void shouldNotModifyStringThatIsNotAUrl() {
+    final String input = "user:passlocalhost:2993/some%20path/b/c/?foo=bar#1234";
+    final String result = UrlSanitizer.sanitizePotentialUrl(input);
+    assertThat(result).isEqualTo("user:passlocalhost:2993/some%20path/b/c/?foo=bar#1234");
+  }
+}

--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/resource/URLResourceLoader.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/resource/URLResourceLoader.java
@@ -13,10 +13,13 @@
 
 package tech.pegasys.teku.infrastructure.io.resource;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Base64;
 import java.util.Optional;
 import java.util.function.Predicate;
 import org.apache.logging.log4j.LogManager;
@@ -43,10 +46,15 @@ public class URLResourceLoader extends ResourceLoader {
       final URL url = new URL(source);
       final URLConnection connection = url.openConnection();
       acceptHeader.ifPresent(type -> connection.setRequestProperty("Accept", type));
+      if (url.getUserInfo() != null) {
+        final String credentials =
+            Base64.getEncoder().encodeToString(url.getUserInfo().getBytes(UTF_8));
+        connection.setRequestProperty("Authorization", "Basic " + credentials);
+      }
       connection.connect();
       return Optional.of(connection.getInputStream());
     } catch (Exception e) {
-      LOG.debug("Failed to load url: " + source, e);
+      LOG.debug("Failed to load resource as URL", e);
       return Optional.empty();
     }
   }

--- a/services/beaconchain/build.gradle
+++ b/services/beaconchain/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   implementation project(':ethereum:statetransition')
   implementation project(':ethereum:weaksubjectivity')
   implementation project(':infrastructure:async')
+  implementation project(':infrastructure:http')
   implementation project(':infrastructure:logging')
   implementation project(':infrastructure:version')
   implementation project(':networking:p2p')

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/WeakSubjectivityInitializer.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/WeakSubjectivityInitializer.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.http.UrlSanitizer;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -43,8 +44,9 @@ class WeakSubjectivityInitializer {
       final Spec spec, final Optional<String> initialStateResource) {
     return initialStateResource.map(
         stateResource -> {
+          final String sanitizedResource = UrlSanitizer.sanitizePotentialUrl(stateResource);
           try {
-            STATUS_LOG.loadingInitialStateResource(stateResource);
+            STATUS_LOG.loadingInitialStateResource(sanitizedResource);
             final BeaconState state = ChainDataLoader.loadState(spec, stateResource);
             final AnchorPoint anchor = AnchorPoint.fromInitialState(spec, state);
             STATUS_LOG.loadedInitialStateResource(
@@ -57,7 +59,7 @@ class WeakSubjectivityInitializer {
           } catch (IOException e) {
             LOG.error("Failed to load initial state", e);
             throw new InvalidConfigurationException(
-                "Failed to load initial state from " + stateResource + ": " + e.getMessage());
+                "Failed to load initial state from " + sanitizedResource + ": " + e.getMessage());
           }
         });
   }


### PR DESCRIPTION
## PR Description
Support reading basic authentication credentials from URLs specified in `--initial-state` (and anywhere else we use `ResourceLoader`).

Ensure the auth credentials in the URL are not logged when printing the initial state source.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
