### PR TITLE
Fix calculation of block performance metrics when head block was locally produced

### DIFF
--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
@@ -87,6 +87,18 @@ public class DefaultPerformanceTrackerTest {
   }
 
   @Test
+  void shouldDisplayBlockInclusionWhenProducedBlockIsChainHead() {
+    final UInt64 lastSlot = spec.computeStartSlotAtEpoch(BLOCK_PERFORMANCE_EVALUATION_INTERVAL);
+    final SignedBlockAndState bestBlock = chainUpdater.advanceChainUntil(2);
+    chainUpdater.updateBestBlock(bestBlock);
+    performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(bestBlock.getSlot()));
+    performanceTracker.saveProducedBlock(bestBlock.getBlock());
+    performanceTracker.onSlot(lastSlot);
+    BlockPerformance expectedBlockPerformance = new BlockPerformance(1, 1, 1);
+    verify(log).performance(expectedBlockPerformance.toString());
+  }
+
+  @Test
   void shouldDisplayOneMissedBlock() {
     chainUpdater.updateBestBlock(chainUpdater.advanceChainUntil(10));
     performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(UInt64.valueOf(1)));


### PR DESCRIPTION
## PR Description
Fixes an exception when the chain head is one of the locally produced blocks because the state doesn't contain the current block root.

Adds a test to cover that corner case.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
