### PR TITLE
Ensure the state used to calculate duties for an epoch is after the fork slot

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -80,6 +80,9 @@ public class SyncCommitteeUtil {
 
   public boolean isStateUsableForCommitteeCalculationAtEpoch(
       final BeaconState state, final UInt64 epoch) {
+    if (state.toVersionAltair().isEmpty()) {
+      return false;
+    }
     final UInt64 syncCommitteePeriod = computeSyncCommitteePeriod(epoch);
     final UInt64 currentEpoch = beaconStateAccessors.getCurrentEpoch(state);
     final UInt64 currentSyncCommitteePeriod = computeSyncCommitteePeriod(currentEpoch);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
@@ -166,11 +166,16 @@ public class SyncCommitteeScheduler implements ValidatorTimingChannel {
     }
 
     public void calculateDuties() {
+
+      // Always use the last epoch in the period since it's the most likely to still be in-memory
+      // This also handles the case where the fork slot is within the sync committee period by
+      // ensuring that we request an epoch after the fork slot has occurred.
       duties =
           duties.or(
               () ->
                   Optional.of(
-                      PendingDuties.calculateDuties(metricsSystem, dutyLoader, periodStartEpoch)));
+                      PendingDuties.calculateDuties(
+                          metricsSystem, dutyLoader, nextPeriodStartEpoch.minusMinZero(1))));
     }
 
     public void recalculate() {


### PR DESCRIPTION
## PR Description
The Altair fork slot is not necessarily the first slot of a sync committee period and sync committees can't be calculated until the fork actually happens. This requires two updates:

1. The validator client can't always use the first epoch of the sync committee period to request duties. This switches it to use the last epoch of the duties. That's always after the fork slot but also the most likely epoch to not be finalized and in memory.
2. The beacon node should consider the head state unsuitable for calculating sync committee duties if it isn't an Altair state.

## Fixed Issue(s)
fixes #3944 
fixes #3945 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
