### PR TITLE
Store assignments in ValidateableSyncCommitteeSignature

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ValidateableSyncCommitteeSignature.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ValidateableSyncCommitteeSignature.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.spec.datastructures.operations.versions.altair;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import java.util.OptionalInt;
 import org.apache.tuweni.bytes.Bytes32;
@@ -68,11 +67,6 @@ public class ValidateableSyncCommitteeSignature {
 
     this.subcommitteeAssignments = Optional.of(assignments);
     return assignments;
-  }
-
-  @VisibleForTesting
-  public void setSubcommitteeAssignments(final SyncSubcommitteeAssignments assignments) {
-    this.subcommitteeAssignments = Optional.of(assignments);
   }
 
   public UInt64 getSlot() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ValidateableSyncCommitteeSignature.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ValidateableSyncCommitteeSignature.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations.versions.altair;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import java.util.OptionalInt;
 import org.apache.tuweni.bytes.Bytes32;
@@ -67,6 +68,11 @@ public class ValidateableSyncCommitteeSignature {
 
     this.subcommitteeAssignments = Optional.of(assignments);
     return assignments;
+  }
+
+  @VisibleForTesting
+  public void setSubcommitteeAssignments(final SyncSubcommitteeAssignments assignments) {
+    this.subcommitteeAssignments = Optional.of(assignments);
   }
 
   public UInt64 getSlot() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SyncSubcommitteeAssignments.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SyncSubcommitteeAssignments.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.datastructures.util;
 
+import static java.util.Collections.emptyMap;
+
 import com.google.common.base.MoreObjects;
 import java.util.Collections;
 import java.util.Map;
@@ -23,6 +25,9 @@ import java.util.Set;
  * form.
  */
 public class SyncSubcommitteeAssignments {
+
+  public static final SyncSubcommitteeAssignments NONE =
+      new SyncSubcommitteeAssignments(emptyMap());
 
   private final Map<Integer, Set<Integer>> subcommitteeToParticipationIndices;
 
@@ -38,6 +43,10 @@ public class SyncSubcommitteeAssignments {
   public Set<Integer> getParticipationBitIndices(final int subcommitteeIndex) {
     return Collections.unmodifiableSet(
         subcommitteeToParticipationIndices.getOrDefault(subcommitteeIndex, Collections.emptySet()));
+  }
+
+  public boolean isEmpty() {
+    return subcommitteeToParticipationIndices.isEmpty();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SyncSubcommitteeAssignments.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SyncSubcommitteeAssignments.java
@@ -17,6 +17,8 @@ import static java.util.Collections.emptyMap;
 
 import com.google.common.base.MoreObjects;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,9 +33,13 @@ public class SyncSubcommitteeAssignments {
 
   private final Map<Integer, Set<Integer>> subcommitteeToParticipationIndices;
 
-  public SyncSubcommitteeAssignments(
+  private SyncSubcommitteeAssignments(
       final Map<Integer, Set<Integer>> subcommitteeToParticipationIndices) {
     this.subcommitteeToParticipationIndices = subcommitteeToParticipationIndices;
+  }
+
+  public static SyncSubcommitteeAssignments.Builder builder() {
+    return new SyncSubcommitteeAssignments.Builder();
   }
 
   public Set<Integer> getAssignedSubcommittees() {
@@ -54,5 +60,21 @@ public class SyncSubcommitteeAssignments {
     return MoreObjects.toStringHelper(this)
         .add("subcommitteeToParticipationIndices", subcommitteeToParticipationIndices)
         .toString();
+  }
+
+  public static class Builder {
+    private final Map<Integer, Set<Integer>> subcommitteeToParticipationIndices = new HashMap<>();
+
+    public Builder addAssignment(
+        final int subcommitteeIndex, final int subcommitteeParticipationIndex) {
+      subcommitteeToParticipationIndices
+          .computeIfAbsent(subcommitteeIndex, __ -> new HashSet<>())
+          .add(subcommitteeParticipationIndex);
+      return this;
+    }
+
+    public SyncSubcommitteeAssignments build() {
+      return new SyncSubcommitteeAssignments(subcommitteeToParticipationIndices);
+    }
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -21,7 +21,6 @@ import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.bytesToUIn
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -102,7 +101,7 @@ public class SyncCommitteeUtil {
               }
               final int subcommitteeSize = getSubcommitteeSize();
               final SszVector<SszPublicKey> pubkeys = syncCommittee.getPubkeys();
-              final Map<UInt64, Map<Integer, Set<Integer>>> subcommitteeAssignments =
+              final Map<UInt64, SyncSubcommitteeAssignments.Builder> subcommitteeAssignments =
                   new HashMap<>();
               for (int index = 0; index < pubkeys.size(); index++) {
                 final BLSPublicKey pubkey = pubkeys.get(index).getBLSPublicKey();
@@ -123,15 +122,11 @@ public class SyncCommitteeUtil {
                 // are created once here and then never modified so safe to access from multiple
                 // threads.
                 subcommitteeAssignments
-                    .computeIfAbsent(validatorIndex, __ -> new HashMap<>())
-                    .computeIfAbsent(subcommitteeIndex, __ -> new HashSet<>())
-                    .add(subcommitteeParticipationIndex);
+                    .computeIfAbsent(validatorIndex, __ -> SyncSubcommitteeAssignments.builder())
+                    .addAssignment(subcommitteeIndex, subcommitteeParticipationIndex);
               }
               return subcommitteeAssignments.entrySet().stream()
-                  .collect(
-                      toUnmodifiableMap(
-                          Map.Entry::getKey,
-                          entry -> new SyncSubcommitteeAssignments(entry.getValue())));
+                  .collect(toUnmodifiableMap(Map.Entry::getKey, entry -> entry.getValue().build()));
             });
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -135,6 +135,12 @@ public class SyncCommitteeUtil {
             });
   }
 
+  public SyncSubcommitteeAssignments getSubcommitteeAssignments(
+      final BeaconState state, final UInt64 epoch, final UInt64 validatorIndex) {
+    return getSyncSubcommittees(state, epoch)
+        .getOrDefault(validatorIndex, SyncSubcommitteeAssignments.NONE);
+  }
+
   public int getSubcommitteeSize() {
     return specConfig.getSyncCommitteeSize() / SYNC_COMMITTEE_SUBNET_COUNT;
   }
@@ -169,13 +175,6 @@ public class SyncCommitteeUtil {
     final SyncSubcommitteeAssignments assignments =
         getSyncSubcommittees(state, epoch).get(validatorIndex);
     return assignments != null ? assignments.getAssignedSubcommittees() : emptySet();
-  }
-
-  public Set<Integer> computeSubnetsForSyncCommittee(
-      final BeaconState state, final UInt64 epoch, final UInt64 validatorIndex) {
-    final SyncSubcommitteeAssignments assignments =
-        getSyncSubcommittees(state, epoch).get(validatorIndex);
-    return assignments == null ? emptySet() : assignments.getAssignedSubcommittees();
   }
 
   public Bytes32 getSyncCommitteeSignatureSigningRoot(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/SyncAggregateAssert.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/SyncAggregateAssert.java
@@ -31,7 +31,7 @@ public class SyncAggregateAssert extends AbstractAssert<SyncAggregateAssert, Syn
   }
 
   public SyncAggregateAssert isEmpty() {
-    return hasSyncCommitteeBits().hasInfinteSignature();
+    return hasSyncCommitteeBits().hasInfiniteSignature();
   }
 
   public SyncAggregateAssert hasSyncCommitteeBits(final Iterable<Integer> bits) {
@@ -49,7 +49,7 @@ public class SyncAggregateAssert extends AbstractAssert<SyncAggregateAssert, Syn
     return this;
   }
 
-  public SyncAggregateAssert hasInfinteSignature() {
+  public SyncAggregateAssert hasInfiniteSignature() {
     if (!actual.getSyncCommitteeSignature().getSignature().isInfinity()) {
       throwAssertionError(
           new BasicErrorMessageFactory(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
@@ -257,7 +257,8 @@ public class SignedContributionAndProofValidator {
       final UInt64 contributionEpoch,
       final UInt64 aggregatorIndex) {
     return syncCommitteeUtil
-        .computeSubnetsForSyncCommittee(state, contributionEpoch, aggregatorIndex)
+        .getSubcommitteeAssignments(state, contributionEpoch, aggregatorIndex)
+        .getAssignedSubcommittees()
         .contains(contribution.getSubcommitteeIndex().intValue());
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignatureValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignatureValidator.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
+import tech.pegasys.teku.spec.datastructures.util.SyncSubcommitteeAssignments;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -116,8 +117,8 @@ public class SyncCommitteeSignatureValidator {
 
     // Always calculate the applicable subcommittees to ensure they are cached and can be used to
     // send the gossip.
-    final Set<Integer> assignedSubcommittees =
-        validateableSignature.calculateApplicableSubcommittees(spec, state);
+    final SyncSubcommitteeAssignments assignedSubcommittees =
+        validateableSignature.calculateAssignments(spec, state);
 
     // [REJECT] The validator producing this sync_committee_signature is in the current sync
     // committee, i.e. state.validators[sync_committee_signature.validator_index].pubkey in
@@ -131,8 +132,9 @@ public class SyncCommitteeSignatureValidator {
     // [REJECT] The subnet_id is correct, i.e. subnet_id in
     // compute_subnets_for_sync_committee(state, sync_committee_signature.validator_index).
     if (validateableSignature.getReceivedSubnetId().isPresent()
-        && !assignedSubcommittees.contains(
-            validateableSignature.getReceivedSubnetId().getAsInt())) {
+        && !assignedSubcommittees
+            .getAssignedSubcommittees()
+            .contains(validateableSignature.getReceivedSubnetId().getAsInt())) {
       LOG.trace("Rejecting sync committee signature because subnet id is incorrect");
       return REJECT;
     }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeSignatureGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeSignatureGossipManagerTest.java
@@ -115,7 +115,6 @@ class SyncCommitteeSignatureGossipManagerTest {
       final ValidateableSyncCommitteeSignature signature, final Integer... subnetIds) {
 
     when(syncCommitteeUtil.getSyncSubcommittees(any(), any(), any())).thenReturn(Set.of(subnetIds));
-    signature.calculateApplicableSubcommittees(
-        spec, dataStructureUtil.stateBuilderAltair().build());
+    signature.calculateAssignments(spec, dataStructureUtil.stateBuilderAltair().build());
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeSignatureGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeSignatureGossipManagerTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
-import java.util.Set;
+import java.util.stream.IntStream;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +32,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
+import tech.pegasys.teku.spec.datastructures.util.SyncSubcommitteeAssignments;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeStateUtils;
@@ -100,21 +101,29 @@ class SyncCommitteeSignatureGossipManagerTest {
     when(syncCommitteeStateUtils.getStateForSyncCommittee(
             signature.getSlot(), signature.getBeaconBlockRoot()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
-    when(syncCommitteeUtil.getSyncSubcommittees(any(), any(), any())).thenReturn(Set.of(1, 3, 5));
+    when(syncCommitteeUtil.getSubcommitteeAssignments(any(), any(), any()))
+        .thenReturn(
+            SyncSubcommitteeAssignments.builder()
+                .addAssignment(1, 1)
+                .addAssignment(3, 1)
+                .addAssignment(5, 1)
+                .build());
 
     gossipManager.publish(signature);
 
     verify(syncCommitteeUtil)
-        .getSyncSubcommittees(state, UInt64.ZERO, signature.getSignature().getValidatorIndex());
+        .getSubcommitteeAssignments(
+            state, UInt64.ZERO, signature.getSignature().getValidatorIndex());
     verify(subnetSubscriptions).gossip(signature.getSignature(), 1);
     verify(subnetSubscriptions).gossip(signature.getSignature(), 3);
     verify(subnetSubscriptions).gossip(signature.getSignature(), 5);
   }
 
   private void withApplicableSubnets(
-      final ValidateableSyncCommitteeSignature signature, final Integer... subnetIds) {
-
-    when(syncCommitteeUtil.getSyncSubcommittees(any(), any(), any())).thenReturn(Set.of(subnetIds));
-    signature.calculateAssignments(spec, dataStructureUtil.stateBuilderAltair().build());
+      final ValidateableSyncCommitteeSignature signature, final int... subnetIds) {
+    final SyncSubcommitteeAssignments.Builder assignmentBuilder =
+        SyncSubcommitteeAssignments.builder();
+    IntStream.of(subnetIds).forEach(subnetId -> assignmentBuilder.addAssignment(subnetId, 1));
+    signature.setSubcommitteeAssignments(assignmentBuilder.build());
   }
 }


### PR DESCRIPTION
## PR Description
Previously `ValidateableSyncCommitteeSignature` cached the applicable subnets, but for aggregation we also need the participation indices for those subnets.  So change it to cache the entire `SyncCommitteeAssignments`.

## Fixed Issue(s)
#3803 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
