### PR TITLE
Optimise collection of Altair validator stats

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/ValidatorStatsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/ValidatorStatsAltair.java
@@ -30,21 +30,17 @@ interface ValidatorStatsAltair extends BeaconStateAltair {
   }
 
   private CorrectAndLiveValidators getValidatorStats(final SszList<SszByte> participationFlags) {
-
-    final int numberOfCorrectValidators =
-        Math.toIntExact(
-            participationFlags.stream()
-                .map(SszByte::get)
-                .filter(ParticipationFlags::isTimelyTarget)
-                .count());
-
-    final int numberOfLiveValidators =
-        Math.toIntExact(
-            participationFlags.stream()
-                .map(SszByte::get)
-                .filter(ParticipationFlags::isAnyFlagSet)
-                .count());
-
+    int numberOfCorrectValidators = 0;
+    int numberOfLiveValidators = 0;
+    for (SszByte participationFlag : participationFlags) {
+      final byte flag = participationFlag.get();
+      if (ParticipationFlags.isTimelyTarget(flag)) {
+        numberOfCorrectValidators++;
+      }
+      if (ParticipationFlags.isAnyFlagSet(flag)) {
+        numberOfLiveValidators++;
+      }
+    }
     return new CorrectAndLiveValidators(numberOfCorrectValidators, numberOfLiveValidators);
   }
 }


### PR DESCRIPTION
## PR Description
Only iterate through the participation flags a single time instead of twice.

## Fixed Issue(s)
#4150 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
