### PR TITLE
Add canonical blocks to `/teku/v1/beacon/blocks/:slot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Early access: Support for automatic fail-over of eth1-endpoints.  Multiple endpoints can be specified with the new `--eth1-endpoints` CLI option. Thanks to Enrico Del Fante.
 - Basic authentication is now supported for `--initial-state`. Infura can now be used as the source of initial states with `--initial-state https://{projectid}:{secret}@eth2-beacon-mainnet.infura.io/eth/v1/debug/beacon/states/finalized`
 - Implement standard rest api `/eth/v2/beacon/blocks/:block_id` which supports altair blocks. Documented under 'Experimental' endpoints until more widely implemented.
+- Implement teku rest api to retrieve all blocks at a slot `/teku/v1/beacon/blocks/:slot`, which will return both canonical and non-canonical blocks at a given slot.
 
 ### Bug Fixes
 - Fixed issue where attestation subnets were not unsubscribed from leading to unnecessary CPU load when running small numbers of validators.

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -38,7 +38,7 @@ import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.Liveness;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.PutLogLevel;
-import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetNonCanonicalBlocks;
+import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetAllBlocksAtSlot;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetSszState;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetStateByBlockRoot;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetAttestations;
@@ -274,7 +274,7 @@ public class BeaconRestApi {
     app.get(GetSszState.ROUTE, new GetSszState(provider, jsonProvider));
     app.get(GetStateByBlockRoot.ROUTE, new GetStateByBlockRoot(provider, jsonProvider));
     app.get(Liveness.ROUTE, new Liveness());
-    app.get(GetNonCanonicalBlocks.ROUTE, new GetNonCanonicalBlocks(provider, jsonProvider));
+    app.get(GetAllBlocksAtSlot.ROUTE, new GetAllBlocksAtSlot(provider, jsonProvider));
   }
 
   private void addNodeHandlers(final DataProvider provider) {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.Liveness;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.PutLogLevel;
+import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetAllBlocksAtSlot;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetSszState;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetStateByBlockRoot;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetAttestations;
@@ -158,6 +159,10 @@ public class BeaconRestApiV1Test {
         .add(Arguments.of(GetBlockHeader.ROUTE, GetBlockHeader.class))
         .add(Arguments.of(GetBlockHeaders.ROUTE, GetBlockHeaders.class))
         .add(Arguments.of(GetBlock.ROUTE, GetBlock.class))
+        .add(
+            Arguments.of(
+                tech.pegasys.teku.beaconrestapi.handlers.v2.beacon.GetBlock.ROUTE,
+                tech.pegasys.teku.beaconrestapi.handlers.v2.beacon.GetBlock.class))
         .add(Arguments.of(GetBlockRoot.ROUTE, GetBlockRoot.class))
         .add(Arguments.of(GetBlockAttestations.ROUTE, GetBlockAttestations.class))
         .add(Arguments.of(GetGenesis.ROUTE, GetGenesis.class))
@@ -205,6 +210,7 @@ public class BeaconRestApiV1Test {
     builder.add(Arguments.of(GetSszState.ROUTE, GetSszState.class));
     builder.add(Arguments.of(GetStateByBlockRoot.ROUTE, GetStateByBlockRoot.class));
     builder.add(Arguments.of(Liveness.ROUTE, Liveness.class));
+    builder.add(Arguments.of(GetAllBlocksAtSlot.ROUTE, GetAllBlocksAtSlot.class));
 
     return builder.build();
   }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -173,7 +173,7 @@ public class ChainDataProvider {
                             state.hashTreeRoot().toUnprefixedHexString())));
   }
 
-  public SafeFuture<Set<SignedBeaconBlock>> getNonCanonicalBlocks(final String slot) {
+  public SafeFuture<Set<SignedBeaconBlock>> getAllBlocksAtSlot(final String slot) {
     if (slot.startsWith("0x")) {
       throw new BadRequestException(
           String.format("block roots are not currently supported: %s", slot));

--- a/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactory.java
@@ -15,10 +15,10 @@ package tech.pegasys.teku.api.blockselector;
 
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -70,10 +70,7 @@ public class BlockSelectorFactory {
   }
 
   public BlockSelector nonCanonicalBlocksSelector(final UInt64 slot) {
-    return () ->
-        client
-            .getNonCanonicalBlocksAtSlot(slot)
-            .thenApply(result -> result.stream().collect(Collectors.toList()));
+    return () -> client.GetAllBlocksAtSlot(slot).thenApply(ArrayList::new);
   }
 
   public BlockSelector finalizedSelector() {

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetAllBlocksAtSlotResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetAllBlocksAtSlotResponse.java
@@ -17,13 +17,26 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Set;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
+import tech.pegasys.teku.spec.SpecMilestone;
 
-public class GetNonCanonicalBlocksResponse {
-  @JsonProperty("data")
-  public final Set<SignedBeaconBlock> data;
+public class GetAllBlocksAtSlotResponse {
+  private final SpecMilestone version;
+
+  private final Set<SignedBeaconBlock> data;
+
+  public Set<SignedBeaconBlock> getData() {
+    return data;
+  }
+
+  public SpecMilestone getVersion() {
+    return version;
+  }
 
   @JsonCreator
-  public GetNonCanonicalBlocksResponse(@JsonProperty("data") final Set<SignedBeaconBlock> data) {
+  public GetAllBlocksAtSlotResponse(
+      @JsonProperty("version") final SpecMilestone version,
+      @JsonProperty("data") final Set<SignedBeaconBlock> data) {
+    this.version = version;
     this.data = data;
   }
 }


### PR DESCRIPTION
- also change the structure of the response to include version

- currently still only returning finalized blocks

partially addresses #2853

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
