### PR TITLE
Add metric to report the number of signatures included in the head block sync aggregate

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -411,15 +411,17 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   public void initMetrics() {
     LOG.debug("BeaconChainController.initMetrics()");
-    eventChannels.subscribe(
-        SlotEventsChannel.class,
+    final BeaconChainMetrics beaconChainMetrics =
         new BeaconChainMetrics(
             spec,
             recentChainData,
             slotProcessor.getNodeSlot(),
             metricsSystem,
             p2pNetwork,
-            eth1DataCache));
+            eth1DataCache);
+    eventChannels
+        .subscribe(SlotEventsChannel.class, beaconChainMetrics)
+        .subscribe(ChainHeadChannel.class, beaconChainMetrics);
   }
 
   public void initDepositProvider() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
@@ -194,7 +194,7 @@ public class BeaconChainMetrics implements SlotEventsChannel, ChainHeadChannel {
         SettableGauge.create(
             metricsSystem,
             TekuMetricCategory.BEACON,
-            "head_live_synccommittee",
+            "head_live_sync_committee",
             "Number of sync committee participant signatures included in the current head block");
 
     final String version = VersionProvider.IMPLEMENTATION_VERSION.replaceAll("^v", "");

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
@@ -32,10 +32,12 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.analysis.ValidatorStats.CorrectAndLiveValidators;
+import tech.pegasys.teku.storage.api.ChainHeadChannel;
+import tech.pegasys.teku.storage.api.ReorgContext;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.validator.coordinator.Eth1DataCache;
 
-public class BeaconChainMetrics implements SlotEventsChannel {
+public class BeaconChainMetrics implements SlotEventsChannel, ChainHeadChannel {
   private static final long NOT_SET = 0L;
   private final RecentChainData recentChainData;
   private final NodeSlot nodeSlot;
@@ -61,6 +63,9 @@ public class BeaconChainMetrics implements SlotEventsChannel {
 
   private final SettableGauge previousEpochParticipationWeight;
   private final SettableGauge previousEpochTotalWeight;
+
+  private final SettableGauge headLiveSyncCommittee;
+
   private final Spec spec;
 
   public BeaconChainMetrics(
@@ -185,6 +190,13 @@ public class BeaconChainMetrics implements SlotEventsChannel {
             "previous_epoch_total_weight",
             "Total effective balance of all active validators in the previous epoch");
 
+    headLiveSyncCommittee =
+        SettableGauge.create(
+            metricsSystem,
+            TekuMetricCategory.BEACON,
+            "head_live_synccommittee",
+            "Number of sync committee participant signatures included in the current head block");
+
     final String version = VersionProvider.IMPLEMENTATION_VERSION.replaceAll("^v", "");
     final LabelledMetric<Counter> versionCounter =
         metricsSystem.createLabelledCounter(
@@ -193,6 +205,24 @@ public class BeaconChainMetrics implements SlotEventsChannel {
             "Teku version in use",
             "version");
     versionCounter.labels(version).inc();
+  }
+
+  @Override
+  public void chainHeadUpdated(
+      final UInt64 slot,
+      final Bytes32 stateRoot,
+      final Bytes32 bestBlockRoot,
+      final boolean epochTransition,
+      final Bytes32 previousDutyDependentRoot,
+      final Bytes32 currentDutyDependentRoot,
+      final Optional<ReorgContext> optionalReorgContext) {
+    recentChainData
+        .getHeadBlock()
+        .flatMap(block -> block.getMessage().getBody().toVersionAltair())
+        .ifPresent(
+            body ->
+                headLiveSyncCommittee.set(
+                    body.getSyncAggregate().getSyncCommitteeBits().getBitCount()));
   }
 
   @Override

--- a/sync/src/main/java/tech/pegasys/teku/sync/events/CoalescingChainHeadChannel.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/events/CoalescingChainHeadChannel.java
@@ -22,7 +22,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.storage.api.ChainHeadChannel;
 import tech.pegasys.teku.storage.api.ReorgContext;
-import tech.pegasys.teku.sync.forward.ForwardSync;
 import tech.pegasys.teku.sync.forward.ForwardSync.SyncSubscriber;
 
 public class CoalescingChainHeadChannel implements ChainHeadChannel, SyncSubscriber {
@@ -35,13 +34,6 @@ public class CoalescingChainHeadChannel implements ChainHeadChannel, SyncSubscri
 
   public CoalescingChainHeadChannel(final ChainHeadChannel delegate) {
     this.delegate = delegate;
-  }
-
-  public static ChainHeadChannel create(
-      final ChainHeadChannel delegate, final ForwardSync syncService) {
-    final CoalescingChainHeadChannel channel = new CoalescingChainHeadChannel(delegate);
-    syncService.subscribeToSyncChanges(channel);
-    return channel;
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Add new metric to report number of signatures included in the current head block. Note that while it may be somewhat more useful to report the total signatures included for the previous epoch, because signatures are not recorded in the state that requires loading every block in the epoch which is potentially expensive.  This gives some insight into the sync committee performance without incurring that cost.

## Fixed Issue(s)
#4103 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
