### PR TITLE
Ignore MIN_ANCHOR_POW_BLOCK_DIFFICULTY in ConstantsReader too

### DIFF
--- a/util/src/main/java/tech/pegasys/teku/util/config/ConstantsReader.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/ConstantsReader.java
@@ -54,6 +54,7 @@ class ConstantsReader {
           "SHARDING_FORK_VERSION",
           "SHARDING_FORK_EPOCH",
           "TRANSITION_TOTAL_DIFFICULTY",
+          "MIN_ANCHOR_POW_BLOCK_DIFFICULTY",
           // Phase0 constants which may exist in legacy config files, but should now be ignored
           "BLS_WITHDRAWAL_PREFIX",
           "TARGET_AGGREGATORS_PER_COMMITTEE",


### PR DESCRIPTION
## PR Description
Ignore `MIN_ANCHOR_POW_BLOCK_DIFFICULTY` when setting up the legacy `Constants` too.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
