### PR TITLE
Offset sync committee duties by a slot

### DIFF
--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -37,7 +37,6 @@ import tech.pegasys.teku.core.synccomittee.SignedContributionAndProofTestBuilder
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
@@ -431,12 +430,15 @@ public class ChainBuilder {
   }
 
   public SignedContributionAndProofTestBuilder createValidSignedContributionAndProofBuilder() {
+    return createValidSignedContributionAndProofBuilder(getLatestSlot());
+  }
+
+  public SignedContributionAndProofTestBuilder createValidSignedContributionAndProofBuilder(
+      final UInt64 slot) {
+    final SyncCommitteeUtil syncCommitteeUtil = spec.getSyncCommitteeUtilRequired(slot);
     final SignedBlockAndState latestBlockAndState = getLatestBlockAndState();
     final Bytes32 beaconBlockRoot = latestBlockAndState.getRoot();
-    final UInt64 slot = latestBlockAndState.getSlot();
-    final UInt64 epoch = spec.computeEpochAtSlot(slot);
-    final SpecVersion specVersion = spec.atSlot(slot);
-    final SyncCommitteeUtil syncCommitteeUtil = specVersion.getSyncCommitteeUtil().orElseThrow();
+    final UInt64 epoch = syncCommitteeUtil.getEpochForDutiesAtSlot(slot);
 
     final Map<UInt64, SyncSubcommitteeAssignments> subcommitteeAssignments =
         syncCommitteeUtil.getSyncSubcommittees(latestBlockAndState.getState(), epoch);

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/synccomittee/SignedContributionAndProofTestBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/synccomittee/SignedContributionAndProofTestBuilder.java
@@ -149,7 +149,7 @@ public class SignedContributionAndProofTestBuilder {
       final UInt64 validatorIndex, final Signer signer) {
     final SyncSubcommitteeAssignments assignments =
         syncCommitteeUtil
-            .getSyncSubcommittees(state, spec.computeEpochAtSlot(slot))
+            .getSyncSubcommittees(state, syncCommitteeUtil.getEpochForDutiesAtSlot(slot))
             .get(validatorIndex);
     checkArgument(
         assignments != null && assignments.getAssignedSubcommittees().contains(subcommitteeIndex),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ValidateableSyncCommitteeSignature.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ValidateableSyncCommitteeSignature.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.SyncSubcommitteeAssignments;
+import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 
 public class ValidateableSyncCommitteeSignature {
   private final SyncCommitteeSignature signature;
@@ -61,10 +62,13 @@ public class ValidateableSyncCommitteeSignature {
     if (currentValue.isPresent()) {
       return currentValue.get();
     }
+    final UInt64 signatureSlot = signature.getSlot();
+    final SyncCommitteeUtil syncCommitteeUtil = spec.getSyncCommitteeUtilRequired(signatureSlot);
     final SyncSubcommitteeAssignments assignments =
-        spec.getSyncCommitteeUtilRequired(signature.getSlot())
-            .getSubcommitteeAssignments(
-                state, spec.computeEpochAtSlot(signature.getSlot()), signature.getValidatorIndex());
+        syncCommitteeUtil.getSubcommitteeAssignments(
+            state,
+            syncCommitteeUtil.getEpochForDutiesAtSlot(signatureSlot),
+            signature.getValidatorIndex());
 
     this.subcommitteeAssignments = Optional.of(assignments);
     return assignments;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
@@ -149,7 +149,8 @@ public class SignedContributionAndProofValidator {
           contributionAndProof.getAggregatorIndex());
       return REJECT;
     }
-    final UInt64 contributionEpoch = spec.computeEpochAtSlot(contribution.getSlot());
+    final UInt64 contributionEpoch =
+        syncCommitteeUtil.getEpochForDutiesAtSlot(contribution.getSlot());
 
     // [REJECT] The aggregator's validator index is within the current sync subcommittee
     // i.e. state.validators[aggregate_and_proof.aggregator_index].pubkey in

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeSignatureGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeSignatureGossipManagerTest.java
@@ -97,10 +97,12 @@ class SyncCommitteeSignatureGossipManagerTest {
         ValidateableSyncCommitteeSignature.fromValidator(
             dataStructureUtil.randomSyncCommitteeSignature());
 
+    final UInt64 dutyEpoch = UInt64.valueOf(333);
     final BeaconStateAltair state = dataStructureUtil.stateBuilderAltair().build();
     when(syncCommitteeStateUtils.getStateForSyncCommittee(
             signature.getSlot(), signature.getBeaconBlockRoot()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
+    when(syncCommitteeUtil.getEpochForDutiesAtSlot(any())).thenReturn(dutyEpoch);
     when(syncCommitteeUtil.getSubcommitteeAssignments(any(), any(), any()))
         .thenReturn(
             SyncSubcommitteeAssignments.builder()
@@ -112,8 +114,7 @@ class SyncCommitteeSignatureGossipManagerTest {
     gossipManager.publish(signature);
 
     verify(syncCommitteeUtil)
-        .getSubcommitteeAssignments(
-            state, UInt64.ZERO, signature.getSignature().getValidatorIndex());
+        .getSubcommitteeAssignments(state, dutyEpoch, signature.getSignature().getValidatorIndex());
     verify(subnetSubscriptions).gossip(signature.getSignature(), 1);
     verify(subnetSubscriptions).gossip(signature.getSignature(), 3);
     verify(subnetSubscriptions).gossip(signature.getSignature(), 5);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeSchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeSchedulerTest.java
@@ -160,7 +160,7 @@ class SyncCommitteeSchedulerTest {
   }
 
   @Test
-  void shouldSwitchToNextCommitteePeriodWhenFirstSlotReached() {
+  void shouldSwitchToNextCommitteePeriodWhenLastSlotOfSyncCommitteePeriodReached() {
     when(earlySubscribeRandomSource.nextInt(epochsPerSyncCommitteePeriod)).thenReturn(5);
     final UInt64 nextSyncCommitteePeriodStartEpoch =
         syncCommitteeUtil.computeFirstEpochOfNextSyncCommitteePeriod(UInt64.ZERO);
@@ -182,10 +182,11 @@ class SyncCommitteeSchedulerTest {
     scheduler.onAttestationCreationDue(subscribeSlot);
     verify(duties).performProductionDuty(subscribeSlot);
 
-    scheduler.onSlot(nextSyncCommitteePeriodStartSlot);
-    scheduler.onAttestationCreationDue(nextSyncCommitteePeriodStartSlot);
-    verify(nextDuties).performProductionDuty(nextSyncCommitteePeriodStartSlot);
-    verify(duties, never()).performProductionDuty(nextSyncCommitteePeriodStartSlot);
+    final UInt64 nextSyncCommitteeFirstDutySlot = nextSyncCommitteePeriodStartSlot.minus(1);
+    scheduler.onSlot(nextSyncCommitteeFirstDutySlot);
+    scheduler.onAttestationCreationDue(nextSyncCommitteeFirstDutySlot);
+    verify(nextDuties).performProductionDuty(nextSyncCommitteeFirstDutySlot);
+    verify(duties, never()).performProductionDuty(nextSyncCommitteeFirstDutySlot);
   }
 
   /**


### PR DESCRIPTION
## PR Description
As per the changes in https://github.com/ethereum/eth2.0-specs/pull/2400 sync committee duties are now performed from one slot prior to the start of the sync committee period to one slot prior to the end.

## Fixed Issue(s)
fixes #3950 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
