### PR TITLE
[Issue 3356] Deprecated BeaconStateUtil cleanup

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalSigner.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalSigner.java
@@ -13,12 +13,6 @@
 
 package tech.pegasys.teku.core.signatures;
 
-import static tech.pegasys.teku.core.signatures.SigningRootUtil.signingRootForSignAggregateAndProof;
-import static tech.pegasys.teku.core.signatures.SigningRootUtil.signingRootForSignAggregationSlot;
-import static tech.pegasys.teku.core.signatures.SigningRootUtil.signingRootForSignAttestationData;
-import static tech.pegasys.teku.core.signatures.SigningRootUtil.signingRootForSignBlock;
-import static tech.pegasys.teku.core.signatures.SigningRootUtil.signingRootForSignVoluntaryExit;
-
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -43,44 +37,46 @@ public class LocalSigner implements Signer {
   private final Spec spec;
   private final BLSKeyPair keypair;
   private final AsyncRunner asyncRunner;
+  private final SigningRootUtil signingRootUtil;
 
   public LocalSigner(final Spec spec, final BLSKeyPair keypair, final AsyncRunner asyncRunner) {
     this.spec = spec;
     this.keypair = keypair;
     this.asyncRunner = asyncRunner;
+    this.signingRootUtil = new SigningRootUtil(spec);
   }
 
   @Override
   public SafeFuture<BLSSignature> createRandaoReveal(final UInt64 epoch, final ForkInfo forkInfo) {
-    return sign(SigningRootUtil.signingRootForRandaoReveal(epoch, forkInfo));
+    return sign(signingRootUtil.signingRootForRandaoReveal(epoch, forkInfo));
   }
 
   @Override
   public SafeFuture<BLSSignature> signBlock(final BeaconBlock block, final ForkInfo forkInfo) {
-    return sign(signingRootForSignBlock(block, forkInfo));
+    return sign(signingRootUtil.signingRootForSignBlock(block, forkInfo));
   }
 
   @Override
   public SafeFuture<BLSSignature> signAttestationData(
       final AttestationData attestationData, final ForkInfo forkInfo) {
-    return sign(signingRootForSignAttestationData(attestationData, forkInfo));
+    return sign(signingRootUtil.signingRootForSignAttestationData(attestationData, forkInfo));
   }
 
   @Override
   public SafeFuture<BLSSignature> signAggregationSlot(final UInt64 slot, final ForkInfo forkInfo) {
-    return sign(signingRootForSignAggregationSlot(slot, forkInfo));
+    return sign(signingRootUtil.signingRootForSignAggregationSlot(slot, forkInfo));
   }
 
   @Override
   public SafeFuture<BLSSignature> signAggregateAndProof(
       final AggregateAndProof aggregateAndProof, final ForkInfo forkInfo) {
-    return sign(signingRootForSignAggregateAndProof(aggregateAndProof, forkInfo));
+    return sign(signingRootUtil.signingRootForSignAggregateAndProof(aggregateAndProof, forkInfo));
   }
 
   @Override
   public SafeFuture<BLSSignature> signVoluntaryExit(
       final VoluntaryExit voluntaryExit, final ForkInfo forkInfo) {
-    return sign(signingRootForSignVoluntaryExit(voluntaryExit, forkInfo));
+    return sign(signingRootUtil.signingRootForSignVoluntaryExit(voluntaryExit, forkInfo));
   }
 
   @Override

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SigningRootUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SigningRootUtil.java
@@ -13,84 +13,91 @@
 
 package tech.pegasys.teku.core.signatures;
 
-import static tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
-import static tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil.compute_signing_root;
-import static tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil.get_domain;
-import static tech.pegasys.teku.util.config.Constants.DOMAIN_BEACON_ATTESTER;
-import static tech.pegasys.teku.util.config.Constants.DOMAIN_SELECTION_PROOF;
-
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.util.config.Constants;
 
 public class SigningRootUtil {
-  public static Bytes signingRootForRandaoReveal(final UInt64 epoch, final ForkInfo forkInfo) {
+  private final Spec spec;
+
+  public SigningRootUtil(final Spec spec) {
+    this.spec = spec;
+  }
+
+  public Bytes signingRootForRandaoReveal(final UInt64 epoch, final ForkInfo forkInfo) {
+    final SpecVersion specVersion = spec.atEpoch(epoch);
     Bytes32 domain =
-        get_domain(
-            Constants.DOMAIN_RANDAO,
+        spec.getDomain(
+            specVersion.getConfig().getDomainRandao(),
             epoch,
             forkInfo.getFork(),
             forkInfo.getGenesisValidatorsRoot());
-    return compute_signing_root(epoch.longValue(), domain);
+    return specVersion.miscHelpers().computeSigningRoot(epoch, domain);
   }
 
-  public static Bytes signingRootForSignBlock(final BeaconBlock block, final ForkInfo forkInfo) {
+  public Bytes signingRootForSignBlock(final BeaconBlock block, final ForkInfo forkInfo) {
+    final SpecVersion specVersion = spec.atSlot(block.getSlot());
     final Bytes32 domain =
-        get_domain(
-            Constants.DOMAIN_BEACON_PROPOSER,
-            compute_epoch_at_slot(block.getSlot()),
+        spec.getDomain(
+            specVersion.getConfig().getDomainBeaconProposer(),
+            spec.computeEpochAtSlot(block.getSlot()),
             forkInfo.getFork(),
             forkInfo.getGenesisValidatorsRoot());
-    return compute_signing_root(block, domain);
+    return specVersion.miscHelpers().computeSigningRoot(block, domain);
   }
 
-  public static Bytes signingRootForSignAttestationData(
+  public Bytes signingRootForSignAttestationData(
       final AttestationData attestationData, final ForkInfo forkInfo) {
+    final SpecVersion specVersion = spec.atSlot(attestationData.getSlot());
     final Bytes32 domain =
-        get_domain(
-            DOMAIN_BEACON_ATTESTER,
+        spec.getDomain(
+            specVersion.getConfig().getDomainBeaconAttester(),
             attestationData.getTarget().getEpoch(),
             forkInfo.getFork(),
             forkInfo.getGenesisValidatorsRoot());
-    return compute_signing_root(attestationData, domain);
+    return specVersion.miscHelpers().computeSigningRoot(attestationData, domain);
   }
 
-  public static Bytes signingRootForSignAggregationSlot(
-      final UInt64 slot, final ForkInfo forkInfo) {
+  public Bytes signingRootForSignAggregationSlot(final UInt64 slot, final ForkInfo forkInfo) {
+    final SpecVersion specVersion = spec.atSlot(slot);
     final Bytes32 domain =
-        get_domain(
-            DOMAIN_SELECTION_PROOF,
-            compute_epoch_at_slot(slot),
+        spec.getDomain(
+            specVersion.getConfig().getDomainSelectionProof(),
+            spec.computeEpochAtSlot(slot),
             forkInfo.getFork(),
             forkInfo.getGenesisValidatorsRoot());
-    return compute_signing_root(slot.longValue(), domain);
+    return specVersion.miscHelpers().computeSigningRoot(slot, domain);
   }
 
-  public static Bytes signingRootForSignAggregateAndProof(
+  public Bytes signingRootForSignAggregateAndProof(
       final AggregateAndProof aggregateAndProof, final ForkInfo forkInfo) {
+    final UInt64 slot = aggregateAndProof.getAggregate().getData().getSlot();
+    final SpecVersion specVersion = spec.atSlot(slot);
     final Bytes32 domain =
-        get_domain(
-            Constants.DOMAIN_AGGREGATE_AND_PROOF,
-            compute_epoch_at_slot(aggregateAndProof.getAggregate().getData().getSlot()),
+        spec.getDomain(
+            specVersion.getConfig().getDomainAggregateAndProof(),
+            spec.computeEpochAtSlot(slot),
             forkInfo.getFork(),
             forkInfo.getGenesisValidatorsRoot());
-    return compute_signing_root(aggregateAndProof, domain);
+    return specVersion.miscHelpers().computeSigningRoot(aggregateAndProof, domain);
   }
 
-  public static Bytes signingRootForSignVoluntaryExit(
+  public Bytes signingRootForSignVoluntaryExit(
       final VoluntaryExit voluntaryExit, final ForkInfo forkInfo) {
+    final SpecVersion specVersion = spec.atEpoch(voluntaryExit.getEpoch());
     final Bytes32 domain =
-        get_domain(
-            Constants.DOMAIN_VOLUNTARY_EXIT,
+        spec.getDomain(
+            specVersion.getConfig().getDomainVoluntaryExit(),
             voluntaryExit.getEpoch(),
             forkInfo.getFork(),
             forkInfo.getGenesisValidatorsRoot());
-    return compute_signing_root(voluntaryExit, domain);
+    return specVersion.miscHelpers().computeSigningRoot(voluntaryExit, domain);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -287,6 +287,16 @@ public class Spec {
     return atState(state).beaconStateAccessors().getBlockRootAtSlot(state, slot);
   }
 
+  public Bytes32 getDomain(
+      final Bytes4 domainType,
+      final UInt64 epoch,
+      final Fork fork,
+      final Bytes32 genesisValidatorsRoot) {
+    return atEpoch(epoch)
+        .beaconStateAccessors()
+        .getDomain(domainType, epoch, fork, genesisValidatorsRoot);
+  }
+
   public Bytes32 getPreviousDutyDependentRoot(BeaconState state) {
     return atState(state).getBeaconStateUtil().getPreviousDutyDependentRoot(state);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/MockStartValidatorKeyPairFactory.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/MockStartValidatorKeyPairFactory.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.datastructures.interop;
 
+import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uintToBytes32;
+
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -24,7 +26,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSecretKey;
 import tech.pegasys.teku.infrastructure.crypto.BouncyCastleMessageDigestFactory;
-import tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil;
 
 public class MockStartValidatorKeyPairFactory {
   private static final BigInteger CURVE_ORDER =
@@ -38,7 +39,7 @@ public class MockStartValidatorKeyPairFactory {
   }
 
   private BLSKeyPair createKeyPairForValidator(final int validatorIndex) {
-    final Bytes hash = sha256(BeaconStateUtil.uint_to_bytes32(validatorIndex));
+    final Bytes hash = sha256(uintToBytes32(validatorIndex));
     final BigInteger privKey = hash.reverse().toUnsignedBigInteger().mod(CURVE_ORDER);
     final Bytes32 privKeyBytes = Bytes32.leftPad(Bytes.of(privKey.toByteArray()));
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/StatusMessage.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/StatusMessage.java
@@ -13,10 +13,10 @@
 
 package tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc;
 
-import static tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil.compute_fork_digest;
-
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.ssz.containers.Container5;
 import tech.pegasys.teku.ssz.containers.ContainerSchema5;
 import tech.pegasys.teku.ssz.primitive.SszBytes32;
@@ -25,7 +25,6 @@ import tech.pegasys.teku.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.ssz.tree.TreeNode;
 import tech.pegasys.teku.ssz.type.Bytes4;
-import tech.pegasys.teku.util.config.Constants;
 
 public class StatusMessage
     extends Container5<StatusMessage, SszBytes4, SszBytes32, SszUInt64, SszBytes32, SszUInt64>
@@ -72,15 +71,16 @@ public class StatusMessage
         SszUInt64.of(headSlot));
   }
 
-  public static StatusMessage createPreGenesisStatus() {
+  public static StatusMessage createPreGenesisStatus(final Spec spec) {
     return new StatusMessage(
-        createPreGenesisForkDigest(), Bytes32.ZERO, UInt64.ZERO, Bytes32.ZERO, UInt64.ZERO);
+        createPreGenesisForkDigest(spec), Bytes32.ZERO, UInt64.ZERO, Bytes32.ZERO, UInt64.ZERO);
   }
 
-  private static Bytes4 createPreGenesisForkDigest() {
-    final Bytes4 genesisFork = Constants.GENESIS_FORK_VERSION;
+  private static Bytes4 createPreGenesisForkDigest(final Spec spec) {
+    final SpecVersion genesisSpec = spec.getGenesisSpec();
+    final Bytes4 genesisFork = genesisSpec.getConfig().getGenesisForkVersion();
     final Bytes32 emptyValidatorsRoot = Bytes32.ZERO;
-    return compute_fork_digest(genesisFork, emptyValidatorsRoot);
+    return genesisSpec.miscHelpers().computeForkDigest(genesisFork, emptyValidatorsRoot);
   }
 
   public Bytes4 getForkDigest() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/AnchorPoint.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/AnchorPoint.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil;
 import tech.pegasys.teku.util.config.Constants;
 
 /**
@@ -77,7 +76,7 @@ public class AnchorPoint extends StateAndBlockSummary {
         SignedBeaconBlock.create(spec, genesisBlock, BLSSignature.empty());
 
     final Bytes32 genesisBlockRoot = genesisBlock.hashTreeRoot();
-    final UInt64 genesisEpoch = BeaconStateUtil.get_current_epoch(genesisState);
+    final UInt64 genesisEpoch = spec.getCurrentEpoch(genesisState);
     final Checkpoint genesisCheckpoint = new Checkpoint(genesisEpoch, genesisBlockRoot);
 
     return new AnchorPoint(genesisCheckpoint, genesisState, signedGenesisBlock);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -224,7 +224,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
     final Bytes signing_root =
         miscHelpers.computeSigningRoot(
             block.getMessage(),
-            beaconStateUtil.getDomain(state, specConfig.getDomainBeaconProposer()));
+            beaconStateAccessors.getDomain(state, specConfig.getDomainBeaconProposer()));
     if (!signatureVerifier.verify(proposerPublicKey.get(), signing_root, block.getSignature())) {
       return BlockValidationResult.failed("Invalid block signature: " + block);
     }
@@ -350,7 +350,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
     // Verify RANDAO reveal
     final BLSPublicKey proposerPublicKey =
         beaconStateAccessors.getValidatorPubKey(state, block.getProposerIndex()).orElseThrow();
-    final Bytes32 domain = beaconStateUtil.getDomain(state, specConfig.getDomainRandao());
+    final Bytes32 domain = beaconStateAccessors.getDomain(state, specConfig.getDomainRandao());
     final Bytes signing_root = miscHelpers.computeSigningRoot(epoch, domain);
     if (!bls.verify(proposerPublicKey, signing_root, block.getBody().getRandao_reveal())) {
       return BlockValidationResult.failed("Randao reveal is invalid.");

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.collections.TekuPair;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
@@ -295,5 +296,26 @@ public abstract class BeaconStateAccessors {
         "Committee information must be derived from a state no older than the previous epoch. State at slot %s is older than cutoff slot %s",
         state.getSlot(),
         oldestQueryableSlot);
+  }
+
+  public Bytes32 getDomain(BeaconState state, Bytes4 domainType, UInt64 messageEpoch) {
+    UInt64 epoch = (messageEpoch == null) ? getCurrentEpoch(state) : messageEpoch;
+    return getDomain(domainType, epoch, state.getFork(), state.getGenesis_validators_root());
+  }
+
+  public Bytes32 getDomain(BeaconState state, Bytes4 domainType) {
+    return getDomain(state, domainType, null);
+  }
+
+  public Bytes32 getDomain(
+      final Bytes4 domainType,
+      final UInt64 epoch,
+      final Fork fork,
+      final Bytes32 genesisValidatorsRoot) {
+    Bytes4 forkVersion =
+        (epoch.compareTo(fork.getEpoch()) < 0)
+            ? fork.getPrevious_version()
+            : fork.getCurrent_version();
+    return miscHelpers.computeDomain(domainType, forkVersion, genesisValidatorsRoot);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -195,7 +195,7 @@ public class AttestationUtil {
 
     BLSSignature signature = indexed_attestation.getSignature();
     Bytes32 domain =
-        beaconStateUtil.getDomain(
+        beaconStateAccessors.getDomain(
             state,
             specConfig.getDomainBeaconAttester(),
             indexed_attestation.getData().getTarget().getEpoch());

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -47,17 +47,14 @@ public class AttestationUtil {
   private static final Logger LOG = LogManager.getLogger();
 
   private final SpecConfig specConfig;
-  private final BeaconStateUtil beaconStateUtil;
   private final BeaconStateAccessors beaconStateAccessors;
   private final MiscHelpers miscHelpers;
 
   public AttestationUtil(
       final SpecConfig specConfig,
-      final BeaconStateUtil beaconStateUtil,
       final BeaconStateAccessors beaconStateAccessors,
       final MiscHelpers miscHelpers) {
     this.specConfig = specConfig;
-    this.beaconStateUtil = beaconStateUtil;
     this.beaconStateAccessors = beaconStateAccessors;
     this.miscHelpers = miscHelpers;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
@@ -25,7 +25,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
@@ -35,7 +34,6 @@ import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.ssz.SszList;
 import tech.pegasys.teku.ssz.collections.SszBitvector;
-import tech.pegasys.teku.ssz.type.Bytes4;
 
 @SuppressWarnings("unused")
 public class BeaconStateUtil {
@@ -88,28 +86,6 @@ public class BeaconStateUtil {
 
   public Bytes32 getCurrentDutyDependentRoot(BeaconState state) {
     return getDutyDependentRoot(state, beaconStateAccessors.getCurrentEpoch(state));
-  }
-
-  public Bytes32 getDomain(BeaconState state, Bytes4 domainType, UInt64 messageEpoch) {
-    UInt64 epoch =
-        (messageEpoch == null) ? beaconStateAccessors.getCurrentEpoch(state) : messageEpoch;
-    return getDomain(domainType, epoch, state.getFork(), state.getGenesis_validators_root());
-  }
-
-  public Bytes32 getDomain(BeaconState state, Bytes4 domainType) {
-    return getDomain(state, domainType, null);
-  }
-
-  public Bytes32 getDomain(
-      final Bytes4 domainType,
-      final UInt64 epoch,
-      final Fork fork,
-      final Bytes32 genesisValidatorsRoot) {
-    Bytes4 forkVersion =
-        (epoch.compareTo(fork.getEpoch()) < 0)
-            ? fork.getPrevious_version()
-            : fork.getCurrent_version();
-    return miscHelpers.computeDomain(domainType, forkVersion, genesisValidatorsRoot);
   }
 
   public List<UInt64> getEffectiveBalances(final BeaconState state) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -203,7 +203,7 @@ public class SyncCommitteeUtil {
   public Bytes32 getSyncCommitteeSignatureSigningRoot(
       final Bytes32 blockRoot, final UInt64 epoch, final ForkInfo forkInfo) {
     final Bytes32 domain =
-        beaconStateUtil.getDomain(
+        beaconStateAccessors.getDomain(
             specConfig.getDomainSyncCommittee(),
             epoch,
             forkInfo.getFork(),
@@ -221,7 +221,7 @@ public class SyncCommitteeUtil {
       final ContributionAndProof contributionAndProof, final ForkInfo forkInfo) {
     final SyncCommitteeContribution contribution = contributionAndProof.getContribution();
     final Bytes32 domain =
-        beaconStateUtil.getDomain(
+        beaconStateAccessors.getDomain(
             specConfig.getDomainContributionAndProof(),
             miscHelpers.computeEpochAtSlot(contribution.getSlot()),
             forkInfo.getFork(),
@@ -234,7 +234,7 @@ public class SyncCommitteeUtil {
     final Bytes4 domainSyncCommitteeSelectionProof =
         specConfig.getDomainSyncCommitteeSelectionProof();
     final Bytes32 domain =
-        beaconStateUtil.getDomain(
+        beaconStateAccessors.getDomain(
             domainSyncCommitteeSelectionProof,
             miscHelpers.computeEpochAtSlot(selectionData.getSlot()),
             forkInfo.getFork(),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -58,7 +58,6 @@ import tech.pegasys.teku.ssz.type.Bytes4;
 public class SyncCommitteeUtil {
 
   private final BeaconStateAccessorsAltair beaconStateAccessors;
-  private final BeaconStateUtil beaconStateUtil;
   private final ValidatorsUtil validatorsUtil;
   private final SpecConfigAltair specConfig;
   private final MiscHelpers miscHelpers;
@@ -66,13 +65,11 @@ public class SyncCommitteeUtil {
 
   public SyncCommitteeUtil(
       final BeaconStateAccessorsAltair beaconStateAccessors,
-      final BeaconStateUtil beaconStateUtil,
       final ValidatorsUtil validatorsUtil,
       final SpecConfigAltair specConfig,
       final MiscHelpers miscHelpers,
       final SchemaDefinitionsAltair schemaDefinitionsAltair) {
     this.beaconStateAccessors = beaconStateAccessors;
-    this.beaconStateUtil = beaconStateUtil;
     this.validatorsUtil = validatorsUtil;
     this.specConfig = specConfig;
     this.miscHelpers = miscHelpers;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -94,7 +94,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
         new BeaconStateUtil(
             config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
-        new AttestationUtil(config, beaconStateUtil, beaconStateAccessors, miscHelpers);
+        new AttestationUtil(config, beaconStateAccessors, miscHelpers);
     final OperationValidator operationValidator =
         OperationValidator.create(beaconStateAccessors, attestationUtil, validatorsUtil);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
@@ -133,12 +133,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
         new BlockProposalUtil(schemaDefinitions, blockProcessor);
     final SyncCommitteeUtil syncCommitteeUtil =
         new SyncCommitteeUtil(
-            beaconStateAccessors,
-            beaconStateUtil,
-            validatorsUtil,
-            config,
-            miscHelpers,
-            schemaDefinitions);
+            beaconStateAccessors, validatorsUtil, config, miscHelpers, schemaDefinitions);
 
     // State upgrade
     final AltairStateUpgrade stateUpgrade =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -181,7 +181,7 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
         .forEach(index -> participantPubkeys.add(committeePubkeys.get(index).getBLSPublicKey()));
     final UInt64 previousSlot = state.getSlot().minusMinZero(1);
     final Bytes32 domain =
-        beaconStateUtil.getDomain(
+        beaconStateAccessors.getDomain(
             state,
             specConfigAltair.getDomainSyncCommittee(),
             miscHelpers.computeEpochAtSlot(previousSlot));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -88,7 +88,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
         new BeaconStateUtil(
             config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
-        new AttestationUtil(config, beaconStateUtil, beaconStateAccessors, miscHelpers);
+        new AttestationUtil(config, beaconStateAccessors, miscHelpers);
     final OperationValidator operationValidator =
         OperationValidator.create(beaconStateAccessors, attestationUtil, validatorsUtil);
     final ValidatorStatusFactoryPhase0 validatorStatusFactory =

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtilTest.java
@@ -143,8 +143,9 @@ public class BeaconStateUtilTest {
             depositData.getWithdrawal_credentials(),
             depositData.getAmount());
     Bytes32 domain =
-        beaconStateUtil.getDomain(
-            createBeaconState(), specConfig.getDomainDeposit(), GENESIS_EPOCH);
+        genesisSpec
+            .beaconStateAccessors()
+            .getDomain(createBeaconState(), specConfig.getDomainDeposit(), GENESIS_EPOCH);
     Bytes signing_root = genesisSpec.miscHelpers().computeSigningRoot(depositMessage, domain);
 
     assertFalse(BLS.verify(pubkey, signing_root, depositData.getSignature()));

--- a/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
+++ b/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.fuzz;
 
+import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.bytesToUInt64;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Optional;
@@ -37,7 +39,6 @@ import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.ssz.SszData;
@@ -218,7 +219,7 @@ public class FuzzUtil {
       return Optional.empty();
     }
     // Mask it to make ensure positive before using remainder.
-    int count = BeaconStateUtil.bytes_to_int64(Bytes.wrap(input, 0, 2)).mod(100).intValue();
+    int count = bytesToUInt64(Bytes.wrap(input, 0, 2)).mod(100).intValue();
 
     Bytes32 seed = Bytes32.wrap(input, 2);
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/DefaultRpcPayloadEncoderTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/DefaultRpcPayloadEncoderTest.java
@@ -19,15 +19,18 @@ import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.DeserializationFailedException;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.ssz.DefaultRpcPayloadEncoder;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.StatusMessage;
 
 public class DefaultRpcPayloadEncoderTest {
-  final DefaultRpcPayloadEncoder<StatusMessage> statusMessageEncoder =
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DefaultRpcPayloadEncoder<StatusMessage> statusMessageEncoder =
       new DefaultRpcPayloadEncoder<>(StatusMessage.SSZ_SCHEMA);
 
   @Test
   public void decode_truncatedMessage() {
-    final StatusMessage statusMessage = StatusMessage.createPreGenesisStatus();
+    final StatusMessage statusMessage = StatusMessage.createPreGenesisStatus(spec);
     final Bytes encoded = statusMessageEncoder.encode(statusMessage);
 
     for (int i = 0; i < encoded.size(); i++) {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/LengthPrefixedEncodingTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/LengthPrefixedEncodingTest.java
@@ -34,17 +34,20 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.LengthOutOfBounds
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.MessageTruncatedException;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.PayloadTruncatedException;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.snappy.SnappyFramedCompressor;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.EmptyMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.teku.ssz.type.Bytes4;
 
 class LengthPrefixedEncodingTest {
-
-  private final RpcEncoding encoding = RpcEncoding.SSZ_SNAPPY;
   private static final Bytes TWO_BYTE_LENGTH_PREFIX = Bytes.fromHexString("0x8002");
   private static final Bytes LENGTH_PREFIX_EXCEEDING_MAXIMUM_LENGTH =
       ProtobufEncoder.encodeVarInt(MAX_CHUNK_SIZE + 1);
+
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final RpcEncoding encoding = RpcEncoding.SSZ_SNAPPY;
 
   @Test
   public void decodePayload_shouldReturnErrorWhenLengthPrefixIsTooLong() {
@@ -155,7 +158,7 @@ class LengthPrefixedEncodingTest {
 
   @Test
   public void decodePayload_shouldReadPayloadWhenExtraDataIsAppended() throws RpcException {
-    final StatusMessage originalMessage = StatusMessage.createPreGenesisStatus();
+    final StatusMessage originalMessage = StatusMessage.createPreGenesisStatus(spec);
     final Bytes encoded = encoding.encodePayload(originalMessage);
     final Bytes extraData = Bytes.of(1, 2, 3, 4);
     List<List<ByteBuf>> testByteBufSlices = Utils.generateTestSlices(encoded, extraData);

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerIntegrationTest.java
@@ -20,12 +20,6 @@ import static org.mockserver.matchers.MatchType.STRICT;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.JsonBody.json;
-import static tech.pegasys.teku.core.signatures.SigningRootUtil.signingRootForRandaoReveal;
-import static tech.pegasys.teku.core.signatures.SigningRootUtil.signingRootForSignAggregateAndProof;
-import static tech.pegasys.teku.core.signatures.SigningRootUtil.signingRootForSignAggregationSlot;
-import static tech.pegasys.teku.core.signatures.SigningRootUtil.signingRootForSignAttestationData;
-import static tech.pegasys.teku.core.signatures.SigningRootUtil.signingRootForSignBlock;
-import static tech.pegasys.teku.core.signatures.SigningRootUtil.signingRootForSignVoluntaryExit;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_PRECONDITION_FAILED;
 import static tech.pegasys.teku.validator.client.signer.ExternalSigner.slashableAttestationMessage;
 import static tech.pegasys.teku.validator.client.signer.ExternalSigner.slashableBlockMessage;
@@ -50,6 +44,7 @@ import tech.pegasys.teku.api.schema.Fork;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.bls.BLSTestUtil;
+import tech.pegasys.teku.core.signatures.SigningRootUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue;
 import tech.pegasys.teku.infrastructure.metrics.StubCounter;
@@ -79,6 +74,7 @@ public class ExternalSignerIntegrationTest {
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   private final ThrottlingTaskQueue queue =
       new ThrottlingTaskQueue(8, metricsSystem, TekuMetricCategory.VALIDATOR, "externalSignerTest");
+  private final SigningRootUtil signingRootUtil = new SigningRootUtil(spec);
 
   private ClientAndServer client;
   private ExternalSigner externalSigner;
@@ -201,7 +197,7 @@ public class ExternalSignerIntegrationTest {
 
     final SigningRequestBody signingRequestBody =
         new SigningRequestBody(
-            signingRootForSignBlock(block, fork),
+            signingRootUtil.signingRootForSignBlock(block, fork),
             SignType.BLOCK,
             Map.of(
                 "fork_info",
@@ -228,7 +224,7 @@ public class ExternalSignerIntegrationTest {
     assertThat(response).isEqualTo(expectedSignature);
     final SigningRequestBody signingRequestBody =
         new SigningRequestBody(
-            signingRootForSignAttestationData(attestationData, fork),
+            signingRootUtil.signingRootForSignAttestationData(attestationData, fork),
             SignType.ATTESTATION,
             Map.of(
                 "fork_info",
@@ -255,7 +251,7 @@ public class ExternalSignerIntegrationTest {
 
     final SigningRequestBody signingRequestBody =
         new SigningRequestBody(
-            signingRootForRandaoReveal(epoch, fork),
+            signingRootUtil.signingRootForRandaoReveal(epoch, fork),
             SignType.RANDAO_REVEAL,
             Map.of("fork_info", createForkInfo(), "randao_reveal", Map.of("epoch", epoch)));
     verifySignRequest(KEYPAIR.getPublicKey().toString(), signingRequestBody);
@@ -278,7 +274,7 @@ public class ExternalSignerIntegrationTest {
 
     final SigningRequestBody signingRequestBody =
         new SigningRequestBody(
-            signingRootForSignAggregationSlot(slot, fork),
+            signingRootUtil.signingRootForSignAggregationSlot(slot, fork),
             SignType.AGGREGATION_SLOT,
             Map.of("fork_info", createForkInfo(), "aggregation_slot", Map.of("slot", slot)));
     verifySignRequest(KEYPAIR.getPublicKey().toString(), signingRequestBody);
@@ -301,7 +297,7 @@ public class ExternalSignerIntegrationTest {
 
     final SigningRequestBody signingRequestBody =
         new SigningRequestBody(
-            signingRootForSignAggregateAndProof(aggregateAndProof, fork),
+            signingRootUtil.signingRootForSignAggregateAndProof(aggregateAndProof, fork),
             SignType.AGGREGATE_AND_PROOF,
             Map.of(
                 "fork_info",
@@ -325,7 +321,7 @@ public class ExternalSignerIntegrationTest {
 
     final SigningRequestBody signingRequestBody =
         new SigningRequestBody(
-            signingRootForSignVoluntaryExit(voluntaryExit, fork),
+            signingRootUtil.signingRootForSignVoluntaryExit(voluntaryExit, fork),
             SignType.VOLUNTARY_EXIT,
             Map.of(
                 "fork_info",

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/LocalValidatorSourceTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/LocalValidatorSourceTest.java
@@ -59,6 +59,7 @@ class LocalValidatorSourceTest {
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final ValidatorConfig config = mock(ValidatorConfig.class);
   private final KeystoreLocker keystoreLocker = mock(KeystoreLocker.class);
+  private final SigningRootUtil signingRootUtil = new SigningRootUtil(spec);
 
   private final LocalValidatorSource validatorSource =
       new LocalValidatorSource(spec, config, keystoreLocker, asyncRunner);
@@ -170,7 +171,7 @@ class LocalValidatorSourceTest {
     final Bytes4 version = Bytes4.fromHexString("0x00000000");
     final UInt64 epoch = UInt64.ZERO;
     final ForkInfo forkInfo = new ForkInfo(new Fork(version, version, UInt64.ZERO), Bytes32.ZERO);
-    final Bytes signingRoot = SigningRootUtil.signingRootForRandaoReveal(epoch, forkInfo);
+    final Bytes signingRoot = signingRootUtil.signingRootForRandaoReveal(epoch, forkInfo);
 
     final SafeFuture<BLSSignature> signingFuture = signer.createRandaoReveal(epoch, forkInfo);
     asyncRunner.executeQueuedActions();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Cut calls to deprecated `BeaconStateUtil`.  Move `getDomain` from `BeaconStateUtil` to `BeaconStateAccessors`. 

## Fixed Issue(s)
Part of #3356

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
