### PR TITLE
Avoid zero batch multiplier

### DIFF
--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstBLS12381.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstBLS12381.java
@@ -185,6 +185,6 @@ public class BlstBLS12381 implements BLS12381 {
   static BigInteger nextBatchRandomMultiplier() {
     byte[] scalarBytes = new byte[BATCH_RANDOM_BYTES];
     getRND().nextBytes(scalarBytes);
-    return new BigInteger(1, scalarBytes);
+    return new BigInteger(1, scalarBytes).add(BigInteger.ONE);
   }
 }


### PR DESCRIPTION
## PR Description

Avoids using a zero multiplier for a signature in [batch verification](https://ethresear.ch/t/fast-verification-of-multiple-bls-signatures/5407). It's ok if we overflow to 65 bits if the RNG gives us 2^64-1 (it never will) since Blst can handle that fine, so we simply add one to the output of the 8 byte RNG.

## Fixed Issue(s)
Fixes #4112 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
