### PR TITLE
Remove createUnsignedAttestation API and create AttestationData directly

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
@@ -39,7 +39,7 @@ import java.util.Optional;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
 import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
-import tech.pegasys.teku.api.schema.Attestation;
+import tech.pegasys.teku.api.schema.AttestationData;
 import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -103,8 +103,8 @@ public class GetAttestationData extends AbstractHandler {
             String.format("'%s' needs to be greater than or equal to 0.", COMMITTEE_INDEX));
       }
 
-      final SafeFuture<Optional<Attestation>> future =
-          provider.createUnsignedAttestationAtSlot(slot, committeeIndex);
+      final SafeFuture<Optional<AttestationData>> future =
+          provider.createAttestationDataAtSlot(slot, committeeIndex);
       handleOptionalResult(ctx, future, this::processResult, SC_BAD_REQUEST);
     } catch (final IllegalArgumentException e) {
       ctx.result(jsonProvider.objectToJSON(new BadRequest(e.getMessage())));
@@ -112,8 +112,8 @@ public class GetAttestationData extends AbstractHandler {
     }
   }
 
-  private Optional<String> processResult(final Context ctx, final Attestation attestation)
+  private Optional<String> processResult(final Context ctx, final AttestationData attestationData)
       throws JsonProcessingException {
-    return Optional.of(jsonProvider.objectToJSON(new GetAttestationDataResponse(attestation.data)));
+    return Optional.of(jsonProvider.objectToJSON(new GetAttestationDataResponse(attestationData)));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationDataTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationDataTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.api.ValidatorDataProvider;
 import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
-import tech.pegasys.teku.api.schema.Attestation;
+import tech.pegasys.teku.api.schema.AttestationData;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -47,7 +47,8 @@ class GetAttestationDataTest {
   private ValidatorDataProvider provider = mock(ValidatorDataProvider.class);
   private final JsonProvider jsonProvider = new JsonProvider();
   private GetAttestationData handler;
-  private Attestation attestation = new Attestation(dataStructureUtil.randomAttestation());
+  private AttestationData attestationData =
+      new AttestationData(dataStructureUtil.randomAttestationData());
 
   @SuppressWarnings("unchecked")
   final ArgumentCaptor<SafeFuture<String>> resultCaptor = ArgumentCaptor.forClass(SafeFuture.class);
@@ -87,7 +88,7 @@ class GetAttestationDataTest {
     Map<String, List<String>> params = Map.of(SLOT, List.of("1"), COMMITTEE_INDEX, List.of("1"));
 
     when(context.queryParamMap()).thenReturn(params);
-    when(provider.createUnsignedAttestationAtSlot(UInt64.ONE, 1))
+    when(provider.createAttestationDataAtSlot(UInt64.ONE, 1))
         .thenReturn(SafeFuture.failedFuture(new ChainDataUnavailableException()));
     handler.handle(context);
 
@@ -103,15 +104,15 @@ class GetAttestationDataTest {
 
     when(context.queryParamMap()).thenReturn(params);
     when(provider.isStoreAvailable()).thenReturn(true);
-    when(provider.createUnsignedAttestationAtSlot(UInt64.ONE, 1))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(attestation)));
+    when(provider.createAttestationDataAtSlot(UInt64.ONE, 1))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(attestationData)));
     handler.handle(context);
 
     verify(context).result(resultCaptor.capture());
     final SafeFuture<String> result = resultCaptor.getValue();
     assertThat(result)
         .isCompletedWithValue(
-            jsonProvider.objectToJSON(new GetAttestationDataResponse(attestation.data)));
+            jsonProvider.objectToJSON(new GetAttestationDataResponse(attestationData)));
   }
 
   private void badRequestParamsTest(final Map<String, List<String>> params, String message)

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -121,21 +121,14 @@ public class ValidatorDataProvider {
     return spec.atSlot(slot).getMilestone();
   }
 
-  public SafeFuture<Optional<Attestation>> createUnsignedAttestationAtSlot(
+  public SafeFuture<Optional<AttestationData>> createAttestationDataAtSlot(
       UInt64 slot, int committeeIndex) {
     if (!isStoreAvailable()) {
       return SafeFuture.failedFuture(new ChainDataUnavailableException());
     }
     return validatorApiChannel
-        .createUnsignedAttestation(slot, committeeIndex)
-        .thenApply(
-            maybeAttestation ->
-                maybeAttestation.map(
-                    attestation ->
-                        new Attestation(
-                            attestation.getAggregation_bits(),
-                            new AttestationData(attestation.getData()),
-                            new BLSSignature(attestation.getAggregate_signature()))));
+        .createAttestationData(slot, committeeIndex)
+        .thenApply(maybeAttestation -> maybeAttestation.map(AttestationData::new));
   }
 
   public void submitAttestations(List<Attestation> attestations) {

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -128,24 +128,24 @@ public class ValidatorDataProviderTest {
   }
 
   @Test
-  void getUnsignedAttestationAtSlot_shouldThrowIfStoreNotFound() {
+  void getAttestationDataAtSlot_shouldThrowIfStoreNotFound() {
     when(combinedChainDataClient.isStoreAvailable()).thenReturn(false);
-    final SafeFuture<Optional<Attestation>> result =
-        provider.createUnsignedAttestationAtSlot(ZERO, 0);
+    final SafeFuture<Optional<tech.pegasys.teku.api.schema.AttestationData>> result =
+        provider.createAttestationDataAtSlot(ZERO, 0);
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::join).hasRootCauseInstanceOf(ChainDataUnavailableException.class);
     verify(combinedChainDataClient).isStoreAvailable();
   }
 
   @Test
-  void getUnsignedAttestationAtSlot_shouldReturnEmptyIfBlockNotFound() {
+  void getAttestationDataAtSlot_shouldReturnEmptyIfBlockNotFound() {
     when(combinedChainDataClient.isStoreAvailable()).thenReturn(true);
-    when(validatorApiChannel.createUnsignedAttestation(ZERO, 0))
+    when(validatorApiChannel.createAttestationData(ZERO, 0))
         .thenReturn(completedFuture(Optional.empty()));
 
-    final SafeFuture<Optional<Attestation>> result =
-        provider.createUnsignedAttestationAtSlot(ZERO, 0);
-    verify(validatorApiChannel).createUnsignedAttestation(ZERO, 0);
+    final SafeFuture<Optional<tech.pegasys.teku.api.schema.AttestationData>> result =
+        provider.createAttestationDataAtSlot(ZERO, 0);
+    verify(validatorApiChannel).createAttestationData(ZERO, 0);
     assertThat(result).isCompletedWithValue(Optional.empty());
   }
 
@@ -184,23 +184,20 @@ public class ValidatorDataProviderTest {
   }
 
   @Test
-  void getUnsignedAttestationAtSlot_shouldReturnAttestation() {
+  void getAttestationDataAtSlot_shouldReturnAttestationData() {
     when(combinedChainDataClient.isStoreAvailable()).thenReturn(true);
-    final tech.pegasys.teku.spec.datastructures.operations.Attestation internalAttestation =
-        dataStructureUtil.randomAttestation();
-    when(validatorApiChannel.createUnsignedAttestation(ONE, 0))
-        .thenReturn(completedFuture(Optional.of(internalAttestation)));
+    final tech.pegasys.teku.spec.datastructures.operations.AttestationData internalData =
+        dataStructureUtil.randomAttestationData();
+    when(validatorApiChannel.createAttestationData(ONE, 0))
+        .thenReturn(completedFuture(Optional.of(internalData)));
 
-    final SafeFuture<Optional<Attestation>> result =
-        provider.createUnsignedAttestationAtSlot(ONE, 0);
+    final SafeFuture<Optional<tech.pegasys.teku.api.schema.AttestationData>> result =
+        provider.createAttestationDataAtSlot(ONE, 0);
     assertThat(result).isCompleted();
-    Attestation attestation = result.join().orElseThrow();
-    assertThat(attestation.data.index).isEqualTo(internalAttestation.getData().getIndex());
-    assertThat(attestation.signature.toHexString())
-        .isEqualTo(internalAttestation.getAggregate_signature().toSSZBytes().toHexString());
-    assertThat(attestation.data.slot).isEqualTo(internalAttestation.getData().getSlot());
-    assertThat(attestation.data.beacon_block_root)
-        .isEqualTo(internalAttestation.getData().getBeacon_block_root());
+    tech.pegasys.teku.api.schema.AttestationData data = result.join().orElseThrow();
+    assertThat(data.index).isEqualTo(internalData.getIndex());
+    assertThat(data.slot).isEqualTo(internalData.getSlot());
+    assertThat(data.beacon_block_root).isEqualTo(internalData.getBeacon_block_root());
   }
 
   @Test

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -58,8 +58,6 @@ public interface ValidatorApiChannel extends ChannelInterface {
   SafeFuture<Optional<BeaconBlock>> createUnsignedBlock(
       UInt64 slot, BLSSignature randaoReveal, Optional<Bytes32> graffiti);
 
-  SafeFuture<Optional<Attestation>> createUnsignedAttestation(UInt64 slot, int committeeIndex);
-
   SafeFuture<Optional<AttestationData>> createAttestationData(UInt64 slot, int committeeIndex);
 
   SafeFuture<Optional<Attestation>> createAggregate(UInt64 slot, Bytes32 attestationHashTreeRoot);

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -245,14 +245,6 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Attestation>> createUnsignedAttestation(
-      final UInt64 slot, final int committeeIndex) {
-    return countRequest(
-        delegate.createUnsignedAttestation(slot, committeeIndex),
-        unsignedAttestationRequestsCounter);
-  }
-
-  @Override
   public SafeFuture<Optional<AttestationData>> createAttestationData(
       final UInt64 slot, final int committeeIndex) {
     return countRequest(

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -60,8 +60,6 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       "beacon_node_sync_committee_duties_requests_total";
   public static final String UNSIGNED_BLOCK_REQUESTS_COUNTER_NAME =
       "beacon_node_unsigned_block_requests_total";
-  public static final String UNSIGNED_ATTESTATION_REQUEST_COUNTER_NAME =
-      "beacon_node_unsigned_attestation_requests_total";
   public static final String ATTESTATION_DATA_REQUEST_COUNTER_NAME =
       "beacon_node_attestation_data_requests_total";
   public static final String AGGREGATE_REQUESTS_COUNTER_NAME =
@@ -89,7 +87,6 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   private final BeaconChainRequestCounter syncCommitteeDutiesRequestCounter;
   private final BeaconChainRequestCounter proposerDutiesRequestCounter;
   private final BeaconChainRequestCounter unsignedBlockRequestsCounter;
-  private final BeaconChainRequestCounter unsignedAttestationRequestsCounter;
   private final BeaconChainRequestCounter attestationDataRequestsCounter;
   private final BeaconChainRequestCounter aggregateRequestsCounter;
   private final BeaconChainRequestCounter createSyncCommitteeContributionCounter;
@@ -132,11 +129,6 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
             metricsSystem,
             UNSIGNED_BLOCK_REQUESTS_COUNTER_NAME,
             "Counter recording the number of requests for unsigned blocks");
-    unsignedAttestationRequestsCounter =
-        BeaconChainRequestCounter.create(
-            metricsSystem,
-            UNSIGNED_ATTESTATION_REQUEST_COUNTER_NAME,
-            "Counter recording the number of requests for unsigned attestations");
     attestationDataRequestsCounter =
         BeaconChainRequestCounter.create(
             metricsSystem,

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -161,10 +161,10 @@ class MetricRecordingValidatorApiChannelTest {
             MetricRecordingValidatorApiChannel.UNSIGNED_BLOCK_REQUESTS_COUNTER_NAME,
             dataStructureUtil.randomBeaconBlock(slot)),
         requestDataTest(
-            "createUnsignedAttestation",
-            channel -> channel.createUnsignedAttestation(slot, 4),
+            "createAttestationData",
+            channel -> channel.createAttestationData(slot, 4),
             MetricRecordingValidatorApiChannel.UNSIGNED_ATTESTATION_REQUEST_COUNTER_NAME,
-            dataStructureUtil.randomAttestation()),
+            dataStructureUtil.randomAttestationData()),
         requestDataTest(
             "createAggregate",
             channel ->

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -163,7 +163,7 @@ class MetricRecordingValidatorApiChannelTest {
         requestDataTest(
             "createAttestationData",
             channel -> channel.createAttestationData(slot, 4),
-            MetricRecordingValidatorApiChannel.UNSIGNED_ATTESTATION_REQUEST_COUNTER_NAME,
+            MetricRecordingValidatorApiChannel.ATTESTATION_DATA_REQUEST_COUNTER_NAME,
             dataStructureUtil.randomAttestationData()),
         requestDataTest(
             "createAggregate",

--- a/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -31,7 +31,6 @@ import tech.pegasys.teku.networking.eth2.gossip.subnets.SyncCommitteeSubscriptio
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
-import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
@@ -107,7 +106,7 @@ public class ValidatorApiHandlerIntegrationTest {
   }
 
   @Test
-  public void createUnsignedAttestation_withRecentBlockAvailable() {
+  public void createAttestationData_withRecentBlockAvailable() {
     final UInt64 targetEpoch = UInt64.valueOf(3);
     final UInt64 targetEpochStartSlot = spec.computeStartSlotAtEpoch(targetEpoch);
     final UInt64 targetSlot = targetEpochStartSlot.plus(2);
@@ -129,10 +128,10 @@ public class ValidatorApiHandlerIntegrationTest {
     final Checkpoint expectedTarget = new Checkpoint(targetEpoch, epochBoundaryBlock.getRoot());
 
     final int committeeIndex = 0;
-    final SafeFuture<Optional<Attestation>> result =
-        handler.createUnsignedAttestation(targetSlot, committeeIndex);
+    final SafeFuture<Optional<AttestationData>> result =
+        handler.createAttestationData(targetSlot, committeeIndex);
     assertThatSafeFuture(result).isCompletedWithNonEmptyOptional();
-    final AttestationData attestation = result.join().get().getData();
+    final AttestationData attestation = result.join().orElseThrow();
     assertThat(attestation.getBeacon_block_root()).isEqualTo(latestBlock.getRoot());
     assertThat(attestation.getSource()).isEqualTo(genesisCheckpoint);
     assertThat(attestation.getTarget()).isEqualTo(expectedTarget);
@@ -158,10 +157,10 @@ public class ValidatorApiHandlerIntegrationTest {
     final Checkpoint expectedTarget = new Checkpoint(targetEpoch, latestBlock.getRoot());
 
     final int committeeIndex = 0;
-    final SafeFuture<Optional<Attestation>> result =
-        handler.createUnsignedAttestation(targetSlot, committeeIndex);
+    final SafeFuture<Optional<AttestationData>> result =
+        handler.createAttestationData(targetSlot, committeeIndex);
     assertThatSafeFuture(result).isCompletedWithNonEmptyOptional();
-    final AttestationData attestation = result.join().get().getData();
+    final AttestationData attestation = result.join().orElseThrow();
     assertThat(attestation.getBeacon_block_root()).isEqualTo(latestBlock.getRoot());
     assertThat(attestation.getSource()).isEqualTo(genesisCheckpoint);
     assertThat(attestation.getTarget()).isEqualTo(expectedTarget);

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -65,7 +65,6 @@ import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProces
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
-import tech.pegasys.teku.ssz.collections.SszBitlist;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
@@ -304,7 +303,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Attestation>> createUnsignedAttestation(
+  public SafeFuture<Optional<AttestationData>> createAttestationData(
       final UInt64 slot, final int committeeIndex) {
     if (isSyncActive()) {
       return NodeSyncingException.failedFuture();
@@ -330,24 +329,17 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                     .thenApply(
                         checkpointState ->
                             Optional.of(
-                                createAttestation(
+                                createAttestationData(
                                     block, checkpointState.getState(), slot, committeeIndex)));
               } else {
-                final Attestation attestation =
-                    createAttestation(block, blockAndState.getState(), slot, committeeIndex);
-                return SafeFuture.completedFuture(Optional.of(attestation));
+                final AttestationData attestationData =
+                    createAttestationData(block, blockAndState.getState(), slot, committeeIndex);
+                return SafeFuture.completedFuture(Optional.of(attestationData));
               }
             });
   }
 
-  @Override
-  public SafeFuture<Optional<AttestationData>> createAttestationData(
-      final UInt64 slot, final int committeeIndex) {
-    return createUnsignedAttestation(slot, committeeIndex)
-        .thenApply(maybeAttestation -> maybeAttestation.map(Attestation::getData));
-  }
-
-  private Attestation createAttestation(
+  private AttestationData createAttestationData(
       final BeaconBlock block,
       final BeaconState state,
       final UInt64 slot,
@@ -363,16 +355,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
               + (committeeCount - 1));
     }
     final UInt64 committeeIndexUnsigned = UInt64.valueOf(committeeIndex);
-    final AttestationData attestationData =
-        spec.getGenericAttestationData(slot, state, block, committeeIndexUnsigned);
-    final List<Integer> committee =
-        spec.atSlot(slot)
-            .getBeaconStateUtil()
-            .getBeaconCommittee(state, slot, committeeIndexUnsigned);
-
-    SszBitlist aggregationBits =
-        Attestation.SSZ_SCHEMA.getAggregationBitsSchema().ofBits(committee.size());
-    return new Attestation(aggregationBits, attestationData, BLSSignature.empty());
+    return spec.getGenericAttestationData(slot, state, block, committeeIndexUnsigned);
   }
 
   @Override

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -443,17 +443,17 @@ class ValidatorApiHandlerTest {
   }
 
   @Test
-  public void createUnsignedAttestation_shouldFailWhenNodeIsSyncing() {
+  public void createAttestationData_shouldFailWhenNodeIsSyncing() {
     nodeIsSyncing();
-    final SafeFuture<Optional<Attestation>> result =
-        validatorApiHandler.createUnsignedAttestation(ONE, 1);
+    final SafeFuture<Optional<AttestationData>> result =
+        validatorApiHandler.createAttestationData(ONE, 1);
 
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get).hasRootCauseInstanceOf(NodeSyncingException.class);
   }
 
   @Test
-  public void createUnsignedAttestation_shouldCreateAttestation() {
+  public void createAttestationData_shouldCreateAttestation() {
     final UInt64 slot = spec.computeStartSlotAtEpoch(EPOCH).plus(ONE);
 
     final BeaconState state = createStateWithActiveValidators(EPOCH_START_SLOT);
@@ -467,26 +467,22 @@ class ValidatorApiHandlerTest {
         .thenReturn(blockAndStateResult);
 
     final int committeeIndex = 0;
-    final SafeFuture<Optional<Attestation>> result =
-        validatorApiHandler.createUnsignedAttestation(slot, committeeIndex);
+    final SafeFuture<Optional<AttestationData>> result =
+        validatorApiHandler.createAttestationData(slot, committeeIndex);
 
     assertThat(result).isCompleted();
-    final Optional<Attestation> maybeAttestation = result.join();
+    final Optional<AttestationData> maybeAttestation = result.join();
     assertThat(maybeAttestation).isPresent();
-    final Attestation attestation = maybeAttestation.orElseThrow();
-    assertThat(attestation.getAggregation_bits())
-        .isEqualTo(Attestation.SSZ_SCHEMA.getAggregationBitsSchema().ofBits(4));
-    assertThat(attestation.getData())
+    final AttestationData attestationData = maybeAttestation.orElseThrow();
+    assertThat(attestationData)
         .isEqualTo(
             spec.getGenericAttestationData(
                 slot, state, block.getMessage(), UInt64.valueOf(committeeIndex)));
-    assertThat(attestation.getData().getSlot()).isEqualTo(slot);
-    assertThat(attestation.getAggregate_signature().toSSZBytes())
-        .isEqualTo(BLSSignature.empty().toSSZBytes());
+    assertThat(attestationData.getSlot()).isEqualTo(slot);
   }
 
   @Test
-  public void createUnsignedAttestation_shouldUseCorrectSourceWhenEpochTransitionRequired() {
+  public void createAttestationData_shouldUseCorrectSourceWhenEpochTransitionRequired() {
     final UInt64 slot = spec.computeStartSlotAtEpoch(EPOCH);
     // Slot is from before the current epoch, so we need to ensure we process the epoch transition
     final UInt64 blockSlot = slot.minus(1);
@@ -508,22 +504,18 @@ class ValidatorApiHandlerTest {
                 CheckpointState.create(new Checkpoint(EPOCH, block.getRoot()), block, rightState)));
 
     final int committeeIndex = 0;
-    final SafeFuture<Optional<Attestation>> result =
-        validatorApiHandler.createUnsignedAttestation(slot, committeeIndex);
+    final SafeFuture<Optional<AttestationData>> result =
+        validatorApiHandler.createAttestationData(slot, committeeIndex);
 
     assertThat(result).isCompleted();
-    final Optional<Attestation> maybeAttestation = result.join();
+    final Optional<AttestationData> maybeAttestation = result.join();
     assertThat(maybeAttestation).isPresent();
-    final Attestation attestation = maybeAttestation.orElseThrow();
-    assertThat(attestation.getAggregation_bits())
-        .isEqualTo(Attestation.SSZ_SCHEMA.getAggregationBitsSchema().ofBits(4));
-    assertThat(attestation.getData())
+    final AttestationData attestationData = maybeAttestation.orElseThrow();
+    assertThat(attestationData)
         .isEqualTo(
             spec.getGenericAttestationData(
                 slot, rightState, block.getMessage(), UInt64.valueOf(committeeIndex)));
-    assertThat(attestation.getData().getSlot()).isEqualTo(slot);
-    assertThat(attestation.getAggregate_signature().toSSZBytes())
-        .isEqualTo(BLSSignature.empty().toSSZBytes());
+    assertThat(attestationData.getSlot()).isEqualTo(slot);
   }
 
   @Test

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -229,16 +229,6 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<Attestation>> createUnsignedAttestation(
-      final UInt64 slot, final int committeeIndex) {
-    return sendRequest(
-        () ->
-            apiClient
-                .createUnsignedAttestation(slot, committeeIndex)
-                .map(tech.pegasys.teku.api.schema.Attestation::asInternalAttestation));
-  }
-
-  @Override
   public SafeFuture<Optional<AttestationData>> createAttestationData(
       final UInt64 slot, final int committeeIndex) {
     return sendRequest(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -24,7 +24,6 @@ import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GE
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_PROPOSER_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_SYNC_COMMITTEE_CONTRIBUTION;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_SYNC_COMMITTEE_DUTIES;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_ATTESTATION;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK_V2;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_VALIDATORS;
@@ -187,16 +186,6 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
     return post(SEND_SIGNED_BLOCK, beaconBlock, createHandler())
         .map(__ -> SendSignedBlockResult.success(Bytes32.ZERO))
         .orElseGet(() -> SendSignedBlockResult.notImported("UNKNOWN"));
-  }
-
-  @Override
-  public Optional<Attestation> createUnsignedAttestation(
-      final UInt64 slot, final int committeeIndex) {
-    final Map<String, String> queryParams = new HashMap<>();
-    queryParams.put("slot", encodeQueryParam(slot));
-    queryParams.put("committee_index", String.valueOf(committeeIndex));
-
-    return get(GET_UNSIGNED_ATTESTATION, queryParams, createHandler(Attestation.class));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -25,7 +25,6 @@ public enum ValidatorApiMethod {
   GET_UNSIGNED_BLOCK("eth/v1/validator/blocks/:slot"),
   GET_UNSIGNED_BLOCK_V2("eth/v2/validator/blocks/:slot"),
   SEND_SIGNED_BLOCK("eth/v1/beacon/blocks"),
-  GET_UNSIGNED_ATTESTATION("validator/attestation"),
   GET_ATTESTATION_DATA("eth/v1/validator/attestation_data"),
   SEND_SIGNED_ATTESTATION("eth/v1/beacon/pool/attestations"),
   SEND_SIGNED_VOLUNTARY_EXIT("eth/v1/beacon/pool/voluntary_exits"),

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -56,8 +56,6 @@ public interface ValidatorRestApiClient {
 
   SendSignedBlockResult sendSignedBlock(SignedBeaconBlock beaconBlock);
 
-  Optional<Attestation> createUnsignedAttestation(UInt64 slot, int committeeIndex);
-
   Optional<AttestationData> createAttestationData(UInt64 slot, int committeeIndex);
 
   void sendSignedAttestation(Attestation attestation);

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -315,29 +315,6 @@ class RemoteValidatorApiHandlerTest {
   }
 
   @Test
-  public void createUnsignedAttestation_WhenNone_ReturnsEmpty() {
-    when(apiClient.createUnsignedAttestation(any(), anyInt())).thenReturn(Optional.empty());
-
-    SafeFuture<Optional<Attestation>> future = apiHandler.createUnsignedAttestation(UInt64.ONE, 0);
-
-    assertThat(unwrapToOptional(future)).isEmpty();
-  }
-
-  @Test
-  public void createUnsignedAttestation_WhenFound_ReturnsAttestation() {
-    final Attestation attestation = dataStructureUtil.randomAttestation();
-    final tech.pegasys.teku.api.schema.Attestation schemaAttestation =
-        new tech.pegasys.teku.api.schema.Attestation(attestation);
-
-    when(apiClient.createUnsignedAttestation(eq(UInt64.ONE), eq(0)))
-        .thenReturn(Optional.of(schemaAttestation));
-
-    SafeFuture<Optional<Attestation>> future = apiHandler.createUnsignedAttestation(UInt64.ONE, 0);
-
-    assertThatSszData(unwrapToValue(future)).isEqualByAllMeansTo(attestation);
-  }
-
-  @Test
   public void createAttestationData_WhenNone_ReturnsEmpty() {
     when(apiClient.createAttestationData(any(), anyInt())).thenReturn(Optional.empty());
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -308,64 +308,6 @@ class OkHttpValidatorRestApiClientTest {
   }
 
   @Test
-  public void createUnsignedAttestation_MakesExpectedRequest() throws Exception {
-    final UInt64 slot = UInt64.ONE;
-    final int committeeIndex = 1;
-
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NO_CONTENT));
-
-    apiClient.createUnsignedAttestation(slot, committeeIndex);
-
-    RecordedRequest request = mockWebServer.takeRequest();
-
-    assertThat(request.getMethod()).isEqualTo("GET");
-    assertThat(request.getPath())
-        .contains(ValidatorApiMethod.GET_UNSIGNED_ATTESTATION.getPath(emptyMap()));
-    assertThat(request.getRequestUrl().queryParameter("slot")).isEqualTo(slot.toString());
-    assertThat(request.getRequestUrl().queryParameter("committee_index"))
-        .isEqualTo(String.valueOf(committeeIndex));
-  }
-
-  @Test
-  public void createUnsignedAttestation_WhenBadRequest_ThrowsIllegalArgumentException() {
-    final UInt64 slot = UInt64.ONE;
-    final int committeeIndex = 1;
-
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_BAD_REQUEST));
-
-    assertThatThrownBy(() -> apiClient.createUnsignedAttestation(slot, committeeIndex))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
-  public void createUnsignedAttestation_WhenNotFound_ThrowsException() {
-    final UInt64 slot = UInt64.ONE;
-    final int committeeIndex = 1;
-
-    // An attestation could not be created for the specified slot
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NOT_FOUND));
-
-    assertThatThrownBy(() -> apiClient.createUnsignedAttestation(slot, committeeIndex))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessageContaining("Unexpected response from Beacon Node API");
-  }
-
-  @Test
-  public void createUnsignedAttestation_WhenSuccess_ReturnsAttestation() {
-    final UInt64 slot = UInt64.ONE;
-    final int committeeIndex = 1;
-    final Attestation expectedAttestation = schemaObjects.attestation();
-
-    mockWebServer.enqueue(
-        new MockResponse().setResponseCode(SC_OK).setBody(asJson(expectedAttestation)));
-
-    Optional<Attestation> attestation = apiClient.createUnsignedAttestation(slot, committeeIndex);
-
-    assertThat(attestation).isPresent();
-    assertThat(attestation.get()).usingRecursiveComparison().isEqualTo(expectedAttestation);
-  }
-
-  @Test
   public void createAttestationData_MakesExpectedRequest() throws Exception {
     final UInt64 slot = UInt64.ONE;
     final int committeeIndex = 1;


### PR DESCRIPTION
## PR Description
We don't need the legacy `createUnsignedAttestation` API anymore (REST API was removed a while back or never existed).  So remove the internals for it and change `createAttestationData` to create just the data directly instead of creating an unsigned attestation and then just returning the data part.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
