### PR TITLE
Fix NullPointerException when requesting genesis data prior to genesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
 - Fixed failures in the `checkMavenCoordinateCollisions` task if it was run prior to running spotless.
+- Fixed a `NullPointerException` from validator clients for new networks, prior to genesis being known.
 
 ### Experimental: New Altair REST APIs
 - implement POST `/eth/v1/beacon/pool/sync_committees` to allow validators to submit sync committee signatures to the beacon node.

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -89,7 +89,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   private final boolean updateHeadForEmptySlots;
 
   private volatile UpdatableStore store;
-  private volatile Optional<GenesisData> genesisData;
+  private volatile Optional<GenesisData> genesisData = Optional.empty();
   private final Map<Bytes4, SpecMilestone> forkDigestToMilestone = new ConcurrentHashMap<>();
   private final Map<SpecMilestone, Bytes4> milestoneToForkDigest = new ConcurrentHashMap<>();
   private volatile Optional<ChainHead> chainHead = Optional.empty();

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -190,6 +190,12 @@ class RecentChainDataTest {
     assertThat(recentChainData.getStore().getTime()).isEqualTo(time);
   }
 
+  @Test
+  void getGenesisData_shouldBeEmptyPreGenesis() {
+    initPreGenesis();
+    assertThat(recentChainData.getGenesisData()).isEmpty();
+  }
+
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void updateHead_validUpdate(final boolean updateHeadForEmptySlots) {


### PR DESCRIPTION
## PR Description
The initial value for `RecentChainData.genesisData` was `null` instead of `Optional.empty` which led to a `NullPointerException` when requesting the genesis data as the validator client does before genesis is known.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
