### PR TITLE
sync committee subscription fix

### DIFF
--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -418,14 +418,14 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   public void subscribeToSyncCommitteeSubnets(
       final Collection<SyncCommitteeSubnetSubscription> subscriptions) {
     for (final SyncCommitteeSubnetSubscription subscription : subscriptions) {
+      final UInt64 unsubscribeSlot =
+          spec.computeStartSlotAtEpoch(subscription.getUntilEpoch().increment());
       final SyncCommitteeUtil syncCommitteeUtil =
           spec.getSyncCommitteeUtilRequired(
               spec.computeStartSlotAtEpoch(subscription.getUntilEpoch()));
       syncCommitteeUtil
           .getSyncSubcommittees(subscription.getSyncCommitteeIndices())
-          .forEach(
-              index ->
-                  syncCommitteeSubscriptionManager.subscribe(index, subscription.getUntilEpoch()));
+          .forEach(index -> syncCommitteeSubscriptionManager.subscribe(index, unsubscribeSlot));
     }
   }
 

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -590,12 +590,16 @@ class ValidatorApiHandlerTest {
         new SyncCommitteeSubnetSubscription(1, Set.of(5, 10), UInt64.valueOf(35));
     validatorApiHandler.subscribeToSyncCommitteeSubnets(List.of(subscription1, subscription2));
     System.out.println(spec.getSyncCommitteeUtilRequired(ZERO).getSubcommitteeSize());
-    verify(syncCommitteeSubscriptionManager).subscribe(0, subscription1.getUntilEpoch());
-    verify(syncCommitteeSubscriptionManager).subscribe(3, subscription1.getUntilEpoch());
-    verify(syncCommitteeSubscriptionManager).subscribe(7, subscription1.getUntilEpoch());
+    final UInt64 unsubscribeSlotSubscription1 =
+        spec.computeStartSlotAtEpoch(UInt64.valueOf(44).increment());
+    final UInt64 unsubscribeSlotSubscription2 =
+        spec.computeStartSlotAtEpoch(UInt64.valueOf(35).increment());
+    verify(syncCommitteeSubscriptionManager).subscribe(0, unsubscribeSlotSubscription1);
+    verify(syncCommitteeSubscriptionManager).subscribe(3, unsubscribeSlotSubscription1);
+    verify(syncCommitteeSubscriptionManager).subscribe(7, unsubscribeSlotSubscription1);
 
-    verify(syncCommitteeSubscriptionManager).subscribe(1, subscription2.getUntilEpoch());
-    verify(syncCommitteeSubscriptionManager).subscribe(2, subscription2.getUntilEpoch());
+    verify(syncCommitteeSubscriptionManager).subscribe(1, unsubscribeSlotSubscription2);
+    verify(syncCommitteeSubscriptionManager).subscribe(2, unsubscribeSlotSubscription2);
     verifyNoMoreInteractions(syncCommitteeSubscriptionManager);
   }
 


### PR DESCRIPTION
epoch / slot translation would mean we were never subscribed to subnets basically, fixed a test so correct behavior is now demonstrated.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
