### PR TITLE
Add SafeFuture.collectAll to make it easier to get all results from a set of futures

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -163,6 +163,20 @@ public class SafeFuture<T> extends CompletableFuture<T> {
         .catchAndRethrow(completionException -> addSuppressedErrors(completionException, futures));
   }
 
+  /**
+   * Waits for all the supplied futures to complete then returns a single future that combines all
+   * the results.
+   *
+   * <p>If all the futures complete successfully the returned future completes with a {@link List}
+   * of each result in the same order as the futures were given.
+   *
+   * <p>If any future completes exceptionally, the returned future completes exceptionally once all
+   * the futures have completed.
+   *
+   * @param futures the futures to collect results from
+   * @param <T> the result type to collect
+   * @return a new future that completes when all the supplied futures complete
+   */
   @SafeVarargs
   public static <T> SafeFuture<List<T>> collectAll(final SafeFuture<T>... futures) {
     return allOf(futures)

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -13,8 +13,11 @@
 
 package tech.pegasys.teku.infrastructure.async;
 
+import static java.util.stream.Collectors.toList;
+
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -158,6 +161,12 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   public static SafeFuture<Void> allOf(final SafeFuture<?>... futures) {
     return of(CompletableFuture.allOf(futures))
         .catchAndRethrow(completionException -> addSuppressedErrors(completionException, futures));
+  }
+
+  @SafeVarargs
+  public static <T> SafeFuture<List<T>> collectAll(final SafeFuture<T>... futures) {
+    return allOf(futures)
+        .thenApply(__ -> Stream.of(futures).map(SafeFuture::join).collect(toList()));
   }
 
   /**


### PR DESCRIPTION
## PR Description
To make it easier to work with multiple futures where the results are needed, add a `collectAll` to `SafeFuture` 
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
