### PR TITLE
Remove changelog items released as part of 21.5.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,14 @@
 For information on changes in released versions of Teku, see the [releases page](https://github.com/ConsenSys/teku/releases).
 
 ## Unreleased Changes
-- Add experimental endpoint for retrieving peer gossip scores at `/teku/v1/nodes/peer_scores`.
-- Fix bug where a REST API request with a missing host header would result in a `NullPointerException`.
 
 ### Additions and Improvements
-- Newly created databases will now use LevelDB for storage instead of RocksDB. This uses less memory and has proven to be more stable. Existing databases are unaffected and will continue to use RocksDB.
-- Support for automatic fail-over of eth1-endpoints.  Multiple endpoints can be specified with the new `--eth1-endpoints` CLI option. Thanks to Enrico Del Fante.
+
+### Bug Fixes
+
+### Experimental: New Altair REST APIs
 - implement POST `/eth/v1/beacon/pool/sync_committees` to allow validators to submit sync committee signatures to the beacon node.
 - implement POST `/eth/v1/validator/duties/sync/{epoch}` for Altair fork.
 - implement GET and POST `/eth/v1/validator/sync_committee_subscriptions` for Altair fork.
 - implement GET `/eth/v2/validator/blocks/{slot}` for Altair fork.
 - `/eth/v1/validator/blocks/{slot}` will now produce an altair block if an altair slot is requested.
-
-### Bug Fixes


### PR DESCRIPTION
## PR Description
Remove released items from changelog.

Create a new category to hold the experimental Altair REST APIs so we can include them in later release notes when they're actually stable.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
