### PR TITLE
Use current chain head when validating sync committee gossip

### DIFF
--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -420,9 +420,13 @@ public class ChainBuilder {
 
   public SignedContributionAndProofTestBuilder createValidSignedContributionAndProofBuilder(
       final UInt64 slot) {
+    return createValidSignedContributionAndProofBuilder(slot, getLatestBlockAndState().getRoot());
+  }
+
+  public SignedContributionAndProofTestBuilder createValidSignedContributionAndProofBuilder(
+      final UInt64 slot, final Bytes32 beaconBlockRoot) {
     final SyncCommitteeUtil syncCommitteeUtil = spec.getSyncCommitteeUtilRequired(slot);
     final SignedBlockAndState latestBlockAndState = getLatestBlockAndState();
-    final Bytes32 beaconBlockRoot = latestBlockAndState.getRoot();
     final UInt64 epoch = syncCommitteeUtil.getEpochForDutiesAtSlot(slot);
 
     final Map<UInt64, SyncSubcommitteeAssignments> subcommitteeAssignments =

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/AbstractBeaconStateBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/AbstractBeaconStateBuilder.java
@@ -115,7 +115,13 @@ abstract class AbstractBeaconStateBuilder<
     genesisValidatorsRoot = dataStructureUtil.randomBytes32();
     slot = dataStructureUtil.randomUInt64();
     fork = dataStructureUtil.randomFork();
-    latestBlockHeader = dataStructureUtil.randomBeaconBlockHeader();
+    latestBlockHeader =
+        new BeaconBlockHeader(
+            slot,
+            dataStructureUtil.randomUInt64(),
+            dataStructureUtil.randomBytes32(),
+            Bytes32.ZERO,
+            dataStructureUtil.randomBytes32());
     blockRoots =
         dataStructureUtil.randomSszBytes32Vector(
             dataStructureUtil.getBeaconStateSchema().getBlockRootsSchema(),

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
@@ -102,7 +102,7 @@ public class SignedContributionAndProofValidator {
     }
 
     return syncCommitteeStateUtils
-        .getStateForSyncCommittee(contribution.getSlot(), contribution.getBeaconBlockRoot())
+        .getStateForSyncCommittee(contribution.getSlot())
         .thenApply(
             maybeState -> {
               if (maybeState.isEmpty()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignatureValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignatureValidator.java
@@ -101,7 +101,7 @@ public class SyncCommitteeSignatureValidator {
     }
 
     return syncCommitteeStateUtils
-        .getStateForSyncCommittee(signature.getSlot(), signature.getBeaconBlockRoot())
+        .getStateForSyncCommittee(signature.getSlot())
         .thenApply(
             maybeState -> {
               if (maybeState.isEmpty()) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignatureValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeSignatureValidatorTest.java
@@ -106,6 +106,7 @@ class SyncCommitteeSignatureValidatorTest {
     final SignedBlockAndState chainHead =
         storageSystem.chainUpdater().advanceChainUntil(period2StartSlot);
     storageSystem.chainUpdater().setCurrentSlot(lastSlotOfPeriod);
+    storageSystem.chainUpdater().updateBestBlock(chainHead);
 
     final SyncCommitteeSignature signature =
         chainBuilder.createSyncCommitteeSignature(lastSlotOfPeriod, chainHead.getRoot());
@@ -206,12 +207,12 @@ class SyncCommitteeSignatureValidatorTest {
   }
 
   @Test
-  void shouldIgnoreWhenBeaconBlockIsNotKnown() {
+  void shouldAcceptWhenValidButBeaconBlockIsUnknown() {
     final SyncCommitteeSignature signature =
         chainBuilder.createSyncCommitteeSignature(
             chainBuilder.getLatestSlot(), dataStructureUtil.randomBytes32());
     assertThat(validator.validate(ValidateableSyncCommitteeSignature.fromValidator(signature)))
-        .isCompletedWithValue(IGNORE);
+        .isCompletedWithValue(ACCEPT);
   }
 
   @Test

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeSignatureGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeSignatureGossipManager.java
@@ -75,7 +75,7 @@ public class SyncCommitteeSignatureGossipManager implements GossipManager {
         publish(signature, subcommitteeAssignments.get().getAssignedSubcommittees());
       } else {
         syncCommitteeStateUtils
-            .getStateForSyncCommittee(signature.getSlot(), signature.getBeaconBlockRoot())
+            .getStateForSyncCommittee(signature.getSlot())
             .finish(
                 maybeState ->
                     maybeState.ifPresentOrElse(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeSignatureGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/SyncCommitteeSignatureGossipManagerTest.java
@@ -99,8 +99,7 @@ class SyncCommitteeSignatureGossipManagerTest {
 
     final UInt64 dutyEpoch = UInt64.valueOf(333);
     final BeaconStateAltair state = dataStructureUtil.stateBuilderAltair().build();
-    when(syncCommitteeStateUtils.getStateForSyncCommittee(
-            signature.getSlot(), signature.getBeaconBlockRoot()))
+    when(syncCommitteeStateUtils.getStateForSyncCommittee(signature.getSlot()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
     when(syncCommitteeUtil.getEpochForDutiesAtSlot(any())).thenReturn(dutyEpoch);
     when(syncCommitteeUtil.getSubcommitteeAssignments(any(), any(), any()))


### PR DESCRIPTION
## PR Description
When validating sync committee gossip (signatures and contributions), always use the latest chain head state rather than the one matching the specified block root.  Sync committees only change very slowly and signatures/contributions are only valid for a single slot so if they aren't valid according to our current state they aren't worth propagating anyway.  Plus we should accept signatures even if we don't yet have the block they reference.

## Fixed Issue(s)
fixes #4140

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
