### PR TITLE
Add validator for SyncCommitteeSignature

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalSigner.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalSigner.java
@@ -114,8 +114,7 @@ public class LocalSigner implements Signer {
 
   private SafeFuture<Bytes> signingRootFromSyncCommitteeUtils(
       final UInt64 slot, final Function<SyncCommitteeUtil, Bytes> createSigningRoot) {
-    return SafeFuture.of(
-        () -> createSigningRoot.apply(spec.getSyncCommitteeUtil(slot).orElseThrow()));
+    return SafeFuture.of(() -> createSigningRoot.apply(spec.getSyncCommitteeUtilRequired(slot)));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -126,6 +126,14 @@ public class Spec {
     return atSlot(slot).getSyncCommitteeUtil();
   }
 
+  public SyncCommitteeUtil getSyncCommitteeUtilRequired(final UInt64 slot) {
+    return getSyncCommitteeUtil(slot)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Fork at slot " + slot + " does not support sync committees"));
+  }
+
   public SpecVersion getGenesisSpec() {
     return atEpoch(UInt64.ZERO);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeSignature.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeSignature.java
@@ -29,6 +29,15 @@ public class SyncCommitteeSignature
     super(schema, backingNode);
   }
 
+  public SyncCommitteeSignature(
+      final SyncCommitteeSignatureSchema schema,
+      final SszUInt64 slot,
+      final SszBytes32 beaconBlockRoot,
+      final SszUInt64 validatorIndex,
+      final SszSignature signature) {
+    super(schema, slot, beaconBlockRoot, validatorIndex, signature);
+  }
+
   public UInt64 getSlot() {
     return getField0().get();
   }
@@ -43,5 +52,10 @@ public class SyncCommitteeSignature
 
   public BLSSignature getSignature() {
     return getField3().getSignature();
+  }
+
+  @Override
+  public SyncCommitteeSignatureSchema getSchema() {
+    return (SyncCommitteeSignatureSchema) super.getSchema();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeSignatureSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeSignatureSchema.java
@@ -13,6 +13,9 @@
 
 package tech.pegasys.teku.spec.datastructures.operations.versions.altair;
 
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 import tech.pegasys.teku.ssz.containers.ContainerSchema4;
@@ -39,5 +42,18 @@ public class SyncCommitteeSignatureSchema
   @Override
   public SyncCommitteeSignature createFromBackingNode(final TreeNode node) {
     return new SyncCommitteeSignature(this, node);
+  }
+
+  public SyncCommitteeSignature create(
+      final UInt64 slot,
+      final Bytes32 beaconBlockRoot,
+      final UInt64 validatorIndex,
+      final BLSSignature signature) {
+    return new SyncCommitteeSignature(
+        this,
+        SszUInt64.of(slot),
+        SszBytes32.of(beaconBlockRoot),
+        SszUInt64.of(validatorIndex),
+        new SszSignature(signature));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ValidateableSyncCommitteeSignature.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ValidateableSyncCommitteeSignature.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations.versions.altair;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+public class ValidateableSyncCommitteeSignature {
+  private final SyncCommitteeSignature signature;
+  private final OptionalInt receivedSubnetId;
+  private volatile Optional<Set<Integer>> applicableSubcommittees = Optional.empty();
+
+  private ValidateableSyncCommitteeSignature(
+      final SyncCommitteeSignature signature, final OptionalInt receivedSubnetId) {
+    this.signature = signature;
+    this.receivedSubnetId = receivedSubnetId;
+  }
+
+  public static ValidateableSyncCommitteeSignature fromValidator(
+      final SyncCommitteeSignature signature) {
+    return new ValidateableSyncCommitteeSignature(signature, OptionalInt.empty());
+  }
+
+  public static ValidateableSyncCommitteeSignature fromNetwork(
+      final SyncCommitteeSignature signature, final int receivedSubnetId) {
+    return new ValidateableSyncCommitteeSignature(signature, OptionalInt.of(receivedSubnetId));
+  }
+
+  public SyncCommitteeSignature getSignature() {
+    return signature;
+  }
+
+  public OptionalInt getReceivedSubnetId() {
+    return receivedSubnetId;
+  }
+
+  public Optional<Set<Integer>> getApplicableSubcommittees() {
+    return applicableSubcommittees;
+  }
+
+  public Set<Integer> calculateApplicableSubcommittees(final Spec spec, final BeaconState state) {
+    final Optional<Set<Integer>> currentValue = this.applicableSubcommittees;
+    if (currentValue.isPresent()) {
+      return currentValue.get();
+    }
+    final Set<Integer> applicableSubcommittees =
+        spec.getSyncCommitteeUtil(signature.getSlot())
+            .orElseThrow()
+            .getSyncSubcommittees(
+                state, spec.computeEpochAtSlot(signature.getSlot()), signature.getValidatorIndex());
+    this.applicableSubcommittees = Optional.of(applicableSubcommittees);
+    return applicableSubcommittees;
+  }
+
+  public UInt64 getSlot() {
+    return signature.getSlot();
+  }
+
+  public Bytes32 getBeaconBlockRoot() {
+    return signature.getBeaconBlockRoot();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ValidateableSyncCommitteeSignature.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ValidateableSyncCommitteeSignature.java
@@ -60,8 +60,7 @@ public class ValidateableSyncCommitteeSignature {
       return currentValue.get();
     }
     final Set<Integer> applicableSubcommittees =
-        spec.getSyncCommitteeUtil(signature.getSlot())
-            .orElseThrow()
+        spec.getSyncCommitteeUtilRequired(signature.getSlot())
             .getSyncSubcommittees(
                 state, spec.computeEpochAtSlot(signature.getSlot()), signature.getValidatorIndex());
     this.applicableSubcommittees = Optional.of(applicableSubcommittees);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -14,12 +14,12 @@
 package tech.pegasys.teku.spec.logic.common.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toUnmodifiableMap;
 import static tech.pegasys.teku.spec.constants.NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.bytesToUInt64;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -164,11 +164,18 @@ public class SyncCommitteeUtil {
     return bytesToUInt64(Hash.sha2_256(signature.toSSZBytes()).slice(0, 8)).mod(modulo).isZero();
   }
 
+  public Set<Integer> getSyncSubcommittees(
+      final BeaconState state, final UInt64 epoch, final UInt64 validatorIndex) {
+    final SyncSubcommitteeAssignments assignments =
+        getSyncSubcommittees(state, epoch).get(validatorIndex);
+    return assignments != null ? assignments.getAssignedSubcommittees() : emptySet();
+  }
+
   public Set<Integer> computeSubnetsForSyncCommittee(
       final BeaconState state, final UInt64 epoch, final UInt64 validatorIndex) {
     final SyncSubcommitteeAssignments assignments =
         getSyncSubcommittees(state, epoch).get(validatorIndex);
-    return assignments == null ? Collections.emptySet() : assignments.getAssignedSubcommittees();
+    return assignments == null ? emptySet() : assignments.getAssignedSubcommittees();
   }
 
   public Bytes32 getSyncCommitteeSignatureSigningRoot(

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtilTest.java
@@ -51,7 +51,7 @@ class SyncCommitteeUtilTest {
   private final int subcommitteeSize = config.getSyncCommitteeSize() / SYNC_COMMITTEE_SUBNET_COUNT;
 
   private final SyncCommitteeUtil syncCommitteeUtil =
-      spec.getSyncCommitteeUtil(UInt64.ZERO).orElseThrow();
+      spec.getSyncCommitteeUtilRequired(UInt64.ZERO);
 
   @Test
   void getSyncSubCommittees_shouldCalculateSubcommitteeAssignments() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -58,6 +58,10 @@ public class TestSpecFactory {
     return create(config, SpecMilestone.PHASE0);
   }
 
+  public static Spec createAltair(final SpecConfig config) {
+    return create(config, SpecMilestone.ALTAIR);
+  }
+
   private static Spec create(
       final SpecConfig config, final SpecMilestone highestSupportedMilestone) {
     return Spec.create(config, highestSupportedMilestone);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignatureValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignatureValidator.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.synccommittee;
+
+import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
+import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.IGNORE;
+import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.REJECT;
+import static tech.pegasys.teku.util.config.Constants.VALID_SYNC_COMMITTEE_SIGNATURE_SET_SIZE;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLS;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.collections.LimitedSet;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
+import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+public class SyncCommitteeSignatureValidator {
+  private static final Logger LOG = LogManager.getLogger();
+  private final Set<UniquenessKey> seenIndices =
+      LimitedSet.create(VALID_SYNC_COMMITTEE_SIGNATURE_SET_SIZE);
+  private final Spec spec;
+  private final RecentChainData recentChainData;
+  private final SyncCommitteeStateUtils syncCommitteeStateUtils;
+
+  public SyncCommitteeSignatureValidator(
+      final Spec spec,
+      final RecentChainData recentChainData,
+      final SyncCommitteeStateUtils syncCommitteeStateUtils) {
+    this.spec = spec;
+    this.recentChainData = recentChainData;
+    this.syncCommitteeStateUtils = syncCommitteeStateUtils;
+  }
+
+  public SafeFuture<InternalValidationResult> validate(
+      final ValidateableSyncCommitteeSignature validateableSignature) {
+
+    final SyncCommitteeSignature signature = validateableSignature.getSignature();
+
+    final Optional<SyncCommitteeUtil> maybeSyncCommitteeUtil =
+        spec.getSyncCommitteeUtil(signature.getSlot());
+    if (maybeSyncCommitteeUtil.isEmpty()) {
+      LOG.trace(
+          "Rejecting sync committee signature because the fork active at slot {} does not support sync committees",
+          signature.getSlot());
+      return SafeFuture.completedFuture(REJECT);
+    }
+    final SyncCommitteeUtil syncCommitteeUtil = maybeSyncCommitteeUtil.get();
+
+    // [IGNORE] The signature's slot is for the current slot, i.e. sync_committee_signature.slot ==
+    // current_slot.
+    if (recentChainData.getCurrentSlot().isEmpty()
+        || !signature.getSlot().equals(recentChainData.getCurrentSlot().orElseThrow())) {
+      LOG.trace("Ignoring sync committee signature because it is not from the current slot");
+      return SafeFuture.completedFuture(IGNORE);
+    }
+
+    // [IGNORE] There has been no other valid sync committee signature for the declared slot for the
+    // validator referenced by sync_committee_signature.validator_index.
+    final UniquenessKey uniquenessKey = getUniquenessKey(signature);
+    if (seenIndices.contains(uniquenessKey)) {
+      return SafeFuture.completedFuture(IGNORE);
+    }
+
+    // [IGNORE] The block being signed over (sync_committee_signature.beacon_block_root) has been
+    // seen (via both gossip and non-gossip sources).
+    if (!recentChainData.containsBlock(signature.getBeaconBlockRoot())) {
+      LOG.trace("Ignoring sync committee signature because beacon block is not known");
+      return SafeFuture.completedFuture(IGNORE);
+    }
+
+    return syncCommitteeStateUtils
+        .getStateForSyncCommittee(signature.getSlot(), signature.getBeaconBlockRoot())
+        .thenApply(
+            maybeState -> {
+              if (maybeState.isEmpty()) {
+                LOG.trace(
+                    "Ignoring sync committee signature because state is not available or not from Altair fork");
+                return IGNORE;
+              }
+              final BeaconStateAltair state = maybeState.get();
+              return validateWithState(
+                  validateableSignature, signature, syncCommitteeUtil, state, uniquenessKey);
+            });
+  }
+
+  private InternalValidationResult validateWithState(
+      final ValidateableSyncCommitteeSignature validateableSignature,
+      final SyncCommitteeSignature signature,
+      final SyncCommitteeUtil syncCommitteeUtil,
+      final BeaconStateAltair state,
+      final UniquenessKey uniquenessKey) {
+    final UInt64 signatureEpoch = spec.computeEpochAtSlot(signature.getSlot());
+
+    // Always calculate the applicable subcommittees to ensure they are cached and can be used to
+    // send the gossip.
+    final Set<Integer> assignedSubcommittees =
+        validateableSignature.calculateApplicableSubcommittees(spec, state);
+
+    // [REJECT] The validator producing this sync_committee_signature is in the current sync
+    // committee, i.e. state.validators[sync_committee_signature.validator_index].pubkey in
+    // state.current_sync_committee.pubkeys.
+    if (assignedSubcommittees.isEmpty()) {
+      LOG.trace(
+          "Rejecting sync committee signature because validator is not in the sync committee");
+      return REJECT;
+    }
+
+    // [REJECT] The subnet_id is correct, i.e. subnet_id in
+    // compute_subnets_for_sync_committee(state, sync_committee_signature.validator_index).
+    if (validateableSignature.getReceivedSubnetId().isPresent()
+        && !assignedSubcommittees.contains(
+            validateableSignature.getReceivedSubnetId().getAsInt())) {
+      LOG.trace("Rejecting sync committee signature because subnet id is incorrect");
+      return REJECT;
+    }
+
+    final Optional<BLSPublicKey> maybeValidatorPublicKey =
+        spec.getValidatorPubKey(state, signature.getValidatorIndex());
+    if (maybeValidatorPublicKey.isEmpty()) {
+      LOG.trace("Rejecting sync committee signature because the validator index is unknown");
+      return REJECT;
+    }
+
+    // [REJECT] The signature is valid for the message beacon_block_root for the validator
+    // referenced by validator_index.
+    final Bytes32 signingRoot =
+        syncCommitteeUtil.getSyncCommitteeSignatureSigningRoot(
+            signature.getBeaconBlockRoot(), signatureEpoch, state.getForkInfo());
+    if (!BLS.verify(maybeValidatorPublicKey.get(), signingRoot, signature.getSignature())) {
+      LOG.trace("Rejecting sync committee signature because the signature is invalid");
+      return REJECT;
+    }
+
+    if (!seenIndices.add(uniquenessKey)) {
+      LOG.trace("Ignoring sync committee signature as a duplicate was processed during validation");
+      return IGNORE;
+    }
+    return ACCEPT;
+  }
+
+  private UniquenessKey getUniquenessKey(final SyncCommitteeSignature signature) {
+    return new UniquenessKey(signature.getValidatorIndex(), signature.getSlot());
+  }
+
+  private static class UniquenessKey {
+    private final UInt64 validatorIndex;
+    private final UInt64 slot;
+
+    private UniquenessKey(final UInt64 validatorIndex, final UInt64 slot) {
+      this.validatorIndex = validatorIndex;
+      this.slot = slot;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final UniquenessKey that = (UniquenessKey) o;
+      return Objects.equals(validatorIndex, that.validatorIndex) && Objects.equals(slot, that.slot);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(validatorIndex, slot);
+    }
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtils.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.synccommittee;
+
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
+import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+public class SyncCommitteeStateUtils {
+  private static final Logger LOG = LogManager.getLogger();
+  private final Spec spec;
+  private final RecentChainData recentChainData;
+
+  public SyncCommitteeStateUtils(final Spec spec, final RecentChainData recentChainData) {
+    this.spec = spec;
+    this.recentChainData = recentChainData;
+  }
+
+  public SafeFuture<Optional<BeaconStateAltair>> getStateForSyncCommittee(
+      final UInt64 slot, final Bytes32 beaconBlockRoot) {
+    return recentChainData
+        .retrieveBlockState(beaconBlockRoot)
+        .thenApply(maybeState -> maybeState.flatMap(BeaconState::toVersionAltair))
+        .thenApply(maybeState -> ensureStateSuitable(slot, beaconBlockRoot, maybeState));
+  }
+
+  private Optional<BeaconStateAltair> ensureStateSuitable(
+      final UInt64 slot,
+      final Bytes32 beaconBlockRoot,
+      final Optional<BeaconStateAltair> maybeState) {
+    if (maybeState.isEmpty()) {
+      return Optional.empty();
+    }
+    final SyncCommitteeUtil syncCommitteeUtil = spec.getSyncCommitteeUtil(slot).orElseThrow();
+    final UInt64 epoch = spec.computeEpochAtSlot(slot);
+    final UInt64 minEpoch = syncCommitteeUtil.getMinEpochForSyncCommitteeAssignments(epoch);
+    final UInt64 stateEpoch = spec.getCurrentEpoch(maybeState.get());
+    if (stateEpoch.isLessThan(minEpoch)) {
+      LOG.warn(
+          "Ignoring sync committee gossip because it refers to a block that is too old. "
+              + "Block root {} from epoch {} is more than two sync committee periods before current epoch {}",
+          beaconBlockRoot,
+          stateEpoch,
+          epoch);
+      return Optional.empty();
+    } else {
+      return maybeState;
+    }
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtils.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtils.java
@@ -50,7 +50,7 @@ public class SyncCommitteeStateUtils {
     if (maybeState.isEmpty()) {
       return Optional.empty();
     }
-    final SyncCommitteeUtil syncCommitteeUtil = spec.getSyncCommitteeUtil(slot).orElseThrow();
+    final SyncCommitteeUtil syncCommitteeUtil = spec.getSyncCommitteeUtilRequired(slot);
     final UInt64 epoch = spec.computeEpochAtSlot(slot);
     final UInt64 minEpoch = syncCommitteeUtil.getMinEpochForSyncCommitteeAssignments(epoch);
     final UInt64 stateEpoch = spec.getCurrentEpoch(maybeState.get());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidatorTest.java
@@ -43,7 +43,10 @@ class SignedContributionAndProofValidatorTest {
   private final ChainBuilder chainBuilder = storageSystem.chainBuilder();
 
   private final SignedContributionAndProofValidator validator =
-      new SignedContributionAndProofValidator(spec, storageSystem.recentChainData());
+      new SignedContributionAndProofValidator(
+          spec,
+          storageSystem.recentChainData(),
+          new SyncCommitteeStateUtils(spec, storageSystem.recentChainData()));
 
   @BeforeEach
   void setUp() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPoolTest.java
@@ -197,8 +197,7 @@ class SyncCommitteeContributionPoolTest {
   private SignedContributionAndProof withParticipationBits(
       final SignedContributionAndProof proof, final Integer... participationBits) {
     final SyncCommitteeContribution contribution = proof.getMessage().getContribution();
-    final SyncCommitteeUtil syncCommitteeUtil =
-        spec.getSyncCommitteeUtil(UInt64.ZERO).orElseThrow();
+    final SyncCommitteeUtil syncCommitteeUtil = spec.getSyncCommitteeUtilRequired(UInt64.ZERO);
     final SyncCommitteeContribution newContribution =
         syncCommitteeUtil.createSyncCommitteeContribution(
             contribution.getSlot(),

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignatureValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignatureValidatorTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.synccommittee;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
+import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.IGNORE;
+import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.REJECT;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.core.ChainBuilder;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.TestConfigLoader;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
+import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
+
+class SyncCommitteeSignatureValidatorTest {
+
+  private final Spec spec =
+      TestSpecFactory.createAltair(
+          TestConfigLoader.loadConfig(
+              "minimal",
+              phase0Builder ->
+                  phase0Builder.altairBuilder(
+                      altairBuilder ->
+                          altairBuilder.syncCommitteeSize(16).altairForkSlot(UInt64.ZERO))));
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final StorageSystem storageSystem =
+      InMemoryStorageSystemBuilder.create().specProvider(spec).numberOfValidators(17).build();
+  private final ChainBuilder chainBuilder = storageSystem.chainBuilder();
+  private final RecentChainData recentChainData = storageSystem.recentChainData();
+
+  private final SyncCommitteeSignatureValidator validator =
+      new SyncCommitteeSignatureValidator(
+          spec, recentChainData, new SyncCommitteeStateUtils(spec, recentChainData));
+
+  @BeforeEach
+  void setUp() {
+    storageSystem.chainUpdater().initializeGenesis();
+  }
+
+  @Test
+  void shouldAcceptWhenValid() {
+    final SyncCommitteeSignature signature = chainBuilder.createValidSyncCommitteeSignature();
+    final int validSubnetId =
+        spec.getSyncCommitteeUtil(UInt64.ZERO)
+            .orElseThrow()
+            .getSyncSubcommittees(
+                chainBuilder.getLatestBlockAndState().getState(),
+                chainBuilder.getLatestEpoch(),
+                signature.getValidatorIndex())
+            .iterator()
+            .next();
+    assertThat(
+            validator.validate(
+                ValidateableSyncCommitteeSignature.fromNetwork(signature, validSubnetId)))
+        .isCompletedWithValue(ACCEPT);
+  }
+
+  @Test
+  void shouldRejectWhenAltairIsNotActiveAtSlot() {
+    final Spec phase0Spec = TestSpecFactory.createMinimalPhase0();
+    final SyncCommitteeSignatureValidator validator =
+        new SyncCommitteeSignatureValidator(
+            phase0Spec, recentChainData, new SyncCommitteeStateUtils(phase0Spec, recentChainData));
+    final SyncCommitteeSignature signature = chainBuilder.createValidSyncCommitteeSignature();
+
+    assertThat(validator.validate(ValidateableSyncCommitteeSignature.fromValidator(signature)))
+        .isCompletedWithValue(REJECT);
+  }
+
+  @Test
+  void shouldRejectWhenNotForTheCurrentSlot() {
+    final SignedBlockAndState latestBlockAndState = chainBuilder.getLatestBlockAndState();
+    final SyncCommitteeSignature signature =
+        chainBuilder.createSyncCommitteeSignature(
+            latestBlockAndState.getSlot().plus(1), latestBlockAndState.getRoot());
+
+    assertThat(validator.validate(ValidateableSyncCommitteeSignature.fromValidator(signature)))
+        .isCompletedWithValue(IGNORE);
+  }
+
+  @Test
+  void shouldIgnoreDuplicateSignatures() {
+    final SyncCommitteeSignature signature = chainBuilder.createValidSyncCommitteeSignature();
+
+    assertThat(validator.validate(ValidateableSyncCommitteeSignature.fromValidator(signature)))
+        .isCompletedWithValue(ACCEPT);
+    assertThat(validator.validate(ValidateableSyncCommitteeSignature.fromValidator(signature)))
+        .isCompletedWithValue(IGNORE);
+  }
+
+  @Test
+  void shouldIgnoreWhenBeaconBlockIsNotKnown() {
+    final SyncCommitteeSignature signature =
+        chainBuilder.createSyncCommitteeSignature(
+            chainBuilder.getLatestSlot(), dataStructureUtil.randomBytes32());
+    assertThat(validator.validate(ValidateableSyncCommitteeSignature.fromValidator(signature)))
+        .isCompletedWithValue(IGNORE);
+  }
+
+  @Test
+  void shouldRejectWhenValidatorIsNotInSyncCommittee() {
+    final SignedBlockAndState target = chainBuilder.getLatestBlockAndState();
+    final BeaconStateAltair state = BeaconStateAltair.required(target.getState());
+    final List<SszPublicKey> committeePubkeys =
+        state.getCurrentSyncCommittee().getPubkeys().asList();
+    // Find a validator key that isn't in the sync committee
+    final BLSPublicKey validatorPublicKey =
+        chainBuilder.getValidatorKeys().stream()
+            .map(BLSKeyPair::getPublicKey)
+            .filter(publicKey -> !committeePubkeys.contains(new SszPublicKey(publicKey)))
+            .findAny()
+            .orElseThrow();
+
+    final SyncCommitteeSignature signature =
+        chainBuilder.createSyncCommitteeSignature(
+            target.getSlot(), target.getRoot(), state, validatorPublicKey);
+
+    assertThat(validator.validate(ValidateableSyncCommitteeSignature.fromValidator(signature)))
+        .isCompletedWithValue(REJECT);
+  }
+
+  @Test
+  void shouldRejectWhenReceivedOnIncorrectSubnet() {
+    final SyncCommitteeSignature signature = chainBuilder.createValidSyncCommitteeSignature();
+    // 9 is never a valid subnet
+    assertThat(validator.validate(ValidateableSyncCommitteeSignature.fromNetwork(signature, 9)))
+        .isCompletedWithValue(REJECT);
+  }
+
+  @Test
+  void shouldRejectWhenValidatorIsUnknown() {
+    final SyncCommitteeSignature template = chainBuilder.createValidSyncCommitteeSignature();
+    final SyncCommitteeSignature signature =
+        template
+            .getSchema()
+            .create(
+                template.getSlot(),
+                template.getBeaconBlockRoot(),
+                // There's only 16 validators
+                UInt64.valueOf(25),
+                template.getSignature());
+    assertThat(validator.validate(ValidateableSyncCommitteeSignature.fromValidator(signature)))
+        .isCompletedWithValue(REJECT);
+  }
+
+  @Test
+  void shouldRejectWhenSignatureIsInvalid() {
+    final SyncCommitteeSignature template = chainBuilder.createValidSyncCommitteeSignature();
+    final SyncCommitteeSignature signature =
+        template
+            .getSchema()
+            .create(
+                template.getSlot(),
+                template.getBeaconBlockRoot(),
+                template.getValidatorIndex(),
+                dataStructureUtil.randomSignature());
+    assertThat(validator.validate(ValidateableSyncCommitteeSignature.fromValidator(signature)))
+        .isCompletedWithValue(REJECT);
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignatureValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignatureValidatorTest.java
@@ -68,8 +68,7 @@ class SyncCommitteeSignatureValidatorTest {
   void shouldAcceptWhenValid() {
     final SyncCommitteeSignature signature = chainBuilder.createValidSyncCommitteeSignature();
     final Set<Integer> applicableSubcommittees =
-        spec.getSyncCommitteeUtil(UInt64.ZERO)
-            .orElseThrow()
+        spec.getSyncCommitteeUtilRequired(UInt64.ZERO)
             .getSyncSubcommittees(
                 chainBuilder.getLatestBlockAndState().getState(),
                 chainBuilder.getLatestEpoch(),

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtilsTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtilsTest.java
@@ -45,7 +45,7 @@ class SyncCommitteeStateUtilsTest {
                               .epochsPerSyncCommitteePeriod(EPOCHS_PER_SYNC_COMMITTEE_PERIOD))));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final SyncCommitteeUtil syncCommitteeUtil =
-      spec.getSyncCommitteeUtil(UInt64.ZERO).orElseThrow();
+      spec.getSyncCommitteeUtilRequired(UInt64.ZERO);
 
   private final Bytes32 blockRoot = dataStructureUtil.randomBytes32();
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtilsTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtilsTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.synccommittee;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.TestConfigLoader;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
+import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+class SyncCommitteeStateUtilsTest {
+
+  private static final int EPOCHS_PER_SYNC_COMMITTEE_PERIOD = 10;
+  private final Spec spec =
+      TestSpecFactory.createAltair(
+          TestConfigLoader.loadConfig(
+              "minimal",
+              builder ->
+                  builder.altairBuilder(
+                      altairBuilder ->
+                          altairBuilder
+                              .altairForkSlot(UInt64.ZERO)
+                              .epochsPerSyncCommitteePeriod(EPOCHS_PER_SYNC_COMMITTEE_PERIOD))));
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final SyncCommitteeUtil syncCommitteeUtil =
+      spec.getSyncCommitteeUtil(UInt64.ZERO).orElseThrow();
+
+  private final Bytes32 blockRoot = dataStructureUtil.randomBytes32();
+
+  private final RecentChainData recentChainData = mock(RecentChainData.class);
+
+  private final SyncCommitteeStateUtils stateUtils =
+      new SyncCommitteeStateUtils(spec, recentChainData);
+
+  @Test
+  void shouldReturnEmptyWhenBlockStateIsNotAvailable() {
+    when(recentChainData.retrieveBlockState(blockRoot))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+    assertThatSafeFuture(stateUtils.getStateForSyncCommittee(UInt64.ONE, blockRoot))
+        .isCompletedWithEmptyOptional();
+  }
+
+  @Test
+  void shouldUseStateFromBeaconBlockRootWhenSlotEqualToBlockSlot() {
+    final UInt64 slot = UInt64.valueOf(500);
+    // State from same slot as block so definitely within the committee period.
+    final BeaconStateAltair state = dataStructureUtil.stateBuilderAltair().slot(slot).build();
+    assertRetrievedStateIsSuitable(slot, state);
+  }
+
+  @Test
+  void shouldUseStateFromBeaconBlockRootWhenBlockSlotWithinSameCommitteePeriod() {
+    final UInt64 slot = UInt64.valueOf(500);
+    // Few skip slots but still in the right region
+    final BeaconStateAltair state =
+        dataStructureUtil.stateBuilderAltair().slot(slot.minusMinZero(3)).build();
+    assertRetrievedStateIsSuitable(slot, state);
+  }
+
+  @Test
+  void shouldUseStateFromBeaconBlockRootWhenBlockSlotInMinimumRequiredEpoch() {
+    final UInt64 slot = UInt64.valueOf(500);
+    final UInt64 epoch = spec.computeEpochAtSlot(slot);
+    final UInt64 stateSlot =
+        spec.computeStartSlotAtEpoch(
+            syncCommitteeUtil.getMinEpochForSyncCommitteeAssignments(epoch));
+    // Few skip slots but still in the right region
+    final BeaconStateAltair state = dataStructureUtil.stateBuilderAltair().slot(stateSlot).build();
+    assertRetrievedStateIsSuitable(slot, state);
+  }
+
+  @Test
+  void shouldReturnEmptyWhenBlockStateIsTooOld() {
+    final UInt64 slot = UInt64.valueOf(500);
+    final UInt64 epoch = spec.computeEpochAtSlot(slot);
+    final UInt64 stateSlot =
+        spec.computeStartSlotAtEpoch(
+                syncCommitteeUtil.getMinEpochForSyncCommitteeAssignments(epoch))
+            .minus(1);
+    final BeaconStateAltair state = dataStructureUtil.stateBuilderAltair().slot(stateSlot).build();
+    when(recentChainData.retrieveBlockState(blockRoot))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
+
+    assertThatSafeFuture(stateUtils.getStateForSyncCommittee(slot, blockRoot))
+        .isCompletedWithEmptyOptional();
+  }
+
+  private void assertRetrievedStateIsSuitable(final UInt64 slot, final BeaconStateAltair state) {
+    when(recentChainData.retrieveBlockState(blockRoot))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
+
+    final SafeFuture<Optional<BeaconStateAltair>> result =
+        stateUtils.getStateForSyncCommittee(slot, blockRoot);
+
+    assertThatSafeFuture(result).isCompletedWithOptionalContaining(state);
+  }
+}

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -84,6 +84,7 @@ import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
 import tech.pegasys.teku.statetransition.genesis.GenesisHandler;
 import tech.pegasys.teku.statetransition.synccommittee.SignedContributionAndProofValidator;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeStateUtils;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.statetransition.validation.AggregateAttestationValidator;
@@ -537,7 +538,9 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   private void initSyncCommitteePools() {
     syncCommitteeContributionPool =
         new SyncCommitteeContributionPool(
-            spec, new SignedContributionAndProofValidator(spec, recentChainData));
+            spec,
+            new SignedContributionAndProofValidator(
+                spec, recentChainData, new SyncCommitteeStateUtils(spec, recentChainData)));
     eventChannels.subscribe(SlotEventsChannel.class, syncCommitteeContributionPool);
   }
 

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -149,6 +149,7 @@ public class Constants {
   public static final int VALID_AGGREGATE_SET_SIZE = 1000;
   public static final int VALID_VALIDATOR_SET_SIZE = 10000;
   public static final int VALID_CONTRIBUTION_AND_PROOF_SET_SIZE = 10000;
+  public static final int VALID_SYNC_COMMITTEE_SIGNATURE_SET_SIZE = 10000;
   public static final int NETWORKING_FAILURE_REPEAT_INTERVAL = 3; // in sec
 
   // Teku specific

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -249,8 +249,7 @@ public class ExternalSigner implements Signer {
 
   private SafeFuture<Bytes> signingRootFromSyncCommitteeUtils(
       final UInt64 slot, final Function<SyncCommitteeUtil, Bytes> createSigningRoot) {
-    return SafeFuture.of(
-        () -> createSigningRoot.apply(spec.getSyncCommitteeUtil(slot).orElseThrow()));
+    return SafeFuture.of(() -> createSigningRoot.apply(spec.getSyncCommitteeUtilRequired(slot)));
   }
 
   private Map<String, Object> forkInfo(final ForkInfo forkInfo) {


### PR DESCRIPTION
## PR Description
Add validator for `SyncCommitteeSignature` gossip.

Uses `ValidateableSyncCommitteeSignature` similar to `ValidateableAttestation` to wrap the actual gossip message with other useful and cached info like the subnet it was received on.

## Fixed Issue(s)
#3803 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
