### PR TITLE
Use the correct slot when creating sync aggregates

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPool.java
@@ -109,10 +109,7 @@ public class SyncCommitteeContributionPool implements SlotEventsChannel {
             .getOrDefault(slot, emptyMap())
             .getOrDefault(parentRoot, emptyMap())
             .values();
-    return spec.atSlot(slot)
-        .getSyncCommitteeUtil()
-        .orElseThrow()
-        .createSyncAggregate(contributions);
+    return spec.getSyncCommitteeUtilRequired(blockSlot).createSyncAggregate(contributions);
   }
 
   /**

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
@@ -137,7 +137,7 @@ public class BlockFactory {
                     .syncAggregate(
                         () ->
                             contributionPool.createSyncAggregateForBlock(
-                                newSlot.minusMinZero(1), parentRoot)))
+                                newSlot, parentRoot)))
         .getBlock();
   }
 }

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
@@ -135,9 +135,7 @@ public class BlockFactory {
                     .deposits(deposits)
                     .voluntaryExits(voluntaryExits)
                     .syncAggregate(
-                        () ->
-                            contributionPool.createSyncAggregateForBlock(
-                                newSlot, parentRoot)))
+                        () -> contributionPool.createSyncAggregateForBlock(newSlot, parentRoot)))
         .getBlock();
   }
 }

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
@@ -87,7 +87,7 @@ class BlockFactoryTest {
     final SyncAggregate result = getSyncAggregate(block);
     assertThatSyncAggregate(result).isNotNull();
     verify(syncCommitteeContributionPool)
-        .createSyncAggregateForBlock(UInt64.ZERO, block.getParentRoot());
+        .createSyncAggregateForBlock(UInt64.ONE, block.getParentRoot());
   }
 
   private SyncAggregate getSyncAggregate(final BeaconBlock block) {
@@ -134,7 +134,7 @@ class BlockFactoryTest {
     final BeaconState previousState =
         recentChainData.retrieveBlockState(bestBlockRoot).join().orElseThrow();
 
-    when(syncCommitteeContributionPool.createSyncAggregateForBlock(newSlot.minus(1), bestBlockRoot))
+    when(syncCommitteeContributionPool.createSyncAggregateForBlock(newSlot, bestBlockRoot))
         .thenAnswer(invocation -> createEmptySyncAggregate(spec));
 
     final BeaconBlock block =


### PR DESCRIPTION
## PR Description
`createSyncAggregateForBlock` expects to be given the slot of the block being created, not the slot the signatures should come from.
And the spec that is used needs to come from the block's slot, otherwise `SyncCommitteeUtil` won't be available when creating the block at the fork slot.

## Fixed Issue(s)
fixes #3943 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
