### PR TITLE
Fix copying of current justified checkpoint during Altair transition

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateFields.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateFields.java
@@ -88,7 +88,7 @@ public enum BeaconStateFields {
     // Finality
     state.setJustification_bits(source.getJustification_bits());
     state.setPrevious_justified_checkpoint(source.getPrevious_justified_checkpoint());
-    state.setCurrent_justified_checkpoint(source.getPrevious_justified_checkpoint());
+    state.setCurrent_justified_checkpoint(source.getCurrent_justified_checkpoint());
     state.setFinalized_checkpoint(source.getFinalized_checkpoint());
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateFieldsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateFieldsTest.java
@@ -1,0 +1,23 @@
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class BeaconStateFieldsTest {
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  @Test
+  void shouldNotCauseModificationsWhenCopyingCommonFields() {
+    final BeaconState source = dataStructureUtil.randomBeaconState();
+    final BeaconState result =
+        source.updated(target -> BeaconStateFields.copyCommonFieldsFromSource(target, source));
+
+    assertThat(result).isEqualTo(source);
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateFieldsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateFieldsTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.spec.datastructures.state.beaconstate.common;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
## PR Description
The current justified checkpoint field was copied incorrectly during the transition to Altair causing a consensus failure with out clients and a delay in justification/finalization over the transition period.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
