### PR TITLE
Return an empty list of errors instead of an Optional from sendSyncCommitteeSignatures

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostSyncCommitteesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostSyncCommitteesIntegrationTest.java
@@ -19,7 +19,6 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUE
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import okhttp3.Response;
 import org.junit.jupiter.api.Test;
@@ -34,7 +33,6 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.SubmitCommitteeSignatureError;
-import tech.pegasys.teku.validator.api.SubmitCommitteeSignaturesResult;
 
 public class PostSyncCommitteesIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
   private final String errorString = "The Error Description";
@@ -51,11 +49,9 @@ public class PostSyncCommitteesIntegrationTest extends AbstractDataBackedRestAPI
                 dataStructureUtil.randomBytes32(),
                 dataStructureUtil.randomUInt64(),
                 new BLSSignature(dataStructureUtil.randomSignature())));
-    final SafeFuture<Optional<SubmitCommitteeSignaturesResult>> future =
+    final SafeFuture<List<SubmitCommitteeSignatureError>> future =
         SafeFuture.completedFuture(
-            Optional.of(
-                new SubmitCommitteeSignaturesResult(
-                    List.of(new SubmitCommitteeSignatureError(UInt64.ZERO, errorString)))));
+            List.of(new SubmitCommitteeSignatureError(UInt64.ZERO, errorString)));
     when(validatorApiChannel.sendSyncCommitteeSignatures(
             requestBody.get(0).asInternalCommitteeSignature(spec).stream()
                 .collect(Collectors.toList())))

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -151,10 +151,16 @@ public class ValidatorDataProvider {
 
   public SafeFuture<Optional<SubmitCommitteeSignaturesResult>> submitCommitteeSignatures(
       final List<SyncCommitteeSignature> signatures) {
-    return validatorApiChannel.sendSyncCommitteeSignatures(
-        signatures.stream()
-            .flatMap(signature -> signature.asInternalCommitteeSignature(spec).stream())
-            .collect(Collectors.toList()));
+    return validatorApiChannel
+        .sendSyncCommitteeSignatures(
+            signatures.stream()
+                .flatMap(signature -> signature.asInternalCommitteeSignature(spec).stream())
+                .collect(Collectors.toList()))
+        .thenApply(
+            errors ->
+                errors.isEmpty()
+                    ? Optional.empty()
+                    : Optional.of(new SubmitCommitteeSignaturesResult(errors)));
   }
 
   public SafeFuture<Optional<Attestation>> createAggregate(

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -77,6 +77,6 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<SendSignedBlockResult> sendSignedBlock(SignedBeaconBlock block);
 
-  SafeFuture<Optional<SubmitCommitteeSignaturesResult>> sendSyncCommitteeSignatures(
+  SafeFuture<List<SubmitCommitteeSignatureError>> sendSyncCommitteeSignatures(
       List<SyncCommitteeSignature> syncCommitteeSignatures);
 }

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -40,7 +40,7 @@ import tech.pegasys.teku.validator.api.AttesterDuties;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
-import tech.pegasys.teku.validator.api.SubmitCommitteeSignaturesResult;
+import tech.pegasys.teku.validator.api.SubmitCommitteeSignatureError;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
@@ -292,7 +292,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<SubmitCommitteeSignaturesResult>> sendSyncCommitteeSignatures(
+  public SafeFuture<List<SubmitCommitteeSignatureError>> sendSyncCommitteeSignatures(
       final List<SyncCommitteeSignature> syncCommitteeSignatures) {
     subscribeSyncCommitteesRequestCounter.inc();
     return delegate.sendSyncCommitteeSignatures(syncCommitteeSignatures);

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -80,7 +80,6 @@ import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.ProposerDuty;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.SubmitCommitteeSignatureError;
-import tech.pegasys.teku.validator.api.SubmitCommitteeSignaturesResult;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuty;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
@@ -485,7 +484,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<SubmitCommitteeSignaturesResult>> sendSyncCommitteeSignatures(
+  public SafeFuture<List<SubmitCommitteeSignatureError>> sendSyncCommitteeSignatures(
       final List<SyncCommitteeSignature> syncCommitteeSignatures) {
 
     final List<SafeFuture<InternalValidationResult>> addedSignatures =
@@ -498,7 +497,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
         .thenApply(this::getSendSyncCommitteesResultFromFutures);
   }
 
-  private Optional<SubmitCommitteeSignaturesResult> getSendSyncCommitteesResultFromFutures(
+  private List<SubmitCommitteeSignatureError> getSendSyncCommitteesResultFromFutures(
       final List<InternalValidationResult> internalValidationResults) {
     final List<SubmitCommitteeSignatureError> errorList = new ArrayList<>();
     for (int index = 0; index < internalValidationResults.size(); index++) {
@@ -506,11 +505,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
           fromInternalValidationResult(internalValidationResults.get(index), index);
       maybeError.ifPresent(errorList::add);
     }
-
-    if (errorList.isEmpty()) {
-      return Optional.empty();
-    }
-    return Optional.of(new SubmitCommitteeSignaturesResult(errorList));
+    return errorList;
   }
 
   private Optional<SubmitCommitteeSignatureError> fromInternalValidationResult(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.remote;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toMap;
 
@@ -58,7 +59,6 @@ import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.ProposerDuty;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.SubmitCommitteeSignatureError;
-import tech.pegasys.teku.validator.api.SubmitCommitteeSignaturesResult;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuty;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
@@ -289,7 +289,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<SubmitCommitteeSignaturesResult>> sendSyncCommitteeSignatures(
+  public SafeFuture<List<SubmitCommitteeSignatureError>> sendSyncCommitteeSignatures(
       final List<SyncCommitteeSignature> syncCommitteeSignatures) {
     return sendRequest(
         () ->
@@ -305,15 +305,15 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
                                     new tech.pegasys.teku.api.schema.BLSSignature(
                                         signature.getSignature())))
                         .collect(Collectors.toList()))
-                .map(this::responseToSyncCommitteeSignatures));
+                .map(this::responseToSyncCommitteeSignatures)
+                .orElse(emptyList()));
   }
 
-  private SubmitCommitteeSignaturesResult responseToSyncCommitteeSignatures(
+  private List<SubmitCommitteeSignatureError> responseToSyncCommitteeSignatures(
       final PostSyncCommitteeFailureResponse postSyncCommitteeFailureResponse) {
-    return new SubmitCommitteeSignaturesResult(
-        postSyncCommitteeFailureResponse.failures.stream()
-            .map(i -> new SubmitCommitteeSignatureError(i.index, i.message))
-            .collect(Collectors.toList()));
+    return postSyncCommitteeFailureResponse.failures.stream()
+        .map(i -> new SubmitCommitteeSignatureError(i.index, i.message))
+        .collect(Collectors.toList());
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Simplify the API for `sendSyncCommitteeSignatures` to always return a list of errors which may be empty instead of an `Optional<List>`.  REST API is unchanged but internally we can hide its weirdness.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
