### PR TITLE
[Issue 4034] Fix threading issue in LevelDbTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Fixed regression where eth_getLogs responses from Infura that rejected the request because they returned too many logs did not retry the request with a smaller request range.
 - Experimental: Fix for eth1 follow distance tracking revealed in Rayonism testnets. Teku incorrectly strictly follows 2048 blocks before the eth1 head but the follow distance should be based on timestamp, not block number.
   An experimental fix for this can be enabled with `--Xeth1-time-based-head-tracking-enabled`. Further testing will be conducted before enabling this by default.
+- Prevent LevelDB transactions from attempting to make any updates after the database is shut down
 
 ### Experimental: New Altair REST APIs
 - implement POST `/eth/v1/beacon/pool/sync_committees` to allow validators to submit sync committee signatures to the beacon node.

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
@@ -279,8 +279,9 @@ public class LevelDbInstance implements KvStoreAccessor {
   }
 
   synchronized void onTransactionClosed(final LevelDbTransaction transaction) {
-    closedTransactionsCounter.inc();
-    openTransactions.remove(transaction);
+    if (openTransactions.remove(transaction)) {
+      closedTransactionsCounter.inc();
+    }
   }
 
   private DBIterator createIterator() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbTransaction.java
@@ -19,7 +19,7 @@ import static tech.pegasys.teku.storage.server.leveldb.LevelDbUtils.getVariableK
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.WriteBatch;
 import tech.pegasys.teku.storage.server.ShuttingDownException;
@@ -29,7 +29,8 @@ import tech.pegasys.teku.storage.server.kvstore.schema.KvStoreVariable;
 
 public class LevelDbTransaction implements KvStoreTransaction {
 
-  private final AtomicBoolean closed = new AtomicBoolean(false);
+  private boolean closed = false;
+  private final ReentrantLock lock = new ReentrantLock();
 
   private final LevelDbInstance dbInstance;
   private final DB db;
@@ -44,67 +45,82 @@ public class LevelDbTransaction implements KvStoreTransaction {
 
   @Override
   public <T> void put(final KvStoreVariable<T> variable, final T value) {
-    assertOpen();
-    writeBatch.put(getVariableKey(variable), variable.getSerializer().serialize(value));
+    applyUpdate(
+        () -> writeBatch.put(getVariableKey(variable), variable.getSerializer().serialize(value)));
   }
 
   @Override
   public <K, V> void put(final KvStoreColumn<K, V> column, final K key, final V value) {
-    assertOpen();
-    writeBatch.put(getColumnKey(column, key), serializeValue(column, value));
+    applyUpdate(() -> writeBatch.put(getColumnKey(column, key), serializeValue(column, value)));
   }
 
   @Override
   public <K, V> void put(final KvStoreColumn<K, V> column, final Map<K, V> data) {
-    assertOpen();
-    data.forEach(
-        (key, value) -> writeBatch.put(getColumnKey(column, key), serializeValue(column, value)));
+    applyUpdate(
+        () ->
+            data.forEach(
+                (key, value) ->
+                    writeBatch.put(getColumnKey(column, key), serializeValue(column, value))));
   }
 
   @Override
   public <K, V> void delete(final KvStoreColumn<K, V> column, final K key) {
-    assertOpen();
-    writeBatch.delete(getColumnKey(column, key));
+    applyUpdate(() -> writeBatch.delete(getColumnKey(column, key)));
   }
 
   @Override
   public <T> void delete(final KvStoreVariable<T> variable) {
-    assertOpen();
-    writeBatch.delete(getVariableKey(variable));
+    applyUpdate(() -> writeBatch.delete(getVariableKey(variable)));
   }
 
   @Override
   public void commit() {
-    assertOpen();
-    try {
-      db.write(writeBatch);
-    } finally {
-      close();
-    }
+    applyUpdate(
+        () -> {
+          try {
+            db.write(writeBatch);
+          } finally {
+            close();
+          }
+        });
   }
 
   @Override
   public void rollback() {
-    assertOpen();
-    close();
+    applyUpdate(this::close);
   }
 
   @Override
   public void close() {
-    if (!closed.compareAndSet(false, true)) {
-      return;
-    }
+    lock.lock();
     try {
+      if (closed) {
+        // Already closed
+        return;
+      }
+      closed = true;
       writeBatch.close();
+      dbInstance.onTransactionClosed(this);
     } catch (IOException e) {
+      dbInstance.onTransactionClosed(this);
       throw new UncheckedIOException(e);
     } finally {
-      dbInstance.onTransactionClosed(this);
+      lock.unlock();
+    }
+  }
+
+  private void applyUpdate(final Runnable operation) {
+    lock.lock();
+    try {
+      assertOpen();
+      operation.run();
+    } finally {
+      lock.unlock();
     }
   }
 
   private void assertOpen() {
-    if (closed.get()) {
+    if (closed) {
       throw new ShuttingDownException();
     }
     dbInstance.assertOpen();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbTransaction.java
@@ -87,7 +87,7 @@ public class LevelDbTransaction implements KvStoreTransaction {
 
   @Override
   public void rollback() {
-    applyUpdate(this::close);
+    close();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -31,7 +30,6 @@ import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.TransactionDB;
-import org.rocksdb.WriteOptions;
 import tech.pegasys.teku.storage.server.ShuttingDownException;
 import tech.pegasys.teku.storage.server.kvstore.ColumnEntry;
 import tech.pegasys.teku.storage.server.kvstore.KvStoreAccessor;
@@ -44,7 +42,7 @@ public class RocksDbInstance implements KvStoreAccessor {
   private final ColumnFamilyHandle defaultHandle;
   private final ImmutableMap<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandles;
   private final List<AutoCloseable> resources;
-  private final Set<Transaction> openTransactions = new HashSet<>();
+  private final Set<RocksDbTransaction> openTransactions = new HashSet<>();
 
   private final AtomicBoolean closed = new AtomicBoolean(false);
 
@@ -144,7 +142,8 @@ public class RocksDbInstance implements KvStoreAccessor {
   @MustBeClosed
   public synchronized KvStoreTransaction startTransaction() {
     assertOpen();
-    Transaction tx = new Transaction(db, defaultHandle, columnHandles, openTransactions::remove);
+    RocksDbTransaction tx =
+        new RocksDbTransaction(db, defaultHandle, columnHandles, openTransactions::remove);
     openTransactions.add(tx);
     return tx;
   }
@@ -170,7 +169,7 @@ public class RocksDbInstance implements KvStoreAccessor {
   @Override
   public synchronized void close() throws Exception {
     if (closed.compareAndSet(false, true)) {
-      for (Transaction openTransaction : openTransactions) {
+      for (RocksDbTransaction openTransaction : openTransactions) {
         openTransaction.closeViaDatabase();
       }
       db.syncWal();
@@ -183,168 +182,6 @@ public class RocksDbInstance implements KvStoreAccessor {
   private void assertOpen() {
     if (closed.get()) {
       throw new ShuttingDownException();
-    }
-  }
-
-  public static class Transaction implements KvStoreTransaction {
-    private final ColumnFamilyHandle defaultHandle;
-    private final ImmutableMap<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandles;
-    private final org.rocksdb.Transaction rocksDbTx;
-    private final WriteOptions writeOptions;
-
-    private final ReentrantLock lock = new ReentrantLock();
-    private final AtomicBoolean closedViaDatabase = new AtomicBoolean(false);
-    private final Consumer<Transaction> onClosed;
-    private boolean closed = false;
-
-    private Transaction(
-        final TransactionDB db,
-        final ColumnFamilyHandle defaultHandle,
-        final ImmutableMap<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandles,
-        final Consumer<Transaction> onClosed) {
-      this.defaultHandle = defaultHandle;
-      this.columnHandles = columnHandles;
-      this.writeOptions = new WriteOptions();
-      this.rocksDbTx = db.beginTransaction(writeOptions);
-      this.onClosed = onClosed;
-    }
-
-    @Override
-    public <T> void put(KvStoreVariable<T> variable, T value) {
-      applyUpdate(
-          () -> {
-            final byte[] serialized = variable.getSerializer().serialize(value);
-            try {
-              rocksDbTx.put(defaultHandle, variable.getId().toArrayUnsafe(), serialized);
-            } catch (RocksDBException e) {
-              throw RocksDbExceptionUtil.wrapException("Failed to put variable", e);
-            }
-          });
-    }
-
-    @Override
-    public <K, V> void put(KvStoreColumn<K, V> column, K key, V value) {
-      applyUpdate(
-          () -> {
-            final byte[] keyBytes = column.getKeySerializer().serialize(key);
-            final byte[] valueBytes = column.getValueSerializer().serialize(value);
-            final ColumnFamilyHandle handle = columnHandles.get(column);
-            try {
-              rocksDbTx.put(handle, keyBytes, valueBytes);
-            } catch (RocksDBException e) {
-              throw RocksDbExceptionUtil.wrapException("Failed to put column data", e);
-            }
-          });
-    }
-
-    @Override
-    public <K, V> void put(KvStoreColumn<K, V> column, Map<K, V> data) {
-      applyUpdate(
-          () -> {
-            final ColumnFamilyHandle handle = columnHandles.get(column);
-            for (Map.Entry<K, V> kvEntry : data.entrySet()) {
-              final byte[] key = column.getKeySerializer().serialize(kvEntry.getKey());
-              final byte[] value = column.getValueSerializer().serialize(kvEntry.getValue());
-              try {
-                rocksDbTx.put(handle, key, value);
-              } catch (RocksDBException e) {
-                throw RocksDbExceptionUtil.wrapException("Failed to put column data", e);
-              }
-            }
-          });
-    }
-
-    @Override
-    public <K, V> void delete(KvStoreColumn<K, V> column, K key) {
-      applyUpdate(
-          () -> {
-            final ColumnFamilyHandle handle = columnHandles.get(column);
-            try {
-              rocksDbTx.delete(handle, column.getKeySerializer().serialize(key));
-            } catch (RocksDBException e) {
-              throw RocksDbExceptionUtil.wrapException("Failed to delete key", e);
-            }
-          });
-    }
-
-    @Override
-    public <T> void delete(KvStoreVariable<T> variable) {
-      applyUpdate(
-          () -> {
-            try {
-              rocksDbTx.delete(defaultHandle, variable.getId().toArrayUnsafe());
-            } catch (RocksDBException e) {
-              throw RocksDbExceptionUtil.wrapException("Failed to delete variable", e);
-            }
-          });
-    }
-
-    @Override
-    public void commit() {
-      applyUpdate(
-          () -> {
-            try {
-              this.rocksDbTx.commit();
-            } catch (RocksDBException e) {
-              throw RocksDbExceptionUtil.wrapException("Failed to commit transaction", e);
-            } finally {
-              close();
-            }
-          });
-    }
-
-    @Override
-    public void rollback() {
-      applyUpdate(
-          () -> {
-            try {
-              this.rocksDbTx.commit();
-            } catch (RocksDBException e) {
-              throw RocksDbExceptionUtil.wrapException("Failed to commit transaction", e);
-            } finally {
-              close();
-            }
-          });
-    }
-
-    private void applyUpdate(final Runnable operation) {
-      lock.lock();
-      try {
-        assertOpen();
-        operation.run();
-      } finally {
-        lock.unlock();
-      }
-    }
-
-    private void assertOpen() {
-      if (closed) {
-        if (closedViaDatabase.get()) {
-          throw new ShuttingDownException();
-        } else {
-          throw new IllegalStateException("Attempt to update a closed transaction");
-        }
-      }
-    }
-
-    private void closeViaDatabase() {
-      closedViaDatabase.set(true);
-      close();
-    }
-
-    @Override
-    public void close() {
-      lock.lock();
-      try {
-        if (!closed) {
-          closed = true;
-          onClosed.accept(this);
-          writeOptions.close();
-          rocksDbTx.close();
-        }
-      } finally {
-        lock.unlock();
-      }
     }
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbTransaction.java
@@ -139,9 +139,9 @@ public class RocksDbTransaction implements KvStoreTransaction {
     applyUpdate(
         () -> {
           try {
-            this.rocksDbTx.commit();
+            this.rocksDbTx.rollback();
           } catch (RocksDBException e) {
-            throw RocksDbExceptionUtil.wrapException("Failed to commit transaction", e);
+            throw RocksDbExceptionUtil.wrapException("Failed to rollback transaction", e);
           } finally {
             close();
           }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbTransaction.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.rocksdb;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.TransactionDB;
+import org.rocksdb.WriteOptions;
+import tech.pegasys.teku.storage.server.ShuttingDownException;
+import tech.pegasys.teku.storage.server.kvstore.KvStoreAccessor.KvStoreTransaction;
+import tech.pegasys.teku.storage.server.kvstore.schema.KvStoreColumn;
+import tech.pegasys.teku.storage.server.kvstore.schema.KvStoreVariable;
+
+public class RocksDbTransaction implements KvStoreTransaction {
+  private final ColumnFamilyHandle defaultHandle;
+  private final ImmutableMap<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandles;
+  private final org.rocksdb.Transaction rocksDbTx;
+  private final WriteOptions writeOptions;
+
+  private final ReentrantLock lock = new ReentrantLock();
+  private final AtomicBoolean closedViaDatabase = new AtomicBoolean(false);
+  private final Consumer<RocksDbTransaction> onClosed;
+  private boolean closed = false;
+
+  RocksDbTransaction(
+      final TransactionDB db,
+      final ColumnFamilyHandle defaultHandle,
+      final ImmutableMap<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandles,
+      final Consumer<RocksDbTransaction> onClosed) {
+    this.defaultHandle = defaultHandle;
+    this.columnHandles = columnHandles;
+    this.writeOptions = new WriteOptions();
+    this.rocksDbTx = db.beginTransaction(writeOptions);
+    this.onClosed = onClosed;
+  }
+
+  @Override
+  public <T> void put(KvStoreVariable<T> variable, T value) {
+    applyUpdate(
+        () -> {
+          final byte[] serialized = variable.getSerializer().serialize(value);
+          try {
+            rocksDbTx.put(defaultHandle, variable.getId().toArrayUnsafe(), serialized);
+          } catch (RocksDBException e) {
+            throw RocksDbExceptionUtil.wrapException("Failed to put variable", e);
+          }
+        });
+  }
+
+  @Override
+  public <K, V> void put(KvStoreColumn<K, V> column, K key, V value) {
+    applyUpdate(
+        () -> {
+          final byte[] keyBytes = column.getKeySerializer().serialize(key);
+          final byte[] valueBytes = column.getValueSerializer().serialize(value);
+          final ColumnFamilyHandle handle = columnHandles.get(column);
+          try {
+            rocksDbTx.put(handle, keyBytes, valueBytes);
+          } catch (RocksDBException e) {
+            throw RocksDbExceptionUtil.wrapException("Failed to put column data", e);
+          }
+        });
+  }
+
+  @Override
+  public <K, V> void put(KvStoreColumn<K, V> column, Map<K, V> data) {
+    applyUpdate(
+        () -> {
+          final ColumnFamilyHandle handle = columnHandles.get(column);
+          for (Map.Entry<K, V> kvEntry : data.entrySet()) {
+            final byte[] key = column.getKeySerializer().serialize(kvEntry.getKey());
+            final byte[] value = column.getValueSerializer().serialize(kvEntry.getValue());
+            try {
+              rocksDbTx.put(handle, key, value);
+            } catch (RocksDBException e) {
+              throw RocksDbExceptionUtil.wrapException("Failed to put column data", e);
+            }
+          }
+        });
+  }
+
+  @Override
+  public <K, V> void delete(KvStoreColumn<K, V> column, K key) {
+    applyUpdate(
+        () -> {
+          final ColumnFamilyHandle handle = columnHandles.get(column);
+          try {
+            rocksDbTx.delete(handle, column.getKeySerializer().serialize(key));
+          } catch (RocksDBException e) {
+            throw RocksDbExceptionUtil.wrapException("Failed to delete key", e);
+          }
+        });
+  }
+
+  @Override
+  public <T> void delete(KvStoreVariable<T> variable) {
+    applyUpdate(
+        () -> {
+          try {
+            rocksDbTx.delete(defaultHandle, variable.getId().toArrayUnsafe());
+          } catch (RocksDBException e) {
+            throw RocksDbExceptionUtil.wrapException("Failed to delete variable", e);
+          }
+        });
+  }
+
+  @Override
+  public void commit() {
+    applyUpdate(
+        () -> {
+          try {
+            this.rocksDbTx.commit();
+          } catch (RocksDBException e) {
+            throw RocksDbExceptionUtil.wrapException("Failed to commit transaction", e);
+          } finally {
+            close();
+          }
+        });
+  }
+
+  @Override
+  public void rollback() {
+    applyUpdate(
+        () -> {
+          try {
+            this.rocksDbTx.commit();
+          } catch (RocksDBException e) {
+            throw RocksDbExceptionUtil.wrapException("Failed to commit transaction", e);
+          } finally {
+            close();
+          }
+        });
+  }
+
+  private void applyUpdate(final Runnable operation) {
+    lock.lock();
+    try {
+      assertOpen();
+      operation.run();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void assertOpen() {
+    if (closed) {
+      if (closedViaDatabase.get()) {
+        throw new ShuttingDownException();
+      } else {
+        throw new IllegalStateException("Attempt to update a closed transaction");
+      }
+    }
+  }
+
+  void closeViaDatabase() {
+    closedViaDatabase.set(true);
+    close();
+  }
+
+  @Override
+  public void close() {
+    lock.lock();
+    try {
+      if (!closed) {
+        closed = true;
+        onClosed.accept(this);
+        writeOptions.close();
+        rocksDbTx.close();
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/AbstractKvStoreDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/AbstractKvStoreDatabaseTest.java
@@ -50,7 +50,7 @@ import tech.pegasys.teku.storage.store.StoreBuilder;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
-public abstract class AbstractRocksDbDatabaseTest extends AbstractStorageBackedDatabaseTest {
+public abstract class AbstractKvStoreDatabaseTest extends AbstractStorageBackedDatabaseTest {
 
   @Test
   public void shouldThrowIfClosedDatabaseIsModified_setGenesis() throws Exception {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/AbstractKvStoreDatabaseWithHotStatesTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/AbstractKvStoreDatabaseWithHotStatesTest.java
@@ -28,7 +28,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.storage.server.StateStorageMode;
 import tech.pegasys.teku.storage.store.StoreConfig;
 
-public abstract class AbstractKvStoreDatabaseWithHotStatesTest extends AbstractRocksDbDatabaseTest {
+public abstract class AbstractKvStoreDatabaseWithHotStatesTest extends AbstractKvStoreDatabaseTest {
 
   @Test
   public void shouldPersistHotStates_everyEpoch() {

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystemArgumentsProvider.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystemArgumentsProvider.java
@@ -85,6 +85,24 @@ public class StorageSystemArgumentsProvider implements ArgumentsProvider {
                     .storageMode(mode)
                     .stateStorageFrequency(storageFrequency)
                     .build());
+        storageSystems.put(
+            describeStorage("leveldb1 (file-backed)", storageFrequency),
+            (dataPath) ->
+                FileBackedStorageSystemBuilder.create()
+                    .version(DatabaseVersion.LEVELDB1)
+                    .dataDir(dataPath)
+                    .storageMode(mode)
+                    .stateStorageFrequency(storageFrequency)
+                    .build());
+        storageSystems.put(
+            describeStorage("leveldb2 (file-backed)", storageFrequency),
+            (dataPath) ->
+                FileBackedStorageSystemBuilder.create()
+                    .version(DatabaseVersion.LEVELDB2)
+                    .dataDir(dataPath)
+                    .storageMode(mode)
+                    .stateStorageFrequency(storageFrequency)
+                    .build());
       }
     }
     return storageSystems.entrySet().stream()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fix threading issue in `LevelDbTransaction`: we had nothing in place to prevent `tx.close()` from running concurrently with other tx update methods.  Individual transactions are not meant to be accessed across multiple threads, but when the database is closed, `tx.close()` can be invoked from a different thread.

Also:
* Move `RocksDbTransaction` out to a separate class
* Rename `AbstractRocksDbDatabaseTest ` to `AbstractKvStoreDatabaseTest`
* Fix `RocksDbTransaction.rollback()`
* Add leveldb instances to `StorageSystemArgumentsProvider`

## Fixed Issue(s)
Fixes #4034 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
