### PR TITLE
Subscribe to sync committee subnets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Remove legacy pure Java BLS cryptography implementation (Mikuli).
 - Added `beacon_eth1_requests_total` metric to report the number of requests sent to eth1 endpoints.
 - Rework network configuration parsing to accept the new config format.  For details on the new format, see the [eth2.0-specs repo](https://github.com/ethereum/eth2.0-specs/pull/2390).  With this change, we no longer support pointing to directories for the network configuration.  Now, the network config (supplied via `--network`) should always point to a single yaml file.
+- For Altair networks, `--p2p-subscribe-all-subnets-enabled` will subscribe to all subcommittee subnets.
 
 ### Bug Fixes
 - Fixed failures in the `checkMavenCoordinateCollisions` task if it was run prior to running spotless.

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -181,7 +181,7 @@ public class TekuNode extends Node {
           assertThat(altairBlock.getMessage().getBody().syncAggregate.syncCommitteeBits)
               .isEqualTo(Bytes.fromHexString("0xffffffff"));
         },
-        2,
+        5,
         MINUTES);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AllSyncCommitteeSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AllSyncCommitteeSubscriptions.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.gossip.subnets;
+
+import static tech.pegasys.teku.spec.constants.NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+
+public class AllSyncCommitteeSubscriptions extends SyncCommitteeSubscriptionManager {
+  public AllSyncCommitteeSubscriptions(final Eth2P2PNetwork p2PNetwork, final Spec spec) {
+    super(p2PNetwork);
+    if (spec.isMilestoneSupported(SpecMilestone.ALTAIR)) {
+      for (int i = 0; i < SYNC_COMMITTEE_SUBNET_COUNT; i++) {
+        p2PNetwork.subscribeToSyncCommitteeSubnetId(i);
+      }
+    }
+  }
+
+  @Override
+  public synchronized void onSlot(final UInt64 slot) {
+    // no-op, we don't need to ever unsubscribe
+  }
+
+  @Override
+  public synchronized void subscribe(final Integer committeeSubnet, final UInt64 unsubscribeSlot) {
+    // already subscribed to all subnets
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -135,8 +135,8 @@ public class P2POptions {
       names = {"--p2p-subscribe-all-subnets-enabled"},
       paramLabel = "<BOOLEAN>",
       description = "",
-      arity = "1",
-      fallbackValue = "false")
+      arity = "0..1",
+      fallbackValue = "true")
   private boolean subscribeAllSubnetsEnabled = false;
 
   @Option(


### PR DESCRIPTION
- if `--p2p-subscribe-all-subnets-enabled` is set, subscribe to all sync committee subnets
- increase AT timeout to help reduce intermittent failures.
- change `--p2p-subscribe-all-subnets-enabled` cli so that fallback is true and allows arity 0 (can enable without having to specify =true)

fixes #4036

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
