### PR TITLE
Update YML load code and prevent job to crash silently

### DIFF
--- a/.openapidoc/config.js
+++ b/.openapidoc/config.js
@@ -5,9 +5,9 @@ const GitUrlParse = require("git-url-parse");
 
 const distDir = process.env.OA_DIST_DIR || "./dist";
 const specDir =
-  process.env.OA_SPEC_DIR || "./spec";
+    process.env.OA_SPEC_DIR || "./spec";
 const gitUrl =
-  process.env.OA_GIT_URL || "git@github.com:Consensys/teku.git";
+    process.env.OA_GIT_URL || "git@github.com:Consensys/teku.git";
 const gitUserName = process.env.OA_GIT_USERNAME || "CircleCI Build";
 const gitEmail = process.env.OA_GIT_EMAIL || "ci-build@consensys.net";
 const branch = process.env.OA_GH_PAGES_BRANCH || "gh-pages";
@@ -20,7 +20,7 @@ module.exports = {
 function getConfig() {
   const repo = GitUrlParse(gitUrl);
   const specs = calculateSpecs();
-  if (specs.length == 0) {
+  if (specs.length === 0) {
     throw new Error("Unable to parse specs in dist" + distDir);
   }
 
@@ -72,7 +72,7 @@ function calculateSpecDetails(specFile) {
 }
 
 function calculateSpecVersion(specFile) {
-  return yaml.safeLoad(fs.readFileSync(specFile, "utf8")).info.version;
+  return yaml.load(fs.readFileSync(specFile, "utf8")).info.version;
 }
 
 function isReleaseVersion(specVersion) {

--- a/.openapidoc/publish.js
+++ b/.openapidoc/publish.js
@@ -10,10 +10,10 @@ const log = (...args) => console.log(...args); // eslint-disable-line no-console
  * Main function to prepare and publish openapi spec to gh-pages branch
  */
 async function main() {
-  const cfg = config.getConfig();
-
-  const { distDir, specs, versions, ghPagesConfig } = cfg;
   try {
+    const cfg = config.getConfig();
+    const {distDir, specs, versions, ghPagesConfig} = cfg;
+
     prepareDistDir(distDir);
 
     specs.forEach(function (spec) {
@@ -23,8 +23,8 @@ async function main() {
     if (specs[0].isReleaseVersion) {
       const versionsJson = await fetchVersions(versions.url);
       const updatedVersionsJson = updateVersions(
-        versionsJson,
-        specs[0].version
+          versionsJson,
+          specs[0].version
       );
       saveVersionsJson(updatedVersionsJson, versions.dist);
     }
@@ -37,7 +37,7 @@ async function main() {
     cleanGhPagesCache();
     await publishToGHPages(distDir, ghPagesConfig);
     log(
-      `OpenAPI specs [${specs[0].version}] published to [${ghPagesConfig.branch}] using user [${ghPagesConfig.user.name}]`
+        `OpenAPI specs [${specs[0].version}] published to [${ghPagesConfig.branch}] using user [${ghPagesConfig.user.name}]`
     );
   } catch (err) {
     log(`ERROR: OpenAPI spec failed to publish: ${err.message}`);
@@ -51,8 +51,8 @@ async function main() {
  * @param {string} dirPath
  */
 function prepareDistDir(dirPath) {
-  fs.rmdirSync(dirPath, { recursive: true });
-  fs.mkdirSync(dirPath, { recursive: true });
+  fs.rmdirSync(dirPath, {recursive: true});
+  fs.mkdirSync(dirPath, {recursive: true});
 }
 
 function copySpecFileToDist(spec) {
@@ -74,7 +74,7 @@ async function fetchVersions(versionsUrl) {
   }
 
   throw new Error(
-    `${versionsUrl} fetch failed with status: ${response.statusText}`
+      `${versionsUrl} fetch failed with status: ${response.statusText}`
   );
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- fix yaml load
- include config in try to catch issues and fail job if any
- some code formatting

Job will now fail if any issue in the JS code (see following test screenshot)
![image](https://user-images.githubusercontent.com/4677568/118246648-88567080-b4a2-11eb-8b2f-0ea741421fce.png)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

The build folder job was failing silently and returned a zero status to the CI making us think it passed.

![image](https://user-images.githubusercontent.com/4677568/118246540-5fce7680-b4a2-11eb-9d4c-c3553e857d3b.png)

## Review

This CI job is not easy to test on the Teku repos itself or in the PR as it involves cross branch commits and push.
I then use a copy of this repos with only the relevant CI and already generated openapi spec file.
The test repos is https://github.com/NicolasMassart/teku-api-doc-test
See specifically :
- the commit that tests that the error is now correctly failing the Job: https://github.com/NicolasMassart/teku-api-doc-test/commit/04019562dd19a8a34ad3e106b8e263decaa60580
- the commit that fixes the job : https://github.com/NicolasMassart/teku-api-doc-test/commit/7e170224028e3001541c3df0e968bdb30da6c73e

The CI result of the success is ![image](https://user-images.githubusercontent.com/4677568/118246934-e420f980-b4a2-11eb-86a9-69e1e3d80daa.png)

Theses changes are then ported to the real Teku repos in this PR.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
