### PR TITLE
Improve error message when keystore password file not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ## Unreleased Changes
 
 ### Additions and Improvements
+- Include expected path for keystore password file in error message when password file is not found.
 
 ### Bug Fixes
 


### PR DESCRIPTION
## PR Description
We've wound up not needing to look in multiple places for the keystore password file, so simplify the code and include the expected path in the error message when password file is not found.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
