### PR TITLE
Add toVersionAltair to BeaconBlockBody

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBody.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBody.java
@@ -13,9 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody;
 
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
@@ -43,4 +45,6 @@ public interface BeaconBlockBody extends SszContainer {
 
   @Override
   BeaconBlockBodySchema<? extends BeaconBlockBody> getSchema();
+
+  Optional<BeaconBlockBodyAltair> toVersionAltair();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltair.java
@@ -13,8 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
@@ -78,11 +77,11 @@ public class BeaconBlockBodyAltair
   }
 
   public static BeaconBlockBodyAltair required(final BeaconBlockBody body) {
-    checkArgument(
-        body instanceof BeaconBlockBodyAltair,
-        "Expected altair block body but got %s",
-        body.getClass());
-    return (BeaconBlockBodyAltair) body;
+    return body.toVersionAltair()
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Expected altair block body but got " + body.getClass().getSimpleName()));
   }
 
   @Override
@@ -132,5 +131,10 @@ public class BeaconBlockBodyAltair
   @Override
   public BeaconBlockBodySchemaAltair getSchema() {
     return (BeaconBlockBodySchemaAltair) super.getSchema();
+  }
+
+  @Override
+  public Optional<BeaconBlockBodyAltair> toVersionAltair() {
+    return Optional.of(this);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0.java
@@ -13,10 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.phase0;
 
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
@@ -115,5 +117,10 @@ public class BeaconBlockBodyPhase0
   @Override
   public BeaconBlockBodySchemaPhase0 getSchema() {
     return (BeaconBlockBodySchemaPhase0) super.getSchema();
+  }
+
+  @Override
+  public Optional<BeaconBlockBodyAltair> toVersionAltair() {
+    return Optional.empty();
   }
 }


### PR DESCRIPTION
## PR Description
Adds a `toVersionAltair()` method to `BeaconBlockBody` to better follow the usual pattern instead of casting in `BeaconBlockBodyAltair`.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
