### PR TITLE
Customize health syncing status via query parameter

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/RestApiConstants.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/RestApiConstants.java
@@ -94,6 +94,10 @@ public class RestApiConstants {
   public static final String PARAM_VALIDATOR_DESCRIPTION =
       "Either hex encoded public key (with 0x prefix) or validator index";
 
+  public static final String SYNCING_STATUS = "syncing_status";
+  public static final String SYNCING_STATUS_DESCRIPTION =
+      "Customize syncing status instead of deafult " + SC_PARTIAL_CONTENT;
+
   public static final String HEADER_ACCEPT = "Accept";
   public static final String HEADER_ACCEPT_JSON = "application/json";
   public static final String HEADER_ACCEPT_OCTET = "application/octet-stream";

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealthTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealthTest.java
@@ -18,7 +18,10 @@ import static javax.servlet.http.HttpServletResponse.SC_PARTIAL_CONTENT;
 import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.CACHE_NONE;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.SYNCING_STATUS;
 
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
 
@@ -29,6 +32,42 @@ public class GetHealthTest extends AbstractBeaconHandlerTest {
     final GetHealth handler = new GetHealth(syncDataProvider, chainDataProvider);
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
     when(syncService.isSyncActive()).thenReturn(true);
+
+    handler.handle(context);
+    verifyCacheStatus(CACHE_NONE);
+    verifyStatusCode(SC_PARTIAL_CONTENT);
+  }
+
+  @Test
+  public void shouldReturnCustomSyncingStatusWhenSyncing() throws Exception {
+    final GetHealth handler = new GetHealth(syncDataProvider, chainDataProvider);
+    when(chainDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.isSyncActive()).thenReturn(true);
+    when(context.queryParamMap()).thenReturn(Map.of(SYNCING_STATUS, List.of("100")));
+
+    handler.handle(context);
+    verifyCacheStatus(CACHE_NONE);
+    verifyStatusCode(100);
+  }
+
+  @Test
+  public void shouldReturnDefaultSyncingStatusWhenSyncingWrongParam() throws Exception {
+    final GetHealth handler = new GetHealth(syncDataProvider, chainDataProvider);
+    when(chainDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.isSyncActive()).thenReturn(true);
+    when(context.queryParamMap()).thenReturn(Map.of(SYNCING_STATUS, List.of("a")));
+
+    handler.handle(context);
+    verifyCacheStatus(CACHE_NONE);
+    verifyStatusCode(SC_PARTIAL_CONTENT);
+  }
+
+  @Test
+  public void shouldReturnDefaultSyncingStatusWhenSyncingMultipleParams() throws Exception {
+    final GetHealth handler = new GetHealth(syncDataProvider, chainDataProvider);
+    when(chainDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.isSyncActive()).thenReturn(true);
+    when(context.queryParamMap()).thenReturn(Map.of(SYNCING_STATUS, List.of("1", "2")));
 
     handler.handle(context);
     verifyCacheStatus(CACHE_NONE);


### PR DESCRIPTION
Customize health check status when node is syncing
- use query parameter to override default syncing status
- return default status if wrong parameter passed

## Documentation

Health check syncing status can be overridden with custom value passed via query parameter `syncing_status`.
Therefore, it would be compatible with kubernetes standard health check where 200-399 statuses are considered healthy.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
