### PR TITLE
Expose a single getBlockProcessor method on spec instead of individual methods

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
@@ -39,48 +39,53 @@ public class DefaultOperationProcessor implements OperationProcessor {
   public void processAttesterSlashing(
       final MutableBeaconState state, final AttesterSlashing attesterSlashings)
       throws BlockProcessingException {
-    spec.processAttesterSlashings(
-        state, beaconBlockBodySchema.getAttesterSlashingsSchema().of(attesterSlashings));
+    spec.getBlockProcessor(state.getSlot())
+        .processAttesterSlashings(
+            state, beaconBlockBodySchema.getAttesterSlashingsSchema().of(attesterSlashings));
   }
 
   @Override
   public void processProposerSlashing(
       final MutableBeaconState state, final ProposerSlashing proposerSlashing)
       throws BlockProcessingException {
-    spec.processProposerSlashings(
-        state, beaconBlockBodySchema.getProposerSlashingsSchema().of(proposerSlashing));
+    spec.getBlockProcessor(state.getSlot())
+        .processProposerSlashings(
+            state, beaconBlockBodySchema.getProposerSlashingsSchema().of(proposerSlashing));
   }
 
   @Override
   public void processBlockHeader(
       final MutableBeaconState state, final BeaconBlockSummary blockHeader)
       throws BlockProcessingException {
-    spec.processBlockHeader(state, blockHeader);
+    spec.getBlockProcessor(state.getSlot()).processBlockHeader(state, blockHeader);
   }
 
   @Override
   public void processDeposit(final MutableBeaconState state, final Deposit deposit)
       throws BlockProcessingException {
-    spec.processDeposits(state, beaconBlockBodySchema.getDepositsSchema().of(deposit));
+    spec.getBlockProcessor(state.getSlot())
+        .processDeposits(state, beaconBlockBodySchema.getDepositsSchema().of(deposit));
   }
 
   @Override
   public void processVoluntaryExit(
       final MutableBeaconState state, final SignedVoluntaryExit voluntaryExit)
       throws BlockProcessingException {
-    spec.processVoluntaryExits(
-        state, beaconBlockBodySchema.getVoluntaryExitsSchema().of(voluntaryExit));
+    spec.getBlockProcessor(state.getSlot())
+        .processVoluntaryExits(
+            state, beaconBlockBodySchema.getVoluntaryExitsSchema().of(voluntaryExit));
   }
 
   @Override
   public void processAttestation(final MutableBeaconState state, final Attestation attestation)
       throws BlockProcessingException {
-    spec.processAttestations(state, beaconBlockBodySchema.getAttestationsSchema().of(attestation));
+    spec.getBlockProcessor(state.getSlot())
+        .processAttestations(state, beaconBlockBodySchema.getAttestationsSchema().of(attestation));
   }
 
   @Override
   public void processSyncCommittee(final MutableBeaconState state, final SyncAggregate aggregate)
       throws BlockProcessingException {
-    spec.atSlot(state.getSlot()).getBlockProcessor().processSyncCommittee(state, aggregate);
+    spec.getBlockProcessor(state.getSlot()).processSyncCommittee(state, aggregate);
   }
 }

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/fuzz/FuzzRegressionTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/fuzz/FuzzRegressionTest.java
@@ -44,7 +44,9 @@ public class FuzzRegressionTest {
     assertThatThrownBy(
             () ->
                 state.updated(
-                    mutableState -> spec.processAttesterSlashings(mutableState, slashings)))
+                    mutableState ->
+                        spec.getBlockProcessor(mutableState.getSlot())
+                            .processAttesterSlashings(mutableState, slashings)))
         .isInstanceOf(BlockProcessingException.class);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -39,15 +39,10 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBui
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
-import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateInvariants;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.datastructures.util.ForkAndSpecMilestone;
@@ -55,7 +50,6 @@ import tech.pegasys.teku.spec.genesis.GenesisGenerator;
 import tech.pegasys.teku.spec.logic.StateTransition;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
-import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
@@ -63,7 +57,6 @@ import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportRe
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
-import tech.pegasys.teku.ssz.SszList;
 import tech.pegasys.teku.ssz.collections.SszBitlist;
 import tech.pegasys.teku.ssz.type.Bytes4;
 
@@ -407,42 +400,14 @@ public class Spec {
 
   // Block Processor Utils
 
+  public BlockProcessor getBlockProcessor(final UInt64 slot) {
+    return atSlot(slot).getBlockProcessor();
+  }
+
   @CheckReturnValue
   public Optional<OperationInvalidReason> validateAttestation(
       final BeaconState state, final AttestationData data) {
     return atState(state).getBlockProcessor().validateAttestation(state, data);
-  }
-
-  public void processBlockHeader(MutableBeaconState state, BeaconBlockSummary blockHeader)
-      throws BlockProcessingException {
-    atState(state).getBlockProcessor().processBlockHeader(state, blockHeader);
-  }
-
-  public void processProposerSlashings(
-      MutableBeaconState state, SszList<ProposerSlashing> proposerSlashings)
-      throws BlockProcessingException {
-    atState(state).getBlockProcessor().processProposerSlashings(state, proposerSlashings);
-  }
-
-  public void processAttesterSlashings(
-      MutableBeaconState state, SszList<AttesterSlashing> attesterSlashings)
-      throws BlockProcessingException {
-    atState(state).getBlockProcessor().processAttesterSlashings(state, attesterSlashings);
-  }
-
-  public void processAttestations(MutableBeaconState state, SszList<Attestation> attestations)
-      throws BlockProcessingException {
-    atState(state).getBlockProcessor().processAttestations(state, attestations);
-  }
-
-  public void processDeposits(MutableBeaconState state, SszList<? extends Deposit> deposits)
-      throws BlockProcessingException {
-    atState(state).getBlockProcessor().processDeposits(state, deposits);
-  }
-
-  public void processVoluntaryExits(MutableBeaconState state, SszList<SignedVoluntaryExit> exits)
-      throws BlockProcessingException {
-    atState(state).getBlockProcessor().processVoluntaryExits(state, exits);
   }
 
   public boolean isEnoughVotesToUpdateEth1Data(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;

--- a/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
+++ b/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
@@ -93,7 +93,10 @@ public class FuzzUtil {
       BeaconState postState =
           structuredInput
               .getState()
-              .updated(state -> spec.processAttestations(state, attestations));
+              .updated(
+                  state ->
+                      spec.getBlockProcessor(state.getSlot())
+                          .processAttestations(state, attestations));
       Bytes output = postState.sszSerialize();
       return Optional.of(output.toArrayUnsafe());
     } catch (BlockProcessingException e) {
@@ -116,9 +119,9 @@ public class FuzzUtil {
           structuredInput
               .getState()
               .updated(
-                  state -> {
-                    spec.processAttesterSlashings(state, slashings);
-                  });
+                  state ->
+                      spec.getBlockProcessor(state.getSlot())
+                          .processAttesterSlashings(state, slashings));
       Bytes output = postState.sszSerialize();
       return Optional.of(output.toArrayUnsafe());
     } catch (BlockProcessingException e) {
@@ -155,9 +158,9 @@ public class FuzzUtil {
           structuredInput
               .getState()
               .updated(
-                  state -> {
-                    spec.processBlockHeader(state, structuredInput.getBlock());
-                  });
+                  state ->
+                      spec.getBlockProcessor(state.getSlot())
+                          .processBlockHeader(state, structuredInput.getBlock()));
       Bytes output = postState.sszSerialize();
       return Optional.of(output.toArrayUnsafe());
     } catch (BlockProcessingException e) {
@@ -177,9 +180,8 @@ public class FuzzUtil {
           structuredInput
               .getState()
               .updated(
-                  state -> {
-                    spec.processDeposits(state, deposits);
-                  });
+                  state ->
+                      spec.getBlockProcessor(state.getSlot()).processDeposits(state, deposits));
       Bytes output = postState.sszSerialize();
       return Optional.of(output.toArrayUnsafe());
     } catch (BlockProcessingException e) {
@@ -202,9 +204,9 @@ public class FuzzUtil {
           structuredInput
               .getState()
               .updated(
-                  state -> {
-                    spec.processProposerSlashings(state, proposerSlashings);
-                  });
+                  state ->
+                      spec.getBlockProcessor(state.getSlot())
+                          .processProposerSlashings(state, proposerSlashings));
       Bytes output = postState.sszSerialize();
       return Optional.of(output.toArrayUnsafe());
     } catch (BlockProcessingException e) {
@@ -252,9 +254,9 @@ public class FuzzUtil {
           structuredInput
               .getState()
               .updated(
-                  state -> {
-                    spec.processVoluntaryExits(state, voluntaryExits);
-                  });
+                  state ->
+                      spec.getBlockProcessor(state.getSlot())
+                          .processVoluntaryExits(state, voluntaryExits));
       Bytes output = postState.sszSerialize();
       return Optional.of(output.toArrayUnsafe());
     } catch (BlockProcessingException e) {


### PR DESCRIPTION
## PR Description
Provide a single `getBlockProcessor` method on `Spec` rather than individually delegating each method call for it.

Makes fuzzutil and reference test code a bit more verbose but simplifies the production code in Spec and makes it a lot easier to see where BlockProcessor methods are actually being used.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
