### PR TITLE
Support subscribing to sync committee signature subnets

### DIFF
--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -71,6 +71,7 @@ import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
@@ -321,6 +322,20 @@ public final class DataStructureUtil {
         randomSszVector(
             syncCommitteeSchema.getPubkeyAggregatesSchema(),
             () -> new SszPublicKey(randomPublicKey())));
+  }
+
+  public SyncCommitteeSignature randomSyncCommitteeSignature() {
+    return randomSyncCommitteeSignature(randomUInt64());
+  }
+
+  public SyncCommitteeSignature randomSyncCommitteeSignature(final long slot) {
+    return randomSyncCommitteeSignature(UInt64.valueOf(slot));
+  }
+
+  public SyncCommitteeSignature randomSyncCommitteeSignature(final UInt64 slot) {
+    return getAltairSchemaDefinitions(UInt64.ZERO)
+        .getSyncCommitteeSignatureSchema()
+        .create(slot, randomBytes32(), randomUInt64(), randomSignature());
   }
 
   public AttestationData randomAttestationData() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignaturePool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignaturePool.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.synccommittee;
+
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
+import tech.pegasys.teku.statetransition.OperationPool.OperationAddedSubscriber;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+
+public class SyncCommitteeSignaturePool {
+
+  private final Subscribers<OperationAddedSubscriber<ValidateableSyncCommitteeSignature>>
+      subscribers = Subscribers.create(true);
+
+  private final SyncCommitteeSignatureValidator validator;
+
+  public SyncCommitteeSignaturePool(final SyncCommitteeSignatureValidator validator) {
+    this.validator = validator;
+  }
+
+  public void subscribeOperationAdded(
+      OperationAddedSubscriber<ValidateableSyncCommitteeSignature> subscriber) {
+    subscribers.subscribe(subscriber);
+  }
+
+  public SafeFuture<InternalValidationResult> add(
+      final ValidateableSyncCommitteeSignature signature) {
+    return validator
+        .validate(signature)
+        .thenPeek(
+            result -> {
+              if (result.isAccept()) {
+                subscribers.forEach(subscriber -> subscriber.onOperationAdded(signature, result));
+              }
+            });
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignaturePoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignaturePoolTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.synccommittee;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
+import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.IGNORE;
+import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.REJECT;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.OperationPool.OperationAddedSubscriber;
+
+class SyncCommitteeSignaturePoolTest {
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createMinimalAltair());
+  private final SyncCommitteeSignatureValidator validator =
+      mock(SyncCommitteeSignatureValidator.class);
+
+  private final ValidateableSyncCommitteeSignature signature =
+      ValidateableSyncCommitteeSignature.fromValidator(
+          dataStructureUtil.randomSyncCommitteeSignature());
+
+  @SuppressWarnings("unchecked")
+  private final OperationAddedSubscriber<ValidateableSyncCommitteeSignature> subscriber =
+      mock(OperationAddedSubscriber.class);
+
+  private final SyncCommitteeSignaturePool pool = new SyncCommitteeSignaturePool(validator);
+
+  @Test
+  void shouldNotifySubscriberWhenValidSignatureAdded() {
+    final ValidateableSyncCommitteeSignature signature = this.signature;
+    pool.subscribeOperationAdded(subscriber);
+    when(validator.validate(signature)).thenReturn(SafeFuture.completedFuture(ACCEPT));
+
+    assertThat(pool.add(signature)).isCompletedWithValue(ACCEPT);
+    verify(subscriber).onOperationAdded(signature, ACCEPT);
+  }
+
+  @Test
+  void shouldNotNotifySubscriberWhenInvalidSignatureAdded() {
+    final ValidateableSyncCommitteeSignature signature = this.signature;
+    pool.subscribeOperationAdded(subscriber);
+    when(validator.validate(signature)).thenReturn(SafeFuture.completedFuture(REJECT));
+
+    assertThat(pool.add(signature)).isCompletedWithValue(REJECT);
+    verifyNoInteractions(subscriber);
+  }
+
+  @Test
+  void shouldNotNotifySubscriberWhenIgnoredSignatureAdded() {
+    final ValidateableSyncCommitteeSignature signature = this.signature;
+    pool.subscribeOperationAdded(subscriber);
+    when(validator.validate(signature)).thenReturn(SafeFuture.completedFuture(IGNORE));
+
+    assertThat(pool.add(signature)).isCompletedWithValue(IGNORE);
+    verifyNoInteractions(subscriber);
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -60,6 +60,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.util.ForkAndSpecMilestone;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
@@ -100,6 +101,9 @@ public class Eth2P2PNetworkBuilder {
   private OperationProcessor<SignedContributionAndProof>
       gossipedSignedContributionAndProofProcessor;
   private GossipPublisher<SignedContributionAndProof> signedContributionAndProofGossipPublisher;
+  private OperationProcessor<ValidateableSyncCommitteeSignature>
+      gossipedSyncCommitteeSignatureProcessor;
+  private GossipPublisher<ValidateableSyncCommitteeSignature> syncCommitteeSignatureGossipPublisher;
 
   private Eth2P2PNetworkBuilder() {}
 
@@ -207,7 +211,9 @@ public class Eth2P2PNetworkBuilder {
             gossipedVoluntaryExitConsumer,
             voluntaryExitGossipPublisher,
             gossipedSignedContributionAndProofProcessor,
-            signedContributionAndProofGossipPublisher);
+            signedContributionAndProofGossipPublisher,
+            gossipedSyncCommitteeSignatureProcessor,
+            syncCommitteeSignatureGossipPublisher);
       default:
         throw new UnsupportedOperationException(
             "Gossip not supported for fork " + forkAndSpecMilestone.getSpecMilestone());
@@ -277,6 +283,9 @@ public class Eth2P2PNetworkBuilder {
         "signedContributionAndProofGossipPublisher", signedContributionAndProofGossipPublisher);
     assertNotNull(
         "gossipedSignedContributionAndProofProcessor", gossipedSignedContributionAndProofProcessor);
+    assertNotNull(
+        "gossipedSyncCommitteeSignatureProcessor", gossipedSyncCommitteeSignatureProcessor);
+    assertNotNull("syncCommitteeSignatureGossipPublisher", syncCommitteeSignatureGossipPublisher);
   }
 
   private void assertNotNull(String fieldName, Object fieldValue) {
@@ -395,6 +404,22 @@ public class Eth2P2PNetworkBuilder {
       final GossipPublisher<SignedContributionAndProof> signedContributionAndProofGossipPublisher) {
     checkNotNull(signedContributionAndProofGossipPublisher);
     this.signedContributionAndProofGossipPublisher = signedContributionAndProofGossipPublisher;
+    return this;
+  }
+
+  public Eth2P2PNetworkBuilder gossipedSyncCommitteeSignatureProcessor(
+      final OperationProcessor<ValidateableSyncCommitteeSignature>
+          gossipedSyncCommitteeSignatureProcessor) {
+    checkNotNull(gossipedSyncCommitteeSignatureProcessor);
+    this.gossipedSyncCommitteeSignatureProcessor = gossipedSyncCommitteeSignatureProcessor;
+    return this;
+  }
+
+  public Eth2P2PNetworkBuilder syncCommitteeSignatureGossipPublisher(
+      final GossipPublisher<ValidateableSyncCommitteeSignature>
+          syncCommitteeSignatureGossipPublisher) {
+    checkNotNull(syncCommitteeSignatureGossipPublisher);
+    this.syncCommitteeSignatureGossipPublisher = syncCommitteeSignatureGossipPublisher;
     return this;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeSignatureGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeSignatureGossipManager.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.gossip;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.networking.eth2.gossip.subnets.SyncCommitteeSubnetSubscriptions;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeStateUtils;
+
+public class SyncCommitteeSignatureGossipManager implements GossipManager {
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Spec spec;
+  private final SyncCommitteeStateUtils syncCommitteeStateUtils;
+  private final SyncCommitteeSubnetSubscriptions subnetSubscriptions;
+  private final GossipPublisher<ValidateableSyncCommitteeSignature> gossipPublisher;
+
+  private final AtomicBoolean shutdown = new AtomicBoolean(false);
+  private final Counter publishSuccessCounter;
+  private final Counter publishFailureCounter;
+  private final long subscriberId;
+
+  public SyncCommitteeSignatureGossipManager(
+      final MetricsSystem metricsSystem,
+      final Spec spec,
+      final SyncCommitteeStateUtils syncCommitteeStateUtils,
+      final SyncCommitteeSubnetSubscriptions subnetSubscriptions,
+      final GossipPublisher<ValidateableSyncCommitteeSignature> gossipPublisher) {
+    this.spec = spec;
+    this.syncCommitteeStateUtils = syncCommitteeStateUtils;
+    this.subnetSubscriptions = subnetSubscriptions;
+    this.gossipPublisher = gossipPublisher;
+    final LabelledMetric<Counter> publishedSyncCommitteeCounter =
+        metricsSystem.createLabelledCounter(
+            TekuMetricCategory.BEACON,
+            "published_sync_committee_signature_total",
+            "Total number of sync committee signatures sent to the gossip network",
+            "result");
+    publishSuccessCounter = publishedSyncCommitteeCounter.labels("success");
+    publishFailureCounter = publishedSyncCommitteeCounter.labels("failure");
+    this.subscriberId = gossipPublisher.subscribe(this::publish);
+  }
+
+  public void publish(final ValidateableSyncCommitteeSignature signature) {
+    if (signature.getReceivedSubnetId().isPresent()) {
+      // Republish only on the subnet we received it on
+      publish(signature.getSignature(), signature.getReceivedSubnetId().getAsInt());
+    } else {
+      // Publish locally produced signatures to all applicable subnets
+      final Optional<Set<Integer>> applicableSubcommittees = signature.getApplicableSubcommittees();
+      if (applicableSubcommittees.isPresent()) {
+        publish(signature, applicableSubcommittees.get());
+      } else {
+        syncCommitteeStateUtils
+            .getStateForSyncCommittee(signature.getSlot(), signature.getBeaconBlockRoot())
+            .finish(
+                maybeState ->
+                    maybeState.ifPresentOrElse(
+                        state ->
+                            publish(
+                                signature, signature.calculateApplicableSubcommittees(spec, state)),
+                        () ->
+                            LOG.error(
+                                "Failed to publish sync committee signature for slot {} because the applicable subnets could not be calculated",
+                                signature.getSlot())),
+                error ->
+                    LOG.error(
+                        "Failed to retrieve state for sync committee signature at slot {}",
+                        signature.getSlot(),
+                        error));
+      }
+    }
+  }
+
+  private void publish(
+      final ValidateableSyncCommitteeSignature signature, final Set<Integer> subnetIds) {
+    subnetIds.forEach(subnetId -> publish(signature.getSignature(), subnetId));
+  }
+
+  private void publish(final SyncCommitteeSignature signature, final int subnetId) {
+    subnetSubscriptions
+        .gossip(signature, subnetId)
+        .finish(
+            __ -> {
+              LOG.trace(
+                  "Successfully published sync committee signature for slot {}",
+                  signature.getSlot());
+              publishSuccessCounter.inc();
+            },
+            error -> {
+              LOG.trace(
+                  "Failed to publish sync committee signature for slot {}",
+                  signature.getSlot(),
+                  error);
+              publishFailureCounter.inc();
+            });
+  }
+
+  public void subscribeToSubnetId(final int subnetId) {
+    LOG.trace("Subscribing to subnet ID {}", subnetId);
+    subnetSubscriptions.subscribeToSubnetId(subnetId);
+  }
+
+  public void unsubscribeFromSubnetId(final int subnetId) {
+    LOG.trace("Unsubscribing to subnet ID {}", subnetId);
+    subnetSubscriptions.unsubscribeFromSubnetId(subnetId);
+  }
+
+  @Override
+  public void shutdown() {
+    if (shutdown.compareAndSet(false, true)) {
+      subnetSubscriptions.close();
+      gossipPublisher.unsubscribe(subscriberId);
+    }
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkSubscriptions.java
@@ -17,6 +17,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
 
 public interface GossipForkSubscriptions {
 
@@ -33,4 +34,10 @@ public interface GossipForkSubscriptions {
   void subscribeToAttestationSubnetId(int subnetId);
 
   void unsubscribeFromAttestationSubnetId(int subnetId);
+
+  void publishSyncCommitteeSignature(ValidateableSyncCommitteeSignature signature);
+
+  void subscribeToSyncCommitteeSignatureSubnet(int subnetId);
+
+  void unsubscribeFromSyncCommitteeSignatureSubnet(int subnetId);
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsAltair.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsAltair.java
@@ -17,7 +17,9 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.GossipPublisher;
 import tech.pegasys.teku.networking.eth2.gossip.SignedContributionAndProofGossipManager;
+import tech.pegasys.teku.networking.eth2.gossip.SyncCommitteeSignatureGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
+import tech.pegasys.teku.networking.eth2.gossip.subnets.SyncCommitteeSubnetSubscriptions;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetwork;
 import tech.pegasys.teku.spec.Spec;
@@ -27,9 +29,11 @@ import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeStateUtils;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0 {
@@ -38,6 +42,11 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
       signedContributionAndProofOperationProcessor;
   private final GossipPublisher<SignedContributionAndProof>
       signedContributionAndProofGossipPublisher;
+  private final OperationProcessor<ValidateableSyncCommitteeSignature>
+      syncCommitteeSignatureOperationProcessor;
+  private final GossipPublisher<ValidateableSyncCommitteeSignature>
+      syncCommitteeSignatureGossipPublisher;
+  private SyncCommitteeSignatureGossipManager syncCommitteeSignatureGossipManager;
 
   public GossipForkSubscriptionsAltair(
       final Fork fork,
@@ -58,7 +67,11 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
       final GossipPublisher<SignedVoluntaryExit> voluntaryExitGossipPublisher,
       final OperationProcessor<SignedContributionAndProof>
           signedContributionAndProofOperationProcessor,
-      final GossipPublisher<SignedContributionAndProof> signedContributionAndProofGossipPublisher) {
+      final GossipPublisher<SignedContributionAndProof> signedContributionAndProofGossipPublisher,
+      final OperationProcessor<ValidateableSyncCommitteeSignature>
+          syncCommitteeSignatureOperationProcessor,
+      final GossipPublisher<ValidateableSyncCommitteeSignature>
+          syncCommitteeSignatureGossipPublisher) {
     super(
         fork,
         spec,
@@ -79,6 +92,8 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
     this.signedContributionAndProofOperationProcessor =
         signedContributionAndProofOperationProcessor;
     this.signedContributionAndProofGossipPublisher = signedContributionAndProofGossipPublisher;
+    this.syncCommitteeSignatureOperationProcessor = syncCommitteeSignatureOperationProcessor;
+    this.syncCommitteeSignatureGossipPublisher = syncCommitteeSignatureGossipPublisher;
   }
 
   @Override
@@ -95,5 +110,37 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
             forkInfo,
             signedContributionAndProofOperationProcessor,
             signedContributionAndProofGossipPublisher));
+
+    final SyncCommitteeSubnetSubscriptions syncCommitteeSubnetSubscriptions =
+        new SyncCommitteeSubnetSubscriptions(
+            discoveryNetwork,
+            gossipEncoding,
+            schemaDefinitions,
+            asyncRunner,
+            syncCommitteeSignatureOperationProcessor,
+            forkInfo);
+    syncCommitteeSignatureGossipManager =
+        new SyncCommitteeSignatureGossipManager(
+            metricsSystem,
+            spec,
+            new SyncCommitteeStateUtils(spec, recentChainData),
+            syncCommitteeSubnetSubscriptions,
+            syncCommitteeSignatureGossipPublisher);
+    addGossipManager(syncCommitteeSignatureGossipManager);
+  }
+
+  @Override
+  public void publishSyncCommitteeSignature(final ValidateableSyncCommitteeSignature signature) {
+    syncCommitteeSignatureGossipManager.publish(signature);
+  }
+
+  @Override
+  public void subscribeToSyncCommitteeSignatureSubnet(final int subnetId) {
+    syncCommitteeSignatureGossipManager.subscribeToSubnetId(subnetId);
+  }
+
+  @Override
+  public void unsubscribeFromSyncCommitteeSignatureSubnet(final int subnetId) {
+    syncCommitteeSignatureGossipManager.unsubscribeFromSubnetId(subnetId);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -194,5 +195,20 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
   @Override
   public void unsubscribeFromAttestationSubnetId(final int subnetId) {
     attestationGossipManager.unsubscribeFromSubnetId(subnetId);
+  }
+
+  @Override
+  public void publishSyncCommitteeSignature(final ValidateableSyncCommitteeSignature signature) {
+    // Does not apply to this fork.
+  }
+
+  @Override
+  public void subscribeToSyncCommitteeSignatureSubnet(final int subnetId) {
+    // Does not apply to this fork.
+  }
+
+  @Override
+  public void unsubscribeFromSyncCommitteeSignatureSubnet(final int subnetId) {
+    // Does not apply to this fork.
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/SyncCommitteeSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/SyncCommitteeSubnetSubscriptions.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.gossip.subnets;
+
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
+import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
+import tech.pegasys.teku.networking.eth2.gossip.topics.TopicNames;
+import tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers.Eth2TopicHandler;
+import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
+
+public class SyncCommitteeSubnetSubscriptions extends CommitteeSubnetSubscriptions {
+
+  private final SchemaDefinitionsAltair schemaDefinitions;
+  private final AsyncRunner asyncRunner;
+  private final OperationProcessor<ValidateableSyncCommitteeSignature> processor;
+  private final ForkInfo forkInfo;
+
+  public SyncCommitteeSubnetSubscriptions(
+      final GossipNetwork gossipNetwork,
+      final GossipEncoding gossipEncoding,
+      final SchemaDefinitionsAltair schemaDefinitions,
+      final AsyncRunner asyncRunner,
+      final OperationProcessor<ValidateableSyncCommitteeSignature> processor,
+      final ForkInfo forkInfo) {
+    super(gossipNetwork, gossipEncoding);
+    this.schemaDefinitions = schemaDefinitions;
+    this.asyncRunner = asyncRunner;
+    this.processor = processor;
+    this.forkInfo = forkInfo;
+  }
+
+  public SafeFuture<?> gossip(final SyncCommitteeSignature signature, final int subnetId) {
+    return gossipNetwork.gossip(
+        TopicNames.getSyncCommitteeSubnetTopic(forkInfo.getForkDigest(), subnetId, gossipEncoding),
+        gossipEncoding.encode(signature));
+  }
+
+  @Override
+  protected Eth2TopicHandler<?> createTopicHandler(final int subnetId) {
+    final OperationProcessor<SyncCommitteeSignature> convertingProcessor =
+        message ->
+            processor.process(ValidateableSyncCommitteeSignature.fromNetwork(message, subnetId));
+    return new Eth2TopicHandler<>(
+        asyncRunner,
+        convertingProcessor,
+        gossipEncoding,
+        forkInfo.getForkDigest(),
+        TopicNames.getSyncCommitteeSubnetTopicName(subnetId),
+        schemaDefinitions.getSyncCommitteeSignatureSchema());
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/TopicNames.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/TopicNames.java
@@ -36,4 +36,13 @@ public class TopicNames {
   public static String getAttestationSubnetTopicName(final int subnetId) {
     return "beacon_attestation_" + subnetId;
   }
+
+  public static String getSyncCommitteeSubnetTopic(
+      final Bytes4 forkDigest, final int subnetId, final GossipEncoding gossipEncoding) {
+    return getTopic(forkDigest, getSyncCommitteeSubnetTopicName(subnetId), gossipEncoding);
+  }
+
+  public static String getSyncCommitteeSubnetTopicName(final int subnetId) {
+    return "sync_committee_" + subnetId;
+  }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeSignatureGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeSignatureGossipManagerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.gossip;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Set;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networking.eth2.gossip.subnets.SyncCommitteeSubnetSubscriptions;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
+import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeStateUtils;
+
+class SyncCommitteeSignatureGossipManagerTest {
+  private final MetricsSystem metricsSystem = new NoOpMetricsSystem();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createMinimalAltair());
+
+  final Spec spec = mock(Spec.class);
+  final SyncCommitteeUtil syncCommitteeUtil = mock(SyncCommitteeUtil.class);
+
+  private final SyncCommitteeStateUtils syncCommitteeStateUtils =
+      mock(SyncCommitteeStateUtils.class);
+  private final SyncCommitteeSubnetSubscriptions subnetSubscriptions =
+      mock(SyncCommitteeSubnetSubscriptions.class);
+
+  @SuppressWarnings("unchecked")
+  private final GossipPublisher<ValidateableSyncCommitteeSignature> publisher =
+      mock(GossipPublisher.class);
+
+  private final SyncCommitteeSignatureGossipManager gossipManager =
+      new SyncCommitteeSignatureGossipManager(
+          metricsSystem, spec, syncCommitteeStateUtils, subnetSubscriptions, publisher);
+
+  @BeforeEach
+  void setUp() {
+    when(subnetSubscriptions.gossip(any(), anyInt())).thenReturn(SafeFuture.completedFuture(null));
+    when(spec.computeEpochAtSlot(any())).thenReturn(UInt64.ZERO);
+    when(spec.getSyncCommitteeUtilRequired(any())).thenReturn(syncCommitteeUtil);
+  }
+
+  @Test
+  void shouldPublishToReceivedSubnetWhenPresent() {
+    final int subnetId = 3;
+    final ValidateableSyncCommitteeSignature signature =
+        ValidateableSyncCommitteeSignature.fromNetwork(
+            dataStructureUtil.randomSyncCommitteeSignature(), subnetId);
+
+    gossipManager.publish(signature);
+
+    verify(subnetSubscriptions).gossip(signature.getSignature(), subnetId);
+  }
+
+  @Test
+  void shouldPublishToAllApplicableSubnetsWhenNoReceivedSubnetsPresent() {
+    final ValidateableSyncCommitteeSignature signature =
+        ValidateableSyncCommitteeSignature.fromValidator(
+            dataStructureUtil.randomSyncCommitteeSignature());
+
+    withApplicableSubnets(signature, 1, 3, 5);
+    gossipManager.publish(signature);
+
+    verify(subnetSubscriptions).gossip(signature.getSignature(), 1);
+    verify(subnetSubscriptions).gossip(signature.getSignature(), 3);
+    verify(subnetSubscriptions).gossip(signature.getSignature(), 5);
+  }
+
+  @Test
+  void shouldCalculateAndPublishToAllApplicableSubnetsWhenAlreadyNotCached() {
+    final ValidateableSyncCommitteeSignature signature =
+        ValidateableSyncCommitteeSignature.fromValidator(
+            dataStructureUtil.randomSyncCommitteeSignature());
+
+    final BeaconStateAltair state = dataStructureUtil.stateBuilderAltair().build();
+    when(syncCommitteeStateUtils.getStateForSyncCommittee(
+            signature.getSlot(), signature.getBeaconBlockRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
+    when(syncCommitteeUtil.getSyncSubcommittees(any(), any(), any())).thenReturn(Set.of(1, 3, 5));
+
+    gossipManager.publish(signature);
+
+    verify(syncCommitteeUtil)
+        .getSyncSubcommittees(state, UInt64.ZERO, signature.getSignature().getValidatorIndex());
+    verify(subnetSubscriptions).gossip(signature.getSignature(), 1);
+    verify(subnetSubscriptions).gossip(signature.getSignature(), 3);
+    verify(subnetSubscriptions).gossip(signature.getSignature(), 5);
+  }
+
+  private void withApplicableSubnets(
+      final ValidateableSyncCommitteeSignature signature, final Integer... subnetIds) {
+
+    when(syncCommitteeUtil.getSyncSubcommittees(any(), any(), any())).thenReturn(Set.of(subnetIds));
+    signature.calculateApplicableSubcommittees(
+        spec, dataStructureUtil.stateBuilderAltair().build());
+  }
+}


### PR DESCRIPTION
## PR Description
Support subscribing to and gossiping sync committee signature messages on subnets.

Note that messages aren't currently stored but are validated correctly.

## Fixed Issue(s)
#3803 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
