### PR TITLE
implement remote call to get sync committee contributions for validator client

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -374,7 +374,7 @@ public class ValidatorDataProvider {
 
   private Iterable<Integer> getAggregationBits(final Bytes aggregationBits, final UInt64 slot) {
     final SchemaDefinitionsAltair altairDefinitions =
-        spec.atSlot(slot).getSchemaDefinitions().toVersionAltair().orElseThrow();
+        SchemaDefinitionsAltair.required(spec.atSlot(slot).getSchemaDefinitions());
     final SyncCommitteeContributionSchema syncCommitteeContributionSchema =
         altairDefinitions.getSyncCommitteeContributionSchema();
     final SszBitvector aggregationBitsVector =

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.request.v1.validator.BeaconCommitteeSubscriptionRequest;
 import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
@@ -48,7 +49,10 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContributionSchema;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
+import tech.pegasys.teku.ssz.collections.SszBitvector;
 import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.validator.api.AttesterDuty;
@@ -288,7 +292,7 @@ public class ValidatorDataProvider {
         contribution.getSlot(),
         contribution.getBeaconBlockRoot(),
         contribution.getSubcommitteeIndex(),
-        contribution.getAggregationBits(),
+        contribution.getAggregationBits().sszSerialize(),
         new BLSSignature(contribution.getSignature()));
   }
 
@@ -348,7 +352,8 @@ public class ValidatorDataProvider {
     final UInt64 subcommitteeIndex =
         signedContributionAndProof.message.contribution.subcommitteeIndex;
     final Iterable<Integer> indices =
-        signedContributionAndProof.message.contribution.aggregationBits.getAllSetBits();
+        getAggregationBits(signedContributionAndProof.message.contribution.aggregationBits, slot);
+
     final tech.pegasys.teku.bls.BLSSignature signature =
         signedContributionAndProof.message.contribution.signature.asInternalBLSSignature();
     final SyncCommitteeContribution contribution =
@@ -365,5 +370,16 @@ public class ValidatorDataProvider {
     return spec.getSyncCommitteeUtilRequired(slot)
         .createSignedContributionAndProof(
             message, signedContributionAndProof.signature.asInternalBLSSignature());
+  }
+
+  private Iterable<Integer> getAggregationBits(final Bytes aggregationBits, final UInt64 slot) {
+    final SchemaDefinitionsAltair altairDefinitions =
+        spec.atSlot(slot).getSchemaDefinitions().toVersionAltair().orElseThrow();
+    final SyncCommitteeContributionSchema syncCommitteeContributionSchema =
+        altairDefinitions.getSyncCommitteeContributionSchema();
+    final SszBitvector aggregationBitsVector =
+        syncCommitteeContributionSchema.getAggregationBitsSchema().fromBytes(aggregationBits);
+
+    return aggregationBitsVector.getAllSetBits();
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeContribution.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeContribution.java
@@ -99,10 +99,8 @@ public class SyncCommitteeContribution {
       asInternalSyncCommitteeContribution(
           final Spec spec, final SyncCommitteeContribution syncCommitteeContribution) {
     final SchemaDefinitionsAltair altairDefinitions =
-        spec.atSlot(syncCommitteeContribution.slot)
-            .getSchemaDefinitions()
-            .toVersionAltair()
-            .orElseThrow();
+        SchemaDefinitionsAltair.required(
+            spec.atSlot(syncCommitteeContribution.slot).getSchemaDefinitions());
     final SyncCommitteeContributionSchema syncCommitteeContributionSchema =
         altairDefinitions.getSyncCommitteeContributionSchema();
 

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeContribution.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeContribution.java
@@ -21,9 +21,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContributionSchema;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 import tech.pegasys.teku.ssz.collections.SszBitvector;
 
 public class SyncCommitteeContribution {
@@ -41,7 +45,7 @@ public class SyncCommitteeContribution {
 
   @JsonProperty("aggregation_bits")
   @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES_SSZ)
-  public final SszBitvector aggregationBits;
+  public final Bytes aggregationBits;
 
   @JsonProperty("signature")
   @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES96)
@@ -52,13 +56,25 @@ public class SyncCommitteeContribution {
       @JsonProperty("slot") final UInt64 slot,
       @JsonProperty("beacon_block_root") final Bytes32 beaconBlockRoot,
       @JsonProperty("subcommittee_index") final UInt64 subcommitteeIndex,
-      @JsonProperty("aggregation_bits") final SszBitvector aggregationBits,
+      @JsonProperty("aggregation_bits") final Bytes aggregationBits,
       @JsonProperty("signature") final BLSSignature signature) {
     this.slot = slot;
     this.beaconBlockRoot = beaconBlockRoot;
     this.subcommitteeIndex = subcommitteeIndex;
     this.aggregationBits = aggregationBits;
     this.signature = signature;
+  }
+
+  public SyncCommitteeContribution(
+      final tech.pegasys.teku.spec.datastructures.operations.versions.altair
+              .SyncCommitteeContribution
+          contribution) {
+    this(
+        contribution.getSlot(),
+        contribution.getBeaconBlockRoot(),
+        contribution.getSubcommitteeIndex(),
+        contribution.getAggregationBits().sszSerialize(),
+        new BLSSignature(contribution.getSignature()));
   }
 
   @Override
@@ -76,5 +92,30 @@ public class SyncCommitteeContribution {
   @Override
   public int hashCode() {
     return Objects.hash(slot, beaconBlockRoot, subcommitteeIndex, aggregationBits, signature);
+  }
+
+  public static tech.pegasys.teku.spec.datastructures.operations.versions.altair
+          .SyncCommitteeContribution
+      asInternalSyncCommitteeContribution(
+          final Spec spec, final SyncCommitteeContribution syncCommitteeContribution) {
+    final SchemaDefinitionsAltair altairDefinitions =
+        spec.atSlot(syncCommitteeContribution.slot)
+            .getSchemaDefinitions()
+            .toVersionAltair()
+            .orElseThrow();
+    final SyncCommitteeContributionSchema syncCommitteeContributionSchema =
+        altairDefinitions.getSyncCommitteeContributionSchema();
+
+    final SszBitvector aggregationBitsVector =
+        syncCommitteeContributionSchema
+            .getAggregationBitsSchema()
+            .fromBytes(syncCommitteeContribution.aggregationBits);
+    return spec.getSyncCommitteeUtilRequired(syncCommitteeContribution.slot)
+        .createSyncCommitteeContribution(
+            syncCommitteeContribution.slot,
+            syncCommitteeContribution.beaconBlockRoot,
+            syncCommitteeContribution.subcommitteeIndex,
+            aggregationBitsVector.getAllSetBits(),
+            syncCommitteeContribution.signature.asInternalBLSSignature());
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -337,7 +337,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
         contribution.getSlot(),
         contribution.getBeaconBlockRoot(),
         contribution.getSubcommitteeIndex(),
-        contribution.getAggregationBits(),
+        contribution.getAggregationBits().sszSerialize(),
         new tech.pegasys.teku.api.schema.BLSSignature(contribution.getSignature()));
   }
 
@@ -361,8 +361,14 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<SyncCommitteeContribution>> createSyncCommitteeContribution(
       final UInt64 slot, final int subcommitteeIndex, final Bytes32 beaconBlockRoot) {
-    throw new UnsupportedOperationException(
-        "REST API for createSyncCommitteeContribution not supported");
+    return sendRequest(
+        () ->
+            apiClient
+                .createSyncCommitteeContribution(slot, subcommitteeIndex, beaconBlockRoot)
+                .map(
+                    contribution ->
+                        tech.pegasys.teku.api.schema.altair.SyncCommitteeContribution
+                            .asInternalSyncCommitteeContribution(spec, contribution)));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -22,6 +22,7 @@ import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GE
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_CONFIG_SPEC;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_GENESIS;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_PROPOSER_DUTIES;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_SYNC_COMMITTEE_CONTRIBUTION;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_SYNC_COMMITTEE_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_ATTESTATION;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK;
@@ -67,6 +68,7 @@ import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationRespo
 import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetNewBlockResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
+import tech.pegasys.teku.api.response.v1.validator.GetSyncCommitteeContributionResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostSyncDutiesResponse;
 import tech.pegasys.teku.api.response.v2.validator.GetNewBlockResponseV2;
@@ -79,6 +81,7 @@ import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.api.schema.SubnetSubscription;
 import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
+import tech.pegasys.teku.api.schema.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -285,6 +288,26 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   public void sendContributionAndProofs(
       final List<SignedContributionAndProof> signedContributionAndProofs) {
     post(SEND_CONTRIBUTION_AND_PROOF, signedContributionAndProofs, createHandler());
+  }
+
+  @Override
+  public Optional<SyncCommitteeContribution> createSyncCommitteeContribution(
+      final UInt64 slot, final int subcommitteeIndex, final Bytes32 beaconBlockRoot) {
+    final Map<String, String> pathParams = Map.of();
+    final Map<String, String> queryParams =
+        Map.of(
+            "slot",
+            slot.toString(),
+            "subcommittee_index",
+            Integer.toString(subcommitteeIndex),
+            "beacon_block_root",
+            beaconBlockRoot.toHexString());
+    return get(
+            GET_SYNC_COMMITTEE_CONTRIBUTION,
+            pathParams,
+            queryParams,
+            createHandler(GetSyncCommitteeContributionResponse.class))
+        .map(response -> response.data);
   }
 
   private ResponseHandler<Void> createHandler() {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -38,6 +38,7 @@ public enum ValidatorApiMethod {
   SUBSCRIBE_TO_SYNC_COMMITTEE_SUBNET("eth/v1/validator/sync_committee_subscriptions"),
   GET_ATTESTATION_DUTIES("eth/v1/validator/duties/attester/:epoch"),
   GET_SYNC_COMMITTEE_DUTIES("eth/v1/validator/duties/sync/:epoch"),
+  GET_SYNC_COMMITTEE_CONTRIBUTION("eth/v1/validator/sync_committee_contribution"),
   GET_PROPOSER_DUTIES("eth/v1/validator/duties/proposer/:epoch"),
   GET_BLOCK_HEADER("eth/v1/beacon/headers/:block_id"),
   GET_CONFIG_SPEC("/eth/v1/config/spec"),

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.api.schema.SubnetSubscription;
 import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
+import tech.pegasys.teku.api.schema.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -81,4 +82,7 @@ public interface ValidatorRestApiClient {
 
   void sendContributionAndProofs(
       final List<SignedContributionAndProof> signedContributionAndProofs);
+
+  Optional<SyncCommitteeContribution> createSyncCommitteeContribution(
+      UInt64 slot, int subcommitteeIndex, Bytes32 beaconBlockRoot);
 }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetNewBlockResponse;
+import tech.pegasys.teku.api.response.v1.validator.GetSyncCommitteeContributionResponse;
 import tech.pegasys.teku.api.response.v2.validator.GetNewBlockResponseV2;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.AttestationData;
@@ -55,6 +56,7 @@ import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.api.schema.SubnetSubscription;
+import tech.pegasys.teku.api.schema.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -536,6 +538,26 @@ class OkHttpValidatorRestApiClientTest {
 
     assertThat(attestation).isPresent();
     assertThat(attestation.get()).usingRecursiveComparison().isEqualTo(expectedAttestation);
+  }
+
+  @Test
+  public void createSyncCommitteeContribution_WhenSuccess_ReturnsContribution() {
+    final SyncCommitteeContribution contribution =
+        schemaObjects.syncCommitteeContribution(UInt64.ONE);
+
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(SC_OK)
+            .setBody(asJson(new GetSyncCommitteeContributionResponse(contribution))));
+
+    final Optional<SyncCommitteeContribution> response =
+        apiClient.createSyncCommitteeContribution(
+            contribution.slot,
+            contribution.subcommitteeIndex.intValue(),
+            contribution.beaconBlockRoot);
+
+    assertThat(response).isPresent();
+    assertThat(response.get()).usingRecursiveComparison().isEqualTo(contribution);
   }
 
   @Test

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/SchemaObjectsTestFixture.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/SchemaObjectsTestFixture.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.api.schema.SubnetSubscription;
 import tech.pegasys.teku.api.schema.Validator;
+import tech.pegasys.teku.api.schema.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -95,6 +96,12 @@ public class SchemaObjectsTestFixture {
     final DataStructureUtil altairData = new DataStructureUtil(altairSpec);
     final SchemaObjectProvider schemaObjectProvider = new SchemaObjectProvider(altairSpec);
     return schemaObjectProvider.getBeaconBlock(altairData.randomBeaconBlock(UInt64.ONE));
+  }
+
+  public SyncCommitteeContribution syncCommitteeContribution(final UInt64 slot) {
+    final Spec altairSpec = TestSpecFactory.createMainnetAltair();
+    final DataStructureUtil altairData = new DataStructureUtil(altairSpec);
+    return new SyncCommitteeContribution(altairData.randomSyncCommitteeContribution(slot));
   }
 
   public SignedBeaconBlock signedBeaconBlock() {


### PR DESCRIPTION

 - needed to change sync committee contributions to bytes so that it could be correctly treated for the round trip.

 - added a validator test for creating sync committee contribution and reading it into the validator client.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
