### PR TITLE
Simplify how block production metrics are calculated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Additions and Improvements
 - Include expected path for keystore password file in error message when password file is not found.
 - Added additional bootnodes for Pyrmont testnet.
+- Optimised how block production metrics are calculated.
 
 ### Bug Fixes
 


### PR DESCRIPTION
## PR Description
Simplify and optimise how block production metrics are calculated.  We only need to store the slot and block root then compare to the historic block roots in the head state rather than loading the entire canonical block from disk.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
