### PR TITLE
implement POST `/eth/v1/validator/contribution_and_proofs`

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -78,6 +78,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetAttestationData;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetProposerDuties;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostAggregateAndProofs;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostAttesterDuties;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostContributionAndProofs;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostSubscribeToBeaconCommitteeSubnet;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostSyncCommitteeSubscriptions;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostSyncDuties;
@@ -314,6 +315,8 @@ public class BeaconRestApi {
     app.post(
         PostSyncCommitteeSubscriptions.ROUTE,
         new PostSyncCommitteeSubscriptions(dataProvider, jsonProvider));
+    app.post(
+        PostContributionAndProofs.ROUTE, new PostContributionAndProofs(dataProvider, jsonProvider));
   }
 
   private void addBeaconHandlers(final DataProvider dataProvider) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostContributionAndProofs.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostContributionAndProofs.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
+
+import static java.util.Arrays.asList;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR_REQUIRED;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import io.javalin.http.Context;
+import io.javalin.http.Handler;
+import io.javalin.plugin.openapi.annotations.HttpMethod;
+import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiContent;
+import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
+import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import org.jetbrains.annotations.NotNull;
+import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.ValidatorDataProvider;
+import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
+import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
+import tech.pegasys.teku.provider.JsonProvider;
+
+public class PostContributionAndProofs implements Handler {
+
+  public static final String ROUTE = "/eth/v1/validator/contribution_and_proofs";
+
+  private final ValidatorDataProvider provider;
+  private final JsonProvider jsonProvider;
+
+  public PostContributionAndProofs(final DataProvider provider, final JsonProvider jsonProvider) {
+    this(provider.getValidatorDataProvider(), jsonProvider);
+  }
+
+  public PostContributionAndProofs(
+      final ValidatorDataProvider provider, final JsonProvider jsonProvider) {
+    this.provider = provider;
+    this.jsonProvider = jsonProvider;
+  }
+
+  @OpenApi(
+      path = ROUTE,
+      method = HttpMethod.POST,
+      summary = "Publish contribution and proofs",
+      tags = {TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED},
+      requestBody =
+          @OpenApiRequestBody(
+              content = {@OpenApiContent(from = SignedContributionAndProof.class, isArray = true)}),
+      description =
+          "Verifies given sync committee contribution and proofs and publishes on appropriate gossipsub topics.",
+      responses = {
+        @OpenApiResponse(
+            status = RES_OK,
+            description = "Successfully published contribution and proofs."),
+        @OpenApiResponse(status = RES_BAD_REQUEST, description = "Invalid parameter supplied."),
+        @OpenApiResponse(status = RES_INTERNAL_ERROR, description = "Beacon node internal error.")
+      })
+  @Override
+  public void handle(@NotNull final Context ctx) throws Exception {
+    try {
+      final SignedContributionAndProof[] signedContributionAndProofs =
+          jsonProvider.jsonToObject(ctx.body(), SignedContributionAndProof[].class);
+
+      provider.sendContributionAndProofs(asList(signedContributionAndProofs));
+      ctx.status(SC_OK);
+    } catch (final JsonMappingException e) {
+      ctx.result(jsonProvider.objectToJSON(new BadRequest(e.getMessage())));
+      ctx.status(SC_BAD_REQUEST);
+    }
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostContributionAndProofs.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostContributionAndProofs.java
@@ -19,6 +19,7 @@ import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_EXPERIMENTAL;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR_REQUIRED;
 
@@ -58,7 +59,7 @@ public class PostContributionAndProofs implements Handler {
       path = ROUTE,
       method = HttpMethod.POST,
       summary = "Publish contribution and proofs",
-      tags = {TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED},
+      tags = {TAG_EXPERIMENTAL},
       requestBody =
           @OpenApiRequestBody(
               content = {@OpenApiContent(from = SignedContributionAndProof.class, isArray = true)}),

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostContributionAndProofs.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostContributionAndProofs.java
@@ -20,8 +20,6 @@ import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_EXPERIMENTAL;
-import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR;
-import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR_REQUIRED;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import io.javalin.http.Context;

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -75,6 +75,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetNewBlock;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetProposerDuties;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostAggregateAndProofs;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostAttesterDuties;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostContributionAndProofs;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostSubscribeToBeaconCommitteeSubnet;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostSyncCommitteeSubscriptions;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
@@ -244,7 +245,8 @@ public class BeaconRestApiV1Test {
         .add(
             Arguments.of(
                 PostSubscribeToBeaconCommitteeSubnet.ROUTE,
-                PostSubscribeToBeaconCommitteeSubnet.class));
+                PostSubscribeToBeaconCommitteeSubnet.class))
+        .add(Arguments.of(PostContributionAndProofs.ROUTE, PostContributionAndProofs.class));
 
     return builder.build();
   }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -280,9 +280,9 @@ public class ValidatorDataProvider {
         duty.getValidatorSyncCommitteeIndices());
   }
 
-  public void sendContributionAndProofs(
+  public SafeFuture<Void> sendContributionAndProofs(
       final List<SignedContributionAndProof> contributionAndProofs) {
-    validatorApiChannel.sendContributionAndProofs(
+    return validatorApiChannel.sendContributionAndProofs(
         contributionAndProofs.stream()
             .map(this::asInternalContributionAndProofs)
             .collect(toList()));

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -33,11 +33,14 @@ import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.ValidatorBlockResult;
+import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -275,5 +278,40 @@ public class ValidatorDataProvider {
         new BLSPubKey(duty.getPublicKey().toBytesCompressed()),
         UInt64.valueOf(duty.getValidatorIndex()),
         duty.getSyncCommitteeIndices());
+  }
+
+  public void sendContributionAndProofs(
+      final List<SignedContributionAndProof> contributionAndProofs) {
+    validatorApiChannel.sendContributionAndProofs(
+        contributionAndProofs.stream()
+            .map(this::asInternalContributionAndProofs)
+            .collect(toList()));
+  }
+
+  private tech.pegasys.teku.spec.datastructures.operations.versions.altair
+          .SignedContributionAndProof
+      asInternalContributionAndProofs(final SignedContributionAndProof signedContributionAndProof) {
+    final UInt64 slot = signedContributionAndProof.message.contribution.slot;
+    final Bytes32 root = signedContributionAndProof.message.contribution.beaconBlockRoot;
+    final UInt64 subcommitteeIndex =
+        signedContributionAndProof.message.contribution.subcommitteeIndex;
+    final Iterable<Integer> indices =
+        signedContributionAndProof.message.contribution.aggregationBits.getAllSetBits();
+    final tech.pegasys.teku.bls.BLSSignature signature =
+        signedContributionAndProof.message.contribution.signature.asInternalBLSSignature();
+    final SyncCommitteeContribution contribution =
+        spec.getSyncCommitteeUtilRequired(slot)
+            .createSyncCommitteeContribution(slot, root, subcommitteeIndex, indices, signature);
+
+    final ContributionAndProof message =
+        spec.getSyncCommitteeUtilRequired(slot)
+            .createContributionAndProof(
+                signedContributionAndProof.message.aggregatorIndex,
+                contribution,
+                signedContributionAndProof.message.selectionProof.asInternalBLSSignature());
+
+    return spec.getSyncCommitteeUtilRequired(slot)
+        .createSignedContributionAndProof(
+            message, signedContributionAndProof.signature.asInternalBLSSignature());
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/ContributionAndProof.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/ContributionAndProof.java
@@ -23,12 +23,15 @@ import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class ContributionAndProof {
+  @JsonProperty("aggregator_index")
   @Schema(type = "string", format = "uint64")
   public final UInt64 aggregatorIndex;
 
+  @JsonProperty("selection_proof")
   @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES96)
   public final BLSSignature selectionProof;
 
+  @JsonProperty("contribution")
   public final SyncCommitteeContribution contribution;
 
   @JsonCreator

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/ContributionAndProof.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/ContributionAndProof.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.schema.altair;
+
+import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES96;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
+import tech.pegasys.teku.api.schema.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class ContributionAndProof {
+  @Schema(type = "string", format = "uint64")
+  public final UInt64 aggregatorIndex;
+
+  @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES96)
+  public final BLSSignature selectionProof;
+
+  public final SyncCommitteeContribution contribution;
+
+  @JsonCreator
+  public ContributionAndProof(
+      @JsonProperty("aggregator_index") final UInt64 aggregatorIndex,
+      @JsonProperty("selection_proof") final BLSSignature selectionProof,
+      @JsonProperty("contribution") final SyncCommitteeContribution contribution) {
+    this.aggregatorIndex = aggregatorIndex;
+    this.selectionProof = selectionProof;
+    this.contribution = contribution;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final ContributionAndProof that = (ContributionAndProof) o;
+    return Objects.equals(aggregatorIndex, that.aggregatorIndex)
+        && Objects.equals(selectionProof, that.selectionProof)
+        && Objects.equals(contribution, that.contribution);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(aggregatorIndex, selectionProof, contribution);
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SignedContributionAndProof.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SignedContributionAndProof.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.schema.altair;
+
+import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES96;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
+import tech.pegasys.teku.api.schema.BLSSignature;
+
+public class SignedContributionAndProof {
+
+  public final ContributionAndProof message;
+
+  @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES96)
+  public final BLSSignature signature;
+
+  @JsonCreator
+  public SignedContributionAndProof(
+      @JsonProperty("message") final ContributionAndProof message,
+      @JsonProperty("signature") final BLSSignature signature) {
+    this.message = message;
+    this.signature = signature;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final SignedContributionAndProof that = (SignedContributionAndProof) o;
+    return Objects.equals(message, that.message) && Objects.equals(signature, that.signature);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(message, signature);
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SignedContributionAndProof.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SignedContributionAndProof.java
@@ -23,8 +23,10 @@ import tech.pegasys.teku.api.schema.BLSSignature;
 
 public class SignedContributionAndProof {
 
+  @JsonProperty("message")
   public final ContributionAndProof message;
 
+  @JsonProperty("signature")
   @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES96)
   public final BLSSignature signature;
 

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeContribution.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeContribution.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.schema.altair;
+
+import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES32;
+import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES96;
+import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES_SSZ;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.schema.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.ssz.collections.SszBitvector;
+
+public class SyncCommitteeContribution {
+  @Schema(type = "string", format = "uint64")
+  public final UInt64 slot;
+
+  @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES32)
+  public final Bytes32 beaconBlockRoot;
+
+  @Schema(type = "string", format = "uint64")
+  public final UInt64 subcommitteeIndex;
+
+  @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES_SSZ)
+  public final SszBitvector aggregationBits;
+
+  @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES96)
+  public final BLSSignature signature;
+
+  @JsonCreator
+  public SyncCommitteeContribution(
+      @JsonProperty("slot") final UInt64 slot,
+      @JsonProperty("beacon_block_root") final Bytes32 beaconBlockRoot,
+      @JsonProperty("subcommittee_index") final UInt64 subcommitteeIndex,
+      @JsonProperty("aggregation_bits") final SszBitvector aggregationBits,
+      @JsonProperty("signature") final BLSSignature signature) {
+    this.slot = slot;
+    this.beaconBlockRoot = beaconBlockRoot;
+    this.subcommitteeIndex = subcommitteeIndex;
+    this.aggregationBits = aggregationBits;
+    this.signature = signature;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final SyncCommitteeContribution that = (SyncCommitteeContribution) o;
+    return Objects.equals(slot, that.slot)
+        && Objects.equals(beaconBlockRoot, that.beaconBlockRoot)
+        && Objects.equals(subcommitteeIndex, that.subcommitteeIndex)
+        && Objects.equals(aggregationBits, that.aggregationBits)
+        && Objects.equals(signature, that.signature);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(slot, beaconBlockRoot, subcommitteeIndex, aggregationBits, signature);
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeContribution.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeContribution.java
@@ -27,18 +27,23 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.collections.SszBitvector;
 
 public class SyncCommitteeContribution {
+  @JsonProperty("slot")
   @Schema(type = "string", format = "uint64")
   public final UInt64 slot;
 
+  @JsonProperty("beacon_block_root")
   @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES32)
   public final Bytes32 beaconBlockRoot;
 
+  @JsonProperty("subcommittee_index")
   @Schema(type = "string", format = "uint64")
   public final UInt64 subcommitteeIndex;
 
+  @JsonProperty("aggregation_bits")
   @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES_SSZ)
   public final SszBitvector aggregationBits;
 
+  @JsonProperty("signature")
   @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES96)
   public final BLSSignature signature;
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
@@ -85,4 +86,6 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<List<SubmitCommitteeSignatureError>> sendSyncCommitteeSignatures(
       List<SyncCommitteeSignature> syncCommitteeSignatures);
+
+  void sendContributionAndProofs(List<SignedContributionAndProof> signedContributionAndProofs);
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -87,5 +87,6 @@ public interface ValidatorApiChannel extends ChannelInterface {
   SafeFuture<List<SubmitCommitteeSignatureError>> sendSyncCommitteeSignatures(
       List<SyncCommitteeSignature> syncCommitteeSignatures);
 
-  void sendContributionAndProofs(List<SignedContributionAndProof> signedContributionAndProofs);
+  SafeFuture<Void> sendContributionAndProofs(
+      List<SignedContributionAndProof> signedContributionAndProofs);
 }

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -340,10 +340,10 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public void sendContributionAndProofs(
+  public SafeFuture<Void> sendContributionAndProofs(
       final List<SignedContributionAndProof> signedContributionAndProofs) {
     sendContributionAndProofsRequestCounter.inc();
-    delegate.sendContributionAndProofs(signedContributionAndProofs);
+    return delegate.sendContributionAndProofs(signedContributionAndProofs);
   }
 
   private <T> SafeFuture<Optional<T>> countRequest(

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
@@ -82,6 +83,8 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       "beacon_node_subscribe_sync_committee_subnet_total";
   public static final String SYNC_COMMITTEE_SEND_SIGNATURES_NAME =
       "beacon_node_send_sync_committee_signatures_total";
+  public static final String SYNC_COMMITTEE_SEND_CONTRIBUTIONS_NAME =
+      "beacon_node_send_sync_committee_contributions_total";
   private final ValidatorApiChannel delegate;
   private final BeaconChainRequestCounter forkInfoRequestCounter;
   private final BeaconChainRequestCounter genesisTimeRequestCounter;
@@ -101,6 +104,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   private final Counter sendAggregateRequestCounter;
   private final Counter sendBlockRequestCounter;
   private final Counter sendSyncCommitteeSignaturesRequestCounter;
+  private final Counter sendContributionAndProofsRequestCounter;
 
   public MetricRecordingValidatorApiChannel(
       final MetricsSystem metricsSystem, final ValidatorApiChannel delegate) {
@@ -197,6 +201,11 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
             TekuMetricCategory.VALIDATOR,
             SYNC_COMMITTEE_SEND_SIGNATURES_NAME,
             "Counter recording the number of signed blocks sent to the beacon node");
+    sendContributionAndProofsRequestCounter =
+        metricsSystem.createCounter(
+            TekuMetricCategory.VALIDATOR,
+            SYNC_COMMITTEE_SEND_CONTRIBUTIONS_NAME,
+            "Counter recording the number of signed contributions and proofs sent to the beacon node");
   }
 
   @Override
@@ -328,6 +337,13 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final List<SyncCommitteeSignature> syncCommitteeSignatures) {
     sendSyncCommitteeSignaturesRequestCounter.inc();
     return delegate.sendSyncCommitteeSignatures(syncCommitteeSignatures);
+  }
+
+  @Override
+  public void sendContributionAndProofs(
+      final List<SignedContributionAndProof> signedContributionAndProofs) {
+    sendContributionAndProofsRequestCounter.inc();
+    delegate.sendContributionAndProofs(signedContributionAndProofs);
   }
 
   private <T> SafeFuture<Optional<T>> countRequest(

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -54,6 +54,7 @@ import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
@@ -520,6 +521,12 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
 
     return SafeFuture.collectAll(addedSignatures.stream())
         .thenApply(this::getSendSyncCommitteesResultFromFutures);
+  }
+
+  @Override
+  public void sendContributionAndProofs(
+      final List<SignedContributionAndProof> signedContributionAndProofs) {
+    throw new UnsupportedOperationException("sendContributionAndProofs not implemented yet");
   }
 
   private List<SubmitCommitteeSignatureError> getSendSyncCommitteesResultFromFutures(

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -524,9 +524,10 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public void sendContributionAndProofs(
+  public SafeFuture<Void> sendContributionAndProofs(
       final List<SignedContributionAndProof> signedContributionAndProofs) {
-    throw new UnsupportedOperationException("sendContributionAndProofs not implemented yet");
+    return SafeFuture.failedFuture(
+        new UnsupportedOperationException("sendContributionAndProofs not implemented yet"));
   }
 
   private List<SubmitCommitteeSignatureError> getSendSyncCommitteesResultFromFutures(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -314,15 +314,14 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public void sendContributionAndProofs(
+  public SafeFuture<Void> sendContributionAndProofs(
       final List<SignedContributionAndProof> signedContributionAndProofs) {
     final List<tech.pegasys.teku.api.schema.altair.SignedContributionAndProof>
         signedContributionsRestSchema =
             signedContributionAndProofs.stream()
                 .map(this::asSignedContributionandProofs)
                 .collect(Collectors.toList());
-    sendRequest(() -> apiClient.sendContributionAndProofs(signedContributionsRestSchema))
-        .finish(error -> LOG.error("Failed to send contribution and proofs", error));
+    return sendRequest(() -> apiClient.sendContributionAndProofs(signedContributionsRestSchema));
   }
 
   private tech.pegasys.teku.api.schema.altair.SignedContributionAndProof

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.api.response.v1.beacon.PostSyncCommitteeFailureResponse
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.api.response.v1.validator.PostSyncDutiesResponse;
+import tech.pegasys.teku.api.schema.altair.ContributionAndProof;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -49,6 +50,7 @@ import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
@@ -309,6 +311,44 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
                         .collect(Collectors.toList()))
                 .map(this::responseToSyncCommitteeSignatures)
                 .orElse(emptyList()));
+  }
+
+  @Override
+  public void sendContributionAndProofs(
+      final List<SignedContributionAndProof> signedContributionAndProofs) {
+    final List<tech.pegasys.teku.api.schema.altair.SignedContributionAndProof>
+        signedContributionsRestSchema =
+            signedContributionAndProofs.stream()
+                .map(this::asSignedContributionandProofs)
+                .collect(Collectors.toList());
+    sendRequest(() -> apiClient.sendContributionAndProofs(signedContributionsRestSchema))
+        .finish(error -> LOG.error("Failed to send contribution and proofs", error));
+  }
+
+  private tech.pegasys.teku.api.schema.altair.SignedContributionAndProof
+      asSignedContributionandProofs(final SignedContributionAndProof signedContributionAndProof) {
+    return new tech.pegasys.teku.api.schema.altair.SignedContributionAndProof(
+        asContributionAndProof(signedContributionAndProof.getMessage()),
+        new tech.pegasys.teku.api.schema.BLSSignature(signedContributionAndProof.getSignature()));
+  }
+
+  private ContributionAndProof asContributionAndProof(
+      final tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof
+          message) {
+    return new ContributionAndProof(
+        message.getAggregatorIndex(),
+        new tech.pegasys.teku.api.schema.BLSSignature(message.getSelectionProof()),
+        asSyncCommitteeContribution(message.getContribution()));
+  }
+
+  private tech.pegasys.teku.api.schema.altair.SyncCommitteeContribution asSyncCommitteeContribution(
+      final SyncCommitteeContribution contribution) {
+    return new tech.pegasys.teku.api.schema.altair.SyncCommitteeContribution(
+        contribution.getSlot(),
+        contribution.getBeaconBlockRoot(),
+        contribution.getSubcommitteeIndex(),
+        contribution.getAggregationBits(),
+        new tech.pegasys.teku.api.schema.BLSSignature(contribution.getSignature()));
   }
 
   private List<SubmitCommitteeSignatureError> responseToSyncCommitteeSignatures(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -27,6 +27,7 @@ import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GE
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_ATTESTATION;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_VALIDATORS;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_CONTRIBUTION_AND_PROOF;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_AGGREGATE_AND_PROOF;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_ATTESTATION;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_BLOCK;
@@ -78,6 +79,7 @@ import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.api.schema.SubnetSubscription;
+import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -276,6 +278,12 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   @Override
   public void subscribeToSyncCommitteeSubnets(
       final List<SyncCommitteeSubnetSubscription> subnetSubscriptions) {}
+
+  @Override
+  public void sendContributionAndProofs(
+      final List<SignedContributionAndProof> signedContributionAndProofs) {
+    post(SEND_CONTRIBUTION_AND_PROOF, signedContributionAndProofs, createHandler());
+  }
 
   private ResponseHandler<Void> createHandler() {
     return createHandler(null);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -32,6 +32,7 @@ public enum ValidatorApiMethod {
   SEND_SYNC_COMMITTEE_SIGNATURES("eth/v1/beacon/pool/sync_committees"),
   GET_AGGREGATE("eth/v1/validator/aggregate_attestation"),
   SEND_SIGNED_AGGREGATE_AND_PROOF("/eth/v1/validator/aggregate_and_proofs"),
+  SEND_CONTRIBUTION_AND_PROOF("eth/v1/validator/contribution_and_proofs"),
   SUBSCRIBE_TO_BEACON_COMMITTEE_SUBNET("eth/v1/validator/beacon_committee_subscriptions"),
   SUBSCRIBE_TO_PERSISTENT_SUBNETS("validator/persistent_subnets_subscription"),
   SUBSCRIBE_TO_SYNC_COMMITTEE_SUBNET("eth/v1/validator/sync_committee_subscriptions"),

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.api.schema.SubnetSubscription;
+import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -80,4 +81,7 @@ public interface ValidatorRestApiClient {
       UInt64 epoch, Collection<Integer> validatorIndices);
 
   void subscribeToSyncCommitteeSubnets(List<SyncCommitteeSubnetSubscription> subnetSubscriptions);
+
+  void sendContributionAndProofs(
+      final List<SignedContributionAndProof> signedContributionAndProofs);
 }


### PR DESCRIPTION
does not have the validator api handler implemented, will throw a not supported exception if called.

Partially addresses #3928

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
