### PR TITLE
Log incorrect deposit sequence errors to console

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -66,7 +66,8 @@ public class StatusLogger {
 
   public void eth1DepositEventsFailure(final Throwable cause) {
     log.fatal(
-        "PLEASE CHECK YOUR ETH1 NODE | Encountered a problem retrieving deposit events from eth1 endpoint.",
+        "PLEASE CHECK YOUR ETH1 NODE | Encountered a problem retrieving deposit events from eth1 endpoint: {}",
+        cause.getMessage(),
         cause);
   }
 

--- a/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
@@ -33,6 +33,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.methods.response.EthBlock;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
+import tech.pegasys.teku.ethereum.pow.api.InvalidDepositEventsException;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -98,7 +99,9 @@ public class DepositFetcher {
                   err);
 
               final Throwable rootCause = Throwables.getRootCause(err);
-              if (rootCause instanceof Eth1RequestException
+              if (rootCause instanceof InvalidDepositEventsException) {
+                STATUS_LOG.eth1DepositEventsFailure(rootCause);
+              } else if (rootCause instanceof Eth1RequestException
                   && ((Eth1RequestException) rootCause)
                       .containsExceptionSolvableWithSmallerRange()) {
                 STATUS_LOG.eth1FetchDepositsRequiresSmallerRange(fetchState.batchSize);

--- a/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
+++ b/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import java.util.concurrent.RejectedExecutionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import tech.pegasys.teku.ethereum.pow.api.InvalidDepositEventsException;
 import tech.pegasys.teku.infrastructure.events.ChannelExceptionHandler;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.infrastructure.logging.StatusLogger;
@@ -90,8 +89,6 @@ public final class TekuDefaultExceptionHandler
     } else if (Throwables.getRootCause(exception) instanceof RejectedExecutionException) {
       LOG.error(
           "Unexpected rejected execution due to full task queue in {}", subscriberDescription);
-    } else if (Throwables.getRootCause(exception) instanceof InvalidDepositEventsException) {
-      statusLog.eth1DepositEventsFailure(exception);
     } else if (isSpecFailure(exception)) {
       statusLog.specificationFailure(subscriberDescription, exception);
     } else {


### PR DESCRIPTION
## PR Description
Ensure that errors with incorrect deposit sequences are logged to the console rather than just as debug logs.

## Fixed Issue(s)
part of #4135 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
