### PR TITLE
Change `/eth/v1/node/health` to notify 206 during startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ For information on changes in released versions of Teku, see the [releases page]
 - Implement alpha.7 spec updates to sync committee logic and rewards
 
 ### Bug Fixes
-- Prevent LevelDB transactions from attempting to make any updates after the database is shut down
+- Prevent LevelDB transactions from attempting to make any updates after the database is shut down.
+- Update `/eth/v1/node/health` to return 206 while node is starting up rather than a 200.
 
 ### Experimental: New Altair REST APIs
 - implement POST `/eth/v1/beacon/pool/sync_committees` to allow validators to submit sync committee signatures to the beacon node.

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostSyncDutiesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostSyncDutiesIntegrationTest.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostSyncDuties;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.sync.events.SyncState;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuty;
 
@@ -48,7 +49,7 @@ public class PostSyncDutiesIntegrationTest extends AbstractDataBackedRestAPIInte
                     List.of(
                         new SyncCommitteeDuty(
                             VALIDATOR_KEYS.get(1).getPublicKey(), 1, Set.of(11))))));
-
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
     when(validatorApiChannel.getSyncCommitteeDuties(ONE, validators)).thenReturn(out);
 
     Response response =

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealthTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealthTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
+import tech.pegasys.teku.sync.events.SyncState;
 
 public class GetHealthTest extends AbstractBeaconHandlerTest {
 
@@ -31,7 +32,18 @@ public class GetHealthTest extends AbstractBeaconHandlerTest {
   public void shouldReturnSyncingStatusWhenSyncing() throws Exception {
     final GetHealth handler = new GetHealth(syncDataProvider, chainDataProvider);
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
-    when(syncService.isSyncActive()).thenReturn(true);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.SYNCING);
+
+    handler.handle(context);
+    verifyCacheStatus(CACHE_NONE);
+    verifyStatusCode(SC_PARTIAL_CONTENT);
+  }
+
+  @Test
+  public void shouldReturnSyncingStatusWhenStartingUp() throws Exception {
+    final GetHealth handler = new GetHealth(syncDataProvider, chainDataProvider);
+    when(chainDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.START_UP);
 
     handler.handle(context);
     verifyCacheStatus(CACHE_NONE);
@@ -42,7 +54,7 @@ public class GetHealthTest extends AbstractBeaconHandlerTest {
   public void shouldReturnCustomSyncingStatusWhenSyncing() throws Exception {
     final GetHealth handler = new GetHealth(syncDataProvider, chainDataProvider);
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
-    when(syncService.isSyncActive()).thenReturn(true);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.SYNCING);
     when(context.queryParamMap()).thenReturn(Map.of(SYNCING_STATUS, List.of("100")));
 
     handler.handle(context);
@@ -54,7 +66,7 @@ public class GetHealthTest extends AbstractBeaconHandlerTest {
   public void shouldReturnDefaultSyncingStatusWhenSyncingWrongParam() throws Exception {
     final GetHealth handler = new GetHealth(syncDataProvider, chainDataProvider);
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
-    when(syncService.isSyncActive()).thenReturn(true);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.SYNCING);
     when(context.queryParamMap()).thenReturn(Map.of(SYNCING_STATUS, List.of("a")));
 
     handler.handle(context);
@@ -66,7 +78,7 @@ public class GetHealthTest extends AbstractBeaconHandlerTest {
   public void shouldReturnDefaultSyncingStatusWhenSyncingMultipleParams() throws Exception {
     final GetHealth handler = new GetHealth(syncDataProvider, chainDataProvider);
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
-    when(syncService.isSyncActive()).thenReturn(true);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.SYNCING);
     when(context.queryParamMap()).thenReturn(Map.of(SYNCING_STATUS, List.of("1", "2")));
 
     handler.handle(context);
@@ -78,7 +90,7 @@ public class GetHealthTest extends AbstractBeaconHandlerTest {
   public void shouldReturnOkWhenInSyncAndReady() throws Exception {
     final GetHealth handler = new GetHealth(syncDataProvider, chainDataProvider);
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
-    when(syncService.isSyncActive()).thenReturn(false);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
 
     handler.handle(context);
     verifyCacheStatus(CACHE_NONE);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/AbstractValidatorApiTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/AbstractValidatorApiTest.java
@@ -23,6 +23,7 @@ import io.javalin.http.Handler;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
+import tech.pegasys.teku.sync.events.SyncState;
 
 public abstract class AbstractValidatorApiTest extends AbstractBeaconHandlerTest {
   protected Handler handler;
@@ -30,7 +31,7 @@ public abstract class AbstractValidatorApiTest extends AbstractBeaconHandlerTest
   @Test
   public void shouldReturnBadRequestIfEpochDoesNotParse() throws Exception {
     when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
-    when(syncService.isSyncActive()).thenReturn(false);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
     when(context.pathParamMap()).thenReturn(Map.of("epoch", "epoch"));
     handler.handle(context);
     verifyStatusCode(SC_BAD_REQUEST);
@@ -39,8 +40,15 @@ public abstract class AbstractValidatorApiTest extends AbstractBeaconHandlerTest
   @Test
   public void shouldReturnNotReadyWhenSyncing() throws Exception {
     when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
-    when(syncService.isSyncActive()).thenReturn(true);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.SYNCING);
+    handler.handle(context);
+    verifyStatusCode(SC_SERVICE_UNAVAILABLE);
+  }
 
+  @Test
+  public void shouldReturnNotReadyWhenStartingUp() throws Exception {
+    when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.START_UP);
     handler.handle(context);
     verifyStatusCode(SC_SERVICE_UNAVAILABLE);
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDutiesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDutiesTest.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.sync.events.SyncState;
 
 public class GetProposerDutiesTest extends AbstractValidatorApiTest {
 
@@ -42,7 +43,7 @@ public class GetProposerDutiesTest extends AbstractValidatorApiTest {
   @Test
   public void shouldGetProposerDuties() throws Exception {
     when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
-    when(syncService.isSyncActive()).thenReturn(false);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
     when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
 
     GetProposerDutiesResponse duties =
@@ -60,7 +61,7 @@ public class GetProposerDutiesTest extends AbstractValidatorApiTest {
   @Test
   public void shouldReturnBadRequestWhenIllegalArgumentExceptionThrown() throws Exception {
     when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
-    when(syncService.isSyncActive()).thenReturn(false);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
     when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
     when(validatorDataProvider.getProposerDuties(UInt64.valueOf(100)))
         .thenReturn(SafeFuture.failedFuture(new IllegalArgumentException("Bad epoch")));

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDutiesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDutiesTest.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.sync.events.SyncState;
 
 public class PostAttesterDutiesTest extends AbstractValidatorApiTest {
 
@@ -44,7 +45,8 @@ public class PostAttesterDutiesTest extends AbstractValidatorApiTest {
   @Test
   public void shouldReturnServiceUnavailableWhenResultIsEmpty() throws Exception {
     when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
-    when(syncService.isSyncActive()).thenReturn(false);
+
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
     when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
     when(context.body()).thenReturn("[\"2\"]");
     when(validatorDataProvider.getAttesterDuties(eq(UInt64.valueOf(100)), any()))
@@ -57,7 +59,7 @@ public class PostAttesterDutiesTest extends AbstractValidatorApiTest {
   @Test
   public void shouldGetAttesterDuties() throws Exception {
     when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
-    when(syncService.isSyncActive()).thenReturn(false);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
     when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
     when(context.body()).thenReturn("[\"2\"]");
 
@@ -77,7 +79,7 @@ public class PostAttesterDutiesTest extends AbstractValidatorApiTest {
   @Test
   public void shouldReturnBadRequestWhenIllegalArgumentExceptionThrown() throws Exception {
     when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
-    when(syncService.isSyncActive()).thenReturn(false);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
     when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
     when(context.body()).thenReturn("[\"2\"]");
     when(validatorDataProvider.getAttesterDuties(UInt64.valueOf(100), List.of(2)))

--- a/data/provider/src/main/java/tech/pegasys/teku/api/SyncDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/SyncDataProvider.java
@@ -40,8 +40,11 @@ public class SyncDataProvider {
     return syncService.unsubscribeFromSyncStateChanges(subscriberId);
   }
 
+  // Sync state can be influenced by needing to sync from nodes, but also from
+  // starting up and having a lack of peers. Consider both 'syncing' and 'startup'
+  // as 'isSyncing', as both of these states will mean that you can't perform duties
   public boolean isSyncing() {
-    return syncService.isSyncActive();
+    return !syncService.getCurrentSyncState().isInSync();
   }
 
   private UInt64 getSlotsBehind(final tech.pegasys.teku.sync.events.SyncingStatus syncingStatus) {


### PR DESCRIPTION
 - During startup before a node has peers, node/health was notifying it was healthy, even though the node wasn't able to service requests.

 - similarly we would potentially have been able to accept a block to post or provide attester and proposer duties when we shouldn't really be performing these actions during startup

 fixes #4078.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
