### PR TITLE
Implement internal validator API for creating sync committee contributuions

### DIFF
--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -866,7 +866,7 @@ public final class DataStructureUtil {
         .create(randomUInt64(), randomSyncCommitteeContribution(slot), randomSignature());
   }
 
-  private SyncCommitteeContribution randomSyncCommitteeContribution(final UInt64 slot) {
+  public SyncCommitteeContribution randomSyncCommitteeContribution(final UInt64 slot) {
     final int subcommitteeSize =
         spec.atSlot(slot).getSyncCommitteeUtil().orElseThrow().getSubcommitteeSize();
     return getAltairSchemaDefinitions(slot)

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
@@ -64,6 +65,9 @@ public interface ValidatorApiChannel extends ChannelInterface {
   SafeFuture<Optional<AttestationData>> createAttestationData(UInt64 slot, int committeeIndex);
 
   SafeFuture<Optional<Attestation>> createAggregate(UInt64 slot, Bytes32 attestationHashTreeRoot);
+
+  SafeFuture<Optional<SyncCommitteeContribution>> createSyncCommitteeContribution(
+      UInt64 slot, int subcommitteeIndex, Bytes32 beaconBlockRoot);
 
   void subscribeToBeaconCommittee(List<CommitteeSubscriptionRequest> requests);
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
@@ -52,7 +53,6 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       "beacon_node_genesis_time_requests_total";
   public static final String GET_VALIDATOR_INDICES_REQUESTS_COUNTER_NAME =
       "beacon_node_get_validator_indices_requests_total";
-  public static final String DUTIES_REQUESTS_COUNTER_NAME = "beacon_node_duties_requests_total";
   public static final String ATTESTATION_DUTIES_REQUESTS_COUNTER_NAME =
       "beacon_node_attestation_duties_requests_total";
   public static final String PROPOSER_DUTIES_REQUESTS_COUNTER_NAME =
@@ -67,6 +67,8 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       "beacon_node_attestation_data_requests_total";
   public static final String AGGREGATE_REQUESTS_COUNTER_NAME =
       "beacon_node_aggregate_requests_total";
+  public static final String CREATE_SYNC_COMMITTEE_CONTRIBUTION_REQUESTS_COUNTER_NAME =
+      "beacon_node_create_sync_committee_contribution_requests_total";
   public static final String AGGREGATION_SUBSCRIPTION_COUNTER_NAME =
       "beacon_node_aggregation_subscription_requests_total";
   public static final String PERSISTENT_SUBSCRIPTION_COUNTER_NAME =
@@ -90,6 +92,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   private final BeaconChainRequestCounter unsignedAttestationRequestsCounter;
   private final BeaconChainRequestCounter attestationDataRequestsCounter;
   private final BeaconChainRequestCounter aggregateRequestsCounter;
+  private final BeaconChainRequestCounter createSyncCommitteeContributionCounter;
   private final Counter getValidatorIndicesRequestCounter;
   private final Counter subscribeAggregationRequestCounter;
   private final Counter subscribePersistentRequestCounter;
@@ -148,6 +151,11 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
         BeaconChainRequestCounter.create(
             metricsSystem,
             AGGREGATE_REQUESTS_COUNTER_NAME,
+            "Counter recording the number of requests for aggregate attestations");
+    createSyncCommitteeContributionCounter =
+        BeaconChainRequestCounter.create(
+            metricsSystem,
+            CREATE_SYNC_COMMITTEE_CONTRIBUTION_REQUESTS_COUNTER_NAME,
             "Counter recording the number of requests for aggregate attestations");
     getValidatorIndicesRequestCounter =
         metricsSystem.createCounter(
@@ -261,6 +269,14 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
     return countRequest(
         delegate.createAggregate(slot, attestationHashTreeRoot), aggregateRequestsCounter);
+  }
+
+  @Override
+  public SafeFuture<Optional<SyncCommitteeContribution>> createSyncCommitteeContribution(
+      final UInt64 slot, final int subcommitteeIndex, final Bytes32 beaconBlockRoot) {
+    return countRequest(
+        delegate.createSyncCommitteeContribution(slot, subcommitteeIndex, beaconBlockRoot),
+        createSyncCommitteeContributionCounter);
   }
 
   @Override

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -171,7 +171,15 @@ class MetricRecordingValidatorApiChannelTest {
             channel ->
                 channel.createAggregate(attestationData.getSlot(), attestationData.hashTreeRoot()),
             MetricRecordingValidatorApiChannel.AGGREGATE_REQUESTS_COUNTER_NAME,
-            dataStructureUtil.randomAttestation()));
+            dataStructureUtil.randomAttestation()),
+        requestDataTest(
+            "createSyncCommitteeContribution",
+            channel ->
+                channel.createSyncCommitteeContribution(
+                    slot, dataStructureUtil.randomPositiveInt(), dataStructureUtil.randomBytes32()),
+            MetricRecordingValidatorApiChannel
+                .CREATE_SYNC_COMMITTEE_CONTRIBUTION_REQUESTS_COUNTER_NAME,
+            dataStructureUtil.randomSyncCommitteeContribution(slot)));
   }
 
   private static <T> Arguments requestDataTest(

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -141,10 +142,13 @@ class MetricRecordingValidatorApiChannelTest {
   }
 
   public static Stream<Arguments> getDataRequestArguments() {
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+    final DataStructureUtil dataStructureUtil =
+        new DataStructureUtil(TestSpecFactory.createMinimalAltair());
     final UInt64 slot = dataStructureUtil.randomUInt64();
     final BLSSignature signature = dataStructureUtil.randomSignature();
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
+    final int subcommitteeIndex = dataStructureUtil.randomPositiveInt();
+    final Bytes32 beaconBlockRoot = dataStructureUtil.randomBytes32();
     return Stream.of(
         requestDataTest(
             "getForkInfo",
@@ -175,8 +179,7 @@ class MetricRecordingValidatorApiChannelTest {
         requestDataTest(
             "createSyncCommitteeContribution",
             channel ->
-                channel.createSyncCommitteeContribution(
-                    slot, dataStructureUtil.randomPositiveInt(), dataStructureUtil.randomBytes32()),
+                channel.createSyncCommitteeContribution(slot, subcommitteeIndex, beaconBlockRoot),
             MetricRecordingValidatorApiChannel
                 .CREATE_SYNC_COMMITTEE_CONTRIBUTION_REQUESTS_COUNTER_NAME,
             dataStructureUtil.randomSyncCommitteeContribution(slot)));

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -54,6 +54,7 @@ import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
@@ -387,6 +388,13 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
             .createAggregateFor(attestationHashTreeRoot)
             .filter(attestation -> attestation.getData().getSlot().equals(slot))
             .map(ValidateableAttestation::getAttestation));
+  }
+
+  @Override
+  public SafeFuture<Optional<SyncCommitteeContribution>> createSyncCommitteeContribution(
+      final UInt64 slot, final int subcommitteeIndex, final Bytes32 beaconBlockRoot) {
+    return SafeFuture.completedFuture(
+        syncCommitteeSignaturePool.createContribution(slot, beaconBlockRoot, subcommitteeIndex));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -49,6 +49,7 @@ import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
@@ -325,6 +326,13 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
             apiClient
                 .createAggregate(slot, attestationHashTreeRoot)
                 .map(tech.pegasys.teku.api.schema.Attestation::asInternalAttestation));
+  }
+
+  @Override
+  public SafeFuture<Optional<SyncCommitteeContribution>> createSyncCommitteeContribution(
+      final UInt64 slot, final int subcommitteeIndex, final Bytes32 beaconBlockRoot) {
+    throw new UnsupportedOperationException(
+        "REST API for createSyncCommitteeContribution not supported");
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Implement the internal validator API to create a sync committee contribution.  REST API isn't yet implemented so `RemoteValidatorApiHandler` throws `UnsupportedOperationException` for this method.

## Fixed Issue(s)
#3929 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
