### PR TITLE
Add CONFIG_NAME back into specs returned from REST API

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
@@ -45,9 +45,11 @@ import tech.pegasys.teku.ssz.type.Bytes4;
 public class SpecConfigReader {
   private static final Logger LOG = LogManager.getLogger();
   private static final String PRESET_KEY = "PRESET_BASE";
+  private static final String CONFIG_NAME_KEY = "CONFIG_NAME";
   private static final ImmutableSet<String> KEYS_TO_IGNORE =
       ImmutableSet.of(
           PRESET_KEY,
+          CONFIG_NAME_KEY,
           // Unsupported, upcoming fork-related keys
           "MERGE_FORK_VERSION",
           "MERGE_FORK_EPOCH",
@@ -125,11 +127,18 @@ public class SpecConfigReader {
   public void loadFromMap(final Map<String, ?> rawValues) {
     processSeenValues(rawValues);
     final Map<String, Object> unprocessedConfig = new HashMap<>(rawValues);
+    final Map<String, Object> apiSpecConfig = new HashMap<>(rawValues);
     // Remove any keys that we're ignoring
-    KEYS_TO_IGNORE.forEach(unprocessedConfig::remove);
+    KEYS_TO_IGNORE.forEach(
+        key -> {
+          unprocessedConfig.remove(key);
+          if (!key.equals(PRESET_KEY) && !key.equals(CONFIG_NAME_KEY)) {
+            apiSpecConfig.remove(key);
+          }
+        });
 
     // Process phase0 config
-    configBuilder.rawConfig(unprocessedConfig);
+    configBuilder.rawConfig(apiSpecConfig);
     streamConfigSetters(configBuilder.getClass())
         .forEach(
             setter -> {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.util.config.Constants;
 
@@ -43,6 +44,21 @@ public class SpecConfigLoaderTest {
       throws Exception {
     final SpecConfig config = SpecConfigLoader.loadConfig(name);
     assertAllFieldsSet(config, configType);
+  }
+
+  /**
+   * For the three networks supported by Infura, go the extra mile and ensure the CONFIG_NAME key is
+   * still included in the raw config which is exposed by the config/spec REST API.
+   *
+   * <p>Prior to Altair, Lighthouse required this field to be a known testnet name, mainnet or
+   * minimal. Post-Altair we will be able to remove this as the new PRESET_BASE key will be
+   * sufficient.
+   */
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(strings = {"prater", "pyrmont", "mainnet"})
+  public void shouldMaintainConfigNameBackwardsCompatibility(final String name) {
+    final SpecConfig config = SpecConfigLoader.loadConfig(name);
+    assertThat(config.getRawConfig().get("CONFIG_NAME")).isEqualTo(name);
   }
 
   @Test

--- a/util/src/main/java/tech/pegasys/teku/util/config/ConstantsReader.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/ConstantsReader.java
@@ -41,6 +41,7 @@ class ConstantsReader {
   private static final ImmutableList<String> FIELDS_TO_IGNORE =
       ImmutableList.of(
           PRESET_FIELD,
+          "CONFIG_NAME", // Legacy field
           // Altair fields
           "ALTAIR_FORK_VERSION",
           "ALTAIR_FORK_EPOCH",

--- a/util/src/main/resources/tech/pegasys/teku/util/config/configs/mainnet.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/configs/mainnet.yaml
@@ -3,6 +3,9 @@
 # Extends the mainnet preset
 PRESET_BASE: 'mainnet'
 
+# For backwards compatibility in the config/spec API
+CONFIG_NAME: "mainnet"
+
 # Genesis
 # ---------------------------------------------------------------
 # `2**14` (= 16,384)

--- a/util/src/main/resources/tech/pegasys/teku/util/config/configs/prater.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/configs/prater.yaml
@@ -1,5 +1,8 @@
 # Prater preset
 
+# For backwards compatibility in the config/spec API
+CONFIG_NAME: "prater"
+
 # Misc
 # ---------------------------------------------------------------
 # 2**6 (= 64)

--- a/util/src/main/resources/tech/pegasys/teku/util/config/configs/pyrmont.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/configs/pyrmont.yaml
@@ -1,5 +1,8 @@
 # Pyrmont preset
 
+# For backwards compatibility in the config/spec API
+CONFIG_NAME: "pyrmont"
+
 # Misc
 # ---------------------------------------------------------------
 # 2**6 (= 64)


### PR DESCRIPTION
## PR Description
Lighthouse requires the `CONFIG_NAME` field to be present in the `/eth/v1/config/spec` endpoint.  That value was removed from the actual spec, but for backwards compatibility, re-add it for pyrmont, prater and mainnet.  Also include the `PRESET_BASE` field in the spec response which will be needed by newer versions of Lighthouse.

Once Altair has been deployed we'll be able to remove `CONFIG_NAME` as everything will have had to be upgraded to versions using `PRESET_BASE`.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

`CONFIG_NAME` was still present when we did the last release so no changelog necessary.
