### PR TITLE
Deafult batch verify signatures to on

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -154,7 +154,7 @@ public class P2POptions {
       description = "If true, turn on batch verification for gossiped attestation signatures",
       hidden = true,
       arity = "0..1")
-  private boolean batchVerifyAttestationSignatures = false;
+  private boolean batchVerifyAttestationSignatures = true;
 
   private int getP2pLowerBound() {
     if (p2pLowerBound > p2pUpperBound) {

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -418,7 +418,12 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                     .dataStorageFrequency(VersionedDatabaseFactory.DEFAULT_STORAGE_FREQUENCY)
                     .dataStorageCreateDbVersion(DatabaseVersion.DEFAULT_VERSION))
         .data(b -> b.dataBasePath(dataPath))
-        .p2p(b -> b.targetSubnetSubscriberCount(2).peerRateLimit(500).peerRequestLimit(50))
+        .p2p(
+            b ->
+                b.targetSubnetSubscriberCount(2)
+                    .peerRateLimit(500)
+                    .peerRequestLimit(50)
+                    .batchVerifyAttestationSignatures(true))
         .discovery(
             d -> d.isDiscoveryEnabled(false).minPeers(64).maxPeers(74).minRandomlySelectedPeers(12))
         .network(


### PR DESCRIPTION
## PR Description
Enable batch signature verification for attestation gossip by default.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
