### PR TITLE
Periodically ping bootnodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For information on changes in released versions of Teku, see the [releases page]
   the `dependent-root` field to detect re-orgs instead of depending on the beacon chain publishing re-org events when empty slots are later filled.
 
 ### Bug Fixes
+- Fix an issue where new peers would not be found after a network outage.
 
 
 ### Experimental: New Altair REST APIs

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
@@ -97,6 +97,7 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
       final SchemaDefinitionsSupplier currentSchemaDefinitionsSupplier) {
     final DiscoveryService discoveryService =
         createDiscoveryService(
+            asyncRunner,
             discoveryConfig,
             p2pConfig,
             kvStore,
@@ -117,6 +118,7 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
   }
 
   private static DiscoveryService createDiscoveryService(
+      final AsyncRunner asyncRunner,
       final DiscoveryConfig discoConfig,
       final NetworkConfig p2pConfig,
       final KeyValueStore<String, Bytes> kvStore,
@@ -125,8 +127,13 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
     final DiscoveryService discoveryService;
     if (discoConfig.isDiscoveryEnabled()) {
       discoveryService =
-          DiscV5Service.create(
-              discoConfig, p2pConfig, kvStore, privateKey, currentSchemaDefinitionsSupplier);
+          new DiscV5Service(
+              asyncRunner,
+              discoConfig,
+              p2pConfig,
+              kvStore,
+              privateKey,
+              currentSchemaDefinitionsSupplier);
     } else {
       discoveryService = new NoOpDiscoveryService();
     }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
@@ -13,9 +13,13 @@
 
 package tech.pegasys.teku.networking.p2p.discovery.discv5;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.ethereum.beacon.discovery.DiscoverySystem;
@@ -23,9 +27,12 @@ import org.ethereum.beacon.discovery.DiscoverySystemBuilder;
 import org.ethereum.beacon.discovery.schema.EnrField;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordBuilder;
+import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
 import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
 import org.ethereum.beacon.discovery.schema.NodeStatus;
 import org.ethereum.beacon.discovery.storage.NewAddressHandler;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.Cancellable;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
@@ -38,43 +45,43 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsSupplier;
 import tech.pegasys.teku.storage.store.KeyValueStore;
 
 public class DiscV5Service extends Service implements DiscoveryService {
+  private static final Logger LOG = LogManager.getLogger();
   private static final String SEQ_NO_STORE_KEY = "local-enr-seqno";
+  private static final Duration BOOTNODE_REFRESH_DELAY = Duration.ofMinutes(2);
+  private final AsyncRunner asyncRunner;
   private final SchemaDefinitionsSupplier currentSchemaDefinitionsSupplier;
-
-  public static DiscoveryService create(
-      final DiscoveryConfig discoConfig,
-      final NetworkConfig p2pConfig,
-      final KeyValueStore<String, Bytes> kvStore,
-      final Bytes privateKey,
-      final SchemaDefinitionsSupplier currentSchemaDefinitionsSupplier) {
-    return new DiscV5Service(
-        discoConfig, p2pConfig, kvStore, privateKey, currentSchemaDefinitionsSupplier);
-  }
 
   private final DiscoverySystem discoverySystem;
   private final KeyValueStore<String, Bytes> kvStore;
+  private final List<NodeRecord> bootnodes;
+  private volatile Cancellable bootnodeRefreshTask;
 
-  private DiscV5Service(
+  public DiscV5Service(
+      final AsyncRunner asyncRunner,
       final DiscoveryConfig discoConfig,
       final NetworkConfig p2pConfig,
       final KeyValueStore<String, Bytes> kvStore,
       final Bytes privateKey,
       final SchemaDefinitionsSupplier currentSchemaDefinitionsSupplier) {
+    this.asyncRunner = asyncRunner;
     this.currentSchemaDefinitionsSupplier = currentSchemaDefinitionsSupplier;
     final String listenAddress = p2pConfig.getNetworkInterface();
     final int listenPort = p2pConfig.getListenPort();
     final String advertisedAddress = p2pConfig.getAdvertisedIp();
     final int advertisedPort = p2pConfig.getAdvertisedPort();
-    final List<String> bootnodes = discoConfig.getBootnodes();
     final UInt64 seqNo =
         kvStore.get(SEQ_NO_STORE_KEY).map(UInt64::fromBytes).orElse(UInt64.ZERO).add(1);
     final NewAddressHandler maybeUpdateNodeRecordHandler =
         maybeUpdateNodeRecord(p2pConfig.hasUserExplicitlySetAdvertisedIp());
-    discoverySystem =
+    this.bootnodes =
+        discoConfig.getBootnodes().stream()
+            .map(NodeRecordFactory.DEFAULT::fromEnr)
+            .collect(Collectors.toList());
+    this.discoverySystem =
         new DiscoverySystemBuilder()
             .listen(listenAddress, listenPort)
             .privateKey(privateKey)
-            .bootnodes(bootnodes.toArray(new String[0]))
+            .bootnodes(bootnodes)
             .localNodeRecord(
                 new NodeRecordBuilder()
                     .privateKey(privateKey)
@@ -103,11 +110,28 @@ public class DiscV5Service extends Service implements DiscoveryService {
 
   @Override
   protected SafeFuture<?> doStart() {
-    return SafeFuture.of(discoverySystem.start());
+    return SafeFuture.of(discoverySystem.start())
+        .thenRun(
+            () ->
+                this.bootnodeRefreshTask =
+                    asyncRunner.runWithFixedDelay(
+                        this::pingBootnodes,
+                        BOOTNODE_REFRESH_DELAY,
+                        error -> LOG.error("Failed to contact discovery bootnodes", error)));
+  }
+
+  private void pingBootnodes() {
+    bootnodes.forEach(
+        bootnode ->
+            SafeFuture.of(discoverySystem.ping(bootnode))
+                .finish(error -> LOG.debug("Bootnode {} is unresponsive", bootnode)));
   }
 
   @Override
   protected SafeFuture<?> doStop() {
+    final Cancellable refreshTask = this.bootnodeRefreshTask;
+    this.bootnodeRefreshTask = null;
+    refreshTask.cancel();
     discoverySystem.stop();
     return SafeFuture.completedFuture(null);
   }


### PR DESCRIPTION
## PR Description
Periodically ping bootnodes.  Ensures we recover after a network outage that causes all discovery nodes to be dropped for failing to respond.

## Fixed Issue(s)
fixes https://github.com/ConsenSys/discovery/issues/114

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
