### PR TITLE
Adds error detection in web3j responses from eth1 endpoint

### DIFF
--- a/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
@@ -125,7 +125,15 @@ public class Web3jEth1Provider extends AbstractMonitorableEth1Provider {
   private <S, T extends Response> SafeFuture<T> sendAsync(final Request<S, T> request) {
     try {
       return SafeFuture.of(request.sendAsync())
-          .thenPeek(__ -> updateLastCall(Result.SUCCESS))
+          .thenApply(
+              response -> {
+                if (response.hasError()) {
+                  throw new RuntimeException(response.getError().getMessage());
+                } else {
+                  updateLastCall(Result.SUCCESS);
+                  return response;
+                }
+              })
           .catchAndRethrow(__ -> updateLastCall(Result.FAILED));
     } catch (RejectedExecutionException ex) {
       LOG.debug("shutting down, ignoring error", ex);


### PR DESCRIPTION
## PR Description

Currently we are not checking if web3j responses from eth1 endpoints contain an error.

example:

**eth_chainId** call:
```
curl --header "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":83}' http://localhost:8545

{"jsonrpc":"2.0","id":83,"error":{"code":-32000,"message":"chain not synced beyond EIP-155 replay-protection fork block"}}
```
Since we are not checking if response contains an error we later fail trying to parse the response:

`Endpoint localhost:8545 [1] is INVALID | Value must be in format 0x[1-9]+[0-9] or 0x0`

Solution:
always check if response contains an error and, if yes throw and actual exception with corresponding error message.