### PR TITLE
Increase target sync subcommittee aggregators to 16

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
@@ -15,5 +15,5 @@ package tech.pegasys.teku.spec.constants;
 
 public class NetworkConstants {
 
-  public static final int SYNC_COMMITTEE_SUBNET_COUNT = 16;
+  public static final int SYNC_COMMITTEE_SUBNET_COUNT = 4;
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
@@ -15,5 +15,5 @@ package tech.pegasys.teku.spec.constants;
 
 public class NetworkConstants {
 
-  public static final int SYNC_COMMITTEE_SUBNET_COUNT = 4;
+  public static final int SYNC_COMMITTEE_SUBNET_COUNT = 16;
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ValidatorConstants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ValidatorConstants.java
@@ -19,5 +19,5 @@ public class ValidatorConstants {
   public static final int RANDOM_SUBNETS_PER_VALIDATOR = 1;
   public static final int EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION = 256;
   // Altair
-  public static final int TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE = 4;
+  public static final int TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE = 16;
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
@@ -99,7 +99,8 @@ class SyncCommitteeAggregationDutyTest {
             "minimal",
             modifier ->
                 modifier.altairBuilder(
-                    altairModifier -> altairModifier.altairForkEpoch(UInt64.ZERO)))
+                    altairModifier ->
+                        altairModifier.altairForkEpoch(UInt64.ZERO).syncCommitteeSize(512)))
         .toVersionAltair()
         .orElseThrow();
   }
@@ -160,7 +161,7 @@ class SyncCommitteeAggregationDutyTest {
   @Test
   void shouldCreateAndSendSignedContributionAndProof() {
     final int committeeIndex = 9;
-    final int subcommitteeIndex = 1;
+    final int subcommitteeIndex = 0;
     withValidatorAggregatingSubnet(validator1, subcommitteeIndex);
 
     final SyncCommitteeAggregationDuty duty =


### PR DESCRIPTION
## PR Description
Increase target sync subcommittee aggregators from 4 to 16 inline with changes in beta.1.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
