### PR TITLE
[Issue-3356] Deprecated BeaconStateUtil cleanup (2)

### DIFF
--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -332,7 +332,7 @@ public class EventSubscriptionManagerTest {
 
   private void triggerAttestationEvent() {
     manager.onNewAttestation(
-        ValidateableAttestation.from(sampleAttestation.asInternalAttestation()));
+        ValidateableAttestation.from(spec, sampleAttestation.asInternalAttestation()));
     asyncRunner.executeQueuedActions();
   }
 

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/SszBenchUtil.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/SszBenchUtil.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.benchmarks.ssz;
 
 import org.openjdk.jmh.infra.Blackhole;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
@@ -31,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
 
 public class SszBenchUtil {
+  private static final Spec SPEC = TestSpecFactory.createDefault();
 
   public static void iterateData(PendingAttestation pa, Blackhole bh) {
     bh.consume(pa.getAggregation_bits());
@@ -116,7 +119,7 @@ public class SszBenchUtil {
   public static void iterateData(AttestationData ad, Blackhole bh) {
     bh.consume(ad.getSlot());
     bh.consume(ad.getIndex());
-    bh.consume(ad.getEarliestSlotForForkChoice());
+    bh.consume(ad.getEarliestSlotForForkChoice(SPEC));
     iterateData(ad.getSource(), bh);
     iterateData(ad.getTarget(), bh);
   }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -119,7 +119,9 @@ public class ForkChoiceTestExecutor implements TestExecutor {
     final Attestation attestation =
         TestDataUtils.loadSsz(
             testDefinition, attestationName + ".ssz_snappy", Attestation.SSZ_SCHEMA);
-    assertThat(forkChoice.onAttestation(ValidateableAttestation.from(attestation))).isCompleted();
+    final Spec spec = testDefinition.getSpec();
+    assertThat(forkChoice.onAttestation(ValidateableAttestation.from(spec, attestation)))
+        .isCompleted();
   }
 
   private void applyBlock(

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -59,7 +59,8 @@ public class ForkChoiceTestExecutor implements TestExecutor {
         InMemoryStorageSystemBuilder.create().specProvider(spec).build();
     final RecentChainData recentChainData = storageSystem.recentChainData();
     recentChainData.initializeFromAnchorPoint(
-        AnchorPoint.fromInitialBlockAndState(new SignedBlockAndState(anchorBlock, anchorState)),
+        AnchorPoint.fromInitialBlockAndState(
+            spec, new SignedBlockAndState(anchorBlock, anchorState)),
         spec.getSlotStartTime(anchorBlock.getSlot(), anchorState.getGenesis_time()));
 
     final ForkChoice forkChoice =

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/stategenerator/CheckpointStateGenerator.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/stategenerator/CheckpointStateGenerator.java
@@ -33,21 +33,21 @@ public abstract class CheckpointStateGenerator {
 
     // Derive checkpoint state
     final BeaconState state = regenerateCheckpointState(spec, checkpoint, blockAndState.getState());
-    return CheckpointState.create(checkpoint, blockAndState.getBlock(), state);
+    return CheckpointState.create(spec, checkpoint, blockAndState.getBlock(), state);
   }
 
   public static BeaconState regenerateCheckpointState(
       final Spec spec, final Checkpoint checkpoint, BeaconState baseState) {
-    if (baseState.getSlot().isGreaterThan(checkpoint.getEpochStartSlot())) {
+    if (baseState.getSlot().isGreaterThan(checkpoint.getEpochStartSlot(spec))) {
       throw new InvalidCheckpointException(
           "Checkpoint state must be at or prior to checkpoint slot boundary");
     }
     try {
-      if (baseState.getSlot().equals(checkpoint.getEpochStartSlot())) {
+      if (baseState.getSlot().equals(checkpoint.getEpochStartSlot(spec))) {
         return baseState;
       }
 
-      return spec.processSlots(baseState, checkpoint.getEpochStartSlot());
+      return spec.processSlots(baseState, checkpoint.getEpochStartSlot(spec));
     } catch (SlotProcessingException | EpochProcessingException | IllegalArgumentException e) {
       throw new InvalidCheckpointException(e);
     }

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StateAtSlotTaskTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StateAtSlotTaskTest.java
@@ -83,7 +83,8 @@ class StateAtSlotTaskTest {
     when(stateProvider.getState(checkpoint.getRoot()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
 
-    final StateAtSlotTask task = createTask(checkpoint.getEpochStartSlot(), checkpoint.getRoot());
+    final StateAtSlotTask task =
+        createTask(checkpoint.getEpochStartSlot(spec), checkpoint.getRoot());
     final SafeFuture<Optional<BeaconState>> result = task.performTask();
     final BeaconState expectedState =
         CheckpointStateGenerator.regenerateCheckpointState(spec, checkpoint, state);
@@ -136,7 +137,7 @@ class StateAtSlotTaskTest {
         CheckpointStateGenerator.regenerateCheckpointState(
             spec, realCheckpoint, newBase.getState());
     final StateAtSlotTask task =
-        createTask(realCheckpoint.getEpochStartSlot(), Bytes32.fromHexStringLenient("0x12"));
+        createTask(realCheckpoint.getEpochStartSlot(spec), Bytes32.fromHexStringLenient("0x12"));
 
     final CachingTaskQueue.CacheableTask<SlotAndBlockRoot, BeaconState> rebasedTask =
         task.rebase(newBase.getState());

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -269,6 +269,11 @@ public class Spec {
     return atState(state).beaconStateAccessors().getPreviousEpoch(state);
   }
 
+  public Bytes32 getSeed(BeaconState state, UInt64 epoch, Bytes4 domainType)
+      throws IllegalArgumentException {
+    return atState(state).beaconStateAccessors().getSeed(state, epoch, domainType);
+  }
+
   public UInt64 computeStartSlotAtEpoch(final UInt64 epoch) {
     return atEpoch(epoch).miscHelpers().computeStartSlotAtEpoch(epoch);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidateableAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidateableAttestation.java
@@ -161,7 +161,7 @@ public class ValidateableAttestation {
   }
 
   public UInt64 getEarliestSlotForForkChoiceProcessing() {
-    return attestation.getEarliestSlotForForkChoiceProcessing();
+    return attestation.getEarliestSlotForForkChoiceProcessing(spec);
   }
 
   public Collection<Bytes32> getDependentBlockRoots() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Attestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Attestation.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 import tech.pegasys.teku.ssz.collections.SszBitlist;
@@ -70,8 +71,8 @@ public class Attestation
     return SSZ_SCHEMA.getAggregationBitsSchema().ofBits(Constants.MAX_VALIDATORS_PER_COMMITTEE);
   }
 
-  public UInt64 getEarliestSlotForForkChoiceProcessing() {
-    return getData().getEarliestSlotForForkChoice();
+  public UInt64 getEarliestSlotForForkChoiceProcessing(final Spec spec) {
+    return getData().getEarliestSlotForForkChoice(spec);
   }
 
   public Collection<Bytes32> getDependentBlockRoots() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationData.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationData.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.datastructures.operations;
 
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.ssz.containers.Container5;
 import tech.pegasys.teku.ssz.containers.ContainerSchema5;
@@ -67,10 +68,10 @@ public class AttestationData
     this(slot, data.getIndex(), data.getBeacon_block_root(), data.getSource(), data.getTarget());
   }
 
-  public UInt64 getEarliestSlotForForkChoice() {
+  public UInt64 getEarliestSlotForForkChoice(final Spec spec) {
     // Attestations can't be processed by fork choice until their slot is in the past and until we
     // are in the same epoch as their target.
-    return getSlot().plus(UInt64.ONE).max(getTarget().getEpochStartSlot());
+    return getSlot().plus(UInt64.ONE).max(getTarget().getEpochStartSlot(spec));
   }
 
   public UInt64 getSlot() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/AnchorPoint.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/AnchorPoint.java
@@ -35,36 +35,45 @@ import tech.pegasys.teku.util.config.Constants;
  * sync.
  */
 public class AnchorPoint extends StateAndBlockSummary {
+  private final Spec spec;
   private final Checkpoint checkpoint;
   private final boolean isGenesis;
 
   private AnchorPoint(
-      final Checkpoint checkpoint, final BeaconState state, final BeaconBlockSummary blockSummary) {
+      final Spec spec,
+      final Checkpoint checkpoint,
+      final BeaconState state,
+      final BeaconBlockSummary blockSummary) {
     super(blockSummary, state);
     checkArgument(
         checkpoint.getRoot().equals(blockSummary.getRoot()), "Checkpoint and block must match");
     checkArgument(
-        checkpoint.getEpochStartSlot().isGreaterThanOrEqualTo(blockSummary.getSlot()),
+        checkpoint.getEpochStartSlot(spec).isGreaterThanOrEqualTo(blockSummary.getSlot()),
         "Block must be at or prior to the start of the checkpoint epoch");
 
+    this.spec = spec;
     this.checkpoint = checkpoint;
     this.isGenesis = checkpoint.getEpoch().equals(UInt64.valueOf(Constants.GENESIS_EPOCH));
   }
 
   public static AnchorPoint create(
-      Checkpoint checkpoint, BeaconState state, Optional<SignedBeaconBlock> block) {
+      final Spec spec,
+      Checkpoint checkpoint,
+      BeaconState state,
+      Optional<SignedBeaconBlock> block) {
     final BeaconBlockSummary blockSummary =
         block.<BeaconBlockSummary>map(a -> a).orElseGet(() -> BeaconBlockHeader.fromState(state));
-    return new AnchorPoint(checkpoint, state, blockSummary);
+    return new AnchorPoint(spec, checkpoint, state, blockSummary);
   }
 
   public static AnchorPoint create(
-      Checkpoint checkpoint, SignedBeaconBlock block, BeaconState state) {
-    return new AnchorPoint(checkpoint, state, block);
+      final Spec spec, Checkpoint checkpoint, SignedBeaconBlock block, BeaconState state) {
+    return new AnchorPoint(spec, checkpoint, state, block);
   }
 
-  public static AnchorPoint create(Checkpoint checkpoint, SignedBlockAndState blockAndState) {
-    return new AnchorPoint(checkpoint, blockAndState.getState(), blockAndState.getBlock());
+  public static AnchorPoint create(
+      final Spec spec, Checkpoint checkpoint, SignedBlockAndState blockAndState) {
+    return new AnchorPoint(spec, checkpoint, blockAndState.getState(), blockAndState.getBlock());
   }
 
   public static AnchorPoint fromGenesisState(final Spec spec, final BeaconState genesisState) {
@@ -78,7 +87,7 @@ public class AnchorPoint extends StateAndBlockSummary {
     final UInt64 genesisEpoch = spec.getCurrentEpoch(genesisState);
     final Checkpoint genesisCheckpoint = new Checkpoint(genesisEpoch, genesisBlockRoot);
 
-    return new AnchorPoint(genesisCheckpoint, genesisState, signedGenesisBlock);
+    return new AnchorPoint(spec, genesisCheckpoint, genesisState, signedGenesisBlock);
   }
 
   public static AnchorPoint fromInitialState(final Spec spec, final BeaconState state) {
@@ -91,7 +100,7 @@ public class AnchorPoint extends StateAndBlockSummary {
       final UInt64 epoch = spec.computeNextEpochBoundary(state.getSlot());
       final Checkpoint checkpoint = new Checkpoint(epoch, header.hashTreeRoot());
 
-      return new AnchorPoint(checkpoint, state, header);
+      return new AnchorPoint(spec, checkpoint, state, header);
     }
   }
 
@@ -114,7 +123,7 @@ public class AnchorPoint extends StateAndBlockSummary {
     final UInt64 epoch = spec.computeNextEpochBoundary(state.getSlot());
     final Checkpoint checkpoint = new Checkpoint(epoch, block.getRoot());
 
-    return new AnchorPoint(checkpoint, state, block);
+    return new AnchorPoint(spec, checkpoint, state, block);
   }
 
   public boolean isGenesis() {
@@ -134,7 +143,7 @@ public class AnchorPoint extends StateAndBlockSummary {
   }
 
   public UInt64 getEpochStartSlot() {
-    return checkpoint.getEpochStartSlot();
+    return checkpoint.getEpochStartSlot(spec);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/AnchorPoint.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/AnchorPoint.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.spec.datastructures.state;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil.compute_next_epoch_boundary;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -89,7 +88,7 @@ public class AnchorPoint extends StateAndBlockSummary {
       final BeaconBlockHeader header = BeaconBlockHeader.fromState(state);
 
       // Calculate closest epoch boundary to use for the checkpoint
-      final UInt64 epoch = compute_next_epoch_boundary(state.getSlot());
+      final UInt64 epoch = spec.computeNextEpochBoundary(state.getSlot());
       final Checkpoint checkpoint = new Checkpoint(epoch, header.hashTreeRoot());
 
       return new AnchorPoint(checkpoint, state, header);
@@ -100,18 +99,19 @@ public class AnchorPoint extends StateAndBlockSummary {
     return state.getSlot().equals(UInt64.valueOf(Constants.GENESIS_SLOT));
   }
 
-  public static AnchorPoint fromInitialBlockAndState(final SignedBlockAndState blockAndState) {
-    return fromInitialBlockAndState(blockAndState.getBlock(), blockAndState.getState());
+  public static AnchorPoint fromInitialBlockAndState(
+      final Spec spec, final SignedBlockAndState blockAndState) {
+    return fromInitialBlockAndState(spec, blockAndState.getBlock(), blockAndState.getState());
   }
 
   public static AnchorPoint fromInitialBlockAndState(
-      final SignedBeaconBlock block, final BeaconState state) {
+      final Spec spec, final SignedBeaconBlock block, final BeaconState state) {
     checkArgument(
         Objects.equals(block.getStateRoot(), state.hashTreeRoot()),
         "State must belong to the given block");
 
     // Calculate closest epoch boundary to use for the checkpoint
-    final UInt64 epoch = compute_next_epoch_boundary(state.getSlot());
+    final UInt64 epoch = spec.computeNextEpochBoundary(state.getSlot());
     final Checkpoint checkpoint = new Checkpoint(epoch, block.getRoot());
 
     return new AnchorPoint(checkpoint, state, block);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Checkpoint.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Checkpoint.java
@@ -13,10 +13,9 @@
 
 package tech.pegasys.teku.spec.datastructures.state;
 
-import static tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
-
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.ssz.containers.Container2;
 import tech.pegasys.teku.ssz.containers.ContainerSchema2;
@@ -60,11 +59,11 @@ public class Checkpoint extends Container2<Checkpoint, SszUInt64, SszBytes32> {
     return getField1().get();
   }
 
-  public UInt64 getEpochStartSlot() {
-    return compute_start_slot_at_epoch(getEpoch());
+  public UInt64 getEpochStartSlot(final Spec spec) {
+    return spec.computeStartSlotAtEpoch(getEpoch());
   }
 
-  public SlotAndBlockRoot toSlotAndBlockRoot() {
-    return new SlotAndBlockRoot(getEpochStartSlot(), getRoot());
+  public SlotAndBlockRoot toSlotAndBlockRoot(final Spec spec) {
+    return new SlotAndBlockRoot(getEpochStartSlot(spec), getRoot());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/CheckpointState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/CheckpointState.java
@@ -26,7 +26,6 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class CheckpointState {
 
-  private final Spec spec;
   private final Checkpoint checkpoint;
   private final BeaconBlockSummary block;
   private final BeaconState state;
@@ -44,7 +43,6 @@ public class CheckpointState {
         state.getSlot().equals(checkpoint.getEpochStartSlot(spec)),
         "State must be advanced to checkpoint epoch boundary slot");
 
-    this.spec = spec;
     this.checkpoint = checkpoint;
     this.block = block;
     this.state = state;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/CheckpointState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/CheckpointState.java
@@ -20,33 +20,42 @@ import com.google.common.base.MoreObjects;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class CheckpointState {
 
+  private final Spec spec;
   private final Checkpoint checkpoint;
   private final BeaconBlockSummary block;
   private final BeaconState state;
 
   private CheckpointState(
-      final Checkpoint checkpoint, final BeaconBlockSummary block, final BeaconState state) {
+      final Spec spec,
+      final Checkpoint checkpoint,
+      final BeaconBlockSummary block,
+      final BeaconState state) {
     checkNotNull(checkpoint);
     checkNotNull(block);
     checkNotNull(state);
     checkArgument(checkpoint.getRoot().equals(block.getRoot()), "Block must match checkpoint root");
     checkArgument(
-        state.getSlot().equals(checkpoint.getEpochStartSlot()),
+        state.getSlot().equals(checkpoint.getEpochStartSlot(spec)),
         "State must be advanced to checkpoint epoch boundary slot");
 
+    this.spec = spec;
     this.checkpoint = checkpoint;
     this.block = block;
     this.state = state;
   }
 
   public static CheckpointState create(
-      final Checkpoint checkpoint, final BeaconBlockSummary block, final BeaconState state) {
-    return new CheckpointState(checkpoint, block, state);
+      final Spec spec,
+      final Checkpoint checkpoint,
+      final BeaconBlockSummary block,
+      final BeaconState state) {
+    return new CheckpointState(spec, checkpoint, block, state);
   }
 
   public Checkpoint getCheckpoint() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -289,7 +289,9 @@ public class ForkChoiceUtil {
 
     // Attestations cannot be from future epochs. If they are, delay consideration until the epoch
     // arrives
-    if (currentSlot.compareTo(attestation.getData().getTarget().getEpochStartSlot()) < 0) {
+    final UInt64 epochStartSlot =
+        miscHelpers.computeStartSlotAtEpoch(attestation.getData().getTarget().getEpoch());
+    if (currentSlot.isLessThan(epochStartSlot)) {
       return AttestationProcessingResult.SAVED_FOR_FUTURE;
     }
     return AttestationProcessingResult.SUCCESSFUL;
@@ -369,12 +371,16 @@ public class ForkChoiceUtil {
   }
 
   private boolean isFinalizedAncestorOfJustified(ReadOnlyStore store) {
-    UInt64 finalizedSlot = store.getFinalizedCheckpoint().getEpochStartSlot();
     return hasAncestorAtSlot(
         store.getForkChoiceStrategy(),
         store.getJustifiedCheckpoint().getRoot(),
-        finalizedSlot,
+        getFinalizedCheckpointStartSlot(store),
         store.getFinalizedCheckpoint().getRoot());
+  }
+
+  private UInt64 getFinalizedCheckpointStartSlot(final ReadOnlyStore store) {
+    final UInt64 finalizedEpoch = store.getFinalizedCheckpoint().getEpoch();
+    return miscHelpers.computeStartSlotAtEpoch(finalizedEpoch);
   }
 
   private Optional<BlockImportResult> checkOnBlockConditions(
@@ -414,11 +420,12 @@ public class ForkChoiceUtil {
     final UInt64 blockSlot = block.getSlot();
 
     // Make sure this block's slot is after the latest finalized slot
-    return blockIsAfterLatestFinalizedSlot(blockSlot, finalizedCheckpoint.getEpochStartSlot())
+    final UInt64 finalizedEpochStartSlot = getFinalizedCheckpointStartSlot(store);
+    return blockIsAfterLatestFinalizedSlot(blockSlot, finalizedEpochStartSlot)
         && hasAncestorAtSlot(
             forkChoiceStrategy,
             block.getParentRoot(),
-            finalizedCheckpoint.getEpochStartSlot(),
+            finalizedEpochStartSlot,
             finalizedCheckpoint.getRoot());
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataTest.java
@@ -24,12 +24,15 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.util.config.Constants;
 
 class AttestationDataTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private UInt64 slot = dataStructureUtil.randomUInt64();
   private UInt64 index = dataStructureUtil.randomUInt64();
   private Bytes32 beaconBlockRoot = dataStructureUtil.randomBytes32();
@@ -63,7 +66,7 @@ class AttestationDataTest {
             new Checkpoint(ONE, Bytes32.ZERO),
             new Checkpoint(ONE, Bytes32.ZERO));
 
-    assertThat(data.getEarliestSlotForForkChoice()).isEqualTo(UInt64.valueOf(61));
+    assertThat(data.getEarliestSlotForForkChoice(spec)).isEqualTo(UInt64.valueOf(61));
   }
 
   @Test
@@ -77,7 +80,7 @@ class AttestationDataTest {
             new Checkpoint(ONE, Bytes32.ZERO),
             target);
 
-    assertThat(data.getEarliestSlotForForkChoice()).isEqualTo(target.getEpochStartSlot());
+    assertThat(data.getEarliestSlotForForkChoice(spec)).isEqualTo(target.getEpochStartSlot(spec));
   }
 
   @Test

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/AnchorPointTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/AnchorPointTest.java
@@ -14,28 +14,30 @@
 package tech.pegasys.teku.spec.datastructures.state;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class AnchorPointTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   @Test
   public void create_withCheckpointPriorToState() {
     final UInt64 epoch = UInt64.valueOf(10);
-    final UInt64 epochStartSlot = compute_start_slot_at_epoch(epoch);
+    final UInt64 epochStartSlot = spec.computeStartSlotAtEpoch(epoch);
 
     final BeaconBlockAndState blockAndState =
         dataStructureUtil.randomBlockAndState(epochStartSlot.plus(1));
     final Checkpoint checkpoint = new Checkpoint(epoch, blockAndState.getRoot());
 
     assertThatThrownBy(
-            () -> AnchorPoint.create(checkpoint, blockAndState.getState(), Optional.empty()))
+            () -> AnchorPoint.create(spec, checkpoint, blockAndState.getState(), Optional.empty()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Block must be at or prior to the start of the checkpoint epoch");
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreFactory.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -29,7 +31,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.util.config.Constants;
 
 public class TestStoreFactory {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   public TestStoreImpl createGenesisStore() {
     return getForkChoiceStore(createAnchorForGenesis());
@@ -48,6 +51,7 @@ public class TestStoreFactory {
 
   public TestStoreImpl createEmptyStore() {
     return new TestStoreImpl(
+        spec,
         UInt64.ZERO,
         UInt64.ZERO,
         Optional.empty(),
@@ -83,6 +87,7 @@ public class TestStoreFactory {
     checkpoint_states.put(anchorCheckpoint, anchorState);
 
     return new TestStoreImpl(
+        spec,
         anchorState.getGenesis_time().plus(anchorState.getSlot().times(SECONDS_PER_SLOT)),
         anchorState.getGenesis_time(),
         Optional.of(anchorCheckpoint),

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -865,7 +865,7 @@ public final class DataStructureUtil {
     final UInt64 anchorEpoch = spec.getCurrentEpoch(anchorState);
     final Checkpoint anchorCheckpoint = new Checkpoint(anchorEpoch, anchorRoot);
 
-    return AnchorPoint.create(anchorCheckpoint, signedAnchorBlock, anchorState);
+    return AnchorPoint.create(spec, anchorCheckpoint, signedAnchorBlock, anchorState);
   }
 
   public SignedContributionAndProof randomSignedContributionAndProof(final long slot) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -843,7 +843,7 @@ public final class DataStructureUtil {
   public AnchorPoint randomAnchorPoint(final UInt64 epoch) {
     final SignedBlockAndState anchorBlockAndState =
         randomSignedBlockAndState(computeStartSlotAtEpoch(epoch));
-    return AnchorPoint.fromInitialBlockAndState(anchorBlockAndState);
+    return AnchorPoint.fromInitialBlockAndState(spec, anchorBlockAndState);
   }
 
   public AnchorPoint createAnchorFromState(final BeaconState anchorState) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationsReOrgManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationsReOrgManager.java
@@ -37,20 +37,20 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 public class OperationsReOrgManager implements ChainHeadChannel {
   private static final Logger LOG = LogManager.getLogger();
 
-  final OperationPool<SignedVoluntaryExit> exitPool;
-  final OperationPool<ProposerSlashing> proposerSlashingPool;
-  final OperationPool<AttesterSlashing> attesterSlashingPool;
-  final AttestationManager attestationManager;
-  final AggregatingAttestationPool attestationPool;
-  final RecentChainData recentChainData;
+  private final OperationPool<SignedVoluntaryExit> exitPool;
+  private final OperationPool<ProposerSlashing> proposerSlashingPool;
+  private final OperationPool<AttesterSlashing> attesterSlashingPool;
+  private final AttestationManager attestationManager;
+  private final AggregatingAttestationPool attestationPool;
+  private final RecentChainData recentChainData;
 
   public OperationsReOrgManager(
-      OperationPool<ProposerSlashing> proposerSlashingPool,
-      OperationPool<AttesterSlashing> attesterSlashingPool,
-      OperationPool<SignedVoluntaryExit> exitPool,
-      AggregatingAttestationPool attestationPool,
-      AttestationManager attestationManager,
-      RecentChainData recentChainData) {
+      final OperationPool<ProposerSlashing> proposerSlashingPool,
+      final OperationPool<AttesterSlashing> attesterSlashingPool,
+      final OperationPool<SignedVoluntaryExit> exitPool,
+      final AggregatingAttestationPool attestationPool,
+      final AttestationManager attestationManager,
+      final RecentChainData recentChainData) {
     this.exitPool = exitPool;
     this.proposerSlashingPool = proposerSlashingPool;
     this.attesterSlashingPool = attesterSlashingPool;
@@ -121,7 +121,7 @@ public class OperationsReOrgManager implements ChainHeadChannel {
     attestations.forEach(
         attestation -> {
           attestationManager
-              .onAttestation(ValidateableAttestation.from(attestation))
+              .onAttestation(ValidateableAttestation.from(recentChainData.getSpec(), attestation))
               .finish(
                   result ->
                       result.ifInvalid(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.bls.BLS;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -30,11 +31,13 @@ import tech.pegasys.teku.ssz.collections.SszBitlist;
  * made redundant by the current aggregate.
  */
 class AggregateAttestationBuilder {
+  private final Spec spec;
   private final Set<ValidateableAttestation> includedAttestations = new HashSet<>();
   private final AttestationData attestationData;
   private SszBitlist currentAggregateBits;
 
-  AggregateAttestationBuilder(final AttestationData attestationData) {
+  AggregateAttestationBuilder(final Spec spec, final AttestationData attestationData) {
+    this.spec = spec;
     this.attestationData = attestationData;
   }
 
@@ -61,6 +64,7 @@ class AggregateAttestationBuilder {
   public ValidateableAttestation buildAggregate() {
     checkState(currentAggregateBits != null, "Must aggregate at least one attestation");
     return ValidateableAttestation.from(
+        spec,
         new Attestation(
             currentAggregateBits,
             attestationData,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -81,6 +81,7 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
                 dataRoot,
                 key ->
                     new MatchingDataAttestationGroup(
+                        spec,
                         attestationData,
                         attestation
                             .getCommitteeShufflingSeed()

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -23,6 +23,7 @@ import java.util.TreeMap;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -45,12 +46,16 @@ class MatchingDataAttestationGroup implements Iterable<ValidateableAttestation> 
   private final NavigableMap<Integer, Set<ValidateableAttestation>> attestationsByValidatorCount =
       new TreeMap<>(Comparator.reverseOrder()); // Most validators first
 
+  private final Spec spec;
   private final AttestationData attestationData;
   private final Bytes32 committeeShufflingSeed;
   private SszBitlist seenAggregationBits = Attestation.createEmptyAggregationBits();
 
   public MatchingDataAttestationGroup(
-      final AttestationData attestationData, final Bytes32 committeeShufflingSeed) {
+      final Spec spec,
+      final AttestationData attestationData,
+      final Bytes32 committeeShufflingSeed) {
+    this.spec = spec;
     this.attestationData = attestationData;
     this.committeeShufflingSeed = committeeShufflingSeed;
   }
@@ -159,7 +164,8 @@ class MatchingDataAttestationGroup implements Iterable<ValidateableAttestation> 
 
     @Override
     public ValidateableAttestation next() {
-      final AggregateAttestationBuilder builder = new AggregateAttestationBuilder(attestationData);
+      final AggregateAttestationBuilder builder =
+          new AggregateAttestationBuilder(spec, attestationData);
       streamRemainingAttestations()
           .forEach(
               candidate -> {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPool.java
@@ -34,6 +34,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -51,6 +52,7 @@ public class PendingPool<T> implements SlotEventsChannel, FinalizedCheckpointCha
   private static final int DEFAULT_MAX_ITEMS = 5000;
   private static final UInt64 GENESIS_SLOT = UInt64.valueOf(Constants.GENESIS_SLOT);
 
+  private final Spec spec;
   private final Subscribers<RequiredBlockRootSubscriber> requiredBlockRootSubscribers =
       Subscribers.create(true);
   private final Subscribers<RequiredBlockRootDroppedSubscriber>
@@ -73,12 +75,14 @@ public class PendingPool<T> implements SlotEventsChannel, FinalizedCheckpointCha
   private volatile UInt64 latestFinalizedSlot = UInt64.valueOf(Constants.GENESIS_SLOT);
 
   PendingPool(
+      final Spec spec,
       final UInt64 historicalSlotTolerance,
       final UInt64 futureSlotTolerance,
       final int maxItems,
       final Function<T, Bytes32> hashTreeRootFunction,
       final Function<T, Collection<Bytes32>> requiredBlockRootsFunction,
       final Function<T, UInt64> targetSlotFunction) {
+    this.spec = spec;
     this.historicalSlotTolerance = historicalSlotTolerance;
     this.futureSlotTolerance = futureSlotTolerance;
     this.maxItems = maxItems;
@@ -87,18 +91,21 @@ public class PendingPool<T> implements SlotEventsChannel, FinalizedCheckpointCha
     this.targetSlotFunction = targetSlotFunction;
   }
 
-  public static PendingPool<SignedBeaconBlock> createForBlocks() {
+  public static PendingPool<SignedBeaconBlock> createForBlocks(final Spec spec) {
     return createForBlocks(
+        spec,
         DEFAULT_HISTORICAL_SLOT_TOLERANCE,
         FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
         DEFAULT_MAX_ITEMS);
   }
 
   public static PendingPool<SignedBeaconBlock> createForBlocks(
+      final Spec spec,
       final UInt64 historicalBlockTolerance,
       final UInt64 futureBlockTolerance,
       final int maxItems) {
     return new PendingPool<>(
+        spec,
         historicalBlockTolerance,
         futureBlockTolerance,
         maxItems,
@@ -107,8 +114,9 @@ public class PendingPool<T> implements SlotEventsChannel, FinalizedCheckpointCha
         SignedBeaconBlock::getSlot);
   }
 
-  public static PendingPool<ValidateableAttestation> createForAttestations() {
+  public static PendingPool<ValidateableAttestation> createForAttestations(final Spec spec) {
     return new PendingPool<>(
+        spec,
         DEFAULT_HISTORICAL_SLOT_TOLERANCE,
         FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
         DEFAULT_MAX_ITEMS,
@@ -298,7 +306,7 @@ public class PendingPool<T> implements SlotEventsChannel, FinalizedCheckpointCha
 
   @Override
   public void onNewFinalizedCheckpoint(final Checkpoint checkpoint) {
-    this.latestFinalizedSlot = checkpoint.getEpochStartSlot();
+    this.latestFinalizedSlot = checkpoint.getEpochStartSlot(spec);
   }
 
   @VisibleForTesting

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -249,7 +249,10 @@ public class AttestationValidator {
         secondsToMillis(
             recentChainData
                 .getGenesisTime()
-                .plus(attestation.getEarliestSlotForForkChoiceProcessing().times(secondsPerSlot)));
+                .plus(
+                    attestation
+                        .getEarliestSlotForForkChoiceProcessing(spec)
+                        .times(secondsPerSlot)));
     final UInt64 discardAttestationsAfterMillis =
         currentTimeMillis.plus(secondsToMillis(MAX_FUTURE_SLOT_ALLOWANCE.times(secondsPerSlot)));
     return attestationSlotTimeMillis.isGreaterThan(discardAttestationsAfterMillis);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockValidator.java
@@ -132,7 +132,8 @@ public class BlockValidator {
   }
 
   private boolean blockSlotIsGreaterThanLatestFinalizedSlot(SignedBeaconBlock block) {
-    UInt64 finalizedSlot = recentChainData.getStore().getFinalizedCheckpoint().getEpochStartSlot();
+    UInt64 finalizedSlot =
+        recentChainData.getStore().getFinalizedCheckpoint().getEpochStartSlot(spec);
     return block.getSlot().compareTo(finalizedSlot) > 0;
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationsReOrgManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationsReOrgManagerTest.java
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -46,8 +48,8 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 @SuppressWarnings("unchecked")
 public class OperationsReOrgManagerTest {
-
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   private final OperationPool<ProposerSlashing> proposerSlashingOperationPool =
       mock(OperationPool.class);
@@ -130,11 +132,11 @@ public class OperationsReOrgManagerTest {
     List<ValidateableAttestation> attestationList = new ArrayList<>();
     attestationList.addAll(
         fork1Block1.getBody().getAttestations().stream()
-            .map(ValidateableAttestation::from)
+            .map(attestation -> ValidateableAttestation.from(spec, attestation))
             .collect(Collectors.toList()));
     attestationList.addAll(
         fork1Block2.getBody().getAttestations().stream()
-            .map(ValidateableAttestation::from)
+            .map(attestation -> ValidateableAttestation.from(spec, attestation))
             .collect(Collectors.toList()));
     assertThat(argument.getAllValues()).containsExactlyInAnyOrderElementsOf(attestationList);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilderTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilderTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -29,11 +31,12 @@ import tech.pegasys.teku.ssz.collections.SszBitlist;
 class AggregateAttestationBuilderTest {
 
   public static final int BITLIST_SIZE = 10;
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final AttestationData attestationData = dataStructureUtil.randomAttestationData();
 
   private final AggregateAttestationBuilder builder =
-      new AggregateAttestationBuilder(attestationData);
+      new AggregateAttestationBuilder(spec, attestationData);
 
   @Test
   public void canAggregate_shouldBeTrueForFirstAttestation() {
@@ -87,6 +90,7 @@ class AggregateAttestationBuilderTest {
     assertThat(builder.buildAggregate())
         .isEqualTo(
             ValidateableAttestation.from(
+                spec,
                 new Attestation(expectedAggregationBits, attestationData, expectedSignature)));
   }
 
@@ -99,6 +103,7 @@ class AggregateAttestationBuilderTest {
     final SszBitlist aggregationBits =
         Attestation.SSZ_SCHEMA.getAggregationBitsSchema().ofBits(BITLIST_SIZE, validators);
     return ValidateableAttestation.from(
+        spec,
         new Attestation(aggregationBits, attestationData, dataStructureUtil.randomSignature()));
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -292,7 +292,7 @@ class AggregatingAttestationPoolTest {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
 
     final Attestation attestation = addAttestationFromValidators(attestationData, 1, 2, 3, 4);
-    aggregatingPool.add(ValidateableAttestation.from(attestation));
+    aggregatingPool.add(ValidateableAttestation.from(spec, attestation));
     assertThat(aggregatingPool.getSize()).isEqualTo(1);
   }
 
@@ -408,7 +408,8 @@ class AggregatingAttestationPoolTest {
         Attestation.SSZ_SCHEMA.getAggregationBitsSchema().ofBits(20, validators);
     final Attestation attestation =
         new Attestation(bitlist, data, dataStructureUtil.randomSignature());
-    ValidateableAttestation validateableAttestation = ValidateableAttestation.from(attestation);
+    ValidateableAttestation validateableAttestation =
+        ValidateableAttestation.from(spec, attestation);
     validateableAttestation.saveCommitteeShufflingSeed(
         dataStructureUtil.randomBeaconState(100, 15));
     aggregatingPool.add(validateableAttestation);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerTest.java
@@ -36,6 +36,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -52,7 +54,8 @@ import tech.pegasys.teku.statetransition.validation.AggregateAttestationValidato
 import tech.pegasys.teku.statetransition.validation.AttestationValidator;
 
 class AttestationManagerTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final EventBus eventBus = new EventBus();
 
   private final AggregatingAttestationPool attestationPool = mock(AggregatingAttestationPool.class);
@@ -85,7 +88,7 @@ class AttestationManagerTest {
   @Test
   public void shouldProcessAttestationsThatAreReadyImmediately() {
     final ValidateableAttestation attestation =
-        ValidateableAttestation.from(dataStructureUtil.randomAttestation());
+        ValidateableAttestation.from(spec, dataStructureUtil.randomAttestation());
     when(forkChoice.onAttestation(any())).thenReturn(completedFuture(SUCCESSFUL));
     attestationManager.onAttestation(attestation).reportExceptions();
 
@@ -99,7 +102,7 @@ class AttestationManagerTest {
   public void shouldProcessAggregatesThatAreReadyImmediately() {
     final ValidateableAttestation aggregate =
         ValidateableAttestation.aggregateFromValidator(
-            dataStructureUtil.randomSignedAggregateAndProof());
+            spec, dataStructureUtil.randomSignedAggregateAndProof());
     when(forkChoice.onAttestation(any())).thenReturn(completedFuture(SUCCESSFUL));
     attestationManager.onAttestation(aggregate).reportExceptions();
 
@@ -116,7 +119,7 @@ class AttestationManagerTest {
     attestationManager.onSlot(currentSlot);
 
     ValidateableAttestation attestation =
-        ValidateableAttestation.from(attestationFromSlot(futureSlot));
+        ValidateableAttestation.from(spec, attestationFromSlot(futureSlot));
     IndexedAttestation randomIndexedAttestation = dataStructureUtil.randomIndexedAttestation();
     when(forkChoice.onAttestation(any())).thenReturn(completedFuture(SAVED_FOR_FUTURE));
     attestationManager.onAttestation(attestation).reportExceptions();
@@ -146,7 +149,7 @@ class AttestationManagerTest {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
     final Bytes32 requiredBlockRoot = block.getMessage().hashTreeRoot();
     final ValidateableAttestation attestation =
-        ValidateableAttestation.from(attestationFromSlot(1, requiredBlockRoot));
+        ValidateableAttestation.from(spec, attestationFromSlot(1, requiredBlockRoot));
     when(forkChoice.onAttestation(any()))
         .thenReturn(completedFuture(UNKNOWN_BLOCK))
         .thenReturn(completedFuture(SUCCESSFUL));
@@ -177,7 +180,7 @@ class AttestationManagerTest {
   @Test
   public void shouldNotPublishProcessedAttestationEventWhenAttestationIsInvalid() {
     final ValidateableAttestation attestation =
-        ValidateableAttestation.from(dataStructureUtil.randomAttestation());
+        ValidateableAttestation.from(spec, dataStructureUtil.randomAttestation());
     when(forkChoice.onAttestation(any()))
         .thenReturn(completedFuture(AttestationProcessingResult.invalid("Didn't like it")));
     attestationManager.onAttestation(attestation).reportExceptions();
@@ -192,7 +195,7 @@ class AttestationManagerTest {
   public void shouldNotPublishProcessedAggregationEventWhenAttestationIsInvalid() {
     final ValidateableAttestation aggregateAndProof =
         ValidateableAttestation.aggregateFromValidator(
-            dataStructureUtil.randomSignedAggregateAndProof());
+            spec, dataStructureUtil.randomSignedAggregateAndProof());
     when(forkChoice.onAttestation(any()))
         .thenReturn(completedFuture(AttestationProcessingResult.invalid("Don't wanna")));
     attestationManager.onAttestation(aggregateAndProof).reportExceptions();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerTest.java
@@ -61,7 +61,7 @@ class AttestationManagerTest {
   private final AggregatingAttestationPool attestationPool = mock(AggregatingAttestationPool.class);
   private final ForkChoice forkChoice = mock(ForkChoice.class);
   private final PendingPool<ValidateableAttestation> pendingAttestations =
-      PendingPool.createForAttestations();
+      PendingPool.createForAttestations(spec);
   private final FutureItems<ValidateableAttestation> futureAttestations =
       FutureItems.create(ValidateableAttestation::getEarliestSlotForForkChoiceProcessing);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
@@ -19,6 +19,8 @@ import static tech.pegasys.teku.statetransition.attestation.AggregatorUtil.aggre
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -27,11 +29,12 @@ import tech.pegasys.teku.ssz.collections.SszBitlist;
 
 class MatchingDataAttestationGroupTest {
   private static final UInt64 SLOT = UInt64.valueOf(1234);
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final AttestationData attestationData = dataStructureUtil.randomAttestationData(SLOT);
 
   private final MatchingDataAttestationGroup group =
-      new MatchingDataAttestationGroup(attestationData, Bytes32.ZERO);
+      new MatchingDataAttestationGroup(spec, attestationData, Bytes32.ZERO);
 
   @Test
   public void isEmpty_shouldBeEmptyInitially() {
@@ -117,6 +120,7 @@ class MatchingDataAttestationGroupTest {
     final ValidateableAttestation attestation = addAttestation(1);
     final ValidateableAttestation copy =
         ValidateableAttestation.from(
+            spec,
             Attestation.SSZ_SCHEMA.sszDeserialize(attestation.getAttestation().sszSerialize()));
 
     assertThat(group.add(copy)).isFalse();
@@ -130,7 +134,7 @@ class MatchingDataAttestationGroupTest {
 
     final Attestation expected =
         aggregateAttestations(attestation1.getAttestation(), attestation2.getAttestation());
-    assertThat(group).containsExactlyInAnyOrder(ValidateableAttestation.from(expected));
+    assertThat(group).containsExactlyInAnyOrder(ValidateableAttestation.from(spec, expected));
   }
 
   @Test
@@ -142,6 +146,7 @@ class MatchingDataAttestationGroupTest {
     assertThat(group)
         .containsExactly(
             ValidateableAttestation.from(
+                spec,
                 aggregateAttestations(
                     bigAttestation.getAttestation(), littleAttestation.getAttestation())),
             mediumAttestation);
@@ -194,6 +199,7 @@ class MatchingDataAttestationGroupTest {
     final SszBitlist aggregationBits =
         Attestation.SSZ_SCHEMA.getAggregationBitsSchema().ofBits(10, validators);
     return ValidateableAttestation.from(
+        spec,
         new Attestation(aggregationBits, attestationData, dataStructureUtil.randomSignature()));
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -415,7 +415,10 @@ public class BlockImporterTest {
     // Verify ws period checks were run
     final CheckpointState finalizedCheckpointState =
         CheckpointState.create(
-            new Checkpoint(UInt64.ZERO, genesis.getRoot()), genesis.getBlock(), genesis.getState());
+            spec,
+            new Checkpoint(UInt64.ZERO, genesis.getRoot()),
+            genesis.getBlock(),
+            genesis.getState());
     verify(weakSubjectivityValidator)
         .validateLatestFinalizedCheckpoint(finalizedCheckpointState, currentSlot);
   }
@@ -456,7 +459,10 @@ public class BlockImporterTest {
     // Verify ws period checks were run
     final CheckpointState finalizedCheckpointState =
         CheckpointState.create(
-            new Checkpoint(UInt64.ZERO, genesis.getRoot()), genesis.getBlock(), genesis.getState());
+            spec,
+            new Checkpoint(UInt64.ZERO, genesis.getRoot()),
+            genesis.getBlock(),
+            genesis.getState());
     verify(weakSubjectivityValidator)
         .validateLatestFinalizedCheckpoint(finalizedCheckpointState, currentSlot);
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -58,7 +58,8 @@ public class BlockManagerTest {
   private final UInt64 futureBlockTolerance = UInt64.valueOf(2);
   private final int maxPendingBlocks = 10;
   private final PendingPool<SignedBeaconBlock> pendingBlocks =
-      PendingPool.createForBlocks(historicalBlockTolerance, futureBlockTolerance, maxPendingBlocks);
+      PendingPool.createForBlocks(
+          spec, historicalBlockTolerance, futureBlockTolerance, maxPendingBlocks);
   private final FutureItems<SignedBeaconBlock> futureBlocks =
       FutureItems.create(SignedBeaconBlock::getSlot);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -366,7 +366,7 @@ class ForkChoiceTest {
             AttestationProcessingResult.invalid(
                 String.format(
                     "Checkpoint state (%s) must be at or prior to checkpoint slot boundary (%s)",
-                    targetBlock.getSlot(), targetCheckpoint.getEpochStartSlot())));
+                    targetBlock.getSlot(), targetCheckpoint.getEpochStartSlot(spec))));
   }
 
   private UInt64 applyAttestationFromValidator(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -360,7 +360,7 @@ class ForkChoiceTest {
                 targetCheckpoint),
             BLSSignature.empty());
     final SafeFuture<AttestationProcessingResult> result =
-        forkChoice.onAttestation(ValidateableAttestation.from(attestation));
+        forkChoice.onAttestation(ValidateableAttestation.from(spec, attestation));
     assertThat(result)
         .isCompletedWithValue(
             AttestationProcessingResult.invalid(
@@ -376,6 +376,7 @@ class ForkChoiceTest {
     final UInt64 updatedAttestationSlot = UInt64.valueOf(20);
     final ValidateableAttestation updatedVote =
         ValidateableAttestation.from(
+            spec,
             new Attestation(
                 Attestation.SSZ_SCHEMA.getAggregationBitsSchema().ofBits(16),
                 new AttestationData(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/PendingPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/PendingPoolTest.java
@@ -22,17 +22,20 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class PendingPoolTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final UInt64 historicalTolerance = UInt64.valueOf(5);
   private final UInt64 futureTolerance = UInt64.valueOf(2);
   private final int maxItems = 15;
   private final PendingPool<SignedBeaconBlock> pendingPool =
-      PendingPool.createForBlocks(historicalTolerance, futureTolerance, maxItems);
+      PendingPool.createForBlocks(spec, historicalTolerance, futureTolerance, maxItems);
   private UInt64 currentSlot = historicalTolerance.times(2);
   private List<Bytes32> requiredRootEvents = new ArrayList<>();
   private List<Bytes32> requiredRootDroppedEvents = new ArrayList<>();
@@ -128,7 +131,7 @@ public class PendingPoolTest {
     final Checkpoint checkpoint = finalizedCheckpoint(finalizedBlock);
     pendingPool.onNewFinalizedCheckpoint(checkpoint);
 
-    final UInt64 slot = checkpoint.getEpochStartSlot().plus(UInt64.ONE);
+    final UInt64 slot = checkpoint.getEpochStartSlot(spec).plus(UInt64.ONE);
     setSlot(slot);
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot.longValue());
 
@@ -146,10 +149,10 @@ public class PendingPoolTest {
     final SignedBeaconBlock finalizedBlock = dataStructureUtil.randomSignedBeaconBlock(10);
     final Checkpoint checkpoint = finalizedCheckpoint(finalizedBlock);
     pendingPool.onNewFinalizedCheckpoint(checkpoint);
-    final long slot = checkpoint.getEpochStartSlot().longValue() + 10;
+    final long slot = checkpoint.getEpochStartSlot(spec).longValue() + 10;
     setSlot(slot);
 
-    final long blockSlot = checkpoint.getEpochStartSlot().longValue();
+    final long blockSlot = checkpoint.getEpochStartSlot(spec).longValue();
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(blockSlot);
 
     pendingPool.add(block);
@@ -417,7 +420,7 @@ public class PendingPoolTest {
   public void prune_finalizedBlocks() {
     final SignedBeaconBlock finalizedBlock = dataStructureUtil.randomSignedBeaconBlock(10);
     final Checkpoint checkpoint = finalizedCheckpoint(finalizedBlock);
-    final long finalizedSlot = checkpoint.getEpochStartSlot().longValue();
+    final long finalizedSlot = checkpoint.getEpochStartSlot(spec).longValue();
     setSlot(finalizedSlot);
 
     // Add a bunch of blocks

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AttestationValidatorTest.java
@@ -305,10 +305,11 @@ class AttestationValidatorTest {
         spec.computeSubnetForAttestation(blockAndState.getState(), attestation);
     assertThat(
             validator.validate(
-                ValidateableAttestation.fromNetwork(attestation, expectedSubnetId + 1)))
+                ValidateableAttestation.fromNetwork(spec, attestation, expectedSubnetId + 1)))
         .isCompletedWithValue(InternalValidationResult.REJECT);
     assertThat(
-            validator.validate(ValidateableAttestation.fromNetwork(attestation, expectedSubnetId)))
+            validator.validate(
+                ValidateableAttestation.fromNetwork(spec, attestation, expectedSubnetId)))
         .isCompletedWithValue(InternalValidationResult.ACCEPT);
   }
 
@@ -322,6 +323,7 @@ class AttestationValidatorTest {
     assertThat(
             validator.validate(
                 ValidateableAttestation.fromNetwork(
+                    spec,
                     new Attestation(
                         attestation.getAggregation_bits(),
                         new AttestationData(
@@ -346,6 +348,7 @@ class AttestationValidatorTest {
     assertThat(
             validator.validate(
                 ValidateableAttestation.fromNetwork(
+                    spec,
                     new Attestation(
                         attestation.getAggregation_bits(),
                         new AttestationData(
@@ -369,7 +372,8 @@ class AttestationValidatorTest {
     final int expectedSubnetId =
         spec.computeSubnetForAttestation(blockAndState.getState(), attestation);
     assertThat(
-            validator.validate(ValidateableAttestation.fromNetwork(attestation, expectedSubnetId)))
+            validator.validate(
+                ValidateableAttestation.fromNetwork(spec, attestation, expectedSubnetId)))
         .isCompletedWithValue(InternalValidationResult.REJECT);
   }
 
@@ -385,7 +389,8 @@ class AttestationValidatorTest {
     final int expectedSubnetId =
         spec.computeSubnetForAttestation(blockAndState.getState(), attestation);
     assertThat(
-            validator.validate(ValidateableAttestation.fromNetwork(attestation, expectedSubnetId)))
+            validator.validate(
+                ValidateableAttestation.fromNetwork(spec, attestation, expectedSubnetId)))
         .isCompletedWithValue(InternalValidationResult.REJECT);
   }
 
@@ -394,7 +399,7 @@ class AttestationValidatorTest {
     return validator
         .validate(
             ValidateableAttestation.fromNetwork(
-                attestation, spec.computeSubnetForAttestation(state, attestation)))
+                spec, attestation, spec.computeSubnetForAttestation(state, attestation)))
         .join();
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/SignedAggregateAndProofValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/SignedAggregateAndProofValidatorTest.java
@@ -143,7 +143,7 @@ class SignedAggregateAndProofValidatorTest {
     final StateAndBlockSummary chainHead = recentChainData.getChainHead().orElseThrow();
     final SignedAggregateAndProof aggregate = generator.validAggregateAndProof(chainHead);
     whenAttestationIsValid(aggregate);
-    assertThat(validator.validate(ValidateableAttestation.aggregateFromValidator(aggregate)))
+    assertThat(validator.validate(ValidateableAttestation.aggregateFromValidator(spec, aggregate)))
         .isCompletedWithValue(InternalValidationResult.ACCEPT);
   }
 
@@ -156,7 +156,7 @@ class SignedAggregateAndProofValidatorTest {
     final SignedAggregateAndProof aggregate =
         generator.validAggregateAndProof(chainHead, currentSlot);
     whenAttestationIsValid(aggregate);
-    assertThat(validator.validate(ValidateableAttestation.aggregateFromValidator(aggregate)))
+    assertThat(validator.validate(ValidateableAttestation.aggregateFromValidator(spec, aggregate)))
         .isCompletedWithValue(InternalValidationResult.ACCEPT);
   }
 
@@ -164,7 +164,8 @@ class SignedAggregateAndProofValidatorTest {
   public void shouldRejectWhenAttestationValidatorRejects() {
     final SignedAggregateAndProof aggregate =
         generator.validAggregateAndProof(recentChainData.getChainHead().orElseThrow());
-    ValidateableAttestation attestation = ValidateableAttestation.aggregateFromValidator(aggregate);
+    ValidateableAttestation attestation =
+        ValidateableAttestation.aggregateFromValidator(spec, aggregate);
     when(attestationValidator.singleOrAggregateAttestationChecks(
             any(), eq(attestation), eq(OptionalInt.empty())))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.REJECT));
@@ -177,7 +178,8 @@ class SignedAggregateAndProofValidatorTest {
   public void shouldIgnoreWhenAttestationValidatorIgnores() {
     final SignedAggregateAndProof aggregate =
         generator.validAggregateAndProof(recentChainData.getChainHead().orElseThrow());
-    ValidateableAttestation attestation = ValidateableAttestation.aggregateFromValidator(aggregate);
+    ValidateableAttestation attestation =
+        ValidateableAttestation.aggregateFromValidator(spec, aggregate);
     when(attestationValidator.singleOrAggregateAttestationChecks(
             any(), eq(attestation), eq(OptionalInt.empty())))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.IGNORE));
@@ -190,7 +192,8 @@ class SignedAggregateAndProofValidatorTest {
   public void shouldSaveForFutureWhenAttestationValidatorSavesForFuture() {
     final SignedAggregateAndProof aggregate =
         generator.validAggregateAndProof(recentChainData.getChainHead().orElseThrow());
-    ValidateableAttestation attestation = ValidateableAttestation.aggregateFromValidator(aggregate);
+    ValidateableAttestation attestation =
+        ValidateableAttestation.aggregateFromValidator(spec, aggregate);
     when(attestationValidator.singleOrAggregateAttestationChecks(
             any(), eq(attestation), eq(OptionalInt.empty())))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.SAVE_FOR_FUTURE));
@@ -203,7 +206,8 @@ class SignedAggregateAndProofValidatorTest {
   public void shouldSaveForFutureWhenStateIsNotAvailable() {
     final SignedBlockAndState target = bestBlock;
     final SignedAggregateAndProof aggregate = generator.validAggregateAndProof(target.toUnsigned());
-    ValidateableAttestation attestation = ValidateableAttestation.aggregateFromValidator(aggregate);
+    ValidateableAttestation attestation =
+        ValidateableAttestation.aggregateFromValidator(spec, aggregate);
     when(attestationValidator.singleOrAggregateAttestationChecks(
             any(), eq(attestation), eq(OptionalInt.empty())))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.SAVE_FOR_FUTURE));
@@ -221,7 +225,8 @@ class SignedAggregateAndProofValidatorTest {
             .aggregatorIndex(ONE)
             .selectionProof(dataStructureUtil.randomSignature())
             .generate();
-    ValidateableAttestation attestation = ValidateableAttestation.aggregateFromValidator(aggregate);
+    ValidateableAttestation attestation =
+        ValidateableAttestation.aggregateFromValidator(spec, aggregate);
     when(attestationValidator.singleOrAggregateAttestationChecks(
             any(), eq(attestation), eq(OptionalInt.empty())))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.SAVE_FOR_FUTURE));
@@ -255,10 +260,12 @@ class SignedAggregateAndProofValidatorTest {
     assertThat(aggregateAndProof1).isNotEqualTo(aggregateAndProof2);
 
     assertThat(
-            validator.validate(ValidateableAttestation.aggregateFromValidator(aggregateAndProof1)))
+            validator.validate(
+                ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof1)))
         .isCompletedWithValue(InternalValidationResult.ACCEPT);
     assertThat(
-            validator.validate(ValidateableAttestation.aggregateFromValidator(aggregateAndProof2)))
+            validator.validate(
+                ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof2)))
         .isCompletedWithValue(InternalValidationResult.IGNORE);
   }
 
@@ -280,9 +287,9 @@ class SignedAggregateAndProofValidatorTest {
     assertThat(aggregateAndProof1).isNotEqualTo(aggregateAndProof2);
 
     ValidateableAttestation attestation1 =
-        ValidateableAttestation.aggregateFromValidator(aggregateAndProof1);
+        ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof1);
     ValidateableAttestation attestation2 =
-        ValidateableAttestation.aggregateFromValidator(aggregateAndProof2);
+        ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof2);
 
     // Sanity check
     assertThat(attestation1.hash_tree_root()).isEqualTo(attestation2.hash_tree_root());
@@ -311,9 +318,9 @@ class SignedAggregateAndProofValidatorTest {
     assertThat(aggregateAndProof1).isNotEqualTo(aggregateAndProof2);
 
     ValidateableAttestation attestation1 =
-        ValidateableAttestation.aggregateFromValidator(aggregateAndProof1);
+        ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof1);
     ValidateableAttestation attestation2 =
-        ValidateableAttestation.aggregateFromValidator(aggregateAndProof2);
+        ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof2);
 
     // Sanity check
     assertThat(attestation1.hash_tree_root()).isEqualTo(attestation2.hash_tree_root());
@@ -344,10 +351,12 @@ class SignedAggregateAndProofValidatorTest {
     whenAttestationIsValid(aggregateAndProof2);
 
     assertThat(
-            validator.validate(ValidateableAttestation.aggregateFromValidator(aggregateAndProof1)))
+            validator.validate(
+                ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof1)))
         .isCompletedWithValue(InternalValidationResult.ACCEPT);
     assertThat(
-            validator.validate(ValidateableAttestation.aggregateFromValidator(aggregateAndProof2)))
+            validator.validate(
+                ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof2)))
         .isCompletedWithValue(InternalValidationResult.ACCEPT);
   }
 
@@ -384,10 +393,12 @@ class SignedAggregateAndProofValidatorTest {
         .isEqualTo(aggregateAndProof2.getMessage().getIndex());
 
     assertThat(
-            validator.validate(ValidateableAttestation.aggregateFromValidator(aggregateAndProof1)))
+            validator.validate(
+                ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof1)))
         .isCompletedWithValue(InternalValidationResult.ACCEPT);
     assertThat(
-            validator.validate(ValidateableAttestation.aggregateFromValidator(aggregateAndProof2)))
+            validator.validate(
+                ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof2)))
         .isCompletedWithValue(InternalValidationResult.ACCEPT);
   }
 
@@ -416,7 +427,7 @@ class SignedAggregateAndProofValidatorTest {
                 .isAggregator(aggregate.getMessage().getSelection_proof(), aggregatorModulo))
         .isFalse();
 
-    assertThat(validator.validate(ValidateableAttestation.aggregateFromValidator(aggregate)))
+    assertThat(validator.validate(ValidateableAttestation.aggregateFromValidator(spec, aggregate)))
         .isCompletedWithValue(InternalValidationResult.REJECT);
   }
 
@@ -441,7 +452,7 @@ class SignedAggregateAndProofValidatorTest {
       fail("Aggregator was in the committee");
     }
 
-    assertThat(validator.validate(ValidateableAttestation.aggregateFromValidator(aggregate)))
+    assertThat(validator.validate(ValidateableAttestation.aggregateFromValidator(spec, aggregate)))
         .isCompletedWithValue(InternalValidationResult.REJECT);
   }
 
@@ -456,7 +467,7 @@ class SignedAggregateAndProofValidatorTest {
             .generate();
     whenAttestationIsValid(aggregate);
 
-    assertThat(validator.validate(ValidateableAttestation.aggregateFromValidator(aggregate)))
+    assertThat(validator.validate(ValidateableAttestation.aggregateFromValidator(spec, aggregate)))
         .isCompletedWithValue(InternalValidationResult.REJECT);
   }
 
@@ -470,9 +481,13 @@ class SignedAggregateAndProofValidatorTest {
     whenAttestationIsValid(invalidAggregate);
     whenAttestationIsValid(validAggregate);
 
-    assertThat(validator.validate(ValidateableAttestation.aggregateFromValidator(invalidAggregate)))
+    assertThat(
+            validator.validate(
+                ValidateableAttestation.aggregateFromValidator(spec, invalidAggregate)))
         .isCompletedWithValue(InternalValidationResult.REJECT);
-    assertThat(validator.validate(ValidateableAttestation.aggregateFromValidator(validAggregate)))
+    assertThat(
+            validator.validate(
+                ValidateableAttestation.aggregateFromValidator(spec, validAggregate)))
         .isCompletedWithValue(InternalValidationResult.ACCEPT);
   }
 
@@ -485,7 +500,8 @@ class SignedAggregateAndProofValidatorTest {
   }
 
   private void whenAttestationIsValid(final SignedAggregateAndProof aggregate) {
-    ValidateableAttestation attestation = ValidateableAttestation.aggregateFromValidator(aggregate);
+    ValidateableAttestation attestation =
+        ValidateableAttestation.aggregateFromValidator(spec, aggregate);
     when(attestationValidator.singleOrAggregateAttestationChecks(
             any(), eq(attestation), eq(OptionalInt.empty())))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidator.java
@@ -104,7 +104,7 @@ public class WeakSubjectivityValidator {
     }
 
     return chainData
-        .getFinalizedBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot())
+        .getFinalizedBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot(spec))
         .thenAccept(
             maybeBlock -> {
               SignedBeaconBlock blockAtCheckpointSlot =
@@ -192,7 +192,7 @@ public class WeakSubjectivityValidator {
       // If the block is at or past the checkpoint, the wsCheckpoint must be an ancestor
       final Optional<Bytes32> ancestor =
           spec.getAncestor(
-              forkChoiceStrategy, block.getParentRoot(), wsCheckpoint.getEpochStartSlot());
+              forkChoiceStrategy, block.getParentRoot(), wsCheckpoint.getEpochStartSlot(spec));
       // If ancestor is not present, the chain must have moved passed the wsCheckpoint
       return ancestor.map(a -> a.equals(wsCheckpoint.getRoot())).orElse(true);
     }

--- a/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidatorTest.java
+++ b/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityValidatorTest.java
@@ -166,7 +166,7 @@ public class WeakSubjectivityValidatorTest {
     // Checkpoint is at the ws epoch, but has a different root
     when(checkpointState.getEpoch()).thenReturn(wsCheckpoint.getEpoch());
     when(checkpointState.getRoot()).thenReturn(Bytes32.fromHexStringLenient("0x02"));
-    when(checkpointState.getBlockSlot()).thenReturn(wsCheckpoint.getEpochStartSlot());
+    when(checkpointState.getBlockSlot()).thenReturn(wsCheckpoint.getEpochStartSlot(spec));
     when(calculator.isWithinWeakSubjectivityPeriod(checkpointState, currentSlot)).thenReturn(true);
 
     validator.validateLatestFinalizedCheckpoint(checkpointState, currentSlot);
@@ -213,7 +213,7 @@ public class WeakSubjectivityValidatorTest {
     // Checkpoint is at the ws epoch, but has a different root
     when(checkpointState.getEpoch()).thenReturn(wsCheckpoint.getEpoch());
     when(checkpointState.getRoot()).thenReturn(Bytes32.fromHexStringLenient("0x02"));
-    when(checkpointState.getBlockSlot()).thenReturn(wsCheckpoint.getEpochStartSlot());
+    when(checkpointState.getBlockSlot()).thenReturn(wsCheckpoint.getEpochStartSlot(spec));
     when(calculator.isWithinWeakSubjectivityPeriod(checkpointState, currentSlot)).thenReturn(false);
     when(calculator.computeWeakSubjectivityPeriod(checkpointState)).thenReturn(mockWsPeriod);
 
@@ -377,7 +377,7 @@ public class WeakSubjectivityValidatorTest {
     assertThat(result).isCompleted();
     verifyNoMoreInteractions(policy);
     verify(chainData).isFinalizedEpoch(wsCheckpoint.getEpoch());
-    verify(chainData).getFinalizedBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot());
+    verify(chainData).getFinalizedBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot(spec));
   }
 
   @Test
@@ -399,7 +399,7 @@ public class WeakSubjectivityValidatorTest {
 
     assertThat(result).isCompleted();
     verify(chainData).isFinalizedEpoch(wsCheckpoint.getEpoch());
-    verify(chainData).getFinalizedBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot());
+    verify(chainData).getFinalizedBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot(spec));
 
     verify(policy)
         .onChainInconsistentWithWeakSubjectivityCheckpoint(
@@ -425,7 +425,7 @@ public class WeakSubjectivityValidatorTest {
 
     assertThat(result).isCompletedExceptionally();
     verify(chainData).isFinalizedEpoch(wsCheckpoint.getEpoch());
-    verify(chainData).getFinalizedBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot());
+    verify(chainData).getFinalizedBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot(spec));
     verifyNoMoreInteractions(policy);
   }
 
@@ -590,7 +590,7 @@ public class WeakSubjectivityValidatorTest {
       final Checkpoint wsCheckpoint, final Optional<SignedBeaconBlock> block) {
     final CombinedChainDataClient client = mock(CombinedChainDataClient.class);
     when(client.isFinalizedEpoch(any())).thenReturn(true);
-    when(client.getFinalizedBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot()))
+    when(client.getFinalizedBlockInEffectAtSlot(wsCheckpoint.getEpochStartSlot(spec)))
         .thenReturn(SafeFuture.completedFuture(block));
 
     return client;

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceTestExecutor.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceTestExecutor.java
@@ -260,7 +260,7 @@ public class ForkChoiceTestExecutor {
 
   private boolean processAttestation(ForkChoice fc, Attestation step) {
     AttestationProcessingResult attestationProcessingResult =
-        fc.onAttestation(ValidateableAttestation.from(step)).join();
+        fc.onAttestation(ValidateableAttestation.from(SPEC, step)).join();
     return attestationProcessingResult.isSuccessful();
   }
 

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GossipMessageHandlerIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GossipMessageHandlerIntegrationTest.java
@@ -207,7 +207,7 @@ public class GossipMessageHandlerIntegrationTest {
         node1.storageClient().getChainHead().orElseThrow();
     Attestation validAttestation = attestationGenerator.validAttestation(bestBlockAndState);
     processedAttestationSubscribers.forEach(
-        s -> s.accept(ValidateableAttestation.from(validAttestation)));
+        s -> s.accept(ValidateableAttestation.from(spec, validAttestation)));
 
     ensureConditionRemainsMet(() -> assertThat(node2attestations).isEmpty());
   }
@@ -257,7 +257,8 @@ public class GossipMessageHandlerIntegrationTest {
     final StateAndBlockSummary bestBlockAndState =
         node1.storageClient().getChainHead().orElseThrow();
     ValidateableAttestation validAttestation =
-        ValidateableAttestation.from(attestationGenerator.validAttestation(bestBlockAndState));
+        ValidateableAttestation.from(
+            spec, attestationGenerator.validAttestation(bestBlockAndState));
 
     final int subnetId =
         spec.computeSubnetForAttestation(
@@ -328,7 +329,7 @@ public class GossipMessageHandlerIntegrationTest {
         spec.computeSubnetForAttestation(bestBlockAndState.getState(), attestation);
 
     ValidateableAttestation validAttestation =
-        ValidateableAttestation.fromNetwork(attestation, subnetId);
+        ValidateableAttestation.fromNetwork(spec, attestation, subnetId);
 
     node1.network().subscribeToAttestationSubnetId(subnetId);
     node2.network().subscribeToAttestationSubnetId(subnetId);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/AggregateAttestationTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/AggregateAttestationTopicHandler.java
@@ -33,7 +33,9 @@ public class AggregateAttestationTopicHandler {
 
     OperationProcessor<SignedAggregateAndProof> convertingProcessor =
         proofMessage ->
-            operationProcessor.process(ValidateableAttestation.aggregateFromNetwork(proofMessage));
+            operationProcessor.process(
+                ValidateableAttestation.aggregateFromNetwork(
+                    recentChainData.getSpec(), proofMessage));
 
     return new Eth2TopicHandler<>(
         recentChainData,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/SingleAttestationTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/SingleAttestationTopicHandler.java
@@ -34,7 +34,9 @@ public class SingleAttestationTopicHandler {
 
     OperationProcessor<Attestation> convertingProcessor =
         attMessage ->
-            operationProcessor.process(ValidateableAttestation.fromNetwork(attMessage, subnetId));
+            operationProcessor.process(
+                ValidateableAttestation.fromNetwork(
+                    recentChainData.getSpec(), attMessage, subnetId));
 
     return new Eth2TopicHandler<>(
         recentChainData,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
@@ -20,11 +20,13 @@ import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.MetadataMessagesFactory;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 public class Eth2PeerFactory {
 
+  private final Spec spec;
   private final StatusMessageFactory statusMessageFactory;
   private final MetadataMessagesFactory metadataMessagesFactory;
   private final MetricsSystem metricsSystem;
@@ -35,6 +37,7 @@ public class Eth2PeerFactory {
   private final int peerRequestLimit;
 
   public Eth2PeerFactory(
+      final Spec spec,
       final MetricsSystem metricsSystem,
       final CombinedChainDataClient chainDataClient,
       final StatusMessageFactory statusMessageFactory,
@@ -43,6 +46,7 @@ public class Eth2PeerFactory {
       final Optional<Checkpoint> requiredCheckpoint,
       final int peerRateLimit,
       final int peerRequestLimit) {
+    this.spec = spec;
     this.metricsSystem = metricsSystem;
     this.chainDataClient = chainDataClient;
     this.timeProvider = timeProvider;
@@ -59,7 +63,7 @@ public class Eth2PeerFactory {
         rpcMethods,
         statusMessageFactory,
         metadataMessagesFactory,
-        PeerChainValidator.create(metricsSystem, chainDataClient, requiredCheckpoint),
+        PeerChainValidator.create(spec, metricsSystem, chainDataClient, requiredCheckpoint),
         new RateTracker(peerRateLimit, 60, timeProvider),
         new RateTracker(peerRequestLimit, 60, timeProvider));
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -133,6 +133,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
         recentChainData,
         metricsSystem,
         new Eth2PeerFactory(
+            spec,
             metricsSystem,
             combinedChainDataClient,
             statusMessageFactory,

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AggregateGossipManagerTest.java
@@ -72,7 +72,7 @@ public class AggregateGossipManagerTest {
   public void onNewAggregate() {
     final SignedAggregateAndProof aggregate = dataStructureUtil.randomSignedAggregateAndProof();
     final Bytes serialized = gossipEncoding.encode(aggregate);
-    gossipManager.onNewAggregate(ValidateableAttestation.aggregateFromValidator(aggregate));
+    gossipManager.onNewAggregate(ValidateableAttestation.aggregateFromValidator(spec, aggregate));
 
     verify(topicChannel).gossip(serialized);
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
@@ -93,13 +93,13 @@ public class AttestationGossipManagerTest {
 
     // Post new attestation
     final Bytes serialized = gossipEncoding.encode(attestation);
-    attestationGossipManager.onNewAttestation(ValidateableAttestation.from(attestation));
+    attestationGossipManager.onNewAttestation(ValidateableAttestation.from(spec, attestation));
 
     verify(gossipNetwork).gossip(getSubnetTopic(subnetId), serialized);
 
     // We should process attestations for different committees on the same subnet
     final Bytes serialized2 = gossipEncoding.encode(attestation2);
-    attestationGossipManager.onNewAttestation(ValidateableAttestation.from(attestation2));
+    attestationGossipManager.onNewAttestation(ValidateableAttestation.from(spec, attestation2));
 
     verify(gossipNetwork).gossip(getSubnetTopic(subnetId), serialized2);
   }
@@ -112,7 +112,7 @@ public class AttestationGossipManagerTest {
     attestationGossipManager.subscribeToSubnetId(subnetId + 1);
 
     // Post new attestation
-    attestationGossipManager.onNewAttestation(ValidateableAttestation.from(attestation));
+    attestationGossipManager.onNewAttestation(ValidateableAttestation.from(spec, attestation));
 
     verify(gossipNetwork).gossip(getSubnetTopic(subnetId), gossipEncoding.encode(attestation));
   }
@@ -131,13 +131,13 @@ public class AttestationGossipManagerTest {
 
     // Attestation for dismissed assignment should be ignored
     final Bytes serialized = gossipEncoding.encode(attestation);
-    attestationGossipManager.onNewAttestation(ValidateableAttestation.from(attestation));
+    attestationGossipManager.onNewAttestation(ValidateableAttestation.from(spec, attestation));
 
     verify(gossipNetwork).gossip(getSubnetTopic(dismissedSubnetId), serialized);
 
     // Attestation for remaining assignment should be processed
     final Bytes serialized2 = gossipEncoding.encode(attestation2);
-    attestationGossipManager.onNewAttestation(ValidateableAttestation.from(attestation2));
+    attestationGossipManager.onNewAttestation(ValidateableAttestation.from(spec, attestation2));
 
     verify(gossipNetwork).gossip(getSubnetTopic(subnetId), serialized2);
   }
@@ -148,7 +148,7 @@ public class AttestationGossipManagerTest {
     when(gossipNetwork.gossip(any(), any())).thenReturn(SafeFuture.completedFuture(null));
 
     // Attestation for dismissed assignment should be ignored
-    attestationGossipManager.onNewAttestation(ValidateableAttestation.from(attestation));
+    attestationGossipManager.onNewAttestation(ValidateableAttestation.from(spec, attestation));
 
     assertThat(getPublishSuccessCounterValue()).isEqualTo(1);
     assertThat(getPublishFailureCounterValue()).isZero();
@@ -161,7 +161,7 @@ public class AttestationGossipManagerTest {
         .thenReturn(SafeFuture.failedFuture(new RuntimeException("Ooops")));
 
     // Attestation for dismissed assignment should be ignored
-    attestationGossipManager.onNewAttestation(ValidateableAttestation.from(attestation));
+    attestationGossipManager.onNewAttestation(ValidateableAttestation.from(spec, attestation));
 
     assertThat(getPublishSuccessCounterValue()).isZero();
     assertThat(getPublishFailureCounterValue()).isEqualTo(1);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
@@ -54,7 +54,7 @@ public class AttestationGossipManagerTest {
       mock(OperationProcessor.class);
 
   private final RecentChainData recentChainData =
-      MemoryOnlyRecentChainData.create(mock(EventBus.class));
+      MemoryOnlyRecentChainData.create(spec, mock(EventBus.class));
   private final GossipNetwork gossipNetwork = mock(GossipNetwork.class);
   private final GossipEncoding gossipEncoding = GossipEncoding.SSZ_SNAPPY;
   private AttestationGossipManager attestationGossipManager;

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManagerTest.java
@@ -192,13 +192,15 @@ class GossipForkManagerTest {
     manager.configureGossipForEpoch(UInt64.ZERO);
 
     final ValidateableAttestation firstForkAttestation =
-        ValidateableAttestation.fromValidator(dataStructureUtil.randomAttestation(0));
+        ValidateableAttestation.fromValidator(spec, dataStructureUtil.randomAttestation(0));
     final ValidateableAttestation secondForkAttestation =
         ValidateableAttestation.fromValidator(
+            spec,
             dataStructureUtil.randomAttestation(
                 spec.computeStartSlotAtEpoch(UInt64.ONE).longValue()));
     final ValidateableAttestation thirdForkAttestation =
         ValidateableAttestation.fromValidator(
+            spec,
             dataStructureUtil.randomAttestation(
                 spec.computeStartSlotAtEpoch(UInt64.valueOf(2)).longValue()));
 
@@ -228,6 +230,7 @@ class GossipForkManagerTest {
 
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromValidator(
+            spec,
             dataStructureUtil.randomAttestation(
                 spec.computeStartSlotAtEpoch(secondFork.getActivationEpoch()).longValue()));
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AggregateTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AggregateTopicHandlerTest.java
@@ -37,7 +37,7 @@ public class AggregateTopicHandlerTest extends AbstractTopicHandlerTest<Validate
   public void handleMessage_validAggregate() {
     final ValidateableAttestation aggregate =
         ValidateableAttestation.aggregateFromValidator(
-            dataStructureUtil.randomSignedAggregateAndProof());
+            spec, dataStructureUtil.randomSignedAggregateAndProof());
     when(processor.process(aggregate))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
 
@@ -53,7 +53,7 @@ public class AggregateTopicHandlerTest extends AbstractTopicHandlerTest<Validate
   public void handleMessage_savedForFuture() {
     final ValidateableAttestation aggregate =
         ValidateableAttestation.aggregateFromValidator(
-            dataStructureUtil.randomSignedAggregateAndProof());
+            spec, dataStructureUtil.randomSignedAggregateAndProof());
     when(processor.process(aggregate))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.SAVE_FOR_FUTURE));
 
@@ -69,7 +69,7 @@ public class AggregateTopicHandlerTest extends AbstractTopicHandlerTest<Validate
   public void handleMessage_ignoredAggregate() {
     final ValidateableAttestation aggregate =
         ValidateableAttestation.aggregateFromValidator(
-            dataStructureUtil.randomSignedAggregateAndProof());
+            spec, dataStructureUtil.randomSignedAggregateAndProof());
     when(processor.process(aggregate))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.IGNORE));
 
@@ -85,7 +85,7 @@ public class AggregateTopicHandlerTest extends AbstractTopicHandlerTest<Validate
   public void handleMessage_invalidAggregate() {
     final ValidateableAttestation aggregate =
         ValidateableAttestation.aggregateFromValidator(
-            dataStructureUtil.randomSignedAggregateAndProof());
+            spec, dataStructureUtil.randomSignedAggregateAndProof());
     when(processor.process(aggregate))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.REJECT));
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
@@ -55,7 +55,7 @@ public class SingleAttestationTopicHandlerTest
     final StateAndBlockSummary blockAndState = recentChainData.getChainHead().orElseThrow();
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromNetwork(
-            attestationGenerator.validAttestation(blockAndState), SUBNET_ID);
+            spec, attestationGenerator.validAttestation(blockAndState), SUBNET_ID);
     when(processor.process(attestation))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
     final Bytes serialized = gossipEncoding.encode(attestation.getAttestation());
@@ -72,7 +72,7 @@ public class SingleAttestationTopicHandlerTest
     final StateAndBlockSummary blockAndState = recentChainData.getChainHead().orElseThrow();
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromNetwork(
-            attestationGenerator.validAttestation(blockAndState), SUBNET_ID);
+            spec, attestationGenerator.validAttestation(blockAndState), SUBNET_ID);
     when(processor.process(attestation))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.IGNORE));
     final Bytes serialized = gossipEncoding.encode(attestation.getAttestation());
@@ -89,7 +89,7 @@ public class SingleAttestationTopicHandlerTest
     final StateAndBlockSummary blockAndState = recentChainData.getChainHead().orElseThrow();
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromNetwork(
-            attestationGenerator.validAttestation(blockAndState), SUBNET_ID);
+            spec, attestationGenerator.validAttestation(blockAndState), SUBNET_ID);
     when(processor.process(attestation))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.SAVE_FOR_FUTURE));
     final Bytes serialized = gossipEncoding.encode(attestation.getAttestation());
@@ -106,7 +106,7 @@ public class SingleAttestationTopicHandlerTest
     final StateAndBlockSummary blockAndState = recentChainData.getChainHead().orElseThrow();
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromNetwork(
-            attestationGenerator.validAttestation(blockAndState), SUBNET_ID);
+            spec, attestationGenerator.validAttestation(blockAndState), SUBNET_ID);
     when(processor.process(attestation))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.REJECT));
     final Bytes serialized = gossipEncoding.encode(attestation.getAttestation());

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
@@ -19,8 +19,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
-import static tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -31,6 +29,8 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -43,8 +43,8 @@ import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.util.config.Constants;
 
 public class PeerChainValidatorTest {
-
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final Eth2Peer peer = mock(Eth2Peer.class);
   private final CombinedChainDataClient combinedChainData = mock(CombinedChainDataClient.class);
   private final UpdatableStore store = mock(UpdatableStore.class);
@@ -58,10 +58,11 @@ public class PeerChainValidatorTest {
   private final UInt64 earlierEpoch = UInt64.valueOf(8L);
   private final UInt64 laterEpoch = UInt64.valueOf(12L);
 
-  private final UInt64 genesisSlot = compute_start_slot_at_epoch(genesisEpoch);
-  private final UInt64 remoteFinalizedEpochSlot = compute_start_slot_at_epoch(remoteFinalizedEpoch);
-  private final UInt64 earlierEpochSlot = compute_start_slot_at_epoch(earlierEpoch);
-  private final UInt64 laterEpochSlot = compute_start_slot_at_epoch(laterEpoch);
+  private final UInt64 genesisSlot = spec.computeStartSlotAtEpoch(genesisEpoch);
+  private final UInt64 remoteFinalizedEpochSlot =
+      spec.computeStartSlotAtEpoch(remoteFinalizedEpoch);
+  private final UInt64 earlierEpochSlot = spec.computeStartSlotAtEpoch(earlierEpoch);
+  private final UInt64 laterEpochSlot = spec.computeStartSlotAtEpoch(laterEpoch);
 
   // Offset slots from epoch to simulate skipped blocks
   private final UInt64 remoteFinalizedBlockSlot = remoteFinalizedEpochSlot.minus(UInt64.ONE);
@@ -87,12 +88,13 @@ public class PeerChainValidatorTest {
       new Checkpoint(laterEpoch, laterBlockAndState.getRoot());
 
   private final AnchorPoint genesisAnchor =
-      AnchorPoint.create(genesisCheckpoint, genesisBlockAndState);
+      AnchorPoint.create(spec, genesisCheckpoint, genesisBlockAndState);
   private final AnchorPoint remoteFinalizedAnchor =
-      AnchorPoint.create(remoteFinalizedCheckpoint, remoteFinalizedBlockAndState);
+      AnchorPoint.create(spec, remoteFinalizedCheckpoint, remoteFinalizedBlockAndState);
   private final AnchorPoint earlierAnchor =
-      AnchorPoint.create(earlierCheckpoint, earlierBlockAndState);
-  private final AnchorPoint laterAnchor = AnchorPoint.create(laterCheckpoint, laterBlockAndState);
+      AnchorPoint.create(spec, earlierCheckpoint, earlierBlockAndState);
+  private final AnchorPoint laterAnchor =
+      AnchorPoint.create(spec, laterCheckpoint, laterBlockAndState);
 
   private PeerStatus remoteStatus;
   private PeerChainValidator peerChainValidator;
@@ -104,7 +106,7 @@ public class PeerChainValidatorTest {
     when(peer.hasStatus()).thenReturn(true);
     when(peer.disconnectCleanly(any())).thenReturn(SafeFuture.completedFuture(null));
 
-    when(combinedChainData.getCurrentEpoch()).thenReturn(compute_epoch_at_slot(laterBlockSlot));
+    when(combinedChainData.getCurrentEpoch()).thenReturn(spec.computeEpochAtSlot(laterBlockSlot));
     when(combinedChainData.getStore()).thenReturn(store);
   }
 
@@ -303,7 +305,7 @@ public class PeerChainValidatorTest {
     forksMatch();
     finalizedCheckpointsMatch();
     final SignedBeaconBlock nonMatchingBlock =
-        dataStructureUtil.randomSignedBeaconBlock(earlierCheckpoint.getEpochStartSlot());
+        dataStructureUtil.randomSignedBeaconBlock(earlierCheckpoint.getEpochStartSlot(spec));
     when(peer.requestBlockByRoot(requiredCheckpoint.getRoot()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(earlierBlockAndState.getBlock())));
     when(peer.requestBlockBySlot(earlierBlockAndState.getSlot()))
@@ -342,7 +344,8 @@ public class PeerChainValidatorTest {
   @Test
   public void remoteChainIsBehindLocalAnchorPoint_disallow() {
     peerChainValidator =
-        PeerChainValidator.create(new NoOpMetricsSystem(), combinedChainData, Optional.empty());
+        PeerChainValidator.create(
+            spec, new NoOpMetricsSystem(), combinedChainData, Optional.empty());
 
     // Setup mocks
     forksMatch();
@@ -490,7 +493,7 @@ public class PeerChainValidatorTest {
     } else {
       final AnchorPoint anchorMissingBlock =
           AnchorPoint.create(
-              finalizedAnchor.getCheckpoint(), finalizedAnchor.getState(), Optional.empty());
+              spec, finalizedAnchor.getCheckpoint(), finalizedAnchor.getState(), Optional.empty());
       when(store.getLatestFinalized()).thenReturn(anchorMissingBlock);
     }
   }
@@ -518,6 +521,7 @@ public class PeerChainValidatorTest {
 
     remoteStatus = status;
     peerChainValidator =
-        PeerChainValidator.create(new NoOpMetricsSystem(), combinedChainData, requiredCheckpoint);
+        PeerChainValidator.create(
+            spec, new NoOpMetricsSystem(), combinedChainData, requiredCheckpoint);
   }
 }

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -102,13 +102,13 @@ public class RespondingEth2Peer implements Eth2Peer {
         head.getSlot());
   }
 
-  private static PeerStatus createStatus(final Checkpoint head, final Checkpoint finalized) {
+  private PeerStatus createStatus(final Checkpoint head, final Checkpoint finalized) {
     return new PeerStatus(
         forkDigest,
         finalized.getRoot(),
         finalized.getEpoch(),
         head.getRoot(),
-        head.getEpochStartSlot());
+        head.getEpochStartSlot(spec));
   }
 
   public void updateStatus(final Checkpoint head, final Checkpoint finalized) {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -328,7 +328,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   private void initPendingBlocks() {
     LOG.debug("BeaconChainController.initPendingBlocks()");
-    pendingBlocks = PendingPool.createForBlocks();
+    pendingBlocks = PendingPool.createForBlocks(spec);
     eventChannels.subscribe(FinalizedCheckpointChannel.class, pendingBlocks);
   }
 
@@ -520,7 +520,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   private void initAttestationManager() {
     final PendingPool<ValidateableAttestation> pendingAttestations =
-        PendingPool.createForAttestations();
+        PendingPool.createForAttestations(spec);
     final FutureItems<ValidateableAttestation> futureAttestations =
         FutureItems.create(
             ValidateableAttestation::getEarliestSlotForForkChoiceProcessing, UInt64.valueOf(3));

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -532,7 +532,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             attestations.forEach(
                 attestation ->
                     aggregateValidator.addSeenAggregate(
-                        ValidateableAttestation.from(attestation))));
+                        ValidateableAttestation.from(spec, attestation))));
     attestationManager =
         AttestationManager.create(
             eventBus,

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -377,7 +377,7 @@ class BeaconChainMetricsTest {
     List<Bytes32> blockRootsList =
         new ArrayList<>(Collections.nCopies(33, dataStructureUtil.randomBytes32()));
     blockRootsList.set(
-        target.getEpochStartSlot().mod(slotsPerHistoricalRoot).intValue(), blockRoot);
+        target.getEpochStartSlot(spec).mod(slotsPerHistoricalRoot).intValue(), blockRoot);
     setBlockRoots(blockRootsList);
     final SszBitlist bitlist1 = bitlistOf(1, 3, 5, 7);
     final SszBitlist bitlist2 = bitlistOf(2, 4, 6, 8);
@@ -435,7 +435,8 @@ class BeaconChainMetricsTest {
 
     List<Bytes32> blockRootsList =
         new ArrayList<>(Collections.nCopies(33, dataStructureUtil.randomBytes32()));
-    final int blockRootIndex = target.getEpochStartSlot().mod(slotsPerHistoricalRoot).intValue();
+    final int blockRootIndex =
+        target.getEpochStartSlot(spec).mod(slotsPerHistoricalRoot).intValue();
     blockRootsList.set(blockRootIndex, blockRoot);
     setBlockRoots(blockRootsList);
     final SszBitlist bitlist1 = bitlistOf(1, 3, 5, 7);

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/ChainHead.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/ChainHead.java
@@ -69,8 +69,8 @@ class ChainHead extends StateAndBlockSummary {
     // Couldn't find a common ancestor in the available block roots so fallback to finalized
     return getState()
         .getFinalized_checkpoint()
-        .getEpochStartSlot()
-        .min(other.getState().getFinalized_checkpoint().getEpochStartSlot());
+        .getEpochStartSlot(spec)
+        .min(other.getState().getFinalized_checkpoint().getEpochStartSlot(spec));
   }
 
   private Bytes32 getBlockRootAtSlot(final UInt64 slot) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -196,7 +196,7 @@ public class CombinedChainDataClient {
         .thenApply(
             checkpointState -> {
               final SignedBeaconBlock block = latestBlockAndState.getBlock();
-              return CheckpointState.create(checkpoint, block, checkpointState.orElseThrow());
+              return CheckpointState.create(spec, checkpoint, block, checkpointState.orElseThrow());
             });
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -468,7 +468,7 @@ class Store implements UpdatableStore {
   @Override
   public SafeFuture<Optional<BeaconState>> retrieveCheckpointState(Checkpoint checkpoint) {
     return checkpointStates.perform(
-        new StateAtSlotTask(spec, checkpoint.toSlotAndBlockRoot(), this::retrieveBlockState));
+        new StateAtSlotTask(spec, checkpoint.toSlotAndBlockRoot(spec), this::retrieveBlockState));
   }
 
   @Override
@@ -491,10 +491,11 @@ class Store implements UpdatableStore {
     return checkpointStates
         .perform(
             new StateAtSlotTask(
-                spec, finalized.getCheckpoint().toSlotAndBlockRoot(), fromAnchor(finalized)))
+                spec, finalized.getCheckpoint().toSlotAndBlockRoot(spec), fromAnchor(finalized)))
         .thenApply(
             maybeState ->
                 CheckpointState.create(
+                    spec,
                     finalized.getCheckpoint(),
                     finalized.getBlockSummary(),
                     maybeState.orElseThrow()));
@@ -506,7 +507,7 @@ class Store implements UpdatableStore {
     return checkpointStates.perform(
         new StateAtSlotTask(
             spec,
-            checkpoint.toSlotAndBlockRoot(),
+            checkpoint.toSlotAndBlockRoot(spec),
             blockRoot -> SafeFuture.completedFuture(Optional.of(latestStateAtEpoch))));
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -194,7 +194,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
       // unlikely to call this on tx objects
       final SignedBlockAndState finalizedBlockAndState =
           retrieveBlockAndState(finalized_checkpoint.get().getRoot()).join().orElseThrow();
-      return AnchorPoint.create(finalized_checkpoint.get(), finalizedBlockAndState);
+      return AnchorPoint.create(spec, finalized_checkpoint.get(), finalizedBlockAndState);
     }
     return store.getLatestFinalized();
   }
@@ -206,6 +206,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
           .thenApply(
               blockAndState ->
                   AnchorPoint.create(
+                      spec,
                       finalizedCheckpoint,
                       blockAndState.orElseThrow(
                           () ->
@@ -309,7 +310,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
       // committed
       return new StateAtSlotTask(
               spec,
-              checkpoint.toSlotAndBlockRoot(),
+              checkpoint.toSlotAndBlockRoot(spec),
               fromBlockAndState(inMemoryCheckpointBlockState))
           .performTask();
     }
@@ -351,7 +352,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
                 return store.retrieveFinalizedCheckpointAndState();
               } else {
                 return SafeFuture.completedFuture(
-                    CheckpointState.create(finalizedCheckpoint, block.get(), state.get()));
+                    CheckpointState.create(spec, finalizedCheckpoint, block.get(), state.get()));
               }
             });
   }

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -523,7 +523,7 @@ class RecentChainDataTest {
 
     // Set up mock store with genesis data and a small chain
     List<SignedBlockAndState> chain = chainBuilder.generateBlocksUpToSlot(3);
-    mockGenesis(store, genesis);
+    mockGenesis(spec, store, genesis);
     mockChainData(store, chain);
 
     // Set store and update best block to genesis
@@ -914,7 +914,7 @@ class RecentChainDataTest {
     // the store
     final List<SignedBlockAndState> expectedBlocks =
         chainBuilder
-            .streamBlocksAndStates(finalizedCheckpoint.getEpochStartSlot())
+            .streamBlocksAndStates(finalizedCheckpoint.getEpochStartSlot(spec))
             .collect(Collectors.toList());
     final Set<Bytes32> blockRoots =
         expectedBlocks.stream().map(SignedBlockAndState::getRoot).collect(Collectors.toSet());

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
@@ -153,7 +153,7 @@ public class StorageBackedRecentChainDataTest {
     assertThat(client).isNotDone();
 
     // Post a store response to complete initialization
-    final AnchorPoint anchorPoint = AnchorPoint.fromInitialBlockAndState(blockAndState);
+    final AnchorPoint anchorPoint = AnchorPoint.fromInitialBlockAndState(spec, blockAndState);
 
     final StoreBuilder storeBuilder =
         StoreBuilder.create()

--- a/storage/src/test/java/tech/pegasys/teku/storage/events/FinalizedChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/events/FinalizedChainDataTest.java
@@ -31,7 +31,7 @@ public class FinalizedChainDataTest {
   private final SignedBlockAndState genesis = chainBuilder.generateGenesis();
   private final Checkpoint genesisCheckpoint =
       chainBuilder.getCurrentCheckpointForEpoch(GENESIS_EPOCH);
-  private final AnchorPoint genesisAnchor = AnchorPoint.fromInitialBlockAndState(genesis);
+  private final AnchorPoint genesisAnchor = AnchorPoint.fromInitialBlockAndState(spec, genesis);
 
   @Test
   public void build_withSingleFinalizedBlock() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
@@ -611,7 +611,7 @@ public abstract class AbstractDatabaseTest {
         chainBuilder.generateBlockAtSlot(spec.computeStartSlotAtEpoch(anchorEpoch));
     final AnchorPoint anchor =
         AnchorPoint.create(
-            new Checkpoint(anchorEpoch, anchorBlockAndState.getRoot()), anchorBlockAndState);
+            spec, new Checkpoint(anchorEpoch, anchorBlockAndState.getRoot()), anchorBlockAndState);
     createStorage(StateStorageMode.PRUNE);
     initFromAnchor(anchor);
 
@@ -694,7 +694,7 @@ public abstract class AbstractDatabaseTest {
     // Primary chain's next block is at 7
     final SignedBlockAndState finalizedBlock = primaryChain.generateBlockAtSlot(7);
     final Checkpoint finalizedCheckpoint = getCheckpointForBlock(primaryChain.getBlockAtSlot(7));
-    final UInt64 firstHotBlockSlot = finalizedCheckpoint.getEpochStartSlot().plus(UInt64.ONE);
+    final UInt64 firstHotBlockSlot = finalizedCheckpoint.getEpochStartSlot(spec).plus(UInt64.ONE);
     primaryChain.generateBlockAtSlot(firstHotBlockSlot);
     // Fork chain's next block is at 6
     forkChain.generateBlockAtSlot(6);
@@ -759,7 +759,7 @@ public abstract class AbstractDatabaseTest {
     // Primary chain's next block is at 7
     final SignedBlockAndState finalizedBlock = primaryChain.generateBlockAtSlot(7);
     final Checkpoint finalizedCheckpoint = getCheckpointForBlock(primaryChain.getBlockAtSlot(7));
-    final UInt64 firstHotBlockSlot = finalizedCheckpoint.getEpochStartSlot().plus(UInt64.ONE);
+    final UInt64 firstHotBlockSlot = finalizedCheckpoint.getEpochStartSlot(spec).plus(UInt64.ONE);
     primaryChain.generateBlockAtSlot(firstHotBlockSlot);
     // Fork chain's next block is at 6
     forkChain.generateBlockAtSlot(6);
@@ -793,6 +793,7 @@ public abstract class AbstractDatabaseTest {
         chainBuilder.generateBlockAtSlot(spec.computeStartSlotAtEpoch(anchorEpoch));
     final AnchorPoint anchor =
         AnchorPoint.create(
+            spec,
             new Checkpoint(anchorEpoch, anchorBlockAndState.getRoot()),
             anchorBlockAndState.getState(),
             Optional.empty());
@@ -856,6 +857,7 @@ public abstract class AbstractDatabaseTest {
         chainBuilder.generateBlockAtSlot(spec.computeStartSlotAtEpoch(anchorEpoch));
     final AnchorPoint anchor =
         AnchorPoint.create(
+            spec,
             new Checkpoint(anchorEpoch, anchorBlockAndState.getRoot()),
             anchorBlockAndState.getState(),
             Optional.empty());
@@ -908,7 +910,7 @@ public abstract class AbstractDatabaseTest {
     // Primary chain's next block is at 7
     final SignedBlockAndState finalizedBlock = primaryChain.generateBlockAtSlot(7);
     final Checkpoint finalizedCheckpoint = getCheckpointForBlock(finalizedBlock.getBlock());
-    final UInt64 pruneToSlot = finalizedCheckpoint.getEpochStartSlot();
+    final UInt64 pruneToSlot = finalizedCheckpoint.getEpochStartSlot(spec);
     // Add some blocks in the next epoch
     final UInt64 hotSlot = pruneToSlot.plus(UInt64.ONE);
     primaryChain.generateBlockAtSlot(hotSlot);

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractStorageBackedDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractStorageBackedDatabaseTest.java
@@ -138,7 +138,7 @@ public abstract class AbstractStorageBackedDatabaseTest extends AbstractDatabase
         chainBuilder.getCurrentCheckpointForEpoch(finalizedEpoch);
 
     // Add some more blocks
-    final UInt64 firstHotBlockSlot = finalizedCheckpoint.getEpochStartSlot().plus(UInt64.ONE);
+    final UInt64 firstHotBlockSlot = finalizedCheckpoint.getEpochStartSlot(spec).plus(UInt64.ONE);
     chainBuilder.generateBlockAtSlot(firstHotBlockSlot);
     chainBuilder.generateBlocksUpToSlot(firstHotBlockSlot.plus(10));
 
@@ -180,7 +180,7 @@ public abstract class AbstractStorageBackedDatabaseTest extends AbstractDatabase
         chainBuilder.generateBlockAtSlot(compute_start_slot_at_epoch(anchorEpoch));
     final AnchorPoint anchor =
         AnchorPoint.create(
-            new Checkpoint(anchorEpoch, anchorBlockAndState.getRoot()), anchorBlockAndState);
+            spec, new Checkpoint(anchorEpoch, anchorBlockAndState.getRoot()), anchorBlockAndState);
     createStorage(tempDir.toFile(), StateStorageMode.PRUNE);
     initFromAnchor(anchor);
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/ChainStorageTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/ChainStorageTest.java
@@ -95,7 +95,8 @@ public class ChainStorageTest {
 
     // Initialize from intermediate anchor point
     final AnchorPoint anchorPoint =
-        AnchorPoint.create(anchorCheckpoint, anchorBlockAndState.getState(), Optional.empty());
+        AnchorPoint.create(
+            spec, anchorCheckpoint, anchorBlockAndState.getState(), Optional.empty());
     storageSystem.recentChainData().initializeFromAnchorPoint(anchorPoint, ZERO);
     final long firstMissingBlockSlot = anchorBlockAndState.getSlot().longValue();
 
@@ -137,11 +138,12 @@ public class ChainStorageTest {
     final long firstMissingBlockSlot;
     if (initializeWithAnchorStateAlone) {
       anchorPoint =
-          AnchorPoint.create(anchorCheckpoint, anchorBlockAndState.getState(), Optional.empty());
+          AnchorPoint.create(
+              spec, anchorCheckpoint, anchorBlockAndState.getState(), Optional.empty());
       storageSystem.recentChainData().initializeFromAnchorPoint(anchorPoint, ZERO);
       firstMissingBlockSlot = anchorBlockAndState.getSlot().longValue();
     } else {
-      anchorPoint = AnchorPoint.create(anchorCheckpoint, anchorBlockAndState);
+      anchorPoint = AnchorPoint.create(spec, anchorCheckpoint, anchorBlockAndState);
       storageSystem.recentChainData().initializeFromAnchorPoint(anchorPoint, ZERO);
       firstMissingBlockSlot = anchorBlockAndState.getSlot().minus(1).longValue();
     }
@@ -204,7 +206,8 @@ public class ChainStorageTest {
 
     // Initialize from intermediate anchor
     final AnchorPoint anchorPoint =
-        AnchorPoint.create(anchorCheckpoint, anchorBlockAndState.getState(), Optional.empty());
+        AnchorPoint.create(
+            spec, anchorCheckpoint, anchorBlockAndState.getState(), Optional.empty());
     storageSystem.recentChainData().initializeFromAnchorPoint(anchorPoint, ZERO);
     final long firstMissingBlockSlot = anchorBlockAndState.getSlot().longValue();
 
@@ -239,7 +242,8 @@ public class ChainStorageTest {
 
     // Initialize from intermediate anchor
     final AnchorPoint anchorPoint =
-        AnchorPoint.create(anchorCheckpoint, anchorBlockAndState.getState(), Optional.empty());
+        AnchorPoint.create(
+            spec, anchorCheckpoint, anchorBlockAndState.getState(), Optional.empty());
     storageSystem.recentChainData().initializeFromAnchorPoint(anchorPoint, ZERO);
     final long firstMissingBlockSlot = anchorBlockAndState.getSlot().longValue();
 
@@ -277,7 +281,8 @@ public class ChainStorageTest {
 
     // Initialize from intermediate anchor
     final AnchorPoint anchorPoint =
-        AnchorPoint.create(anchorCheckpoint, anchorBlockAndState.getState(), Optional.empty());
+        AnchorPoint.create(
+            spec, anchorCheckpoint, anchorBlockAndState.getState(), Optional.empty());
     storageSystem.recentChainData().initializeFromAnchorPoint(anchorPoint, ZERO);
     final long firstMissingBlockSlot = anchorBlockAndState.getSlot().longValue();
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/AbstractKvStoreDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/AbstractKvStoreDatabaseTest.java
@@ -200,7 +200,9 @@ public abstract class AbstractKvStoreDatabaseTest extends AbstractStorageBackedD
     database.close();
 
     assertThatThrownBy(
-            () -> database.getLatestAvailableFinalizedState(genesisCheckpoint.getEpochStartSlot()))
+            () ->
+                database.getLatestAvailableFinalizedState(
+                    genesisCheckpoint.getEpochStartSlot(spec)))
         .isInstanceOf(ShuttingDownException.class);
   }
 
@@ -259,7 +261,7 @@ public abstract class AbstractKvStoreDatabaseTest extends AbstractStorageBackedD
     SignedBlockAndState finalizedBlock = chainBuilder.getBlockAndStateAtSlot(finalizedSlot);
     final Checkpoint finalizedCheckpoint = getCheckpointForBlock(finalizedBlock.getBlock());
     final long firstHotBlockSlot =
-        finalizedCheckpoint.getEpochStartSlot().plus(UInt64.ONE).longValue();
+        finalizedCheckpoint.getEpochStartSlot(spec).plus(UInt64.ONE).longValue();
     for (int i = 0; i < hotBlockCount; i++) {
       chainBuilder.generateBlockAtSlot(firstHotBlockSlot + i);
     }

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
@@ -102,7 +102,8 @@ public abstract class AbstractStoreTest {
       Checkpoint checkpoint = chainBuilder.getCurrentCheckpointForEpoch(i);
       SignedBlockAndState blockAndState = chainBuilder.getBlockAndState(checkpoint.getRoot()).get();
       allCheckpoints.add(
-          CheckpointState.create(checkpoint, blockAndState.getBlock(), blockAndState.getState()));
+          CheckpointState.create(
+              spec, checkpoint, blockAndState.getBlock(), blockAndState.getState()));
     }
     assertThat(allCheckpoints.size()).isEqualTo(epochsToProcess + 1);
 
@@ -141,7 +142,7 @@ public abstract class AbstractStoreTest {
         .anchor(Optional.empty())
         .genesisTime(genesis.getState().getGenesis_time())
         .time(genesis.getState().getGenesis_time())
-        .latestFinalized(AnchorPoint.create(genesisCheckpoint, genesis))
+        .latestFinalized(AnchorPoint.create(spec, genesisCheckpoint, genesis))
         .justifiedCheckpoint(genesisCheckpoint)
         .bestJustifiedCheckpoint(genesisCheckpoint)
         .blockInformation(

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -61,7 +61,7 @@ class StoreTest extends AbstractStoreTest {
                     Optional.empty(),
                     genesisTime.minus(1),
                     genesisTime,
-                    AnchorPoint.create(genesisCheckpoint, genesis),
+                    AnchorPoint.create(spec, genesisCheckpoint, genesis),
                     genesisCheckpoint,
                     genesisCheckpoint,
                     Collections.emptyMap(),
@@ -157,7 +157,7 @@ class StoreTest extends AbstractStoreTest {
     final SafeFuture<Optional<BeaconState>> result = store.retrieveCheckpointState(checkpoint);
     assertThatSafeFuture(result).isCompletedWithNonEmptyOptional();
     final BeaconState checkpointState = result.join().orElseThrow();
-    assertThat(checkpointState.getSlot()).isEqualTo(checkpoint.getEpochStartSlot());
+    assertThat(checkpointState.getSlot()).isEqualTo(checkpoint.getEpochStartSlot(spec));
     assertThat(checkpointState.getLatest_block_header().hashTreeRoot())
         .isEqualTo(checkpoint.getRoot());
   }
@@ -186,7 +186,7 @@ class StoreTest extends AbstractStoreTest {
     assertThatSafeFuture(resultFuture).isCompletedWithNonEmptyOptional();
     final BeaconState result = resultFuture.join().orElseThrow();
     assertThat(result.getSlot()).isGreaterThan(baseState.getSlot());
-    assertThat(result.getSlot()).isEqualTo(checkpoint.getEpochStartSlot());
+    assertThat(result.getSlot()).isEqualTo(checkpoint.getEpochStartSlot(spec));
     assertThat(result.getLatest_block_header().hashTreeRoot()).isEqualTo(checkpoint.getRoot());
   }
 
@@ -322,7 +322,7 @@ class StoreTest extends AbstractStoreTest {
 
     // Check store is updated
     chainBuilder
-        .streamBlocksAndStates(checkpoint3.getEpochStartSlot(), chainBuilder.getLatestSlot())
+        .streamBlocksAndStates(checkpoint3.getEpochStartSlot(spec), chainBuilder.getLatestSlot())
         .forEach(
             b ->
                 assertThat(store.retrieveBlockAndState(b.getRoot()))
@@ -343,7 +343,7 @@ class StoreTest extends AbstractStoreTest {
     // Check store was pruned as expected
     final List<Bytes32> expectedBlockRoots =
         chainBuilder
-            .streamBlocksAndStates(checkpoint1.getEpochStartSlot())
+            .streamBlocksAndStates(checkpoint1.getEpochStartSlot(spec))
             .map(SignedBlockAndState::getRoot)
             .collect(Collectors.toList());
     assertThat(store.getOrderedBlockRoots()).containsExactlyElementsOf(expectedBlockRoots);

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/MockStoreHelper.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/MockStoreHelper.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_EPOCH;
 import java.util.List;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -42,12 +43,14 @@ public class MockStoreHelper {
     }
   }
 
-  public static void mockGenesis(final UpdatableStore store, final SignedBlockAndState genesis) {
+  public static void mockGenesis(
+      final Spec spec, final UpdatableStore store, final SignedBlockAndState genesis) {
     mockChainData(store, List.of(genesis));
     final Checkpoint genesisCheckpoint = new Checkpoint(GENESIS_EPOCH, genesis.getRoot());
     when(store.getJustifiedCheckpoint()).thenReturn(genesisCheckpoint);
     when(store.getFinalizedCheckpoint()).thenReturn(genesisCheckpoint);
     when(store.getBestJustifiedCheckpoint()).thenReturn(genesisCheckpoint);
-    when(store.getLatestFinalized()).thenReturn(AnchorPoint.create(genesisCheckpoint, genesis));
+    when(store.getLatestFinalized())
+        .thenReturn(AnchorPoint.create(spec, genesisCheckpoint, genesis));
   }
 }

--- a/sync/src/main/java/tech/pegasys/teku/sync/SyncServiceFactory.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/SyncServiceFactory.java
@@ -131,6 +131,7 @@ public class SyncServiceFactory {
     final AsyncRunner asyncRunner =
         asyncRunnerFactory.create(HistoricalBlockSyncService.class.getSimpleName(), 1);
     return HistoricalBlockSyncService.create(
+        recentChainData.getSpec(),
         metrics,
         storageUpdateChannel,
         asyncRunner,

--- a/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/MultipeerSyncService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/MultipeerSyncService.java
@@ -95,6 +95,7 @@ public class MultipeerSyncService extends Service implements ForwardSyncService 
             batchSync);
     final PeerChainTracker peerChainTracker =
         new PeerChainTracker(
+            recentChainData.getSpec(),
             eventThread,
             p2pNetwork,
             new SyncSourceFactory(asyncRunner, timeProvider),

--- a/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/chains/PeerChainTracker.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/chains/PeerChainTracker.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 
 /**
@@ -26,6 +27,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
  * current peer set, both for finalized and non-finalized chains.
  */
 public class PeerChainTracker {
+  private final Spec spec;
   private final EventThread eventThread;
   private final P2PNetwork<Eth2Peer> p2pNetwork;
   private final Subscribers<Runnable> chainsUpdatedSubscribers = Subscribers.create(true);
@@ -35,11 +37,13 @@ public class PeerChainTracker {
   private volatile long connectSubscription;
 
   public PeerChainTracker(
+      final Spec spec,
       final EventThread eventThread,
       final P2PNetwork<Eth2Peer> p2pNetwork,
       final SyncSourceFactory syncSourceFactory,
       final TargetChains finalizedChains,
       final TargetChains nonfinalizedChains) {
+    this.spec = spec;
     this.eventThread = eventThread;
     this.p2pNetwork = p2pNetwork;
     this.syncSourceFactory = syncSourceFactory;
@@ -80,7 +84,7 @@ public class PeerChainTracker {
     final SyncSource syncSource = syncSourceFactory.getOrCreateSyncSource(peer);
     final SlotAndBlockRoot finalizedChainHead =
         new SlotAndBlockRoot(
-            status.getFinalizedCheckpoint().getEpochStartSlot(), status.getFinalizedRoot());
+            status.getFinalizedCheckpoint().getEpochStartSlot(spec), status.getFinalizedRoot());
     finalizedChains.onPeerStatusUpdated(syncSource, finalizedChainHead);
 
     final SlotAndBlockRoot nonFinalizedChainHead =

--- a/sync/src/main/java/tech/pegasys/teku/sync/historical/HistoricalBlockSyncService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/historical/HistoricalBlockSyncService.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.service.serviceutils.Service;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -49,6 +50,7 @@ public class HistoricalBlockSyncService extends Service {
   private static final Duration RETRY_TIMEOUT = Duration.ofMinutes(1);
   private static final UInt64 BATCH_SIZE = UInt64.valueOf(50);
 
+  private final Spec spec;
   private final SettableGauge historicSyncGauge;
   private final StorageUpdateChannel storageUpdateChannel;
   private final AsyncRunner asyncRunner;
@@ -65,6 +67,7 @@ public class HistoricalBlockSyncService extends Service {
 
   @VisibleForTesting
   HistoricalBlockSyncService(
+      final Spec spec,
       final MetricsSystem metricsSystem,
       final StorageUpdateChannel storageUpdateChannel,
       final AsyncRunner asyncRunner,
@@ -72,6 +75,7 @@ public class HistoricalBlockSyncService extends Service {
       final CombinedChainDataClient chainData,
       final SyncStateProvider syncStateProvider,
       final UInt64 batchSize) {
+    this.spec = spec;
     this.storageUpdateChannel = storageUpdateChannel;
 
     this.asyncRunner = asyncRunner;
@@ -98,6 +102,7 @@ public class HistoricalBlockSyncService extends Service {
   }
 
   public static HistoricalBlockSyncService create(
+      final Spec spec,
       final MetricsSystem metricsSystem,
       final StorageUpdateChannel storageUpdateChannel,
       final AsyncRunner asyncRunner,
@@ -105,6 +110,7 @@ public class HistoricalBlockSyncService extends Service {
       final CombinedChainDataClient chainData,
       final SyncStateProvider syncStateProvider) {
     return new HistoricalBlockSyncService(
+        spec,
         metricsSystem,
         storageUpdateChannel,
         asyncRunner,
@@ -248,7 +254,7 @@ public class HistoricalBlockSyncService extends Service {
             p ->
                 p.getStatus()
                     .getFinalizedCheckpoint()
-                    .getEpochStartSlot()
+                    .getEpochStartSlot(spec)
                     .isGreaterThan(earliestBlock.getSlot()))
         .findAny();
   }

--- a/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/chains/PeerChainTrackerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/forward/multipeer/chains/PeerChainTrackerTest.java
@@ -33,11 +33,14 @@ import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedSubscriber;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class PeerChainTrackerTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   @SuppressWarnings("unchecked")
   private final P2PNetwork<Eth2Peer> p2pNetwork = mock(P2PNetwork.class);
@@ -60,7 +63,7 @@ class PeerChainTrackerTest {
 
   private final PeerChainTracker tracker =
       new PeerChainTracker(
-          eventThread, p2pNetwork, syncSourceFactory, finalizedChains, nonfinalizedChains);
+          spec, eventThread, p2pNetwork, syncSourceFactory, finalizedChains, nonfinalizedChains);
 
   @BeforeEach
   void setUp() {

--- a/sync/src/test/java/tech/pegasys/teku/sync/forward/singlepeer/AbstractSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/forward/singlepeer/AbstractSyncTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
@@ -29,6 +30,8 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -37,12 +40,18 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.util.config.Constants;
 
 public abstract class AbstractSyncTest {
+  protected final Spec spec = TestSpecFactory.createDefault();
   protected final Eth2Peer peer = mock(Eth2Peer.class);
   protected final BlockImporter blockImporter = mock(BlockImporter.class);
   protected final RecentChainData storageClient = mock(RecentChainData.class);
 
-  protected final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  protected final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   protected final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+
+  @BeforeEach
+  public void setup() {
+    when(storageClient.getSpec()).thenReturn(spec);
+  }
 
   @SuppressWarnings("unchecked")
   protected final ArgumentCaptor<RpcResponseListener<SignedBeaconBlock>>

--- a/sync/src/test/java/tech/pegasys/teku/sync/forward/singlepeer/PeerSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/forward/singlepeer/PeerSyncTest.java
@@ -65,11 +65,11 @@ public class PeerSyncTest extends AbstractSyncTest {
               PEER_HEAD_BLOCK_ROOT,
               PEER_HEAD_SLOT));
 
-  private final PeerSync peerSync =
-      new PeerSync(asyncRunner, storageClient, blockImporter, new NoOpMetricsSystem());
+  private PeerSync peerSync;
 
   @BeforeEach
   public void setUp() {
+    super.setup();
     when(storageClient.getFinalizedEpoch()).thenReturn(UInt64.ZERO);
     when(peer.getStatus()).thenReturn(PEER_STATUS);
     when(peer.disconnectCleanly(any())).thenReturn(SafeFuture.completedFuture(null));
@@ -79,6 +79,8 @@ public class PeerSyncTest extends AbstractSyncTest {
         SafeFuture.completedFuture(BlockImportResult.successful(block));
     when(blockImporter.importBlock(any())).thenReturn(result);
     when(storageClient.getHeadSlot()).thenReturn(UInt64.ONE);
+
+    peerSync = new PeerSync(asyncRunner, storageClient, blockImporter, new NoOpMetricsSystem());
   }
 
   @Test
@@ -97,7 +99,7 @@ public class PeerSyncTest extends AbstractSyncTest {
   void sync_failedImport_unknownParent_fromNonFinalRange() {
     final SignedBeaconBlock block =
         dataStructureUtil.randomSignedBeaconBlock(
-            PEER_STATUS.getFinalizedCheckpoint().getEpochStartSlot().plus(1));
+            PEER_STATUS.getFinalizedCheckpoint().getEpochStartSlot(spec).plus(1));
     testFailedBlockImport(() -> BlockImportResult.FAILED_UNKNOWN_PARENT, false, block);
   }
 

--- a/sync/src/test/java/tech/pegasys/teku/sync/historical/HistoricalBlockSyncServiceTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/historical/HistoricalBlockSyncServiceTest.java
@@ -70,6 +70,7 @@ public class HistoricalBlockSyncServiceTest {
   private final UInt64 batchSize = UInt64.valueOf(5);
   private final HistoricalBlockSyncService service =
       new HistoricalBlockSyncService(
+          spec,
           metricsSystem,
           storageUpdateChannel,
           asyncRunner,
@@ -364,7 +365,7 @@ public class HistoricalBlockSyncServiceTest {
     final Optional<SignedBeaconBlock> block =
         includeAnchorBlock ? Optional.of(anchorStateAndBlock.getBlock()) : Optional.empty();
     final AnchorPoint anchorPoint =
-        AnchorPoint.create(anchorCheckpoint, anchorStateAndBlock.getState(), block);
+        AnchorPoint.create(spec, anchorCheckpoint, anchorStateAndBlock.getState(), block);
     storageSystem.recentChainData().initializeFromAnchorPoint(anchorPoint, UInt64.ZERO);
 
     return anchorPoint;

--- a/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
+++ b/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
@@ -100,7 +100,7 @@ public class SyncingNodeManager {
             recentChainData, forkChoice, WeakSubjectivityFactory.lenientValidator(), eventBus);
 
     BlockValidator blockValidator = new BlockValidator(spec, recentChainData);
-    final PendingPool<SignedBeaconBlock> pendingBlocks = PendingPool.createForBlocks();
+    final PendingPool<SignedBeaconBlock> pendingBlocks = PendingPool.createForBlocks(spec);
     final FutureItems<SignedBeaconBlock> futureBlocks =
         FutureItems.create(SignedBeaconBlock::getSlot);
     BlockManager blockManager =

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -445,7 +445,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   public void sendSignedAttestation(
       final Attestation attestation, final Optional<Integer> expectedValidatorIndex) {
     attestationManager
-        .onAttestation(ValidateableAttestation.fromValidator(attestation))
+        .onAttestation(ValidateableAttestation.fromValidator(spec, attestation))
         .finish(
             result -> {
               if (!result.isInvalid()) {
@@ -471,7 +471,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public void sendAggregateAndProof(final SignedAggregateAndProof aggregateAndProof) {
     attestationManager
-        .onAttestation(ValidateableAttestation.aggregateFromValidator(aggregateAndProof))
+        .onAttestation(ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof))
         .finish(
             result -> {
               result.ifInvalid(

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -523,7 +523,8 @@ class ValidatorApiHandlerTest {
     when(chainDataClient.getCheckpointState(EPOCH, blockAndState))
         .thenReturn(
             SafeFuture.completedFuture(
-                CheckpointState.create(new Checkpoint(EPOCH, block.getRoot()), block, rightState)));
+                CheckpointState.create(
+                    spec, new Checkpoint(EPOCH, block.getRoot()), block, rightState)));
     when(forkChoiceTrigger.prepareForAttestationProduction(slot)).thenReturn(SafeFuture.COMPLETE);
 
     final int committeeIndex = 0;

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -557,7 +557,7 @@ class ValidatorApiHandlerTest {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     final Optional<Attestation> aggregate = Optional.of(dataStructureUtil.randomAttestation());
     when(attestationPool.createAggregateFor(eq(attestationData.hashTreeRoot())))
-        .thenReturn(aggregate.map(ValidateableAttestation::from));
+        .thenReturn(aggregate.map(attestation -> ValidateableAttestation.from(spec, attestation)));
 
     assertThat(
             validatorApiHandler.createAggregate(
@@ -623,7 +623,7 @@ class ValidatorApiHandlerTest {
         .thenReturn(completedFuture(SUCCESSFUL));
     validatorApiHandler.sendSignedAttestation(attestation);
 
-    verify(attestationManager).onAttestation(ValidateableAttestation.from(attestation));
+    verify(attestationManager).onAttestation(ValidateableAttestation.from(spec, attestation));
   }
 
   @Test
@@ -695,7 +695,7 @@ class ValidatorApiHandlerTest {
     validatorApiHandler.sendAggregateAndProof(aggregateAndProof);
 
     verify(attestationManager)
-        .onAttestation(ValidateableAttestation.aggregateFromValidator(aggregateAndProof));
+        .onAttestation(ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof));
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Cut usages of the deprecated `BeaconStateUtil`.  Update the following classes:
* `ValidateableAttestation`
* `AnchorPoint`
* `Checkpoint`

## Fixed Issue(s)
Part of #3356

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
