### PR TITLE
Move reporting of duty results to PendingDuties

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -20,12 +20,14 @@ import java.util.function.BiConsumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 
 public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   private static final Logger LOG = LogManager.getLogger();
+  private final MetricsSystem metricsSystem;
   private final String dutyType;
   private final Spec spec;
   private final boolean useDependentRoots;
@@ -38,11 +40,13 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   private Optional<UInt64> currentEpoch = Optional.empty();
 
   protected AbstractDutyScheduler(
+      final MetricsSystem metricsSystem,
       final String dutyType,
       final DutyLoader<?> epochDutiesScheduler,
       final int lookAheadEpochs,
       final boolean useDependentRoots,
       final Spec spec) {
+    this.metricsSystem = metricsSystem;
     this.dutyType = dutyType;
     this.epochDutiesScheduler = epochDutiesScheduler;
     this.lookAheadEpochs = lookAheadEpochs;
@@ -127,7 +131,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   }
 
   private PendingDuties createEpochDuties(final UInt64 epochNumber) {
-    return PendingDuties.calculateDuties(epochDutiesScheduler, epochNumber);
+    return PendingDuties.calculateDuties(metricsSystem, epochDutiesScheduler, epochNumber);
   }
 
   private void removePriorEpochs(final UInt64 epochNumber) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
@@ -29,7 +29,7 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
       final DutyLoader<?> dutyLoader,
       final boolean useDependentRoots,
       final Spec spec) {
-    super("attestation", dutyLoader, LOOKAHEAD_EPOCHS, useDependentRoots, spec);
+    super(metricsSystem, "attestation", dutyLoader, LOOKAHEAD_EPOCHS, useDependentRoots, spec);
 
     metricsSystem.createIntegerGauge(
         TekuMetricCategory.VALIDATOR,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -29,7 +29,7 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
       final DutyLoader<?> dutyLoader,
       final boolean useDependentRoots,
       final Spec spec) {
-    super("block", dutyLoader, LOOKAHEAD_EPOCHS, useDependentRoots, spec);
+    super(metricsSystem, "block", dutyLoader, LOOKAHEAD_EPOCHS, useDependentRoots, spec);
 
     metricsSystem.createIntegerGauge(
         TekuMetricCategory.VALIDATOR,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -152,8 +152,7 @@ public class ValidatorClientService extends Service {
                 validatorApiChannel,
                 forkProvider,
                 dependentRoot ->
-                    new SlotBasedScheduledDuties<>(
-                        attestationDutyFactory, dependentRoot, metricsSystem),
+                    new SlotBasedScheduledDuties<>(attestationDutyFactory, dependentRoot),
                 validators,
                 validatorIndexProvider,
                 beaconCommitteeSubscriptions,
@@ -163,8 +162,7 @@ public class ValidatorClientService extends Service {
             asyncRunner,
             new BlockProductionDutyLoader(
                 validatorApiChannel,
-                dependentRoot ->
-                    new SlotBasedScheduledDuties<>(blockDutyFactory, dependentRoot, metricsSystem),
+                dependentRoot -> new SlotBasedScheduledDuties<>(blockDutyFactory, dependentRoot),
                 validators,
                 validatorIndexProvider));
     final boolean useDependentRoots = config.getValidatorConfig().useDependentRoots();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
@@ -130,7 +130,6 @@ public class AggregationDuty implements Duty {
               validatorApiChannel.sendAggregateAndProof(
                   new SignedAggregateAndProof(aggregateAndProof, signature));
               return DutyResult.success(
-                  aggregator.validator.getPublicKey(),
                   aggregateAndProof.getAggregate().getData().getBeacon_block_root());
             });
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AttestationDutyFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AttestationDutyFactory.java
@@ -42,4 +42,14 @@ public class AttestationDutyFactory
   public AggregationDuty createAggregationDuty(final UInt64 slot, final Validator validator) {
     return new AggregationDuty(slot, validatorApiChannel, forkProvider, VALIDATOR_LOGGER);
   }
+
+  @Override
+  public String getProductionType() {
+    return "attestation";
+  }
+
+  @Override
+  public String getAggregationType() {
+    return "aggregate";
+  }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDuty.java
@@ -150,10 +150,7 @@ public class AttestationProductionDuty implements Duty {
             signedAttestation ->
                 validatorApiChannel.sendSignedAttestation(
                     signedAttestation, Optional.of(validator.getValidatorIndex())))
-        .thenApply(
-            __ ->
-                DutyResult.success(
-                    validator.validator.getPublicKey(), attestationData.getBeacon_block_root()));
+        .thenApply(__ -> DutyResult.success(attestationData.getBeacon_block_root()));
   }
 
   private Attestation createSignedAttestation(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockDutyFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockDutyFactory.java
@@ -44,4 +44,15 @@ public class BlockDutyFactory implements DutyFactory<BlockProductionDuty, Duty> 
   public Duty createAggregationDuty(final UInt64 slot, final Validator validator) {
     throw new UnsupportedOperationException("Aggregation not supported for blocks");
   }
+
+  @Override
+  public String getProductionType() {
+    return "block";
+  }
+
+  @Override
+  public String getAggregationType() {
+    // Aggregation is never used but getters should be safe to call so return a placeholder
+    return "";
+  }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
@@ -70,7 +70,7 @@ public class BlockProductionDuty implements Duty {
         .thenApply(
             result -> {
               if (result.isPublished()) {
-                return DutyResult.success(validator.getPublicKey(), signedBlock.getRoot());
+                return DutyResult.success(signedBlock.getRoot());
               }
               return DutyResult.forError(
                   validator.getPublicKey(),

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/Duty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/Duty.java
@@ -13,19 +13,8 @@
 
 package tech.pegasys.teku.validator.client.duties;
 
-import java.util.Optional;
-import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
 public interface Duty {
   SafeFuture<DutyResult> performDuty();
-
-  String getProducedType();
-
-  Optional<BLSPublicKey> getValidatorIdentifier();
-
-  default Optional<String> getValidatorIdString() {
-    return getValidatorIdentifier()
-        .map(publicKey -> publicKey.toBytesCompressed().toShortHexString());
-  }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/DutyFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/DutyFactory.java
@@ -21,4 +21,8 @@ public interface DutyFactory<P extends Duty, A extends Duty> {
   P createProductionDuty(UInt64 slot, Validator validator);
 
   A createAggregationDuty(UInt64 slot, Validator validator);
+
+  String getProductionType();
+
+  String getAggregationType();
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/DutyResult.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/DutyResult.java
@@ -23,44 +23,57 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.NodeSyncingException;
 
 public class DutyResult {
-  public static final DutyResult NO_OP = new DutyResult(0, 0, emptySet(), emptyList());
+  public static final DutyResult NO_OP = new DutyResult(0, 0, emptySet(), emptySet(), emptyList());
   private final int successCount;
   private final int nodeSyncingCount;
+  private final Set<BLSPublicKey> validatorKeys;
   private final Set<Bytes32> roots;
   private final List<Throwable> errors;
 
   private DutyResult(
       final int successCount,
       final int nodeSyncingCount,
+      final Set<BLSPublicKey> validatorKeys,
       final Set<Bytes32> roots,
       final List<Throwable> errors) {
     this.successCount = successCount;
     this.nodeSyncingCount = nodeSyncingCount;
+    this.validatorKeys = validatorKeys;
     this.roots = roots;
     this.errors = errors;
   }
 
-  public static DutyResult success(final Bytes32 result) {
-    return new DutyResult(1, 0, singleton(result), emptyList());
+  public static DutyResult success(final BLSPublicKey validatorKey, final Bytes32 result) {
+    return new DutyResult(1, 0, singleton(validatorKey), singleton(result), emptyList());
   }
 
   public static DutyResult forError(final Throwable error) {
+    return forError(emptySet(), error);
+  }
+
+  public static DutyResult forError(final BLSPublicKey validatorKey, final Throwable error) {
+    return forError(singleton(validatorKey), error);
+  }
+
+  public static DutyResult forError(final Set<BLSPublicKey> validatorKeys, final Throwable error) {
     // Not using getRootCause here because we only want to unwrap CompletionException
     Throwable cause = error;
     while (cause instanceof CompletionException && cause.getCause() != null) {
       cause = cause.getCause();
     }
     if (cause instanceof NodeSyncingException) {
-      return new DutyResult(0, 1, emptySet(), emptyList());
+      return new DutyResult(0, 1, validatorKeys, emptySet(), emptyList());
     } else {
-      return new DutyResult(0, 0, emptySet(), List.of(cause));
+      return new DutyResult(0, 0, validatorKeys, emptySet(), List.of(cause));
     }
   }
 
@@ -78,6 +91,9 @@ public class DutyResult {
     final int combinedSuccessCount = this.successCount + other.successCount;
     final int combinedSyncingCount = this.nodeSyncingCount + other.nodeSyncingCount;
 
+    final Set<BLSPublicKey> combinedValidatorKeys = new HashSet<>(this.validatorKeys);
+    combinedValidatorKeys.addAll(other.validatorKeys);
+
     final Set<Bytes32> combinedRoots = new HashSet<>(this.roots);
     combinedRoots.addAll(other.roots);
 
@@ -85,21 +101,40 @@ public class DutyResult {
     combinedErrors.addAll(other.errors);
 
     return new DutyResult(
-        combinedSuccessCount, combinedSyncingCount, combinedRoots, combinedErrors);
+        combinedSuccessCount,
+        combinedSyncingCount,
+        combinedValidatorKeys,
+        combinedRoots,
+        combinedErrors);
   }
 
-  public void report(
-      final String producedType,
-      final UInt64 slot,
-      final Optional<String> validatorKey,
-      final ValidatorLogger logger) {
+  public int getSuccessCount() {
+    return successCount;
+  }
+
+  public int getFailureCount() {
+    return errors.size() + nodeSyncingCount;
+  }
+
+  public void report(final String producedType, final UInt64 slot, final ValidatorLogger logger) {
     if (successCount > 0) {
       logger.dutyCompleted(producedType, slot, successCount, roots);
     }
     if (nodeSyncingCount > 0) {
       logger.dutySkippedWhileSyncing(producedType, slot, nodeSyncingCount);
     }
-    errors.forEach(error -> logger.dutyFailed(producedType, slot, validatorKey, error));
+    errors.forEach(error -> logger.dutyFailed(producedType, slot, summarizeKeys(), error));
+  }
+
+  private Optional<String> summarizeKeys() {
+    if (validatorKeys.size() > 10) {
+      return Optional.empty();
+    } else {
+      return Optional.of(
+          validatorKeys.stream()
+              .map(BLSPublicKey::toAbbreviatedString)
+              .collect(Collectors.joining(", ")));
+    }
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ScheduledDuties.java
@@ -14,15 +14,20 @@
 package tech.pegasys.teku.validator.client.duties;
 
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface ScheduledDuties {
 
   boolean requiresRecalculation(Bytes32 newHeadDependentRoot);
 
-  void performProductionDuty(UInt64 slot);
+  SafeFuture<DutyResult> performProductionDuty(UInt64 slot);
 
-  void performAggregationDuty(UInt64 slot);
+  String getProductionType();
+
+  SafeFuture<DutyResult> performAggregationDuty(UInt64 slot);
+
+  String getAggregationType();
 
   int countDuties();
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -47,6 +47,7 @@ import tech.pegasys.teku.validator.client.duties.AggregationDuty;
 import tech.pegasys.teku.validator.client.duties.AttestationDutyFactory;
 import tech.pegasys.teku.validator.client.duties.AttestationProductionDuty;
 import tech.pegasys.teku.validator.client.duties.BeaconCommitteeSubscriptions;
+import tech.pegasys.teku.validator.client.duties.DutyResult;
 import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
@@ -71,6 +72,10 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
         .thenReturn(
             completedFuture(
                 Optional.of(new AttesterDuties(dataStructureUtil.randomBytes32(), emptyList()))));
+    when(scheduledDuties.performProductionDuty(any()))
+        .thenReturn(SafeFuture.completedFuture(DutyResult.NO_OP));
+    when(scheduledDuties.performAggregationDuty(any()))
+        .thenReturn(SafeFuture.completedFuture(DutyResult.NO_OP));
   }
 
   @Test

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -813,9 +813,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
         new AttestationDutyLoader(
             validatorApiChannel,
             forkProvider,
-            dependentRoot ->
-                new SlotBasedScheduledDuties<>(
-                    attestationDutyFactory, dependentRoot, metricsSystem),
+            dependentRoot -> new SlotBasedScheduledDuties<>(attestationDutyFactory, dependentRoot),
             new OwnedValidators(Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2)),
             validatorIndexProvider,
             beaconCommitteeSubscriptions,

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
@@ -350,8 +350,7 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
                 new BlockProductionDutyLoader(
                     validatorApiChannel,
                     dependentRoot ->
-                        new SlotBasedScheduledDuties<>(
-                            blockDutyFactory, dependentRoot, metricsSystem),
+                        new SlotBasedScheduledDuties<>(blockDutyFactory, dependentRoot),
                     new OwnedValidators(
                         Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2)),
                     validatorIndexProvider)),

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
@@ -43,6 +43,7 @@ import tech.pegasys.teku.validator.api.ProposerDuty;
 import tech.pegasys.teku.validator.client.duties.BlockDutyFactory;
 import tech.pegasys.teku.validator.client.duties.BlockProductionDuty;
 import tech.pegasys.teku.validator.client.duties.Duty;
+import tech.pegasys.teku.validator.client.duties.DutyResult;
 import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
@@ -285,6 +286,8 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
     // last slot of epoch 0
     final UInt64 slot =
         spec.computeStartSlotAtEpoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1)).decrement();
+    when(scheduledDuties.performProductionDuty(slot))
+        .thenReturn(SafeFuture.completedFuture(DutyResult.success(Bytes32.ZERO)));
 
     when(validatorApiChannel.getProposerDuties(ZERO))
         .thenReturn(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/PendingDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/PendingDutiesTest.java
@@ -30,7 +30,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
-import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubCounter;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
@@ -66,11 +65,9 @@ class PendingDutiesTest {
     when(scheduledDuties.getAggregationType()).thenReturn(AGGREGATION_TYPE);
 
     when(scheduledDuties.performProductionDuty(any()))
-        .thenReturn(
-            SafeFuture.completedFuture(DutyResult.success(BLSPublicKey.empty(), Bytes32.ZERO)));
+        .thenReturn(SafeFuture.completedFuture(DutyResult.success(Bytes32.ZERO)));
     when(scheduledDuties.performAggregationDuty(any()))
-        .thenReturn(
-            SafeFuture.completedFuture(DutyResult.success(BLSPublicKey.empty(), Bytes32.ZERO)));
+        .thenReturn(SafeFuture.completedFuture(DutyResult.success(Bytes32.ZERO)));
   }
 
   @Test
@@ -233,8 +230,8 @@ class PendingDutiesTest {
 
   @Test
   void shouldReportTotalNumberOfSuccessesAndFailuresToMetrics() {
-    final DutyResult result1 = DutyResult.success(BLSPublicKey.empty(), Bytes32.ZERO);
-    final DutyResult result2 = DutyResult.success(BLSPublicKey.empty(), Bytes32.ZERO);
+    final DutyResult result1 = DutyResult.success(Bytes32.ZERO);
+    final DutyResult result2 = DutyResult.success(Bytes32.ZERO);
     final DutyResult result3 = DutyResult.forError(new Throwable("Oh no!"));
     final DutyResult dutyResult = result1.combine(result2.combine(result3));
     when(scheduledDuties.performProductionDuty(ZERO))

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
@@ -214,7 +214,11 @@ class AggregationDutyTest {
     performAndReportDuty();
 
     verify(validatorLogger)
-        .dutyFailed(eq(TYPE), eq(SLOT), eq(Optional.empty()), any(IllegalStateException.class));
+        .dutyFailed(
+            eq(TYPE),
+            eq(SLOT),
+            eq(Optional.of(validator1.getPublicKey().toAbbreviatedString())),
+            any(IllegalStateException.class));
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -226,7 +230,9 @@ class AggregationDutyTest {
 
     performAndReportDuty();
 
-    verify(validatorLogger).dutyFailed(TYPE, SLOT, Optional.empty(), exception);
+    verify(validatorLogger)
+        .dutyFailed(
+            TYPE, SLOT, Optional.of(validator1.getPublicKey().toAbbreviatedString()), exception);
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -263,7 +269,9 @@ class AggregationDutyTest {
 
     performAndReportDuty();
     verify(validatorApiChannel, never()).sendAggregateAndProof(any());
-    verify(validatorLogger).dutyFailed(TYPE, SLOT, Optional.empty(), exception);
+    verify(validatorLogger)
+        .dutyFailed(
+            TYPE, SLOT, Optional.of(validator1.getPublicKey().toAbbreviatedString()), exception);
     verifyNoMoreInteractions(validatorLogger);
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
@@ -214,7 +214,12 @@ class AttestationProductionDutyTest {
 
     verify(validatorLogger)
         .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
-    verify(validatorLogger).dutyFailed(TYPE, SLOT, Optional.empty(), signingFailure);
+    verify(validatorLogger)
+        .dutyFailed(
+            TYPE,
+            SLOT,
+            Optional.of(validator1.getPublicKey().toAbbreviatedString()),
+            signingFailure);
     verifyNoMoreInteractions(validatorLogger);
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
@@ -48,6 +48,7 @@ import tech.pegasys.teku.validator.client.Validator;
 
 class AttestationProductionDutyTest {
 
+  private static final String TYPE = "attesation";
   private static final UInt64 SLOT = UInt64.valueOf(1488);
 
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
@@ -62,11 +63,6 @@ class AttestationProductionDutyTest {
   @BeforeEach
   public void setUp() {
     when(forkProvider.getForkInfo()).thenReturn(completedFuture(fork));
-  }
-
-  @Test
-  public void shouldReportCorrectProducedType() {
-    assertThat(duty.getProducedType()).isEqualTo("attestation");
   }
 
   @Test
@@ -88,11 +84,7 @@ class AttestationProductionDutyTest {
 
     assertThat(attestationFuture).isCompletedWithValue(Optional.empty());
     verify(validatorLogger)
-        .dutyFailed(
-            eq(duty.getProducedType()),
-            eq(SLOT),
-            eq(duty.getValidatorIdString()),
-            any(IllegalStateException.class));
+        .dutyFailed(eq(TYPE), eq(SLOT), eq(Optional.empty()), any(IllegalStateException.class));
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -130,14 +122,9 @@ class AttestationProductionDutyTest {
 
     verify(validatorApiChannel).sendSignedAttestation(expectedAttestation, Optional.of(10));
     verify(validatorLogger)
-        .dutyCompleted(
-            duty.getProducedType(), SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
+        .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
     verify(validatorLogger)
-        .dutyFailed(
-            eq(duty.getProducedType()),
-            eq(SLOT),
-            eq(duty.getValidatorIdString()),
-            any(IllegalStateException.class));
+        .dutyFailed(eq(TYPE), eq(SLOT), eq(Optional.empty()), any(IllegalStateException.class));
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -178,10 +165,8 @@ class AttestationProductionDutyTest {
     verify(validatorApiChannel).sendSignedAttestation(expectedAttestation, Optional.of(10));
 
     verify(validatorLogger)
-        .dutyCompleted(
-            duty.getProducedType(), SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
-    verify(validatorLogger)
-        .dutyFailed(duty.getProducedType(), SLOT, duty.getValidatorIdString(), failure);
+        .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
+    verify(validatorLogger).dutyFailed(TYPE, SLOT, Optional.empty(), failure);
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -216,10 +201,8 @@ class AttestationProductionDutyTest {
     verify(validatorApiChannel).sendSignedAttestation(expectedAttestation, Optional.of(10));
 
     verify(validatorLogger)
-        .dutyCompleted(
-            duty.getProducedType(), SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
-    verify(validatorLogger)
-        .dutyFailed(duty.getProducedType(), SLOT, duty.getValidatorIdString(), signingFailure);
+        .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
+    verify(validatorLogger).dutyFailed(TYPE, SLOT, Optional.empty(), signingFailure);
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -241,8 +224,7 @@ class AttestationProductionDutyTest {
 
     verify(validatorApiChannel).sendSignedAttestation(expectedAttestation, Optional.of(10));
     verify(validatorLogger)
-        .dutyCompleted(
-            duty.getProducedType(), SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
+        .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -289,8 +271,7 @@ class AttestationProductionDutyTest {
     // Should have only needed to create one unsigned attestation and reused it for each validator
     verify(validatorApiChannel, times(1)).createAttestationData(any(), anyInt());
     verify(validatorLogger)
-        .dutyCompleted(
-            duty.getProducedType(), SLOT, 3, Set.of(attestationData.getBeacon_block_root()));
+        .dutyCompleted(TYPE, SLOT, 3, Set.of(attestationData.getBeacon_block_root()));
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -342,7 +323,7 @@ class AttestationProductionDutyTest {
     verify(validatorApiChannel, times(2)).createAttestationData(any(), anyInt());
     verify(validatorLogger)
         .dutyCompleted(
-            duty.getProducedType(),
+            TYPE,
             SLOT,
             3,
             Set.of(
@@ -388,8 +369,6 @@ class AttestationProductionDutyTest {
   private void performAndReportDuty() {
     final SafeFuture<DutyResult> result = duty.performDuty();
     assertThat(result).isCompleted();
-    result
-        .join()
-        .report(duty.getProducedType(), SLOT, duty.getValidatorIdString(), validatorLogger);
+    result.join().report(TYPE, SLOT, validatorLogger);
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.core.signatures.Signer;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
@@ -51,7 +52,8 @@ class AttestationProductionDutyTest {
   private static final String TYPE = "attesation";
   private static final UInt64 SLOT = UInt64.valueOf(1488);
 
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final ForkInfo fork = dataStructureUtil.randomForkInfo();
   private final ForkProvider forkProvider = mock(ForkProvider.class);
   private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
@@ -84,7 +86,11 @@ class AttestationProductionDutyTest {
 
     assertThat(attestationFuture).isCompletedWithValue(Optional.empty());
     verify(validatorLogger)
-        .dutyFailed(eq(TYPE), eq(SLOT), eq(Optional.empty()), any(IllegalStateException.class));
+        .dutyFailed(
+            eq(TYPE),
+            eq(SLOT),
+            eq(Optional.of(validator.getPublicKey().toAbbreviatedString())),
+            any(IllegalStateException.class));
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -124,7 +130,11 @@ class AttestationProductionDutyTest {
     verify(validatorLogger)
         .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
     verify(validatorLogger)
-        .dutyFailed(eq(TYPE), eq(SLOT), eq(Optional.empty()), any(IllegalStateException.class));
+        .dutyFailed(
+            eq(TYPE),
+            eq(SLOT),
+            eq(Optional.of(validator1.getPublicKey().toAbbreviatedString())),
+            any(IllegalStateException.class));
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -166,7 +176,9 @@ class AttestationProductionDutyTest {
 
     verify(validatorLogger)
         .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
-    verify(validatorLogger).dutyFailed(TYPE, SLOT, Optional.empty(), failure);
+    verify(validatorLogger)
+        .dutyFailed(
+            TYPE, SLOT, Optional.of(validator1.getPublicKey().toAbbreviatedString()), failure);
     verifyNoMoreInteractions(validatorLogger);
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -124,7 +124,11 @@ class BlockProductionDutyTest {
     performAndReportDuty();
 
     verify(validatorLogger)
-        .dutyFailed(eq(TYPE), eq(SLOT), eq(Optional.empty()), any(IllegalStateException.class));
+        .dutyFailed(
+            eq(TYPE),
+            eq(SLOT),
+            eq(Optional.of(validator.getPublicKey().toAbbreviatedString())),
+            any(IllegalStateException.class));
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -144,7 +148,8 @@ class BlockProductionDutyTest {
 
   public void assertDutyFails(final RuntimeException error) {
     performAndReportDuty();
-    verify(validatorLogger).dutyFailed(TYPE, SLOT, Optional.empty(), error);
+    verify(validatorLogger)
+        .dutyFailed(TYPE, SLOT, Optional.of(validator.getPublicKey().toAbbreviatedString()), error);
     verifyNoMoreInteractions(validatorLogger);
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/DutyResultTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/DutyResultTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -36,13 +37,13 @@ class DutyResultTest {
   private static final String TYPE = "type";
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final ValidatorLogger validatorLogger = mock(ValidatorLogger.class);
-  private final Optional<String> validatorId =
-      Optional.of(dataStructureUtil.randomValidator().getPubkeyBytes().toShortHexString());
+  private final BLSPublicKey validatorKey = dataStructureUtil.randomPublicKey();
+  private final Optional<String> validatorId = Optional.of(validatorKey.toAbbreviatedString());
 
   @Test
   void shouldReportSuccess() {
     final Bytes32 root = dataStructureUtil.randomBytes32();
-    DutyResult.success(root).report(TYPE, SLOT, validatorId, validatorLogger);
+    DutyResult.success(validatorKey, root).report(TYPE, SLOT, validatorLogger);
 
     verify(validatorLogger).dutyCompleted(TYPE, SLOT, 1, Set.of(root));
     verifyNoMoreInteractions(validatorLogger);
@@ -51,7 +52,7 @@ class DutyResultTest {
   @Test
   void shouldReportError() {
     final RuntimeException error = new RuntimeException("Oh no");
-    DutyResult.forError(error).report(TYPE, SLOT, validatorId, validatorLogger);
+    DutyResult.forError(error).report(TYPE, SLOT, validatorLogger);
 
     verify(validatorLogger).dutyFailed(TYPE, SLOT, validatorId, error);
     verifyNoMoreInteractions(validatorLogger);
@@ -59,8 +60,7 @@ class DutyResultTest {
 
   @Test
   void shouldReportNodeSyncing() {
-    DutyResult.forError(new NodeSyncingException())
-        .report(TYPE, SLOT, validatorId, validatorLogger);
+    DutyResult.forError(new NodeSyncingException()).report(TYPE, SLOT, validatorLogger);
 
     verify(validatorLogger).dutySkippedWhileSyncing(TYPE, SLOT, 1);
     verifyNoMoreInteractions(validatorLogger);
@@ -72,10 +72,10 @@ class DutyResultTest {
     final Bytes32 root2 = dataStructureUtil.randomBytes32();
 
     final DutyResult combined =
-        DutyResult.success(root1)
-            .combine(DutyResult.success(root2))
-            .combine(DutyResult.success(root1));
-    combined.report(TYPE, SLOT, validatorId, validatorLogger);
+        DutyResult.success(validatorKey, root1)
+            .combine(DutyResult.success(validatorKey, root2))
+            .combine(DutyResult.success(validatorKey, root1));
+    combined.report(TYPE, SLOT, validatorLogger);
 
     verify(validatorLogger).dutyCompleted(TYPE, SLOT, 3, Set.of(root1, root2));
     verifyNoMoreInteractions(validatorLogger);
@@ -90,7 +90,7 @@ class DutyResultTest {
         DutyResult.forError(exception1)
             .combine(DutyResult.forError(exception2))
             .combine(DutyResult.forError(exception1));
-    combined.report(TYPE, SLOT, validatorId, validatorLogger);
+    combined.report(TYPE, SLOT, validatorLogger);
 
     verify(validatorLogger, times(2)).dutyFailed(TYPE, SLOT, validatorId, exception1);
     verify(validatorLogger).dutyFailed(TYPE, SLOT, validatorId, exception2);
@@ -103,7 +103,7 @@ class DutyResultTest {
         DutyResult.forError(new NodeSyncingException())
             .combine(DutyResult.forError(new NodeSyncingException()))
             .combine(DutyResult.forError(new NodeSyncingException()));
-    combined.report(TYPE, SLOT, validatorId, validatorLogger);
+    combined.report(TYPE, SLOT, validatorLogger);
 
     verify(validatorLogger).dutySkippedWhileSyncing(TYPE, SLOT, 3);
     verifyNoMoreInteractions(validatorLogger);
@@ -117,14 +117,14 @@ class DutyResultTest {
     final RuntimeException exception2 = new RuntimeException("Oops");
 
     final DutyResult combined =
-        DutyResult.success(root1)
+        DutyResult.success(validatorKey, root1)
             .combine(DutyResult.forError(exception1))
             .combine(DutyResult.forError(new NodeSyncingException()))
             .combine(DutyResult.forError(exception2))
             .combine(DutyResult.forError(new NodeSyncingException()))
-            .combine(DutyResult.success(root2))
-            .combine(DutyResult.success(root1));
-    combined.report(TYPE, SLOT, validatorId, validatorLogger);
+            .combine(DutyResult.success(validatorKey, root2))
+            .combine(DutyResult.success(validatorKey, root1));
+    combined.report(TYPE, SLOT, validatorLogger);
 
     verify(validatorLogger).dutyCompleted(TYPE, SLOT, 3, Set.of(root1, root2));
     verify(validatorLogger).dutySkippedWhileSyncing(TYPE, SLOT, 2);
@@ -142,15 +142,15 @@ class DutyResultTest {
     final SafeFuture<DutyResult> combinedFuture =
         DutyResult.combine(
             List.of(
-                SafeFuture.completedFuture(DutyResult.success(root1)),
+                SafeFuture.completedFuture(DutyResult.success(validatorKey, root1)),
                 SafeFuture.completedFuture(DutyResult.forError(exception1)),
                 SafeFuture.failedFuture(exception2),
                 SafeFuture.completedFuture(DutyResult.forError(new NodeSyncingException())),
                 SafeFuture.failedFuture(new NodeSyncingException()),
-                SafeFuture.completedFuture(DutyResult.success(root2))));
+                SafeFuture.completedFuture(DutyResult.success(validatorKey, root2))));
 
     assertThat(combinedFuture).isCompleted();
-    combinedFuture.join().report(TYPE, SLOT, validatorId, validatorLogger);
+    combinedFuture.join().report(TYPE, SLOT, validatorLogger);
     verify(validatorLogger).dutyCompleted(TYPE, SLOT, 2, Set.of(root1, root2));
     verify(validatorLogger).dutyFailed(TYPE, SLOT, validatorId, exception1);
     verify(validatorLogger).dutyFailed(TYPE, SLOT, validatorId, exception2);
@@ -166,13 +166,13 @@ class DutyResultTest {
     final SafeFuture<DutyResult> combinedFuture = DutyResult.combine(List.of(future1, future2));
     assertThat(combinedFuture).isNotDone();
 
-    future1.complete(DutyResult.success(root));
+    future1.complete(DutyResult.success(validatorKey, root));
     assertThat(combinedFuture).isNotDone();
 
-    future2.complete(DutyResult.success(root));
+    future2.complete(DutyResult.success(validatorKey, root));
     assertThat(combinedFuture).isCompleted();
 
-    combinedFuture.join().report(TYPE, SLOT, validatorId, validatorLogger);
+    combinedFuture.join().report(TYPE, SLOT, validatorLogger);
     verify(validatorLogger).dutyCompleted(TYPE, SLOT, 2, Set.of(root));
     verifyNoMoreInteractions(validatorLogger);
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/SlotBasedScheduledDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/SlotBasedScheduledDutiesTest.java
@@ -104,9 +104,7 @@ class SlotBasedScheduledDutiesTest {
     final T mockDuty = mock(dutyType);
     when(mockDuty.performDuty())
         .thenReturn(
-            SafeFuture.completedFuture(
-                DutyResult.success(
-                    dataStructureUtil.randomPublicKey(), dataStructureUtil.randomBytes32())));
+            SafeFuture.completedFuture(DutyResult.success(dataStructureUtil.randomBytes32())));
     return mockDuty;
   }
 


### PR DESCRIPTION
## PR Description
Moves reporting of duty results from `ScheduledDuties` to `PendingDuties` so it can be reused.

Also reports the validators affected by a failure to perform duties rather than just one of them.  Need to revisit to ensure we don't log an individual stack trace for every single error when multiple validators fail to perform the same action.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
