### PR TITLE
Add support for retrieving blocks as ssz to v2 api

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetSszState.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetSszState.java
@@ -95,8 +95,7 @@ public class GetSszState implements Handler {
               }
               final SszResponse sszResponse = result.get();
               ctx.header(
-                  "Content-Disposition",
-                  "filename=\"" + sszResponse.stateAbbreviatedHash + ".ssz\"");
+                  "Content-Disposition", "filename=\"" + sszResponse.abbreviatedHash + ".ssz\"");
               ctx.contentType("application/octet-stream");
               return sszResponse.byteStream;
             }));

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetSszState.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetSszState.java
@@ -38,7 +38,7 @@ import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
-import tech.pegasys.teku.api.response.StateSszResponse;
+import tech.pegasys.teku.api.response.SszResponse;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.provider.JsonProvider;
@@ -81,7 +81,7 @@ public class GetSszState implements Handler {
     final Map<String, String> pathParamMap = ctx.pathParamMap();
     ctx.header(Header.CACHE_CONTROL, CACHE_NONE);
 
-    SafeFuture<Optional<StateSszResponse>> future =
+    SafeFuture<Optional<SszResponse>> future =
         chainDataProvider.getBeaconStateSsz(pathParamMap.get(PARAM_STATE_ID));
     ctx.result(
         future.thenApplyChecked(
@@ -93,12 +93,12 @@ public class GetSszState implements Handler {
                     SC_NOT_FOUND,
                     "State not found: " + pathParamMap.get(PARAM_STATE_ID));
               }
-              final StateSszResponse stateSszResponse = result.get();
+              final SszResponse sszResponse = result.get();
               ctx.header(
                   "Content-Disposition",
-                  "filename=\"" + stateSszResponse.stateAbbreviatedHash + ".ssz\"");
+                  "filename=\"" + sszResponse.stateAbbreviatedHash + ".ssz\"");
               ctx.contentType("application/octet-stream");
-              return stateSszResponse.byteStream;
+              return sszResponse.byteStream;
             }));
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetStateByBlockRoot.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetStateByBlockRoot.java
@@ -38,7 +38,7 @@ import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
-import tech.pegasys.teku.api.response.StateSszResponse;
+import tech.pegasys.teku.api.response.SszResponse;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.provider.JsonProvider;
@@ -80,7 +80,7 @@ public class GetStateByBlockRoot implements Handler {
     final Map<String, String> pathParamMap = ctx.pathParamMap();
     ctx.header(Header.CACHE_CONTROL, CACHE_NONE);
 
-    SafeFuture<Optional<StateSszResponse>> future =
+    SafeFuture<Optional<SszResponse>> future =
         chainDataProvider.getBeaconStateSszByBlockRoot(pathParamMap.get(PARAM_BLOCK_ID));
     ctx.result(
         future.thenApplyChecked(
@@ -92,12 +92,12 @@ public class GetStateByBlockRoot implements Handler {
                     SC_NOT_FOUND,
                     "State by block root not found: " + pathParamMap.get(PARAM_BLOCK_ID));
               }
-              final StateSszResponse stateSszResponse = result.get();
+              final SszResponse sszResponse = result.get();
               ctx.header(
                   "Content-Disposition",
-                  "filename=\"" + stateSszResponse.stateAbbreviatedHash + ".ssz\"");
+                  "filename=\"" + sszResponse.stateAbbreviatedHash + ".ssz\"");
               ctx.contentType("application/octet-stream");
-              return stateSszResponse.byteStream;
+              return sszResponse.byteStream;
             }));
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetStateByBlockRoot.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetStateByBlockRoot.java
@@ -94,8 +94,7 @@ public class GetStateByBlockRoot implements Handler {
               }
               final SszResponse sszResponse = result.get();
               ctx.header(
-                  "Content-Disposition",
-                  "filename=\"" + sszResponse.stateAbbreviatedHash + ".ssz\"");
+                  "Content-Disposition", "filename=\"" + sszResponse.abbreviatedHash + ".ssz\"");
               ctx.contentType("application/octet-stream");
               return sszResponse.byteStream;
             }));

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetState.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetState.java
@@ -42,7 +42,7 @@ import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
-import tech.pegasys.teku.api.response.StateSszResponse;
+import tech.pegasys.teku.api.response.SszResponse;
 import tech.pegasys.teku.api.response.v1.debug.GetStateResponse;
 import tech.pegasys.teku.api.schema.BeaconState;
 import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
@@ -91,7 +91,7 @@ public class GetState extends AbstractHandler implements Handler {
     final Optional<String> maybeAcceptHeader = Optional.ofNullable(ctx.header(HEADER_ACCEPT));
     final Map<String, String> pathParamMap = ctx.pathParamMap();
     if (maybeAcceptHeader.orElse("").equalsIgnoreCase(HEADER_ACCEPT_OCTET)) {
-      final SafeFuture<Optional<StateSszResponse>> future =
+      final SafeFuture<Optional<SszResponse>> future =
           chainDataProvider.getBeaconStateSsz(pathParamMap.get(PARAM_STATE_ID));
       handleOptionalSszResult(
           ctx, future, this::handleSszResult, this::resultFilename, SC_NOT_FOUND);
@@ -104,12 +104,12 @@ public class GetState extends AbstractHandler implements Handler {
     }
   }
 
-  private String resultFilename(final StateSszResponse response) {
+  private String resultFilename(final SszResponse response) {
     return response.stateAbbreviatedHash + ".ssz";
   }
 
   private Optional<ByteArrayInputStream> handleSszResult(
-      final Context context, final StateSszResponse response) {
+      final Context context, final SszResponse response) {
     return Optional.of(response.byteStream);
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetState.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetState.java
@@ -105,7 +105,7 @@ public class GetState extends AbstractHandler implements Handler {
   }
 
   private String resultFilename(final SszResponse response) {
-    return response.stateAbbreviatedHash + ".ssz";
+    return response.abbreviatedHash + ".ssz";
   }
 
   private Optional<ByteArrayInputStream> handleSszResult(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetBlock.java
@@ -100,7 +100,7 @@ public class GetBlock extends AbstractHandler implements Handler {
   }
 
   private String resultFilename(final SszResponse response) {
-    return response.stateAbbreviatedHash + ".ssz";
+    return response.abbreviatedHash + ".ssz";
   }
 
   private Optional<ByteArrayInputStream> handleSszResult(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/debug/GetState.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/debug/GetState.java
@@ -102,7 +102,7 @@ public class GetState extends AbstractHandler implements Handler {
   }
 
   private String resultFilename(final SszResponse response) {
-    return response.stateAbbreviatedHash + ".ssz";
+    return response.abbreviatedHash + ".ssz";
   }
 
   private Optional<ByteArrayInputStream> handleSszResult(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/debug/GetState.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/debug/GetState.java
@@ -41,7 +41,7 @@ import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
-import tech.pegasys.teku.api.response.StateSszResponse;
+import tech.pegasys.teku.api.response.SszResponse;
 import tech.pegasys.teku.api.response.v2.debug.GetStateResponseV2;
 import tech.pegasys.teku.api.schema.BeaconState;
 import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
@@ -88,7 +88,7 @@ public class GetState extends AbstractHandler implements Handler {
     final Optional<String> maybeAcceptHeader = Optional.ofNullable(ctx.header(HEADER_ACCEPT));
     final Map<String, String> pathParamMap = ctx.pathParamMap();
     if (maybeAcceptHeader.orElse("").equalsIgnoreCase(HEADER_ACCEPT_OCTET)) {
-      final SafeFuture<Optional<StateSszResponse>> future =
+      final SafeFuture<Optional<SszResponse>> future =
           chainDataProvider.getBeaconStateSsz(pathParamMap.get(PARAM_STATE_ID));
       handleOptionalSszResult(
           ctx, future, this::handleSszResult, this::resultFilename, SC_NOT_FOUND);
@@ -101,12 +101,12 @@ public class GetState extends AbstractHandler implements Handler {
     }
   }
 
-  private String resultFilename(final StateSszResponse response) {
+  private String resultFilename(final SszResponse response) {
     return response.stateAbbreviatedHash + ".ssz";
   }
 
   private Optional<ByteArrayInputStream> handleSszResult(
-      final Context context, final StateSszResponse response) {
+      final Context context, final SszResponse response) {
     return Optional.of(response.byteStream);
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -34,7 +34,7 @@ import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.blockselector.BlockSelectorFactory;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
-import tech.pegasys.teku.api.response.StateSszResponse;
+import tech.pegasys.teku.api.response.SszResponse;
 import tech.pegasys.teku.api.response.v1.beacon.BlockHeader;
 import tech.pegasys.teku.api.response.v1.beacon.EpochCommitteeResponse;
 import tech.pegasys.teku.api.response.v1.beacon.FinalityCheckpointsResponse;
@@ -124,6 +124,19 @@ public class ChainDataProvider {
         .thenApply(maybeBlock -> maybeBlock.map(schemaObjectProvider::getSignedBeaconBlock));
   }
 
+  public SafeFuture<Optional<SszResponse>> getBlockSsz(final String slotParameter) {
+    return defaultBlockSelectorFactory
+        .defaultBlockSelector(slotParameter)
+        .getSingleBlock()
+        .thenApply(
+            maybeBlock ->
+                maybeBlock.map(
+                    block ->
+                        new SszResponse(
+                            new ByteArrayInputStream(block.sszSerialize().toArrayUnsafe()),
+                            block.hashTreeRoot().toUnprefixedHexString())));
+  }
+
   public SafeFuture<Optional<Root>> getBlockRoot(final String slotParameter) {
     return defaultBlockSelectorFactory
         .defaultBlockSelector(slotParameter)
@@ -170,7 +183,7 @@ public class ChainDataProvider {
         .thenApply(maybeState -> maybeState.map(schemaObjectProvider::getBeaconState));
   }
 
-  public SafeFuture<Optional<StateSszResponse>> getBeaconStateSsz(final String stateIdParam) {
+  public SafeFuture<Optional<SszResponse>> getBeaconStateSsz(final String stateIdParam) {
     return defaultStateSelectorFactory
         .defaultStateSelector(stateIdParam)
         .getState()
@@ -178,7 +191,7 @@ public class ChainDataProvider {
             maybeState ->
                 maybeState.map(
                     state ->
-                        new StateSszResponse(
+                        new SszResponse(
                             new ByteArrayInputStream(state.sszSerialize().toArrayUnsafe()),
                             state.hashTreeRoot().toUnprefixedHexString())));
   }
@@ -197,7 +210,7 @@ public class ChainDataProvider {
     }
   }
 
-  public SafeFuture<Optional<StateSszResponse>> getBeaconStateSszByBlockRoot(
+  public SafeFuture<Optional<SszResponse>> getBeaconStateSszByBlockRoot(
       final String blockRootParam) {
     return defaultStateSelectorFactory
         .byBlockRootStateSelector(blockRootParam)
@@ -206,7 +219,7 @@ public class ChainDataProvider {
             maybeState ->
                 maybeState.map(
                     state ->
-                        new StateSszResponse(
+                        new SszResponse(
                             new ByteArrayInputStream(state.sszSerialize().toArrayUnsafe()),
                             state.hashTreeRoot().toUnprefixedHexString())));
   }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/SszResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/SszResponse.java
@@ -17,10 +17,10 @@ import java.io.ByteArrayInputStream;
 
 public class SszResponse {
   public final ByteArrayInputStream byteStream;
-  public final String stateAbbreviatedHash;
+  public final String abbreviatedHash;
 
   public SszResponse(final ByteArrayInputStream byteStream, final String abbreviatedHash) {
     this.byteStream = byteStream;
-    this.stateAbbreviatedHash = abbreviatedHash;
+    this.abbreviatedHash = abbreviatedHash;
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/SszResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/SszResponse.java
@@ -15,13 +15,13 @@ package tech.pegasys.teku.api.response;
 
 import java.io.ByteArrayInputStream;
 
-public class StateSszResponse {
+public class SszResponse {
   public final ByteArrayInputStream byteStream;
   public final String stateAbbreviatedHash;
 
-  public StateSszResponse(
-      final ByteArrayInputStream byteStream, final String stateAbbreviatedHash) {
+  public SszResponse(
+      final ByteArrayInputStream byteStream, final String abbreviatedHash) {
     this.byteStream = byteStream;
-    this.stateAbbreviatedHash = stateAbbreviatedHash;
+    this.stateAbbreviatedHash = abbreviatedHash;
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/SszResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/SszResponse.java
@@ -19,8 +19,7 @@ public class SszResponse {
   public final ByteArrayInputStream byteStream;
   public final String stateAbbreviatedHash;
 
-  public SszResponse(
-      final ByteArrayInputStream byteStream, final String abbreviatedHash) {
+  public SszResponse(final ByteArrayInputStream byteStream, final String abbreviatedHash) {
     this.byteStream = byteStream;
     this.stateAbbreviatedHash = abbreviatedHash;
   }


### PR DESCRIPTION
## PR Description
Add support for returning blocks as SSZ based on the `Accept` header, matching the support for states.

Only applied to the v2 api since it's the way of the future anyway.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
