### PR TITLE
Update validator client to switch Fork instances during forks

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -31,7 +31,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import picocli.CommandLine;
-import tech.pegasys.teku.api.schema.Fork;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
@@ -202,10 +201,6 @@ public class VoluntaryExitCommand implements Runnable {
     return apiClient.getGenesis().map(response -> response.getData().getGenesisValidatorsRoot());
   }
 
-  private Optional<tech.pegasys.teku.spec.datastructures.state.Fork> getFork() {
-    return apiClient.getFork().map(Fork::asInternalFork);
-  }
-
   private void initialise() {
     config = tekuConfiguration();
     final AsyncRunnerFactory asyncRunnerFactory =
@@ -222,13 +217,8 @@ public class VoluntaryExitCommand implements Runnable {
 
     spec = getSpec();
 
-    final Optional<tech.pegasys.teku.spec.datastructures.state.Fork> maybeFork = getFork();
-    if (maybeFork.isEmpty()) {
-      SUB_COMMAND_LOG.error("Unable to fetch fork, cannot generate an exit.");
-      System.exit(1);
-    }
-    fork = maybeFork.get();
     validateOrDefaultEpoch();
+    fork = spec.getForkSchedule().getFork(epoch);
 
     // get genesis time
     final Optional<Bytes32> maybeRoot = getGenesisRoot();

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -34,13 +34,10 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
-import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 
 public interface ValidatorApiChannel extends ChannelInterface {
   int UKNOWN_VALIDATOR_ID = -1;
-
-  SafeFuture<Optional<Fork>> getFork(UInt64 epoch);
 
   SafeFuture<Optional<GenesisData>> getGenesisData();
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -40,7 +40,7 @@ import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 public interface ValidatorApiChannel extends ChannelInterface {
   int UKNOWN_VALIDATOR_ID = -1;
 
-  SafeFuture<Optional<Fork>> getFork();
+  SafeFuture<Optional<Fork>> getFork(UInt64 epoch);
 
   SafeFuture<Optional<GenesisData>> getGenesisData();
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -48,7 +48,6 @@ import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
 public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
 
-  public static final String FORK_REQUESTS_COUNTER_NAME = "beacon_node_fork_info_requests_total";
   public static final String GENESIS_TIME_REQUESTS_COUNTER_NAME =
       "beacon_node_genesis_time_requests_total";
   public static final String GET_VALIDATOR_INDICES_REQUESTS_COUNTER_NAME =
@@ -85,7 +84,6 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   public static final String SYNC_COMMITTEE_SEND_CONTRIBUTIONS_NAME =
       "beacon_node_send_sync_committee_contributions_total";
   private final ValidatorApiChannel delegate;
-  private final BeaconChainRequestCounter forkInfoRequestCounter;
   private final BeaconChainRequestCounter genesisTimeRequestCounter;
   private final BeaconChainRequestCounter attestationDutiesRequestCounter;
   private final BeaconChainRequestCounter syncCommitteeDutiesRequestCounter;
@@ -108,12 +106,6 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   public MetricRecordingValidatorApiChannel(
       final MetricsSystem metricsSystem, final ValidatorApiChannel delegate) {
     this.delegate = delegate;
-
-    forkInfoRequestCounter =
-        BeaconChainRequestCounter.create(
-            metricsSystem,
-            FORK_REQUESTS_COUNTER_NAME,
-            "Counter recording the number of requests for fork info");
 
     genesisTimeRequestCounter =
         BeaconChainRequestCounter.create(

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -209,8 +209,8 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Fork>> getFork() {
-    return countRequest(delegate.getFork(), forkInfoRequestCounter);
+  public SafeFuture<Optional<Fork>> getFork(final UInt64 epoch) {
+    return countRequest(delegate.getFork(epoch), forkInfoRequestCounter);
   }
 
   @Override

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -36,7 +36,6 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
-import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.validator.api.AttesterDuties;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
@@ -206,11 +205,6 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
             TekuMetricCategory.VALIDATOR,
             SYNC_COMMITTEE_SEND_CONTRIBUTIONS_NAME,
             "Counter recording the number of signed contributions and proofs sent to the beacon node");
-  }
-
-  @Override
-  public SafeFuture<Optional<Fork>> getFork(final UInt64 epoch) {
-    return countRequest(delegate.getFork(epoch), forkInfoRequestCounter);
   }
 
   @Override

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -145,6 +145,7 @@ class MetricRecordingValidatorApiChannelTest {
     final DataStructureUtil dataStructureUtil =
         new DataStructureUtil(TestSpecFactory.createMinimalAltair());
     final UInt64 slot = dataStructureUtil.randomUInt64();
+    final UInt64 epoch = dataStructureUtil.randomEpoch();
     final BLSSignature signature = dataStructureUtil.randomSignature();
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     final int subcommitteeIndex = dataStructureUtil.randomPositiveInt();
@@ -152,7 +153,7 @@ class MetricRecordingValidatorApiChannelTest {
     return Stream.of(
         requestDataTest(
             "getForkInfo",
-            ValidatorApiChannel::getFork,
+            validatorApiChannel -> validatorApiChannel.getFork(epoch),
             MetricRecordingValidatorApiChannel.FORK_REQUESTS_COUNTER_NAME,
             dataStructureUtil.randomFork()),
         requestDataTest(

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -145,17 +145,11 @@ class MetricRecordingValidatorApiChannelTest {
     final DataStructureUtil dataStructureUtil =
         new DataStructureUtil(TestSpecFactory.createMinimalAltair());
     final UInt64 slot = dataStructureUtil.randomUInt64();
-    final UInt64 epoch = dataStructureUtil.randomEpoch();
     final BLSSignature signature = dataStructureUtil.randomSignature();
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     final int subcommitteeIndex = dataStructureUtil.randomPositiveInt();
     final Bytes32 beaconBlockRoot = dataStructureUtil.randomBytes32();
     return Stream.of(
-        requestDataTest(
-            "getForkInfo",
-            validatorApiChannel -> validatorApiChannel.getFork(epoch),
-            MetricRecordingValidatorApiChannel.FORK_REQUESTS_COUNTER_NAME,
-            dataStructureUtil.randomFork()),
         requestDataTest(
             "getGenesisData",
             ValidatorApiChannel::getGenesisData,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -147,7 +147,7 @@ public class AttestationDutyLoader
       final int aggregatorModulo,
       final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture) {
     return forkProvider
-        .getForkInfo()
+        .getForkInfo(slot)
         .thenCompose(forkInfo -> validator.getSigner().signAggregationSlot(slot, forkInfo))
         .thenAccept(
             slotSignature -> {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ForkProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ForkProvider.java
@@ -13,86 +13,28 @@
 
 package tech.pegasys.teku.validator.client;
 
-import static tech.pegasys.teku.util.config.Constants.FORK_REFRESH_TIME;
-import static tech.pegasys.teku.util.config.Constants.FORK_RETRY_DELAY;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.service.serviceutils.Service;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.beaconnode.GenesisDataProvider;
 
-public class ForkProvider extends Service {
-  private static final Logger LOG = LogManager.getLogger();
-
-  private final AsyncRunner asyncRunner;
-  private final ValidatorApiChannel validatorApiChannel;
+public class ForkProvider {
+  private final Spec spec;
   private final GenesisDataProvider genesisDataProvider;
 
-  private volatile SafeFuture<ForkInfo> currentFork = new SafeFuture<>();
-
-  public ForkProvider(
-      final AsyncRunner asyncRunner,
-      final ValidatorApiChannel validatorApiChannel,
-      final GenesisDataProvider genesisDataProvider) {
-    this.asyncRunner = asyncRunner;
-    this.validatorApiChannel = validatorApiChannel;
+  public ForkProvider(final Spec spec, final GenesisDataProvider genesisDataProvider) {
+    this.spec = spec;
     this.genesisDataProvider = genesisDataProvider;
   }
 
-  public SafeFuture<ForkInfo> getForkInfo() {
-    return currentFork;
-  }
-
-  public SafeFuture<ForkInfo> loadForkInfo() {
-    return requestForkInfo()
-        .exceptionallyCompose(
-            error -> {
-              LOG.error("Failed to retrieve current fork info. Retrying after delay", error);
-              return asyncRunner.runAfterDelay(this::loadForkInfo, FORK_RETRY_DELAY);
-            });
-  }
-
-  private SafeFuture<ForkInfo> requestForkInfo() {
-    return genesisDataProvider.getGenesisValidatorsRoot().thenCompose(this::requestFork);
-  }
-
-  public SafeFuture<ForkInfo> requestFork(final Bytes32 genesisValidatorsRoot) {
-    return validatorApiChannel
-        .getFork()
-        .thenCompose(
-            maybeFork -> {
-              if (maybeFork.isEmpty()) {
-                LOG.trace("Fork info not available, retrying");
-                return asyncRunner.runAfterDelay(this::requestForkInfo, FORK_RETRY_DELAY);
-              }
-              final ForkInfo forkInfo =
-                  new ForkInfo(maybeFork.orElseThrow(), genesisValidatorsRoot);
-              currentFork.complete(forkInfo);
-              currentFork = SafeFuture.completedFuture(forkInfo);
-              // Periodically refresh the current fork info.
-              asyncRunner.runAfterDelay(this::loadForkInfo, FORK_REFRESH_TIME).reportExceptions();
-              return SafeFuture.completedFuture(forkInfo);
-            });
-  }
-
-  @Override
-  public String toString() {
-    return "ForkProvider{" + "currentFork=" + currentFork + '}';
-  }
-
-  @Override
-  protected SafeFuture<?> doStart() {
-    loadForkInfo().propagateTo(currentFork);
-    return SafeFuture.COMPLETE;
-  }
-
-  @Override
-  protected SafeFuture<?> doStop() {
-    return SafeFuture.COMPLETE;
+  public SafeFuture<ForkInfo> getForkInfo(final UInt64 slot) {
+    return genesisDataProvider
+        .getGenesisValidatorsRoot()
+        .thenApply(
+            genesisValidatorsRoot ->
+                new ForkInfo(
+                    spec.getForkSchedule().getFork(spec.computeEpochAtSlot(slot)),
+                    genesisValidatorsRoot));
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -54,7 +54,7 @@ public class ValidatorClientService extends Service {
   private final ForkProvider forkProvider;
   private final Spec spec;
 
-  private List<ValidatorTimingChannel> validatorTimingChannels = new ArrayList<>();
+  private final List<ValidatorTimingChannel> validatorTimingChannels = new ArrayList<>();
   private ValidatorStatusLogger validatorStatusLogger;
   private ValidatorIndexProvider validatorIndexProvider;
 
@@ -97,8 +97,7 @@ public class ValidatorClientService extends Service {
     final ValidatorApiChannel validatorApiChannel = beaconNodeApi.getValidatorApi();
     final GenesisDataProvider genesisDataProvider =
         new GenesisDataProvider(asyncRunner, validatorApiChannel);
-    final ForkProvider forkProvider =
-        new ForkProvider(asyncRunner, validatorApiChannel, genesisDataProvider);
+    final ForkProvider forkProvider = new ForkProvider(config.getSpec(), genesisDataProvider);
 
     final ValidatorLoader validatorLoader = createValidatorLoader(config, asyncRunner, services);
 
@@ -216,7 +215,6 @@ public class ValidatorClientService extends Service {
     return initializationComplete.thenCompose(
         (__) -> {
           SystemSignalListener.registerReloadConfigListener(validatorLoader::loadValidators);
-          forkProvider.start().reportExceptions();
           validatorIndexProvider.lookupValidators();
           eventChannels.subscribe(
               ValidatorTimingChannel.class,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AggregationDuty.java
@@ -121,7 +121,7 @@ public class AggregationDuty implements Duty {
     final AggregateAndProof aggregateAndProof =
         new AggregateAndProof(aggregator.validatorIndex, aggregate, aggregator.proof);
     return forkProvider
-        .getForkInfo()
+        .getForkInfo(slot)
         .thenCompose(
             forkInfo ->
                 aggregator.validator.getSigner().signAggregateAndProof(aggregateAndProof, forkInfo))

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDuty.java
@@ -84,7 +84,7 @@ public class AttestationProductionDuty implements Duty {
     if (validatorsByCommitteeIndex.isEmpty()) {
       return SafeFuture.completedFuture(DutyResult.NO_OP);
     }
-    return forkProvider.getForkInfo().thenCompose(this::produceAttestations);
+    return forkProvider.getForkInfo(slot).thenCompose(this::produceAttestations);
   }
 
   private SafeFuture<DutyResult> produceAttestations(final ForkInfo forkInfo) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
@@ -53,7 +53,7 @@ public class BlockProductionDuty implements Duty {
   @Override
   public SafeFuture<DutyResult> performDuty() {
     LOG.trace("Creating block for validator {} at slot {}", validator.getPublicKey(), slot);
-    return forkProvider.getForkInfo().thenCompose(this::produceBlock);
+    return forkProvider.getForkInfo(slot).thenCompose(this::produceBlock);
   }
 
   public SafeFuture<DutyResult> produceBlock(final ForkInfo forkInfo) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDuty.java
@@ -67,7 +67,7 @@ public class SyncCommitteeAggregationDuty {
     }
     final SyncCommitteeUtil syncCommitteeUtil = maybeSyncCommitteeUtils.get();
     return forkProvider
-        .getForkInfo()
+        .getForkInfo(slot)
         .thenCompose(
             forkInfo ->
                 SafeFuture.collectAll(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDuty.java
@@ -59,7 +59,7 @@ public class SyncCommitteeProductionDuty {
       return SafeFuture.completedFuture(DutyResult.NO_OP);
     }
     return forkProvider
-        .getForkInfo()
+        .getForkInfo(slot)
         .thenCompose(forkInfo -> produceSignatures(forkInfo, slot, blockRoot))
         .exceptionally(
             error ->

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AbstractDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AbstractDutySchedulerTest.java
@@ -62,6 +62,6 @@ public abstract class AbstractDutySchedulerTest {
         SafeFuture.failedFuture(new UnsupportedOperationException("This test ignores aggregation"));
     when(validator1Signer.signAggregationSlot(any(), any())).thenReturn(rejectAggregationSignature);
     when(validator2Signer.signAggregationSlot(any(), any())).thenReturn(rejectAggregationSignature);
-    when(forkProvider.getForkInfo()).thenReturn(completedFuture(fork));
+    when(forkProvider.getForkInfo(any())).thenReturn(completedFuture(fork));
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
@@ -81,7 +81,7 @@ class AttestationDutyLoaderTest {
   void setUp() {
     when(validatorIndexProvider.getValidatorIndices(any()))
         .thenReturn(SafeFuture.completedFuture(VALIDATOR_INDICES));
-    when(forkProvider.getForkInfo()).thenReturn(SafeFuture.completedFuture(forkInfo));
+    when(forkProvider.getForkInfo(any())).thenReturn(SafeFuture.completedFuture(forkInfo));
   }
 
   @Test

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ForkProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ForkProviderTest.java
@@ -15,130 +15,50 @@ package tech.pegasys.teku.validator.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
-import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
 
-import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
-import tech.pegasys.teku.spec.datastructures.state.Fork;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.beaconnode.GenesisDataProvider;
 
 class ForkProviderTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
-  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
-  private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
-
-  private final ForkInfo forkInfo = dataStructureUtil.randomForkInfo();
+  private final Spec spec = TestSpecFactory.createMinimalWithAltairFork(UInt64.valueOf(16));
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final GenesisDataProvider genesisDataProvider = mock(GenesisDataProvider.class);
 
-  private final ForkProvider forkProvider =
-      new ForkProvider(asyncRunner, validatorApiChannel, genesisDataProvider);
+  private final Bytes32 genesisValidatorsRoot = dataStructureUtil.randomBytes32();
 
-  @Test
-  public void shouldRequestForkWhenNotPreviouslyLoaded() {
-    final SafeFuture<Optional<Fork>> forkRequest = new SafeFuture<>();
-    when(validatorApiChannel.getFork()).thenReturn(forkRequest);
+  private final ForkProvider forkProvider = new ForkProvider(spec, genesisDataProvider);
+
+  @BeforeEach
+  void setUp() {
     when(genesisDataProvider.getGenesisValidatorsRoot())
-        .thenReturn(SafeFuture.completedFuture(forkInfo.getGenesisValidatorsRoot()));
-
-    forkProvider.start().reportExceptions();
-    final SafeFuture<ForkInfo> result = forkProvider.getForkInfo();
-
-    assertThat(result).isNotDone();
-
-    forkRequest.complete(Optional.of(forkInfo.getFork()));
-    assertThat(result).isCompletedWithValue(forkInfo);
+        .thenReturn(SafeFuture.completedFuture(genesisValidatorsRoot));
   }
 
   @Test
-  public void shouldReturnCachedForkWhenPreviouslyLoaded() {
-    when(validatorApiChannel.getFork())
-        .thenReturn(completedFuture(Optional.of(forkInfo.getFork())));
-    when(genesisDataProvider.getGenesisValidatorsRoot())
-        .thenReturn(SafeFuture.completedFuture(forkInfo.getGenesisValidatorsRoot()));
+  void shouldLookupCorrectFork() {
+    final ForkInfo phase0 =
+        new ForkInfo(spec.getForkSchedule().getFork(UInt64.ZERO), genesisValidatorsRoot);
+    final ForkInfo altair =
+        new ForkInfo(spec.getForkSchedule().getFork(UInt64.valueOf(2)), genesisValidatorsRoot);
 
-    // First request loads the fork
-    forkProvider.start().reportExceptions();
-    assertThat(forkProvider.getForkInfo()).isCompletedWithValue(forkInfo);
-    verify(validatorApiChannel).getFork();
+    // Should convert slot to epoch when retrieving fork.
+    assertThat(forkProvider.getForkInfo(UInt64.valueOf(0))).isCompletedWithValue(phase0);
+    assertThat(forkProvider.getForkInfo(UInt64.valueOf(1))).isCompletedWithValue(phase0);
+    assertThat(forkProvider.getForkInfo(UInt64.valueOf(2))).isCompletedWithValue(phase0);
+    assertThat(forkProvider.getForkInfo(UInt64.valueOf(15))).isCompletedWithValue(phase0);
 
-    // Subsequent requests just return the cached version
-    assertThat(forkProvider.getForkInfo()).isCompletedWithValue(forkInfo);
-    verifyNoMoreInteractions(validatorApiChannel);
-  }
-
-  @Test
-  public void shouldPeriodicallyRequestUpdatedFork() {
-    final ForkInfo updatedFork =
-        new ForkInfo(dataStructureUtil.randomFork(), forkInfo.getGenesisValidatorsRoot());
-    when(genesisDataProvider.getGenesisValidatorsRoot())
-        .thenReturn(SafeFuture.completedFuture(forkInfo.getGenesisValidatorsRoot()));
-    when(validatorApiChannel.getFork())
-        .thenReturn(completedFuture(Optional.of(forkInfo.getFork())))
-        .thenReturn(completedFuture(Optional.of(updatedFork.getFork())));
-
-    forkProvider.start().reportExceptions();
-    assertThat(forkProvider.getForkInfo()).isCompletedWithValue(forkInfo);
-
-    // Update is scheduled
-    assertThat(asyncRunner.hasDelayedActions()).isTrue();
-
-    // And after it runs we get the updated fork
-    asyncRunner.executeQueuedActions();
-    assertThat(forkProvider.getForkInfo()).isCompletedWithValue(updatedFork);
-  }
-
-  @Test
-  public void shouldOnlySendSingleRequestWhenForkNotPreviouslyLoaded() {
-    final SafeFuture<Optional<Fork>> forkFuture = new SafeFuture<>();
-    when(validatorApiChannel.getFork()).thenReturn(forkFuture);
-    when(genesisDataProvider.getGenesisValidatorsRoot())
-        .thenReturn(SafeFuture.completedFuture(forkInfo.getGenesisValidatorsRoot()));
-
-    forkProvider.start().reportExceptions();
-    // First request loads the fork
-    final SafeFuture<ForkInfo> result1 = forkProvider.getForkInfo();
-    final SafeFuture<ForkInfo> result2 = forkProvider.getForkInfo();
-    assertThat(result1).isNotCompleted();
-    assertThat(result2).isNotCompleted();
-    verify(validatorApiChannel).getFork();
-    verifyNoMoreInteractions(validatorApiChannel);
-
-    forkFuture.complete(Optional.of(forkInfo.getFork()));
-    assertThat(result1).isCompletedWithValue(this.forkInfo);
-    assertThat(result2).isCompletedWithValue(this.forkInfo);
-
-    // Subsequent requests just return the cached version
-    assertThat(forkProvider.getForkInfo()).isCompletedWithValue(this.forkInfo);
-    verifyNoMoreInteractions(validatorApiChannel);
-  }
-
-  @Test
-  public void shouldRetryWhenForkFailsToLoad() {
-    when(genesisDataProvider.getGenesisValidatorsRoot())
-        .thenReturn(SafeFuture.completedFuture(forkInfo.getGenesisValidatorsRoot()));
-    when(validatorApiChannel.getFork())
-        .thenReturn(failedFuture(new RuntimeException("Nope")))
-        .thenReturn(completedFuture(Optional.of(forkInfo.getFork())));
-    forkProvider.start().reportExceptions();
-    // First request fails
-    final SafeFuture<ForkInfo> result = forkProvider.getForkInfo();
-    verify(validatorApiChannel).getFork();
-    assertThat(result).isNotDone();
-    assertThat(asyncRunner.hasDelayedActions()).isTrue();
-
-    // Retry is scheduled.
-    asyncRunner.executeQueuedActions();
-    verify(validatorApiChannel, times(2)).getFork();
-    assertThat(result).isCompletedWithValue(forkInfo);
+    assertThat(forkProvider.getForkInfo(UInt64.valueOf(16))).isCompletedWithValue(altair);
+    assertThat(forkProvider.getForkInfo(UInt64.valueOf(18))).isCompletedWithValue(altair);
+    // This is the last fork so should continue indefinitely
+    assertThat(forkProvider.getForkInfo(UInt64.valueOf(24982))).isCompletedWithValue(altair);
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
@@ -66,7 +66,7 @@ class AggregationDutyTest {
 
   @BeforeEach
   public void setUp() {
-    when(forkProvider.getForkInfo()).thenReturn(SafeFuture.completedFuture(forkInfo));
+    when(forkProvider.getForkInfo(any())).thenReturn(SafeFuture.completedFuture(forkInfo));
   }
 
   @Test

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
@@ -64,7 +64,7 @@ class AttestationProductionDutyTest {
 
   @BeforeEach
   public void setUp() {
-    when(forkProvider.getForkInfo()).thenReturn(completedFuture(fork));
+    when(forkProvider.getForkInfo(any())).thenReturn(completedFuture(fork));
   }
 
   @Test

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -67,7 +67,7 @@ class BlockProductionDutyTest {
 
   @BeforeEach
   public void setUp() {
-    when(forkProvider.getForkInfo()).thenReturn(completedFuture(fork));
+    when(forkProvider.getForkInfo(any())).thenReturn(completedFuture(fork));
   }
 
   @Test

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
@@ -91,7 +91,7 @@ class SyncCommitteeAggregationDutyTest {
 
   @BeforeEach
   void setUp() {
-    when(forkProvider.getForkInfo()).thenReturn(SafeFuture.completedFuture(forkInfo));
+    when(forkProvider.getForkInfo(any())).thenReturn(SafeFuture.completedFuture(forkInfo));
 
     // Default to not returning errors when sending
     when(validatorApiChannel.sendSignedContributionAndProofs(any()))
@@ -111,7 +111,7 @@ class SyncCommitteeAggregationDutyTest {
     final SyncCommitteeAggregationDuty duty =
         createDuty(committeeAssignment(validator1, 233, 1), committeeAssignment(validator2, 45, 2));
     final Exception exception = new RuntimeException("Ooopsie");
-    when(forkProvider.getForkInfo()).thenReturn(SafeFuture.failedFuture(exception));
+    when(forkProvider.getForkInfo(any())).thenReturn(SafeFuture.failedFuture(exception));
 
     produceAggregatesAndReport(duty);
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDutyTest.java
@@ -63,7 +63,7 @@ class SyncCommitteeProductionDutyTest {
 
   @BeforeEach
   void setUp() {
-    when(forkProvider.getForkInfo()).thenReturn(SafeFuture.completedFuture(forkInfo));
+    when(forkProvider.getForkInfo(any())).thenReturn(SafeFuture.completedFuture(forkInfo));
     when(validatorApiChannel.sendSyncCommitteeSignatures(any()))
         .thenReturn(SafeFuture.completedFuture(emptyList()));
   }
@@ -81,7 +81,7 @@ class SyncCommitteeProductionDutyTest {
     final SyncCommitteeProductionDuty duty = createDuty(committeeAssignment(validator, 55, 1));
     final UInt64 slot = UInt64.valueOf(25);
     final Exception exception = new RuntimeException("Oh dang");
-    when(forkProvider.getForkInfo()).thenReturn(SafeFuture.failedFuture(exception));
+    when(forkProvider.getForkInfo(any())).thenReturn(SafeFuture.failedFuture(exception));
 
     produceSignaturesAndReport(duty, slot);
 

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -58,7 +58,6 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedCo
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
-import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
@@ -153,14 +152,6 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     this.syncCommitteeSignaturePool = syncCommitteeSignaturePool;
     this.syncCommitteeContributionPool = syncCommitteeContributionPool;
     this.syncCommitteeSubscriptionManager = syncCommitteeSubscriptionManager;
-  }
-
-  @Override
-  public SafeFuture<Optional<Fork>> getFork(final UInt64 epoch) {
-    return SafeFuture.completedFuture(
-        spec.getForkSchedule()
-            .getNextFork(epoch)
-            .or(() -> Optional.of(spec.getForkSchedule().getFork(epoch))));
   }
 
   @Override

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -156,9 +156,11 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Fork>> getFork() {
+  public SafeFuture<Optional<Fork>> getFork(final UInt64 epoch) {
     return SafeFuture.completedFuture(
-        combinedChainDataClient.getBestState().map(BeaconState::getFork));
+        spec.getForkSchedule()
+            .getNextFork(epoch)
+            .or(() -> Optional.of(spec.getForkSchedule().getFork(epoch))));
   }
 
   @Override

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -59,6 +59,7 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedCo
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.CheckpointState;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
@@ -489,18 +490,38 @@ class ValidatorApiHandlerTest {
   }
 
   @Test
-  public void getFork_shouldReturnEmptyWhenHeadStateNotAvailable() {
-    when(chainDataClient.getBestState()).thenReturn(Optional.empty());
+  public void getNextFork_shouldReturnNextForkWhenOneIsPresent() {
+    final UInt64 forkSlot = UInt64.valueOf(16);
+    final Spec spec = TestSpecFactory.createMinimalWithAltairFork(forkSlot);
+    final Fork expectedFork = spec.getForkSchedule().getFork(forkSlot);
+    final ValidatorApiHandler validatorApiHandler =
+        new ValidatorApiHandler(
+            chainDataProvider,
+            chainDataClient,
+            syncStateProvider,
+            blockFactory,
+            blockImportChannel,
+            blockGossipChannel,
+            attestationPool,
+            attestationManager,
+            attestationTopicSubscriptions,
+            activeValidatorTracker,
+            dutyMetrics,
+            performanceTracker,
+            spec,
+            forkChoiceTrigger,
+            syncCommitteeSignaturePool,
+            syncCommitteeContributionPool,
+            syncCommitteeSubscriptionManager);
 
-    assertThat(validatorApiHandler.getFork()).isCompletedWithValue(Optional.empty());
+    assertThat(validatorApiHandler.getFork(ZERO)).isCompletedWithValue(Optional.of(expectedFork));
   }
 
   @Test
-  public void getFork_shouldReturnForkFromHeadState() {
-    final BeaconState state = dataStructureUtil.randomBeaconState();
-    when(chainDataClient.getBestState()).thenReturn(Optional.of(state));
+  public void getNextFork_shouldReturnCurrentForkWhenThereIsNoNextFork() {
+    final Fork expectedFork = spec.getForkSchedule().getFork(ZERO);
 
-    assertThat(validatorApiHandler.getFork()).isCompletedWithValue(Optional.of(state.getFork()));
+    assertThat(validatorApiHandler.getFork(ZERO)).isCompletedWithValue(Optional.of(expectedFork));
   }
 
   @Test

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -59,7 +59,6 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedCo
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.CheckpointState;
-import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
@@ -487,41 +486,6 @@ class ValidatorApiHandlerTest {
             validatorApiHandler.createAggregate(
                 aggregate.get().getData().getSlot(), attestationData.hashTreeRoot()))
         .isCompletedWithValue(aggregate);
-  }
-
-  @Test
-  public void getNextFork_shouldReturnNextForkWhenOneIsPresent() {
-    final UInt64 forkSlot = UInt64.valueOf(16);
-    final Spec spec = TestSpecFactory.createMinimalWithAltairFork(forkSlot);
-    final Fork expectedFork = spec.getForkSchedule().getFork(forkSlot);
-    final ValidatorApiHandler validatorApiHandler =
-        new ValidatorApiHandler(
-            chainDataProvider,
-            chainDataClient,
-            syncStateProvider,
-            blockFactory,
-            blockImportChannel,
-            blockGossipChannel,
-            attestationPool,
-            attestationManager,
-            attestationTopicSubscriptions,
-            activeValidatorTracker,
-            dutyMetrics,
-            performanceTracker,
-            spec,
-            forkChoiceTrigger,
-            syncCommitteeSignaturePool,
-            syncCommitteeContributionPool,
-            syncCommitteeSubscriptionManager);
-
-    assertThat(validatorApiHandler.getFork(ZERO)).isCompletedWithValue(Optional.of(expectedFork));
-  }
-
-  @Test
-  public void getNextFork_shouldReturnCurrentForkWhenThereIsNoNextFork() {
-    final Fork expectedFork = spec.getForkSchedule().getFork(ZERO);
-
-    assertThat(validatorApiHandler.getFork(ZERO)).isCompletedWithValue(Optional.of(expectedFork));
   }
 
   @Test

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -21,11 +21,13 @@ import com.google.common.base.Throwables;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
@@ -87,14 +89,27 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Fork>> getFork() {
+  public SafeFuture<Optional<Fork>> getFork(final UInt64 epoch) {
     return sendRequest(
         () ->
             apiClient
-                .getFork()
-                .map(
-                    result ->
-                        new Fork(result.previous_version, result.current_version, result.epoch)));
+                .getForkSchedule()
+                .map(forkSchedule -> forkSchedule.data)
+                .flatMap(
+                    forks -> {
+                      final TreeSet<tech.pegasys.teku.api.schema.Fork> sortedForks =
+                          new TreeSet<>(Comparator.comparing(fork -> fork.epoch));
+                      sortedForks.addAll(forks);
+                      tech.pegasys.teku.api.schema.Fork previousFork = null;
+                      for (tech.pegasys.teku.api.schema.Fork fork : sortedForks) {
+                        if (fork.epoch.isGreaterThan(epoch)) {
+                          return Optional.of(fork);
+                        }
+                        previousFork = fork;
+                      }
+                      return Optional.ofNullable(previousFork);
+                    })
+                .map(tech.pegasys.teku.api.schema.Fork::asInternalFork));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -21,13 +21,11 @@ import com.google.common.base.Throwables;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
@@ -55,7 +53,6 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
-import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.validator.api.AttesterDuties;
 import tech.pegasys.teku.validator.api.AttesterDuty;
@@ -86,30 +83,6 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
     this.spec = spec;
     this.apiClient = apiClient;
     this.asyncRunner = asyncRunner;
-  }
-
-  @Override
-  public SafeFuture<Optional<Fork>> getFork(final UInt64 epoch) {
-    return sendRequest(
-        () ->
-            apiClient
-                .getForkSchedule()
-                .map(forkSchedule -> forkSchedule.data)
-                .flatMap(
-                    forks -> {
-                      final TreeSet<tech.pegasys.teku.api.schema.Fork> sortedForks =
-                          new TreeSet<>(Comparator.comparing(fork -> fork.epoch));
-                      sortedForks.addAll(forks);
-                      tech.pegasys.teku.api.schema.Fork previousFork = null;
-                      for (tech.pegasys.teku.api.schema.Fork fork : sortedForks) {
-                        if (fork.epoch.isGreaterThan(epoch)) {
-                          return Optional.of(fork);
-                        }
-                        previousFork = fork;
-                      }
-                      return Optional.ofNullable(previousFork);
-                    })
-                .map(tech.pegasys.teku.api.schema.Fork::asInternalFork));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -20,7 +20,6 @@ import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GE
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_BLOCK_HEADER;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_CONFIG_SPEC;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_FORK;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_FORK_SCHEDULE;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_GENESIS;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_PROPOSER_DUTIES;
@@ -60,7 +59,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.request.v1.validator.BeaconCommitteeSubscriptionRequest;
 import tech.pegasys.teku.api.response.v1.beacon.GetBlockHeaderResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
-import tech.pegasys.teku.api.response.v1.beacon.GetStateForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateValidatorsResponse;
 import tech.pegasys.teku.api.response.v1.beacon.PostSyncCommitteeFailureResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
@@ -76,7 +74,6 @@ import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.AttestationData;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.api.schema.BeaconBlock;
-import tech.pegasys.teku.api.schema.Fork;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
@@ -104,16 +101,6 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   public OkHttpValidatorRestApiClient(final HttpUrl baseEndpoint, final OkHttpClient okHttpClient) {
     this.baseEndpoint = baseEndpoint;
     this.httpClient = okHttpClient;
-  }
-
-  @Override
-  public Optional<Fork> getFork() {
-    return get(
-            GET_FORK,
-            Map.of("state_id", "head"),
-            EMPTY_QUERY_PARAMS,
-            createHandler(GetStateForkResponse.class))
-        .map(GetStateForkResponse::getData);
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GE
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_BLOCK_HEADER;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_CONFIG_SPEC;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_FORK;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_FORK_SCHEDULE;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_GENESIS;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_PROPOSER_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_SYNC_COMMITTEE_DUTIES;
@@ -63,6 +64,7 @@ import tech.pegasys.teku.api.response.v1.beacon.GetStateForkResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateValidatorsResponse;
 import tech.pegasys.teku.api.response.v1.beacon.PostSyncCommitteeFailureResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
+import tech.pegasys.teku.api.response.v1.config.GetForkScheduleResponse;
 import tech.pegasys.teku.api.response.v1.config.GetSpecResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
@@ -112,6 +114,15 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
             EMPTY_QUERY_PARAMS,
             createHandler(GetStateForkResponse.class))
         .map(GetStateForkResponse::getData);
+  }
+
+  @Override
+  public Optional<GetForkScheduleResponse> getForkSchedule() {
+    return get(
+        GET_FORK_SCHEDULE,
+        EMPTY_QUERY_PARAMS,
+        EMPTY_QUERY_PARAMS,
+        createHandler(GetForkScheduleResponse.class));
   }
 
   public Optional<GetSpecResponse> getConfigSpec() {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -20,7 +20,6 @@ import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GE
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_ATTESTATION_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_BLOCK_HEADER;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_CONFIG_SPEC;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_FORK_SCHEDULE;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_GENESIS;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_PROPOSER_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_SYNC_COMMITTEE_DUTIES;
@@ -62,7 +61,6 @@ import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateValidatorsResponse;
 import tech.pegasys.teku.api.response.v1.beacon.PostSyncCommitteeFailureResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
-import tech.pegasys.teku.api.response.v1.config.GetForkScheduleResponse;
 import tech.pegasys.teku.api.response.v1.config.GetSpecResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
@@ -101,15 +99,6 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   public OkHttpValidatorRestApiClient(final HttpUrl baseEndpoint, final OkHttpClient okHttpClient) {
     this.baseEndpoint = baseEndpoint;
     this.httpClient = okHttpClient;
-  }
-
-  @Override
-  public Optional<GetForkScheduleResponse> getForkSchedule() {
-    return get(
-        GET_FORK_SCHEDULE,
-        EMPTY_QUERY_PARAMS,
-        EMPTY_QUERY_PARAMS,
-        createHandler(GetForkScheduleResponse.class));
   }
 
   public Optional<GetSpecResponse> getConfigSpec() {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 public enum ValidatorApiMethod {
   GET_FORK("eth/v1/beacon/states/:state_id/fork"),
+  GET_FORK_SCHEDULE("/eth/v1/config/fork_schedule"),
   GET_GENESIS("eth/v1/beacon/genesis"),
   GET_VALIDATORS("eth/v1/beacon/states/head/validators"),
   GET_DUTIES("validator/duties"),

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -19,7 +19,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.util.Map;
 
 public enum ValidatorApiMethod {
-  GET_FORK("eth/v1/beacon/states/:state_id/fork"),
   GET_FORK_SCHEDULE("/eth/v1/config/fork_schedule"),
   GET_GENESIS("eth/v1/beacon/genesis"),
   GET_VALIDATORS("eth/v1/beacon/states/head/validators"),

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -19,7 +19,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.util.Map;
 
 public enum ValidatorApiMethod {
-  GET_FORK_SCHEDULE("/eth/v1/config/fork_schedule"),
   GET_GENESIS("eth/v1/beacon/genesis"),
   GET_VALIDATORS("eth/v1/beacon/states/head/validators"),
   GET_DUTIES("validator/duties"),

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.AttestationData;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.api.schema.BeaconBlock;
-import tech.pegasys.teku.api.schema.Fork;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
@@ -42,8 +41,6 @@ import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 
 public interface ValidatorRestApiClient {
-
-  Optional<Fork> getFork();
 
   Optional<GetForkScheduleResponse> getForkSchedule();
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -21,7 +21,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.beacon.PostSyncCommitteeFailureResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
-import tech.pegasys.teku.api.response.v1.config.GetForkScheduleResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostSyncDutiesResponse;
@@ -41,8 +40,6 @@ import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 
 public interface ValidatorRestApiClient {
-
-  Optional<GetForkScheduleResponse> getForkSchedule();
 
   Optional<GetGenesisResponse> getGenesis();
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -21,6 +21,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.beacon.PostSyncCommitteeFailureResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
+import tech.pegasys.teku.api.response.v1.config.GetForkScheduleResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostSyncDutiesResponse;
@@ -43,6 +44,8 @@ import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 public interface ValidatorRestApiClient {
 
   Optional<Fork> getFork();
+
+  Optional<GetForkScheduleResponse> getForkSchedule();
 
   Optional<GetGenesisResponse> getGenesis();
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -543,7 +543,7 @@ class RemoteValidatorApiHandlerTest {
 
   @Test
   void shouldRetryAfterDelayWhenRequestRateLimited() {
-    when(apiClient.getForkSchedule()).thenThrow(new RateLimitedException("/fork"));
+    when(apiClient.getGenesis()).thenThrow(new RateLimitedException("/fork"));
 
     final SafeFuture<Optional<tech.pegasys.teku.spec.datastructures.genesis.GenesisData>> result =
         apiHandler.getGenesisData();
@@ -551,7 +551,7 @@ class RemoteValidatorApiHandlerTest {
     for (int i = 0; i < MAX_RATE_LIMITING_RETRIES; i++) {
       asyncRunner.executeQueuedActions();
       assertThat(result).isNotDone();
-      verify(apiClient, times(i + 1)).getForkSchedule();
+      verify(apiClient, times(i + 1)).getGenesis();
     }
 
     asyncRunner.executeQueuedActions();

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -673,7 +673,7 @@ class OkHttpValidatorRestApiClientTest {
     apiClient = new OkHttpValidatorRestApiClient(url, okHttpClient);
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NO_CONTENT));
 
-    apiClient.getForkSchedule();
+    apiClient.getGenesis();
 
     RecordedRequest request = mockWebServer.takeRequest();
 
@@ -687,7 +687,7 @@ class OkHttpValidatorRestApiClientTest {
   void shouldThrowRateLimitedExceptionWhen429ResponseReceived() {
     mockWebServer.enqueue(new MockResponse().setResponseCode(429));
 
-    assertThatThrownBy(() -> apiClient.getForkSchedule()).isInstanceOf(RateLimitedException.class);
+    assertThatThrownBy(() -> apiClient.getGenesis()).isInstanceOf(RateLimitedException.class);
   }
 
   private String asJson(Object object) {


### PR DESCRIPTION
## PR Description
Update the `ForkProvider` the validator client uses to retrieve the fork from the `spec` rather than loading via the `ValidatorAPiChannel.getFork()` and specify the slot to get the fork for.  This ensures the right fork is used when transitioning from phase0 to altair.

The `getFork()` method is no longer required so is removed.

## Fixed Issue(s)
fixes #3946 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
