### PR TITLE
Enable time based eth1 follow distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ For information on changes in released versions of Teku, see the [releases page]
 - Prevent LevelDB transactions from attempting to make any updates after the database is shut down.
 - Update `/eth/v1/node/health` to return 206 while node is starting up rather than a 200.
 - Fixed issue which cause a small reduction in attestation rewards when using `--Xvalidators-dependent-root-enabled`.
+- Fixed issue with eth1 follow distance tracking revealed in Rayonism testnets. Teku incorrectly strictly follows 2048 blocks before the eth1 head but the follow distance should be based on timestamp, not block number.
+  This change can be disabled with `--Xeth1-time-based-head-tracking-enabled=false` if required.
+
 
 ### Experimental: New Altair REST APIs
 - implement POST `/eth/v1/beacon/pool/sync_committees` to allow validators to submit sync committee signatures to the beacon node.

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
@@ -43,7 +43,7 @@ public class DepositOptions {
       hidden = true,
       arity = "0..1",
       fallbackValue = "true")
-  private boolean useTimeBasedHeadTracking = false;
+  private boolean useTimeBasedHeadTracking = true;
 
   public void configure(final TekuConfiguration.Builder builder) {
     builder.powchain(

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -408,7 +408,8 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
             b ->
                 b.eth1Endpoints(List.of("http://localhost:8545"))
                     .depositContract(address)
-                    .eth1LogsMaxBlockRange(10_000))
+                    .eth1LogsMaxBlockRange(10_000)
+                    .useTimeBasedHeadTracking(true))
         .store(b -> b.hotStatePersistenceFrequencyInEpochs(2))
         .storageConfiguration(
             b ->

--- a/util/src/main/resources/tech/pegasys/teku/util/config/configs/less-swift.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/configs/less-swift.yaml
@@ -49,8 +49,8 @@ TARGET_AGGREGATORS_PER_COMMITTEE: 16
 RANDOM_SUBNETS_PER_VALIDATOR: 1
 # 2**8 (= 256)
 EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION: 256
-# 14 (estimate from Eth1 mainnet)
-SECONDS_PER_ETH1_BLOCK: 14
+# 1 (expect besu dev mode which creates blocks as fast as possible)
+SECONDS_PER_ETH1_BLOCK: 1
 
 
 # Deposit contract

--- a/util/src/main/resources/tech/pegasys/teku/util/config/configs/swift.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/configs/swift.yaml
@@ -49,8 +49,8 @@ TARGET_AGGREGATORS_PER_COMMITTEE: 16
 RANDOM_SUBNETS_PER_VALIDATOR: 1
 # 2**8 (= 256)
 EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION: 256
-# 14 (estimate from Eth1 mainnet)
-SECONDS_PER_ETH1_BLOCK: 14
+# 1 (expect besu dev mode which creates blocks as fast as possible)
+SECONDS_PER_ETH1_BLOCK: 1
 
 
 # Deposit contract


### PR DESCRIPTION
## PR Description
Switch `--Xeth1-time-based-head-tracking-enabled` to default to enabled.  Testing has shown this mostly has no effect on eth1 voting behaviour and in some corner cases improves accuracy by adding more blocks to the cache.

## Fixed Issue(s)
fixes #4005 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
