### PR TITLE
Subscribe to sync committee subnets

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -14,7 +14,9 @@
 package tech.pegasys.teku.api;
 
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -192,7 +194,7 @@ public class ValidatorDataProvider {
   }
 
   public void subscribeToSyncCommitteeSubnets(
-      final List<SyncCommitteeSubnetSubscription> subscriptions) {
+      final Collection<SyncCommitteeSubnetSubscription> subscriptions) {
     validatorApiChannel.subscribeToSyncCommitteeSubnets(
         subscriptions.stream()
             .map(
@@ -201,7 +203,7 @@ public class ValidatorDataProvider {
                         subscription.validatorIndex.intValue(),
                         subscription.syncCommitteeIndices.stream()
                             .map(UInt64::intValue)
-                            .collect(toList()),
+                            .collect(toSet()),
                         subscription.untilEpoch))
             .collect(toList()));
   }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/SyncCommitteeSubnetSubscription.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/SyncCommitteeSubnetSubscription.java
@@ -13,17 +13,17 @@
 
 package tech.pegasys.teku.validator.api;
 
-import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class SyncCommitteeSubnetSubscription {
   private final int validatorIndex;
-  private final List<Integer> syncCommitteeIndices;
+  private final Set<Integer> syncCommitteeIndices;
   private final UInt64 untilEpoch;
 
   public SyncCommitteeSubnetSubscription(
-      final int validatorIndex, final List<Integer> syncCommitteeIndices, final UInt64 untilEpoch) {
+      final int validatorIndex, final Set<Integer> syncCommitteeIndices, final UInt64 untilEpoch) {
     this.validatorIndex = validatorIndex;
     this.syncCommitteeIndices = syncCommitteeIndices;
     this.untilEpoch = untilEpoch;
@@ -33,7 +33,7 @@ public class SyncCommitteeSubnetSubscription {
     return validatorIndex;
   }
 
-  public List<Integer> getSyncCommitteeIndices() {
+  public Set<Integer> getSyncCommitteeIndices() {
     return syncCommitteeIndices;
   }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -67,7 +67,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   void subscribeToBeaconCommittee(List<CommitteeSubscriptionRequest> requests);
 
-  void subscribeToSyncCommitteeSubnets(List<SyncCommitteeSubnetSubscription> subscriptions);
+  void subscribeToSyncCommitteeSubnets(Collection<SyncCommitteeSubnetSubscription> subscriptions);
 
   void subscribeToPersistentSubnets(Set<SubnetSubscription> subnetSubscriptions);
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -271,7 +271,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
 
   @Override
   public void subscribeToSyncCommitteeSubnets(
-      final List<SyncCommitteeSubnetSubscription> subscriptions) {
+      final Collection<SyncCommitteeSubnetSubscription> subscriptions) {
     subscribeSyncCommitteeRequestCounter.inc();
     delegate.subscribeToSyncCommitteeSubnets(subscriptions);
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyLoader.java
@@ -51,7 +51,7 @@ public abstract class AbstractDutyLoader<D, S extends ScheduledDuties> implement
                               () ->
                                   new NodeDataUnavailableException(
                                       "Duties could not be calculated because chain data was not yet available")))
-                  .thenCompose(this::scheduleAllDuties)
+                  .thenCompose(duties -> scheduleAllDuties(epoch, duties))
                   .thenApply(Optional::of);
             });
   }
@@ -59,5 +59,5 @@ public abstract class AbstractDutyLoader<D, S extends ScheduledDuties> implement
   protected abstract SafeFuture<Optional<D>> requestDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndices);
 
-  protected abstract SafeFuture<S> scheduleAllDuties(final D duties);
+  protected abstract SafeFuture<S> scheduleAllDuties(UInt64 epoch, D duties);
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -72,7 +72,7 @@ public class AttestationDutyLoader
 
   @Override
   protected SafeFuture<SlotBasedScheduledDuties<?, ?>> scheduleAllDuties(
-      final AttesterDuties duties) {
+      final UInt64 epoch, final AttesterDuties duties) {
     final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> scheduledDuties =
         scheduledDutiesFactory.apply(duties.getDependentRoot());
     return SafeFuture.allOf(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
@@ -53,7 +53,7 @@ public class BlockProductionDutyLoader
 
   @Override
   protected SafeFuture<SlotBasedScheduledDuties<?, ?>> scheduleAllDuties(
-      final ProposerDuties duties) {
+      final UInt64 epoch, final ProposerDuties duties) {
     final SlotBasedScheduledDuties<BlockProductionDuty, Duty> scheduledDuties =
         scheduledDutiesFactory.apply(duties.getDependentRoot());
     duties.getDuties().forEach(duty -> scheduleDuty(scheduledDuties, duty));

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.duties.synccommittee;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.core.signatures.Signer;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.SyncCommitteeSubnetSubscription;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.ForkProvider;
+import tech.pegasys.teku.validator.client.Validator;
+
+class SyncCommitteeScheduledDutiesTest {
+
+  private static final UInt64 PERIOD_END_EPOCH = UInt64.valueOf(429);
+  private final Spec spec = TestSpecFactory.createMinimalAltair();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final ChainHeadTracker chainHeadTracker = mock(ChainHeadTracker.class);
+  private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
+  private final ForkProvider forkProvider = mock(ForkProvider.class);
+
+  private final Validator validator1 = createValidator();
+  private final Validator validator2 = createValidator();
+
+  @Test
+  void shouldSubscribeToSubnets() {
+    final SyncCommitteeScheduledDuties duties =
+        validBuilder()
+            .committeeAssignment(validator1, 50, 1)
+            .committeeAssignment(validator1, 50, 2)
+            .committeeAssignment(validator1, 50, 3)
+            .committeeAssignment(validator2, 70, 2)
+            .committeeAssignment(validator2, 70, 6)
+            .build();
+
+    duties.subscribeToSubnets();
+
+    verify(validatorApiChannel)
+        .subscribeToSyncCommitteeSubnets(
+            Set.of(
+                new SyncCommitteeSubnetSubscription(50, Set.of(1, 2, 3), PERIOD_END_EPOCH),
+                new SyncCommitteeSubnetSubscription(70, Set.of(2, 6), PERIOD_END_EPOCH)));
+  }
+
+  public SyncCommitteeScheduledDuties.Builder validBuilder() {
+    return SyncCommitteeScheduledDuties.builder()
+        .chainHeadTracker(chainHeadTracker)
+        .validatorApiChannel(validatorApiChannel)
+        .spec(spec)
+        .forkProvider(forkProvider)
+        .lastEpochInCommitteePeriod(PERIOD_END_EPOCH);
+  }
+
+  private Validator createValidator() {
+    return new Validator(dataStructureUtil.randomPublicKey(), mock(Signer.class), Optional::empty);
+  }
+}

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -410,7 +410,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public void subscribeToSyncCommitteeSubnets(
-      final List<SyncCommitteeSubnetSubscription> subscriptions) {
+      final Collection<SyncCommitteeSubnetSubscription> subscriptions) {
     for (final SyncCommitteeSubnetSubscription subscription : subscriptions) {
       subscription
           .getSyncCommitteeIndices()

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -347,7 +347,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public void subscribeToSyncCommitteeSubnets(
-      final List<SyncCommitteeSubnetSubscription> subscriptions) {
+      final Collection<SyncCommitteeSubnetSubscription> subscriptions) {
     sendRequest(
             () ->
                 apiClient.subscribeToSyncCommitteeSubnets(


### PR DESCRIPTION
## PR Description
Update the validator client so that it instructs the beacon node to subscribe to required sync committee subnets.

Also changes `ValidatorApiChannel.subscribeToSyncCommitteeSubnets` to accept a `Collection` instead of a `List` and use a set to track the subnets in a subscription request.  Fits better with what the validator client needs to track and there's no point supporting duplicates in the subnets to subscribe to.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
