### PR TITLE
Push combining validator keys into a single string into the ValidatorLogger to make testing easier

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.infrastructure.logging;
 
 import com.google.common.base.Strings;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
@@ -24,6 +23,7 @@ import tech.pegasys.teku.infrastructure.logging.ColorConsolePrinter.Color;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class ValidatorLogger {
+  private static final int VALIDATOR_KEY_LIMIT = 20;
   public static final ValidatorLogger VALIDATOR_LOGGER =
       new ValidatorLogger(LoggingConfigurator.VALIDATOR_LOGGER_NAME);
   public static final int LONGEST_TYPE_LENGTH = "attestation".length();
@@ -70,13 +70,23 @@ public class ValidatorLogger {
   public void dutyFailed(
       final String producedType,
       final UInt64 slot,
-      final Optional<String> maybeKey,
+      final Set<String> maybeKey,
       final Throwable error) {
     final String errorString =
         String.format(
             "%sFailed to produce %s  Slot: %s%s",
-            PREFIX, producedType, slot, maybeKey.map(key -> " Validator: " + key).orElse(""));
+            PREFIX, producedType, slot, formatValidators(maybeKey));
     log.error(ColorConsolePrinter.print(errorString, Color.RED), error);
+  }
+
+  private String formatValidators(final Set<String> keys) {
+    if (keys.isEmpty()) {
+      return "";
+    }
+    final String suffix = keys.size() > VALIDATOR_KEY_LIMIT ? "… (" + keys.size() + " total)" : "";
+    return keys.stream()
+        .limit(VALIDATOR_KEY_LIMIT)
+        .collect(Collectors.joining(", ", " Validator: ", suffix));
   }
 
   private void logDuty(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/PendingDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/PendingDuties.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.client;
 
+import static java.util.Collections.emptySet;
 import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
 
 import com.google.common.base.Throwables;
@@ -86,7 +87,7 @@ class PendingDuties {
   private void reportDutyFailure(
       final Throwable error, final String producedType, final UInt64 slot) {
     dutiesPerformedCounter.labels(producedType, "failed").inc();
-    VALIDATOR_LOGGER.dutyFailed(producedType, slot, Optional.empty(), error);
+    VALIDATOR_LOGGER.dutyFailed(producedType, slot, emptySet(), error);
   }
 
   private void reportDutySuccess(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/DutyResult.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/DutyResult.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
@@ -35,7 +34,6 @@ import tech.pegasys.teku.validator.api.NodeSyncingException;
 
 public class DutyResult {
   public static final DutyResult NO_OP = new DutyResult(0, 0, emptySet(), emptyMap());
-  private static final int SUMMARY_VALIDATOR_LIMIT = 20;
   private final int successCount;
   private final int nodeSyncingCount;
   private final Set<Bytes32> roots;
@@ -134,20 +132,10 @@ public class DutyResult {
                     producedType, slot, summarizeKeys(failure.validatorKeys), failure.error));
   }
 
-  private Optional<String> summarizeKeys(final Set<BLSPublicKey> validatorKeys) {
-    if (validatorKeys.isEmpty()) {
-      return Optional.empty();
-    }
-    final String suffix =
-        validatorKeys.size() > SUMMARY_VALIDATOR_LIMIT
-            ? "… (" + validatorKeys.size() + " total)"
-            : "";
-    return Optional.of(
-        validatorKeys.stream()
-                .limit(SUMMARY_VALIDATOR_LIMIT)
-                .map(BLSPublicKey::toAbbreviatedString)
-                .collect(Collectors.joining(", "))
-            + suffix);
+  private Set<String> summarizeKeys(final Set<BLSPublicKey> validatorKeys) {
+    return validatorKeys.stream()
+        .map(BLSPublicKey::toAbbreviatedString)
+        .collect(Collectors.toSet());
   }
 
   @Override

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
@@ -217,7 +217,7 @@ class AggregationDutyTest {
         .dutyFailed(
             eq(TYPE),
             eq(SLOT),
-            eq(Optional.of(validator1.getPublicKey().toAbbreviatedString())),
+            eq(Set.of(validator1.getPublicKey().toAbbreviatedString())),
             any(IllegalStateException.class));
     verifyNoMoreInteractions(validatorLogger);
   }
@@ -231,8 +231,7 @@ class AggregationDutyTest {
     performAndReportDuty();
 
     verify(validatorLogger)
-        .dutyFailed(
-            TYPE, SLOT, Optional.of(validator1.getPublicKey().toAbbreviatedString()), exception);
+        .dutyFailed(TYPE, SLOT, Set.of(validator1.getPublicKey().toAbbreviatedString()), exception);
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -270,8 +269,7 @@ class AggregationDutyTest {
     performAndReportDuty();
     verify(validatorApiChannel, never()).sendAggregateAndProof(any());
     verify(validatorLogger)
-        .dutyFailed(
-            TYPE, SLOT, Optional.of(validator1.getPublicKey().toAbbreviatedString()), exception);
+        .dutyFailed(TYPE, SLOT, Set.of(validator1.getPublicKey().toAbbreviatedString()), exception);
     verifyNoMoreInteractions(validatorLogger);
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
@@ -89,7 +89,7 @@ class AttestationProductionDutyTest {
         .dutyFailed(
             eq(TYPE),
             eq(SLOT),
-            eq(Optional.of(validator.getPublicKey().toAbbreviatedString())),
+            eq(Set.of(validator.getPublicKey().toAbbreviatedString())),
             any(IllegalStateException.class));
     verifyNoMoreInteractions(validatorLogger);
   }
@@ -133,7 +133,7 @@ class AttestationProductionDutyTest {
         .dutyFailed(
             eq(TYPE),
             eq(SLOT),
-            eq(Optional.of(validator1.getPublicKey().toAbbreviatedString())),
+            eq(Set.of(validator1.getPublicKey().toAbbreviatedString())),
             any(IllegalStateException.class));
     verifyNoMoreInteractions(validatorLogger);
   }
@@ -177,8 +177,7 @@ class AttestationProductionDutyTest {
     verify(validatorLogger)
         .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
     verify(validatorLogger)
-        .dutyFailed(
-            TYPE, SLOT, Optional.of(validator1.getPublicKey().toAbbreviatedString()), failure);
+        .dutyFailed(TYPE, SLOT, Set.of(validator1.getPublicKey().toAbbreviatedString()), failure);
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -216,10 +215,7 @@ class AttestationProductionDutyTest {
         .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
     verify(validatorLogger)
         .dutyFailed(
-            TYPE,
-            SLOT,
-            Optional.of(validator1.getPublicKey().toAbbreviatedString()),
-            signingFailure);
+            TYPE, SLOT, Set.of(validator1.getPublicKey().toAbbreviatedString()), signingFailure);
     verifyNoMoreInteractions(validatorLogger);
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -127,7 +127,7 @@ class BlockProductionDutyTest {
         .dutyFailed(
             eq(TYPE),
             eq(SLOT),
-            eq(Optional.of(validator.getPublicKey().toAbbreviatedString())),
+            eq(Set.of(validator.getPublicKey().toAbbreviatedString())),
             any(IllegalStateException.class));
     verifyNoMoreInteractions(validatorLogger);
   }
@@ -149,7 +149,7 @@ class BlockProductionDutyTest {
   public void assertDutyFails(final RuntimeException error) {
     performAndReportDuty();
     verify(validatorLogger)
-        .dutyFailed(TYPE, SLOT, Optional.of(validator.getPublicKey().toAbbreviatedString()), error);
+        .dutyFailed(TYPE, SLOT, Set.of(validator.getPublicKey().toAbbreviatedString()), error);
     verifyNoMoreInteractions(validatorLogger);
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/DutyResultTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/DutyResultTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
@@ -37,7 +36,7 @@ class DutyResultTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
   private final ValidatorLogger validatorLogger = mock(ValidatorLogger.class);
   private final BLSPublicKey validatorKey = dataStructureUtil.randomPublicKey();
-  private final Optional<String> validatorId = Optional.of(validatorKey.toAbbreviatedString());
+  private final Set<String> validatorId = Set.of(validatorKey.toAbbreviatedString());
 
   @Test
   void shouldReportSuccess() {
@@ -153,7 +152,7 @@ class DutyResultTest {
     combinedFuture.join().report(TYPE, SLOT, validatorLogger);
     verify(validatorLogger).dutyCompleted(TYPE, SLOT, 2, Set.of(root1, root2));
     verify(validatorLogger).dutyFailed(TYPE, SLOT, validatorId, exception1);
-    verify(validatorLogger).dutyFailed(TYPE, SLOT, Optional.empty(), exception2);
+    verify(validatorLogger).dutyFailed(TYPE, SLOT, Set.of(), exception2);
     verify(validatorLogger).dutySkippedWhileSyncing(TYPE, SLOT, 2);
     verifyNoMoreInteractions(validatorLogger);
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDutyTest.java
@@ -88,7 +88,7 @@ class SyncCommitteeProductionDutyTest {
         .dutyFailed(
             eq(SIGNATURE_TYPE),
             eq(slot),
-            eq(Optional.of(validator.getPublicKey().toAbbreviatedString())),
+            eq(Set.of(validator.getPublicKey().toAbbreviatedString())),
             any(IllegalStateException.class));
   }
 
@@ -105,7 +105,7 @@ class SyncCommitteeProductionDutyTest {
         .dutyFailed(
             SIGNATURE_TYPE,
             slot,
-            Optional.of(validator.getPublicKey().toAbbreviatedString()),
+            Set.of(validator.getPublicKey().toAbbreviatedString()),
             exception);
   }
 
@@ -122,7 +122,7 @@ class SyncCommitteeProductionDutyTest {
         .dutyFailed(
             SIGNATURE_TYPE,
             slot,
-            Optional.of(validator.getPublicKey().toAbbreviatedString()),
+            Set.of(validator.getPublicKey().toAbbreviatedString()),
             exception);
   }
 
@@ -156,7 +156,7 @@ class SyncCommitteeProductionDutyTest {
         .dutyFailed(
             SIGNATURE_TYPE,
             slot,
-            Optional.of(validator2.getPublicKey().toAbbreviatedString()),
+            Set.of(validator2.getPublicKey().toAbbreviatedString()),
             exception);
   }
 
@@ -197,7 +197,7 @@ class SyncCommitteeProductionDutyTest {
         .dutyFailed(
             eq(SIGNATURE_TYPE),
             eq(slot),
-            eq(Optional.of(validator.getPublicKey().toAbbreviatedString())),
+            eq(Set.of(validator.getPublicKey().toAbbreviatedString())),
             argThat(error -> error.getMessage().equals("API Rejected")));
   }
 


### PR DESCRIPTION
## PR Description
So that it's easier to test that multiple validator keys are passed to `ValidatorLogger.dutyFailed` push the formatting of keys into a list into `ValidatorLogger`.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
