### PR TITLE
implement POST `/eth/v1/beacon/pool/sync_committees`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,6 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Additions and Improvements
 - Newly created databases will now use LevelDB for storage instead of RocksDB. This uses less memory and has proven to be more stable. Existing databases are unaffected and will continue to use RocksDB.
 - Support for automatic fail-over of eth1-endpoints.  Multiple endpoints can be specified with the new `--eth1-endpoints` CLI option. Thanks to Enrico Del Fante.
+- implement `/eth/v1/beacon/pool/sync_committees` to allow validators to submit sync committee signatures to the beacon node.
 
 ### Bug Fixes

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostSyncCommitteesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostSyncCommitteesIntegrationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.v1.beacon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import okhttp3.Response;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.response.v1.beacon.PostSyncCommitteeFailureResponse;
+import tech.pegasys.teku.api.schema.BLSSignature;
+import tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostSyncCommittees;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.SubmitCommitteeSignatureError;
+import tech.pegasys.teku.validator.api.SubmitCommitteeSignaturesResult;
+
+public class PostSyncCommitteesIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
+  private final Spec spec = TestSpecFactory.createMinimalAltair();
+  DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final String errorString = "The Error Description";
+
+  @Test
+  void shouldSubmitSyncCommitteesAndGetResponse() throws IOException {
+    startRestAPIAtGenesis(SpecMilestone.ALTAIR);
+    final List<SyncCommitteeSignature> requestBody =
+        List.of(
+            new SyncCommitteeSignature(
+                UInt64.ONE,
+                dataStructureUtil.randomBytes32(),
+                dataStructureUtil.randomUInt64(),
+                new BLSSignature(dataStructureUtil.randomSignature())));
+    final SafeFuture<Optional<SubmitCommitteeSignaturesResult>> future =
+        SafeFuture.completedFuture(
+            Optional.of(
+                new SubmitCommitteeSignaturesResult(
+                    List.of(new SubmitCommitteeSignatureError(UInt64.ZERO, errorString)))));
+    when(validatorApiChannel.sendSyncCommitteeSignatures(
+            List.of(requestBody.get(0).asInternalCommitteeSignature())))
+        .thenReturn(future);
+    Response response = post(PostSyncCommittees.ROUTE, jsonProvider.objectToJSON(requestBody));
+
+    assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
+    final PostSyncCommitteeFailureResponse responseBody =
+        jsonProvider.jsonToObject(response.body().string(), PostSyncCommitteeFailureResponse.class);
+
+    assertThat(responseBody.failures.get(0).message).isEqualTo(errorString);
+  }
+}

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostSyncCommitteesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostSyncCommitteesIntegrationTest.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostSyncCommittees;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -37,12 +36,12 @@ import tech.pegasys.teku.validator.api.SubmitCommitteeSignatureError;
 import tech.pegasys.teku.validator.api.SubmitCommitteeSignaturesResult;
 
 public class PostSyncCommitteesIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
-  private final Spec spec = TestSpecFactory.createMinimalAltair();
-  DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final String errorString = "The Error Description";
 
   @Test
   void shouldSubmitSyncCommitteesAndGetResponse() throws IOException {
+    spec = TestSpecFactory.createMinimalAltair();
+    DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
     startRestAPIAtGenesis(SpecMilestone.ALTAIR);
     final List<SyncCommitteeSignature> requestBody =
         List.of(

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostSyncCommitteesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostSyncCommitteesIntegrationTest.java
@@ -68,4 +68,22 @@ public class PostSyncCommitteesIntegrationTest extends AbstractDataBackedRestAPI
 
     assertThat(responseBody.failures.get(0).message).isEqualTo(errorString);
   }
+
+  @Test
+  void phase0SlotCausesBadRequest() throws IOException {
+    startRestAPIAtGenesis(SpecMilestone.PHASE0);
+    spec = TestSpecFactory.createMinimalPhase0();
+    DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    final List<SyncCommitteeSignature> requestBody =
+        List.of(
+            new SyncCommitteeSignature(
+                UInt64.ONE,
+                dataStructureUtil.randomBytes32(),
+                dataStructureUtil.randomUInt64(),
+                new BLSSignature(dataStructureUtil.randomSignature())));
+    Response response = post(PostSyncCommittees.ROUTE, jsonProvider.objectToJSON(requestBody));
+    assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
+    assertThat(response.body().string())
+        .contains("Could not create sync committee signature at phase0 slot 1");
+  }
 }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostSyncCommitteesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostSyncCommitteesIntegrationTest.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUE
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import okhttp3.Response;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.response.v1.beacon.PostSyncCommitteeFailureResponse;
@@ -56,7 +57,8 @@ public class PostSyncCommitteesIntegrationTest extends AbstractDataBackedRestAPI
                 new SubmitCommitteeSignaturesResult(
                     List.of(new SubmitCommitteeSignatureError(UInt64.ZERO, errorString)))));
     when(validatorApiChannel.sendSyncCommitteeSignatures(
-            List.of(requestBody.get(0).asInternalCommitteeSignature())))
+            requestBody.get(0).asInternalCommitteeSignature(spec).stream()
+                .collect(Collectors.toList())))
         .thenReturn(future);
     Response response = post(PostSyncCommittees.ROUTE, jsonProvider.objectToJSON(requestBody));
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -62,6 +62,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostAttestation;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostAttesterSlashing;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostBlock;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostProposerSlashing;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostSyncCommittees;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostVoluntaryExit;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.config.GetDepositContract;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.config.GetForkSchedule;
@@ -343,6 +344,7 @@ public class BeaconRestApi {
     app.post(PostProposerSlashing.ROUTE, new PostProposerSlashing(dataProvider, jsonProvider));
     app.get(GetVoluntaryExits.ROUTE, new GetVoluntaryExits(dataProvider, jsonProvider));
     app.post(PostVoluntaryExit.ROUTE, new PostVoluntaryExit(dataProvider, jsonProvider));
+    app.post(PostSyncCommittees.ROUTE, new PostSyncCommittees(dataProvider, jsonProvider));
   }
 
   private void addEventHandler(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostSyncCommittees.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostSyncCommittees.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
+
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_EXPERIMENTAL;
+import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.google.common.base.Throwables;
+import io.javalin.http.Context;
+import io.javalin.plugin.openapi.annotations.HttpMethod;
+import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiContent;
+import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
+import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.ValidatorDataProvider;
+import tech.pegasys.teku.api.response.v1.beacon.PostSyncCommitteeFailure;
+import tech.pegasys.teku.api.response.v1.beacon.PostSyncCommitteeFailureResponse;
+import tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
+import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.validator.api.SubmitCommitteeSignatureError;
+import tech.pegasys.teku.validator.api.SubmitCommitteeSignaturesResult;
+
+public class PostSyncCommittees extends AbstractHandler {
+  public static final String ROUTE = "/eth/v1/beacon/pool/sync_committees";
+  private final ValidatorDataProvider provider;
+
+  public PostSyncCommittees(final DataProvider provider, final JsonProvider jsonProvider) {
+    this(provider.getValidatorDataProvider(), jsonProvider);
+  }
+
+  public PostSyncCommittees(final ValidatorDataProvider provider, final JsonProvider jsonProvider) {
+    super(jsonProvider);
+    this.provider = provider;
+  }
+
+  @OpenApi(
+      path = ROUTE,
+      method = HttpMethod.POST,
+      summary = "Submit sync committee signatures to node",
+      tags = {TAG_EXPERIMENTAL},
+      requestBody =
+          @OpenApiRequestBody(
+              content = {@OpenApiContent(from = SyncCommitteeSignature.class, isArray = true)}),
+      description =
+          "Submits sync committee signature objects to the node.\n\n"
+              + "Sync committee signatures are not present in phase0, but are required for Altair networks.\n\n"
+              + "If a sync committee signature is validated successfully the node MUST publish that sync committee signature on all applicable subnets.\n\n"
+              + "If one or more sync committee signatures fail validation the node MUST return a 400 error with details of which sync committee signatures have failed, and why.",
+      responses = {
+        @OpenApiResponse(
+            status = RES_OK,
+            description = "The sync committee signatures were accepted, validated, and submitted"),
+        @OpenApiResponse(
+            status = RES_BAD_REQUEST,
+            description = "Errors with one or more sync committee signature",
+            content = @OpenApiContent(from = PostSyncCommitteeFailureResponse.class)),
+        @OpenApiResponse(status = RES_INTERNAL_ERROR)
+      })
+  @Override
+  public void handle(final Context ctx) throws Exception {
+    try {
+      final String body = ctx.body();
+      final List<SyncCommitteeSignature> signatures =
+          Arrays.asList(jsonProvider.jsonToObject(body, SyncCommitteeSignature[].class));
+      final SafeFuture<Optional<SubmitCommitteeSignaturesResult>> future =
+          provider.submitCommitteeSignatures(signatures);
+
+      handleOptionalResult(
+          ctx, future, this::handleResult, this::handleError, SC_SERVICE_UNAVAILABLE);
+
+    } catch (final IllegalArgumentException | JsonMappingException e) {
+      ctx.result(BadRequest.badRequest(jsonProvider, e.getMessage()));
+      ctx.status(SC_BAD_REQUEST);
+    }
+  }
+
+  private Optional<String> handleResult(Context ctx, final SubmitCommitteeSignaturesResult response)
+      throws JsonProcessingException {
+    final List<SubmitCommitteeSignatureError> errors = response.getErrors();
+    if (errors.isEmpty()) {
+      ctx.status(SC_OK);
+      return Optional.empty();
+    }
+
+    final PostSyncCommitteeFailureResponse data =
+        new PostSyncCommitteeFailureResponse(
+            SC_BAD_REQUEST,
+            "Some sync committee subscriptions failed, refer to errors for details",
+            errors.stream()
+                .map(e -> new PostSyncCommitteeFailure(e.getIndex(), e.getMessage()))
+                .collect(Collectors.toList()));
+    ctx.status(SC_BAD_REQUEST);
+    return Optional.of(jsonProvider.objectToJSON(data));
+  }
+
+  private SafeFuture<String> handleError(final Context ctx, final Throwable error) {
+    final Throwable rootCause = Throwables.getRootCause(error);
+    if (rootCause instanceof IllegalArgumentException) {
+      ctx.status(SC_BAD_REQUEST);
+      return SafeFuture.of(() -> BadRequest.badRequest(jsonProvider, rootCause.getMessage()));
+    } else {
+      return failedFuture(error);
+    }
+  }
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -153,7 +153,7 @@ public class ValidatorDataProvider {
       final List<SyncCommitteeSignature> signatures) {
     return validatorApiChannel.sendSyncCommitteeSignatures(
         signatures.stream()
-            .map(SyncCommitteeSignature::asInternalCommitteeSignature)
+            .map(signature -> signature.asInternalCommitteeSignature())
             .collect(Collectors.toList()));
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -17,6 +17,7 @@ import static java.util.stream.Collectors.toList;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.request.v1.validator.BeaconCommitteeSubscriptionRequest;
 import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
@@ -29,6 +30,7 @@ import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.ValidatorBlockResult;
+import tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -38,6 +40,7 @@ import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.validator.api.AttesterDuty;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuty;
+import tech.pegasys.teku.validator.api.SubmitCommitteeSignaturesResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
 public class ValidatorDataProvider {
@@ -142,6 +145,14 @@ public class ValidatorDataProvider {
 
               return new ValidatorBlockResult(responseCode, result.getRejectionReason(), hashRoot);
             });
+  }
+
+  public SafeFuture<Optional<SubmitCommitteeSignaturesResult>> submitCommitteeSignatures(
+      final List<SyncCommitteeSignature> signatures) {
+    return validatorApiChannel.sendSyncCommitteeSignatures(
+        signatures.stream()
+            .map(SyncCommitteeSignature::asInternalCommitteeSignature)
+            .collect(Collectors.toList()));
   }
 
   public SafeFuture<Optional<Attestation>> createAggregate(

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -153,7 +153,7 @@ public class ValidatorDataProvider {
       final List<SyncCommitteeSignature> signatures) {
     return validatorApiChannel.sendSyncCommitteeSignatures(
         signatures.stream()
-            .map(signature -> signature.asInternalCommitteeSignature())
+            .flatMap(signature -> signature.asInternalCommitteeSignature(spec).stream())
             .collect(Collectors.toList()));
   }
 

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/PostSyncCommitteeFailure.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/PostSyncCommitteeFailure.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.response.v1.beacon;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class PostSyncCommitteeFailure {
+  @Schema(type = "string", format = "uint64")
+  public final UInt64 index;
+
+  public final String message;
+
+  @JsonCreator
+  public PostSyncCommitteeFailure(
+      @JsonProperty("index") final UInt64 index, @JsonProperty("message") final String message) {
+    this.index = index;
+    this.message = message;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final PostSyncCommitteeFailure that = (PostSyncCommitteeFailure) o;
+    return Objects.equals(index, that.index) && Objects.equals(message, that.message);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(index, message);
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/PostSyncCommitteeFailureResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/PostSyncCommitteeFailureResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.response.v1.beacon;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class PostSyncCommitteeFailureResponse {
+  @Schema(type = "string", format = "uint64")
+  public final UInt64 code;
+
+  public final String message;
+  public final List<PostSyncCommitteeFailure> failures;
+
+  @JsonCreator
+  public PostSyncCommitteeFailureResponse(
+      @JsonProperty("code") final int code,
+      @JsonProperty("message") final String message,
+      @JsonProperty("failures") final List<PostSyncCommitteeFailure> failures) {
+    this.code = UInt64.valueOf(code);
+    this.message = message;
+    this.failures = failures;
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeSignature.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeSignature.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.schema.altair;
+
+import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES32;
+import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES96;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.schema.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignatureSchema;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.ssz.primitive.SszUInt64;
+
+public class SyncCommitteeSignature {
+  @Schema(type = "string", format = "uint64")
+  @JsonProperty("slot")
+  public final UInt64 slot;
+
+  @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES32)
+  @JsonProperty("beacon_block_root")
+  public final Bytes32 beaconBlockRoot;
+
+  @Schema(type = "string", format = "uint64")
+  @JsonProperty("validator_index")
+  public final UInt64 validatorIndex;
+
+  @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES96)
+  @JsonProperty("signature")
+  public final BLSSignature signature;
+
+  @JsonCreator
+  public SyncCommitteeSignature(
+      @JsonProperty("slot") final UInt64 slot,
+      @JsonProperty("beacon_block_root") final Bytes32 beaconBlockRoot,
+      @JsonProperty("validator_index") final UInt64 validatorIndex,
+      @JsonProperty("signature") final BLSSignature signature) {
+    this.slot = slot;
+    this.beaconBlockRoot = beaconBlockRoot;
+    this.validatorIndex = validatorIndex;
+    this.signature = signature;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final SyncCommitteeSignature that = (SyncCommitteeSignature) o;
+    return Objects.equals(slot, that.slot)
+        && Objects.equals(beaconBlockRoot, that.beaconBlockRoot)
+        && Objects.equals(validatorIndex, that.validatorIndex)
+        && Objects.equals(signature, that.signature);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(slot, beaconBlockRoot, validatorIndex, signature);
+  }
+
+  public static tech.pegasys.teku.spec.datastructures.operations.versions.altair
+          .SyncCommitteeSignature
+      asInternalCommitteeSignature(final SyncCommitteeSignature syncCommitteeSignature) {
+    return new tech.pegasys.teku.spec.datastructures.operations.versions.altair
+        .SyncCommitteeSignature(
+        SyncCommitteeSignatureSchema.INSTANCE,
+        SszUInt64.of(syncCommitteeSignature.slot),
+        SszBytes32.of(syncCommitteeSignature.beaconBlockRoot),
+        SszUInt64.of(syncCommitteeSignature.validatorIndex),
+        new SszSignature(syncCommitteeSignature.signature.asInternalBLSSignature()));
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeSignature.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeSignature.java
@@ -21,8 +21,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
 import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -30,8 +28,6 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 
 public class SyncCommitteeSignature {
-  private static final Logger LOG = LogManager.getLogger();
-
   @Schema(type = "string", format = "uint64")
   @JsonProperty("slot")
   public final UInt64 slot;
@@ -82,10 +78,11 @@ public class SyncCommitteeSignature {
     final Optional<SchemaDefinitionsAltair> maybeSchema =
         spec.atSlot(slot).getSchemaDefinitions().toVersionAltair();
     if (maybeSchema.isEmpty()) {
-      LOG.trace(
-          "could not get schema definition for sync committee at slot {} for validator {}",
-          slot,
-          validatorIndex);
+      final String message =
+          String.format(
+              "Could not create sync committee signature at phase0 slot %s for validator %s",
+              slot, validatorIndex);
+      throw new IllegalArgumentException(message);
     }
     return maybeSchema.map(
         schema ->

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeSignature.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeSignature.java
@@ -73,15 +73,14 @@ public class SyncCommitteeSignature {
     return Objects.hash(slot, beaconBlockRoot, validatorIndex, signature);
   }
 
-  public static tech.pegasys.teku.spec.datastructures.operations.versions.altair
-          .SyncCommitteeSignature
-      asInternalCommitteeSignature(final SyncCommitteeSignature syncCommitteeSignature) {
+  public tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature
+      asInternalCommitteeSignature() {
     return new tech.pegasys.teku.spec.datastructures.operations.versions.altair
         .SyncCommitteeSignature(
         SyncCommitteeSignatureSchema.INSTANCE,
-        SszUInt64.of(syncCommitteeSignature.slot),
-        SszBytes32.of(syncCommitteeSignature.beaconBlockRoot),
-        SszUInt64.of(syncCommitteeSignature.validatorIndex),
-        new SszSignature(syncCommitteeSignature.signature.asInternalBLSSignature()));
+        SszUInt64.of(slot),
+        SszBytes32.of(beaconBlockRoot),
+        SszUInt64.of(validatorIndex),
+        new SszSignature(signature.asInternalBLSSignature()));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitions.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitions.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.schemas;
 
+import java.util.Optional;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
@@ -27,4 +28,6 @@ public interface SchemaDefinitions {
   BeaconBlockSchema getBeaconBlockSchema();
 
   BeaconBlockBodySchema<?> getBeaconBlockBodySchema();
+
+  Optional<SchemaDefinitionsAltair> toVersionAltair();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.schemas;
 
 import com.google.common.base.Preconditions;
+import java.util.Optional;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
@@ -74,6 +75,11 @@ public class SchemaDefinitionsAltair implements SchemaDefinitions {
   @Override
   public BeaconBlockBodySchema<?> getBeaconBlockBodySchema() {
     return beaconBlockBodySchema;
+  }
+
+  @Override
+  public Optional<SchemaDefinitionsAltair> toVersionAltair() {
+    return Optional.of(this);
   }
 
   public SyncCommitteeContributionSchema getSyncCommitteeContributionSchema() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.schemas;
 
+import java.util.Optional;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
@@ -48,5 +49,10 @@ public class SchemaDefinitionsPhase0 implements SchemaDefinitions {
   @Override
   public BeaconBlockBodySchema<?> getBeaconBlockBodySchema() {
     return beaconBlockBodySchema;
+  }
+
+  @Override
+  public Optional<SchemaDefinitionsAltair> toVersionAltair() {
+    return Optional.empty();
   }
 }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -183,6 +183,11 @@ public class SafeFuture<T> extends CompletableFuture<T> {
         .thenApply(__ -> Stream.of(futures).map(SafeFuture::join).collect(toList()));
   }
 
+  @SuppressWarnings("unchecked")
+  public static <T> SafeFuture<List<T>> collectAll(final Stream<SafeFuture<T>> futures) {
+    return collectAll(futures.toArray(SafeFuture[]::new));
+  }
+
   /**
    * Adds the {@link Throwable} from each future as a suppressed exception to completionException
    * unless it is already set as the cause.

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -188,11 +188,6 @@ public class SafeFuture<T> extends CompletableFuture<T> {
         .thenApply(__ -> Stream.of(futures).map(SafeFuture::join).collect(toList()));
   }
 
-  @SuppressWarnings("unchecked")
-  public static <T> SafeFuture<List<T>> collectAll(final Stream<SafeFuture<T>> futures) {
-    return collectAll(futures.toArray(SafeFuture[]::new));
-  }
-
   /**
    * Adds the {@link Throwable} from each future as a suppressed exception to completionException
    * unless it is already set as the cause.

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -490,7 +490,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             DutyMetrics.create(metricsSystem, timeProvider, recentChainData, spec),
             performanceTracker,
             spec,
-            forkChoiceTrigger);
+            forkChoiceTrigger,
+            syncCommitteeSignaturePool);
     eventChannels
         .subscribe(SlotEventsChannel.class, attestationTopicSubscriber)
         .subscribe(SlotEventsChannel.class, activeValidatorTracker)

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitCommitteeSignatureError.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitCommitteeSignatureError.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.api;
+
+import java.util.Objects;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class SubmitCommitteeSignatureError {
+  private final UInt64 index;
+  private final String message;
+
+  public SubmitCommitteeSignatureError(final UInt64 index, final String message) {
+    this.index = index;
+    this.message = message;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final SubmitCommitteeSignatureError that = (SubmitCommitteeSignatureError) o;
+    return Objects.equals(index, that.index) && Objects.equals(message, that.message);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(index, message);
+  }
+
+  public UInt64 getIndex() {
+    return index;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitCommitteeSignaturesResult.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitCommitteeSignaturesResult.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.api;
+
+import java.util.List;
+import java.util.Objects;
+
+public class SubmitCommitteeSignaturesResult {
+  private final List<SubmitCommitteeSignatureError> errors;
+
+  public SubmitCommitteeSignaturesResult(final List<SubmitCommitteeSignatureError> errors) {
+    this.errors = errors;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final SubmitCommitteeSignaturesResult that = (SubmitCommitteeSignaturesResult) o;
+    return Objects.equals(errors, that.errors);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(errors);
+  }
+
+  public List<SubmitCommitteeSignatureError> getErrors() {
+    return errors;
+  }
+}

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 
@@ -72,4 +73,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
   void sendAggregateAndProof(SignedAggregateAndProof aggregateAndProof);
 
   SafeFuture<SendSignedBlockResult> sendSignedBlock(SignedBeaconBlock block);
+
+  SafeFuture<Optional<SubmitCommitteeSignaturesResult>> sendSyncCommitteeSignatures(
+      List<SyncCommitteeSignature> syncCommitteeSignatures);
 }

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -33,12 +33,14 @@ import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.validator.api.AttesterDuties;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
+import tech.pegasys.teku.validator.api.SubmitCommitteeSignaturesResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
 public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
@@ -70,6 +72,8 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   public static final String PUBLISHED_AGGREGATE_COUNTER_NAME =
       "beacon_node_published_aggregate_total";
   public static final String PUBLISHED_BLOCK_COUNTER_NAME = "beacon_node_published_block_total";
+  public static final String COMMITTEE_SUBSCRIPTION_COUNTER_NAME =
+      "beacon_node_subscribe_sync_committee_total";
   private final ValidatorApiChannel delegate;
   private final BeaconChainRequestCounter forkInfoRequestCounter;
   private final BeaconChainRequestCounter genesisTimeRequestCounter;
@@ -85,6 +89,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   private final Counter sendAttestationRequestCounter;
   private final Counter sendAggregateRequestCounter;
   private final Counter sendBlockRequestCounter;
+  private final Counter subscribeSyncCommitteesRequestCounter;
 
   public MetricRecordingValidatorApiChannel(
       final MetricsSystem metricsSystem, final ValidatorApiChannel delegate) {
@@ -160,6 +165,11 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
         metricsSystem.createCounter(
             TekuMetricCategory.VALIDATOR,
             PUBLISHED_BLOCK_COUNTER_NAME,
+            "Counter recording the number of signed blocks sent to the beacon node");
+    subscribeSyncCommitteesRequestCounter =
+        metricsSystem.createCounter(
+            TekuMetricCategory.VALIDATOR,
+            COMMITTEE_SUBSCRIPTION_COUNTER_NAME,
             "Counter recording the number of signed blocks sent to the beacon node");
   }
 
@@ -262,6 +272,13 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   public SafeFuture<SendSignedBlockResult> sendSignedBlock(final SignedBeaconBlock block) {
     sendBlockRequestCounter.inc();
     return delegate.sendSignedBlock(block);
+  }
+
+  @Override
+  public SafeFuture<Optional<SubmitCommitteeSignaturesResult>> sendSyncCommitteeSignatures(
+      final List<SyncCommitteeSignature> syncCommitteeSignatures) {
+    subscribeSyncCommitteesRequestCounter.inc();
+    return delegate.sendSyncCommitteeSignatures(syncCommitteeSignatures);
   }
 
   private <T> SafeFuture<Optional<T>> countRequest(

--- a/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeSignaturePool;
 import tech.pegasys.teku.storage.client.ChainUpdater;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.server.StateStorageMode;
@@ -73,6 +74,8 @@ public class ValidatorApiHandlerIntegrationTest {
   private final ForkChoiceTrigger forkChoiceTrigger = mock(ForkChoiceTrigger.class);
 
   private final ChainUpdater chainUpdater = storageSystem.chainUpdater();
+  private final SyncCommitteeSignaturePool syncCommitteeSignaturePool =
+      mock(SyncCommitteeSignaturePool.class);
   private final ValidatorApiHandler handler =
       new ValidatorApiHandler(
           chainDataProvider,
@@ -88,7 +91,8 @@ public class ValidatorApiHandlerIntegrationTest {
           mock(DutyMetrics.class),
           performanceTracker,
           spec,
-          forkChoiceTrigger);
+          forkChoiceTrigger,
+          syncCommitteeSignaturePool);
 
   @BeforeEach
   public void setup() {

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -500,14 +500,13 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
 
   private Optional<SubmitCommitteeSignaturesResult> getSendSyncCommitteesResultFromFutures(
       final List<InternalValidationResult> internalValidationResults) {
-    final List<SubmitCommitteeSignatureError> errorList =
-        internalValidationResults.stream()
-            .flatMap(
-                validationResult ->
-                    this.fromInternalValidationResult(
-                        validationResult, internalValidationResults.indexOf(validationResult))
-                        .stream())
-            .collect(toList());
+    final List<SubmitCommitteeSignatureError> errorList = new ArrayList<>();
+    for (int index = 0; index < internalValidationResults.size(); index++) {
+      final Optional<SubmitCommitteeSignatureError> maybeError =
+          fromInternalValidationResult(internalValidationResults.get(index), index);
+      maybeError.ifPresent(errorList::add);
+    }
+
     if (errorList.isEmpty()) {
       return Optional.empty();
     }

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -54,6 +54,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
@@ -67,6 +68,8 @@ import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeSignaturePool;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.sync.events.SyncStateProvider;
 import tech.pegasys.teku.validator.api.AttesterDuties;
@@ -76,6 +79,7 @@ import tech.pegasys.teku.validator.api.NodeSyncingException;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.ProposerDuty;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
+import tech.pegasys.teku.validator.api.SubmitCommitteeSignatureError;
 import tech.pegasys.teku.validator.api.SubmitCommitteeSignaturesResult;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuty;
@@ -106,6 +110,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   private final PerformanceTracker performanceTracker;
   private final Spec spec;
   private final ForkChoiceTrigger forkChoiceTrigger;
+  private final SyncCommitteeSignaturePool syncCommitteeSignaturePool;
 
   public ValidatorApiHandler(
       final ChainDataProvider chainDataProvider,
@@ -121,7 +126,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final DutyMetrics dutyMetrics,
       final PerformanceTracker performanceTracker,
       final Spec spec,
-      final ForkChoiceTrigger forkChoiceTrigger) {
+      final ForkChoiceTrigger forkChoiceTrigger,
+      final SyncCommitteeSignaturePool syncCommitteeSignaturePool) {
     this.chainDataProvider = chainDataProvider;
     this.combinedChainDataClient = combinedChainDataClient;
     this.syncStateProvider = syncStateProvider;
@@ -136,6 +142,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     this.performanceTracker = performanceTracker;
     this.spec = spec;
     this.forkChoiceTrigger = forkChoiceTrigger;
+    this.syncCommitteeSignaturePool = syncCommitteeSignaturePool;
   }
 
   @Override
@@ -480,8 +487,42 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<SubmitCommitteeSignaturesResult>> sendSyncCommitteeSignatures(
       final List<SyncCommitteeSignature> syncCommitteeSignatures) {
-    // TODO 3906 implement send sync committee signatures
-    throw new UnsupportedOperationException("sendSyncCommitteeSignatures not implemented yet.");
+
+    final List<SafeFuture<InternalValidationResult>> addedSignatures =
+        syncCommitteeSignatures.stream()
+            .map(ValidateableSyncCommitteeSignature::fromValidator)
+            .map(syncCommitteeSignaturePool::add)
+            .collect(toList());
+
+    return SafeFuture.collectAll(addedSignatures.stream())
+        .thenApply(this::getSendSyncCommitteesResultFromFutures);
+  }
+
+  private Optional<SubmitCommitteeSignaturesResult> getSendSyncCommitteesResultFromFutures(
+      final List<InternalValidationResult> internalValidationResults) {
+    final List<SubmitCommitteeSignatureError> errorList =
+        internalValidationResults.stream()
+            .flatMap(
+                validationResult ->
+                    this.fromInternalValidationResult(
+                        validationResult, internalValidationResults.indexOf(validationResult))
+                        .stream())
+            .collect(toList());
+    if (errorList.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(new SubmitCommitteeSignaturesResult(errorList));
+  }
+
+  private Optional<SubmitCommitteeSignatureError> fromInternalValidationResult(
+      final InternalValidationResult internalValidationResult, final int resultIndex) {
+    if (!internalValidationResult.isReject()) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        new SubmitCommitteeSignatureError(
+            UInt64.valueOf(resultIndex),
+            internalValidationResult.getDescription().orElse("Rejected")));
   }
 
   @VisibleForTesting

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -51,6 +51,7 @@ import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
@@ -72,6 +73,7 @@ import tech.pegasys.teku.validator.api.NodeSyncingException;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.ProposerDuty;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
+import tech.pegasys.teku.validator.api.SubmitCommitteeSignaturesResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 
@@ -452,6 +454,13 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                 return SendSignedBlockResult.notImported(result.getFailureReason().name());
               }
             });
+  }
+
+  @Override
+  public SafeFuture<Optional<SubmitCommitteeSignaturesResult>> sendSyncCommitteeSignatures(
+      final List<SyncCommitteeSignature> syncCommitteeSignatures) {
+    // TODO 3906 implement send sync committee signatures
+    throw new UnsupportedOperationException("sendSyncCommitteeSignatures not implemented yet.");
   }
 
   @VisibleForTesting

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -67,6 +67,7 @@ import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeSignaturePool;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.sync.events.SyncState;
 import tech.pegasys.teku.sync.events.SyncStateProvider;
@@ -103,6 +104,8 @@ class ValidatorApiHandlerTest {
   private final ChainDataProvider chainDataProvider = mock(ChainDataProvider.class);
   private final DutyMetrics dutyMetrics = mock(DutyMetrics.class);
   private final ForkChoiceTrigger forkChoiceTrigger = mock(ForkChoiceTrigger.class);
+  private final SyncCommitteeSignaturePool syncCommitteeSignaturePool =
+      mock(SyncCommitteeSignaturePool.class);
 
   private final ValidatorApiHandler validatorApiHandler =
       new ValidatorApiHandler(
@@ -119,7 +122,8 @@ class ValidatorApiHandlerTest {
           dutyMetrics,
           performanceTracker,
           spec,
-          forkChoiceTrigger);
+          forkChoiceTrigger,
+          syncCommitteeSignaturePool);
 
   @BeforeEach
   public void setUp() {

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -34,6 +34,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.CheckpointState;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
@@ -68,6 +70,8 @@ import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeSignaturePool;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.sync.events.SyncState;
 import tech.pegasys.teku.sync.events.SyncStateProvider;
@@ -78,13 +82,15 @@ import tech.pegasys.teku.validator.api.NodeSyncingException;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.ProposerDuty;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
+import tech.pegasys.teku.validator.api.SubmitCommitteeSignatureError;
+import tech.pegasys.teku.validator.api.SubmitCommitteeSignaturesResult;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
 
 class ValidatorApiHandlerTest {
 
   private static final UInt64 EPOCH = UInt64.valueOf(13);
   private static final UInt64 PREVIOUS_EPOCH = EPOCH.minus(ONE);
-  private final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private final Spec spec = TestSpecFactory.createMinimalAltair();
   private final UInt64 EPOCH_START_SLOT = spec.computeStartSlotAtEpoch(EPOCH);
   private final UInt64 PREVIOUS_EPOCH_START_SLOT = spec.computeStartSlotAtEpoch(PREVIOUS_EPOCH);
 
@@ -625,6 +631,48 @@ class ValidatorApiHandlerTest {
     assertThatSafeFuture(
             validatorApiHandler.getValidatorIndices(List.of(validator0, unknownValidator)))
         .isCompletedWithValue(Map.of(validator0, 0));
+  }
+
+  @Test
+  void sendSyncCommitteeSignatures_shouldAllowEmptyRequest() {
+    final List<SyncCommitteeSignature> signatures = List.of();
+    final SafeFuture<Optional<SubmitCommitteeSignaturesResult>> result =
+        validatorApiHandler.sendSyncCommitteeSignatures(signatures);
+    assertThat(result).isCompleted();
+  }
+
+  @Test
+  void sendSyncCommitteeSignatures_shouldAddSignaturesToPool()
+      throws ExecutionException, InterruptedException {
+    final SyncCommitteeSignature signature = dataStructureUtil.randomSyncCommitteeSignature();
+    final List<SyncCommitteeSignature> signatures = List.of(signature);
+    when(syncCommitteeSignaturePool.add(any()))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                InternalValidationResult.create(ValidationResultCode.ACCEPT, "")));
+    final SafeFuture<Optional<SubmitCommitteeSignaturesResult>> result =
+        validatorApiHandler.sendSyncCommitteeSignatures(signatures);
+    assertThat(result).isCompleted();
+    assertThat(result.get()).isEmpty();
+  }
+
+  @Test
+  void sendSyncCommitteeSignatures_shouldRaiseErrors()
+      throws ExecutionException, InterruptedException {
+    final SyncCommitteeSignature signature = dataStructureUtil.randomSyncCommitteeSignature();
+    final List<SyncCommitteeSignature> signatures = List.of(signature);
+    when(syncCommitteeSignaturePool.add(any()))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                InternalValidationResult.create(ValidationResultCode.REJECT, "Rejected")));
+    final SafeFuture<Optional<SubmitCommitteeSignaturesResult>> result =
+        validatorApiHandler.sendSyncCommitteeSignatures(signatures);
+    assertThat(result).isCompleted();
+    final SubmitCommitteeSignaturesResult unwrappedResult = result.get().orElseThrow();
+    assertThat(unwrappedResult)
+        .isEqualTo(
+            new SubmitCommitteeSignaturesResult(
+                List.of(new SubmitCommitteeSignatureError(UInt64.ZERO, "Rejected"))));
   }
 
   private <T> Optional<T> assertCompletedSuccessfully(final SafeFuture<Optional<T>> result) {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -297,13 +297,13 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
                 .sendSyncCommitteeSignatures(
                     syncCommitteeSignatures.stream()
                         .map(
-                            i ->
+                            signature ->
                                 new tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature(
-                                    i.getSlot(),
-                                    i.getBeaconBlockRoot(),
-                                    i.getValidatorIndex(),
+                                    signature.getSlot(),
+                                    signature.getBeaconBlockRoot(),
+                                    signature.getValidatorIndex(),
                                     new tech.pegasys.teku.api.schema.BLSSignature(
-                                        i.getSignature())))
+                                        signature.getSignature())))
                         .collect(Collectors.toList()))
                 .map(this::responseToSyncCommitteeSignatures));
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -58,6 +58,7 @@ import tech.pegasys.teku.api.response.v1.beacon.GetBlockHeaderResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateValidatorsResponse;
+import tech.pegasys.teku.api.response.v1.beacon.PostSyncCommitteeFailureResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.config.GetSpecResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationResponse;
@@ -74,6 +75,7 @@ import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.api.schema.SubnetSubscription;
+import tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
@@ -246,6 +248,13 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   @Override
   public void subscribeToPersistentSubnets(final Set<SubnetSubscription> subnetSubscriptions) {
     post(SUBSCRIBE_TO_PERSISTENT_SUBNETS, subnetSubscriptions, createHandler());
+  }
+
+  @Override
+  public Optional<PostSyncCommitteeFailureResponse> sendSyncCommitteeSignatures(
+      final List<SyncCommitteeSignature> syncCommitteeSignatures) {
+    // FIXME
+    return Optional.empty();
   }
 
   private ResponseHandler<Void> createHandler() {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -258,7 +258,8 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
     // FIXME
     return Optional.empty();
   }
-    @Override
+
+  @Override
   public Optional<PostSyncDutiesResponse> getSyncCommitteeDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndices) {
     return post(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -31,6 +31,7 @@ import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SE
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_ATTESTATION;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_BLOCK;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_VOLUNTARY_EXIT;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SYNC_COMMITTEE_SIGNATURES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_BEACON_COMMITTEE_SUBNET;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_PERSISTENT_SUBNETS;
 
@@ -255,8 +256,10 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   @Override
   public Optional<PostSyncCommitteeFailureResponse> sendSyncCommitteeSignatures(
       final List<SyncCommitteeSignature> syncCommitteeSignatures) {
-    // FIXME
-    return Optional.empty();
+    return post(
+        SEND_SYNC_COMMITTEE_SIGNATURES,
+        syncCommitteeSignatures,
+        createHandler(PostSyncCommitteeFailureResponse.class));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -29,6 +29,7 @@ public enum ValidatorApiMethod {
   GET_ATTESTATION_DATA("eth/v1/validator/attestation_data"),
   SEND_SIGNED_ATTESTATION("eth/v1/beacon/pool/attestations"),
   SEND_SIGNED_VOLUNTARY_EXIT("eth/v1/beacon/pool/voluntary_exits"),
+  SEND_SYNC_COMMITTEE_SIGNATURES("eth/v1/beacon/pool/sync_committees"),
   GET_AGGREGATE("eth/v1/validator/aggregate_attestation"),
   SEND_SIGNED_AGGREGATE_AND_PROOF("/eth/v1/validator/aggregate_and_proofs"),
   SUBSCRIBE_TO_BEACON_COMMITTEE_SUBNET("eth/v1/validator/beacon_committee_subscriptions"),

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
+import tech.pegasys.teku.api.response.v1.beacon.PostSyncCommitteeFailureResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
@@ -31,6 +32,7 @@ import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.api.schema.SubnetSubscription;
+import tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
@@ -68,4 +70,7 @@ public interface ValidatorRestApiClient {
   void subscribeToBeaconCommittee(List<CommitteeSubscriptionRequest> requests);
 
   void subscribeToPersistentSubnets(Set<SubnetSubscription> subnetSubscriptions);
+
+  Optional<PostSyncCommitteeFailureResponse> sendSyncCommitteeSignatures(
+      List<SyncCommitteeSignature> syncCommitteeSignatures);
 }


### PR DESCRIPTION
 - in order to support the altair milestone, validators need to be able to submit sync committee signatures.

 - currently marked experimental as the standard api spec is not finalized.

fixes #3906

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
