### PR TITLE
Convert to subnet id when processing sync committee subscriptions

### DIFF
--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -418,8 +418,11 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   public void subscribeToSyncCommitteeSubnets(
       final Collection<SyncCommitteeSubnetSubscription> subscriptions) {
     for (final SyncCommitteeSubnetSubscription subscription : subscriptions) {
-      subscription
-          .getSyncCommitteeIndices()
+      final SyncCommitteeUtil syncCommitteeUtil =
+          spec.getSyncCommitteeUtilRequired(
+              spec.computeStartSlotAtEpoch(subscription.getUntilEpoch()));
+      syncCommitteeUtil
+          .getSyncSubcommittees(subscription.getSyncCommitteeIndices())
           .forEach(
               index ->
                   syncCommitteeSubscriptionManager.subscribe(index, subscription.getUntilEpoch()));

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -34,6 +34,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -85,6 +86,7 @@ import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.ProposerDuty;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.SubmitCommitteeSignatureError;
+import tech.pegasys.teku.validator.api.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
 
 class ValidatorApiHandlerTest {
@@ -517,6 +519,18 @@ class ValidatorApiHandlerTest {
 
     verifyNoInteractions(attestationTopicSubscriptions);
     verify(activeValidatorTracker).onCommitteeSubscriptionRequest(validatorIndex, aggregationSlot);
+  }
+
+  @Test
+  void subscribeToSyncCommitteeSubnets_shouldConvertCommitteeIndexToSubnetId() {
+    final SyncCommitteeSubnetSubscription subscription1 =
+        new SyncCommitteeSubnetSubscription(1, Set.of(1, 2, 15, 30), UInt64.valueOf(44));
+    final SyncCommitteeSubnetSubscription subscription2 =
+        new SyncCommitteeSubnetSubscription(1, Set.of(5, 10), UInt64.valueOf(35));
+    validatorApiHandler.subscribeToSyncCommitteeSubnets(List.of(subscription1, subscription2));
+    System.out.println(spec.getSyncCommitteeUtilRequired(ZERO).getSubcommitteeSize());
+    verify(syncCommitteeSubscriptionManager).subscribe(0, subscription1.getUntilEpoch());
+    verify(syncCommitteeSubscriptionManager).subscribe(0, subscription1.getUntilEpoch());
   }
 
   @Test

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
@@ -530,7 +531,12 @@ class ValidatorApiHandlerTest {
     validatorApiHandler.subscribeToSyncCommitteeSubnets(List.of(subscription1, subscription2));
     System.out.println(spec.getSyncCommitteeUtilRequired(ZERO).getSubcommitteeSize());
     verify(syncCommitteeSubscriptionManager).subscribe(0, subscription1.getUntilEpoch());
-    verify(syncCommitteeSubscriptionManager).subscribe(0, subscription1.getUntilEpoch());
+    verify(syncCommitteeSubscriptionManager).subscribe(3, subscription1.getUntilEpoch());
+    verify(syncCommitteeSubscriptionManager).subscribe(7, subscription1.getUntilEpoch());
+
+    verify(syncCommitteeSubscriptionManager).subscribe(1, subscription2.getUntilEpoch());
+    verify(syncCommitteeSubscriptionManager).subscribe(2, subscription2.getUntilEpoch());
+    verifyNoMoreInteractions(syncCommitteeSubscriptionManager);
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Convert the committee index to subcommittee ID when processing sync committee subscription requests.

## Fixed Issue(s)
fixes #3942 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
