### PR TITLE
Add metric to report number of eth1 requests sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # Changelog
 
 ## Upcoming Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Changelog
 
 ## Upcoming Breaking Changes
@@ -17,7 +18,8 @@ For information on changes in released versions of Teku, see the [releases page]
 - Optimised how block production metrics are calculated.
 - implement GET `/eth/v1/node/peer_count` standard api endpoint.
 - When handling blocksByRange requests that target blocks we haven't yet downloaded, return the standard "resource unavailable" response code (3) rather than a custom response code.
-- Remove legacy pure Java BLS cryptography implementation (Mikuli). 
+- Remove legacy pure Java BLS cryptography implementation (Mikuli).
+- Added `beacon_eth1_requests_total` metric to report the number of requests sent to eth1 endpoints.
 
 ### Bug Fixes
 - Fixed failures in the `checkMavenCoordinateCollisions` task if it was run prior to running spotless.

--- a/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Web3jEth1Provider.java
@@ -24,6 +24,9 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.DefaultBlockParameterName;
@@ -38,6 +41,7 @@ import org.web3j.protocol.core.methods.response.EthChainId;
 import org.web3j.protocol.core.methods.response.EthLog;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.exception.RejectedRequestException;
@@ -51,16 +55,25 @@ public class Web3jEth1Provider extends AbstractMonitorableEth1Provider {
   private final String id;
   private final Web3j web3j;
   private final AsyncRunner asyncRunner;
+  private final LabelledMetric<Counter> requestCounter;
 
   public Web3jEth1Provider(
+      final MetricsSystem metricsSystem,
       final String id,
       final Web3j web3j,
       final AsyncRunner asyncRunner,
-      TimeProvider timeProvider) {
+      final TimeProvider timeProvider) {
     super(timeProvider);
     this.web3j = web3j;
     this.asyncRunner = asyncRunner;
     this.id = id;
+    requestCounter =
+        metricsSystem.createLabelledCounter(
+            TekuMetricCategory.BEACON,
+            "eth1_requests_total",
+            "Counter of the number of requests made to the eth1-endpoint, by endpoint ID and JSON-RPC method",
+            "endpoint",
+            "method");
   }
 
   @Override
@@ -125,6 +138,7 @@ public class Web3jEth1Provider extends AbstractMonitorableEth1Provider {
   @SuppressWarnings("rawtypes")
   private <S, T extends Response> SafeFuture<T> sendAsync(final Request<S, T> request) {
     try {
+      requestCounter.labels(id, request.getMethod()).inc();
       return SafeFuture.of(request.sendAsync())
           .thenApply(
               response -> {

--- a/pow/src/test/java/tech/pegasys/teku/pow/Web3jEth1ProviderTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/Web3jEth1ProviderTest.java
@@ -32,6 +32,7 @@ import org.web3j.protocol.core.methods.response.EthSyncing;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.exception.RejectedRequestException;
@@ -55,6 +56,7 @@ public class Web3jEth1ProviderTest {
     timeProvider = StubTimeProvider.withTimeInSeconds(1000);
     provider =
         new Web3jEth1Provider(
+            new StubMetricsSystem(),
             Eth1Provider.generateEth1ProviderId(0, "https://eth.test.org:1234/test"),
             web3,
             asyncRunner,

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -76,6 +76,7 @@ public class PowchainService extends Service {
                 .mapToObj(
                     idx ->
                         new Web3jEth1Provider(
+                            serviceConfig.getMetricsSystem(),
                             Eth1Provider.generateEth1ProviderId(
                                 idx + 1, powConfig.getEth1Endpoints().get(idx)),
                             web3js.get(idx),


### PR DESCRIPTION
## PR Description
Add a metric to report the number of requests made to eth1 endpoints. This is generally useful but will also help us compare the performance of #4040 


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
