### PR TITLE
Fix null gossipType in Eth2TopicHandler (Altair)

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
@@ -86,11 +86,6 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
         gossipType);
   }
 
-  // legacy, maybe remove this
-  protected SszSchema<T> getGossipType() {
-    return gossipType;
-  }
-
   protected void publishMessage(T message) {
     final Bytes data = gossipEncoding.encode(message);
     channel.gossip(data);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AbstractGossipManager.java
@@ -31,7 +31,6 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
 
   private final GossipEncoding gossipEncoding;
   private final GossipPublisher<T> publisher;
-  private final SszSchema<T> gossipType;
 
   private final AtomicBoolean shutdown = new AtomicBoolean(false);
   private final TopicChannel channel;
@@ -59,7 +58,6 @@ public abstract class AbstractGossipManager<T extends SszData> implements Gossip
     this.channel = gossipNetwork.subscribe(topicHandler.getTopic(), topicHandler);
     this.gossipEncoding = gossipEncoding;
     this.publisher = publisher;
-    this.gossipType = gossipType;
 
     this.subscriberId = publisher.subscribe(this::publishMessage);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
@@ -41,11 +41,8 @@ public class AttesterSlashingGossipManager extends AbstractGossipManager<Atteste
         gossipEncoding,
         forkInfo,
         processor,
-        publisher);
+        publisher,
+        AttesterSlashing.SSZ_SCHEMA);
   }
 
-  @Override
-  protected SszSchema<AttesterSlashing> getGossipType() {
-    return AttesterSlashing.SSZ_SCHEMA;
-  }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
@@ -20,7 +20,6 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
 import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.ssz.schema.SszSchema;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class AttesterSlashingGossipManager extends AbstractGossipManager<AttesterSlashing> {
@@ -44,5 +43,4 @@ public class AttesterSlashingGossipManager extends AbstractGossipManager<Atteste
         publisher,
         AttesterSlashing.SSZ_SCHEMA);
   }
-
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
@@ -41,11 +41,8 @@ public class ProposerSlashingGossipManager extends AbstractGossipManager<Propose
         gossipEncoding,
         forkInfo,
         processor,
-        publisher);
+        publisher,
+        ProposerSlashing.SSZ_SCHEMA);
   }
 
-  @Override
-  protected SszSchema<ProposerSlashing> getGossipType() {
-    return ProposerSlashing.SSZ_SCHEMA;
-  }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ProposerSlashingGossipManager.java
@@ -20,7 +20,6 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
 import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.ssz.schema.SszSchema;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class ProposerSlashingGossipManager extends AbstractGossipManager<ProposerSlashing> {
@@ -44,5 +43,4 @@ public class ProposerSlashingGossipManager extends AbstractGossipManager<Propose
         publisher,
         ProposerSlashing.SSZ_SCHEMA);
   }
-
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedContributionAndProofGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedContributionAndProofGossipManager.java
@@ -21,7 +21,6 @@ import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
-import tech.pegasys.teku.ssz.schema.SszSchema;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class SignedContributionAndProofGossipManager
@@ -47,5 +46,4 @@ public class SignedContributionAndProofGossipManager
         publisher,
         schemaDefinitions.getSignedContributionAndProofSchema());
   }
-
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedContributionAndProofGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/SignedContributionAndProofGossipManager.java
@@ -27,8 +27,6 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 public class SignedContributionAndProofGossipManager
     extends AbstractGossipManager<SignedContributionAndProof> {
 
-  private final SszSchema<SignedContributionAndProof> gossipType;
-
   public SignedContributionAndProofGossipManager(
       final RecentChainData recentChainData,
       final SchemaDefinitionsAltair schemaDefinitions,
@@ -46,12 +44,8 @@ public class SignedContributionAndProofGossipManager
         gossipEncoding,
         forkInfo,
         processor,
-        publisher);
-    gossipType = schemaDefinitions.getSignedContributionAndProofSchema();
+        publisher,
+        schemaDefinitions.getSignedContributionAndProofSchema());
   }
 
-  @Override
-  protected SszSchema<SignedContributionAndProof> getGossipType() {
-    return gossipType;
-  }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
@@ -43,5 +43,4 @@ public class VoluntaryExitGossipManager extends AbstractGossipManager<SignedVolu
         publisher,
         SignedVoluntaryExit.SSZ_SCHEMA);
   }
-
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/VoluntaryExitGossipManager.java
@@ -20,7 +20,6 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
 import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.ssz.schema.SszSchema;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class VoluntaryExitGossipManager extends AbstractGossipManager<SignedVoluntaryExit> {
@@ -41,11 +40,8 @@ public class VoluntaryExitGossipManager extends AbstractGossipManager<SignedVolu
         gossipEncoding,
         forkInfo,
         processor,
-        publisher);
+        publisher,
+        SignedVoluntaryExit.SSZ_SCHEMA);
   }
 
-  @Override
-  protected SszSchema<SignedVoluntaryExit> getGossipType() {
-    return SignedVoluntaryExit.SSZ_SCHEMA;
-  }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
@@ -130,7 +130,7 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
   protected ValidationResult handleMessageProcessingError(Throwable err) {
     final ValidationResult response;
     if (ExceptionUtil.getCause(err, DecodingException.class).isPresent()) {
-      LOG.trace("Received malformed gossip message on {}", getTopic());
+      LOG.warn("Received malformed gossip message on {}", getTopic());
       response = ValidationResult.Invalid;
     } else if (ExceptionUtil.getCause(err, RejectedExecutionException.class).isPresent()) {
       LOG.warn(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
@@ -130,7 +130,7 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
   protected ValidationResult handleMessageProcessingError(Throwable err) {
     final ValidationResult response;
     if (ExceptionUtil.getCause(err, DecodingException.class).isPresent()) {
-      LOG.warn("Received malformed gossip message on {}", getTopic());
+      LOG.debug("Received malformed gossip message on {}", getTopic());
       response = ValidationResult.Invalid;
     } else if (ExceptionUtil.getCause(err, RejectedExecutionException.class).isPresent()) {
       LOG.warn(


### PR DESCRIPTION
The SignedContributionAndProofGossipManager should fetch the ssz schema of the message type before constructing AbstractGossipManager super type. Previously it would construct the super type first, which would call a sub-method, which would retrieve an uninitialized field, as the constructor of the sub-class didn't complete yet.

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)

Fixes #4164 (Fixes the malformed thing, effect on performance yet to be seen, need to deploy it to all devnet teku nodes)

See comment https://github.com/ConsenSys/teku/issues/4164#issuecomment-881705177 in particular

## Changes

Change the base class to take the message type directly, instead of the bug-prone abstract method. Other topics worked because they would return static schemas, unlike the new altair topic which relied on its own constructor to complete for valid schema data.

## Documentation

- [ x I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
