### PR TITLE
Use SecureRandom as part of BLS batch verification

### DIFF
--- a/bls/build.gradle
+++ b/bls/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-crypto'
   implementation 'org.apache.tuweni:tuweni-ssz'
   implementation 'tech.pegasys:jblst'
+  implementation project(':infrastructure:crypto')
   implementation project(':infrastructure:logging')
 
   testImplementation('com.googlecode.json-simple:json-simple') {

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstBLS12381.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstBLS12381.java
@@ -16,9 +16,9 @@ package tech.pegasys.teku.bls.impl.blst;
 import static tech.pegasys.teku.bls.impl.blst.HashToCurve.ETH2_DST;
 
 import java.math.BigInteger;
+import java.security.SecureRandom;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -32,19 +32,17 @@ import tech.pegasys.teku.bls.impl.BLS12381;
 import tech.pegasys.teku.bls.impl.KeyPair;
 import tech.pegasys.teku.bls.impl.PublicKey;
 import tech.pegasys.teku.bls.impl.Signature;
+import tech.pegasys.teku.infrastructure.crypto.SecureRandomProvider;
 
 public class BlstBLS12381 implements BLS12381 {
 
   private static final int BATCH_RANDOM_BYTES = 8;
+  // Note: SecureRandom is thread-safe.
+  // We avoid creating new instances as that reads from /dev/random which may block on entropy
+  private static final SecureRandom random = SecureRandomProvider.createSecureRandom();
 
   private static Random getRND() {
-    // Milagro RAND has some issues with generating 'small' random numbers
-    // and is not thread safe
-    // Using non-secure random due to the JDK Linux secure random issue:
-    // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6521844
-    // A potential attack here has a very limited application and is not feasible
-    // Thus using non-secure random doesn't significantly mitigate the security
-    return ThreadLocalRandom.current();
+    return random;
   }
 
   public static BlstSignature sign(BlstSecretKey secretKey, Bytes message) {


### PR DESCRIPTION
## PR Description
Use `SecureRandom` as part of BLS batch verification.

## Fixed Issue(s)
fixes #4136

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
