### PR TITLE
Fix PostSyncCommittees to return 200 when there are no errors instead of 503

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
 - Fix an issue where new peers would not be found after a network outage.
+- `/eth/v1/beacon/pool/sync_committees` incorrectly returned 503 when there were no errors instead of 200.
 
 
 ### Experimental: New Altair REST APIs

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -185,18 +185,14 @@ public class ValidatorDataProvider {
             });
   }
 
-  public SafeFuture<Optional<SubmitCommitteeSignaturesResult>> submitCommitteeSignatures(
+  public SafeFuture<SubmitCommitteeSignaturesResult> submitCommitteeSignatures(
       final List<SyncCommitteeSignature> signatures) {
     return validatorApiChannel
         .sendSyncCommitteeSignatures(
             signatures.stream()
                 .flatMap(signature -> signature.asInternalCommitteeSignature(spec).stream())
                 .collect(Collectors.toList()))
-        .thenApply(
-            errors ->
-                errors.isEmpty()
-                    ? Optional.empty()
-                    : Optional.of(new SubmitCommitteeSignaturesResult(errors)));
+        .thenApply(SubmitCommitteeSignaturesResult::new);
   }
 
   public SafeFuture<Optional<Attestation>> createAggregate(


### PR DESCRIPTION
## PR Description
Posting sync committee signatures was returning 503 when there were no errors because the empty list was being mapped to an empty `Optional`. Got rid of the optional to avoid that confusion.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
