### PR TITLE
Calculate epoch based on spec from http endpoint for exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
 - Fixed issue where attestation subnets were not unsubscribed from leading to unnecessary CPU load when running small numbers of validators.
 - Fixed issue where validator duties were not invalidated in response to new blocks correctly when using dependent roots.
+- Fixed issue where exit epoch for voluntary exits would be incorrectly calculated.

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecFactory.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecFactory.java
@@ -23,13 +23,16 @@ public interface SpecFactory {
     return PHASE0;
   }
 
-  Spec create(String configName);
+  default Spec create(String configName) {
+    return create(SpecConfigLoader.loadConfig(configName));
+  }
+
+  Spec create(SpecConfig config);
 
   class Phase0SpecFactory implements SpecFactory {
 
     @Override
-    public Spec create(String configName) {
-      final SpecConfig config = SpecConfigLoader.loadConfig(configName);
+    public Spec create(SpecConfig config) {
       return Spec.create(config, SpecMilestone.PHASE0);
     }
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
@@ -266,7 +266,7 @@ public class SpecConfigBuilder {
     checkArgument(value != null, "Missing value for spec constant '%s'", camelToSnakeCase(name));
   }
 
-  public SpecConfigBuilder rawConfig(final Map<String, Object> rawConfig) {
+  public SpecConfigBuilder rawConfig(final Map<String, ?> rawConfig) {
     checkNotNull(rawConfig);
     this.rawConfig.putAll(rawConfig);
     return this;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigLoader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigLoader.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.infrastructure.io.resource.ResourceLoader;
@@ -29,6 +30,12 @@ public class SpecConfigLoader {
   public static SpecConfig loadConfig(final String configName) {
     final SpecConfigReader reader = new SpecConfigReader();
     processConfig(configName, reader::read);
+    return reader.build();
+  }
+
+  public static SpecConfig loadConfig(final Map<String, ?> config) {
+    final SpecConfigReader reader = new SpecConfigReader();
+    reader.loadFromMap(config);
     return reader.build();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
@@ -65,6 +65,10 @@ public class SpecConfigReader {
 
   public void read(final InputStream source) throws IOException {
     final Map<String, Object> rawValues = readValues(source);
+    loadFromMap(rawValues);
+  }
+
+  public void loadFromMap(final Map<String, ?> rawValues) {
     processSeenValues(rawValues);
     final Map<String, Object> unprocessConfig = new HashMap<>(rawValues);
 
@@ -96,7 +100,7 @@ public class SpecConfigReader {
     }
   }
 
-  private void processSeenValues(final Map<String, Object> rawValues) {
+  private void processSeenValues(final Map<String, ? extends Object> rawValues) {
     if (seenValues.isEmpty()) {
       seenValues.putAll(rawValues);
       return;

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.cli.subcommand;
 
-import static tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
-
 import com.google.common.base.Throwables;
 import java.io.UncheckedIOException;
 import java.net.ConnectException;
@@ -47,9 +45,10 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
 import tech.pegasys.teku.infrastructure.async.MetricTrackingExecutorFactory;
 import tech.pegasys.teku.infrastructure.logging.SubCommandLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.util.config.InvalidConfigurationException;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 import tech.pegasys.teku.validator.client.loader.PublicKeyLoader;
@@ -76,6 +75,7 @@ public class VoluntaryExitCommand implements Runnable {
   private OwnedValidators validators;
   private TekuConfiguration config;
   private final MetricsSystem metricsSystem = new NoOpMetricsSystem();
+  private Spec spec;
 
   @CommandLine.Mixin(name = "Validator Keys")
   private ValidatorKeysOptions validatorKeysOptions;
@@ -118,6 +118,7 @@ public class VoluntaryExitCommand implements Runnable {
   private void confirmExits() {
     SUB_COMMAND_LOG.display("Exits are going to be generated for validators: ");
     SUB_COMMAND_LOG.display(getValidatorAbbreviatedKeys());
+    SUB_COMMAND_LOG.display("Epoch: " + epoch.toString());
     SUB_COMMAND_LOG.display("");
     SUB_COMMAND_LOG.display(
         "These validators won't be able to be re-activated, and withdrawals aren't likely to be possible until Phase 2 of eth2 Mainnet.");
@@ -175,10 +176,24 @@ public class VoluntaryExitCommand implements Runnable {
     }
   }
 
+  private Spec getSpec() {
+    try {
+      return apiClient
+          .getConfigSpec()
+          .map(response -> SpecFactory.getDefault().create(response.data.get("CONFIG_NAME")))
+          .orElseThrow();
+    } catch (Exception ex) {
+      SUB_COMMAND_LOG.error(
+          "Failed to retrieve network config. Check beacon node is accepting REST requests.");
+      System.exit(1);
+    }
+    return null;
+  }
+
   private Optional<UInt64> getEpoch() {
     return apiClient
         .getBlockHeader("head")
-        .map(response -> compute_epoch_at_slot(response.data.header.message.slot));
+        .map(response -> spec.computeEpochAtSlot(response.data.header.message.slot));
   }
 
   private Optional<Bytes32> getGenesisRoot() {
@@ -203,6 +218,8 @@ public class VoluntaryExitCommand implements Runnable {
             .map(this::buildHttpEndpoint)
             .orElseThrow();
 
+    spec = getSpec();
+
     final Optional<tech.pegasys.teku.spec.datastructures.state.Fork> maybeFork = getFork();
     if (maybeFork.isEmpty()) {
       SUB_COMMAND_LOG.error("Unable to fetch fork, cannot generate an exit.");
@@ -221,7 +238,7 @@ public class VoluntaryExitCommand implements Runnable {
 
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
-            config.validatorClient().getSpec(),
+            spec,
             config.validatorClient().getValidatorConfig(),
             config.validatorClient().getInteropConfig(),
             new RejectingSlashingProtector(),
@@ -246,7 +263,7 @@ public class VoluntaryExitCommand implements Runnable {
     {
       HttpUrl apiEndpoint = HttpUrl.get(endpoint);
       final OkHttpClient.Builder httpClientBuilder =
-          new OkHttpClient.Builder().readTimeout(Constants.SECONDS_PER_SLOT * 2, TimeUnit.SECONDS);
+          new OkHttpClient.Builder().readTimeout(30, TimeUnit.SECONDS);
       OkHttpClientAuthLoggingIntercepter.addAuthenticator(apiEndpoint, httpClientBuilder);
       // Strip any authentication info from the URL to ensure it doesn't get logged.
       apiEndpoint = apiEndpoint.newBuilder().username("").password("").build();

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -47,6 +47,7 @@ import tech.pegasys.teku.infrastructure.logging.SubCommandLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigLoader;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.util.config.InvalidConfigurationException;
@@ -180,7 +181,8 @@ public class VoluntaryExitCommand implements Runnable {
     try {
       return apiClient
           .getConfigSpec()
-          .map(response -> SpecFactory.getDefault().create(response.data.get("CONFIG_NAME")))
+          .map(response -> SpecConfigLoader.loadConfig(response.data))
+          .map(specConfig -> SpecFactory.getDefault().create(specConfig))
           .orElseThrow();
     } catch (Exception ex) {
       SUB_COMMAND_LOG.error(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GE
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DATA;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_BLOCK_HEADER;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_CONFIG_SPEC;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_FORK;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_GENESIS;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_PROPOSER_DUTIES;
@@ -58,6 +59,7 @@ import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateValidatorsResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
+import tech.pegasys.teku.api.response.v1.config.GetSpecResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetNewBlockResponse;
@@ -102,6 +104,14 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
             EMPTY_QUERY_PARAMS,
             createHandler(GetStateForkResponse.class))
         .map(GetStateForkResponse::getData);
+  }
+
+  public Optional<GetSpecResponse> getConfigSpec() {
+    return get(
+        GET_CONFIG_SPEC,
+        EMPTY_QUERY_PARAMS,
+        EMPTY_QUERY_PARAMS,
+        createHandler(GetSpecResponse.class));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -36,6 +36,7 @@ public enum ValidatorApiMethod {
   GET_ATTESTATION_DUTIES("eth/v1/validator/duties/attester/:epoch"),
   GET_PROPOSER_DUTIES("eth/v1/validator/duties/proposer/:epoch"),
   GET_BLOCK_HEADER("eth/v1/beacon/headers/:block_id"),
+  GET_CONFIG_SPEC("/eth/v1/config/spec"),
   EVENTS("eth/v1/events");
 
   private final String path;


### PR DESCRIPTION
The endpoint provides the full spec, but the spec builder takes a map of string to object so the output of the api wasn't fully compatible. Ideally I could just load from the http response rather than using stored configuration, but at least the name will provide the spec to load.

fixes #3862

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
