### PR TITLE
Add readiness endpoint

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.Liveness;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.PutLogLevel;
+import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.Readiness;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetAllBlocksAtSlot;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetSszState;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetStateByBlockRoot;
@@ -284,6 +285,7 @@ public class BeaconRestApi {
     app.get(GetSszState.ROUTE, new GetSszState(provider, jsonProvider));
     app.get(GetStateByBlockRoot.ROUTE, new GetStateByBlockRoot(provider, jsonProvider));
     app.get(Liveness.ROUTE, new Liveness());
+    app.get(Readiness.ROUTE, new Readiness(provider));
     app.get(GetAllBlocksAtSlot.ROUTE, new GetAllBlocksAtSlot(provider, jsonProvider));
     app.get(GetPeersScore.ROUTE, new GetPeersScore(provider, jsonProvider));
   }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/Readiness.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/Readiness.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.CACHE_NONE;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_TEKU;
+
+import io.javalin.core.util.Header;
+import io.javalin.http.Context;
+import io.javalin.http.Handler;
+import io.javalin.plugin.openapi.annotations.HttpMethod;
+import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import tech.pegasys.teku.api.ChainDataProvider;
+import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.SyncDataProvider;
+
+public class Readiness implements Handler {
+  public static final String ROUTE = "/teku/v1/admin/readiness";
+  private final SyncDataProvider syncProvider;
+  private final ChainDataProvider chainDataProvider;
+
+  public Readiness(final DataProvider provider) {
+    this.syncProvider = provider.getSyncDataProvider();
+    this.chainDataProvider = provider.getChainDataProvider();
+  }
+
+  Readiness(final SyncDataProvider syncProvider, final ChainDataProvider chainDataProvider) {
+    this.syncProvider = syncProvider;
+    this.chainDataProvider = chainDataProvider;
+  }
+
+  @OpenApi(
+      path = ROUTE,
+      method = HttpMethod.GET,
+      summary = "Get node readiness",
+      description = "Returns 200 if the node is ready to accept traffic",
+      tags = {TAG_TEKU},
+      responses = {
+        @OpenApiResponse(status = RES_OK, description = "Node is ready"),
+        @OpenApiResponse(
+            status = RES_SERVICE_UNAVAILABLE,
+            description = "Node not initialized or having issues")
+      })
+  @Override
+  public void handle(final Context ctx) throws Exception {
+    ctx.header(Header.CACHE_CONTROL, CACHE_NONE);
+    if (!chainDataProvider.isStoreAvailable() || syncProvider.isSyncing()) {
+      ctx.status(SC_SERVICE_UNAVAILABLE);
+    } else {
+      ctx.status(SC_OK);
+    }
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.Liveness;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.PutLogLevel;
+import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.Readiness;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetAllBlocksAtSlot;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetSszState;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetStateByBlockRoot;
@@ -225,6 +226,7 @@ public class BeaconRestApiV1Test {
     builder.add(Arguments.of(GetSszState.ROUTE, GetSszState.class));
     builder.add(Arguments.of(GetStateByBlockRoot.ROUTE, GetStateByBlockRoot.class));
     builder.add(Arguments.of(Liveness.ROUTE, Liveness.class));
+    builder.add(Arguments.of(Readiness.ROUTE, Readiness.class));
     builder.add(Arguments.of(GetAllBlocksAtSlot.ROUTE, GetAllBlocksAtSlot.class));
 
     return builder.build();

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/ReadinessTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/ReadinessTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.CACHE_NONE;
+
+import io.javalin.core.util.Header;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
+import tech.pegasys.teku.sync.events.SyncState;
+
+public class ReadinessTest extends AbstractBeaconHandlerTest {
+
+  @Test
+  public void shouldReturnOkWhenInSyncAndReady() throws Exception {
+    final Readiness handler = new Readiness(syncDataProvider, chainDataProvider);
+    when(chainDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+
+    handler.handle(context);
+    verify(context).header(Header.CACHE_CONTROL, CACHE_NONE);
+    verify(context).status(SC_OK);
+  }
+
+  @Test
+  public void shouldReturnUnavailableWhenStoreNotAvailable() throws Exception {
+    final Readiness handler = new Readiness(syncDataProvider, chainDataProvider);
+    when(chainDataProvider.isStoreAvailable()).thenReturn(false);
+
+    handler.handle(context);
+    verifyCacheStatus(CACHE_NONE);
+    verifyStatusCode(SC_SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  public void shouldReturnUnavailableWhenStartingUp() throws Exception {
+    final Readiness handler = new Readiness(syncDataProvider, chainDataProvider);
+    when(chainDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.START_UP);
+
+    handler.handle(context);
+    verifyCacheStatus(CACHE_NONE);
+    verifyStatusCode(SC_SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  public void shouldReturnUnavailableWhenSyncing() throws Exception {
+    final Readiness handler = new Readiness(syncDataProvider, chainDataProvider);
+    when(chainDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.SYNCING);
+
+    handler.handle(context);
+    verifyCacheStatus(CACHE_NONE);
+    verifyStatusCode(SC_SERVICE_UNAVAILABLE);
+  }
+}


### PR DESCRIPTION
## PR Description

New readiness endpoint that aligns with kubernetes readiness probes:
- add new readiness endpoint
- include endpoint in beacon rest api
- add tests to cover different scenarios

## Documentation

Running Teku in Kubernetes requires liveness and readiness endpoints in order to manage the container correctly. 
Using readiness probe to check when container can accept traffic.
And using liveness probe to check when container becomes unresponsive and needs to be restarted.

Logic for new readiness endpoint is as follows:
- Returns 200 if node can accept traffic.
- Returns 500 if node is not initialized. 

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
