### PR TITLE
Separate attestation processing into a separate class

### DIFF
--- a/bls/src/main/java/tech/pegasys/teku/bls/BLSSignatureVerifier.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/BLSSignatureVerifier.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.bls;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes;
 
 /**
@@ -34,6 +33,8 @@ public interface BLSSignatureVerifier {
   /** Just delegates verify to {@link BLS#fastAggregateVerify(List, Bytes, BLSSignature)} */
   BLSSignatureVerifier SIMPLE = BLS::fastAggregateVerify;
 
+  BLSSignatureVerifier NOOP = (publicKeys, message, signature) -> true;
+
   /**
    * Verifies an aggregate BLS signature against a message using the list of public keys. In case of
    * non-aggregate signature [publicKeys] list should contain just a single entry
@@ -49,29 +50,5 @@ public interface BLSSignatureVerifier {
   /** Shortcut to {@link #verify(List, Bytes, BLSSignature)} for non-aggregate case */
   default boolean verify(BLSPublicKey publicKey, Bytes message, BLSSignature signature) {
     return verify(Collections.singletonList(publicKey), message, signature);
-  }
-
-  /**
-   * Convenient shortcut to throw exception when signature verification fails
-   *
-   * @throws InvalidSignatureException when signature is invalid
-   */
-  default void verifyAndThrow(
-      BLSPublicKey publicKey, Bytes message, BLSSignature signature, Supplier<String> errMessage)
-      throws InvalidSignatureException {
-    if (!verify(publicKey, message, signature)) {
-      throw new InvalidSignatureException(errMessage.get());
-    }
-  }
-
-  /**
-   * Convenient shortcut to throw exception when signature verification fails
-   *
-   * @throws InvalidSignatureException when signature is invalid
-   */
-  default void verifyAndThrow(
-      BLSPublicKey publicKey, Bytes message, BLSSignature signature, String errMessage)
-      throws InvalidSignatureException {
-    verifyAndThrow(publicKey, message, signature, () -> errMessage);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -35,7 +35,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
@@ -414,7 +413,7 @@ public class Spec {
 
   public Optional<OperationInvalidReason> validateAttestation(
       final BeaconState state, final AttestationData data) {
-    return atState(state).getBlockProcessor().validateAttestation(state, data);
+    return atState(state).getAttestationProcessor().validateAttestation(state, data);
   }
 
   public void processBlockHeader(MutableBeaconState state, BeaconBlockSummary blockHeader)
@@ -436,12 +435,9 @@ public class Spec {
 
   public void processAttestations(MutableBeaconState state, SszList<Attestation> attestations)
       throws BlockProcessingException {
-    atState(state).getBlockProcessor().processAttestations(state, attestations);
-  }
-
-  public void processSyncAggregate(MutableBeaconState state, SyncAggregate syncAggregate)
-      throws BlockProcessingException {
-    atState(state).getBlockProcessor().processSyncCommittee(state, syncAggregate);
+    atState(state)
+        .getAttestationProcessor()
+        .processAttestations(state, attestations, IndexedAttestationCache.NOOP);
   }
 
   public void processAttestations(
@@ -450,7 +446,7 @@ public class Spec {
       IndexedAttestationCache indexedAttestationCache)
       throws BlockProcessingException {
     atState(state)
-        .getBlockProcessor()
+        .getAttestationProcessor()
         .processAttestations(state, attestations, indexedAttestationCache);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.attestation.AttestationProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.StateTransition;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatusFactory;
@@ -65,6 +66,11 @@ public class DelegatingSpecLogic implements SpecLogic {
   @Override
   public BlockProcessor getBlockProcessor() {
     return specLogic.getBlockProcessor();
+  }
+
+  @Override
+  public AttestationProcessor getAttestationProcessor() {
+    return specLogic.getAttestationProcessor();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.attestation.AttestationProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.StateTransition;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatusFactory;
@@ -42,6 +43,8 @@ public interface SpecLogic {
   EpochProcessor getEpochProcessor();
 
   BlockProcessor getBlockProcessor();
+
+  AttestationProcessor getAttestationProcessor();
 
   StateTransition getStateTransition();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/AbstractSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/AbstractSpecLogic.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.attestation.AttestationProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.StateTransition;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatusFactory;
@@ -43,6 +44,7 @@ public abstract class AbstractSpecLogic implements SpecLogic {
   protected final ValidatorStatusFactory validatorStatusFactory;
   protected final EpochProcessor epochProcessor;
   protected final BlockProcessor blockProcessor;
+  protected final AttestationProcessor attestationProcessor;
   protected final StateTransition stateTransition;
   protected final ForkChoiceUtil forkChoiceUtil;
   protected final BlockProposalUtil blockProposalUtil;
@@ -59,6 +61,7 @@ public abstract class AbstractSpecLogic implements SpecLogic {
       final ValidatorStatusFactory validatorStatusFactory,
       final EpochProcessor epochProcessor,
       final BlockProcessor blockProcessor,
+      final AttestationProcessor attestationProcessor,
       final StateTransition stateTransition,
       final ForkChoiceUtil forkChoiceUtil,
       final BlockProposalUtil blockProposalUtil) {
@@ -73,6 +76,7 @@ public abstract class AbstractSpecLogic implements SpecLogic {
     this.validatorStatusFactory = validatorStatusFactory;
     this.epochProcessor = epochProcessor;
     this.blockProcessor = blockProcessor;
+    this.attestationProcessor = attestationProcessor;
     this.stateTransition = stateTransition;
     this.forkChoiceUtil = forkChoiceUtil;
     this.blockProposalUtil = blockProposalUtil;
@@ -106,6 +110,11 @@ public abstract class AbstractSpecLogic implements SpecLogic {
   @Override
   public BlockProcessor getBlockProcessor() {
     return blockProcessor;
+  }
+
+  @Override
+  public AttestationProcessor getAttestationProcessor() {
+    return attestationProcessor;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -173,6 +173,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
   }
 
   @Override
+  @CheckReturnValue
   public BlockValidationResult validatePostState(
       final BeaconState postState, final SignedBeaconBlock block) {
     if (!block.getMessage().getStateRoot().equals(postState.hashTreeRoot())) {
@@ -249,6 +250,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
         });
   }
 
+  @CheckReturnValue
   protected boolean verifyRandao(BeaconState state, BeaconBlock block, BLSSignatureVerifier bls) {
     UInt64 epoch = miscHelpers.computeEpochAtSlot(block.getSlot());
     // Verify RANDAO reveal

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
@@ -14,33 +14,25 @@
 package tech.pegasys.teku.spec.logic.common.block;
 
 import java.util.Map;
-import java.util.Optional;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
-import tech.pegasys.teku.bls.BLSSignatureVerifier.InvalidSignatureException;
 import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
-import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
-import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
 import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BlockValidationResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.ssz.SszList;
 
 public interface BlockProcessor {
-  Optional<OperationInvalidReason> validateAttestation(
-      final BeaconState state, final AttestationData data);
 
   BlockValidationResult verifySignatures(
       BeaconState preState,
@@ -55,9 +47,6 @@ public interface BlockProcessor {
 
   void processRandaoNoValidation(MutableBeaconState state, BeaconBlockBody body)
       throws BlockProcessingException;
-
-  void verifyRandao(BeaconState state, BeaconBlock block, BLSSignatureVerifier bls)
-      throws InvalidSignatureException;
 
   void processEth1Data(MutableBeaconState state, BeaconBlockBody body);
 
@@ -79,29 +68,8 @@ public interface BlockProcessor {
       MutableBeaconState state, SszList<ProposerSlashing> proposerSlashings)
       throws BlockProcessingException;
 
-  boolean verifyProposerSlashings(
-      BeaconState state,
-      SszList<ProposerSlashing> proposerSlashings,
-      BLSSignatureVerifier signatureVerifier);
-
   void processAttesterSlashings(
       MutableBeaconState state, SszList<AttesterSlashing> attesterSlashings)
-      throws BlockProcessingException;
-
-  void processAttestations(MutableBeaconState state, SszList<Attestation> attestations)
-      throws BlockProcessingException;
-
-  void processAttestations(
-      MutableBeaconState state,
-      SszList<Attestation> attestations,
-      IndexedAttestationCache indexedAttestationCache)
-      throws BlockProcessingException;
-
-  void verifyAttestationSignatures(
-      BeaconState state,
-      SszList<Attestation> attestations,
-      BLSSignatureVerifier signatureVerifier,
-      IndexedAttestationCache indexedAttestationCache)
       throws BlockProcessingException;
 
   void processDeposits(MutableBeaconState state, SszList<? extends Deposit> deposits)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/attestation/AttestationProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/attestation/AttestationProcessor.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.operations.attestation;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.List;
+import java.util.Optional;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
+import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataStateTransitionValidator;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
+import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
+import tech.pegasys.teku.ssz.SszList;
+
+public abstract class AttestationProcessor {
+
+  protected final BeaconStateUtil beaconStateUtil;
+  protected final AttestationUtil attestationUtil;
+  private final AttestationDataStateTransitionValidator attestationValidator;
+
+  protected AttestationProcessor(
+      final BeaconStateUtil beaconStateUtil,
+      final AttestationUtil attestationUtil,
+      final AttestationDataStateTransitionValidator attestationValidator) {
+    this.beaconStateUtil = beaconStateUtil;
+    this.attestationUtil = attestationUtil;
+    this.attestationValidator = attestationValidator;
+  }
+
+  public Optional<OperationInvalidReason> validateAttestation(
+      final BeaconState state, final AttestationData data) {
+    return attestationValidator.validate(state, data);
+  }
+
+  protected void assertAttestationValid(
+      final MutableBeaconState state, final Attestation attestation) {
+    final AttestationData data = attestation.getData();
+
+    final Optional<OperationInvalidReason> invalidReason = validateAttestation(state, data);
+    checkArgument(
+        invalidReason.isEmpty(),
+        "process_attestations: %s",
+        invalidReason.map(OperationInvalidReason::describe).orElse(""));
+
+    List<Integer> committee =
+        beaconStateUtil.getBeaconCommittee(state, data.getSlot(), data.getIndex());
+    checkArgument(
+        attestation.getAggregation_bits().size() == committee.size(),
+        "process_attestations: Attestation aggregation bits and committee don't have the same length");
+  }
+
+  public void processAttestations(
+      MutableBeaconState state,
+      SszList<Attestation> attestations,
+      IndexedAttestationCache indexedAttestationCache)
+      throws BlockProcessingException {
+    processAttestations(state, attestations, indexedAttestationCache, BLSSignatureVerifier.SIMPLE);
+  }
+
+  public void processAttestations(
+      MutableBeaconState state,
+      SszList<Attestation> attestations,
+      IndexedAttestationCache indexedAttestationCache,
+      BLSSignatureVerifier signatureVerifier)
+      throws BlockProcessingException {
+    final IndexedAttestationProvider indexedAttestationProvider =
+        createIndexedAttestationProvider(state, indexedAttestationCache);
+
+    for (Attestation attestation : attestations) {
+      // Validate
+      assertAttestationValid(state, attestation);
+      processAttestation(state, attestation, indexedAttestationProvider);
+      verifyAttestationSignature(state, indexedAttestationProvider, signatureVerifier, attestation);
+    }
+  }
+
+  public void verifyAttestationSignatures(
+      BeaconState state,
+      SszList<Attestation> attestations,
+      BLSSignatureVerifier signatureVerifier,
+      IndexedAttestationCache indexedAttestationCache)
+      throws BlockProcessingException {
+    verifyAttestationSignatures(
+        state,
+        attestations,
+        signatureVerifier,
+        createIndexedAttestationProvider(state, indexedAttestationCache));
+  }
+
+  protected void verifyAttestationSignatures(
+      BeaconState state,
+      SszList<Attestation> attestations,
+      BLSSignatureVerifier signatureVerifier,
+      IndexedAttestationProvider indexedAttestationProvider)
+      throws BlockProcessingException {
+
+    Optional<AttestationProcessingResult> processResult =
+        attestations.stream()
+            .map(indexedAttestationProvider::getIndexedAttestation)
+            .map(
+                attestation ->
+                    attestationUtil.isValidIndexedAttestation(
+                        state, attestation, signatureVerifier))
+            .filter(result -> !result.isSuccessful())
+            .findAny();
+    if (processResult.isPresent()) {
+      throw new BlockProcessingException(
+          "Invalid attestation: " + processResult.get().getInvalidReason());
+    }
+  }
+
+  public void verifyAttestationSignature(
+      final MutableBeaconState state,
+      final IndexedAttestationProvider indexedAttestationProvider,
+      final BLSSignatureVerifier signatureVerifier,
+      final Attestation attestation)
+      throws BlockProcessingException {
+    final IndexedAttestation indexedAttestation =
+        indexedAttestationProvider.getIndexedAttestation(attestation);
+    final AttestationProcessingResult validationResult =
+        attestationUtil.isValidIndexedAttestation(state, indexedAttestation, signatureVerifier);
+    if (!validationResult.isSuccessful()) {
+      throw new BlockProcessingException(
+          "Invalid attestation: " + validationResult.getInvalidReason());
+    }
+  }
+
+  private IndexedAttestationProvider createIndexedAttestationProvider(
+      BeaconState state, IndexedAttestationCache indexedAttestationCache) {
+    return (attestation) ->
+        indexedAttestationCache.computeIfAbsent(
+            attestation, () -> attestationUtil.getIndexedAttestation(state, attestation));
+  }
+
+  /**
+   * Corresponds to fork-specific logic from "process_attestation" spec method. Common validation
+   * and signature verification logic can be found in {@link #processAttestations}.
+   *
+   * @param genericState The state corresponding to the block being processed
+   * @param attestation An attestation in the body of the block being processed
+   * @param indexedAttestationProvider provider for indexed attestations
+   */
+  protected abstract void processAttestation(
+      final MutableBeaconState genericState,
+      final Attestation attestation,
+      final IndexedAttestationProvider indexedAttestationProvider);
+
+  protected interface IndexedAttestationProvider {
+    IndexedAttestation getIndexedAttestation(final Attestation attestation);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateMutatorsAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.operations.attestation.AttestationProcessorAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.StateTransitionAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.EpochProcessorAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.ValidatorStatusFactoryAltair;
@@ -51,6 +52,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
       final ValidatorStatusFactoryAltair validatorStatusFactory,
       final EpochProcessorAltair epochProcessor,
       final BlockProcessorAltair blockProcessor,
+      final AttestationProcessorAltair attestationProcessor,
       final StateTransitionAltair stateTransition,
       final ForkChoiceUtil forkChoiceUtil,
       final BlockProposalUtil blockProposalUtil,
@@ -67,6 +69,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
         validatorStatusFactory,
         epochProcessor,
         blockProcessor,
+        attestationProcessor,
         stateTransition,
         forkChoiceUtil,
         blockProposalUtil);
@@ -118,6 +121,15 @@ public class SpecLogicAltair extends AbstractSpecLogic {
             validatorsUtil,
             beaconStateUtil,
             validatorStatusFactory);
+    final AttestationProcessorAltair attestationProcessor =
+        new AttestationProcessorAltair(
+            beaconStateUtil,
+            attestationUtil,
+            attestationValidator,
+            config,
+            beaconStateAccessors,
+            miscHelpers,
+            beaconStateMutators);
     final BlockProcessorAltair blockProcessor =
         new BlockProcessorAltair(
             config,
@@ -128,7 +140,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
             beaconStateUtil,
             attestationUtil,
             validatorsUtil,
-            attestationValidator);
+            attestationProcessor);
     final StateTransitionAltair stateTransition =
         StateTransitionAltair.create(config, blockProcessor, epochProcessor);
     final ForkChoiceUtil forkChoiceUtil =
@@ -156,6 +168,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
         validatorStatusFactory,
         epochProcessor,
         blockProcessor,
+        attestationProcessor,
         stateTransition,
         forkChoiceUtil,
         blockProposalUtil,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/operations/attestation/AttestationProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/operations/attestation/AttestationProcessorAltair.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.altair.operations.attestation;
+
+import static tech.pegasys.teku.spec.constants.IncentivizationWeights.PROPOSER_WEIGHT;
+import static tech.pegasys.teku.spec.constants.IncentivizationWeights.WEIGHT_DENOMINATOR;
+import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.integerSquareRoot;
+
+import java.util.ArrayList;
+import java.util.List;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.constants.ParticipationFlags;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.MutableBeaconStateAltair;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
+import tech.pegasys.teku.spec.logic.common.operations.attestation.AttestationProcessor;
+import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataStateTransitionValidator;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair.FlagIndexAndWeight;
+import tech.pegasys.teku.ssz.SszMutableList;
+import tech.pegasys.teku.ssz.collections.SszUInt64List;
+import tech.pegasys.teku.ssz.primitive.SszByte;
+import tech.pegasys.teku.ssz.primitive.SszUInt64;
+
+public class AttestationProcessorAltair extends AttestationProcessor {
+
+  private final SpecConfig specConfig;
+  private final BeaconStateAccessorsAltair beaconStateAccessors;
+  private final MiscHelpersAltair miscHelpersAltair;
+  private final BeaconStateMutators beaconStateMutators;
+
+  public AttestationProcessorAltair(
+      final BeaconStateUtil beaconStateUtil,
+      final AttestationUtil attestationUtil,
+      final AttestationDataStateTransitionValidator attestationValidator,
+      final SpecConfig specConfig,
+      final BeaconStateAccessorsAltair beaconStateAccessors,
+      final MiscHelpersAltair miscHelpersAltair,
+      final BeaconStateMutators beaconStateMutators) {
+    super(beaconStateUtil, attestationUtil, attestationValidator);
+    this.specConfig = specConfig;
+    this.beaconStateAccessors = beaconStateAccessors;
+    this.miscHelpersAltair = miscHelpersAltair;
+    this.beaconStateMutators = beaconStateMutators;
+  }
+
+  protected void processAttestation(
+      final MutableBeaconState genericState,
+      final Attestation attestation,
+      final IndexedAttestationProvider indexedAttestationProvider) {
+    final MutableBeaconStateAltair state = MutableBeaconStateAltair.required(genericState);
+    final AttestationData data = attestation.getData();
+
+    final SszMutableList<SszByte> epochParticipation;
+    final Checkpoint justifiedCheckpoint;
+    if (data.getTarget().getEpoch().equals(beaconStateAccessors.getCurrentEpoch(state))) {
+      epochParticipation = state.getCurrentEpochParticipation();
+      justifiedCheckpoint = state.getCurrent_justified_checkpoint();
+    } else {
+      epochParticipation = state.getPreviousEpochParticipation();
+      justifiedCheckpoint = state.getPrevious_justified_checkpoint();
+    }
+
+    // Matching roots
+    final boolean isMatchingHead =
+        data.getBeacon_block_root()
+            .equals(beaconStateUtil.getBlockRootAtSlot(state, data.getSlot()));
+    final boolean isMatchingSource = data.getSource().equals(justifiedCheckpoint);
+    final boolean isMatchingTarget =
+        data.getTarget()
+            .getRoot()
+            .equals(beaconStateUtil.getBlockRoot(state, data.getTarget().getEpoch()));
+
+    // Participation flag indices
+    final List<Integer> participationFlagIndices = new ArrayList<>();
+    final UInt64 stateSlot = state.getSlot();
+    final UInt64 dataSlot = data.getSlot();
+    if (isMatchingHead
+        && isMatchingTarget
+        && stateSlot.equals(dataSlot.plus(specConfig.getMinAttestationInclusionDelay()))) {
+      participationFlagIndices.add(ParticipationFlags.TIMELY_HEAD_FLAG_INDEX);
+    }
+    if (isMatchingSource
+        && stateSlot.isLessThanOrEqualTo(
+            dataSlot.plus(integerSquareRoot(specConfig.getSlotsPerEpoch())))) {
+      participationFlagIndices.add(ParticipationFlags.TIMELY_SOURCE_FLAG_INDEX);
+    }
+    if (isMatchingTarget
+        && stateSlot.isLessThanOrEqualTo(dataSlot.plus(specConfig.getSlotsPerEpoch()))) {
+      participationFlagIndices.add(ParticipationFlags.TIMELY_TARGET_FLAG_INDEX);
+    }
+
+    // Update epoch participation flags
+    UInt64 proposerRewardNumerator = UInt64.ZERO;
+    final SszUInt64List attestingIndices =
+        indexedAttestationProvider.getIndexedAttestation(attestation).getAttesting_indices();
+    for (SszUInt64 attestingIndex : attestingIndices) {
+      final int index = attestingIndex.get().intValue();
+      byte participationFlags = epochParticipation.get(index).get();
+      final UInt64 baseReward = beaconStateAccessors.getBaseReward(state, index);
+      boolean shouldUpdate = false;
+      for (FlagIndexAndWeight flagIndicesAndWeight : miscHelpersAltair.getFlagIndicesAndWeights()) {
+        final int flagIndex = flagIndicesAndWeight.getIndex();
+        final UInt64 weight = flagIndicesAndWeight.getWeight();
+
+        if (participationFlagIndices.contains(flagIndex)
+            && !miscHelpersAltair.hasFlag(participationFlags, flagIndex)) {
+          shouldUpdate = true;
+          participationFlags = miscHelpersAltair.addFlag(participationFlags, flagIndex);
+          proposerRewardNumerator = proposerRewardNumerator.plus(baseReward.times(weight));
+        }
+      }
+
+      if (shouldUpdate) {
+        epochParticipation.set(index, SszByte.of(participationFlags));
+      }
+    }
+
+    if (!proposerRewardNumerator.isZero()) {
+      final int proposerIndex = beaconStateAccessors.getBeaconProposerIndex(state);
+      final UInt64 proposerRewardDenominator =
+          WEIGHT_DENOMINATOR
+              .minus(PROPOSER_WEIGHT)
+              .times(WEIGHT_DENOMINATOR)
+              .dividedBy(PROPOSER_WEIGHT);
+      final UInt64 proposerReward = proposerRewardNumerator.dividedBy(proposerRewardDenominator);
+      beaconStateMutators.increaseBalance(state, proposerIndex, proposerReward);
+    }
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/operations/attestation/AttestationProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/operations/attestation/AttestationProcessorAltair.java
@@ -62,6 +62,7 @@ public class AttestationProcessorAltair extends AttestationProcessor {
     this.beaconStateMutators = beaconStateMutators;
   }
 
+  @Override
   protected void processAttestation(
       final MutableBeaconState genericState,
       final Attestation attestation,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.versions.phase0.block.BlockProcessorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.helpers.BeaconStateAccessorsPhase0;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.attestation.AttestationProcessorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.EpochProcessorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.ValidatorStatusFactoryPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
@@ -49,6 +50,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
       final ValidatorStatusFactoryPhase0 validatorStatusFactory,
       final EpochProcessorPhase0 epochProcessor,
       final BlockProcessorPhase0 blockProcessor,
+      final AttestationProcessorPhase0 attestationProcessor,
       final StateTransition stateTransition,
       final ForkChoiceUtil forkChoiceUtil,
       final BlockProposalUtil blockProposalUtil) {
@@ -64,6 +66,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
         validatorStatusFactory,
         epochProcessor,
         blockProcessor,
+        attestationProcessor,
         stateTransition,
         forkChoiceUtil,
         blockProposalUtil);
@@ -109,6 +112,9 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
             validatorsUtil,
             beaconStateUtil,
             validatorStatusFactory);
+    final AttestationProcessorPhase0 attestationProcessor =
+        new AttestationProcessorPhase0(
+            beaconStateAccessors, beaconStateUtil, attestationUtil, attestationValidator);
     final BlockProcessorPhase0 blockProcessor =
         new BlockProcessorPhase0(
             config,
@@ -119,7 +125,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
             beaconStateUtil,
             attestationUtil,
             validatorsUtil,
-            attestationValidator);
+            attestationProcessor);
     final StateTransition stateTransition =
         StateTransition.create(config, blockProcessor, epochProcessor);
     final ForkChoiceUtil forkChoiceUtil =
@@ -139,6 +145,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
         validatorStatusFactory,
         epochProcessor,
         blockProcessor,
+        attestationProcessor,
         stateTransition,
         forkChoiceUtil,
         blockProposalUtil);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
@@ -13,24 +13,19 @@
 
 package tech.pegasys.teku.spec.logic.versions.phase0.block;
 
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
-import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
-import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.MutableBeaconStatePhase0;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
-import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataStateTransitionValidator;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.attestation.AttestationProcessorPhase0;
 
 public final class BlockProcessorPhase0 extends AbstractBlockProcessor {
 
@@ -43,7 +38,7 @@ public final class BlockProcessorPhase0 extends AbstractBlockProcessor {
       final BeaconStateUtil beaconStateUtil,
       final AttestationUtil attestationUtil,
       final ValidatorsUtil validatorsUtil,
-      final AttestationDataStateTransitionValidator attestationValidator) {
+      final AttestationProcessorPhase0 attestationProcessor) {
     super(
         specConfig,
         predicates,
@@ -53,29 +48,7 @@ public final class BlockProcessorPhase0 extends AbstractBlockProcessor {
         beaconStateUtil,
         attestationUtil,
         validatorsUtil,
-        attestationValidator);
-  }
-
-  @Override
-  protected void processAttestation(
-      final MutableBeaconState genericState,
-      final Attestation attestation,
-      final IndexedAttestationProvider indexedAttestationProvider) {
-    final MutableBeaconStatePhase0 state = MutableBeaconStatePhase0.required(genericState);
-    final AttestationData data = attestation.getData();
-
-    PendingAttestation pendingAttestation =
-        new PendingAttestation(
-            attestation.getAggregation_bits(),
-            data,
-            state.getSlot().minus(data.getSlot()),
-            UInt64.valueOf(beaconStateAccessors.getBeaconProposerIndex(state)));
-
-    if (data.getTarget().getEpoch().equals(beaconStateAccessors.getCurrentEpoch(state))) {
-      state.getCurrent_epoch_attestations().append(pendingAttestation);
-    } else {
-      state.getPrevious_epoch_attestations().append(pendingAttestation);
-    }
+        attestationProcessor);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/attestation/AttestationProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/attestation/AttestationProcessorPhase0.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.phase0.operations.attestation;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.MutableBeaconStatePhase0;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.operations.attestation.AttestationProcessor;
+import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataStateTransitionValidator;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
+
+public class AttestationProcessorPhase0 extends AttestationProcessor {
+  final BeaconStateAccessors beaconStateAccessors;
+
+  public AttestationProcessorPhase0(
+      final BeaconStateAccessors beaconStateAccessors,
+      final BeaconStateUtil beaconStateUtil,
+      final AttestationUtil attestationUtil,
+      final AttestationDataStateTransitionValidator attestationValidator) {
+    super(beaconStateUtil, attestationUtil, attestationValidator);
+    this.beaconStateAccessors = beaconStateAccessors;
+  }
+
+  protected void processAttestation(
+      final MutableBeaconState genericState,
+      final Attestation attestation,
+      final IndexedAttestationProvider indexedAttestationProvider) {
+    final MutableBeaconStatePhase0 state = MutableBeaconStatePhase0.required(genericState);
+    final AttestationData data = attestation.getData();
+
+    PendingAttestation pendingAttestation =
+        new PendingAttestation(
+            attestation.getAggregation_bits(),
+            data,
+            state.getSlot().minus(data.getSlot()),
+            UInt64.valueOf(beaconStateAccessors.getBeaconProposerIndex(state)));
+
+    if (data.getTarget().getEpoch().equals(beaconStateAccessors.getCurrentEpoch(state))) {
+      state.getCurrent_epoch_attestations().append(pendingAttestation);
+    } else {
+      state.getPrevious_epoch_attestations().append(pendingAttestation);
+    }
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/attestation/AttestationProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/attestation/AttestationProcessorPhase0.java
@@ -37,6 +37,7 @@ public class AttestationProcessorPhase0 extends AttestationProcessor {
     this.beaconStateAccessors = beaconStateAccessors;
   }
 
+  @Override
   protected void processAttestation(
       final MutableBeaconState genericState,
       final Attestation attestation,


### PR DESCRIPTION
## PR Description
Separate attestation processing logic from `BlockProcessor` since it's a big enough chunk of code and accessed directly in a few places separate from actually processing blocks.

Also helps to start teasing apart the different places that are doing signature verification for attestations.

## Fixed Issue(s)
#3834 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
