### PR TITLE
Use Eth1HeadTracker to find initial chain head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Fix an issue where new peers would not be found after a network outage.
 - Fix a file handle leak in jvm-libp2p.
 - `/eth/v1/beacon/pool/sync_committees` incorrectly returned 503 when there were no errors instead of 200.
+- Fix an issue where deposits for the PoW chain could be loaded out of order on restart.
 
 
 ### Experimental: New Altair REST APIs

--- a/pow/src/main/java/tech/pegasys/teku/pow/Eth1DepositManager.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Eth1DepositManager.java
@@ -168,10 +168,10 @@ public class Eth1DepositManager {
   }
 
   private SafeFuture<EthBlock.Block> getHead() {
-    final SafeFuture<UInt64> headBlockNumber = new SafeFuture<>();
-    final long subscriberId = headTracker.subscribe(headBlockNumber::complete);
+    final SafeFuture<UInt64> headBlockNumberFuture = new SafeFuture<>();
+    final long subscriberId = headTracker.subscribe(headBlockNumberFuture::complete);
 
-    return headBlockNumber
+    return headBlockNumberFuture
         .thenPeek(__ -> headTracker.unsubscribe(subscriberId))
         .thenCompose(eth1Provider::getGuaranteedEth1Block)
         .exceptionallyCompose(

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -146,7 +146,8 @@ public class PowchainService extends Service {
             eth1DepositStorageChannel,
             depositProcessingController,
             new MinimumGenesisTimeBlockFinder(eth1Provider, eth1DepositContractDeployBlock),
-            eth1DepositContractDeployBlock);
+            eth1DepositContractDeployBlock,
+            headTracker);
 
     eth1ProviderMonitor = new Eth1ProviderMonitor(eth1ProviderSelector, asyncRunner);
   }


### PR DESCRIPTION
## PR Description
Previously the startup process for eth1 tracking reimplemented the follow distance logic which meant it was still following based on the number of blocks rather than time.  Now it uses the current head tracking implementation.

## Fixed Issue(s)
fixes #4135 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
