### PR TITLE
Add cli option to override the altair fork block and enable it

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -78,7 +78,7 @@ public class TekuNode extends Node {
     super(network, TEKU_DOCKER_IMAGE, LOG);
     this.httpClient = httpClient;
     this.config = config;
-    this.spec = SpecFactory.getDefault().create(config.getNetworkName());
+    this.spec = SpecFactory.create(config.getNetworkName());
 
     container
         .withWorkingDirectory(WORKING_DIRECTORY)

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -145,11 +145,12 @@ public class Eth2NetworkConfiguration {
     private Eth1Address eth1DepositContractAddress;
     private Optional<UInt64> eth1DepositContractDeployBlock = Optional.empty();
     private boolean balanceAttackMitigationEnabled = false;
+    private Optional<UInt64> altairForkSlot = Optional.empty();
 
     public Eth2NetworkConfiguration build() {
       checkNotNull(constants, "Missing constants");
 
-      final Spec spec = SpecFactory.getDefault().create(constants);
+      final Spec spec = SpecFactory.create(constants, altairForkSlot);
       // if the deposit contract was not set, default from constants
       if (eth1DepositContractAddress == null) {
         eth1DepositContractAddress(
@@ -225,6 +226,11 @@ public class Eth2NetworkConfiguration {
 
     public Builder balanceAttackMitigationEnabled(final boolean balanceAttackMitigationEnabled) {
       this.balanceAttackMitigationEnabled = balanceAttackMitigationEnabled;
+      return this;
+    }
+
+    public Builder altairForkSlot(final UInt64 altairForkSlot) {
+      this.altairForkSlot = Optional.of(altairForkSlot);
       return this;
     }
 

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -43,6 +43,7 @@ public class Eth2NetworkConfiguration {
   private final int startupTargetPeerCount;
   private final int startupTimeoutSeconds;
   private final List<String> discoveryBootnodes;
+  private final Optional<UInt64> altairForkSlot;
   private final Eth1Address eth1DepositContractAddress;
   private final Optional<UInt64> eth1DepositContractDeployBlock;
   private final boolean balanceAttackMitigationEnabled;
@@ -57,7 +58,8 @@ public class Eth2NetworkConfiguration {
       final List<String> discoveryBootnodes,
       final Eth1Address eth1DepositContractAddress,
       final Optional<UInt64> eth1DepositContractDeployBlock,
-      final boolean balanceAttackMitigationEnabled) {
+      final boolean balanceAttackMitigationEnabled,
+      final Optional<UInt64> altairForkSlot) {
     this.spec = spec;
     this.constants = constants;
     this.initialState = initialState;
@@ -65,6 +67,7 @@ public class Eth2NetworkConfiguration {
     this.startupTargetPeerCount = startupTargetPeerCount;
     this.startupTimeoutSeconds = startupTimeoutSeconds;
     this.discoveryBootnodes = discoveryBootnodes;
+    this.altairForkSlot = altairForkSlot;
     this.eth1DepositContractAddress =
         eth1DepositContractAddress == null
             ? new Eth1Address(spec.getGenesisSpecConfig().getDepositContractAddress())
@@ -130,6 +133,10 @@ public class Eth2NetworkConfiguration {
     return balanceAttackMitigationEnabled;
   }
 
+  public Optional<UInt64> getAltairForkSlot() {
+    return altairForkSlot;
+  }
+
   @Override
   public String toString() {
     return constants;
@@ -166,7 +173,8 @@ public class Eth2NetworkConfiguration {
           discoveryBootnodes,
           eth1DepositContractAddress,
           eth1DepositContractDeployBlock,
-          balanceAttackMitigationEnabled);
+          balanceAttackMitigationEnabled,
+          altairForkSlot);
     }
 
     public Builder constants(final String constants) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecFactory.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecFactory.java
@@ -13,27 +13,32 @@
 
 package tech.pegasys.teku.spec;
 
+import java.util.Optional;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigLoader;
 
-public interface SpecFactory {
-  SpecFactory PHASE0 = new Phase0SpecFactory();
+public class SpecFactory {
 
-  static SpecFactory getDefault() {
-    return PHASE0;
+  public static Spec create(String configName) {
+    return create(configName, Optional.empty());
   }
 
-  default Spec create(String configName) {
-    return create(SpecConfigLoader.loadConfig(configName));
+  public static Spec create(String configName, final Optional<UInt64> altairForkSlot) {
+    final SpecConfig config =
+        SpecConfigLoader.loadConfig(
+            configName,
+            builder ->
+                altairForkSlot.ifPresent(
+                    florkSlot ->
+                        builder.altairBuilder(
+                            altairBuilder -> altairBuilder.altairForkSlot(florkSlot))));
+    return create(config, altairForkSlot);
   }
 
-  Spec create(SpecConfig config);
-
-  class Phase0SpecFactory implements SpecFactory {
-
-    @Override
-    public Spec create(SpecConfig config) {
-      return Spec.create(config, SpecMilestone.PHASE0);
-    }
+  public static Spec create(final SpecConfig config, final Optional<UInt64> altairForkSlot) {
+    final SpecMilestone highestMilestoneSupported =
+        altairForkSlot.map(__ -> SpecMilestone.ALTAIR).orElse(SpecMilestone.PHASE0);
+    return Spec.create(config, highestMilestoneSupported);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecFactory.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecFactory.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.config.SpecConfigBuilder;
 import tech.pegasys.teku.spec.config.SpecConfigLoader;
 
 public class SpecFactory {
@@ -29,11 +30,13 @@ public class SpecFactory {
         SpecConfigLoader.loadConfig(
             configName,
             builder ->
-                altairForkSlot.ifPresent(
-                    florkSlot ->
-                        builder.altairBuilder(
-                            altairBuilder -> altairBuilder.altairForkSlot(florkSlot))));
+                altairForkSlot.ifPresent(forkSlot -> overrideAltairForkSlot(builder, forkSlot)));
     return create(config, altairForkSlot);
+  }
+
+  private static void overrideAltairForkSlot(
+      final SpecConfigBuilder builder, final UInt64 forkSlot) {
+    builder.altairBuilder(altairBuilder -> altairBuilder.altairForkSlot(forkSlot));
   }
 
   public static Spec create(final SpecConfig config, final Optional<UInt64> altairForkSlot) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigLoader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigLoader.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.infrastructure.io.resource.ResourceLoader;
 import tech.pegasys.teku.spec.networks.Eth2Network;
@@ -28,9 +29,14 @@ import tech.pegasys.teku.util.config.Constants;
 public class SpecConfigLoader {
 
   public static SpecConfig loadConfig(final String configName) {
+    return loadConfig(configName, __ -> {});
+  }
+
+  public static SpecConfig loadConfig(
+      final String configName, final Consumer<SpecConfigBuilder> modifier) {
     final SpecConfigReader reader = new SpecConfigReader();
     processConfig(configName, reader::read);
-    return reader.build();
+    return reader.build(modifier);
   }
 
   public static SpecConfig loadConfig(final Map<String, ?> config) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -99,7 +99,7 @@ public class SyncCommitteeUtil {
     final UInt64 currentSyncCommitteePeriod = computeSyncCommitteePeriod(currentEpoch);
     checkArgument(
         isStateUsableForCommitteeCalculationAtEpoch(state, epoch),
-        "State must be in the same or previous sync committee period. Cannot calculate epoch {} from state at slot {}",
+        "State must be in the same or previous sync committee period. Cannot calculate epoch %s from state at slot %s",
         epoch,
         state.getSlot());
     final BeaconStateAltair altairState = BeaconStateAltair.required(state);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/SpecFactoryTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/SpecFactoryTest.java
@@ -27,7 +27,7 @@ public class SpecFactoryTest {
 
   @Test
   public void defaultFactoryShouldOnlySupportPhase0_mainnet() {
-    final Spec spec = SpecFactory.getDefault().create("mainnet");
+    final Spec spec = SpecFactory.create("mainnet");
     assertThat(spec.getForkSchedule().getSupportedMilestones())
         .containsExactly(SpecMilestone.PHASE0);
   }
@@ -35,7 +35,7 @@ public class SpecFactoryTest {
   @ParameterizedTest(name = "{0}")
   @MethodSource("getKnownConfigNames")
   public void defaultFactoryShouldOnlySupportPhase0(final String configName) {
-    final Spec spec = SpecFactory.getDefault().create(configName);
+    final Spec spec = SpecFactory.create(configName);
     assertThat(spec.getForkSchedule().getSupportedMilestones())
         .containsExactly(SpecMilestone.PHASE0);
   }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.logging.ColorConsolePrinter.Color;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class StatusLogger {
@@ -45,6 +46,13 @@ public class StatusLogger {
         "This software is licensed under the Apache License, Version 2.0 (the \"License\"); "
             + "you may not use this software except in compliance with the License. "
             + "You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0");
+  }
+
+  public void warnForkSlotChanged(final String milestoneName, final UInt64 newSlot) {
+    log.warn(
+        print(
+            milestoneName + " configuration has been overridden to activate at slot " + newSlot,
+            Color.YELLOW));
   }
 
   public void fatalError(final String description, final Throwable cause) {

--- a/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.infrastructure.version.VersionProvider;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.services.ServiceController;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.util.config.Constants;
 
 public abstract class AbstractNode implements Node {
@@ -56,6 +57,7 @@ public abstract class AbstractNode implements Node {
     LoggingConfigurator.update(tekuConfig.loggingConfig());
 
     STATUS_LOG.onStartup(VersionProvider.VERSION);
+    reportForkSlotOverrides(tekuConfig);
     this.metricsEndpoint = new MetricsEndpoint(tekuConfig.metricsConfig(), vertx);
     final MetricsSystem metricsSystem = metricsEndpoint.getMetricsSystem();
     final TekuDefaultExceptionHandler subscriberExceptionHandler =
@@ -73,6 +75,14 @@ public abstract class AbstractNode implements Node {
             metricsSystem,
             DataDirLayout.createFrom(tekuConfig.dataConfig()));
     Constants.setConstants(tekuConfig.eth2NetworkConfiguration().getConstants());
+  }
+
+  private void reportForkSlotOverrides(final TekuConfiguration tekuConfig) {
+    tekuConfig
+        .eth2NetworkConfiguration()
+        .getAltairForkSlot()
+        .ifPresent(
+            forkSlot -> STATUS_LOG.warnForkSlotChanged(SpecMilestone.ALTAIR.name(), forkSlot));
   }
 
   protected abstract ServiceController getServiceController();

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import tech.pegasys.teku.config.TekuConfiguration;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
 
 public class Eth2NetworkOptions {
@@ -46,6 +47,14 @@ public class Eth2NetworkOptions {
           "Contract address for the deposit contract. Only required when creating a custom network.",
       arity = "1")
   private String eth1DepositContractAddress = null; // Depends on network configuration
+
+  @Option(
+      names = {"--Xnetwork-altair-fork-slot"},
+      hidden = true,
+      paramLabel = "<slot>",
+      description = "Override the Altair fork activation slot.",
+      arity = "1")
+  private UInt64 altairForkSlot;
 
   @Option(
       names = {"--Xstartup-target-peer-count"},
@@ -133,6 +142,9 @@ public class Eth2NetworkOptions {
     }
     if (forkChoiceBalanceAttackMitigationEnabled != null) {
       builder.balanceAttackMitigationEnabled(forkChoiceBalanceAttackMitigationEnabled);
+    }
+    if (altairForkSlot != null) {
+      builder.altairForkSlot(altairForkSlot);
     }
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -181,7 +181,7 @@ public class VoluntaryExitCommand implements Runnable {
       return apiClient
           .getConfigSpec()
           .map(response -> SpecConfigLoader.loadConfig(response.data))
-          .map(specConfig -> SpecFactory.getDefault().create(specConfig))
+          .map(specConfig -> SpecFactory.create(specConfig, Optional.empty()))
           .orElseThrow();
     } catch (Exception ex) {
       SUB_COMMAND_LOG.error(

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.options;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
+import tech.pegasys.teku.config.TekuConfiguration;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+
+class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
+  @Test
+  void shouldNotEnableAltairByDefault() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    final Spec spec = config.eth2NetworkConfiguration().getSpec();
+    assertThat(spec.getForkSchedule().getHighestSupportedMilestone())
+        .isEqualTo(SpecMilestone.PHASE0);
+  }
+
+  @Test
+  void shouldUseAltairForkBlockIfSpecified() {
+    final TekuConfiguration config =
+        getTekuConfigurationFromArguments("--Xnetwork-altair-fork-slot", "64");
+    final Spec spec = config.eth2NetworkConfiguration().getSpec();
+    assertThat(spec.getForkSchedule().getSpecMilestoneAtSlot(UInt64.valueOf(64)))
+        .isEqualTo(SpecMilestone.ALTAIR);
+  }
+}


### PR DESCRIPTION
## PR Description
Adds a `--X` option to override the Altair fork slot to make testing easier.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
