### PR TITLE
Workaround for duplicate resource srcDir entries gradle build issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -438,6 +438,13 @@ subprojects {
     options.incremental = true
   }
 
+  tasks.withType(Copy) {
+    // For some (un-spotted) reasons module resource path could be included twice
+    // In such cases gradle 7.0+ build just fails as there is no deduplication strategy
+    // Refer to https://github.com/gradle/gradle/issues/17236
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+  }
+
   sourceSets {
     integrationTest {
       java {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Thanks to @asanso for reporting this issue:

Gradle build under some conditions fails with the error below when executing gradle task  `:eth-reference-tests:processReferenceTestResources`: 

> Entry eth2.0-spec-tests/tests/general/phase0/ssz_generic/uints/valid/uint_256_zero_2/value.yaml is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/7.0.2/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.

The problem for some reasons only appears: 
1. On Windows with running `gradlew.bat :eth-reference-tests:processReferenceTestResources`
2. On Windows when executing the mentioned gradle task in Intellij IDEA (2020.x)
3. On Mac when executing the mentioned gradle task in Intellij IDEA (2020.x)

Executing `./gradlew :eth-reference-tests:processReferenceTestResources` on Mac works however

The actual file may depend on platform, but while experimenting I was leaving the only one file in resources and shorten it path and the issue still persisted. 

I was trying to debug the gradle build and indeed saw duplicating resource src paths somewhere deep in gradle classes: 
![изображение](https://user-images.githubusercontent.com/8173857/124608405-60b6cf80-de77-11eb-868f-5905adb0d6dc.png)

I've found the suggested workaround in this gradle issue discussion: https://github.com/gradle/gradle/issues/17236

Initially tried the `DuplicatesStrategy.WARN` but it print enormous number of messages (for every reference test file)

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
