### PR TITLE
Avoid declaring referenceTest/resources directory twice

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -460,7 +460,6 @@ subprojects {
         srcDir file('src/referenceTest/generated_tests')
         srcDir file('src/referenceTest/java')
       }
-      resources.srcDir file('src/referenceTest/resources')
     }
   }
 


### PR DESCRIPTION
## PR Description
Gradle automatically adds `src/<sourceSetName>/resources` as a resources srcDir but for `referenceTest` we were also manually adding it, resulting in it being duplicated.  In some situations that could result in the build failing as described in https://github.com/ConsenSys/teku/pull/4134

acceptanceTest and integrationTest source sets also declare resources but they are `acceptance-test` rather than `acceptanceTest` so it's not a duplicate.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
