### PR TITLE
Include epoch info in message when state is unsuitable for calculating sync committee

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -99,7 +99,9 @@ public class SyncCommitteeUtil {
     final UInt64 currentSyncCommitteePeriod = computeSyncCommitteePeriod(currentEpoch);
     checkArgument(
         isStateUsableForCommitteeCalculationAtEpoch(state, epoch),
-        "State must be in the same or previous sync committee period");
+        "State must be in the same or previous sync committee period. Cannot calculate epoch {} from state at slot {}",
+        epoch,
+        state.getSlot());
     final BeaconStateAltair altairState = BeaconStateAltair.required(state);
     return BeaconStateCache.getTransitionCaches(altairState)
         .getSyncCommitteeCache()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -204,10 +204,7 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
     aggregate
         .getSyncCommitteeBits()
         .streamAllSetBits()
-        .forEach(
-            index -> {
-              participantPubkeys.add(committeePubkeys.get(index).getBLSPublicKey());
-            });
+        .forEach(index -> participantPubkeys.add(committeePubkeys.get(index).getBLSPublicKey()));
     final UInt64 previousSlot = state.getSlot().minusMinZero(1);
     final Bytes32 domain =
         beaconStateUtil.getDomain(


### PR DESCRIPTION
## PR Description
Include the state slot and request epoch in the error message when sync committee assignments can't be calculated because the state isn't suitable.

Plus one minor formatting tidy up.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
