### PR TITLE
Consider eth1 endpoints in sync if they are close to chain head

### DIFF
--- a/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
@@ -35,7 +35,6 @@ import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.EthCall;
 import org.web3j.protocol.core.methods.response.EthChainId;
 import org.web3j.protocol.core.methods.response.EthLog;
-import org.web3j.protocol.core.methods.response.EthSyncing;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
@@ -170,7 +169,8 @@ public class Web3jEth1Provider extends AbstractMonitorableEth1Provider {
 
   @Override
   public SafeFuture<Boolean> ethSyncing() {
-    return sendAsync(web3j.ethSyncing()).thenApply(EthSyncing::isSyncing);
+    return sendAsync(web3j.ethSyncing())
+        .thenApply(response -> Web3jInSyncCheck.isSyncing(id, response));
   }
 
   @Override

--- a/pow/src/main/java/tech/pegasys/teku/pow/Web3jInSyncCheck.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Web3jInSyncCheck.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.pow;
+
+import java.math.BigInteger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.web3j.protocol.core.methods.response.EthSyncing;
+import org.web3j.protocol.core.methods.response.EthSyncing.Syncing;
+
+public class Web3jInSyncCheck {
+  private static final Logger LOG = LogManager.getLogger();
+  private static final BigInteger TOLERANCE = BigInteger.TEN;
+
+  public static boolean isSyncing(final String id, final EthSyncing syncingResponse) {
+    if (!syncingResponse.isSyncing()) {
+      return false;
+    }
+    if (!(syncingResponse.getResult() instanceof EthSyncing.Syncing)) {
+      return syncingResponse.isSyncing();
+    }
+    try {
+      final Syncing syncingDetails = (Syncing) syncingResponse.getResult();
+      final BigInteger currentBlock = parseJsonRpcValue(syncingDetails.getCurrentBlock());
+      final BigInteger highestBlock = parseJsonRpcValue(syncingDetails.getHighestBlock());
+      if (currentBlock.add(TOLERANCE).compareTo(highestBlock) >= 0) {
+        // If we're close to the chain head, consider the node in sync
+        // Avoids marking the node as invalid while it imports the latest block
+        LOG.debug(
+            "Eth1 endpiont {} syncing but close to head so considering it valid. Current block {} Highest block: {}",
+            id,
+            currentBlock,
+            highestBlock);
+        return false;
+      }
+      return true;
+    } catch (final NumberFormatException | NullPointerException e) {
+      LOG.error("Failed to parse syncing details from eth1 endpoint {}", id, e);
+      return syncingResponse.isSyncing();
+    }
+  }
+
+  private static BigInteger parseJsonRpcValue(final String value) {
+    return value.startsWith("0x")
+        ? new BigInteger(value.substring("0x".length()), 16)
+        : new BigInteger(value);
+  }
+}

--- a/pow/src/test/java/tech/pegasys/teku/pow/Web3jInSyncCheckTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/Web3jInSyncCheckTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.pow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.web3j.protocol.core.methods.response.EthSyncing;
+
+class Web3jInSyncCheckTest {
+  @Test
+  void shouldNotBeSyncingWhenSyncingIsFalse() {
+    final EthSyncing response = new EthSyncing();
+    final EthSyncing.Result result = new EthSyncing.Result();
+    result.setSyncing(false);
+    response.setResult(result);
+    assertThat(Web3jInSyncCheck.isSyncing("nodeId", response)).isFalse();
+  }
+
+  @Test
+  void shouldNotBeSyncingWhenCurrentBlockCloseToHighestBlock() {
+    final EthSyncing response = new EthSyncing();
+    final EthSyncing.Syncing result = new EthSyncing.Syncing("0x0", "0x10", "0x19", null, null);
+    result.setSyncing(true);
+    response.setResult(result);
+    assertThat(Web3jInSyncCheck.isSyncing("nodeId", response)).isFalse();
+  }
+
+  @Test
+  void shouldBeSyncingWhenCurrentBlockNotCloseToHighestBlock() {
+    final EthSyncing response = new EthSyncing();
+    final EthSyncing.Syncing result = new EthSyncing.Syncing("0x0", "0x10", "0x30", null, null);
+    result.setSyncing(true);
+    response.setResult(result);
+    assertThat(Web3jInSyncCheck.isSyncing("nodeId", response)).isTrue();
+  }
+
+  @Test
+  void shouldBeSyncingWhenResultIsNotSyncingType() {
+    final EthSyncing response = new EthSyncing();
+    final EthSyncing.Result result = new EthSyncing.Result();
+    result.setSyncing(true);
+    response.setResult(result);
+    assertThat(Web3jInSyncCheck.isSyncing("nodeId", response)).isTrue();
+  }
+}


### PR DESCRIPTION
## PR Description
Add some tolerance to in-sync checks for eth1-providers to avoid considering them not in sync because they are importing the new head block.

## Fixed Issue(s)


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
