### PR TITLE
return error when contributions are invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For information on changes in released versions of Teku, see the [releases page]
   `/eth/v2/debug/beacon/states/:state_id` so that it comes back as an array rather than a byte string.
 - `/eth/v1/beacon/pool/sync_committees` incorrectly returned 503 when there were no errors instead of 200.
 - Fix an issue where deposits for the PoW chain could be loaded out of order on restart.
+- Fix `/eth/v1/validator/contribution_and_proofs` to return errors.
 
 ### Experimental: New Altair REST APIs
 - implement POST `/eth/v1/beacon/pool/sync_committees` to allow validators to submit sync committee signatures to the beacon node.

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/InternalValidationResult.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/InternalValidationResult.java
@@ -24,9 +24,8 @@ public class InternalValidationResult {
   public static InternalValidationResult IGNORE =
       InternalValidationResult.create(ValidationResultCode.IGNORE);
 
-  @Deprecated
   public static InternalValidationResult REJECT =
-      InternalValidationResult.create(ValidationResultCode.REJECT);
+      InternalValidationResult.create(ValidationResultCode.REJECT, "Failed validation");
 
   public static InternalValidationResult SAVE_FOR_FUTURE =
       InternalValidationResult.create(ValidationResultCode.SAVE_FOR_FUTURE);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/InternalValidationResult.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/InternalValidationResult.java
@@ -23,8 +23,11 @@ public class InternalValidationResult {
       InternalValidationResult.create(ValidationResultCode.ACCEPT);
   public static InternalValidationResult IGNORE =
       InternalValidationResult.create(ValidationResultCode.IGNORE);
+
+  @Deprecated
   public static InternalValidationResult REJECT =
       InternalValidationResult.create(ValidationResultCode.REJECT);
+
   public static InternalValidationResult SAVE_FOR_FUTURE =
       InternalValidationResult.create(ValidationResultCode.SAVE_FOR_FUTURE);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidatorTest.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.statetransition.synccommittee;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.IGNORE;
-import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.REJECT;
 
 import java.time.Duration;
 import org.apache.tuweni.bytes.Bytes32;
@@ -130,7 +129,7 @@ class SignedContributionAndProofValidatorTest {
             .subcommitteeIndex(NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT + 1)
             .build();
     final SafeFuture<InternalValidationResult> result = validator.validate(message);
-    assertThat(result).isCompletedWithValue(REJECT);
+    assertThat(result).isCompletedWithValueMatching(InternalValidationResult::isReject);
   }
 
   @Test
@@ -148,7 +147,8 @@ class SignedContributionAndProofValidatorTest {
             .createValidSignedContributionAndProofBuilder()
             .aggregatorIndex(UInt64.valueOf(10_000))
             .build();
-    assertThat(validator.validate(message)).isCompletedWithValue(REJECT);
+    assertThat(validator.validate(message))
+        .isCompletedWithValueMatching(InternalValidationResult::isReject);
   }
 
   @Test
@@ -158,7 +158,8 @@ class SignedContributionAndProofValidatorTest {
             .createValidSignedContributionAndProofBuilder()
             .aggregatorNotInSyncSubcommittee()
             .build();
-    assertThat(validator.validate(message)).isCompletedWithValue(REJECT);
+    assertThat(validator.validate(message))
+        .isCompletedWithValueMatching(InternalValidationResult::isReject);
   }
 
   @Test
@@ -168,7 +169,8 @@ class SignedContributionAndProofValidatorTest {
             .createValidSignedContributionAndProofBuilder()
             .selectionProof(dataStructureUtil.randomSignature())
             .build();
-    assertThat(validator.validate(message)).isCompletedWithValue(REJECT);
+    assertThat(validator.validate(message))
+        .isCompletedWithValueMatching(InternalValidationResult::isReject);
   }
 
   @Test
@@ -178,7 +180,8 @@ class SignedContributionAndProofValidatorTest {
             .createValidSignedContributionAndProofBuilder()
             .signedContributionAndProofSignature(dataStructureUtil.randomSignature())
             .build();
-    assertThat(validator.validate(message)).isCompletedWithValue(REJECT);
+    assertThat(validator.validate(message))
+        .isCompletedWithValueMatching(InternalValidationResult::isReject);
   }
 
   @Test
@@ -188,7 +191,8 @@ class SignedContributionAndProofValidatorTest {
             .createValidSignedContributionAndProofBuilder()
             .addParticipantSignature(dataStructureUtil.randomSignature())
             .build();
-    assertThat(validator.validate(message)).isCompletedWithValue(REJECT);
+    assertThat(validator.validate(message))
+        .isCompletedWithValueMatching(InternalValidationResult::isReject);
   }
 
   @Test

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -566,7 +566,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                       .collect(toList());
               if (!errorMessages.isEmpty()) {
                 throw new IllegalArgumentException(
-                    "Invalid contribution and proofs: \n" + String.join("\n", errorMessages));
+                    "Invalid contribution and proofs: ;" + String.join(";", errorMessages));
               }
             });
   }


### PR DESCRIPTION
Previously when a contribution and proof was rejected, the error reason was only in trace. Now the errors should be returned, in a semi-colon separated list if there are multiple.

Ignored entries will still not result in an error being returned to the user.

fixes #4138

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
