### PR TITLE
Improve Altair validator logging outpuT

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -26,7 +26,7 @@ public class ValidatorLogger {
   private static final int VALIDATOR_KEY_LIMIT = 20;
   public static final ValidatorLogger VALIDATOR_LOGGER =
       new ValidatorLogger(LoggingConfigurator.VALIDATOR_LOGGER_NAME);
-  public static final int LONGEST_TYPE_LENGTH = "attestation".length();
+  public static final int LONGEST_TYPE_LENGTH = "sync_contribution".length();
   private static final String PREFIX = "Validator   *** ";
 
   private final Logger log;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
@@ -98,7 +98,7 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
 
   @Override
   public String getProductionType() {
-    return "sync_committee_signature";
+    return "sync_signature";
   }
 
   @Override
@@ -117,7 +117,7 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
 
   @Override
   public String getAggregationType() {
-    return "sync_committee_contribution";
+    return "sync_contribution";
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Tidies up the validator logging output in Altair by shortening the sync committee type names and updating the longest type in ValidatorLogger.  This leaves a little more whitespace pre-altair but it still looks good and is shorter than our usual "Slot Event" lines:

```
Slot Event  *** Slot: 1, Block: a1a50f..be1c, Epoch: 0, Finalized checkpoint: 0, Finalized root: bf2da9..c3b8, Peers: 0
2021-05-07 13:15:59.017 | validator-async-5         | INFO  | teku-validator-log             | Validator   *** Published aggregate          Count: 2, Slot: 1, Root: a1a50f..be1c
2021-05-07 13:16:01.019 | validator-async-3         | INFO  | teku-validator-log             | Validator   *** Published block              Count: 1, Slot: 2, Root: dc9f6c..bcc9
2021-05-07 13:16:01.140 | validator-async-0         | INFO  | teku-validator-log             | Validator   *** Published attestation        Count: 8, Slot: 2, Root: dc9f6c..bcc9
2021-05-07 13:16:03.121 | TimeTickChannel-0         | INFO  | teku-event-log                 | Slot Event  *** Slot: 2, Block: dc9f6c..bcc9, Epoch: 0, Finalized checkpoint: 0, Finalized root: bf2da9..c3b8, Peers: 0
```

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
