### PR TITLE
Remove caching for meta data messages

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/MetadataMessagesFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/MetadataMessagesFactory.java
@@ -25,7 +25,6 @@ public class MetadataMessagesFactory {
   private final AtomicLong seqNumberGenerator = new AtomicLong(0L);
   private Iterable<Integer> attestationSubnetIds = Collections.emptyList();
   private Iterable<Integer> syncCommitteeSubnetIds = Collections.emptyList();
-  private MetadataMessage currentMetadata;
 
   public synchronized void updateAttestationSubnetIds(Iterable<Integer> attestationSubnetIds) {
     this.attestationSubnetIds = attestationSubnetIds;
@@ -39,17 +38,10 @@ public class MetadataMessagesFactory {
 
   private void handleUpdate() {
     seqNumberGenerator.incrementAndGet();
-    // Clear cache
-    currentMetadata = null;
   }
 
   public synchronized MetadataMessage createMetadataMessage(MetadataMessageSchema<?> schema) {
-    if (currentMetadata == null) {
-      currentMetadata =
-          schema.create(getCurrentSeqNumber(), attestationSubnetIds, syncCommitteeSubnetIds);
-    }
-
-    return currentMetadata;
+    return schema.create(getCurrentSeqNumber(), attestationSubnetIds, syncCommitteeSubnetIds);
   }
 
   public PingMessage createPingMessage() {


### PR DESCRIPTION
## PR Description
There are now two forms of metadata message so caching is more complex and given the messages are cheap to create and not created very often the cache doesn't provide enough value.

## Fixed Issue(s)
fixes #4137 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
