### PR TITLE
implement `/teku/v1/beacon/blocks/:slot` for non-canonical block retrieval

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.Liveness;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.PutLogLevel;
+import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetNonCanonicalBlocks;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetSszState;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetStateByBlockRoot;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetAttestations;
@@ -273,6 +274,7 @@ public class BeaconRestApi {
     app.get(GetSszState.ROUTE, new GetSszState(provider, jsonProvider));
     app.get(GetStateByBlockRoot.ROUTE, new GetStateByBlockRoot(provider, jsonProvider));
     app.get(Liveness.ROUTE, new Liveness());
+    app.get(GetNonCanonicalBlocks.ROUTE, new GetNonCanonicalBlocks(provider, jsonProvider));
   }
 
   private void addNodeHandlers(final DataProvider provider) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetNonCanonicalBlocks.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetNonCanonicalBlocks.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon;
+
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.CACHE_NONE;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_NOT_FOUND;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.SLOT;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_EXPERIMENTAL;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
+
+import io.javalin.core.util.Header;
+import io.javalin.http.Context;
+import io.javalin.http.Handler;
+import io.javalin.plugin.openapi.annotations.HttpMethod;
+import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiContent;
+import io.javalin.plugin.openapi.annotations.OpenApiParam;
+import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import java.util.Map;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import tech.pegasys.teku.api.ChainDataProvider;
+import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.response.v1.teku.GetNonCanonicalBlocksResponse;
+import tech.pegasys.teku.api.schema.SignedBeaconBlock;
+import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.provider.JsonProvider;
+
+public class GetNonCanonicalBlocks implements Handler {
+  public static final String ROUTE = "/teku/v1/beacon/blocks/:slot";
+  private final ChainDataProvider chainDataProvider;
+  private final JsonProvider jsonProvider;
+
+  public GetNonCanonicalBlocks(final DataProvider dataProvider, final JsonProvider jsonProvider) {
+    this(dataProvider.getChainDataProvider(), jsonProvider);
+  }
+
+  public GetNonCanonicalBlocks(
+      final ChainDataProvider chainDataProvider, final JsonProvider jsonProvider) {
+    this.jsonProvider = jsonProvider;
+    this.chainDataProvider = chainDataProvider;
+  }
+
+  @OpenApi(
+      path = ROUTE,
+      method = HttpMethod.GET,
+      summary = "Get Non-canonical blocks",
+      tags = {TAG_EXPERIMENTAL},
+      description = "Get non canonical blocks by slot.",
+      pathParams = {
+        @OpenApiParam(name = SLOT, description = "slot of the non-canonical blocks to retrieve.")
+      },
+      responses = {
+        @OpenApiResponse(
+            status = RES_OK,
+            content = @OpenApiContent(from = GetNonCanonicalBlocksResponse.class)),
+        @OpenApiResponse(status = RES_BAD_REQUEST),
+        @OpenApiResponse(status = RES_NOT_FOUND),
+        @OpenApiResponse(status = RES_INTERNAL_ERROR),
+        @OpenApiResponse(status = RES_SERVICE_UNAVAILABLE, description = SERVICE_UNAVAILABLE)
+      })
+  @Override
+  public void handle(@NotNull final Context ctx) throws Exception {
+    final Map<String, String> pathParamMap = ctx.pathParamMap();
+    ctx.header(Header.CACHE_CONTROL, CACHE_NONE);
+
+    SafeFuture<Set<SignedBeaconBlock>> future =
+        chainDataProvider.getNonCanonicalBlocks(pathParamMap.get(SLOT));
+    ctx.result(
+        future.thenApplyChecked(
+            result -> {
+              if (result.isEmpty()) {
+                ctx.status(SC_NOT_FOUND);
+                return BadRequest.serialize(
+                    jsonProvider, SC_NOT_FOUND, "Blocks not found: " + pathParamMap.get(SLOT));
+              }
+
+              return jsonProvider.objectToJSON(new GetNonCanonicalBlocksResponse(result));
+            }));
+  }
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -173,6 +173,20 @@ public class ChainDataProvider {
                             state.hashTreeRoot().toUnprefixedHexString())));
   }
 
+  public SafeFuture<Set<SignedBeaconBlock>> getNonCanonicalBlocks(final String slot) {
+    if (slot.startsWith("0x")) {
+      throw new BadRequestException(
+          String.format("block roots are not currently supported: %s", slot));
+    } else {
+      return defaultBlockSelectorFactory
+          .nonCanonicalBlocksSelector(UInt64.valueOf(slot))
+          .getBlock()
+          .thenApply(
+              blockList ->
+                  blockList.stream().map(SignedBeaconBlock::new).collect(Collectors.toSet()));
+    }
+  }
+
   public SafeFuture<Optional<StateSszResponse>> getBeaconStateSszByBlockRoot(
       final String blockRootParam) {
     return defaultStateSelectorFactory

--- a/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactory.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -66,6 +67,13 @@ public class BlockSelectorFactory {
 
   public BlockSelector headSelector() {
     return () -> optionalToList(SafeFuture.completedFuture(client.getBestBlock()));
+  }
+
+  public BlockSelector nonCanonicalBlocksSelector(final UInt64 slot) {
+    return () ->
+        client
+            .getNonCanonicalBlocksAtSlot(slot)
+            .thenApply(result -> result.stream().collect(Collectors.toList()));
   }
 
   public BlockSelector finalizedSelector() {

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetNonCanonicalBlocksResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetNonCanonicalBlocksResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.response.v1.teku;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Set;
+import tech.pegasys.teku.api.schema.SignedBeaconBlock;
+
+public class GetNonCanonicalBlocksResponse {
+  @JsonProperty("data")
+  public final Set<SignedBeaconBlock> data;
+
+  @JsonCreator
+  public GetNonCanonicalBlocksResponse(@JsonProperty("data") final Set<SignedBeaconBlock> data) {
+    this.data = data;
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
@@ -67,4 +67,6 @@ public interface StorageQueryChannel extends ChannelInterface {
   SafeFuture<Optional<BeaconState>> getFinalizedStateByBlockRoot(final Bytes32 blockRoot);
 
   SafeFuture<Optional<UInt64>> getFinalizedSlotByStateRoot(final Bytes32 stateRoot);
+
+  SafeFuture<Set<SignedBeaconBlock>> getNonCanonicalBlocksBySlot(final UInt64 slot);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NavigableMap;
 import java.util.Optional;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -484,5 +485,9 @@ public class CombinedChainDataClient {
     return historicalChainData
         .getEarliestAvailableBlock()
         .thenApply(res -> res.<BeaconBlockSummary>map(b -> b).or(() -> latestFinalized));
+  }
+
+  public SafeFuture<Set<SignedBeaconBlock>> getNonCanonicalBlocksAtSlot(final UInt64 slot) {
+    return historicalChainData.getNonCanonicalBlocksBySlot(slot);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -211,6 +211,11 @@ public class ChainStorage implements StorageUpdateChannel, StorageQueryChannel, 
     return SafeFuture.of(() -> database.getSlotForFinalizedStateRoot(stateRoot));
   }
 
+  @Override
+  public SafeFuture<Set<SignedBeaconBlock>> getNonCanonicalBlocksBySlot(final UInt64 slot) {
+    return SafeFuture.of(() -> database.getNonCanonicalBlocksAtSlot(slot));
+  }
+
   private Optional<BeaconState> getLatestFinalizedStateAtSlotSync(final UInt64 slot) {
     return finalizedStateCache.getFinalizedState(slot);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -113,6 +113,8 @@ public interface Database extends AutoCloseable {
 
   Optional<MinGenesisTimeBlockEvent> getMinGenesisTimeBlock();
 
+  Set<SignedBeaconBlock> getNonCanonicalBlocksAtSlot(final UInt64 slot);
+
   @MustBeClosed
   Stream<DepositsFromBlockEvent> streamDepositsFromBlocks();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.storage.server.noop;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -146,6 +147,11 @@ public class NoOpDatabase implements Database {
   @Override
   public Optional<MinGenesisTimeBlockEvent> getMinGenesisTimeBlock() {
     return Optional.empty();
+  }
+
+  @Override
+  public Set<SignedBeaconBlock> getNonCanonicalBlocksAtSlot(final UInt64 slot) {
+    return new HashSet<>();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbFinalizedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/RocksDbFinalizedDao.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.storage.server.rocksdb.dataaccess;
 
 import com.google.errorprone.annotations.MustBeClosed;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -40,6 +41,8 @@ public interface RocksDbFinalizedDao extends AutoCloseable {
 
   Optional<SignedBeaconBlock> getLatestFinalizedBlockAtSlot(UInt64 slot);
 
+  Set<SignedBeaconBlock> getNonCanonicalBlocksAtSlot(UInt64 slot);
+
   Optional<BeaconState> getLatestAvailableFinalizedState(UInt64 maxSlot);
 
   @MustBeClosed
@@ -58,6 +61,8 @@ public interface RocksDbFinalizedDao extends AutoCloseable {
     void addFinalizedBlock(final SignedBeaconBlock block);
 
     void addNonCanonicalBlock(final SignedBeaconBlock block);
+
+    void addNonCanonicalRootAtSlot(final UInt64 slot, final Set<Bytes32> blockRoots);
 
     void addFinalizedState(final Bytes32 blockRoot, final BeaconState state);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V4FinalizedRocksDbDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V4FinalizedRocksDbDao.java
@@ -72,8 +72,7 @@ public class V4FinalizedRocksDbDao implements RocksDbFinalizedDao {
     Optional<Set<Bytes32>> maybeRoots = db.get(schema.getColumnNonCanonicalRootsBySlot(), slot);
     return maybeRoots.stream()
         .flatMap(Collection::stream)
-        .map(root -> db.get(schema.getColumnNonCanonicalBlocksByRoot(), root))
-        .flatMap(Optional::stream)
+        .flatMap(root -> db.get(schema.getColumnNonCanonicalBlocksByRoot(), root).stream())
         .collect(Collectors.toSet());
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V4FinalizedRocksDbDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/dataaccess/V4FinalizedRocksDbDao.java
@@ -14,7 +14,11 @@
 package tech.pegasys.teku.storage.server.rocksdb.dataaccess;
 
 import com.google.errorprone.annotations.MustBeClosed;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -61,6 +65,16 @@ public class V4FinalizedRocksDbDao implements RocksDbFinalizedDao {
   public Optional<SignedBeaconBlock> getLatestFinalizedBlockAtSlot(final UInt64 slot) {
     return db.getFloorEntry(schema.getColumnFinalizedBlocksBySlot(), slot)
         .map(ColumnEntry::getValue);
+  }
+
+  @Override
+  public Set<SignedBeaconBlock> getNonCanonicalBlocksAtSlot(final UInt64 slot) {
+    Optional<Set<Bytes32>> maybeRoots = db.get(schema.getColumnNonCanonicalRootsBySlot(), slot);
+    return maybeRoots.stream()
+        .flatMap(Collection::stream)
+        .map(root -> db.get(schema.getColumnNonCanonicalBlocksByRoot(), root))
+        .flatMap(Optional::stream)
+        .collect(Collectors.toSet());
   }
 
   @Override
@@ -141,6 +155,15 @@ public class V4FinalizedRocksDbDao implements RocksDbFinalizedDao {
     @Override
     public void addNonCanonicalBlock(final SignedBeaconBlock block) {
       transaction.put(schema.getColumnNonCanonicalBlocksByRoot(), block.getRoot(), block);
+    }
+
+    @Override
+    public void addNonCanonicalRootAtSlot(final UInt64 slot, final Set<Bytes32> blockRoots) {
+      Optional<Set<Bytes32>> maybeRoots = db.get(schema.getColumnNonCanonicalRootsBySlot(), slot);
+      final Set<Bytes32> roots = maybeRoots.orElse(new HashSet<>());
+      if (roots.addAll(blockRoots)) {
+        transaction.put(schema.getColumnNonCanonicalRootsBySlot(), slot, roots);
+      }
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/SchemaFinalized.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/SchemaFinalized.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.server.rocksdb.schema;
 
+import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -28,4 +29,6 @@ public interface SchemaFinalized extends Schema {
   RocksDbColumn<Bytes32, UInt64> getColumnSlotsByFinalizedStateRoot();
 
   RocksDbColumn<Bytes32, SignedBeaconBlock> getColumnNonCanonicalBlocksByRoot();
+
+  RocksDbColumn<UInt64, Set<Bytes32>> getColumnNonCanonicalRootsBySlot();
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/V4SchemaFinalized.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/V4SchemaFinalized.java
@@ -13,11 +13,13 @@
 
 package tech.pegasys.teku.storage.server.rocksdb.schema;
 
+import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.BLOCK_ROOTS_SERIALIZER;
 import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.BYTES32_SERIALIZER;
 import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.UINT64_SERIALIZER;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -33,6 +35,8 @@ public class V4SchemaFinalized implements SchemaFinalized {
   private final RocksDbColumn<Bytes32, SignedBeaconBlock> nonCanonicalBlocksByRoot;
   private static final RocksDbColumn<Bytes32, UInt64> SLOTS_BY_FINALIZED_STATE_ROOT =
       RocksDbColumn.create(4, BYTES32_SERIALIZER, UINT64_SERIALIZER);
+  private static final RocksDbColumn<UInt64, Set<Bytes32>> NON_CANONICAL_BLOCK_ROOTS_BY_SLOT =
+      RocksDbColumn.create(6, UINT64_SERIALIZER, BLOCK_ROOTS_SERIALIZER);
 
   private V4SchemaFinalized(final Spec spec) {
     finalizedBlocksBySlot =
@@ -75,13 +79,19 @@ public class V4SchemaFinalized implements SchemaFinalized {
   }
 
   @Override
+  public RocksDbColumn<UInt64, Set<Bytes32>> getColumnNonCanonicalRootsBySlot() {
+    return NON_CANONICAL_BLOCK_ROOTS_BY_SLOT;
+  }
+
+  @Override
   public List<RocksDbColumn<?, ?>> getAllColumns() {
     return List.of(
         SLOTS_BY_FINALIZED_ROOT,
         finalizedBlocksBySlot,
         finalizedStatesBySlot,
         SLOTS_BY_FINALIZED_STATE_ROOT,
-        nonCanonicalBlocksByRoot);
+        nonCanonicalBlocksByRoot,
+        NON_CANONICAL_BLOCK_ROOTS_BY_SLOT);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/V6SchemaFinalized.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/schema/V6SchemaFinalized.java
@@ -13,11 +13,13 @@
 
 package tech.pegasys.teku.storage.server.rocksdb.schema;
 
+import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.BLOCK_ROOTS_SERIALIZER;
 import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.BYTES32_SERIALIZER;
 import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.UINT64_SERIALIZER;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -41,6 +43,8 @@ public class V6SchemaFinalized implements SchemaFinalized {
   private final RocksDbColumn<Bytes32, SignedBeaconBlock> nonCanonicalBlocksByRoot;
   private static final RocksDbColumn<Bytes32, UInt64> SLOTS_BY_FINALIZED_STATE_ROOT =
       RocksDbColumn.create(ID_OFFSET + 4, BYTES32_SERIALIZER, UINT64_SERIALIZER);
+  private static final RocksDbColumn<UInt64, Set<Bytes32>> NON_CANONICAL_BLOCK_ROOTS_BY_SLOT =
+      RocksDbColumn.create(ID_OFFSET + 6, UINT64_SERIALIZER, BLOCK_ROOTS_SERIALIZER);
 
   private V6SchemaFinalized(final Spec spec) {
     finalizedBlocksBySlot =
@@ -84,13 +88,19 @@ public class V6SchemaFinalized implements SchemaFinalized {
   }
 
   @Override
+  public RocksDbColumn<UInt64, Set<Bytes32>> getColumnNonCanonicalRootsBySlot() {
+    return NON_CANONICAL_BLOCK_ROOTS_BY_SLOT;
+  }
+
+  @Override
   public List<RocksDbColumn<?, ?>> getAllColumns() {
     return List.of(
         SLOTS_BY_FINALIZED_ROOT,
         finalizedBlocksBySlot,
         finalizedStatesBySlot,
         SLOTS_BY_FINALIZED_STATE_ROOT,
-        nonCanonicalBlocksByRoot);
+        nonCanonicalBlocksByRoot,
+        NON_CANONICAL_BLOCK_ROOTS_BY_SLOT);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/Bytes32SetSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/Bytes32SetSerializer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.rocksdb.serialization;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.ssz.SSZ;
+
+public class Bytes32SetSerializer implements RocksDbSerializer<Set<Bytes32>> {
+  @Override
+  public Set<Bytes32> deserialize(final byte[] data) {
+    return SSZ.decode(
+        Bytes.of(data),
+        reader -> {
+          final Set<Bytes32> output = new HashSet<>();
+          while (!reader.isComplete()) {
+            output.add(Bytes32.wrap(reader.readFixedBytes(Bytes32.SIZE)));
+          }
+          return output;
+        });
+  }
+
+  @Override
+  public byte[] serialize(final Set<Bytes32> value) {
+    Bytes bytes = SSZ.encode(writer -> value.forEach(writer::writeFixedBytes));
+    return bytes.toArrayUnsafe();
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/RocksDbSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/serialization/RocksDbSerializer.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.server.rocksdb.serialization;
 
+import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.event.DepositsFromBlockEvent;
@@ -41,6 +42,7 @@ public interface RocksDbSerializer<T> {
       new SlotAndBlockRootSerializer();
   RocksDbSerializer<CheckpointEpochs> CHECKPOINT_EPOCHS_SERIALIZER =
       new CheckpointEpochsSerializer();
+  RocksDbSerializer<Set<Bytes32>> BLOCK_ROOTS_SERIALIZER = new Bytes32SetSerializer();
 
   static RocksDbSerializer<BeaconState> createStateSerializer(final Spec spec) {
     return new BeaconStateSerializer(spec);

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/serialization/Bytes32SetSerializerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/serialization/Bytes32SetSerializerTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.rocksdb.serialization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.storage.server.rocksdb.serialization.RocksDbSerializer.BLOCK_ROOTS_SERIALIZER;
+
+import java.util.Set;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+
+public class Bytes32SetSerializerTest {
+
+  final Set<Bytes32> inputData = Set.of(Bytes32.ZERO, Bytes32.random());
+
+  @Test
+  public void shouldPackAndUnpack() {
+    final byte[] data = BLOCK_ROOTS_SERIALIZER.serialize(inputData);
+    final Set<Bytes32> result = BLOCK_ROOTS_SERIALIZER.deserialize(data);
+    assertThat(result).isEqualTo(inputData);
+  }
+}

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -102,5 +103,10 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
   @Override
   public SafeFuture<Optional<UInt64>> getFinalizedSlotByStateRoot(final Bytes32 stateRoot) {
     return SafeFuture.completedFuture(Optional.empty());
+  }
+
+  @Override
+  public SafeFuture<Set<SignedBeaconBlock>> getNonCanonicalBlocksBySlot(final UInt64 slot) {
+    return SafeFuture.completedFuture(new HashSet<>());
   }
 }


### PR DESCRIPTION

 - non canonical blocks are only stored with development flag `--Xdata-storage-non-canonical-blocks-enabled` enabled, otherwise an empty set will always be returned.

 partially addresses #2853

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
