### PR TITLE
Fix paths used to determine split of reference tests across executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
           path: build/test-results
 
   acceptanceTests:
-    parallelism: 2
+    parallelism: 3
     executor: machine_executor
     steps:
       - prepare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,14 +243,19 @@ jobs:
           name: ReferenceTests
           no_output_timeout: 30m
           command: |
-            CLASSNAMES=$(circleci tests glob "**/src/referenceTest/generated/**/*Test.java" \
-              | sed 's@.*/src/referenceTest/generated/@@' \
+            CLASSNAMES=$(circleci tests glob "**/src/referenceTest/generated_tests/**/*Test.java" \
+              | sed 's@.*/src/referenceTest/generated_tests/@@' \
               | sed 's@/@.@g' \
               | sed 's/.\{5\}$//' \
               | circleci tests split --split-by=timings --timings-type=classname)
             # Format the arguments to "./gradlew test"
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
             echo "Prepared arguments for Gradle: $GRADLE_ARGS"
+            if [[ -z "$GRADLE_ARGS" ]]
+            then
+              echo "Failed to determine correct distribution of tests across nodes"
+              exit 1
+            fi
             ./gradlew --no-daemon --parallel -x generateReferenceTestClasses -x processReferenceTestResources -x cleanReferenceTestClasses referenceTest $GRADLE_ARGS
       - capture_test_results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
           path: build/test-results
 
   acceptanceTests:
-    parallelism: 4
+    parallelism: 3
     executor: machine_executor
     steps:
       - prepare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,11 @@ jobs:
             # Format the arguments to "./gradlew test"
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
             echo "Prepared arguments for Gradle: $GRADLE_ARGS"
+            if [[ -z "$GRADLE_ARGS" ]]
+            then
+              echo "Failed to determine correct distribution of tests across nodes"
+              exit 1
+            fi
             ./gradlew --no-daemon --parallel test $GRADLE_ARGS
       - capture_test_results
 
@@ -194,6 +199,11 @@ jobs:
             # Format the arguments to "./gradlew test"
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
             echo "Prepared arguments for Gradle: $GRADLE_ARGS"
+            if [[ -z "$GRADLE_ARGS" ]]
+            then
+              echo "Failed to determine correct distribution of tests across nodes"
+              exit 1
+            fi
             ./gradlew --no-daemon --parallel acceptanceTest $GRADLE_ARGS
       - capture_test_results
       - capture_test_artifacts
@@ -233,7 +243,7 @@ jobs:
             - ./eth-reference-tests/
 
   referenceTests:
-    parallelism: 7
+    parallelism: 5
     executor: large_executor
     steps:
       - prepare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
           path: build/test-results
 
   acceptanceTests:
-    parallelism: 3
+    parallelism: 4
     executor: machine_executor
     steps:
       - prepare
@@ -243,7 +243,7 @@ jobs:
             - ./eth-reference-tests/
 
   referenceTests:
-    parallelism: 5
+    parallelism: 4
     executor: large_executor
     steps:
       - prepare


### PR DESCRIPTION
## PR Description
We were running all reference tests on all parallel executors instead of splitting them across executors properly.

Fix that so reference tests will run a lot faster and make the job fail if we fail like this again.

Also adjusted parallelism - reduce reference tests since they aren't the bottleneck now and increased acceptance tests because they are.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
