### PR TITLE
[Issue 3883] Set syncnets ENR field

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
@@ -272,22 +272,19 @@ public class ActiveEth2P2PNetwork extends DelegatingP2PNetwork<Eth2Peer> impleme
 
   @Override
   public void setLongTermAttestationSubnetSubscriptions(final Iterable<Integer> subnetIndices) {
-    attestationSubnetService.updateSubscriptions(subnetIndices);
+    attestationSubnetService.setSubscriptions(subnetIndices);
   }
 
   @Override
   public void subscribeToSyncCommitteeSubnetId(final int subnetId) {
     gossipForkManager.subscribeToSyncCommitteeSubnetId(subnetId);
+    syncCommitteeSubnetService.addSubscription(subnetId);
   }
 
   @Override
   public void unsubscribeFromSyncCommitteeSubnetId(final int subnetId) {
     gossipForkManager.unsubscribeFromSyncCommitteeSubnetId(subnetId);
-  }
-
-  @Override
-  public void setSyncCommitteeSubnetSubscriptions(final Iterable<Integer> subnetIndices) {
-    syncCommitteeSubnetService.updateSubscriptions(subnetIndices);
+    syncCommitteeSubnetService.removeSubscription(subnetId);
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetwork.java
@@ -32,7 +32,5 @@ public interface Eth2P2PNetwork extends P2PNetwork<Eth2Peer> {
 
   void unsubscribeFromSyncCommitteeSubnetId(final int subnetId);
 
-  void setSyncCommitteeSubnetSubscriptions(final Iterable<Integer> subnetIndices);
-
   MetadataMessage getMetadata();
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetwork.java
@@ -28,5 +28,11 @@ public interface Eth2P2PNetwork extends P2PNetwork<Eth2Peer> {
 
   void setLongTermAttestationSubnetSubscriptions(final Iterable<Integer> subnetIndices);
 
+  void subscribeToSyncCommitteeSubnetId(final int subnetId);
+
+  void unsubscribeFromSyncCommitteeSubnetId(final int subnetId);
+
+  void setSyncCommitteeSubnetSubscriptions(final Iterable<Integer> subnetIndices);
+
   MetadataMessage getMetadata();
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -115,7 +115,8 @@ public class Eth2P2PNetworkBuilder {
     validate();
 
     // Setup eth2 handlers
-    final AttestationSubnetService attestationSubnetService = new AttestationSubnetService();
+    final SubnetSubscriptionService attestationSubnetService = new SubnetSubscriptionService();
+    final SubnetSubscriptionService syncCommitteeSubnetService = new SubnetSubscriptionService();
     final RpcEncoding rpcEncoding = RpcEncoding.SSZ_SNAPPY;
     final Eth2PeerManager eth2PeerManager =
         Eth2PeerManager.create(
@@ -153,6 +154,7 @@ public class Eth2P2PNetworkBuilder {
         eventChannels,
         recentChainData,
         attestationSubnetService,
+        syncCommitteeSubnetService,
         gossipEncoding,
         config.getGossipConfigurator(),
         processedAttestationSubscriptionProvider);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/SubnetSubscriptionService.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/SubnetSubscriptionService.java
@@ -20,18 +20,18 @@ import tech.pegasys.teku.infrastructure.subscribers.ValueObserver;
  * Service tracks long term attestation subnet subscriptions and notifies subscribers on their
  * changes
  */
-public class AttestationSubnetService {
-  ObservableValue<Iterable<Integer>> attSubnetSubscriptions = new ObservableValue<>(true);
+public class SubnetSubscriptionService {
+  ObservableValue<Iterable<Integer>> subnetSubscriptions = new ObservableValue<>(true);
 
   public synchronized void updateSubscriptions(final Iterable<Integer> subnetIndices) {
-    attSubnetSubscriptions.set(subnetIndices);
+    subnetSubscriptions.set(subnetIndices);
   }
 
   public synchronized long subscribeToUpdates(ValueObserver<Iterable<Integer>> observer) {
-    return attSubnetSubscriptions.subscribe(observer);
+    return subnetSubscriptions.subscribe(observer);
   }
 
   public void unsubscribe(long subscriptionId) {
-    attSubnetSubscriptions.unsubscribe(subscriptionId);
+    subnetSubscriptions.unsubscribe(subscriptionId);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/SubnetSubscriptionService.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/SubnetSubscriptionService.java
@@ -13,6 +13,9 @@
 
 package tech.pegasys.teku.networking.eth2;
 
+import com.google.common.collect.Sets;
+import java.util.HashSet;
+import java.util.Set;
 import tech.pegasys.teku.infrastructure.subscribers.ObservableValue;
 import tech.pegasys.teku.infrastructure.subscribers.ValueObserver;
 
@@ -23,8 +26,20 @@ import tech.pegasys.teku.infrastructure.subscribers.ValueObserver;
 public class SubnetSubscriptionService {
   ObservableValue<Iterable<Integer>> subnetSubscriptions = new ObservableValue<>(true);
 
-  public synchronized void updateSubscriptions(final Iterable<Integer> subnetIndices) {
+  public synchronized void setSubscriptions(final Iterable<Integer> subnetIndices) {
     subnetSubscriptions.set(subnetIndices);
+  }
+
+  public synchronized void addSubscription(final int subnet) {
+    final Set<Integer> values = getSubnets();
+    values.add(subnet);
+    subnetSubscriptions.set(values);
+  }
+
+  public synchronized void removeSubscription(final int subnet) {
+    final Set<Integer> values = getSubnets();
+    values.remove(subnet);
+    subnetSubscriptions.set(values);
   }
 
   public synchronized long subscribeToUpdates(ValueObserver<Iterable<Integer>> observer) {
@@ -33,5 +48,9 @@ public class SubnetSubscriptionService {
 
   public void unsubscribe(long subscriptionId) {
     subnetSubscriptions.unsubscribe(subscriptionId);
+  }
+
+  private Set<Integer> getSubnets() {
+    return subnetSubscriptions.get().map(Sets::newHashSet).orElseGet(HashSet::new);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/mock/NoOpEth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/mock/NoOpEth2P2PNetwork.java
@@ -40,9 +40,6 @@ public class NoOpEth2P2PNetwork extends MockP2PNetwork<Eth2Peer> implements Eth2
   public void unsubscribeFromSyncCommitteeSubnetId(final int subnetId) {}
 
   @Override
-  public void setSyncCommitteeSubnetSubscriptions(final Iterable<Integer> subnetIndices) {}
-
-  @Override
   public MetadataMessage getMetadata() {
     return MetadataMessage.DEFAULT;
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/mock/NoOpEth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/mock/NoOpEth2P2PNetwork.java
@@ -34,6 +34,15 @@ public class NoOpEth2P2PNetwork extends MockP2PNetwork<Eth2Peer> implements Eth2
   public void setLongTermAttestationSubnetSubscriptions(final Iterable<Integer> subnetIndices) {}
 
   @Override
+  public void subscribeToSyncCommitteeSubnetId(final int subnetId) {}
+
+  @Override
+  public void unsubscribeFromSyncCommitteeSubnetId(final int subnetId) {}
+
+  @Override
+  public void setSyncCommitteeSubnetSubscriptions(final Iterable<Integer> subnetIndices) {}
+
+  @Override
   public MetadataMessage getMetadata() {
     return MetadataMessage.DEFAULT;
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -28,7 +28,7 @@ import tech.pegasys.teku.infrastructure.async.RootCauseExceptionHandler;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
-import tech.pegasys.teku.networking.eth2.AttestationSubnetService;
+import tech.pegasys.teku.networking.eth2.SubnetSubscriptionService;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.MetadataMessagesFactory;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
@@ -102,7 +102,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
       final RecentChainData recentChainData,
       final StorageQueryChannel historicalChainData,
       final MetricsSystem metricsSystem,
-      final AttestationSubnetService attestationSubnetService,
+      final SubnetSubscriptionService attestationSubnetService,
       final RpcEncoding rpcEncoding,
       final Optional<Checkpoint> requiredCheckpoint,
       final Duration eth2RpcPingInterval,

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetworkTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetworkTest.java
@@ -59,8 +59,10 @@ public class ActiveEth2P2PNetworkTest {
   private final Eth2PeerManager peerManager = mock(Eth2PeerManager.class);
   private final GossipForkManager gossipForkManager = mock(GossipForkManager.class);
   private final EventChannels eventChannels = mock(EventChannels.class);
-  private final AttestationSubnetService attestationSubnetService =
-      mock(AttestationSubnetService.class);
+  private final SubnetSubscriptionService attestationSubnetService =
+      mock(SubnetSubscriptionService.class);
+  private final SubnetSubscriptionService syncCommitteeSubnetService =
+      mock(SubnetSubscriptionService.class);
 
   // Real dependencies
   private final RecentChainData recentChainData = storageSystem.recentChainData();
@@ -150,6 +152,7 @@ public class ActiveEth2P2PNetworkTest {
         eventChannels,
         recentChainData,
         attestationSubnetService,
+        syncCommitteeSubnetService,
         gossipEncoding,
         gossipConfigurator,
         processedAttestationSubscriptionProvider);

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -173,7 +173,9 @@ public class Eth2P2PNetworkFactory {
     protected Eth2P2PNetwork buildNetwork(final P2PConfig config) {
       {
         // Setup eth2 handlers
-        final AttestationSubnetService attestationSubnetService = new AttestationSubnetService();
+        final SubnetSubscriptionService attestationSubnetService = new SubnetSubscriptionService();
+        final SubnetSubscriptionService syncCommitteeSubnetService =
+            new SubnetSubscriptionService();
         final Eth2PeerManager eth2PeerManager =
             Eth2PeerManager.create(
                 asyncRunner,
@@ -274,6 +276,7 @@ public class Eth2P2PNetworkFactory {
             eventChannels,
             recentChainData,
             attestationSubnetService,
+            syncCommitteeSubnetService,
             gossipEncoding,
             GossipConfigurator.NOOP,
             processedAttestationSubscriptionProvider);

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.p2p.discovery;
 
 import static java.util.stream.Collectors.toList;
+import static tech.pegasys.teku.spec.constants.NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT;
 import static tech.pegasys.teku.util.config.Constants.ATTESTATION_SUBNET_COUNT;
 
 import java.util.Optional;
@@ -50,6 +51,7 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
   private static final Logger LOG = LogManager.getLogger();
 
   public static final String ATTESTATION_SUBNET_ENR_FIELD = "attnets";
+  public static final String SYNC_COMMITTEE_SUBNET_ENR_FIELD = "syncnets";
   public static final String ETH2_ENR_FIELD = "eth2";
 
   private final Spec spec;
@@ -157,6 +159,12 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
     discoveryService.updateCustomENRField(
         ATTESTATION_SUBNET_ENR_FIELD,
         SszBitvectorSchema.create(ATTESTATION_SUBNET_COUNT).ofBits(subnetIds).sszSerialize());
+  }
+
+  public void setSyncCommitteeSubnetSubscriptions(Iterable<Integer> subnetIds) {
+    discoveryService.updateCustomENRField(
+        SYNC_COMMITTEE_SUBNET_ENR_FIELD,
+        SszBitvectorSchema.create(SYNC_COMMITTEE_SUBNET_COUNT).ofBits(subnetIds).sszSerialize());
   }
 
   public void setPreGenesisForkInfo() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add methods for adding / removing sync committee subnet subscriptions to `Eth2P2PNetwork`.  When sync committee subscriptions are updated, update discovery `syncnets` ENR field. 

## Fixed Issue(s)
Fixes #3883

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
