### PR TITLE
Add metric to report the number of correct signatures produced

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SyncCommitteeMetrics.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SyncCommitteeMetrics.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.services.beaconchain;
+
+import java.util.List;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.SettableGauge;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+public class SyncCommitteeMetrics {
+  private static final Logger LOG = LogManager.getLogger();
+  private final Spec spec;
+  private final RecentChainData recentChainData;
+
+  private final SettableGauge previousLiveSyncCommittee;
+
+  private UInt64 lastProcessedEpoch = UInt64.ZERO;
+
+  public SyncCommitteeMetrics(
+      final Spec spec, final RecentChainData recentChainData, final MetricsSystem metricsSystem) {
+    this.spec = spec;
+    this.recentChainData = recentChainData;
+
+    previousLiveSyncCommittee =
+        SettableGauge.create(
+            metricsSystem,
+            TekuMetricCategory.BEACON,
+            "previous_live_synccommittee",
+            "Number of sync committee participant signatures that were included on chain during previous epoch");
+  }
+
+  public void updateSyncCommitteeMetrics(final UInt64 slot, final StateAndBlockSummary chainHead) {
+    final UInt64 previousEpoch = spec.computeEpochAtSlot(slot).minusMinZero(1);
+    final UInt64 previousEpochStartSlot = spec.computeStartSlotAtEpoch(previousEpoch);
+    if (previousEpoch.isLessThanOrEqualTo(lastProcessedEpoch)
+        || chainHead.getState().toVersionAltair().isEmpty()
+        || chainHead.getSlot().isLessThan(previousEpochStartSlot)) {
+      return;
+    }
+
+    SafeFuture.collectAll(
+            UInt64.range(
+                    previousEpochStartSlot.min(chainHead.getSlot()),
+                    spec.computeStartSlotAtEpoch(previousEpoch.plus(1)).min(chainHead.getSlot()))
+                .map(slotInEpoch -> getBlockAtSlotExact(chainHead, slotInEpoch)))
+        .finish(
+            this::updateSyncCommitteeMetrics,
+            error ->
+                LOG.warn(
+                    "Unable to update sync committee metrics for epoch {}", previousEpoch, error));
+    lastProcessedEpoch = previousEpoch;
+  }
+
+  private SafeFuture<Optional<BeaconBlock>> getBlockAtSlotExact(
+      final StateAndBlockSummary chainHead, final UInt64 slotInEpoch) {
+    return recentChainData
+        .retrieveBlockByRoot(spec.getBlockRootAtSlot(chainHead.getState(), slotInEpoch))
+        .thenApply(maybeBlock -> maybeBlock.filter(block -> block.getSlot().equals(slotInEpoch)));
+  }
+
+  private void updateSyncCommitteeMetrics(final List<Optional<BeaconBlock>> blocks) {
+    final int totalIncludedSignatures =
+        blocks.stream()
+            .flatMap(Optional::stream)
+            .flatMap(block -> block.getBody().toVersionAltair().stream())
+            .mapToInt(
+                blockBody -> blockBody.getSyncAggregate().getSyncCommitteeBits().getBitCount())
+            .sum();
+    previousLiveSyncCommittee.set(totalIncludedSignatures);
+  }
+}

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/SyncCommitteePerformance.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/SyncCommitteePerformance.java
@@ -20,14 +20,17 @@ import java.util.Objects;
 public class SyncCommitteePerformance {
   private final int numberOfExpectedSignatures;
   private final int numberOfProducedSignatures;
+  private final int numberOfCorrectSignatures;
   private final int numberOfIncludedSignatures;
 
   public SyncCommitteePerformance(
       final int numberOfExpectedSignatures,
       final int numberOfProducedSignatures,
+      final int numberOfCorrectSignatures,
       final int numberOfIncludedSignatures) {
     this.numberOfExpectedSignatures = numberOfExpectedSignatures;
     this.numberOfProducedSignatures = numberOfProducedSignatures;
+    this.numberOfCorrectSignatures = numberOfCorrectSignatures;
     this.numberOfIncludedSignatures = numberOfIncludedSignatures;
   }
 
@@ -37,6 +40,10 @@ public class SyncCommitteePerformance {
 
   public int getNumberOfProducedSignatures() {
     return numberOfProducedSignatures;
+  }
+
+  public int getNumberOfCorrectSignatures() {
+    return numberOfCorrectSignatures;
   }
 
   public int getNumberOfIncludedSignatures() {
@@ -54,21 +61,26 @@ public class SyncCommitteePerformance {
     final SyncCommitteePerformance that = (SyncCommitteePerformance) o;
     return numberOfExpectedSignatures == that.numberOfExpectedSignatures
         && numberOfProducedSignatures == that.numberOfProducedSignatures
+        && numberOfCorrectSignatures == that.numberOfCorrectSignatures
         && numberOfIncludedSignatures == that.numberOfIncludedSignatures;
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        numberOfExpectedSignatures, numberOfProducedSignatures, numberOfIncludedSignatures);
+        numberOfExpectedSignatures,
+        numberOfProducedSignatures,
+        numberOfCorrectSignatures,
+        numberOfIncludedSignatures);
   }
 
   @Override
   public String toString() {
     return String.format(
-        "Sync committee performance: " + "expected %d, produced %d, included %d (%d%%)",
+        "Sync committee performance: " + "expected %d, produced %d, correct %d, included %d (%d%%)",
         numberOfExpectedSignatures,
         numberOfProducedSignatures,
+        numberOfCorrectSignatures,
         numberOfIncludedSignatures,
         getPercentage(numberOfIncludedSignatures, numberOfProducedSignatures));
   }

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/ValidatorPerformanceMetrics.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/ValidatorPerformanceMetrics.java
@@ -37,6 +37,7 @@ public class ValidatorPerformanceMetrics {
   // Sync Committee Performance Metrics
   private final SettableGauge numberOfExpectedSignatures;
   private final SettableGauge numberOfProducedSignatures;
+  private final SettableGauge numberOfCorrectSignatures;
   private final SettableGauge numberOfIncludedSignatures;
 
   public ValidatorPerformanceMetrics(final MetricsSystem metricsSystem) {
@@ -124,6 +125,12 @@ public class ValidatorPerformanceMetrics {
             TekuMetricCategory.VALIDATOR_PERFORMANCE,
             "produced_sync_committee_signatures",
             "Number of produced sync committee signatures");
+    numberOfCorrectSignatures =
+        SettableGauge.create(
+            metricsSystem,
+            TekuMetricCategory.VALIDATOR_PERFORMANCE,
+            "correct_sync_committee_signatures",
+            "Number of produced sync committee signatures with the correct block root");
     numberOfIncludedSignatures =
         SettableGauge.create(
             metricsSystem,
@@ -153,6 +160,7 @@ public class ValidatorPerformanceMetrics {
   public void updateSyncCommitteePerformance(final SyncCommitteePerformance performance) {
     numberOfExpectedSignatures.set(performance.getNumberOfExpectedSignatures());
     numberOfProducedSignatures.set(performance.getNumberOfProducedSignatures());
+    numberOfCorrectSignatures.set(performance.getNumberOfCorrectSignatures());
     numberOfIncludedSignatures.set(performance.getNumberOfIncludedSignatures());
   }
 }

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
@@ -74,7 +74,7 @@ public class DefaultPerformanceTrackerTest {
   void beforeEach() {
     when(validatorTracker.getNumberOfValidatorsForEpoch(any())).thenReturn(0);
     when(syncCommitteePerformanceTracker.calculatePerformance(any()))
-        .thenReturn(SafeFuture.completedFuture(new SyncCommitteePerformance(0, 0, 0)));
+        .thenReturn(SafeFuture.completedFuture(new SyncCommitteePerformance(0, 0, 0, 0)));
     chainUpdater.initializeGenesis();
     performanceTracker.start(UInt64.ZERO);
   }
@@ -326,7 +326,7 @@ public class DefaultPerformanceTrackerTest {
 
   @Test
   void shouldReportSyncCommitteePerformance() {
-    final SyncCommitteePerformance performance = new SyncCommitteePerformance(10, 9, 8);
+    final SyncCommitteePerformance performance = new SyncCommitteePerformance(10, 9, 8, 7);
     final UInt64 epoch = UInt64.valueOf(2);
     when(syncCommitteePerformanceTracker.calculatePerformance(epoch.minus(1)))
         .thenReturn(SafeFuture.completedFuture(performance));

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/ValidatorPerformanceMetricsTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/ValidatorPerformanceMetricsTest.java
@@ -24,6 +24,7 @@ public class ValidatorPerformanceMetricsTest {
 
   private static final int NUMBER_OF_EXPECTED_SIGNATURES = 64;
   private static final int NUMBER_OF_PRODUCED_SIGNATURES = 60;
+  private static final int NUMBER_OF_CORRECT_SIGNATURES = 55;
   private static final int NUMBER_OF_INCLUDED_SIGNATURES = 52;
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   public final ValidatorPerformanceMetrics validatorPerformanceMetrics =
@@ -61,6 +62,7 @@ public class ValidatorPerformanceMetricsTest {
       new SyncCommitteePerformance(
           NUMBER_OF_EXPECTED_SIGNATURES,
           NUMBER_OF_PRODUCED_SIGNATURES,
+          NUMBER_OF_CORRECT_SIGNATURES,
           NUMBER_OF_INCLUDED_SIGNATURES);
 
   @BeforeEach
@@ -153,6 +155,15 @@ public class ValidatorPerformanceMetricsTest {
                 .getGauge(VALIDATOR_PERFORMANCE, "produced_sync_committee_signatures")
                 .getValue())
         .isEqualTo(NUMBER_OF_PRODUCED_SIGNATURES);
+  }
+
+  @Test
+  void getCorrectSignatures() {
+    assertThat(
+            metricsSystem
+                .getGauge(VALIDATOR_PERFORMANCE, "correct_sync_committee_signatures")
+                .getValue())
+        .isEqualTo(NUMBER_OF_CORRECT_SIGNATURES);
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Add a metric that reports the number of sync committee signatures produced that had the correct block root for that slot. These are the produced signatures that are eligible for inclusion in the next slot and so give a better indication of how well the validator is performing vs issues with inclusion caused by gossip or block producers.

## Fixed Issue(s)
#4103 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
