### PR TITLE
Move computeStartSlotAtEpoch to MiscHelpers to match its location in the spec

### DIFF
--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDutiesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDutiesTest.java
@@ -31,15 +31,12 @@ import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 
 public class GetProposerDutiesTest extends AbstractValidatorApiTest {
-  private BeaconStateUtil beaconStateUtil;
 
   @BeforeEach
   public void setup() {
     handler = new GetProposerDuties(syncDataProvider, validatorDataProvider, jsonProvider);
-    beaconStateUtil = spec.atSlot(UInt64.ZERO).getBeaconStateUtil();
   }
 
   @Test
@@ -51,8 +48,7 @@ public class GetProposerDutiesTest extends AbstractValidatorApiTest {
     GetProposerDutiesResponse duties =
         new GetProposerDutiesResponse(
             Bytes32.fromHexString("0x1234"),
-            List.of(
-                getProposerDuty(2, beaconStateUtil.computeStartSlotAtEpoch(UInt64.valueOf(100)))));
+            List.of(getProposerDuty(2, spec.computeStartSlotAtEpoch(UInt64.valueOf(100)))));
     when(validatorDataProvider.getProposerDuties(eq(UInt64.valueOf(100))))
         .thenReturn(SafeFuture.completedFuture(Optional.of(duties)));
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDutiesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDutiesTest.java
@@ -62,8 +62,7 @@ public class PostAttesterDutiesTest extends AbstractValidatorApiTest {
     when(context.body()).thenReturn("[\"2\"]");
 
     final UInt64 epoch = UInt64.valueOf(100);
-    final UInt64 startSlot =
-        spec.atEpoch(epoch).getBeaconStateUtil().computeStartSlotAtEpoch(epoch);
+    final UInt64 startSlot = spec.computeStartSlotAtEpoch(epoch);
     PostAttesterDutiesResponse duties =
         new PostAttesterDutiesResponse(
             Bytes32.fromHexString("0x1234"), List.of(getDuty(2, 1, 2, 10, 3, startSlot)));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -265,7 +265,7 @@ public class Spec {
   }
 
   public UInt64 computeStartSlotAtEpoch(final UInt64 epoch) {
-    return atEpoch(epoch).getBeaconStateUtil().computeStartSlotAtEpoch(epoch);
+    return atEpoch(epoch).miscHelpers().computeStartSlotAtEpoch(epoch);
   }
 
   public UInt64 computeEpochAtSlot(final UInt64 slot) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -89,8 +89,11 @@ public class MiscHelpers {
   }
 
   public UInt64 computeEpochAtSlot(UInt64 slot) {
-    // TODO this should take into account hard forks
     return slot.dividedBy(specConfig.getSlotsPerEpoch());
+  }
+
+  public UInt64 computeStartSlotAtEpoch(UInt64 epoch) {
+    return epoch.times(specConfig.getSlotsPerEpoch());
   }
 
   public UInt64 computeActivationExitEpoch(UInt64 epoch) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -223,7 +223,7 @@ public class AttestationUtil {
     UInt64 epoch = miscHelpers.computeEpochAtSlot(slot);
     // Get variables necessary that can be shared among Attestations of all validators
     Bytes32 beacon_block_root = block.getRoot();
-    UInt64 start_slot = beaconStateUtil.computeStartSlotAtEpoch(epoch);
+    UInt64 start_slot = miscHelpers.computeStartSlotAtEpoch(epoch);
     Bytes32 epoch_boundary_block_root =
         start_slot.compareTo(slot) == 0 || state.getSlot().compareTo(start_slot) <= 0
             ? block.getRoot()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
@@ -91,7 +91,9 @@ public class BeaconStateUtil {
 
   public UInt64 computeNextEpochBoundary(final UInt64 slot) {
     final UInt64 currentEpoch = miscHelpers.computeEpochAtSlot(slot);
-    return computeStartSlotAtEpoch(currentEpoch).equals(slot) ? currentEpoch : currentEpoch.plus(1);
+    return miscHelpers.computeStartSlotAtEpoch(currentEpoch).equals(slot)
+        ? currentEpoch
+        : currentEpoch.plus(1);
   }
 
   public Bytes32 getBlockRootAtSlot(BeaconState state, UInt64 slot)
@@ -106,11 +108,7 @@ public class BeaconStateUtil {
   }
 
   public Bytes32 getBlockRoot(BeaconState state, UInt64 epoch) throws IllegalArgumentException {
-    return getBlockRootAtSlot(state, computeStartSlotAtEpoch(epoch));
-  }
-
-  public UInt64 computeStartSlotAtEpoch(UInt64 epoch) {
-    return epoch.times(specConfig.getSlotsPerEpoch());
+    return getBlockRootAtSlot(state, miscHelpers.computeStartSlotAtEpoch(epoch));
   }
 
   public Bytes32 computeDomain(Bytes4 domainType) {
@@ -258,7 +256,7 @@ public class BeaconStateUtil {
 
   public UInt64 getEarliestQueryableSlotForTargetEpoch(final UInt64 epoch) {
     final UInt64 previousEpoch = epoch.compareTo(UInt64.ZERO) > 0 ? epoch.minus(UInt64.ONE) : epoch;
-    return computeStartSlotAtEpoch(previousEpoch);
+    return miscHelpers.computeStartSlotAtEpoch(previousEpoch);
   }
 
   private void validateStateForCommitteeQuery(BeaconState state, UInt64 slot) {
@@ -325,7 +323,7 @@ public class BeaconStateUtil {
   }
 
   private Bytes32 getDutyDependentRoot(final BeaconState state, final UInt64 epoch) {
-    final UInt64 slot = computeStartSlotAtEpoch(epoch).minusMinZero(1);
+    final UInt64 slot = miscHelpers.computeStartSlotAtEpoch(epoch).minusMinZero(1);
     return slot.equals(state.getSlot())
         // No previous block, use algorithm for calculating the genesis block root
         ? BeaconBlock.fromGenesisState(schemaDefinitions, state).getRoot()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -86,7 +86,7 @@ public class ForkChoiceUtil {
 
   public UInt64 computeSlotsSinceEpochStart(UInt64 slot) {
     final UInt64 epoch = miscHelpers.computeEpochAtSlot(slot);
-    final UInt64 epochStartSlot = beaconStateUtil.computeStartSlotAtEpoch(epoch);
+    final UInt64 epochStartSlot = miscHelpers.computeStartSlotAtEpoch(epoch);
     return slot.minus(epochStartSlot);
   }
 
@@ -262,7 +262,7 @@ public class ForkChoiceUtil {
     }
 
     // LMD vote must be consistent with FFG vote target
-    final UInt64 target_slot = beaconStateUtil.computeStartSlotAtEpoch(target.getEpoch());
+    final UInt64 target_slot = miscHelpers.computeStartSlotAtEpoch(target.getEpoch());
     if (getAncestor(forkChoiceStrategy, attestation.getData().getBeacon_block_root(), target_slot)
         .map(ancestorRoot -> !ancestorRoot.equals(target.getRoot()))
         .orElse(true)) {
@@ -444,7 +444,7 @@ public class ForkChoiceUtil {
     }
 
     UInt64 justifiedSlot =
-        beaconStateUtil.computeStartSlotAtEpoch(store.getJustifiedCheckpoint().getEpoch());
+        miscHelpers.computeStartSlotAtEpoch(store.getJustifiedCheckpoint().getEpoch());
     return hasAncestorAtSlot(
         forkChoiceStrategy,
         new_justified_checkpoint.getRoot(),

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtilTest.java
@@ -89,7 +89,7 @@ public class BeaconStateUtilTest {
   @Test
   void compute_next_epoch_boundary_slotAtBoundary() {
     final UInt64 expectedEpoch = UInt64.valueOf(2);
-    final UInt64 slot = beaconStateUtil.computeStartSlotAtEpoch(expectedEpoch);
+    final UInt64 slot = spec.computeStartSlotAtEpoch(expectedEpoch);
 
     assertThat(beaconStateUtil.computeNextEpochBoundary(slot)).isEqualTo(expectedEpoch);
   }
@@ -97,7 +97,7 @@ public class BeaconStateUtilTest {
   @Test
   void compute_next_epoch_boundary_slotPriorToBoundary() {
     final UInt64 expectedEpoch = UInt64.valueOf(2);
-    final UInt64 slot = beaconStateUtil.computeStartSlotAtEpoch(expectedEpoch).minus(1);
+    final UInt64 slot = spec.computeStartSlotAtEpoch(expectedEpoch).minus(1);
 
     assertThat(beaconStateUtil.computeNextEpochBoundary(slot)).isEqualTo(expectedEpoch);
   }
@@ -195,7 +195,7 @@ public class BeaconStateUtilTest {
   @ParameterizedTest(name = "n={0}")
   @MethodSource("getNValues")
   void isSlotAtNthEpochBoundary_withSkippedBlock(final int n) {
-    final int nthStartSlot = beaconStateUtil.computeStartSlotAtEpoch(UInt64.valueOf(n)).intValue();
+    final int nthStartSlot = spec.computeStartSlotAtEpoch(UInt64.valueOf(n)).intValue();
 
     final UInt64 genesisSlot = UInt64.ZERO;
     final UInt64 block1Slot = UInt64.valueOf(nthStartSlot + 1);
@@ -207,7 +207,7 @@ public class BeaconStateUtilTest {
   @ParameterizedTest(name = "n={0}")
   @MethodSource("getNValues")
   public void isSlotAtNthEpochBoundary_withSkippedEpochs_oneEpochAndSlotSkipped(final int n) {
-    final int nthStartSlot = beaconStateUtil.computeStartSlotAtEpoch(UInt64.valueOf(n)).intValue();
+    final int nthStartSlot = spec.computeStartSlotAtEpoch(UInt64.valueOf(n)).intValue();
 
     final UInt64 genesisSlot = UInt64.ZERO;
     final UInt64 block1Slot = UInt64.valueOf(nthStartSlot + SLOTS_PER_EPOCH + 1);
@@ -220,8 +220,7 @@ public class BeaconStateUtilTest {
   @ParameterizedTest(name = "n={0}")
   @MethodSource("getNValues")
   public void isSlotAtNthEpochBoundary_withSkippedEpochs_nearlyNEpochsSkipped(final int n) {
-    final int startSlotAt2N =
-        beaconStateUtil.computeStartSlotAtEpoch(UInt64.valueOf(n * 2L)).intValue();
+    final int startSlotAt2N = spec.computeStartSlotAtEpoch(UInt64.valueOf(n * 2L)).intValue();
 
     final UInt64 genesisSlot = UInt64.ZERO;
     final UInt64 block1Slot = UInt64.valueOf(startSlotAt2N - 1);
@@ -335,7 +334,7 @@ public class BeaconStateUtilTest {
   @Test
   void getAttestersTotalEffectiveBalance_shouldRejectRequestFromBeyondLookAheadPeriod() {
     final BeaconState state = dataStructureUtil.randomBeaconState(UInt64.ONE);
-    final UInt64 epoch3Start = beaconStateUtil.computeStartSlotAtEpoch(UInt64.valueOf(3));
+    final UInt64 epoch3Start = spec.computeStartSlotAtEpoch(UInt64.valueOf(3));
     assertThatThrownBy(() -> beaconStateUtil.getAttestersTotalEffectiveBalance(state, epoch3Start))
         .isInstanceOf(IllegalArgumentException.class);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -360,7 +360,7 @@ public class CombinedChainDataClient {
     List<CommitteeAssignment> result = new ArrayList<>();
     final BeaconStateUtil beaconStateUtil = spec.atEpoch(epoch).getBeaconStateUtil();
     final int slotsPerEpoch = spec.slotsPerEpoch(epoch);
-    final UInt64 startingSlot = beaconStateUtil.computeStartSlotAtEpoch(epoch);
+    final UInt64 startingSlot = spec.computeStartSlotAtEpoch(epoch);
     int committeeCount = beaconStateUtil.getCommitteeCountPerSlot(state, epoch).intValue();
     for (int i = 0; i < slotsPerEpoch; i++) {
       UInt64 slot = startingSlot.plus(i);


### PR DESCRIPTION
## PR Description
Move `computeStartSlotAtEpoch` to `MiscHelpers` which matches the category the spec has it in.  Remove a todo about `computeEpochAtSlot` needing to deal with forks - it's inside the `Spec` so any fork that changes slots per epoch will have to redefine it to handle the difference.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
