### PR TITLE
Ensure the state used to calculate sync committee duties is not before the fork slot

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -284,7 +284,10 @@ public class SyncCommitteeUtil {
     // Can look-ahead one sync committee period.
     final UInt64 requiredSyncCommitteePeriod =
         computeSyncCommitteePeriod(requiredEpoch).minusMinZero(1);
-    return requiredSyncCommitteePeriod.times(specConfig.getEpochsPerSyncCommitteePeriod());
+    return requiredSyncCommitteePeriod
+        .times(specConfig.getEpochsPerSyncCommitteePeriod())
+        // But can't use a state from before the Altair fork
+        .max(miscHelpers.computeEpochAtSlot(specConfig.getAltairForkSlot()));
   }
 
   public UInt64 computeFirstEpochOfCurrentSyncCommitteePeriod(final UInt64 currentEpoch) {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtilTest.java
@@ -156,6 +156,18 @@ class SyncCommitteeUtilTest {
     assertMinEpochForSyncCommitteePeriod(5);
   }
 
+  @Test
+  void getMinEpochForSyncCommitteeAssignments_shouldNotAllowEpochToBeLessThanForkEpoch() {
+    final UInt64 altairForkEpoch = UInt64.ONE;
+    final UInt64 altairForkSlot = spec.computeStartSlotAtEpoch(altairForkEpoch);
+    final Spec spec = TestSpecFactory.createMinimalWithAltairFork(altairForkSlot);
+    final SyncCommitteeUtil syncCommitteeUtil = spec.getSyncCommitteeUtilRequired(altairForkSlot);
+    assertThat(syncCommitteeUtil.getMinEpochForSyncCommitteeAssignments(altairForkEpoch))
+        .isEqualTo(altairForkEpoch);
+    assertThat(syncCommitteeUtil.getMinEpochForSyncCommitteeAssignments(UInt64.valueOf(2)))
+        .isEqualTo(altairForkEpoch);
+  }
+
   private void assertMinEpochForSyncCommitteePeriod(final int period) {
     final UInt64 epochsPerPeriod = UInt64.valueOf(config.getEpochsPerSyncCommitteePeriod());
     UInt64.range(epochsPerPeriod.times(period), epochsPerPeriod.times(period + 1))

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -641,7 +641,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     final UInt64 stateEpoch = spec.getCurrentEpoch(bestState);
     if (epoch.isGreaterThan(stateEpoch)) {
       // Use the earliest possible epoch since we'll need to process empty slots
-      requiredEpoch = syncCommitteeUtil.computeFirstEpochOfCurrentSyncCommitteePeriod(epoch);
+      requiredEpoch = syncCommitteeUtil.getMinEpochForSyncCommitteeAssignments(epoch);
     } else {
       // Use the latest possible epoch since it's most likely to still be in memory
       requiredEpoch = syncCommitteeUtil.computeLastEpochOfCurrentSyncCommitteePeriod(epoch);


### PR DESCRIPTION
## PR Description
When calculating sync committee duties, ensure the state is after the Altair fork activates.
  
## Fixed Issue(s)
fixes #3959

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
