### PR TITLE
Add MIN_ANCHOR_POW_BLOCK_DIFFICULTY to the list of config items we ignore

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
@@ -55,7 +55,8 @@ public class SpecConfigReader {
           "MERGE_FORK_EPOCH",
           "SHARDING_FORK_VERSION",
           "SHARDING_FORK_EPOCH",
-          "TRANSITION_TOTAL_DIFFICULTY");
+          "TRANSITION_TOTAL_DIFFICULTY",
+          "MIN_ANCHOR_POW_BLOCK_DIFFICULTY");
   private static final ImmutableSet<String> CONSTANT_KEYS =
       ImmutableSet.of(
           // Phase0 constants which may exist in legacy config files, but should now be ignored


### PR DESCRIPTION
## PR Description
`MIN_ANCHOR_POW_BLOCK_DIFFICULTY` looks to be the new name for `TRANSITION_TOTAL_DIFFICULTY`.  Will ignore both now to ensure compatibility with existing config files.

Ignoring this makes it easier to setup new devnets which are including this entry in the config files.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
