### PR TITLE
Upgrade jvm-libp2p - fixes file handle leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
 - Fix an issue where new peers would not be found after a network outage.
+- Fix a file handle leak in jvm-libp2p.
 
 
 ### Experimental: New Altair REST APIs

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -41,7 +41,7 @@ dependencyManagement {
     dependency 'io.protostuff:protostuff-core:1.6.2'
     dependency 'io.protostuff:protostuff-runtime:1.6.2'
 
-    dependency 'io.libp2p:jvm-libp2p-minimal:0.8.2-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p-minimal:0.8.3-RELEASE'
     dependency 'tech.pegasys:jblst:0.3.3-1'
 
     dependency 'org.hdrhistogram:HdrHistogram:2.1.12'


### PR DESCRIPTION
## PR Description
Fix a file handle leak in jvm-libp2p by upgrading to 0.8.3.

## Fixed Issue(s)
fixes #4104 


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
