### PR TITLE
Retrieve the hashTreeRoot from the immutable preState to fully benefit from caching

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/StateTransition.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/StateTransition.java
@@ -150,10 +150,10 @@ public class StateTransition {
    * Processes slot
    */
   private BeaconState processSlot(final SpecVersion spec, final BeaconState preState) {
+    // Cache state root
+    Bytes32 previous_state_root = preState.hashTreeRoot();
     return preState.updated(
         state -> {
-          // Cache state root
-          Bytes32 previous_state_root = state.hashTreeRoot();
           int index = state.getSlot().mod(spec.getSlotsPerHistoricalRoot()).intValue();
           state.getState_roots().setElement(index, previous_state_root);
 


### PR DESCRIPTION
## PR Description
When processing slots, the previous state root has to be added to the historical roots.  Previously we would get a mutable version of the state and immediately calculate it's hash tree root to get that value.  This changes it so we get the hash tree root of the immutable preState instead so that we can utilise a precalculated hash if one already exists.  It's only a minor improvement since the hash tree root of each SSZ node is cached and we benefit from the next level down, but it is a small saving.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
