### PR TITLE
Don't produce sync signatures early when a block is received

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignatureValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignatureValidator.java
@@ -93,6 +93,7 @@ public class SyncCommitteeSignatureValidator {
       final UniquenessKey key =
           getUniquenessKey(signature, validateableSignature.getReceivedSubnetId().getAsInt());
       if (seenIndices.contains(key)) {
+        LOG.trace("Ignoring sync committee signature {} because it has already been seen", key);
         return SafeFuture.completedFuture(IGNORE);
       }
       uniquenessKey = Optional.of(key);
@@ -174,6 +175,7 @@ public class SyncCommitteeSignatureValidator {
     // [IGNORE] There has been no other valid sync committee signature for the declared slot for the
     // validator referenced by sync_committee_signature.validator_index.
     if (seenIndices.containsAll(uniquenessKeys)) {
+      LOG.trace("Ignoring sync committee signature because it has already been seen");
       return IGNORE;
     }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
@@ -32,7 +32,7 @@ public interface ValidatorTimingChannel extends VoidReturningChannelInterface {
 
   void onBlockProductionDue(UInt64 slot);
 
-  void onAttestationCreationDue(UInt64 slot);
+  void onAttestationCreationDue(UInt64 slot, boolean blockReceived);
 
   void onAttestationAggregationDue(UInt64 slot);
 }

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
@@ -87,7 +87,7 @@ public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
       LOG.warn("Skipping attestation for slot {} due to unexpected delay in slot processing", slot);
       return;
     }
-    validatorTimingChannel.onAttestationCreationDue(slot);
+    validatorTimingChannel.onAttestationCreationDue(slot, false);
   }
 
   private void onAggregationDue(final UInt64 scheduledTime, final UInt64 actualTime) {

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapterTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapterTest.java
@@ -111,12 +111,14 @@ class TimeBasedEventAdapterTest {
     // Attestation should not fire at the start of the slot
     timeProvider.advanceTimeBySeconds(timeUntilNextSlot);
     asyncRunner.executeDueActionsRepeatedly();
-    verify(validatorTimingChannel, never()).onAttestationCreationDue(UInt64.valueOf(nextSlot));
+    verify(validatorTimingChannel, never())
+        .onAttestationCreationDue(UInt64.valueOf(nextSlot), false);
 
     // But does fire 1/3rds through the slot
     timeProvider.advanceTimeBySeconds(secondsPerSlot / 3);
     asyncRunner.executeDueActionsRepeatedly();
-    verify(validatorTimingChannel, times(1)).onAttestationCreationDue(UInt64.valueOf(nextSlot));
+    verify(validatorTimingChannel, times(1))
+        .onAttestationCreationDue(UInt64.valueOf(nextSlot), false);
   }
 
   @Test

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -161,7 +161,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   public void onBlockProductionDue(final UInt64 slot) {}
 
   @Override
-  public void onAttestationCreationDue(final UInt64 slot) {}
+  public void onAttestationCreationDue(final UInt64 slot, final boolean receivedBlock) {}
 
   protected void onProductionDue(final UInt64 slot) {
     // Check slot being null for the edge case of genesis slot (i.e. slot 0)

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
@@ -39,7 +39,7 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
   }
 
   @Override
-  public void onAttestationCreationDue(final UInt64 slot) {
+  public void onAttestationCreationDue(final UInt64 slot, final boolean receivedBlock) {
     onProductionDue(slot);
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
@@ -109,7 +109,10 @@ public class SyncCommitteeScheduler implements ValidatorTimingChannel {
   }
 
   @Override
-  public void onAttestationCreationDue(final UInt64 slot) {
+  public void onAttestationCreationDue(final UInt64 slot, final boolean receivedBlock) {
+    if (receivedBlock) {
+      return;
+    }
     getDutiesForSlot(slot).ifPresent(duties -> duties.onProductionDue(slot));
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -89,8 +89,8 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
   }
 
   @Override
-  public void onAttestationCreationDue(final UInt64 slot) {
-    delegates.forEach(delegate -> delegate.onAttestationCreationDue(slot));
+  public void onAttestationCreationDue(final UInt64 slot, final boolean receivedBlock) {
+    delegates.forEach(delegate -> delegate.onAttestationCreationDue(slot, receivedBlock));
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
@@ -54,7 +54,7 @@ public class ChainHeadTracker implements ValidatorTimingChannel {
   public void onBlockProductionDue(final UInt64 slot) {}
 
   @Override
-  public void onAttestationCreationDue(final UInt64 slot) {}
+  public void onAttestationCreationDue(final UInt64 slot, final boolean receivedBlock) {}
 
   @Override
   public void onAttestationAggregationDue(final UInt64 slot) {}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -374,7 +374,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   @Test
   public void shouldNotProcessAttestationIfEpochIsUnknown() {
     createDutySchedulerWithMockDuties();
-    dutyScheduler.onAttestationCreationDue(ONE);
+    dutyScheduler.onAttestationCreationDue(ONE, false);
     verify(scheduledDuties, never()).performProductionDuty(ZERO);
   }
 
@@ -394,7 +394,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     // first slot of epoch 2
     final UInt64 slot = spec.computeStartSlotAtEpoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1));
     dutyScheduler.onSlot(ONE); // epoch 0
-    dutyScheduler.onAttestationCreationDue(slot);
+    dutyScheduler.onAttestationCreationDue(slot, false);
     verify(scheduledDuties, never()).performProductionDuty(slot);
   }
 
@@ -416,7 +416,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     final UInt64 slot =
         spec.computeStartSlotAtEpoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1)).decrement();
     dutyScheduler.onSlot(ONE); // epoch 0
-    dutyScheduler.onAttestationCreationDue(slot);
+    dutyScheduler.onAttestationCreationDue(slot, false);
     verify(scheduledDuties).performProductionDuty(slot);
   }
 
@@ -433,7 +433,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     dutyScheduler.onSlot(ZERO);
 
     dutyScheduler.onBlockProductionDue(ZERO);
-    dutyScheduler.onAttestationCreationDue(ZERO);
+    dutyScheduler.onAttestationCreationDue(ZERO, false);
     dutyScheduler.onAttestationAggregationDue(ZERO);
     // Duties haven't been loaded yet.
     verify(scheduledDuties, never()).performProductionDuty(ZERO);
@@ -469,11 +469,11 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
     verify(attestationDuty).addValidator(validator1, 3, 6, 5, 10);
 
     // Execute
-    dutyScheduler.onAttestationCreationDue(attestationProductionSlot);
+    dutyScheduler.onAttestationCreationDue(attestationProductionSlot, true);
     verify(attestationDuty).performDuty();
 
     // Somehow we triggered the same slot again.
-    dutyScheduler.onAttestationCreationDue(attestationProductionSlot);
+    dutyScheduler.onAttestationCreationDue(attestationProductionSlot, false);
     // But shouldn't produce another block and get ourselves slashed.
     verifyNoMoreInteractions(attestationDuty);
   }
@@ -542,7 +542,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validator2CommitteeSize);
 
     // Execute
-    dutyScheduler.onAttestationCreationDue(attestationSlot);
+    dutyScheduler.onAttestationCreationDue(attestationSlot, true);
     verify(attestationDuty).performDuty();
   }
 
@@ -610,7 +610,7 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validator2CommitteeSize);
 
     // Execute
-    dutyScheduler.onAttestationCreationDue(attestationSlot);
+    dutyScheduler.onAttestationCreationDue(attestationSlot, false);
     verify(attestationDuty).performDuty();
   }
 
@@ -678,10 +678,10 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             validator2CommitteeSize);
 
     // Execute
-    dutyScheduler.onAttestationCreationDue(attestationSlot);
+    dutyScheduler.onAttestationCreationDue(attestationSlot, false);
     verify(attestationDuty).performDuty();
 
-    dutyScheduler.onAttestationCreationDue(attestationSlot);
+    dutyScheduler.onAttestationCreationDue(attestationSlot, false);
     verifyNoMoreInteractions(attestationDuty);
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeSchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeSchedulerTest.java
@@ -93,7 +93,7 @@ class SyncCommitteeSchedulerTest {
     UInt64.range(UInt64.ONE, UInt64.valueOf(10))
         .forEach(
             slot -> {
-              scheduler.onAttestationCreationDue(slot);
+              scheduler.onAttestationCreationDue(slot, false);
               verify(duties).performProductionDuty(slot);
             });
   }
@@ -179,12 +179,12 @@ class SyncCommitteeSchedulerTest {
     getRequestedDutiesForSyncCommitteePeriod(1).complete(Optional.of(nextDuties));
 
     // Subscribed, but still performing duties for first sync committee period
-    scheduler.onAttestationCreationDue(subscribeSlot);
+    scheduler.onAttestationCreationDue(subscribeSlot, false);
     verify(duties).performProductionDuty(subscribeSlot);
 
     final UInt64 nextSyncCommitteeFirstDutySlot = nextSyncCommitteePeriodStartSlot.minus(1);
     scheduler.onSlot(nextSyncCommitteeFirstDutySlot);
-    scheduler.onAttestationCreationDue(nextSyncCommitteeFirstDutySlot);
+    scheduler.onAttestationCreationDue(nextSyncCommitteeFirstDutySlot, false);
     verify(nextDuties).performProductionDuty(nextSyncCommitteeFirstDutySlot);
     verify(duties, never()).performProductionDuty(nextSyncCommitteeFirstDutySlot);
   }
@@ -210,7 +210,7 @@ class SyncCommitteeSchedulerTest {
     getRequestedDutiesForSyncCommitteePeriod(1).complete(Optional.of(nextDuties));
 
     // Unexpectedly jump ahead to the next committee period without getting a slot event first
-    scheduler.onAttestationCreationDue(nextSyncCommitteePeriodStartSlot);
+    scheduler.onAttestationCreationDue(nextSyncCommitteePeriodStartSlot, false);
     scheduler.onAttestationAggregationDue(nextSyncCommitteePeriodStartSlot);
 
     // Should use duties from the next period
@@ -222,7 +222,7 @@ class SyncCommitteeSchedulerTest {
         syncCommitteeUtil.computeFirstEpochOfNextSyncCommitteePeriod(
             nextSyncCommitteePeriodStartEpoch);
     final UInt64 tooFarInFutureSlot = spec.computeStartSlotAtEpoch(tooFarInFutureEpoch);
-    scheduler.onAttestationCreationDue(tooFarInFutureSlot);
+    scheduler.onAttestationCreationDue(tooFarInFutureSlot, false);
     scheduler.onAttestationAggregationDue(tooFarInFutureSlot);
 
     verify(duties, never()).performProductionDuty(tooFarInFutureSlot);

--- a/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/IndependentTimerEventChannelEventAdapter.java
+++ b/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/IndependentTimerEventChannelEventAdapter.java
@@ -74,6 +74,6 @@ public class IndependentTimerEventChannelEventAdapter
             validatorTimingChannel.onChainReorg(slot, reorgContext.getCommonAncestorSlot()));
     validatorTimingChannel.onHeadUpdate(
         slot, previousDutyDependentRoot, currentDutyDependentRoot, bestBlockRoot);
-    validatorTimingChannel.onAttestationCreationDue(slot);
+    validatorTimingChannel.onAttestationCreationDue(slot, true);
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/EventSourceHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/EventSourceHandler.java
@@ -107,7 +107,7 @@ class EventSourceHandler implements EventHandler {
         headEvent.previousDutyDependentRoot,
         headEvent.currentDutyDependentRoot,
         headEvent.block);
-    validatorTimingChannel.onAttestationCreationDue(headEvent.slot);
+    validatorTimingChannel.onAttestationCreationDue(headEvent.slot, true);
   }
 
   private void handleChainReorgEvent(final MessageEvent messageEvent)

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/EventSourceHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/EventSourceHandlerTest.java
@@ -67,7 +67,7 @@ class EventSourceHandlerTest {
     verify(validatorTimingChannel)
         .onHeadUpdate(
             eq(slot), eq(previousDutyDependentRoot), eq(currentDutyDependentRoot), eq(blockRoot));
-    verify(validatorTimingChannel).onAttestationCreationDue(slot);
+    verify(validatorTimingChannel).onAttestationCreationDue(slot, true);
     verifyNoMoreInteractions(validatorTimingChannel);
   }
 


### PR DESCRIPTION
## PR Description
Always wait until 1/3rd through the slot before producing sync committee signatures. Publishing as soon as a block is received can lead to a race condition between the sync committee signatures and the block gossip being processed resulting in the signature being ignored because the block is unknown.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
