### PR TITLE
[Issue-3356] Cut deprecated logic from AttesterSlashingValidator

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -355,6 +355,11 @@ public class Spec {
         .validate(store, validateableAttestation, maybeTargetState);
   }
 
+  public Optional<OperationInvalidReason> validateAttesterSlashing(
+      final BeaconState state, final AttesterSlashing attesterSlashing) {
+    return atState(state).getOperationValidator().validateAttesterSlashing(state, attesterSlashing);
+  }
+
   public BlockImportResult onBlock(
       final MutableStore store,
       final SignedBeaconBlock signedBlock,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatusFactory;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
@@ -60,6 +61,11 @@ public class DelegatingSpecLogic implements SpecLogic {
   @Override
   public AttestationUtil getAttestationUtil() {
     return specLogic.getAttestationUtil();
+  }
+
+  @Override
+  public OperationValidator getOperationValidator() {
+    return specLogic.getOperationValidator();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatusFactory;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
@@ -40,6 +41,8 @@ public interface SpecLogic {
   BeaconStateUtil getBeaconStateUtil();
 
   AttestationUtil getAttestationUtil();
+
+  OperationValidator getOperationValidator();
 
   EpochProcessor getEpochProcessor();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/AbstractSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/AbstractSpecLogic.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatusFactory;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
@@ -41,11 +42,13 @@ public abstract class AbstractSpecLogic implements SpecLogic {
   protected final ValidatorsUtil validatorsUtil;
   protected final BeaconStateUtil beaconStateUtil;
   protected final AttestationUtil attestationUtil;
+  protected final OperationValidator operationValidator;
   protected final ValidatorStatusFactory validatorStatusFactory;
   protected final EpochProcessor epochProcessor;
   protected final BlockProcessor blockProcessor;
   protected final ForkChoiceUtil forkChoiceUtil;
   protected final BlockProposalUtil blockProposalUtil;
+
   // State upgrade
   protected final Optional<StateUpgrade<?>> stateUpgrade;
 
@@ -58,6 +61,7 @@ public abstract class AbstractSpecLogic implements SpecLogic {
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
       final AttestationUtil attestationUtil,
+      final OperationValidator operationValidator,
       final ValidatorStatusFactory validatorStatusFactory,
       final EpochProcessor epochProcessor,
       final BlockProcessor blockProcessor,
@@ -77,6 +81,7 @@ public abstract class AbstractSpecLogic implements SpecLogic {
     this.blockProcessor = blockProcessor;
     this.forkChoiceUtil = forkChoiceUtil;
     this.blockProposalUtil = blockProposalUtil;
+    this.operationValidator = operationValidator;
     this.stateUpgrade = stateUpgrade;
   }
 
@@ -103,6 +108,11 @@ public abstract class AbstractSpecLogic implements SpecLogic {
   @Override
   public AttestationUtil getAttestationUtil() {
     return attestationUtil;
+  }
+
+  @Override
+  public OperationValidator getOperationValidator() {
+    return operationValidator;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/OperationValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/OperationValidator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.operations.validation;
+
+import java.util.Optional;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.operations.validation.AttesterSlashingValidator.SlashedIndicesCaptor;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
+
+public class OperationValidator {
+  private final AttesterSlashingValidator attesterSlashingValidator;
+
+  private OperationValidator(final AttesterSlashingValidator attesterSlashingValidator) {
+    this.attesterSlashingValidator = attesterSlashingValidator;
+  }
+
+  public static OperationValidator create(
+      final BeaconStateAccessors beaconStateAccessors,
+      final AttestationUtil attestationUtil,
+      final ValidatorsUtil validatorsUtil) {
+    final AttesterSlashingValidator attesterSlashingValidator =
+        new AttesterSlashingValidator(beaconStateAccessors, attestationUtil, validatorsUtil);
+    return new OperationValidator(attesterSlashingValidator);
+  }
+
+  public Optional<OperationInvalidReason> validateAttesterSlashing(
+      final BeaconState state, final AttesterSlashing attesterSlashing) {
+    return attesterSlashingValidator.validate(state, attesterSlashing);
+  }
+
+  public Optional<OperationInvalidReason> validateAttesterSlashing(
+      final BeaconState state,
+      final AttesterSlashing attesterSlashing,
+      SlashedIndicesCaptor slashedIndicesCaptor) {
+    return attesterSlashingValidator.validate(state, attesterSlashing, slashedIndicesCaptor);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataStateTransitionValidator;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
@@ -48,6 +49,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
       final AttestationUtil attestationUtil,
+      final OperationValidator operationValidator,
       final ValidatorStatusFactoryAltair validatorStatusFactory,
       final EpochProcessorAltair epochProcessor,
       final BlockProcessorAltair blockProcessor,
@@ -64,6 +66,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
         validatorsUtil,
         beaconStateUtil,
         attestationUtil,
+        operationValidator,
         validatorStatusFactory,
         epochProcessor,
         blockProcessor,
@@ -101,6 +104,8 @@ public class SpecLogicAltair extends AbstractSpecLogic {
             beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtil(config, beaconStateUtil, beaconStateAccessors, miscHelpers);
+    final OperationValidator operationValidator =
+        OperationValidator.create(beaconStateAccessors, attestationUtil, validatorsUtil);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(
             config,
@@ -128,7 +133,8 @@ public class SpecLogicAltair extends AbstractSpecLogic {
             beaconStateUtil,
             attestationUtil,
             validatorsUtil,
-            attestationValidator);
+            attestationValidator,
+            operationValidator);
     final ForkChoiceUtil forkChoiceUtil =
         new ForkChoiceUtil(config, beaconStateUtil, attestationUtil, blockProcessor, miscHelpers);
     final BlockProposalUtil blockProposalUtil =
@@ -155,6 +161,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
         validatorsUtil,
         beaconStateUtil,
         attestationUtil,
+        operationValidator,
         validatorStatusFactory,
         epochProcessor,
         blockProcessor,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataStateTransitionValidator;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
@@ -69,7 +70,8 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
       final BeaconStateUtil beaconStateUtil,
       final AttestationUtil attestationUtil,
       final ValidatorsUtil validatorsUtil,
-      final AttestationDataStateTransitionValidator attestationValidator) {
+      final AttestationDataStateTransitionValidator attestationValidator,
+      final OperationValidator operationValidator) {
     super(
         specConfig,
         predicates,
@@ -79,7 +81,8 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
         beaconStateUtil,
         attestationUtil,
         validatorsUtil,
-        attestationValidator);
+        attestationValidator,
+        operationValidator);
 
     this.specConfigAltair = specConfig;
     this.miscHelpersAltair = miscHelpers;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataStateTransitionValidator;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
@@ -45,6 +46,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
       final AttestationUtil attestationUtil,
+      final OperationValidator operationValidator,
       final ValidatorStatusFactoryPhase0 validatorStatusFactory,
       final EpochProcessorPhase0 epochProcessor,
       final BlockProcessorPhase0 blockProcessor,
@@ -59,6 +61,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
         validatorsUtil,
         beaconStateUtil,
         attestationUtil,
+        operationValidator,
         validatorStatusFactory,
         epochProcessor,
         blockProcessor,
@@ -95,6 +98,8 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
             beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtil(config, beaconStateUtil, beaconStateAccessors, miscHelpers);
+    final OperationValidator operationValidator =
+        OperationValidator.create(beaconStateAccessors, attestationUtil, validatorsUtil);
     final ValidatorStatusFactoryPhase0 validatorStatusFactory =
         new ValidatorStatusFactoryPhase0(
             config, beaconStateUtil, attestationUtil, beaconStateAccessors, predicates);
@@ -117,7 +122,8 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
             beaconStateUtil,
             attestationUtil,
             validatorsUtil,
-            attestationValidator);
+            attestationValidator,
+            operationValidator);
     final ForkChoiceUtil forkChoiceUtil =
         new ForkChoiceUtil(config, beaconStateUtil, attestationUtil, blockProcessor, miscHelpers);
     final BlockProposalUtil blockProposalUtil =
@@ -132,6 +138,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
         validatorsUtil,
         beaconStateUtil,
         attestationUtil,
+        operationValidator,
         validatorStatusFactory,
         epochProcessor,
         blockProcessor,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataStateTransitionValidator;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
@@ -43,7 +44,8 @@ public final class BlockProcessorPhase0 extends AbstractBlockProcessor {
       final BeaconStateUtil beaconStateUtil,
       final AttestationUtil attestationUtil,
       final ValidatorsUtil validatorsUtil,
-      final AttestationDataStateTransitionValidator attestationValidator) {
+      final AttestationDataStateTransitionValidator attestationValidator,
+      final OperationValidator operationValidator) {
     super(
         specConfig,
         predicates,
@@ -53,7 +55,8 @@ public final class BlockProcessorPhase0 extends AbstractBlockProcessor {
         beaconStateUtil,
         attestationUtil,
         validatorsUtil,
-        attestationValidator);
+        attestationValidator,
+        operationValidator);
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttesterSlashingValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttesterSlashingValidator.java
@@ -21,9 +21,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.collections.LimitedSet;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.logic.common.operations.validation.AttesterSlashingStateTransitionValidator;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -32,13 +32,11 @@ public class AttesterSlashingValidator implements OperationValidator<AttesterSla
 
   private final RecentChainData recentChainData;
   private final Set<UInt64> seenIndices = LimitedSet.create(VALID_VALIDATOR_SET_SIZE);
-  private final AttesterSlashingStateTransitionValidator transitionValidator;
+  private final Spec spec;
 
-  public AttesterSlashingValidator(
-      RecentChainData recentChainData,
-      AttesterSlashingStateTransitionValidator attesterSlashingStateTransitionValidator) {
+  public AttesterSlashingValidator(RecentChainData recentChainData, final Spec spec) {
     this.recentChainData = recentChainData;
-    this.transitionValidator = attesterSlashingStateTransitionValidator;
+    this.spec = spec;
   }
 
   @Override
@@ -63,7 +61,7 @@ public class AttesterSlashingValidator implements OperationValidator<AttesterSla
 
   @Override
   public boolean validateForStateTransition(BeaconState state, AttesterSlashing slashing) {
-    Optional<OperationInvalidReason> invalidReason = transitionValidator.validate(state, slashing);
+    Optional<OperationInvalidReason> invalidReason = spec.validateAttesterSlashing(state, slashing);
 
     if (invalidReason.isPresent()) {
       LOG.trace(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -70,7 +70,6 @@ import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.operations.signatures.ProposerSlashingSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.operations.signatures.VoluntaryExitSignatureVerifier;
-import tech.pegasys.teku.spec.logic.common.operations.validation.AttesterSlashingStateTransitionValidator;
 import tech.pegasys.teku.spec.logic.common.operations.validation.ProposerSlashingStateTransitionValidator;
 import tech.pegasys.teku.spec.logic.common.operations.validation.VoluntaryExitStateTransitionValidator;
 import tech.pegasys.teku.statetransition.EpochCachePrimer;
@@ -356,13 +355,10 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   private void initAttesterSlashingPool() {
     LOG.debug("BeaconChainController.initAttesterSlashingPool()");
-    AttesterSlashingValidator validator =
-        new AttesterSlashingValidator(
-            recentChainData, new AttesterSlashingStateTransitionValidator());
     attesterSlashingPool =
         new OperationPool<>(
             beaconBlockSchemaSupplier.andThen(BeaconBlockBodySchema::getAttesterSlashingsSchema),
-            validator);
+            new AttesterSlashingValidator(recentChainData, spec));
     blockImporter.subscribeToVerifiedBlockAttesterSlashings(attesterSlashingPool::removeAll);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Cut deprecated logic from `AttesterSlashingValidator`, delegating to new spec utilities instead.  Rework how this validator is created to facilitate injecting the new spec-related dependencies. 

## Fixed Issue(s)
Part of #3356 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
