### PR TITLE
Ensure that fork choice has run prior to creating attestations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
 - Prevent LevelDB transactions from attempting to make any updates after the database is shut down
+- Fixed issue which cause a small reduction in attestation rewards when using `--Xvalidators-dependent-root-enabled`.
 
 ### Experimental: New Altair REST APIs
 - implement POST `/eth/v1/beacon/pool/sync_committees` to allow validators to submit sync committee signatures to the beacon node.

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceRatchet.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceRatchet.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/**
+ * Provides a ratchet-like functionality for running fork choice. Callers request that fork choice
+ * be run for a specific slot and this class tracks which slot fork choice has been run for, only
+ * running it again when the slot needs to ratchet up. Thus the slot we run fork choice for only
+ * ever moves up and fork choice is never run for old slots, avoiding unnecessary work.
+ */
+class ForkChoiceRatchet {
+
+  private static final Logger LOG = LogManager.getLogger();
+  private final AtomicReference<ForkChoiceUpdate> latestCompletedForkChoice =
+      new AtomicReference<>();
+
+  private final ForkChoice forkChoice;
+
+  ForkChoiceRatchet(final ForkChoice forkChoice) {
+    this.forkChoice = forkChoice;
+  }
+
+  void scheduleForkChoiceForSlot(final UInt64 slot) {
+    processHead(slot);
+  }
+
+  SafeFuture<Void> ensureForkChoiceCompleteForSlot(final UInt64 slot) {
+    final ForkChoiceUpdate forkChoiceUpdate = processHead(slot);
+    if (forkChoiceUpdate.nodeSlot.isGreaterThan(slot)) {
+      return SafeFuture.COMPLETE;
+    } else if (forkChoiceUpdate.nodeSlot.equals(slot)) {
+      return forkChoiceUpdate.result;
+    } else {
+      // Only possible if processHead messed up somehow
+      return SafeFuture.failedFuture(
+          new IllegalStateException(
+              "Requested fork choice be processed for slot "
+                  + slot
+                  + " but result indicates fork choice was only up to "
+                  + forkChoiceUpdate.nodeSlot));
+    }
+  }
+
+  private ForkChoiceUpdate processHead(final UInt64 nodeSlot) {
+    // Keep trying to get our slot processed until we or someone else gets it done
+    while (true) {
+      final ForkChoiceUpdate previousUpdate = latestCompletedForkChoice.get();
+      if (previousUpdate != null && previousUpdate.nodeSlot.isGreaterThanOrEqualTo(nodeSlot)) {
+        LOG.debug(
+            "Skipping fork choice update for slot {} as high water mark is already {}",
+            nodeSlot,
+            previousUpdate.nodeSlot);
+        return previousUpdate;
+      }
+      final ForkChoiceUpdate newUpdate = new ForkChoiceUpdate(nodeSlot);
+      if (latestCompletedForkChoice.compareAndSet(previousUpdate, newUpdate)) {
+        forkChoice
+            .processHead(nodeSlot)
+            // We handle errors in fork choice by logging them but then continuing
+            // as we don't want to fail to produce a block because fork choice failed.
+            .handleException(error -> LOG.error("Fork choice process head failed", error))
+            .propagateTo(newUpdate.result);
+        return newUpdate;
+      }
+    }
+  }
+
+  private static class ForkChoiceUpdate {
+
+    private final UInt64 nodeSlot;
+    private final SafeFuture<Void> result = new SafeFuture<>();
+
+    private ForkChoiceUpdate(final UInt64 nodeSlot) {
+      this.nodeSlot = nodeSlot;
+    }
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTrigger.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTrigger.java
@@ -25,11 +25,13 @@ public interface ForkChoiceTrigger {
         : new OriginalForkChoiceTrigger(forkChoice);
   }
 
-  void onSlotStartedWhileSyncing(final UInt64 nodeSlot);
+  void onSlotStartedWhileSyncing(final UInt64 slot);
 
-  void onSlotStarted(final UInt64 nodeSlot);
+  void onSlotStarted(final UInt64 slot);
 
-  void onAttestationsDueForSlot(final UInt64 nodeSlot);
+  void onAttestationsDueForSlot(final UInt64 slot);
 
   SafeFuture<Void> prepareForBlockProduction(final UInt64 slot);
+
+  SafeFuture<Void> prepareForAttestationProduction(final UInt64 slot);
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceRatchetTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceRatchetTest.java
@@ -87,4 +87,15 @@ class ForkChoiceRatchetTest {
     processHeadResult.complete(true);
     assertThat(result).isCompleted();
   }
+
+  @Test
+  void ensureForkChoiceCompleteForSlot_shouldNotFailWhenForkChoiceFails() {
+    // Don't make block or attestation fail if fork choice fails, just go with the fork we're on
+    final SafeFuture<Void> result = ratchet.ensureForkChoiceCompleteForSlot(UInt64.ONE);
+    verify(forkChoice).processHead(UInt64.ONE);
+    assertThat(result).isNotDone();
+
+    processHeadResult.completeExceptionally(new RuntimeException("Ka-boom!"));
+    assertThat(result).isCompleted();
+  }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceRatchetTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceRatchetTest.java
@@ -25,11 +25,11 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-class BalanceAttackMitigationForkChoiceTriggerTest {
+class ForkChoiceRatchetTest {
 
   private final ForkChoice forkChoice = mock(ForkChoice.class);
   private final SafeFuture<Boolean> processHeadResult = new SafeFuture<>();
-  private final ForkChoiceTrigger trigger = ForkChoiceTrigger.create(forkChoice, true);
+  private final ForkChoiceRatchet ratchet = new ForkChoiceRatchet(forkChoice);
 
   @BeforeEach
   void setUp() {
@@ -37,68 +37,37 @@ class BalanceAttackMitigationForkChoiceTriggerTest {
   }
 
   @Test
-  void shouldNotifyBlockDueWhenAttestationsDue() {
-    trigger.onAttestationsDueForSlot(UInt64.ONE);
-    verify(forkChoice).onBlocksDueForSlot(UInt64.ONE);
-    verifyNoMoreInteractions(forkChoice);
-  }
-
-  @Test
-  void shouldProcessHeadForEndingSlotOnSlotStart() {
-    trigger.onSlotStarted(UInt64.ONE);
-    verify(forkChoice).processHead(UInt64.ZERO);
-  }
-
-  @Test
-  void shouldProcessHeadForEndingSlotOnSlotStartAvoidingUnderflow() {
-    trigger.onSlotStarted(UInt64.ZERO);
-    verify(forkChoice).processHead(UInt64.ZERO);
-  }
-
-  @Test
-  void shouldProcessHeadOnSlotWhileSyncing() {
-    trigger.onSlotStartedWhileSyncing(UInt64.ONE);
-    verify(forkChoice).processHead(UInt64.ZERO);
-  }
-
-  @Test
-  void shouldProcessHeadOnSlotWhileSyncingAvoidingUnderflow() {
-    trigger.onSlotStartedWhileSyncing(UInt64.ZERO);
-    verify(forkChoice).processHead(UInt64.ZERO);
-  }
-
-  @Test
   void shouldNotRunForkChoiceAgainForTheSameSlot() {
-    trigger.onSlotStartedWhileSyncing(UInt64.ONE);
-    verify(forkChoice).processHead(UInt64.ZERO);
+    ratchet.scheduleForkChoiceForSlot(UInt64.ONE);
+    verify(forkChoice).processHead(UInt64.ONE);
 
-    trigger.onSlotStartedWhileSyncing(UInt64.ONE);
+    ratchet.scheduleForkChoiceForSlot(UInt64.ONE);
     verifyNoMoreInteractions(forkChoice);
   }
 
   @Test
   void shouldNotRunForkChoiceWhenSlotIsLessThanPreviousRun() {
-    trigger.onSlotStartedWhileSyncing(UInt64.valueOf(3));
+    ratchet.scheduleForkChoiceForSlot(UInt64.valueOf(2));
     verify(forkChoice).processHead(UInt64.valueOf(2));
 
-    trigger.onSlotStartedWhileSyncing(UInt64.ONE);
+    ratchet.scheduleForkChoiceForSlot(UInt64.ONE);
     verifyNoMoreInteractions(forkChoice);
   }
 
   @Test
-  void prepareForBlockProduction_shouldBeCompleteWhenLastForkChoiceForLaterSlot() {
-    trigger.onSlotStartedWhileSyncing(UInt64.valueOf(3));
+  void ensureForkChoiceCompleteForSlot_shouldBeCompleteWhenLastForkChoiceForLaterSlot() {
+    ratchet.scheduleForkChoiceForSlot(UInt64.valueOf(3));
 
-    final SafeFuture<Void> result = trigger.prepareForBlockProduction(UInt64.ONE);
+    final SafeFuture<Void> result = ratchet.ensureForkChoiceCompleteForSlot(UInt64.ONE);
     assertThat(result).isCompleted();
   }
 
   @Test
-  void prepareForBlockProduction_shouldCompleteWhenCurrentRunCompletesIfSlotIsTheSame() {
-    trigger.onSlotStartedWhileSyncing(UInt64.valueOf(2));
+  void ensureForkChoiceCompleteForSlot_shouldCompleteWhenCurrentRunCompletesIfSlotIsTheSame() {
+    ratchet.scheduleForkChoiceForSlot(UInt64.ONE);
     verify(forkChoice).processHead(UInt64.ONE);
 
-    final SafeFuture<Void> result = trigger.prepareForBlockProduction(UInt64.ONE);
+    final SafeFuture<Void> result = ratchet.ensureForkChoiceCompleteForSlot(UInt64.ONE);
     verifyNoMoreInteractions(forkChoice);
     assertThat(result).isNotDone();
 
@@ -107,11 +76,11 @@ class BalanceAttackMitigationForkChoiceTriggerTest {
   }
 
   @Test
-  void prepareForBlockProduction_shouldRunForkChoiceWhenSlotIsGreaterThanLastRun() {
-    trigger.onSlotStartedWhileSyncing(UInt64.ONE);
+  void ensureForkChoiceCompleteForSlot_shouldRunForkChoiceWhenSlotIsGreaterThanLastRun() {
+    ratchet.scheduleForkChoiceForSlot(UInt64.ZERO);
     verify(forkChoice).processHead(UInt64.ZERO);
 
-    final SafeFuture<Void> result = trigger.prepareForBlockProduction(UInt64.ONE);
+    final SafeFuture<Void> result = ratchet.ensureForkChoiceCompleteForSlot(UInt64.ONE);
     verify(forkChoice).processHead(UInt64.ONE);
     assertThat(result).isNotDone();
 

--- a/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.coordinator;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
@@ -103,6 +104,7 @@ public class ValidatorApiHandlerIntegrationTest {
   @BeforeEach
   public void setup() {
     when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    when(forkChoiceTrigger.prepareForAttestationProduction(any())).thenReturn(SafeFuture.COMPLETE);
   }
 
   @Test
@@ -153,6 +155,7 @@ public class ValidatorApiHandlerIntegrationTest {
       latestBlock = chainUpdater.advanceChain();
       chainUpdater.updateBestBlock(latestBlock);
     }
+    chainUpdater.setCurrentSlot(targetSlot);
     assertThat(latestBlock).isNotNull();
     final Checkpoint expectedTarget = new Checkpoint(targetEpoch, latestBlock.getRoot());
 


### PR DESCRIPTION
## PR Description
Ensure that fork choice has run prior to creating attestations. 

This only makes a difference when using dependent roots as otherwise fork choice is automatically run before sending the event that triggers attestation creation. Not running fork choice prior to creating attestations results in a reduction in attestation rewards which this change fixes.

## Fixed Issue(s)
#3569 


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
