### PR TITLE
Fix handling of eth_getLogs errors that return too many logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Fixed failures in the `checkMavenCoordinateCollisions` task if it was run prior to running spotless.
 - Use system default character set for console output rather than forcing UTF-8. Avoids corrupting characters on systems using charsets that are not ascii based.
 - Fixed a `NullPointerException` from validator clients for new networks, prior to genesis being known.
+- Fixed regression where eth_getLogs responses from Infura that rejected the request because they returned too many logs did not retry the request with a smaller request range.
 
 ### Experimental: New Altair REST APIs
 - implement POST `/eth/v1/beacon/pool/sync_committees` to allow validators to submit sync committee signatures to the beacon node.

--- a/pow/src/main/java/tech/pegasys/teku/pow/exception/RejectedRequestException.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/exception/RejectedRequestException.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.pow.exception;
 
 public class RejectedRequestException extends RuntimeException {
 
-  public RejectedRequestException(final String message) {
-    super(message);
+  public RejectedRequestException(final int code, final String message) {
+    super(code + ": " + message);
   }
 }

--- a/pow/src/test/java/tech/pegasys/teku/pow/DepositsFetcherTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/DepositsFetcherTest.java
@@ -168,7 +168,7 @@ public class DepositsFetcherTest {
 
     // But there are too many results
     final Eth1RequestException err = new Eth1RequestException();
-    err.addSuppressed(new RejectedRequestException("Nah mate"));
+    err.addSuppressed(new RejectedRequestException(-32005, "Nah mate"));
     request1Response.completeExceptionally(err);
 
     // So it halves the batch size and retries

--- a/pow/src/test/java/tech/pegasys/teku/pow/FallbackAwareEth1ProviderSelectorTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/FallbackAwareEth1ProviderSelectorTest.java
@@ -121,7 +121,7 @@ public class FallbackAwareEth1ProviderSelectorTest {
         .thenReturn(failingProviderGetLogsWithError(new RuntimeException("error")));
     when(node2.ethGetLogs(ethLogFilter))
         .thenReturn(
-            failingProviderGetLogsWithError(new RejectedRequestException("socket timeout error")));
+            failingProviderGetLogsWithError(new RejectedRequestException(-32005, "too many")));
     when(node3.ethGetLogs(ethLogFilter))
         .thenReturn(failingProviderGetLogsWithError(new RuntimeException("error")));
 

--- a/pow/src/test/java/tech/pegasys/teku/pow/Web3jEth1ProviderTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/Web3jEth1ProviderTest.java
@@ -17,22 +17,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.Response;
+import org.web3j.protocol.core.methods.request.EthFilter;
 import org.web3j.protocol.core.methods.response.EthChainId;
+import org.web3j.protocol.core.methods.response.EthLog;
+import org.web3j.protocol.core.methods.response.EthLog.LogResult;
 import org.web3j.protocol.core.methods.response.EthSyncing;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.pow.exception.RejectedRequestException;
 import tech.pegasys.teku.util.config.Constants;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
-public class Web3jEth1MonitorableProviderTest {
+public class Web3jEth1ProviderTest {
   final Web3j web3 = mock(Web3j.class);
   final Request request1 = mock(Request.class);
   final Request request2 = mock(Request.class);
@@ -197,6 +203,19 @@ public class Web3jEth1MonitorableProviderTest {
 
     // after the interval needs to be validated
     assertThat(provider.needsToBeValidated()).isTrue();
+  }
+
+  @Test
+  void shouldThrowRejectedRequestExceptionWhenInfuraRejectsRequestWithTooManyLogs() {
+    final EthFilter filter = new EthFilter();
+    final EthLog response = new EthLog();
+    response.setError(new Response.Error(-32005, "query returned more than 10000 results"));
+    when(web3.ethGetLogs(filter)).thenReturn(request1);
+    when(request1.sendAsync()).thenReturn(SafeFuture.completedFuture(response));
+
+    final SafeFuture<List<LogResult<?>>> result = provider.ethGetLogs(filter);
+    SafeFutureAssert.assertThatSafeFuture(result)
+        .isCompletedExceptionallyWith(RejectedRequestException.class);
   }
 
   private void prepareRequestWithSyncingResponse(Request request, boolean isSyncing) {


### PR DESCRIPTION
## PR Description
A regression was introduced with retrieving deposits when the error handling of web3j responses was fixed.  We no longer detected cases where too many logs were returned and we need to reduce the requested block range.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
