### PR TITLE
Enable Altair if it is present in the spec config

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/fork/TransitionTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/fork/TransitionTestExecutor.java
@@ -17,7 +17,6 @@ import static tech.pegasys.teku.ssz.SszDataAssert.assertThatSszData;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
-import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.opentest4j.TestAbortedException;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
@@ -61,7 +60,7 @@ public class TransitionTestExecutor implements TestExecutor {
         TestConfigLoader.loadConfig(
             testDefinition.getConfigName(),
             c -> c.altairBuilder(a -> a.altairForkEpoch(forkEpoch)));
-    final Spec spec = SpecFactory.create(config, Optional.of(forkEpoch));
+    final Spec spec = SpecFactory.create(config);
     final BeaconState preState =
         TestDataUtils.loadSsz(testDefinition, "pre.ssz_snappy", spec::deserializeBeaconState);
     final BeaconState postState =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecFactory.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecFactory.java
@@ -13,9 +13,14 @@
 
 package tech.pegasys.teku.spec;
 
+import static tech.pegasys.teku.spec.SpecMilestone.ALTAIR;
+import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
+import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
+
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.config.SpecConfigBuilder;
 import tech.pegasys.teku.spec.config.SpecConfigLoader;
 
@@ -32,7 +37,7 @@ public class SpecFactory {
             builder ->
                 altairForkEpoch.ifPresent(
                     forkEpoch -> overrideAltairForkEpoch(builder, forkEpoch)));
-    return create(config, altairForkEpoch);
+    return create(config);
   }
 
   private static void overrideAltairForkEpoch(
@@ -40,9 +45,12 @@ public class SpecFactory {
     builder.altairBuilder(altairBuilder -> altairBuilder.altairForkEpoch(forkEpoch));
   }
 
-  public static Spec create(final SpecConfig config, final Optional<UInt64> altairForkEpoch) {
+  public static Spec create(final SpecConfig config) {
+    final UInt64 altairForkEpoch =
+        config.toVersionAltair().map(SpecConfigAltair::getAltairForkEpoch).orElse(FAR_FUTURE_EPOCH);
+
     final SpecMilestone highestMilestoneSupported =
-        altairForkEpoch.map(__ -> SpecMilestone.ALTAIR).orElse(SpecMilestone.PHASE0);
+        altairForkEpoch.equals(FAR_FUTURE_EPOCH) ? PHASE0 : ALTAIR;
     return Spec.create(config, highestMilestoneSupported);
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -181,7 +181,7 @@ public class VoluntaryExitCommand implements Runnable {
       return apiClient
           .getConfigSpec()
           .map(response -> SpecConfigLoader.loadConfig(response.data))
-          .map(specConfig -> SpecFactory.create(specConfig, Optional.empty()))
+          .map(SpecFactory::create)
           .orElseThrow();
     } catch (Exception ex) {
       SUB_COMMAND_LOG.error(


### PR DESCRIPTION
## PR Description
CLI override option is no longer required if Altair is enabled in the config. This lets us use the standard testnet config instead of having to also add the fork epoch as an override.

The override CLI option is still available to change the epoch that Altair activates, including disabling it by setting it to the `FAR_FUTURE_EPOCH` value.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
