### PR TITLE
Update to discovery 0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ## Unreleased Changes
 
 ### Additions and Improvements
+- Fixed issues in discv5 `PING` and `PONG` message handling which resulted in not updating peer's ENR records correctly.
 - Implement alpha.7 spec updates to sync committee logic and rewards
 
 ### Bug Fixes

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -153,7 +153,7 @@ dependencyManagement {
     dependency "org.testcontainers:testcontainers:1.15.3"
     dependency "org.testcontainers:junit-jupiter:1.15.3"
 
-    dependency 'tech.pegasys.discovery:discovery:0.4.5'
+    dependency 'tech.pegasys.discovery:discovery:0.4.7'
 
     dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.15'
 


### PR DESCRIPTION
## PR Description
Update discovery to 0.4.7. Includes fixes for publishing the correct ENR sequence number and update peer's ENRs when their sequence number increases.

## Fixed Issue(s)
fixes #4048 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
