### PR TITLE
Add time based eth1 head tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ For information on changes in released versions of Teku, see the [releases page]
 - Use system default character set for console output rather than forcing UTF-8. Avoids corrupting characters on systems using charsets that are not ascii based.
 - Fixed a `NullPointerException` from validator clients for new networks, prior to genesis being known.
 - Fixed regression where eth_getLogs responses from Infura that rejected the request because they returned too many logs did not retry the request with a smaller request range.
+- Experimental: Fix for eth1 follow distance tracking revealed in Rayonism testnets. Teku incorrectly strictly follows 2048 blocks before the eth1 head but the follow distance should be based on timestamp, not block number.
+  An experimental fix for this can be enabled with `--Xeth1-time-based-head-tracking-enabled`. Further testing will be conducted before enabling this by default.
 
 ### Experimental: New Altair REST APIs
 - implement POST `/eth/v1/beacon/pool/sync_committees` to allow validators to submit sync committee signatures to the beacon node.

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/runloop/AsyncRunLoop.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/runloop/AsyncRunLoop.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.async.runloop;
+
+import java.time.Duration;
+import java.util.concurrent.CompletionException;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.ExceptionThrowingRunnable;
+
+public class AsyncRunLoop {
+  private final RunLoopLogic logic;
+  private final AsyncRunner asyncRunner;
+  private final Duration retryDelay;
+
+  public AsyncRunLoop(
+      final RunLoopLogic logic, final AsyncRunner asyncRunner, final Duration retryDelay) {
+    this.logic = logic;
+    this.asyncRunner = asyncRunner;
+    this.retryDelay = retryDelay;
+  }
+
+  public void start() {
+    logic.init().thenRun(this::nextLoop).finish(error -> onError(error, this::start));
+  }
+
+  private void nextLoop() {
+    asyncRunner
+        .runAfterDelay(logic::advance, logic.getDelayUntilNextAdvance())
+        .finish(this::nextLoop, error -> onError(error, this::nextLoop));
+  }
+
+  private void onError(final Throwable error, final ExceptionThrowingRunnable retryAction) {
+    if (error instanceof CompletionException && error.getCause() != null) {
+      logic.onError(error.getCause());
+    } else {
+      logic.onError(error);
+    }
+    asyncRunner.runAfterDelay(retryAction, retryDelay).reportExceptions();
+  }
+}

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/runloop/RunLoopLogic.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/runloop/RunLoopLogic.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.async.runloop;
+
+import java.time.Duration;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+/**
+ * Implements the logic to be used inside an {@link AsyncRunLoop}.
+ *
+ * <p>While multiple threads may be used to call into this class, it is guaranteed that only one
+ * method will be executing at any given time, including waiting for any returned future to
+ * complete. Additionally happens-before memory semantics are guaranteed so that any variable
+ * changes performed in one method will be visible to subsequently invoked methods.
+ */
+public interface RunLoopLogic {
+  /** Called when the run loop first starts to perform any initial setup. */
+  SafeFuture<Void> init();
+
+  /** Called each time around the run loop. */
+  SafeFuture<Void> advance();
+
+  /**
+   * Determine the delay from current time before {@link #advance()} is to be called again.
+   *
+   * <p>While generally this will be called only once per loop, with {@link #advance()} then being
+   * called after the specified delay, it may be called multiple times between calls to {@link
+   * #advance()} if required and should adjust the returned duration to account for any time that
+   * has passed.
+   */
+  Duration getDelayUntilNextAdvance();
+
+  /**
+   * Called to notify of an exception that occurred either while executing one of the methods of
+   * this class or when a returned future completes exceptionally.
+   *
+   * <p>The run loop will automatically retry after a delay, this method only needs to update any
+   * internal state in response to the error message and log it if appropriate.
+   *
+   * @param t the error that occurred
+   */
+  void onError(Throwable t);
+}

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/runloop/AsyncRunLoopTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/runloop/AsyncRunLoopTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.infrastructure.async.runloop;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -98,6 +99,7 @@ class AsyncRunLoopTest {
     when(logic.getDelayUntilNextAdvance()).thenReturn(firstAdvanceDelay, secondAdvanceDelay);
 
     runLoop.start();
+    verify(logic).init();
     verify(logic, never()).advance();
 
     advanceTime(firstAdvanceDelay);
@@ -110,6 +112,9 @@ class AsyncRunLoopTest {
     // Advance remaining time until second advance is due and confirm it is invoked
     advanceTime(secondAdvanceDelay.minus(firstAdvanceDelay));
     verify(logic, times(2)).advance();
+
+    verify(logic, atLeastOnce()).getDelayUntilNextAdvance();
+    verifyNoMoreInteractions(logic);
   }
 
   @Test

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/runloop/AsyncRunLoopTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/runloop/AsyncRunLoopTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.async.runloop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+
+class AsyncRunLoopTest {
+  private final Duration RETRY_DELAY = Duration.ofSeconds(10);
+  private final RunLoopLogic logic = mock(RunLoopLogic.class);
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInMillis(100_000);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
+
+  private final AsyncRunLoop runLoop = new AsyncRunLoop(logic, asyncRunner, RETRY_DELAY);
+
+  @BeforeEach
+  void setUp() {
+    // By default init completes but advance doesn't
+    when(logic.init()).thenReturn(SafeFuture.COMPLETE);
+    when(logic.advance()).thenReturn(new SafeFuture<>());
+  }
+
+  @Test
+  void shouldCallInitWhenStarted() {
+    runLoop.start();
+
+    verify(logic).init();
+  }
+
+  @Test
+  void shouldRetryAfterDelayIfInitFails() {
+    final Throwable error = new RuntimeException("Computer says no");
+    when(logic.init()).thenReturn(SafeFuture.failedFuture(error)).thenReturn(SafeFuture.COMPLETE);
+
+    runLoop.start();
+
+    verify(logic).init();
+    verify(logic).onError(error);
+
+    assertThat(asyncRunner.hasDelayedActions()).isTrue();
+    advanceTime(RETRY_DELAY);
+    verify(logic, times(2)).init();
+  }
+
+  @Test
+  void shouldWaitThenCallAdvanceAfterInitCompletes() {
+    final SafeFuture<Void> initResult = new SafeFuture<>();
+    final Duration advanceDelay = Duration.ofSeconds(3);
+    when(logic.init()).thenReturn(initResult);
+    when(logic.getDelayUntilNextAdvance()).thenReturn(advanceDelay);
+
+    runLoop.start();
+    verify(logic).init();
+    verifyNoMoreInteractions(logic);
+
+    // Time advances but because init hasn't completed we are no closer to triggering advance
+    advanceTime(advanceDelay);
+
+    initResult.complete(null);
+    verify(logic).getDelayUntilNextAdvance();
+    verifyNoMoreInteractions(logic);
+
+    // Delay starts after init completes and then triggers advance when due
+    advanceTime(advanceDelay);
+
+    verify(logic).advance();
+    verifyNoMoreInteractions(logic);
+  }
+
+  @Test
+  void shouldScheduleNextAdvanceWhenFirstAdvanceCompletes() {
+    final Duration firstAdvanceDelay = Duration.ofSeconds(2);
+    final Duration secondAdvanceDelay = Duration.ofSeconds(20);
+    when(logic.advance()).thenReturn(SafeFuture.COMPLETE).thenReturn(new SafeFuture<>());
+    when(logic.getDelayUntilNextAdvance()).thenReturn(firstAdvanceDelay, secondAdvanceDelay);
+
+    runLoop.start();
+    verify(logic, never()).advance();
+
+    advanceTime(firstAdvanceDelay);
+    verify(logic, times(1)).advance();
+
+    // Shouldn't use same delay for second advance so this won't wait long enough
+    advanceTime(firstAdvanceDelay);
+    verify(logic, times(1)).advance();
+
+    // Advance remaining time until second advance is due and confirm it is invoked
+    advanceTime(secondAdvanceDelay.minus(firstAdvanceDelay));
+    verify(logic, times(2)).advance();
+  }
+
+  @Test
+  void shouldRetryAfterDelayWhenAdvanceFails() {
+    final Duration advanceDelay = Duration.ofSeconds(5);
+    final Throwable error = new RuntimeException("Computer says no");
+    when(logic.advance()).thenReturn(SafeFuture.failedFuture(error)).thenReturn(new SafeFuture<>());
+    when(logic.getDelayUntilNextAdvance()).thenReturn(advanceDelay);
+
+    runLoop.start();
+    advanceTime(advanceDelay);
+
+    verify(logic).advance();
+    verify(logic).onError(error);
+
+    assertThat(asyncRunner.hasDelayedActions()).isTrue();
+    advanceTime(RETRY_DELAY);
+
+    verify(logic, times(2)).advance();
+  }
+
+  private void advanceTime(final Duration advanceDelay) {
+    timeProvider.advanceTimeBy(advanceDelay);
+    asyncRunner.executeDueActions();
+  }
+}

--- a/infrastructure/time/src/testFixtures/java/tech/pegasys/teku/infrastructure/time/StubTimeProvider.java
+++ b/infrastructure/time/src/testFixtures/java/tech/pegasys/teku/infrastructure/time/StubTimeProvider.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.infrastructure.time;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
@@ -38,6 +39,10 @@ public class StubTimeProvider implements TimeProvider {
 
   public static StubTimeProvider withTimeInMillis(final UInt64 timeInMillis) {
     return new StubTimeProvider(timeInMillis);
+  }
+
+  public void advanceTimeBy(final Duration duration) {
+    advanceTimeByMillis(duration.toMillis());
   }
 
   public void advanceTimeBySeconds(final long seconds) {

--- a/pow/build.gradle
+++ b/pow/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
   implementation project(':bls')
   implementation project(':ethereum:pow:api')
+  implementation project(':ethereum:spec')
   implementation project(':infrastructure:async')
   implementation project(':ssz')
   implementation project(':util')

--- a/pow/src/main/java/tech/pegasys/teku/pow/BlockBasedEth1HeadTracker.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/BlockBasedEth1HeadTracker.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.pow;
+
+import static tech.pegasys.teku.util.config.Constants.ETH1_FOLLOW_DISTANCE;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.web3j.protocol.core.methods.response.EthBlock.Block;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.util.config.Constants;
+
+public class BlockBasedEth1HeadTracker implements Eth1HeadTracker {
+  private static final Logger LOG = LogManager.getLogger();
+  private final AtomicBoolean running = new AtomicBoolean(false);
+  private final AsyncRunner asyncRunner;
+  private final Eth1Provider eth1Provider;
+  private Optional<UInt64> headAtFollowDistance = Optional.empty();
+  private final AtomicBoolean reachedHead = new AtomicBoolean(false);
+
+  private final Subscribers<HeadUpdatedSubscriber> subscribers = Subscribers.create(true);
+
+  public BlockBasedEth1HeadTracker(final AsyncRunner asyncRunner, final Eth1Provider eth1Provider) {
+    this.asyncRunner = asyncRunner;
+    this.eth1Provider = eth1Provider;
+  }
+
+  @Override
+  public void start() {
+    if (!running.compareAndSet(false, true)) {
+      return;
+    }
+    pollLatestHead();
+  }
+
+  private void pollLatestHead() {
+    if (!running.get()) {
+      return;
+    }
+    eth1Provider
+        .getLatestEth1Block()
+        .thenAccept(this::onLatestBlockHead)
+        .exceptionally(
+            error -> {
+              LOG.debug("Failed to get latest Eth1 chain head. Will retry.", error);
+              return null;
+            })
+        .always(
+            () ->
+                asyncRunner
+                    .runAfterDelay(
+                        this::pollLatestHead,
+                        Duration.ofSeconds(Constants.SECONDS_PER_ETH1_BLOCK.longValue()))
+                    .finish(
+                        () -> {},
+                        error ->
+                            LOG.error("Scheduling next check of Eth1 chain head failed", error)));
+  }
+
+  private void onLatestBlockHead(final Block headBlock) {
+    final UInt64 headBlockNumber = UInt64.valueOf(headBlock.getNumber());
+    if (headBlockNumber.compareTo(ETH1_FOLLOW_DISTANCE) < 0) {
+      LOG.debug("Not processing Eth1 blocks because chain has not reached minimum follow distance");
+      return;
+    }
+    final UInt64 newHeadAtFollowDistance = headBlockNumber.minus(ETH1_FOLLOW_DISTANCE);
+    if (headAtFollowDistance
+        .map(current -> current.compareTo(newHeadAtFollowDistance) < 0)
+        .orElse(true)) {
+      if (reachedHead.compareAndSet(false, true)) {
+        reachedHead.set(true);
+      }
+      headAtFollowDistance = Optional.of(newHeadAtFollowDistance);
+      LOG.debug("ETH1 block at follow distance updated to {}", newHeadAtFollowDistance);
+      subscribers.deliver(HeadUpdatedSubscriber::onHeadUpdated, newHeadAtFollowDistance);
+    }
+  }
+
+  @Override
+  public long subscribe(final HeadUpdatedSubscriber subscriber) {
+    return subscribers.subscribe(subscriber);
+  }
+
+  @Override
+  public void unsubscribe(final long subscriberId) {
+    subscribers.unsubscribe(subscriberId);
+  }
+
+  @Override
+  public void stop() {
+    running.set(false);
+  }
+}

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1HeadTracker.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1HeadTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ConsenSys AG.
+ * Copyright 2021 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,97 +13,20 @@
 
 package tech.pegasys.teku.pow;
 
-import static tech.pegasys.teku.util.config.Constants.ETH1_FOLLOW_DISTANCE;
-
-import java.time.Duration;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.web3j.protocol.core.methods.response.EthBlock.Block;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
-import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.util.config.Constants;
 
-public class Eth1HeadTracker {
-  private static final Logger LOG = LogManager.getLogger();
-  private final AtomicBoolean running = new AtomicBoolean(false);
-  private final AsyncRunner asyncRunner;
-  private final Eth1Provider eth1Provider;
-  private Optional<UInt64> headAtFollowDistance = Optional.empty();
-  private final AtomicBoolean reachedHead = new AtomicBoolean(false);
+public interface Eth1HeadTracker {
 
-  private final Subscribers<HeadUpdatedSubscriber> subscribers = Subscribers.create(true);
+  void start();
 
-  public Eth1HeadTracker(final AsyncRunner asyncRunner, final Eth1Provider eth1Provider) {
-    this.asyncRunner = asyncRunner;
-    this.eth1Provider = eth1Provider;
-  }
+  void stop();
 
-  public void start() {
-    if (!running.compareAndSet(false, true)) {
-      return;
-    }
-    pollLatestHead();
-  }
+  long subscribe(HeadUpdatedSubscriber subscriber);
 
-  private void pollLatestHead() {
-    if (!running.get()) {
-      return;
-    }
-    eth1Provider
-        .getLatestEth1Block()
-        .thenAccept(this::onLatestBlockHead)
-        .exceptionally(
-            error -> {
-              LOG.debug("Failed to get latest Eth1 chain head. Will retry.", error);
-              return null;
-            })
-        .always(
-            () ->
-                asyncRunner
-                    .runAfterDelay(
-                        this::pollLatestHead,
-                        Duration.ofSeconds(Constants.SECONDS_PER_ETH1_BLOCK.longValue()))
-                    .finish(
-                        () -> {},
-                        error ->
-                            LOG.error("Scheduling next check of Eth1 chain head failed", error)));
-  }
+  void unsubscribe(long subscriberId);
 
-  private void onLatestBlockHead(final Block headBlock) {
-    final UInt64 headBlockNumber = UInt64.valueOf(headBlock.getNumber());
-    if (headBlockNumber.compareTo(ETH1_FOLLOW_DISTANCE) < 0) {
-      LOG.debug("Not processing Eth1 blocks because chain has not reached minimum follow distance");
-      return;
-    }
-    final UInt64 newHeadAtFollowDistance = headBlockNumber.minus(ETH1_FOLLOW_DISTANCE);
-    if (headAtFollowDistance
-        .map(current -> current.compareTo(newHeadAtFollowDistance) < 0)
-        .orElse(true)) {
-      if (reachedHead.compareAndSet(false, true)) {
-        reachedHead.set(true);
-      }
-      headAtFollowDistance = Optional.of(newHeadAtFollowDistance);
-      LOG.debug("ETH1 block at follow distance updated to {}", newHeadAtFollowDistance);
-      subscribers.deliver(HeadUpdatedSubscriber::onHeadUpdated, newHeadAtFollowDistance);
-    }
-  }
+  interface HeadUpdatedSubscriber {
 
-  public long subscribe(final HeadUpdatedSubscriber subscriber) {
-    return subscribers.subscribe(subscriber);
-  }
-
-  public void unsubscribe(final long subscriberId) {
-    subscribers.unsubscribe(subscriberId);
-  }
-
-  public void stop() {
-    running.set(false);
-  }
-
-  public interface HeadUpdatedSubscriber {
     void onHeadUpdated(final UInt64 canonicalHead);
   }
 }

--- a/pow/src/main/java/tech/pegasys/teku/pow/TimeBasedEth1HeadTracker.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/TimeBasedEth1HeadTracker.java
@@ -18,7 +18,6 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.base.Throwables;
 import java.math.BigInteger;
 import java.time.Duration;
-import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.web3j.protocol.core.methods.response.EthBlock.Block;

--- a/pow/src/main/java/tech/pegasys/teku/pow/TimeBasedEth1HeadTracker.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/TimeBasedEth1HeadTracker.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.base.Throwables;
 import java.math.BigInteger;
 import java.time.Duration;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.web3j.protocol.core.methods.response.EthBlock.Block;
@@ -203,7 +204,7 @@ public class TimeBasedEth1HeadTracker implements Eth1HeadTracker, RunLoopLogic {
 
   private void notifyNewHead(final Block headBlock) {
     searchForwards = true;
-    if (lastNotifiedChainHead != headBlock) {
+    if (!headBlock.equals(lastNotifiedChainHead)) {
       LOG.trace(
           "Found new latest block before follow distance at block number {}, timestamp {}",
           headBlock.getNumber(),

--- a/pow/src/main/java/tech/pegasys/teku/pow/TimeBasedEth1HeadTracker.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/TimeBasedEth1HeadTracker.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.pow;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.base.Throwables;
+import java.math.BigInteger;
+import java.time.Duration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.web3j.protocol.core.methods.response.EthBlock.Block;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.runloop.AsyncRunLoop;
+import tech.pegasys.teku.infrastructure.async.runloop.RunLoopLogic;
+import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.util.config.Constants;
+
+public class TimeBasedEth1HeadTracker implements Eth1HeadTracker, RunLoopLogic {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Spec spec;
+  private final TimeProvider timeProvider;
+  private final AsyncRunner asyncRunner;
+  private final Eth1Provider eth1Provider;
+
+  private final Subscribers<HeadUpdatedSubscriber> subscribers = Subscribers.create(true);
+
+  private boolean searchForwards = false;
+  private UInt64 nextAdvanceTimeInSeconds = UInt64.ZERO;
+  private Block lastNotifiedChainHead;
+  private Block nextCandidateHead;
+
+  public TimeBasedEth1HeadTracker(
+      final Spec spec,
+      final TimeProvider timeProvider,
+      final AsyncRunner asyncRunner,
+      final Eth1Provider eth1Provider) {
+    this.spec = spec;
+    this.timeProvider = timeProvider;
+    this.asyncRunner = asyncRunner;
+    this.eth1Provider = eth1Provider;
+  }
+
+  @Override
+  public void start() {
+    new AsyncRunLoop(this, asyncRunner, Constants.ETH1_DEPOSIT_REQUEST_RETRY_TIMEOUT).start();
+  }
+
+  @Override
+  public SafeFuture<Void> init() {
+    return eth1Provider
+        .getLatestEth1Block()
+        .thenCompose(
+            headBlock -> {
+              if (isOldEnough(headBlock)) {
+                LOG.trace("Head block is old enough");
+                waitUntilNextEth1BlockExpected();
+                return SafeFuture.completedFuture(headBlock);
+              } else {
+                LOG.trace("Retrieving block at follow distance");
+                return getBlock(
+                    UInt64.valueOf(headBlock.getNumber()).minusMinZero(getEth1FollowDistance()));
+              }
+            })
+        .thenAccept(
+            block -> {
+              nextCandidateHead = block;
+              if (isOldEnough(block)) {
+                LOG.trace("Init block is old enough");
+                notifyNewHead(block);
+              } else if (block.getNumber().equals(BigInteger.ZERO)) {
+                // Nothing before genesis so wait for it to be old enough then search forwards
+                LOG.trace("Genesis block is not old enough");
+                searchForwards = true;
+                waitForBlockToBeOldEnough(block);
+              }
+            });
+  }
+
+  @Override
+  public SafeFuture<Void> advance() {
+    checkState(nextCandidateHead != null, "Init has not completed successfully");
+    if (!searchForwards) {
+      return searchBackwards();
+    } else {
+      return stepForward();
+    }
+  }
+
+  private SafeFuture<Void> stepForward() {
+    LOG.trace("Searching forwards from block {}", nextCandidateHead.getNumber());
+    if (isOldEnough(nextCandidateHead)) {
+      notifyNewHead(nextCandidateHead);
+      return eth1Provider
+          .getEth1Block(UInt64.valueOf(nextCandidateHead.getNumber()).plus(1))
+          .thenAccept(
+              maybeBlock ->
+                  maybeBlock.ifPresentOrElse(
+                      this::waitForBlockToBeOldEnough, this::waitUntilNextEth1BlockExpected));
+    }
+    return SafeFuture.COMPLETE;
+  }
+
+  private SafeFuture<Void> searchBackwards() {
+    LOG.trace(
+        "Searching backwards from block {} with timestamp {}. Still {}s too recent",
+        nextCandidateHead::getNumber,
+        nextCandidateHead::getTimestamp,
+        () -> UInt64.valueOf(nextCandidateHead.getTimestamp()).minusMinZero(getCutOffTime()));
+    final UInt64 previousBlockNumber =
+        UInt64.valueOf(nextCandidateHead.getNumber()).minusMinZero(1);
+    return getBlock(previousBlockNumber)
+        .thenAccept(
+            block -> {
+              if (isOldEnough(block)) {
+                notifyNewHead(block);
+                waitForBlockToBeOldEnough(nextCandidateHead);
+              } else {
+                nextCandidateHead = block;
+              }
+            });
+  }
+
+  private void waitUntilNextEth1BlockExpected() {
+    LOG.trace("Waiting until next eth1 block expected");
+    nextAdvanceTimeInSeconds = timeProvider.getTimeInSeconds().plus(getSecondsPerEth1Block());
+  }
+
+  private void waitForBlockToBeOldEnough(final Block block) {
+    nextCandidateHead = block;
+    nextAdvanceTimeInSeconds =
+        UInt64.valueOf(block.getTimestamp()).plus(getFollowDistanceInSeconds());
+    LOG.trace(
+        "Waiting until block {} is old enough at {}", block.getNumber(), nextAdvanceTimeInSeconds);
+  }
+
+  private SafeFuture<Block> getBlock(final UInt64 blockNumber) {
+    return eth1Provider
+        .getEth1Block(blockNumber)
+        .thenApply(
+            maybeBlock -> maybeBlock.orElseThrow(() -> new BlockUnavailableException(blockNumber)));
+  }
+
+  @Override
+  public Duration getDelayUntilNextAdvance() {
+    return Duration.ofSeconds(
+        nextAdvanceTimeInSeconds.minusMinZero(timeProvider.getTimeInSeconds()).longValue());
+  }
+
+  @Override
+  public void onError(final Throwable t) {
+    final Throwable rootCause = Throwables.getRootCause(t);
+    if (rootCause instanceof BlockUnavailableException) {
+      LOG.error(
+          "Block number {} not yet available. Retrying after delay.",
+          ((BlockUnavailableException) rootCause).getBlockNumber());
+    } else {
+      LOG.error("Failed to update eth1 chain head", t);
+    }
+  }
+
+  private boolean isOldEnough(final Block headBlock) {
+    final UInt64 cutOffTime = getCutOffTime();
+    final long blockTime = headBlock.getTimestamp().longValueExact();
+    return cutOffTime.isGreaterThanOrEqualTo(blockTime);
+  }
+
+  private UInt64 getCutOffTime() {
+    return timeProvider.getTimeInSeconds().minusMinZero(getFollowDistanceInSeconds());
+  }
+
+  private UInt64 getFollowDistanceInSeconds() {
+    return getEth1FollowDistance().times(getSecondsPerEth1Block());
+  }
+
+  private UInt64 getSecondsPerEth1Block() {
+    return spec.getGenesisSpecConfig().getSecondsPerEth1Block();
+  }
+
+  private UInt64 getEth1FollowDistance() {
+    return spec.getGenesisSpecConfig().getEth1FollowDistance();
+  }
+
+  @Override
+  public void stop() {}
+
+  private void notifyNewHead(final Block headBlock) {
+    searchForwards = true;
+    if (lastNotifiedChainHead != headBlock) {
+      LOG.trace(
+          "Found new latest block before follow distance at block number {}, timestamp {}",
+          headBlock.getNumber(),
+          headBlock.getTimestamp());
+      lastNotifiedChainHead = headBlock;
+      subscribers.deliver(
+          HeadUpdatedSubscriber::onHeadUpdated, UInt64.valueOf(headBlock.getNumber()));
+    }
+  }
+
+  @Override
+  public long subscribe(final HeadUpdatedSubscriber subscriber) {
+    return subscribers.subscribe(subscriber);
+  }
+
+  @Override
+  public void unsubscribe(final long subscriberId) {
+    subscribers.unsubscribe(subscriberId);
+  }
+
+  private static class BlockUnavailableException extends RuntimeException {
+    private final UInt64 blockNumber;
+
+    private BlockUnavailableException(final UInt64 blockNumber) {
+      super("Block " + blockNumber + " unavailable");
+      this.blockNumber = blockNumber;
+    }
+
+    public UInt64 getBlockNumber() {
+      return blockNumber;
+    }
+  }
+}

--- a/pow/src/test/java/tech/pegasys/teku/pow/BlockBasedEth1HeadTrackerTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/BlockBasedEth1HeadTrackerTest.java
@@ -30,13 +30,13 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.Eth1HeadTracker.HeadUpdatedSubscriber;
 import tech.pegasys.teku.util.config.Constants;
 
-class Eth1HeadTrackerTest {
+class BlockBasedEth1HeadTrackerTest {
   private static final long FOLLOW_DISTANCE = 1000;
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final Eth1Provider eth1Provider = mock(Eth1Provider.class);
   private final HeadUpdatedSubscriber subscriber = mock(HeadUpdatedSubscriber.class);
 
-  private final Eth1HeadTracker tracker = new Eth1HeadTracker(asyncRunner, eth1Provider);
+  private final Eth1HeadTracker tracker = new BlockBasedEth1HeadTracker(asyncRunner, eth1Provider);
 
   @BeforeAll
   static void setConstants() {

--- a/pow/src/test/java/tech/pegasys/teku/pow/DepositProcessingControllerTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/DepositProcessingControllerTest.java
@@ -43,7 +43,7 @@ public class DepositProcessingControllerTest {
   private final Eth1EventsChannel eth1EventsChannel = mock(Eth1EventsChannel.class);
   private final DepositFetcher depositFetcher = mock(DepositFetcher.class);
   private final Eth1BlockFetcher eth1BlockFetcher = mock(Eth1BlockFetcher.class);
-  private final Eth1HeadTracker headTracker = Mockito.mock(Eth1HeadTracker.class);
+  private final Eth1HeadTracker headTracker = Mockito.mock(BlockBasedEth1HeadTracker.class);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
 
   private final DepositProcessingController depositProcessingController =

--- a/pow/src/test/java/tech/pegasys/teku/pow/TimeBasedEth1HeadTrackerTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/TimeBasedEth1HeadTrackerTest.java
@@ -99,7 +99,7 @@ class TimeBasedEth1HeadTrackerTest {
     assertThat(headTracker.init()).isCompleted();
 
     verify(eth1Provider).getLatestEth1Block();
-    final long followDistanceBlockNumber = blocks.size() - FOLLOW_DISTANCE - 1;
+    final int followDistanceBlockNumber = blocks.size() - FOLLOW_DISTANCE - 1;
     verifyBlockRequested(followDistanceBlockNumber);
     verify(subscriber).onHeadUpdated(UInt64.valueOf(followDistanceBlockNumber));
     verifyNoMoreInteractions(subscriber);

--- a/pow/src/test/java/tech/pegasys/teku/pow/TimeBasedEth1HeadTrackerTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/TimeBasedEth1HeadTrackerTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.pow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.web3j.protocol.core.methods.response.EthBlock.Block;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.pow.Eth1HeadTracker.HeadUpdatedSubscriber;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.TestConfigLoader;
+
+class TimeBasedEth1HeadTrackerTest {
+
+  private static final int FOLLOW_DISTANCE = 10;
+  private static final int SECONDS_PER_BLOCK = 2;
+  private static final int FOLLOW_TIME = FOLLOW_DISTANCE * SECONDS_PER_BLOCK;
+
+  private final Spec spec =
+      TestSpecFactory.createPhase0(
+          TestConfigLoader.loadPhase0Config(
+              "minimal",
+              builder ->
+                  builder
+                      .eth1FollowDistance(UInt64.valueOf(FOLLOW_DISTANCE))
+                      .secondsPerEth1Block(UInt64.valueOf(SECONDS_PER_BLOCK))));
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInMillis(0);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
+  private final Eth1Provider eth1Provider = mock(Eth1Provider.class);
+  private final HeadUpdatedSubscriber subscriber = mock(HeadUpdatedSubscriber.class);
+
+  private final TimeBasedEth1HeadTracker headTracker =
+      new TimeBasedEth1HeadTracker(spec, timeProvider, asyncRunner, eth1Provider);
+
+  @BeforeEach
+  void setUp() {
+    headTracker.subscribe(subscriber);
+    when(eth1Provider.getEth1Block(any(UInt64.class)))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+  }
+
+  @Test
+  void init_shouldNotNotifyAnyHeadIfGenesisIsNotOldEnough() {
+    timeProvider.advanceTimeBySeconds(FOLLOW_TIME);
+    withBlockTimestamps(5, 10, 15);
+    assertThat(headTracker.init()).isCompleted();
+    verify(eth1Provider).getLatestEth1Block();
+    verify(eth1Provider).getEth1Block(UInt64.ZERO);
+    verifyNoInteractions(subscriber);
+
+    // Should wait until the genesis block is old enough
+    assertThat(headTracker.getDelayUntilNextAdvance()).isEqualTo(Duration.ofSeconds(5));
+  }
+
+  @Test
+  void init_shouldLoadCurrentHeadBlockAndUseItAsLatestWhenOldEnough() {
+    timeProvider.advanceTimeBySeconds(FOLLOW_TIME + 1000);
+    withBlockTimestamps(5, 10, 100);
+    assertThat(headTracker.init()).isCompleted();
+
+    verify(eth1Provider).getLatestEth1Block();
+    verify(subscriber).onHeadUpdated(UInt64.valueOf(2));
+  }
+
+  @Test
+  void init_shouldRetrieveBlockAtFollowDistanceIfHeadNotOldEnough() {
+    timeProvider.advanceTimeBySeconds(FOLLOW_TIME + 150);
+    final List<Block> blocks =
+        withBlockTimestamps(1, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100);
+    assertThat(headTracker.init()).isCompleted();
+
+    verify(eth1Provider).getLatestEth1Block();
+    final long followDistanceBlockNumber = blocks.size() - FOLLOW_DISTANCE - 1;
+    verifyBlockRequested(followDistanceBlockNumber);
+    verify(subscriber).onHeadUpdated(UInt64.valueOf(followDistanceBlockNumber));
+    verifyNoMoreInteractions(subscriber);
+
+    // Since follow distance block is old enough, next advance should begin searching forward
+    assertThat(headTracker.getDelayUntilNextAdvance()).isEqualTo(Duration.ZERO);
+    assertThat(headTracker.advance()).isCompleted();
+    verifyBlockRequested(followDistanceBlockNumber + 1);
+    verifyNoMoreInteractions(subscriber);
+  }
+
+  @Test
+  void init_shouldNotNotifyBlockAtFollowDistanceIfItIsNotOldEnough() {
+    timeProvider.advanceTimeBySeconds(FOLLOW_TIME + 150);
+    withBlockTimestamps(1, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200);
+    assertThat(headTracker.init()).isCompleted();
+
+    verifyNoMoreInteractions(subscriber);
+  }
+
+  @Test
+  void advance_shouldWalkBackwardsIfBlockInTimeRangeHasNotYetBeenFound() {
+    timeProvider.advanceTimeBySeconds(FOLLOW_TIME + 150);
+    withBlockTimestamps(1, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300);
+    assertThat(headTracker.init()).isCompleted();
+    verifyBlockRequested(3);
+    verifyNoMoreInteractions(subscriber);
+
+    // Still haven't reached a block inside the range
+    assertThat(headTracker.advance()).isCompleted();
+    verifyBlockRequested(2);
+    verifyNoMoreInteractions(subscriber);
+
+    // Finally reach a block in the range
+    assertThat(headTracker.advance()).isCompleted();
+    verifyBlockRequested(1);
+    verify(subscriber).onHeadUpdated(UInt64.valueOf(1));
+    verifyNoMoreInteractions(subscriber);
+  }
+
+  @Test
+  void advance_shouldStepForwardAfterBackwardsSearchCompletes() {
+    timeProvider.advanceTimeBySeconds(FOLLOW_TIME + 150);
+    withBlockTimestamps(1, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300);
+    assertThat(headTracker.init()).isCompleted();
+    verifyBlockRequested(3);
+    verifyNoMoreInteractions(subscriber);
+
+    // Still haven't reached a block inside the range
+    assertThat(headTracker.advance()).isCompleted();
+    verifyBlockRequested(2);
+    verifyNoMoreInteractions(subscriber);
+    assertThat(headTracker.getDelayUntilNextAdvance()).isEqualTo(Duration.ZERO);
+
+    // Finally reach a block in the range
+    assertThat(headTracker.advance()).isCompleted();
+    verifyBlockRequested(1);
+    verify(subscriber).onHeadUpdated(UInt64.valueOf(1));
+    verifyNoMoreInteractions(subscriber);
+
+    // Should start stepping forward again, waiting for block 2 to be within the time period
+    assertThat(headTracker.getDelayUntilNextAdvance()).isEqualTo(Duration.ofSeconds(50));
+
+    timeProvider.advanceTimeBySeconds(50);
+    assertThat(headTracker.advance()).isCompleted();
+    // Shouldn't request block 2 again as we already have it
+    verifyBlockRequested(2);
+    verify(subscriber).onHeadUpdated(UInt64.valueOf(2));
+  }
+
+  @Test
+  void advance_shouldRetrieveNextBlockIfNextCandidateHeadIsNowOldEnough() {
+    timeProvider.advanceTimeBySeconds(FOLLOW_TIME + 150);
+    withBlockTimestamps(1, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100);
+    // Should notify new head without waiting for next request to complete
+    final long nextHeadBlockNumber = advanceUtilNextBlockIsNotInRange();
+
+    final Duration delayUntilNextBlockIncluded = headTracker.getDelayUntilNextAdvance();
+    timeProvider.advanceTimeBy(delayUntilNextBlockIncluded);
+
+    assertThat(headTracker.advance()).isCompleted();
+    verify(subscriber).onHeadUpdated(UInt64.valueOf(nextHeadBlockNumber));
+
+    assertThat(headTracker.getDelayUntilNextAdvance()).isEqualTo(Duration.ofSeconds(100));
+  }
+
+  @Test
+  void advance_shouldDoNothingIfNextBlockNotInTimePeriodYet() {
+    // Normally wouldn't be called but worth covering just in case
+    timeProvider.advanceTimeBySeconds(FOLLOW_TIME + 150);
+    withBlockTimestamps(1, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100);
+    advanceUtilNextBlockIsNotInRange();
+
+    assertThat(headTracker.getDelayUntilNextAdvance()).isEqualTo(Duration.ofSeconds(50));
+
+    reset(eth1Provider, subscriber); // Ignore any previous calls.
+    assertThat(headTracker.advance()).isCompleted();
+    verifyNoMoreInteractions(eth1Provider);
+    verifyNoMoreInteractions(subscriber);
+  }
+
+  @Test
+  void getDelayUntilNextAdvance_shouldWaitBlockPeriodWhenInitialHeadIsAlreadyOldEnough() {
+    // Should be targeting seconds per block after the current head block
+    timeProvider.advanceTimeBySeconds(FOLLOW_TIME + 500);
+    withBlockTimestamps(1, 100, 200);
+
+    assertThat(headTracker.init()).isCompleted();
+    verify(subscriber).onHeadUpdated(UInt64.valueOf(2));
+
+    assertThat(headTracker.getDelayUntilNextAdvance())
+        .isEqualTo(Duration.ofSeconds(SECONDS_PER_BLOCK));
+
+    // Should get closer as time progresses
+    timeProvider.advanceTimeBySeconds(1);
+    assertThat(headTracker.getDelayUntilNextAdvance())
+        .isEqualTo(Duration.ofSeconds(SECONDS_PER_BLOCK - 1));
+
+    // And should reset to seconds per block after advance tries to get the next block again
+    timeProvider.advanceTimeBySeconds(SECONDS_PER_BLOCK);
+    assertThat(headTracker.advance()).isCompleted();
+    verifyBlockRequested(3);
+    verifyNoMoreInteractions(subscriber);
+
+    assertThat(headTracker.getDelayUntilNextAdvance())
+        .isEqualTo(Duration.ofSeconds(SECONDS_PER_BLOCK));
+  }
+
+  @Test
+  void getDelayUntilNextAdvance_shouldWaitBlockPeriodBeforeAdvancingWhenHeadBlockReached() {
+    timeProvider.advanceTimeBySeconds(FOLLOW_TIME + 150);
+    final List<Block> blocks =
+        withBlockTimestamps(1, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100);
+    advanceUtilNextBlockIsNotInRange();
+    assertThat(headTracker.getDelayUntilNextAdvance()).isEqualTo(Duration.ofSeconds(50));
+
+    // Make all blocks old enough
+    timeProvider.advanceTimeBySeconds(1000);
+    while (headTracker.getDelayUntilNextAdvance().equals(Duration.ZERO)) {
+      assertThat(headTracker.advance()).isCompleted();
+    }
+    verify(subscriber).onHeadUpdated(UInt64.valueOf(blocks.size() - 1));
+    // Should have tried to get the next block but found it doesn't exist
+    verifyBlockRequested(blocks.size());
+
+    assertThat(headTracker.getDelayUntilNextAdvance())
+        .isEqualTo(Duration.ofSeconds(SECONDS_PER_BLOCK));
+
+    // Should get closer as time progresses
+    timeProvider.advanceTimeBySeconds(1);
+    assertThat(headTracker.getDelayUntilNextAdvance())
+        .isEqualTo(Duration.ofSeconds(SECONDS_PER_BLOCK - 1));
+
+    // And should reset to seconds per block after advance tries to get the next block again
+    timeProvider.advanceTimeBySeconds(SECONDS_PER_BLOCK);
+    assertThat(headTracker.advance()).isCompleted();
+  }
+
+  private void verifyBlockRequested(final long blockNumber) {
+    verify(eth1Provider).getEth1Block(UInt64.valueOf(blockNumber));
+  }
+
+  private long advanceUtilFirstBlockInRangeFound() {
+    final AtomicReference<UInt64> firstHead = new AtomicReference<>();
+    headTracker.subscribe(firstHead::set);
+    assertThat(headTracker.init()).isCompleted();
+    verify(eth1Provider).getLatestEth1Block();
+    while (firstHead.get() == null) {
+      assertThat(headTracker.advance()).isCompleted();
+    }
+    verify(subscriber).onHeadUpdated(firstHead.get());
+    return firstHead.get().longValue();
+  }
+
+  private long advanceUtilNextBlockIsNotInRange() {
+    long nextBlockNumber = advanceUtilFirstBlockInRangeFound();
+    while (headTracker.getDelayUntilNextAdvance().equals(Duration.ZERO)) {
+      assertThat(headTracker.advance()).isCompleted();
+      nextBlockNumber++;
+    }
+    return nextBlockNumber;
+  }
+
+  private List<Block> withBlockTimestamps(final long... timestamps) {
+    final List<Block> blocks = new ArrayList<>();
+    for (int blockNumber = 0; blockNumber < timestamps.length; blockNumber++) {
+      final Block block = new Block();
+      block.setNumber("0x" + Integer.toHexString(blockNumber));
+      block.setTimestamp("0x" + Long.toHexString(timestamps[blockNumber]));
+      when(eth1Provider.getEth1Block(UInt64.valueOf(blockNumber)))
+          .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
+
+      blocks.add(block);
+    }
+
+    when(eth1Provider.getLatestEth1Block())
+        .thenReturn(SafeFuture.completedFuture(blocks.get(blocks.size() - 1)));
+    return blocks;
+  }
+}

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
@@ -20,23 +20,31 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 
 public class PowchainConfiguration {
+
+  private final Spec spec;
   private final List<String> eth1Endpoints;
   private final Eth1Address depositContract;
   private final Optional<UInt64> depositContractDeployBlock;
   private final int eth1LogsMaxBlockRange;
+  private final boolean useTimeBasedHeadTracking;
 
   private PowchainConfiguration(
+      final Spec spec,
       final List<String> eth1Endpoints,
       final Eth1Address depositContract,
       final Optional<UInt64> depositContractDeployBlock,
-      final int eth1LogsMaxBlockRange) {
+      final int eth1LogsMaxBlockRange,
+      final boolean useTimeBasedHeadTracking) {
+    this.spec = spec;
     this.eth1Endpoints = eth1Endpoints;
     this.depositContract = depositContract;
     this.depositContractDeployBlock = depositContractDeployBlock;
     this.eth1LogsMaxBlockRange = eth1LogsMaxBlockRange;
+    this.useTimeBasedHeadTracking = useTimeBasedHeadTracking;
   }
 
   public static Builder builder() {
@@ -45,6 +53,10 @@ public class PowchainConfiguration {
 
   public boolean isEnabled() {
     return !eth1Endpoints.isEmpty();
+  }
+
+  public Spec getSpec() {
+    return spec;
   }
 
   public List<String> getEth1Endpoints() {
@@ -63,21 +75,33 @@ public class PowchainConfiguration {
     return eth1LogsMaxBlockRange;
   }
 
+  public boolean useTimeBasedHeadTracking() {
+    return useTimeBasedHeadTracking;
+  }
+
   public static class Builder {
+    private Spec spec;
     private List<String> eth1Endpoints = new ArrayList<>();
     private Eth1Address depositContract;
     private Optional<UInt64> depositContractDeployBlock = Optional.empty();
     private int eth1LogsMaxBlockRange;
+    private boolean useTimeBasedHeadTracking = false;
 
     private Builder() {}
 
     public PowchainConfiguration build() {
       validate();
       return new PowchainConfiguration(
-          eth1Endpoints, depositContract, depositContractDeployBlock, eth1LogsMaxBlockRange);
+          spec,
+          eth1Endpoints,
+          depositContract,
+          depositContractDeployBlock,
+          eth1LogsMaxBlockRange,
+          useTimeBasedHeadTracking);
     }
 
     private void validate() {
+      checkNotNull(spec, "Must specify a spec");
       if (!eth1Endpoints.isEmpty()) {
         checkNotNull(
             depositContract,
@@ -112,6 +136,16 @@ public class PowchainConfiguration {
 
     public Builder eth1LogsMaxBlockRange(final int eth1LogsMaxBlockRange) {
       this.eth1LogsMaxBlockRange = eth1LogsMaxBlockRange;
+      return this;
+    }
+
+    public Builder specProvider(final Spec spec) {
+      this.spec = spec;
+      return this;
+    }
+
+    public Builder useTimeBasedHeadTracking(final boolean useTimeBasedHeadTracking) {
+      this.useTimeBasedHeadTracking = useTimeBasedHeadTracking;
       return this;
     }
   }

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.infrastructure.async.ExceptionThrowingRunnable;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
+import tech.pegasys.teku.pow.BlockBasedEth1HeadTracker;
 import tech.pegasys.teku.pow.DepositEventsAccessor;
 import tech.pegasys.teku.pow.DepositFetcher;
 import tech.pegasys.teku.pow.DepositProcessingController;
@@ -46,6 +47,7 @@ import tech.pegasys.teku.pow.Eth1ProviderSelector;
 import tech.pegasys.teku.pow.FallbackAwareEth1Provider;
 import tech.pegasys.teku.pow.MinimumGenesisTimeBlockFinder;
 import tech.pegasys.teku.pow.ThrottlingEth1Provider;
+import tech.pegasys.teku.pow.TimeBasedEth1HeadTracker;
 import tech.pegasys.teku.pow.ValidatingEth1EventsPublisher;
 import tech.pegasys.teku.pow.Web3jEth1Provider;
 import tech.pegasys.teku.pow.api.Eth1EventsChannel;
@@ -117,7 +119,13 @@ public class PowchainService extends Service {
             asyncRunner,
             powConfig.getEth1LogsMaxBlockRange());
 
-    headTracker = new Eth1HeadTracker(asyncRunner, eth1Provider);
+    if (powConfig.useTimeBasedHeadTracking()) {
+      headTracker =
+          new TimeBasedEth1HeadTracker(
+              powConfig.getSpec(), serviceConfig.getTimeProvider(), asyncRunner, eth1Provider);
+    } else {
+      headTracker = new BlockBasedEth1HeadTracker(asyncRunner, eth1Provider);
+    }
     final DepositProcessingController depositProcessingController =
         new DepositProcessingController(
             eth1Provider,

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
@@ -36,8 +36,20 @@ public class DepositOptions {
       arity = "1")
   private int eth1LogsMaxBlockRange = 10_000;
 
+  @Option(
+      names = {"--Xeth1-time-based-head-tracking-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Enable experimental time based Eth1 head tracking",
+      hidden = true,
+      arity = "0..1",
+      fallbackValue = "true")
+  private boolean useTimeBasedHeadTracking = false;
+
   public void configure(final TekuConfiguration.Builder builder) {
     builder.powchain(
-        b -> b.eth1Endpoints(eth1Endpoints).eth1LogsMaxBlockRange(eth1LogsMaxBlockRange));
+        b ->
+            b.eth1Endpoints(eth1Endpoints)
+                .eth1LogsMaxBlockRange(eth1LogsMaxBlockRange)
+                .useTimeBasedHeadTracking(useTimeBasedHeadTracking));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -180,13 +180,12 @@ public class TekuConfiguration {
           eth2NetworkConfigurationBuilder.build();
       final Spec spec = eth2NetworkConfiguration.getSpec();
 
+      // Add specs
       interopConfigBuilder.specProvider(spec);
-      // Update storage config
       storageConfigurationBuilder.specProvider(spec);
-      // Update weak subjectivity
       weakSubjectivityBuilder.specProvider(spec);
-      // Update p2p config
       p2pConfigBuilder.specProvider(spec);
+      powchainConfigBuilder.specProvider(spec);
 
       return new TekuConfiguration(
           eth2NetworkConfiguration,


### PR DESCRIPTION
## PR Description
Adds a new `TimeBasedEth1HeadTracker` which uses block timestamp to decide if the block is old enough rather than just block number.

Currently this is toggled off as further testing and tweaking is required and the previous block number based approach is used. It works well on MainNet but may need to be smarter on testnets where the block time differs from the expected value a lot more.

This is built on a new async primitive `AsyncRunLoop` which abstracts out the error handling and async delays from the actual business logic and makes the code significantly simpler.

## Fixed Issue(s)
#4005 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
