### PR TITLE
update rest postBlock to support altair blocks

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -232,7 +232,8 @@ public class TekuNode extends Node {
     if (result.isEmpty()) {
       return Optional.empty();
     } else {
-      return Optional.of(jsonProvider.jsonToObject(result, GetBlockResponse.class).data);
+      return Optional.of(
+          (SignedBeaconBlock) jsonProvider.jsonToObject(result, GetBlockResponse.class).getData());
     }
   }
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -232,8 +232,7 @@ public class TekuNode extends Node {
     if (result.isEmpty()) {
       return Optional.empty();
     } else {
-      return Optional.of(
-          (SignedBeaconBlock) jsonProvider.jsonToObject(result, GetBlockResponse.class).getData());
+      return Optional.of(jsonProvider.jsonToObject(result, GetBlockResponse.class).data);
     }
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlock.java
@@ -26,8 +26,7 @@ import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_SERVICE_UNAVA
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_BEACON;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR_REQUIRED;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
@@ -35,6 +34,8 @@ import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
@@ -44,6 +45,7 @@ import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.provider.JsonProvider;
 
 public class PostBlock implements Handler {
+  private static final Logger LOG = LogManager.getLogger();
   public static final String ROUTE = "/eth/v1/beacon/blocks";
 
   private final JsonProvider jsonProvider;
@@ -101,7 +103,7 @@ public class PostBlock implements Handler {
       }
 
       final SignedBeaconBlock signedBeaconBlock =
-          jsonProvider.jsonToObject(ctx.body(), SignedBeaconBlock.class);
+          validatorDataProvider.parseBlock(jsonProvider, ctx.body());
 
       ctx.result(
           validatorDataProvider
@@ -109,10 +111,11 @@ public class PostBlock implements Handler {
               .thenApplyChecked(
                   validatorBlockResult -> handleResponseContext(ctx, validatorBlockResult)));
 
-    } catch (final JsonMappingException | JsonParseException ex) {
+    } catch (final JsonProcessingException ex) {
       ctx.status(SC_BAD_REQUEST);
       ctx.result(BadRequest.badRequest(jsonProvider, ex.getMessage()));
     } catch (final Exception ex) {
+      LOG.error("Failed to post block due to internal error", ex);
       ctx.status(SC_INTERNAL_SERVER_ERROR);
       ctx.result(BadRequest.internalError(jsonProvider, ex.getMessage()));
     }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlockTest.java
@@ -35,6 +35,8 @@ import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.ValidatorBlockResult;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class PostBlockTest {
@@ -44,12 +46,13 @@ class PostBlockTest {
   private final Context context = mock(Context.class);
   private final ValidatorDataProvider validatorDataProvider = mock(ValidatorDataProvider.class);
   private final SyncDataProvider syncDataProvider = mock(SyncDataProvider.class);
+  private final Spec spec = TestSpecFactory.createMinimalPhase0();
 
   private final JsonProvider jsonProvider = new JsonProvider();
   private final PostBlock handler =
       new PostBlock(validatorDataProvider, syncDataProvider, jsonProvider);
 
-  DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   @Test
   void shouldReturnUnavailableIfSyncing() throws Exception {
@@ -64,6 +67,8 @@ class PostBlockTest {
   void shouldReturnBadRequestIfArgumentNotJSON() throws Exception {
     when(syncDataProvider.isSyncing()).thenReturn(false);
     when(context.body()).thenReturn("Not a beacon block.");
+    when(validatorDataProvider.parseBlock(any(), any()))
+        .thenThrow(mock(JsonProcessingException.class));
 
     handler.handle(context);
 
@@ -77,6 +82,8 @@ class PostBlockTest {
 
     when(syncDataProvider.isSyncing()).thenReturn(false);
     when(context.body()).thenReturn(notASignedBlock);
+    when(validatorDataProvider.parseBlock(any(), any()))
+        .thenThrow(mock(JsonProcessingException.class));
 
     handler.handle(context);
 

--- a/data/serializer/build.gradle
+++ b/data/serializer/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   implementation project(':bls')
   implementation project(':ethereum:spec')
 
+  testImplementation project(':data:provider')
   testImplementation testFixtures(project(':ethereum:spec'))
   testImplementation testFixtures(project(':ethereum:networks'))
   testImplementation testFixtures(project(':ssz'))

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/GetBlockResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/GetBlockResponse.java
@@ -15,11 +15,19 @@ package tech.pegasys.teku.api.response.v1.beacon;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
+import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
+import tech.pegasys.teku.api.schema.interfaces.VersionedData;
+import tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0;
 
 public class GetBlockResponse {
-  @JsonProperty("data")
-  public final SignedBeaconBlock data;
+  private final VersionedData data;
+
+  @Schema(oneOf = {SignedBeaconBlockPhase0.class, SignedBeaconBlockAltair.class})
+  public VersionedData getData() {
+    return data;
+  }
 
   @JsonCreator
   public GetBlockResponse(@JsonProperty("data") final SignedBeaconBlock data) {

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/GetBlockResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/GetBlockResponse.java
@@ -14,18 +14,19 @@
 package tech.pegasys.teku.api.response.v1.beacon;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
-import tech.pegasys.teku.api.schema.interfaces.VersionedData;
+import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
 import tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0;
 
 public class GetBlockResponse {
-  private final VersionedData data;
+  @JsonIgnore public final SignedBeaconBlock data;
 
   @Schema(oneOf = {SignedBeaconBlockPhase0.class, SignedBeaconBlockAltair.class})
-  public VersionedData getData() {
+  public SignedBlock getData() {
     return data;
   }
 

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/GetNewBlockResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/GetNewBlockResponse.java
@@ -14,11 +14,21 @@
 package tech.pegasys.teku.api.response.v1.validator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import tech.pegasys.teku.api.schema.BeaconBlock;
+import tech.pegasys.teku.api.schema.altair.BeaconBlockAltair;
+import tech.pegasys.teku.api.schema.interfaces.UnsignedBlock;
+import tech.pegasys.teku.api.schema.phase0.BeaconBlockPhase0;
 
 public class GetNewBlockResponse {
-  public final BeaconBlock data;
+  @JsonIgnore public final BeaconBlock data;
+
+  @Schema(oneOf = {BeaconBlockPhase0.class, BeaconBlockAltair.class})
+  public UnsignedBlock getData() {
+    return data;
+  }
 
   @JsonCreator
   public GetNewBlockResponse(@JsonProperty("data") final BeaconBlock data) {

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v2/beacon/GetBlockResponseV2.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v2/beacon/GetBlockResponseV2.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
-import tech.pegasys.teku.api.schema.interfaces.VersionedData;
+import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
 import tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0;
 import tech.pegasys.teku.spec.SpecMilestone;
 
@@ -35,14 +35,14 @@ public class GetBlockResponseV2 {
     @JsonSubTypes.Type(value = SignedBeaconBlockPhase0.class, name = "PHASE0"),
     @JsonSubTypes.Type(value = SignedBeaconBlockAltair.class, name = "ALTAIR")
   })
-  private final VersionedData data;
+  private final SignedBlock data;
 
   public SpecMilestone getVersion() {
     return version;
   }
 
   @Schema(oneOf = {SignedBeaconBlockPhase0.class, SignedBeaconBlockAltair.class})
-  public VersionedData getData() {
+  public SignedBlock getData() {
     return data;
   }
 

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v2/validator/GetNewBlockResponseV2.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v2/validator/GetNewBlockResponseV2.java
@@ -14,21 +14,22 @@
 package tech.pegasys.teku.api.response.v2.validator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.altair.BeaconBlockAltair;
-import tech.pegasys.teku.api.schema.interfaces.VersionedData;
+import tech.pegasys.teku.api.schema.interfaces.UnsignedBlock;
 import tech.pegasys.teku.api.schema.phase0.BeaconBlockPhase0;
 import tech.pegasys.teku.spec.SpecMilestone;
 
 public class GetNewBlockResponseV2 {
 
   public final SpecMilestone version;
-  private final BeaconBlock data;
+  @JsonIgnore public final BeaconBlock data;
 
   @Schema(oneOf = {BeaconBlockPhase0.class, BeaconBlockAltair.class})
-  public VersionedData getData() {
+  public UnsignedBlock getData() {
     return data;
   }
 

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/BeaconBlock.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/BeaconBlock.java
@@ -20,12 +20,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.api.schema.interfaces.VersionedData;
+import tech.pegasys.teku.api.schema.interfaces.UnsignedBlock;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
 
-public class BeaconBlock implements VersionedData {
+public class BeaconBlock implements UnsignedBlock {
   @Schema(type = "string", format = "uint64")
   public final UInt64 slot;
 

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/BeaconBlockBody.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/BeaconBlockBody.java
@@ -21,9 +21,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 
 public class BeaconBlockBody {
@@ -84,36 +86,44 @@ public class BeaconBlockBody {
   }
 
   public tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody
-      asInternalBeaconBlockBody(final SpecVersion spec) {
+      asInternalBeaconBlockBody(
+          final SpecVersion spec, Consumer<BeaconBlockBodyBuilder> builderRef) {
     BeaconBlockBodySchema<?> schema = spec.getSchemaDefinitions().getBeaconBlockBodySchema();
     return schema.createBlockBody(
-        builder ->
-            builder
-                .randaoReveal(randao_reveal.asInternalBLSSignature())
-                .eth1Data(
-                    new tech.pegasys.teku.spec.datastructures.blocks.Eth1Data(
-                        eth1_data.deposit_root, eth1_data.deposit_count, eth1_data.block_hash))
-                .graffiti(graffiti)
-                .attestations(
-                    attestations.stream()
-                        .map(Attestation::asInternalAttestation)
-                        .collect(schema.getAttestationsSchema().collector()))
-                .proposerSlashings(
-                    proposer_slashings.stream()
-                        .map(ProposerSlashing::asInternalProposerSlashing)
-                        .collect(schema.getProposerSlashingsSchema().collector()))
-                .attesterSlashings(
-                    attester_slashings.stream()
-                        .map(AttesterSlashing::asInternalAttesterSlashing)
-                        .collect(schema.getAttesterSlashingsSchema().collector()))
-                .deposits(
-                    deposits.stream()
-                        .map(Deposit::asInternalDeposit)
-                        .collect(schema.getDepositsSchema().collector()))
-                .voluntaryExits(
-                    voluntary_exits.stream()
-                        .map(SignedVoluntaryExit::asInternalSignedVoluntaryExit)
-                        .collect(schema.getVoluntaryExitsSchema().collector())));
+        builder -> {
+          builderRef.accept(builder);
+          builder
+              .randaoReveal(randao_reveal.asInternalBLSSignature())
+              .eth1Data(
+                  new tech.pegasys.teku.spec.datastructures.blocks.Eth1Data(
+                      eth1_data.deposit_root, eth1_data.deposit_count, eth1_data.block_hash))
+              .graffiti(graffiti)
+              .attestations(
+                  attestations.stream()
+                      .map(Attestation::asInternalAttestation)
+                      .collect(schema.getAttestationsSchema().collector()))
+              .proposerSlashings(
+                  proposer_slashings.stream()
+                      .map(ProposerSlashing::asInternalProposerSlashing)
+                      .collect(schema.getProposerSlashingsSchema().collector()))
+              .attesterSlashings(
+                  attester_slashings.stream()
+                      .map(AttesterSlashing::asInternalAttesterSlashing)
+                      .collect(schema.getAttesterSlashingsSchema().collector()))
+              .deposits(
+                  deposits.stream()
+                      .map(Deposit::asInternalDeposit)
+                      .collect(schema.getDepositsSchema().collector()))
+              .voluntaryExits(
+                  voluntary_exits.stream()
+                      .map(SignedVoluntaryExit::asInternalSignedVoluntaryExit)
+                      .collect(schema.getVoluntaryExitsSchema().collector()));
+        });
+  }
+
+  public tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody
+      asInternalBeaconBlockBody(final SpecVersion spec) {
+    return asInternalBeaconBlockBody(spec, (builder) -> {});
   }
 
   @Override

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SignedBeaconBlock.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SignedBeaconBlock.java
@@ -19,10 +19,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
-import tech.pegasys.teku.api.schema.interfaces.VersionedData;
+import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
 import tech.pegasys.teku.spec.Spec;
 
-public class SignedBeaconBlock implements VersionedData {
+public class SignedBeaconBlock implements SignedBlock {
   private final BeaconBlock message;
 
   @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES96)

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/BeaconBlockAltair.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/BeaconBlockAltair.java
@@ -17,10 +17,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.schema.BeaconBlock;
-import tech.pegasys.teku.api.schema.interfaces.VersionedData;
+import tech.pegasys.teku.api.schema.interfaces.UnsignedBlock;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class BeaconBlockAltair extends BeaconBlock implements VersionedData {
+public class BeaconBlockAltair extends BeaconBlock implements UnsignedBlock {
   private final BeaconBlockBodyAltair body;
 
   @JsonProperty("body")

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SignedBeaconBlockAltair.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SignedBeaconBlockAltair.java
@@ -17,9 +17,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
-import tech.pegasys.teku.api.schema.interfaces.VersionedData;
+import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
 
-public class SignedBeaconBlockAltair extends SignedBeaconBlock implements VersionedData {
+public class SignedBeaconBlockAltair extends SignedBeaconBlock implements SignedBlock {
   private final BeaconBlockAltair message;
 
   @Override

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/SignedBlock.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/SignedBlock.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.schema.interfaces;
+
+public interface SignedBlock {}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/UnsignedBlock.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/UnsignedBlock.java
@@ -13,4 +13,4 @@
 
 package tech.pegasys.teku.api.schema.interfaces;
 
-public interface VersionedData {}
+public interface UnsignedBlock {}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/phase0/BeaconBlockPhase0.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/phase0/BeaconBlockPhase0.java
@@ -18,10 +18,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.BeaconBlockBody;
-import tech.pegasys.teku.api.schema.interfaces.VersionedData;
+import tech.pegasys.teku.api.schema.interfaces.UnsignedBlock;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class BeaconBlockPhase0 extends BeaconBlock implements VersionedData {
+public class BeaconBlockPhase0 extends BeaconBlock implements UnsignedBlock {
   @JsonCreator
   public BeaconBlockPhase0(
       @JsonProperty("slot") final UInt64 slot,

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/phase0/SignedBeaconBlockPhase0.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/phase0/SignedBeaconBlockPhase0.java
@@ -18,9 +18,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
-import tech.pegasys.teku.api.schema.interfaces.VersionedData;
+import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
 
-public class SignedBeaconBlockPhase0 extends SignedBeaconBlock implements VersionedData {
+public class SignedBeaconBlockPhase0 extends SignedBeaconBlock implements SignedBlock {
   @JsonCreator
   public SignedBeaconBlockPhase0(
       @JsonProperty("message") final BeaconBlock message,

--- a/data/serializer/src/test/java/tech/pegasys/teku/api/schema/altair/BeaconBlockBodyAltairTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/api/schema/altair/BeaconBlockBodyAltairTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.schema.altair;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.SchemaObjectProvider;
+import tech.pegasys.teku.api.schema.BeaconBlock;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class BeaconBlockBodyAltairTest {
+  private final Spec spec = TestSpecFactory.createMinimalAltair();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final SchemaObjectProvider schemaObjectProvider = new SchemaObjectProvider(spec);
+
+  @Test
+  void asInternalBeaconBlockBody_ShouldConvertAltairBlock() {
+    final tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock internalBlock =
+        dataStructureUtil.randomBeaconBlock(ONE);
+    final BeaconBlock block = schemaObjectProvider.getBeaconBlock(internalBlock);
+
+    assertThat(block).isInstanceOf(BeaconBlockAltair.class);
+    assertThat(block.asInternalBeaconBlock(spec)).isEqualTo(internalBlock);
+  }
+}


### PR DESCRIPTION
 - fixed swagger structures to show signed beacon blocks and unsigned beacon blocks in the swagger definitions.
 - added test cases to show conversion from schema to internal objects is possible
 - Signed blocks are now parsed depending on what milestone they are at, allowing us to handle phase0 and altair blocks being submitted.
 - the block post is compatible with the existing post, so no changelog entry is required.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
