### PR TITLE
Rename SyncCommitteeSignature to SyncCommitteeMessage

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostSyncCommitteesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostSyncCommitteesIntegrationTest.java
@@ -27,7 +27,7 @@ import okhttp3.Response;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.response.v1.beacon.PostSyncCommitteeFailureResponse;
 import tech.pegasys.teku.api.schema.BLSSignature;
-import tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.api.schema.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostSyncCommittees;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -35,7 +35,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.validator.api.SubmitCommitteeSignatureError;
+import tech.pegasys.teku.validator.api.SubmitCommitteeMessageError;
 
 public class PostSyncCommitteesIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
   private final String errorString = "The Error Description";
@@ -45,17 +45,17 @@ public class PostSyncCommitteesIntegrationTest extends AbstractDataBackedRestAPI
     spec = TestSpecFactory.createMinimalAltair();
     DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
     startRestAPIAtGenesis(SpecMilestone.ALTAIR);
-    final List<SyncCommitteeSignature> requestBody =
+    final List<SyncCommitteeMessage> requestBody =
         List.of(
-            new SyncCommitteeSignature(
+            new SyncCommitteeMessage(
                 UInt64.ONE,
                 dataStructureUtil.randomBytes32(),
                 dataStructureUtil.randomUInt64(),
                 new BLSSignature(dataStructureUtil.randomSignature())));
-    final SafeFuture<List<SubmitCommitteeSignatureError>> future =
+    final SafeFuture<List<SubmitCommitteeMessageError>> future =
         SafeFuture.completedFuture(
-            List.of(new SubmitCommitteeSignatureError(UInt64.ZERO, errorString)));
-    when(validatorApiChannel.sendSyncCommitteeSignatures(
+            List.of(new SubmitCommitteeMessageError(UInt64.ZERO, errorString)));
+    when(validatorApiChannel.sendSyncCommitteeMessages(
             requestBody.get(0).asInternalCommitteeSignature(spec).stream()
                 .collect(Collectors.toList())))
         .thenReturn(future);
@@ -73,16 +73,16 @@ public class PostSyncCommitteesIntegrationTest extends AbstractDataBackedRestAPI
     spec = TestSpecFactory.createMinimalAltair();
     DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
     startRestAPIAtGenesis(SpecMilestone.ALTAIR);
-    final List<SyncCommitteeSignature> requestBody =
+    final List<SyncCommitteeMessage> requestBody =
         List.of(
-            new SyncCommitteeSignature(
+            new SyncCommitteeMessage(
                 UInt64.ONE,
                 dataStructureUtil.randomBytes32(),
                 dataStructureUtil.randomUInt64(),
                 new BLSSignature(dataStructureUtil.randomSignature())));
-    final SafeFuture<List<SubmitCommitteeSignatureError>> future =
+    final SafeFuture<List<SubmitCommitteeMessageError>> future =
         SafeFuture.completedFuture(Collections.emptyList());
-    when(validatorApiChannel.sendSyncCommitteeSignatures(any())).thenReturn(future);
+    when(validatorApiChannel.sendSyncCommitteeMessages(any())).thenReturn(future);
     Response response = post(PostSyncCommittees.ROUTE, jsonProvider.objectToJSON(requestBody));
 
     assertThat(response.code()).isEqualTo(SC_OK);
@@ -94,9 +94,9 @@ public class PostSyncCommitteesIntegrationTest extends AbstractDataBackedRestAPI
     startRestAPIAtGenesis(SpecMilestone.PHASE0);
     spec = TestSpecFactory.createMinimalPhase0();
     DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-    final List<SyncCommitteeSignature> requestBody =
+    final List<SyncCommitteeMessage> requestBody =
         List.of(
-            new SyncCommitteeSignature(
+            new SyncCommitteeMessage(
                 UInt64.ONE,
                 dataStructureUtil.randomBytes32(),
                 dataStructureUtil.randomUInt64(),

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostSyncCommittees.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostSyncCommittees.java
@@ -37,13 +37,13 @@ import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
 import tech.pegasys.teku.api.response.v1.beacon.PostSyncCommitteeFailure;
 import tech.pegasys.teku.api.response.v1.beacon.PostSyncCommitteeFailureResponse;
-import tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.api.schema.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.provider.JsonProvider;
-import tech.pegasys.teku.validator.api.SubmitCommitteeSignatureError;
-import tech.pegasys.teku.validator.api.SubmitCommitteeSignaturesResult;
+import tech.pegasys.teku.validator.api.SubmitCommitteeMessageError;
+import tech.pegasys.teku.validator.api.SubmitCommitteeMessagesResult;
 
 public class PostSyncCommittees extends AbstractHandler {
   public static final String ROUTE = "/eth/v1/beacon/pool/sync_committees";
@@ -61,23 +61,23 @@ public class PostSyncCommittees extends AbstractHandler {
   @OpenApi(
       path = ROUTE,
       method = HttpMethod.POST,
-      summary = "Submit sync committee signatures to node",
+      summary = "Submit sync committee messages to node",
       tags = {TAG_EXPERIMENTAL},
       requestBody =
           @OpenApiRequestBody(
-              content = {@OpenApiContent(from = SyncCommitteeSignature.class, isArray = true)}),
+              content = {@OpenApiContent(from = SyncCommitteeMessage.class, isArray = true)}),
       description =
-          "Submits sync committee signature objects to the node.\n\n"
-              + "Sync committee signatures are not present in phase0, but are required for Altair networks.\n\n"
-              + "If a sync committee signature is validated successfully the node MUST publish that sync committee signature on all applicable subnets.\n\n"
-              + "If one or more sync committee signatures fail validation the node MUST return a 400 error with details of which sync committee signatures have failed, and why.",
+          "Submits sync committee message objects to the node.\n\n"
+              + "Sync committee messages are not present in phase0, but are required for Altair networks.\n\n"
+              + "If a sync committee message is validated successfully the node MUST publish that sync committee message on all applicable subnets.\n\n"
+              + "If one or more sync committee messages fail validation the node MUST return a 400 error with details of which sync committee messages have failed, and why.",
       responses = {
         @OpenApiResponse(
             status = RES_OK,
-            description = "The sync committee signatures were accepted, validated, and submitted"),
+            description = "The sync committee messages were accepted, validated, and submitted"),
         @OpenApiResponse(
             status = RES_BAD_REQUEST,
-            description = "Errors with one or more sync committee signature",
+            description = "Errors with one or more sync committee messages",
             content = @OpenApiContent(from = PostSyncCommitteeFailureResponse.class)),
         @OpenApiResponse(status = RES_INTERNAL_ERROR)
       })
@@ -85,10 +85,10 @@ public class PostSyncCommittees extends AbstractHandler {
   public void handle(final Context ctx) throws Exception {
     try {
       final String body = ctx.body();
-      final List<SyncCommitteeSignature> signatures =
-          Arrays.asList(jsonProvider.jsonToObject(body, SyncCommitteeSignature[].class));
-      final SafeFuture<SubmitCommitteeSignaturesResult> future =
-          provider.submitCommitteeSignatures(signatures);
+      final List<SyncCommitteeMessage> messages =
+          Arrays.asList(jsonProvider.jsonToObject(body, SyncCommitteeMessage[].class));
+      final SafeFuture<SubmitCommitteeMessagesResult> future =
+          provider.submitCommitteeSignatures(messages);
 
       ctx.result(
           future
@@ -101,9 +101,9 @@ public class PostSyncCommittees extends AbstractHandler {
     }
   }
 
-  private String handleResult(Context ctx, final SubmitCommitteeSignaturesResult response)
+  private String handleResult(Context ctx, final SubmitCommitteeMessagesResult response)
       throws JsonProcessingException {
-    final List<SubmitCommitteeSignatureError> errors = response.getErrors();
+    final List<SubmitCommitteeMessageError> errors = response.getErrors();
     if (errors.isEmpty()) {
       ctx.status(SC_OK);
       return null;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetSyncCommitteeContribution.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetSyncCommitteeContribution.java
@@ -80,7 +80,7 @@ public class GetSyncCommitteeContribution extends AbstractHandler {
             required = true)
       },
       description =
-          "Returns a `SyncCommitteeContribution` that is the aggregate of `SyncCommitteeSignature` "
+          "Returns a `SyncCommitteeContribution` that is the aggregate of `SyncCommitteeMessage` "
               + "values known to this node matching the specified slot, subcommittee index and beacon block root.",
       responses = {
         @OpenApiResponse(

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -40,7 +40,7 @@ import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.ValidatorBlockResult;
 import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
 import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
-import tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.api.schema.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -58,7 +58,7 @@ import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.validator.api.AttesterDuty;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuty;
-import tech.pegasys.teku.validator.api.SubmitCommitteeSignaturesResult;
+import tech.pegasys.teku.validator.api.SubmitCommitteeMessagesResult;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuty;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
@@ -185,14 +185,14 @@ public class ValidatorDataProvider {
             });
   }
 
-  public SafeFuture<SubmitCommitteeSignaturesResult> submitCommitteeSignatures(
-      final List<SyncCommitteeSignature> signatures) {
+  public SafeFuture<SubmitCommitteeMessagesResult> submitCommitteeSignatures(
+      final List<SyncCommitteeMessage> messages) {
     return validatorApiChannel
-        .sendSyncCommitteeSignatures(
-            signatures.stream()
-                .flatMap(signature -> signature.asInternalCommitteeSignature(spec).stream())
+        .sendSyncCommitteeMessages(
+            messages.stream()
+                .flatMap(message -> message.asInternalCommitteeSignature(spec).stream())
                 .collect(Collectors.toList()))
-        .thenApply(SubmitCommitteeSignaturesResult::new);
+        .thenApply(SubmitCommitteeMessagesResult::new);
   }
 
   public SafeFuture<Optional<Attestation>> createAggregate(

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeMessage.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SyncCommitteeMessage.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 
-public class SyncCommitteeSignature {
+public class SyncCommitteeMessage {
   @Schema(type = "string", format = "uint64")
   @JsonProperty("slot")
   public final UInt64 slot;
@@ -45,7 +45,7 @@ public class SyncCommitteeSignature {
   public final BLSSignature signature;
 
   @JsonCreator
-  public SyncCommitteeSignature(
+  public SyncCommitteeMessage(
       @JsonProperty("slot") final UInt64 slot,
       @JsonProperty("beacon_block_root") final Bytes32 beaconBlockRoot,
       @JsonProperty("validator_index") final UInt64 validatorIndex,
@@ -60,7 +60,7 @@ public class SyncCommitteeSignature {
   public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    final SyncCommitteeSignature that = (SyncCommitteeSignature) o;
+    final SyncCommitteeMessage that = (SyncCommitteeMessage) o;
     return Objects.equals(slot, that.slot)
         && Objects.equals(beaconBlockRoot, that.beaconBlockRoot)
         && Objects.equals(validatorIndex, that.validatorIndex)
@@ -73,7 +73,7 @@ public class SyncCommitteeSignature {
   }
 
   public Optional<
-          tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature>
+          tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage>
       asInternalCommitteeSignature(final Spec spec) {
     final Optional<SchemaDefinitionsAltair> maybeSchema =
         spec.atSlot(slot).getSchemaDefinitions().toVersionAltair();
@@ -87,7 +87,7 @@ public class SyncCommitteeSignature {
     return maybeSchema.map(
         schema ->
             schema
-                .getSyncCommitteeSignatureSchema()
+                .getSyncCommitteeMessageSchema()
                 .create(slot, beaconBlockRoot, validatorIndex, signature.asInternalBLSSignature()));
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
@@ -95,6 +95,6 @@ public class DefaultOperationProcessor implements OperationProcessor {
   public void processSyncCommittee(final MutableBeaconState state, final SyncAggregate aggregate)
       throws BlockProcessingException {
     spec.getBlockProcessor(state.getSlot())
-        .processSyncCommittee(state, aggregate, BLSSignatureVerifier.SIMPLE);
+        .processSyncAggregate(state, aggregate, BLSSignatureVerifier.SIMPLE);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
@@ -79,7 +79,7 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
               "ssz_static/SyncCommitteeMessage",
               new SszTestExecutor<>(
                   schemas ->
-                      SchemaDefinitionsAltair.required(schemas).getSyncCommitteeSignatureSchema()))
+                      SchemaDefinitionsAltair.required(schemas).getSyncCommitteeMessageSchema()))
           .put(
               "ssz_static/SyncAggregatorSelectionData",
               new SszTestExecutor<>(

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalSigner.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalSigner.java
@@ -80,12 +80,12 @@ public class LocalSigner implements Signer {
   }
 
   @Override
-  public SafeFuture<BLSSignature> signSyncCommitteeSignature(
+  public SafeFuture<BLSSignature> signSyncCommitteeMessage(
       final UInt64 slot, final Bytes32 beaconBlockRoot, final ForkInfo forkInfo) {
     return signingRootFromSyncCommitteeUtils(
             slot,
             utils ->
-                utils.getSyncCommitteeSignatureSigningRoot(
+                utils.getSyncCommitteeMessageSigningRoot(
                     beaconBlockRoot, spec.computeEpochAtSlot(slot), forkInfo))
         .thenCompose(this::sign);
   }

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/Signer.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/Signer.java
@@ -40,7 +40,7 @@ public interface Signer {
 
   SafeFuture<BLSSignature> signVoluntaryExit(VoluntaryExit voluntaryExit, ForkInfo forkInfo);
 
-  SafeFuture<BLSSignature> signSyncCommitteeSignature(
+  SafeFuture<BLSSignature> signSyncCommitteeMessage(
       UInt64 slot, Bytes32 beaconBlockRoot, ForkInfo forkInfo);
 
   SafeFuture<BLSSignature> signSyncCommitteeSelectionProof(

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SlashingProtectedSigner.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SlashingProtectedSigner.java
@@ -122,9 +122,9 @@ public class SlashingProtectedSigner implements Signer {
   }
 
   @Override
-  public SafeFuture<BLSSignature> signSyncCommitteeSignature(
+  public SafeFuture<BLSSignature> signSyncCommitteeMessage(
       final UInt64 slot, final Bytes32 beaconBlockRoot, final ForkInfo forkInfo) {
-    return delegate.signSyncCommitteeSignature(slot, beaconBlockRoot, forkInfo);
+    return delegate.signSyncCommitteeMessage(slot, beaconBlockRoot, forkInfo);
   }
 
   @Override

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -47,7 +47,7 @@ import tech.pegasys.teku.spec.datastructures.interop.MockStartValidatorKeyPairFa
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncAggregatorSelectionData;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
@@ -461,22 +461,22 @@ public class ChainBuilder {
     throw new IllegalStateException("No valid sync subcommittee aggregators found");
   }
 
-  public SyncCommitteeSignature createValidSyncCommitteeSignature() {
+  public SyncCommitteeMessage createValidSyncCommitteeMessage() {
     final SignedBlockAndState target = getLatestBlockAndState();
-    return createSyncCommitteeSignature(target.getSlot(), target.getRoot());
+    return createSyncCommitteeMessage(target.getSlot(), target.getRoot());
   }
 
-  public SyncCommitteeSignature createSyncCommitteeSignature(
+  public SyncCommitteeMessage createSyncCommitteeMessage(
       final UInt64 slot, final Bytes32 blockRoot) {
     final BeaconStateAltair state =
         BeaconStateAltair.required(getLatestBlockAndStateAtSlot(slot).getState());
 
     final BLSPublicKey pubKey =
         state.getCurrentSyncCommittee().getPubkeys().get(0).getBLSPublicKey();
-    return createSyncCommitteeSignature(slot, blockRoot, state, pubKey);
+    return createSyncCommitteeMessage(slot, blockRoot, state, pubKey);
   }
 
-  public SyncCommitteeSignature createSyncCommitteeSignature(
+  public SyncCommitteeMessage createSyncCommitteeMessage(
       final UInt64 slot,
       final Bytes32 blockRoot,
       final BeaconStateAltair state,
@@ -484,10 +484,10 @@ public class ChainBuilder {
     final int validatorIndex = spec.getValidatorIndex(state, validatorPublicKey).orElseThrow();
     final BLSSignature signature =
         getSigner(validatorIndex)
-            .signSyncCommitteeSignature(slot, blockRoot, state.getForkInfo())
+            .signSyncCommitteeMessage(slot, blockRoot, state.getForkInfo())
             .join();
     return SchemaDefinitionsAltair.required(spec.atSlot(slot).getSchemaDefinitions())
-        .getSyncCommitteeSignatureSchema()
+        .getSyncCommitteeMessageSchema()
         .create(slot, blockRoot, UInt64.valueOf(validatorIndex), signature);
   }
 

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/signatures/NoOpSigner.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/signatures/NoOpSigner.java
@@ -64,7 +64,7 @@ public class NoOpSigner implements Signer {
   }
 
   @Override
-  public SafeFuture<BLSSignature> signSyncCommitteeSignature(
+  public SafeFuture<BLSSignature> signSyncCommitteeMessage(
       final UInt64 slot, final Bytes32 beaconBlockRoot, final ForkInfo forkInfo) {
     return new SafeFuture<>();
   }

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/synccomittee/SignedContributionAndProofTestBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/synccomittee/SignedContributionAndProofTestBuilder.java
@@ -157,7 +157,7 @@ public class SignedContributionAndProofTestBuilder {
         validatorIndex,
         subcommitteeIndex);
     final BLSSignature syncSignature =
-        signer.signSyncCommitteeSignature(slot, beaconBlockRoot, state.getForkInfo()).join();
+        signer.signSyncCommitteeMessage(slot, beaconBlockRoot, state.getForkInfo()).join();
     final Set<Integer> participationIndices =
         assignments.getParticipationBitIndices(subcommitteeIndex);
     // Have to add signature once for each time the validator appears in the subcommittee

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeMessage.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeMessage.java
@@ -22,15 +22,15 @@ import tech.pegasys.teku.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.ssz.tree.TreeNode;
 
-public class SyncCommitteeSignature
-    extends Container4<SyncCommitteeSignature, SszUInt64, SszBytes32, SszUInt64, SszSignature> {
+public class SyncCommitteeMessage
+    extends Container4<SyncCommitteeMessage, SszUInt64, SszBytes32, SszUInt64, SszSignature> {
 
-  SyncCommitteeSignature(final SyncCommitteeSignatureSchema schema, final TreeNode backingNode) {
+  SyncCommitteeMessage(final SyncCommitteeMessageSchema schema, final TreeNode backingNode) {
     super(schema, backingNode);
   }
 
-  public SyncCommitteeSignature(
-      final SyncCommitteeSignatureSchema schema,
+  public SyncCommitteeMessage(
+      final SyncCommitteeMessageSchema schema,
       final SszUInt64 slot,
       final SszBytes32 beaconBlockRoot,
       final SszUInt64 validatorIndex,
@@ -55,7 +55,7 @@ public class SyncCommitteeSignature
   }
 
   @Override
-  public SyncCommitteeSignatureSchema getSchema() {
-    return (SyncCommitteeSignatureSchema) super.getSchema();
+  public SyncCommitteeMessageSchema getSchema() {
+    return (SyncCommitteeMessageSchema) super.getSchema();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeMessageSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeMessageSchema.java
@@ -24,15 +24,14 @@ import tech.pegasys.teku.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.ssz.tree.TreeNode;
 
-public class SyncCommitteeSignatureSchema
-    extends ContainerSchema4<
-        SyncCommitteeSignature, SszUInt64, SszBytes32, SszUInt64, SszSignature> {
+public class SyncCommitteeMessageSchema
+    extends ContainerSchema4<SyncCommitteeMessage, SszUInt64, SszBytes32, SszUInt64, SszSignature> {
 
-  public static final SyncCommitteeSignatureSchema INSTANCE = new SyncCommitteeSignatureSchema();
+  public static final SyncCommitteeMessageSchema INSTANCE = new SyncCommitteeMessageSchema();
 
-  private SyncCommitteeSignatureSchema() {
+  private SyncCommitteeMessageSchema() {
     super(
-        "SyncCommitteeSignature",
+        "SyncCommitteeMessage",
         namedSchema("slot", SszPrimitiveSchemas.UINT64_SCHEMA),
         namedSchema("beacon_block_root", SszPrimitiveSchemas.BYTES32_SCHEMA),
         namedSchema("validator_index", SszPrimitiveSchemas.UINT64_SCHEMA),
@@ -40,16 +39,16 @@ public class SyncCommitteeSignatureSchema
   }
 
   @Override
-  public SyncCommitteeSignature createFromBackingNode(final TreeNode node) {
-    return new SyncCommitteeSignature(this, node);
+  public SyncCommitteeMessage createFromBackingNode(final TreeNode node) {
+    return new SyncCommitteeMessage(this, node);
   }
 
-  public SyncCommitteeSignature create(
+  public SyncCommitteeMessage create(
       final UInt64 slot,
       final Bytes32 beaconBlockRoot,
       final UInt64 validatorIndex,
       final BLSSignature signature) {
-    return new SyncCommitteeSignature(
+    return new SyncCommitteeMessage(
         this,
         SszUInt64.of(slot),
         SszBytes32.of(beaconBlockRoot),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ValidateableSyncCommitteeMessage.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ValidateableSyncCommitteeMessage.java
@@ -23,29 +23,28 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.SyncSubcommitteeAssignments;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 
-public class ValidateableSyncCommitteeSignature {
-  private final SyncCommitteeSignature signature;
+public class ValidateableSyncCommitteeMessage {
+  private final SyncCommitteeMessage message;
   private final OptionalInt receivedSubnetId;
   private volatile Optional<SyncSubcommitteeAssignments> subcommitteeAssignments = Optional.empty();
 
-  private ValidateableSyncCommitteeSignature(
-      final SyncCommitteeSignature signature, final OptionalInt receivedSubnetId) {
-    this.signature = signature;
+  private ValidateableSyncCommitteeMessage(
+      final SyncCommitteeMessage message, final OptionalInt receivedSubnetId) {
+    this.message = message;
     this.receivedSubnetId = receivedSubnetId;
   }
 
-  public static ValidateableSyncCommitteeSignature fromValidator(
-      final SyncCommitteeSignature signature) {
-    return new ValidateableSyncCommitteeSignature(signature, OptionalInt.empty());
+  public static ValidateableSyncCommitteeMessage fromValidator(final SyncCommitteeMessage message) {
+    return new ValidateableSyncCommitteeMessage(message, OptionalInt.empty());
   }
 
-  public static ValidateableSyncCommitteeSignature fromNetwork(
-      final SyncCommitteeSignature signature, final int receivedSubnetId) {
-    return new ValidateableSyncCommitteeSignature(signature, OptionalInt.of(receivedSubnetId));
+  public static ValidateableSyncCommitteeMessage fromNetwork(
+      final SyncCommitteeMessage message, final int receivedSubnetId) {
+    return new ValidateableSyncCommitteeMessage(message, OptionalInt.of(receivedSubnetId));
   }
 
-  public SyncCommitteeSignature getSignature() {
-    return signature;
+  public SyncCommitteeMessage getMessage() {
+    return message;
   }
 
   public OptionalInt getReceivedSubnetId() {
@@ -62,13 +61,13 @@ public class ValidateableSyncCommitteeSignature {
     if (currentValue.isPresent()) {
       return currentValue.get();
     }
-    final UInt64 signatureSlot = signature.getSlot();
-    final SyncCommitteeUtil syncCommitteeUtil = spec.getSyncCommitteeUtilRequired(signatureSlot);
+    final UInt64 messageSlot = message.getSlot();
+    final SyncCommitteeUtil syncCommitteeUtil = spec.getSyncCommitteeUtilRequired(messageSlot);
     final SyncSubcommitteeAssignments assignments =
         syncCommitteeUtil.getSubcommitteeAssignments(
             state,
-            syncCommitteeUtil.getEpochForDutiesAtSlot(signatureSlot),
-            signature.getValidatorIndex());
+            syncCommitteeUtil.getEpochForDutiesAtSlot(messageSlot),
+            message.getValidatorIndex());
 
     this.subcommitteeAssignments = Optional.of(assignments);
     return assignments;
@@ -80,10 +79,10 @@ public class ValidateableSyncCommitteeSignature {
   }
 
   public UInt64 getSlot() {
-    return signature.getSlot();
+    return message.getSlot();
   }
 
   public Bytes32 getBeaconBlockRoot() {
-    return signature.getBeaconBlockRoot();
+    return message.getBeaconBlockRoot();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
@@ -107,7 +107,7 @@ public interface BlockProcessor {
       BLSSignatureVerifier signatureVerifier)
       throws BlockProcessingException;
 
-  void processSyncCommittee(
+  void processSyncAggregate(
       MutableBeaconState state, SyncAggregate syncAggregate, BLSSignatureVerifier signatureVerifier)
       throws BlockProcessingException;
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -198,7 +198,7 @@ public class SyncCommitteeUtil {
     return committeeIndices.stream().map(index -> index / subcommitteeSize).collect(toSet());
   }
 
-  public Bytes32 getSyncCommitteeSignatureSigningRoot(
+  public Bytes32 getSyncCommitteeMessageSigningRoot(
       final Bytes32 blockRoot, final UInt64 epoch, final ForkInfo forkInfo) {
     final Bytes32 domain =
         beaconStateAccessors.getDomain(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -98,7 +98,7 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
     final BeaconBlockBodyAltair blockBody = BeaconBlockBodyAltair.required(block.getBody());
 
     super.processBlock(state, block, indexedAttestationCache, signatureVerifier);
-    processSyncCommittee(state, blockBody.getSyncAggregate(), signatureVerifier);
+    processSyncAggregate(state, blockBody.getSyncAggregate(), signatureVerifier);
   }
 
   @Override
@@ -168,7 +168,7 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
   }
 
   @Override
-  public void processSyncCommittee(
+  public void processSyncAggregate(
       final MutableBeaconState baseState,
       final SyncAggregate aggregate,
       final BLSSignatureVerifier signatureVerifier)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
@@ -83,7 +83,7 @@ public final class BlockProcessorPhase0 extends AbstractBlockProcessor {
   }
 
   @Override
-  public void processSyncCommittee(
+  public void processSyncAggregate(
       final MutableBeaconState state,
       final SyncAggregate syncAggregate,
       final BLSSignatureVerifier signatureVerifier)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -25,7 +25,7 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.Contribu
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncAggregatorSelectionDataSchema;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContributionSchema;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignatureSchema;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessageSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateSchemaAltair;
 
 public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
@@ -102,8 +102,8 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
     return signedContributionAndProofSchema;
   }
 
-  public SyncCommitteeSignatureSchema getSyncCommitteeSignatureSchema() {
-    return SyncCommitteeSignatureSchema.INSTANCE;
+  public SyncCommitteeMessageSchema getSyncCommitteeMessageSchema() {
+    return SyncCommitteeMessageSchema.INSTANCE;
   }
 
   public SyncAggregatorSelectionDataSchema getSyncAggregatorSelectionDataSchema() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -73,7 +73,7 @@ import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
@@ -347,22 +347,22 @@ public final class DataStructureUtil {
     return validators.get(index).getPublicKey();
   }
 
-  public SyncCommitteeSignature randomSyncCommitteeSignature() {
-    return randomSyncCommitteeSignature(randomUInt64());
+  public SyncCommitteeMessage randomSyncCommitteeMessage() {
+    return randomSyncCommitteeMessage(randomUInt64());
   }
 
-  public SyncCommitteeSignature randomSyncCommitteeSignature(final long slot) {
-    return randomSyncCommitteeSignature(UInt64.valueOf(slot));
+  public SyncCommitteeMessage randomSyncCommitteeMessage(final long slot) {
+    return randomSyncCommitteeMessage(UInt64.valueOf(slot));
   }
 
-  public SyncCommitteeSignature randomSyncCommitteeSignature(final UInt64 slot) {
-    return randomSyncCommitteeSignature(slot, randomBytes32());
+  public SyncCommitteeMessage randomSyncCommitteeMessage(final UInt64 slot) {
+    return randomSyncCommitteeMessage(slot, randomBytes32());
   }
 
-  public SyncCommitteeSignature randomSyncCommitteeSignature(
+  public SyncCommitteeMessage randomSyncCommitteeMessage(
       final UInt64 slot, final Bytes32 beaconBlockRoot) {
     return getAltairSchemaDefinitions(UInt64.ZERO)
-        .getSyncCommitteeSignatureSchema()
+        .getSyncCommitteeMessageSchema()
         .create(slot, beaconBlockRoot, randomUInt64(), randomSignature());
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
@@ -230,7 +230,7 @@ public class SignedContributionAndProofValidator {
 
     if (!signatureVerifier.verify(
         contributorPublicKeys,
-        syncCommitteeUtil.getSyncCommitteeSignatureSigningRoot(
+        syncCommitteeUtil.getSyncCommitteeMessageSigningRoot(
             contribution.getBeaconBlockRoot(), contributionEpoch, state.getForkInfo()),
         contribution.getSignature())) {
       return failureResult(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -61,7 +61,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.util.ForkAndSpecMilestone;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsSupplier;
@@ -103,9 +103,9 @@ public class Eth2P2PNetworkBuilder {
   private OperationProcessor<SignedContributionAndProof>
       gossipedSignedContributionAndProofProcessor;
   private GossipPublisher<SignedContributionAndProof> signedContributionAndProofGossipPublisher;
-  private OperationProcessor<ValidateableSyncCommitteeSignature>
-      gossipedSyncCommitteeSignatureProcessor;
-  private GossipPublisher<ValidateableSyncCommitteeSignature> syncCommitteeSignatureGossipPublisher;
+  private OperationProcessor<ValidateableSyncCommitteeMessage>
+      gossipedSyncCommitteeMessageProcessor;
+  private GossipPublisher<ValidateableSyncCommitteeMessage> syncCommitteeMessageGossipPublisher;
 
   private Eth2P2PNetworkBuilder() {}
 
@@ -218,8 +218,8 @@ public class Eth2P2PNetworkBuilder {
             voluntaryExitGossipPublisher,
             gossipedSignedContributionAndProofProcessor,
             signedContributionAndProofGossipPublisher,
-            gossipedSyncCommitteeSignatureProcessor,
-            syncCommitteeSignatureGossipPublisher);
+            gossipedSyncCommitteeMessageProcessor,
+            syncCommitteeMessageGossipPublisher);
       default:
         throw new UnsupportedOperationException(
             "Gossip not supported for fork " + forkAndSpecMilestone.getSpecMilestone());
@@ -302,9 +302,8 @@ public class Eth2P2PNetworkBuilder {
         "signedContributionAndProofGossipPublisher", signedContributionAndProofGossipPublisher);
     assertNotNull(
         "gossipedSignedContributionAndProofProcessor", gossipedSignedContributionAndProofProcessor);
-    assertNotNull(
-        "gossipedSyncCommitteeSignatureProcessor", gossipedSyncCommitteeSignatureProcessor);
-    assertNotNull("syncCommitteeSignatureGossipPublisher", syncCommitteeSignatureGossipPublisher);
+    assertNotNull("gossipedSyncCommitteeMessageProcessor", gossipedSyncCommitteeMessageProcessor);
+    assertNotNull("syncCommitteeMessageGossipPublisher", syncCommitteeMessageGossipPublisher);
   }
 
   private void assertNotNull(String fieldName, Object fieldValue) {
@@ -426,19 +425,18 @@ public class Eth2P2PNetworkBuilder {
     return this;
   }
 
-  public Eth2P2PNetworkBuilder gossipedSyncCommitteeSignatureProcessor(
-      final OperationProcessor<ValidateableSyncCommitteeSignature>
-          gossipedSyncCommitteeSignatureProcessor) {
-    checkNotNull(gossipedSyncCommitteeSignatureProcessor);
-    this.gossipedSyncCommitteeSignatureProcessor = gossipedSyncCommitteeSignatureProcessor;
+  public Eth2P2PNetworkBuilder gossipedSyncCommitteeMessageProcessor(
+      final OperationProcessor<ValidateableSyncCommitteeMessage>
+          gossipedSyncCommitteeMessageProcessor) {
+    checkNotNull(gossipedSyncCommitteeMessageProcessor);
+    this.gossipedSyncCommitteeMessageProcessor = gossipedSyncCommitteeMessageProcessor;
     return this;
   }
 
-  public Eth2P2PNetworkBuilder syncCommitteeSignatureGossipPublisher(
-      final GossipPublisher<ValidateableSyncCommitteeSignature>
-          syncCommitteeSignatureGossipPublisher) {
-    checkNotNull(syncCommitteeSignatureGossipPublisher);
-    this.syncCommitteeSignatureGossipPublisher = syncCommitteeSignatureGossipPublisher;
+  public Eth2P2PNetworkBuilder syncCommitteeMessageGossipPublisher(
+      final GossipPublisher<ValidateableSyncCommitteeMessage> syncCommitteeMessageGossipPublisher) {
+    checkNotNull(syncCommitteeMessageGossipPublisher);
+    this.syncCommitteeMessageGossipPublisher = syncCommitteeMessageGossipPublisher;
     return this;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkSubscriptions.java
@@ -17,7 +17,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeMessage;
 
 public interface GossipForkSubscriptions {
 
@@ -35,9 +35,9 @@ public interface GossipForkSubscriptions {
 
   void unsubscribeFromAttestationSubnetId(int subnetId);
 
-  void publishSyncCommitteeSignature(ValidateableSyncCommitteeSignature signature);
+  void publishSyncCommitteeMessage(ValidateableSyncCommitteeMessage message);
 
-  void subscribeToSyncCommitteeSignatureSubnet(int subnetId);
+  void subscribeToSyncCommitteeSubnet(int subnetId);
 
-  void unsubscribeFromSyncCommitteeSignatureSubnet(int subnetId);
+  void unsubscribeFromSyncCommitteeSubnet(int subnetId);
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsAltair.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsAltair.java
@@ -17,7 +17,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.GossipPublisher;
 import tech.pegasys.teku.networking.eth2.gossip.SignedContributionAndProofGossipManager;
-import tech.pegasys.teku.networking.eth2.gossip.SyncCommitteeSignatureGossipManager;
+import tech.pegasys.teku.networking.eth2.gossip.SyncCommitteeMessageGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.subnets.SyncCommitteeSubnetSubscriptions;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
@@ -29,7 +29,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
@@ -42,11 +42,11 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
       signedContributionAndProofOperationProcessor;
   private final GossipPublisher<SignedContributionAndProof>
       signedContributionAndProofGossipPublisher;
-  private final OperationProcessor<ValidateableSyncCommitteeSignature>
-      syncCommitteeSignatureOperationProcessor;
-  private final GossipPublisher<ValidateableSyncCommitteeSignature>
-      syncCommitteeSignatureGossipPublisher;
-  private SyncCommitteeSignatureGossipManager syncCommitteeSignatureGossipManager;
+  private final OperationProcessor<ValidateableSyncCommitteeMessage>
+      syncCommitteeMessageOperationProcessor;
+  private final GossipPublisher<ValidateableSyncCommitteeMessage>
+      syncCommitteeMessageGossipPublisher;
+  private SyncCommitteeMessageGossipManager syncCommitteeMessageGossipManager;
 
   public GossipForkSubscriptionsAltair(
       final Fork fork,
@@ -68,10 +68,9 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
       final OperationProcessor<SignedContributionAndProof>
           signedContributionAndProofOperationProcessor,
       final GossipPublisher<SignedContributionAndProof> signedContributionAndProofGossipPublisher,
-      final OperationProcessor<ValidateableSyncCommitteeSignature>
-          syncCommitteeSignatureOperationProcessor,
-      final GossipPublisher<ValidateableSyncCommitteeSignature>
-          syncCommitteeSignatureGossipPublisher) {
+      final OperationProcessor<ValidateableSyncCommitteeMessage>
+          syncCommitteeMessageOperationProcessor,
+      final GossipPublisher<ValidateableSyncCommitteeMessage> syncCommitteeMessageGossipPublisher) {
     super(
         fork,
         spec,
@@ -92,8 +91,8 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
     this.signedContributionAndProofOperationProcessor =
         signedContributionAndProofOperationProcessor;
     this.signedContributionAndProofGossipPublisher = signedContributionAndProofGossipPublisher;
-    this.syncCommitteeSignatureOperationProcessor = syncCommitteeSignatureOperationProcessor;
-    this.syncCommitteeSignatureGossipPublisher = syncCommitteeSignatureGossipPublisher;
+    this.syncCommitteeMessageOperationProcessor = syncCommitteeMessageOperationProcessor;
+    this.syncCommitteeMessageGossipPublisher = syncCommitteeMessageGossipPublisher;
   }
 
   @Override
@@ -119,30 +118,30 @@ public class GossipForkSubscriptionsAltair extends GossipForkSubscriptionsPhase0
             gossipEncoding,
             schemaDefinitions,
             asyncRunner,
-            syncCommitteeSignatureOperationProcessor,
+            syncCommitteeMessageOperationProcessor,
             forkInfo);
-    syncCommitteeSignatureGossipManager =
-        new SyncCommitteeSignatureGossipManager(
+    syncCommitteeMessageGossipManager =
+        new SyncCommitteeMessageGossipManager(
             metricsSystem,
             spec,
             new SyncCommitteeStateUtils(spec, recentChainData),
             syncCommitteeSubnetSubscriptions,
-            syncCommitteeSignatureGossipPublisher);
-    addGossipManager(syncCommitteeSignatureGossipManager);
+            syncCommitteeMessageGossipPublisher);
+    addGossipManager(syncCommitteeMessageGossipManager);
   }
 
   @Override
-  public void publishSyncCommitteeSignature(final ValidateableSyncCommitteeSignature signature) {
-    syncCommitteeSignatureGossipManager.publish(signature);
+  public void publishSyncCommitteeMessage(final ValidateableSyncCommitteeMessage message) {
+    syncCommitteeMessageGossipManager.publish(message);
   }
 
   @Override
-  public void subscribeToSyncCommitteeSignatureSubnet(final int subnetId) {
-    syncCommitteeSignatureGossipManager.subscribeToSubnetId(subnetId);
+  public void subscribeToSyncCommitteeSubnet(final int subnetId) {
+    syncCommitteeMessageGossipManager.subscribeToSubnetId(subnetId);
   }
 
   @Override
-  public void unsubscribeFromSyncCommitteeSignatureSubnet(final int subnetId) {
-    syncCommitteeSignatureGossipManager.unsubscribeFromSubnetId(subnetId);
+  public void unsubscribeFromSyncCommitteeSubnet(final int subnetId) {
+    syncCommitteeMessageGossipManager.unsubscribeFromSubnetId(subnetId);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
@@ -38,7 +38,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -212,17 +212,17 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
   }
 
   @Override
-  public void publishSyncCommitteeSignature(final ValidateableSyncCommitteeSignature signature) {
+  public void publishSyncCommitteeMessage(final ValidateableSyncCommitteeMessage message) {
     // Does not apply to this fork.
   }
 
   @Override
-  public void subscribeToSyncCommitteeSignatureSubnet(final int subnetId) {
+  public void subscribeToSyncCommitteeSubnet(final int subnetId) {
     // Does not apply to this fork.
   }
 
   @Override
-  public void unsubscribeFromSyncCommitteeSignatureSubnet(final int subnetId) {
+  public void unsubscribeFromSyncCommitteeSubnet(final int subnetId) {
     // Does not apply to this fork.
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/SyncCommitteeSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/SyncCommitteeSubnetSubscriptions.java
@@ -21,8 +21,8 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopics;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
 import tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers.Eth2TopicHandler;
 import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -31,7 +31,7 @@ public class SyncCommitteeSubnetSubscriptions extends CommitteeSubnetSubscriptio
 
   private final SchemaDefinitionsAltair schemaDefinitions;
   private final AsyncRunner asyncRunner;
-  private final OperationProcessor<ValidateableSyncCommitteeSignature> processor;
+  private final OperationProcessor<ValidateableSyncCommitteeMessage> processor;
   private final ForkInfo forkInfo;
 
   public SyncCommitteeSubnetSubscriptions(
@@ -40,7 +40,7 @@ public class SyncCommitteeSubnetSubscriptions extends CommitteeSubnetSubscriptio
       final GossipEncoding gossipEncoding,
       final SchemaDefinitionsAltair schemaDefinitions,
       final AsyncRunner asyncRunner,
-      final OperationProcessor<ValidateableSyncCommitteeSignature> processor,
+      final OperationProcessor<ValidateableSyncCommitteeMessage> processor,
       final ForkInfo forkInfo) {
     super(recentChainData, gossipNetwork, gossipEncoding);
     this.schemaDefinitions = schemaDefinitions;
@@ -49,18 +49,18 @@ public class SyncCommitteeSubnetSubscriptions extends CommitteeSubnetSubscriptio
     this.forkInfo = forkInfo;
   }
 
-  public SafeFuture<?> gossip(final SyncCommitteeSignature signature, final int subnetId) {
+  public SafeFuture<?> gossip(final SyncCommitteeMessage message, final int subnetId) {
     return gossipNetwork.gossip(
         GossipTopics.getSyncCommitteeSubnetTopic(
             forkInfo.getForkDigest(spec), subnetId, gossipEncoding),
-        gossipEncoding.encode(signature));
+        gossipEncoding.encode(message));
   }
 
   @Override
   protected Eth2TopicHandler<?> createTopicHandler(final int subnetId) {
-    final OperationProcessor<SyncCommitteeSignature> convertingProcessor =
+    final OperationProcessor<SyncCommitteeMessage> convertingProcessor =
         message ->
-            processor.process(ValidateableSyncCommitteeSignature.fromNetwork(message, subnetId));
+            processor.process(ValidateableSyncCommitteeMessage.fromNetwork(message, subnetId));
     return new Eth2TopicHandler<>(
         recentChainData,
         asyncRunner,
@@ -68,6 +68,6 @@ public class SyncCommitteeSubnetSubscriptions extends CommitteeSubnetSubscriptio
         gossipEncoding,
         forkInfo.getForkDigest(spec),
         GossipTopicName.getSyncCommitteeSubnetTopicName(subnetId),
-        schemaDefinitions.getSyncCommitteeSignatureSchema());
+        schemaDefinitions.getSyncCommitteeMessageSchema());
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManagerTest.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeMessage;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -272,7 +272,7 @@ class GossipForkManagerTest {
   }
 
   @Test
-  void shouldPublishSyncCommitteeSignatureToForkForSignatureSlot() {
+  void shouldPublishSyncCommitteeMessageToForkForSignatureSlot() {
     final GossipForkSubscriptions firstFork = forkAtEpoch(0);
     final GossipForkSubscriptions secondFork = forkAtEpoch(1);
     final GossipForkSubscriptions thirdFork = forkAtEpoch(2);
@@ -280,51 +280,50 @@ class GossipForkManagerTest {
     final GossipForkManager manager = managerForForks(firstFork, secondFork, thirdFork);
     manager.configureGossipForEpoch(UInt64.ZERO);
 
-    final ValidateableSyncCommitteeSignature firstForkSignature =
-        ValidateableSyncCommitteeSignature.fromValidator(
-            dataStructureUtil.randomSyncCommitteeSignature(0));
-    final ValidateableSyncCommitteeSignature secondForkSignature =
-        ValidateableSyncCommitteeSignature.fromValidator(
-            dataStructureUtil.randomSyncCommitteeSignature(
-                spec.computeStartSlotAtEpoch(UInt64.ONE)));
-    final ValidateableSyncCommitteeSignature thirdForkSignature =
-        ValidateableSyncCommitteeSignature.fromValidator(
-            dataStructureUtil.randomSyncCommitteeSignature(
+    final ValidateableSyncCommitteeMessage firstForkMessage =
+        ValidateableSyncCommitteeMessage.fromValidator(
+            dataStructureUtil.randomSyncCommitteeMessage(0));
+    final ValidateableSyncCommitteeMessage secondForkMessage =
+        ValidateableSyncCommitteeMessage.fromValidator(
+            dataStructureUtil.randomSyncCommitteeMessage(spec.computeStartSlotAtEpoch(UInt64.ONE)));
+    final ValidateableSyncCommitteeMessage thirdForkMessage =
+        ValidateableSyncCommitteeMessage.fromValidator(
+            dataStructureUtil.randomSyncCommitteeMessage(
                 spec.computeStartSlotAtEpoch(UInt64.valueOf(2))));
 
-    manager.publishSyncCommitteeSignature(firstForkSignature);
-    verify(firstFork).publishSyncCommitteeSignature(firstForkSignature);
-    verify(secondFork, never()).publishSyncCommitteeSignature(firstForkSignature);
-    verify(thirdFork, never()).publishSyncCommitteeSignature(firstForkSignature);
+    manager.publishSyncCommitteeMessage(firstForkMessage);
+    verify(firstFork).publishSyncCommitteeMessage(firstForkMessage);
+    verify(secondFork, never()).publishSyncCommitteeMessage(firstForkMessage);
+    verify(thirdFork, never()).publishSyncCommitteeMessage(firstForkMessage);
 
-    manager.publishSyncCommitteeSignature(secondForkSignature);
-    verify(firstFork, never()).publishSyncCommitteeSignature(secondForkSignature);
-    verify(secondFork).publishSyncCommitteeSignature(secondForkSignature);
-    verify(thirdFork, never()).publishSyncCommitteeSignature(secondForkSignature);
+    manager.publishSyncCommitteeMessage(secondForkMessage);
+    verify(firstFork, never()).publishSyncCommitteeMessage(secondForkMessage);
+    verify(secondFork).publishSyncCommitteeMessage(secondForkMessage);
+    verify(thirdFork, never()).publishSyncCommitteeMessage(secondForkMessage);
 
-    manager.publishSyncCommitteeSignature(thirdForkSignature);
-    verify(firstFork, never()).publishSyncCommitteeSignature(thirdForkSignature);
-    verify(secondFork, never()).publishSyncCommitteeSignature(thirdForkSignature);
-    verify(thirdFork).publishSyncCommitteeSignature(thirdForkSignature);
+    manager.publishSyncCommitteeMessage(thirdForkMessage);
+    verify(firstFork, never()).publishSyncCommitteeMessage(thirdForkMessage);
+    verify(secondFork, never()).publishSyncCommitteeMessage(thirdForkMessage);
+    verify(thirdFork).publishSyncCommitteeMessage(thirdForkMessage);
   }
 
   @Test
-  void shouldNotPublishSyncCommitteeSignaturesToForksThatAreNotActive() {
+  void shouldNotPublishSyncCommitteeMessagesToForksThatAreNotActive() {
     final GossipForkSubscriptions firstFork = forkAtEpoch(0);
     final GossipForkSubscriptions secondFork = forkAtEpoch(10);
 
     final GossipForkManager manager = managerForForks(firstFork, secondFork);
     manager.configureGossipForEpoch(UInt64.ZERO);
 
-    final ValidateableSyncCommitteeSignature signature =
-        ValidateableSyncCommitteeSignature.fromValidator(
-            dataStructureUtil.randomSyncCommitteeSignature(
+    final ValidateableSyncCommitteeMessage message =
+        ValidateableSyncCommitteeMessage.fromValidator(
+            dataStructureUtil.randomSyncCommitteeMessage(
                 spec.computeStartSlotAtEpoch(secondFork.getActivationEpoch())));
 
-    manager.publishSyncCommitteeSignature(signature);
+    manager.publishSyncCommitteeMessage(message);
 
-    verify(firstFork, never()).publishSyncCommitteeSignature(signature);
-    verify(secondFork, never()).publishSyncCommitteeSignature(signature);
+    verify(firstFork, never()).publishSyncCommitteeMessage(message);
+    verify(secondFork, never()).publishSyncCommitteeMessage(message);
   }
 
   @ParameterizedTest
@@ -475,12 +474,10 @@ class GossipForkManagerTest {
             "sync committee",
             GossipForkManager::subscribeToSyncCommitteeSubnetId,
             GossipForkManager::unsubscribeFromSyncCommitteeSubnetId,
+            (manager, subnetId) -> verify(manager).subscribeToSyncCommitteeSubnet(subnetId),
             (manager, subnetId) ->
-                verify(manager).subscribeToSyncCommitteeSignatureSubnet(subnetId),
-            (manager, subnetId) ->
-                verify(manager, never()).subscribeToSyncCommitteeSignatureSubnet(subnetId),
-            (manager, subnetId) ->
-                verify(manager).unsubscribeFromSyncCommitteeSignatureSubnet(subnetId)));
+                verify(manager, never()).subscribeToSyncCommitteeSubnet(subnetId),
+            (manager, subnetId) -> verify(manager).unsubscribeFromSyncCommitteeSubnet(subnetId)));
   }
 
   private static class SubscriptionType {

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -148,7 +148,7 @@ public class Constants {
   public static final int VALID_AGGREGATE_SET_SIZE = 1000;
   public static final int VALID_VALIDATOR_SET_SIZE = 10000;
   public static final int VALID_CONTRIBUTION_AND_PROOF_SET_SIZE = 10000;
-  public static final int VALID_SYNC_COMMITTEE_SIGNATURE_SET_SIZE = 10000;
+  public static final int VALID_SYNC_COMMITTEE_MESSAGE_SET_SIZE = 10000;
   public static final int NETWORKING_FAILURE_REPEAT_INTERVAL = 3; // in sec
 
   // Teku specific

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitCommitteeMessageError.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitCommitteeMessageError.java
@@ -16,11 +16,11 @@ package tech.pegasys.teku.validator.api;
 import java.util.Objects;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class SubmitCommitteeSignatureError {
+public class SubmitCommitteeMessageError {
   private final UInt64 index;
   private final String message;
 
-  public SubmitCommitteeSignatureError(final UInt64 index, final String message) {
+  public SubmitCommitteeMessageError(final UInt64 index, final String message) {
     this.index = index;
     this.message = message;
   }
@@ -29,7 +29,7 @@ public class SubmitCommitteeSignatureError {
   public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    final SubmitCommitteeSignatureError that = (SubmitCommitteeSignatureError) o;
+    final SubmitCommitteeMessageError that = (SubmitCommitteeMessageError) o;
     return Objects.equals(index, that.index) && Objects.equals(message, that.message);
   }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitCommitteeMessagesResult.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitCommitteeMessagesResult.java
@@ -16,10 +16,10 @@ package tech.pegasys.teku.validator.api;
 import java.util.List;
 import java.util.Objects;
 
-public class SubmitCommitteeSignaturesResult {
-  private final List<SubmitCommitteeSignatureError> errors;
+public class SubmitCommitteeMessagesResult {
+  private final List<SubmitCommitteeMessageError> errors;
 
-  public SubmitCommitteeSignaturesResult(final List<SubmitCommitteeSignatureError> errors) {
+  public SubmitCommitteeMessagesResult(final List<SubmitCommitteeMessageError> errors) {
     this.errors = errors;
   }
 
@@ -27,7 +27,7 @@ public class SubmitCommitteeSignaturesResult {
   public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    final SubmitCommitteeSignaturesResult that = (SubmitCommitteeSignaturesResult) o;
+    final SubmitCommitteeMessagesResult that = (SubmitCommitteeMessagesResult) o;
     return Objects.equals(errors, that.errors);
   }
 
@@ -36,7 +36,7 @@ public class SubmitCommitteeSignaturesResult {
     return Objects.hash(errors);
   }
 
-  public List<SubmitCommitteeSignatureError> getErrors() {
+  public List<SubmitCommitteeMessageError> getErrors() {
     return errors;
   }
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -33,7 +33,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 
 public interface ValidatorApiChannel extends ChannelInterface {
@@ -79,8 +79,8 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<SendSignedBlockResult> sendSignedBlock(SignedBeaconBlock block);
 
-  SafeFuture<List<SubmitCommitteeSignatureError>> sendSyncCommitteeSignatures(
-      List<SyncCommitteeSignature> syncCommitteeSignatures);
+  SafeFuture<List<SubmitCommitteeMessageError>> sendSyncCommitteeMessages(
+      List<SyncCommitteeMessage> syncCommitteeMessages);
 
   SafeFuture<Void> sendSignedContributionAndProofs(
       Collection<SignedContributionAndProof> signedContributionAndProofs);

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -35,13 +35,13 @@ import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.validator.api.AttesterDuties;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
-import tech.pegasys.teku.validator.api.SubmitCommitteeSignatureError;
+import tech.pegasys.teku.validator.api.SubmitCommitteeMessageError;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
 import tech.pegasys.teku.validator.api.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
@@ -77,8 +77,8 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   public static final String PUBLISHED_BLOCK_COUNTER_NAME = "beacon_node_published_block_total";
   public static final String SYNC_COMMITTEE_SUBNET_SUBSCRIPTION_NAME =
       "beacon_node_subscribe_sync_committee_subnet_total";
-  public static final String SYNC_COMMITTEE_SEND_SIGNATURES_NAME =
-      "beacon_node_send_sync_committee_signatures_total";
+  public static final String SYNC_COMMITTEE_SEND_MESSAGES_NAME =
+      "beacon_node_send_sync_committee_messages_total";
   public static final String SYNC_COMMITTEE_SEND_CONTRIBUTIONS_NAME =
       "beacon_node_send_sync_committee_contributions_total";
   private final ValidatorApiChannel delegate;
@@ -97,7 +97,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   private final Counter sendAttestationRequestCounter;
   private final Counter sendAggregateRequestCounter;
   private final Counter sendBlockRequestCounter;
-  private final Counter sendSyncCommitteeSignaturesRequestCounter;
+  private final Counter sendSyncCommitteeMessagesRequestCounter;
   private final Counter sendContributionAndProofsRequestCounter;
 
   public MetricRecordingValidatorApiChannel(
@@ -179,11 +179,11 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
             TekuMetricCategory.VALIDATOR,
             SYNC_COMMITTEE_SUBNET_SUBSCRIPTION_NAME,
             "Counter recording the number of subscription requests for sync committee subnets sent to the beacon node");
-    sendSyncCommitteeSignaturesRequestCounter =
+    sendSyncCommitteeMessagesRequestCounter =
         metricsSystem.createCounter(
             TekuMetricCategory.VALIDATOR,
-            SYNC_COMMITTEE_SEND_SIGNATURES_NAME,
-            "Counter recording the number of signed blocks sent to the beacon node");
+            SYNC_COMMITTEE_SEND_MESSAGES_NAME,
+            "Counter recording the number of sync committee messages sent to the beacon node");
     sendContributionAndProofsRequestCounter =
         metricsSystem.createCounter(
             TekuMetricCategory.VALIDATOR,
@@ -303,10 +303,10 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<List<SubmitCommitteeSignatureError>> sendSyncCommitteeSignatures(
-      final List<SyncCommitteeSignature> syncCommitteeSignatures) {
-    sendSyncCommitteeSignaturesRequestCounter.inc();
-    return delegate.sendSyncCommitteeSignatures(syncCommitteeSignatures);
+  public SafeFuture<List<SubmitCommitteeMessageError>> sendSyncCommitteeMessages(
+      final List<SyncCommitteeMessage> syncCommitteeMessages) {
+    sendSyncCommitteeMessagesRequestCounter.inc();
+    return delegate.sendSyncCommitteeMessages(syncCommitteeMessages);
   }
 
   @Override

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerAltairIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerAltairIntegrationTest.java
@@ -113,19 +113,19 @@ public class ExternalSignerAltairIntegrationTest {
   }
 
   @Test
-  public void shouldSignSyncCommitteeSignature() throws Exception {
+  public void shouldSignSyncCommitteeMessage() throws Exception {
     final Bytes expectedSigningRoot =
         signingRootFromSyncCommitteeUtils(
                 slot,
                 utils ->
-                    utils.getSyncCommitteeSignatureSigningRoot(
+                    utils.getSyncCommitteeMessageSigningRoot(
                         beaconBlockRoot, spec.computeEpochAtSlot(slot), forkInfo))
             .get();
     final BLSSignature expectedSignature = BLS.sign(KEYPAIR.getSecretKey(), expectedSigningRoot);
     client.when(request()).respond(response().withBody(expectedSignature.toString()));
 
     final BLSSignature response =
-        externalSigner.signSyncCommitteeSignature(slot, beaconBlockRoot, forkInfo).join();
+        externalSigner.signSyncCommitteeMessage(slot, beaconBlockRoot, forkInfo).join();
 
     assertThat(response).isEqualTo(expectedSignature);
 

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerAltairIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerAltairIntegrationTest.java
@@ -132,11 +132,11 @@ public class ExternalSignerAltairIntegrationTest {
     final SigningRequestBody signingRequestBody =
         new SigningRequestBody(
             expectedSigningRoot,
-            SignType.SYNC_COMMITTEE_SIGNATURE,
+            SignType.SYNC_COMMITTEE_MESSAGE,
             Map.of(
                 "fork_info",
                 createForkInfo(forkInfo),
-                "sync_committee_signature",
+                "sync_committee_message",
                 Map.of("beacon_block_root", beaconBlockRoot, "slot", slot)));
 
     verifySignRequest(client, KEYPAIR.getPublicKey().toString(), signingRequestBody);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
@@ -78,7 +78,7 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
     lastSignatureBlockRoot = chainHeadTracker.getCurrentChainHead(slot);
     lastSignatureSlot = Optional.of(slot);
     return lastSignatureBlockRoot
-        .map(blockRoot -> productionDuty.produceSignatures(slot, blockRoot))
+        .map(blockRoot -> productionDuty.produceMessages(slot, blockRoot))
         .orElseGet(() -> headUnavailableFailure(slot));
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -198,13 +198,13 @@ public class ExternalSigner implements Signer {
             signingRoot ->
                 sign(
                     signingRoot,
-                    SignType.SYNC_COMMITTEE_SIGNATURE,
+                    SignType.SYNC_COMMITTEE_MESSAGE,
                     Map.of(
-                        "sync_committee_signature",
+                        "sync_committee_message",
                         Map.of("beacon_block_root", beaconBlockRoot, "slot", slot),
                         FORK_INFO,
                         forkInfo(forkInfo)),
-                    slashableGenericMessage("sync committee signature")));
+                    slashableGenericMessage("sync committee message")));
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -187,12 +187,12 @@ public class ExternalSigner implements Signer {
   }
 
   @Override
-  public SafeFuture<BLSSignature> signSyncCommitteeSignature(
+  public SafeFuture<BLSSignature> signSyncCommitteeMessage(
       final UInt64 slot, final Bytes32 beaconBlockRoot, final ForkInfo forkInfo) {
     return signingRootFromSyncCommitteeUtils(
             slot,
             utils ->
-                utils.getSyncCommitteeSignatureSigningRoot(
+                utils.getSyncCommitteeMessageSigningRoot(
                     beaconBlockRoot, spec.computeEpochAtSlot(slot), forkInfo))
         .thenCompose(
             signingRoot ->

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/SignType.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/SignType.java
@@ -28,8 +28,8 @@ public enum SignType {
   AGGREGATE_AND_PROOF,
   @JsonProperty("voluntary_exit")
   VOLUNTARY_EXIT,
-  @JsonProperty("sync_committee_signature")
-  SYNC_COMMITTEE_SIGNATURE,
+  @JsonProperty("sync_committee_message")
+  SYNC_COMMITTEE_MESSAGE,
   @JsonProperty("sync_committee_selection_proof")
   SYNC_COMMITTEE_SELECTION_PROOF,
   @JsonProperty("sync_committee_contribution_and_proof")

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
@@ -112,7 +112,7 @@ class SyncCommitteeScheduledDutiesTest {
         .thenReturn(Optional.of(dataStructureUtil.randomBytes32()));
 
     final DutyResult expectedDutyResult = DutyResult.success(blockRoot);
-    when(productionDuty.produceSignatures(slot, blockRoot))
+    when(productionDuty.produceMessages(slot, blockRoot))
         .thenReturn(SafeFuture.completedFuture(expectedDutyResult));
     when(aggregationDuty.produceAggregates(slot, blockRoot))
         .thenReturn(SafeFuture.completedFuture(expectedDutyResult));
@@ -122,7 +122,7 @@ class SyncCommitteeScheduledDutiesTest {
     assertThat(duties.performProductionDuty(slot)).isCompletedWithValue(expectedDutyResult);
     assertThat(duties.performAggregationDuty(slot)).isCompletedWithValue(expectedDutyResult);
 
-    verify(productionDuty).produceSignatures(slot, blockRoot);
+    verify(productionDuty).produceMessages(slot, blockRoot);
     verify(aggregationDuty).produceAggregates(slot, blockRoot);
   }
 

--- a/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/validator/coordinator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -39,7 +39,7 @@ import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
-import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeSignaturePool;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeMessagePool;
 import tech.pegasys.teku.storage.client.ChainUpdater;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.server.StateStorageMode;
@@ -75,8 +75,8 @@ public class ValidatorApiHandlerIntegrationTest {
   private final ForkChoiceTrigger forkChoiceTrigger = mock(ForkChoiceTrigger.class);
 
   private final ChainUpdater chainUpdater = storageSystem.chainUpdater();
-  private final SyncCommitteeSignaturePool syncCommitteeSignaturePool =
-      mock(SyncCommitteeSignaturePool.class);
+  private final SyncCommitteeMessagePool syncCommitteeMessagePool =
+      mock(SyncCommitteeMessagePool.class);
   private final SyncCommitteeContributionPool syncCommitteeContributionPool =
       mock(SyncCommitteeContributionPool.class);
   private final SyncCommitteeSubscriptionManager syncCommitteeSubscriptionManager =
@@ -97,7 +97,7 @@ public class ValidatorApiHandlerIntegrationTest {
           performanceTracker,
           spec,
           forkChoiceTrigger,
-          syncCommitteeSignaturePool,
+          syncCommitteeMessagePool,
           syncCommitteeContributionPool,
           syncCommitteeSubscriptionManager);
 

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -39,7 +39,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.ssz.collections.SszBitlist;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -155,7 +155,7 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
     if (!currentEpoch.isZero()) {
       final SyncCommitteePerformance syncCommitteePerformance =
           syncCommitteePerformanceTracker.calculatePerformance(currentEpoch.minus(1)).join();
-      if (syncCommitteePerformance.getNumberOfExpectedSignatures() > 0) {
+      if (syncCommitteePerformance.getNumberOfExpectedMessages() > 0) {
         if (mode.isLoggingEnabled()) {
           statusLogger.performance(syncCommitteePerformance.toString());
         }
@@ -356,8 +356,8 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
   }
 
   @Override
-  public void saveProducedSyncCommitteeSignature(final SyncCommitteeSignature signature) {
-    syncCommitteePerformanceTracker.saveProducedSyncCommitteeSignature(signature);
+  public void saveProducedSyncCommitteeMessage(final SyncCommitteeMessage message) {
+    syncCommitteePerformanceTracker.saveProducedSyncCommitteeMessage(message);
   }
 
   static long getPercentage(final long numerator, final long denominator) {

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/NoOpPerformanceTracker.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/NoOpPerformanceTracker.java
@@ -17,7 +17,7 @@ import java.util.Set;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 
 public class NoOpPerformanceTracker implements PerformanceTracker {
 
@@ -40,7 +40,7 @@ public class NoOpPerformanceTracker implements PerformanceTracker {
       final UInt64 periodEndEpoch) {}
 
   @Override
-  public void saveProducedSyncCommitteeSignature(final SyncCommitteeSignature signature) {}
+  public void saveProducedSyncCommitteeMessage(final SyncCommitteeMessage message) {}
 
   @Override
   public void onSlot(UInt64 slot) {}

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/PerformanceTracker.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/PerformanceTracker.java
@@ -18,7 +18,7 @@ import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 
 public interface PerformanceTracker extends SlotEventsChannel {
 
@@ -33,5 +33,5 @@ public interface PerformanceTracker extends SlotEventsChannel {
   void saveExpectedSyncCommitteeParticipant(
       int validatorIndex, Set<Integer> syncCommitteeIndices, UInt64 periodEndEpoch);
 
-  void saveProducedSyncCommitteeSignature(SyncCommitteeSignature signature);
+  void saveProducedSyncCommitteeMessage(SyncCommitteeMessage message);
 }

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/SyncCommitteePerformance.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/SyncCommitteePerformance.java
@@ -18,36 +18,36 @@ import static tech.pegasys.teku.validator.coordinator.performance.DefaultPerform
 import java.util.Objects;
 
 public class SyncCommitteePerformance {
-  private final int numberOfExpectedSignatures;
-  private final int numberOfProducedSignatures;
-  private final int numberOfCorrectSignatures;
-  private final int numberOfIncludedSignatures;
+  private final int numberOfExpectedMessages;
+  private final int numberOfProducedMessages;
+  private final int numberOfCorrectMessages;
+  private final int numberOfIncludedMessages;
 
   public SyncCommitteePerformance(
-      final int numberOfExpectedSignatures,
-      final int numberOfProducedSignatures,
-      final int numberOfCorrectSignatures,
-      final int numberOfIncludedSignatures) {
-    this.numberOfExpectedSignatures = numberOfExpectedSignatures;
-    this.numberOfProducedSignatures = numberOfProducedSignatures;
-    this.numberOfCorrectSignatures = numberOfCorrectSignatures;
-    this.numberOfIncludedSignatures = numberOfIncludedSignatures;
+      final int numberOfExpectedMessages,
+      final int numberOfProducedMessages,
+      final int numberOfCorrectMessages,
+      final int numberOfIncludedMessages) {
+    this.numberOfExpectedMessages = numberOfExpectedMessages;
+    this.numberOfProducedMessages = numberOfProducedMessages;
+    this.numberOfCorrectMessages = numberOfCorrectMessages;
+    this.numberOfIncludedMessages = numberOfIncludedMessages;
   }
 
-  public int getNumberOfExpectedSignatures() {
-    return numberOfExpectedSignatures;
+  public int getNumberOfExpectedMessages() {
+    return numberOfExpectedMessages;
   }
 
-  public int getNumberOfProducedSignatures() {
-    return numberOfProducedSignatures;
+  public int getNumberOfProducedMessages() {
+    return numberOfProducedMessages;
   }
 
-  public int getNumberOfCorrectSignatures() {
-    return numberOfCorrectSignatures;
+  public int getNumberOfCorrectMessages() {
+    return numberOfCorrectMessages;
   }
 
-  public int getNumberOfIncludedSignatures() {
-    return numberOfIncludedSignatures;
+  public int getNumberOfIncludedMessages() {
+    return numberOfIncludedMessages;
   }
 
   @Override
@@ -59,29 +59,29 @@ public class SyncCommitteePerformance {
       return false;
     }
     final SyncCommitteePerformance that = (SyncCommitteePerformance) o;
-    return numberOfExpectedSignatures == that.numberOfExpectedSignatures
-        && numberOfProducedSignatures == that.numberOfProducedSignatures
-        && numberOfCorrectSignatures == that.numberOfCorrectSignatures
-        && numberOfIncludedSignatures == that.numberOfIncludedSignatures;
+    return numberOfExpectedMessages == that.numberOfExpectedMessages
+        && numberOfProducedMessages == that.numberOfProducedMessages
+        && numberOfCorrectMessages == that.numberOfCorrectMessages
+        && numberOfIncludedMessages == that.numberOfIncludedMessages;
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        numberOfExpectedSignatures,
-        numberOfProducedSignatures,
-        numberOfCorrectSignatures,
-        numberOfIncludedSignatures);
+        numberOfExpectedMessages,
+        numberOfProducedMessages,
+        numberOfCorrectMessages,
+        numberOfIncludedMessages);
   }
 
   @Override
   public String toString() {
     return String.format(
         "Sync committee performance: " + "expected %d, produced %d, correct %d, included %d (%d%%)",
-        numberOfExpectedSignatures,
-        numberOfProducedSignatures,
-        numberOfCorrectSignatures,
-        numberOfIncludedSignatures,
-        getPercentage(numberOfIncludedSignatures, numberOfProducedSignatures));
+        numberOfExpectedMessages,
+        numberOfProducedMessages,
+        numberOfCorrectMessages,
+        numberOfIncludedMessages,
+        getPercentage(numberOfIncludedMessages, numberOfProducedMessages));
   }
 }

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/ValidatorPerformanceMetrics.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/ValidatorPerformanceMetrics.java
@@ -35,10 +35,10 @@ public class ValidatorPerformanceMetrics {
   private final SettableGauge numberOfIncludedBlocks;
 
   // Sync Committee Performance Metrics
-  private final SettableGauge numberOfExpectedSignatures;
-  private final SettableGauge numberOfProducedSignatures;
-  private final SettableGauge numberOfCorrectSignatures;
-  private final SettableGauge numberOfIncludedSignatures;
+  private final SettableGauge numberOfExpectedMessages;
+  private final SettableGauge numberOfProducedMessages;
+  private final SettableGauge numberOfCorrectMessages;
+  private final SettableGauge numberOfIncludedMessages;
 
   public ValidatorPerformanceMetrics(final MetricsSystem metricsSystem) {
 
@@ -113,30 +113,30 @@ public class ValidatorPerformanceMetrics {
             "Number of included blocks");
 
     // Sync Committee Performance Metrics
-    numberOfExpectedSignatures =
+    numberOfExpectedMessages =
         SettableGauge.create(
             metricsSystem,
             TekuMetricCategory.VALIDATOR_PERFORMANCE,
-            "expected_sync_committee_signatures",
-            "Number of expected sync committee signatures");
-    numberOfProducedSignatures =
+            "expected_sync_committee_messages",
+            "Number of expected sync committee messages");
+    numberOfProducedMessages =
         SettableGauge.create(
             metricsSystem,
             TekuMetricCategory.VALIDATOR_PERFORMANCE,
-            "produced_sync_committee_signatures",
-            "Number of produced sync committee signatures");
-    numberOfCorrectSignatures =
+            "produced_sync_committee_messages",
+            "Number of produced sync committee messages");
+    numberOfCorrectMessages =
         SettableGauge.create(
             metricsSystem,
             TekuMetricCategory.VALIDATOR_PERFORMANCE,
-            "correct_sync_committee_signatures",
-            "Number of produced sync committee signatures with the correct block root");
-    numberOfIncludedSignatures =
+            "correct_sync_committee_messages",
+            "Number of produced sync committee messages with the correct block root");
+    numberOfIncludedMessages =
         SettableGauge.create(
             metricsSystem,
             TekuMetricCategory.VALIDATOR_PERFORMANCE,
-            "included_sync_committee_signatures",
-            "Number of included sync committee signatures");
+            "included_sync_committee_messages",
+            "Number of included sync committee messages");
   }
 
   public void updateAttestationPerformanceMetrics(
@@ -158,9 +158,9 @@ public class ValidatorPerformanceMetrics {
   }
 
   public void updateSyncCommitteePerformance(final SyncCommitteePerformance performance) {
-    numberOfExpectedSignatures.set(performance.getNumberOfExpectedSignatures());
-    numberOfProducedSignatures.set(performance.getNumberOfProducedSignatures());
-    numberOfCorrectSignatures.set(performance.getNumberOfCorrectSignatures());
-    numberOfIncludedSignatures.set(performance.getNumberOfIncludedSignatures());
+    numberOfExpectedMessages.set(performance.getNumberOfExpectedMessages());
+    numberOfProducedMessages.set(performance.getNumberOfProducedMessages());
+    numberOfCorrectMessages.set(performance.getNumberOfCorrectMessages());
+    numberOfIncludedMessages.set(performance.getNumberOfIncludedMessages());
   }
 }

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/SyncCommitteePerformanceTrackerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/SyncCommitteePerformanceTrackerTest.java
@@ -40,8 +40,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignatureSchema;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessageSchema;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -55,8 +55,8 @@ class SyncCommitteePerformanceTrackerTest {
 
   private final SchemaDefinitionsAltair schemaDefinitionsAltair =
       SchemaDefinitionsAltair.required(spec.getGenesisSchemaDefinitions());
-  private final SyncCommitteeSignatureSchema signatureSchema =
-      schemaDefinitionsAltair.getSyncCommitteeSignatureSchema();
+  private final SyncCommitteeMessageSchema messageSchema =
+      schemaDefinitionsAltair.getSyncCommitteeMessageSchema();
 
   private SyncCommitteePerformanceTracker tracker =
       new SyncCommitteePerformanceTracker(spec, combinedChainDataClient);
@@ -75,25 +75,24 @@ class SyncCommitteePerformanceTrackerTest {
   }
 
   @Test
-  void shouldExpectSignaturesForEachPositionInCommitteeAtEachSlot() {
+  void shouldExpectMessagesForEachPositionInCommitteeAtEachSlot() {
     tracker.saveExpectedSyncCommitteeParticipant(1, Set.of(2, 5, 6), UInt64.valueOf(3));
 
     final int expected = 3 * spec.getSlotsPerEpoch(UInt64.ZERO);
-    assertThat(calculatePerformance(UInt64.ONE).getNumberOfExpectedSignatures())
-        .isEqualTo(expected);
+    assertThat(calculatePerformance(UInt64.ONE).getNumberOfExpectedMessages()).isEqualTo(expected);
   }
 
   @Test
-  void shouldCountNumberOfProducedSignatures() {
+  void shouldCountNumberOfProducedMessages() {
     tracker.saveExpectedSyncCommitteeParticipant(1, Set.of(2, 7, 8), UInt64.valueOf(3));
-    tracker.saveProducedSyncCommitteeSignature(createSignature(1, 1));
-    tracker.saveProducedSyncCommitteeSignature(createSignature(1, 3));
+    tracker.saveProducedSyncCommitteeMessage(createMessage(1, 1));
+    tracker.saveProducedSyncCommitteeMessage(createMessage(1, 3));
 
-    assertThat(calculatePerformance(UInt64.ZERO).getNumberOfProducedSignatures()).isEqualTo(6);
+    assertThat(calculatePerformance(UInt64.ZERO).getNumberOfProducedMessages()).isEqualTo(6);
   }
 
   @Test
-  void shouldCountNumberOfCorrectSignatures() {
+  void shouldCountNumberOfCorrectMessages() {
     final Spec specSpy = spy(spec);
     tracker = new SyncCommitteePerformanceTracker(specSpy, combinedChainDataClient);
     final Bytes32 slot1Hash = dataStructureUtil.randomBytes32();
@@ -107,40 +106,40 @@ class SyncCommitteePerformanceTrackerTest {
     doReturn(slot1Hash).when(specSpy).getBlockRootAtSlot(chainHead.getState(), UInt64.ONE);
 
     tracker.saveExpectedSyncCommitteeParticipant(1, Set.of(2, 7, 8), UInt64.valueOf(3));
-    tracker.saveProducedSyncCommitteeSignature(createSignature(1, 1, slot1Hash));
-    tracker.saveProducedSyncCommitteeSignature(createSignature(1, 2, wrongBlockRoot));
-    tracker.saveProducedSyncCommitteeSignature(createSignature(1, 3, wrongBlockRoot));
-    tracker.saveProducedSyncCommitteeSignature(createSignature(1, 4, chainHead.getRoot()));
+    tracker.saveProducedSyncCommitteeMessage(createMessage(1, 1, slot1Hash));
+    tracker.saveProducedSyncCommitteeMessage(createMessage(1, 2, wrongBlockRoot));
+    tracker.saveProducedSyncCommitteeMessage(createMessage(1, 3, wrongBlockRoot));
+    tracker.saveProducedSyncCommitteeMessage(createMessage(1, 4, chainHead.getRoot()));
 
     // Slots 1 and 4 are correct, 2 and 3 are incorrect.
-    assertThat(calculatePerformance(UInt64.ZERO).getNumberOfCorrectSignatures()).isEqualTo(6);
+    assertThat(calculatePerformance(UInt64.ZERO).getNumberOfCorrectMessages()).isEqualTo(6);
   }
 
   @Test
-  void shouldCountNumberOfIncludedSignatures() {
+  void shouldCountNumberOfIncludedMessages() {
     tracker.saveExpectedSyncCommitteeParticipant(1, Set.of(2, 7, 8), UInt64.valueOf(3));
 
     // Not included as no block was present
-    tracker.saveProducedSyncCommitteeSignature(createSignature(1, 1));
+    tracker.saveProducedSyncCommitteeMessage(createMessage(1, 1));
 
-    // Block produced, but this signature not included
-    tracker.saveProducedSyncCommitteeSignature(createSignature(1, 2));
+    // Block produced, but this message not included
+    tracker.saveProducedSyncCommitteeMessage(createMessage(1, 2));
     withSyncAggregate(3, 9, 12, 15);
 
-    // Included (along with some other signatures)
-    tracker.saveProducedSyncCommitteeSignature(createSignature(1, 3));
+    // Included (along with some other messages)
+    tracker.saveProducedSyncCommitteeMessage(createMessage(1, 3));
     withSyncAggregate(4, 2, 7, 8, 9, 12, 15);
 
-    assertThat(calculatePerformance(UInt64.ZERO).getNumberOfIncludedSignatures()).isEqualTo(3);
+    assertThat(calculatePerformance(UInt64.ZERO).getNumberOfIncludedMessages()).isEqualTo(3);
   }
 
-  private SyncCommitteeSignature createSignature(final int validatorIndex, final int slot) {
-    return createSignature(validatorIndex, slot, Bytes32.ZERO);
+  private SyncCommitteeMessage createMessage(final int validatorIndex, final int slot) {
+    return createMessage(validatorIndex, slot, Bytes32.ZERO);
   }
 
-  private SyncCommitteeSignature createSignature(
+  private SyncCommitteeMessage createMessage(
       final int validatorIndex, final int slot, final Bytes32 blockRoot) {
-    return signatureSchema.create(
+    return messageSchema.create(
         UInt64.valueOf(slot), blockRoot, UInt64.valueOf(validatorIndex), BLSSignature.empty());
   }
 

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/ValidatorPerformanceMetricsTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/ValidatorPerformanceMetricsTest.java
@@ -22,10 +22,10 @@ import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 
 public class ValidatorPerformanceMetricsTest {
 
-  private static final int NUMBER_OF_EXPECTED_SIGNATURES = 64;
-  private static final int NUMBER_OF_PRODUCED_SIGNATURES = 60;
-  private static final int NUMBER_OF_CORRECT_SIGNATURES = 55;
-  private static final int NUMBER_OF_INCLUDED_SIGNATURES = 52;
+  private static final int NUMBER_OF_EXPECTED_MESSAGES = 64;
+  private static final int NUMBER_OF_PRODUCED_MESSAGES = 60;
+  private static final int NUMBER_OF_CORRECT_MESSAGES = 55;
+  private static final int NUMBER_OF_INCLUDED_MESSAGES = 52;
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   public final ValidatorPerformanceMetrics validatorPerformanceMetrics =
       new ValidatorPerformanceMetrics(metricsSystem);
@@ -60,10 +60,10 @@ public class ValidatorPerformanceMetricsTest {
 
   private final SyncCommitteePerformance syncCommitteePerformance =
       new SyncCommitteePerformance(
-          NUMBER_OF_EXPECTED_SIGNATURES,
-          NUMBER_OF_PRODUCED_SIGNATURES,
-          NUMBER_OF_CORRECT_SIGNATURES,
-          NUMBER_OF_INCLUDED_SIGNATURES);
+          NUMBER_OF_EXPECTED_MESSAGES,
+          NUMBER_OF_PRODUCED_MESSAGES,
+          NUMBER_OF_CORRECT_MESSAGES,
+          NUMBER_OF_INCLUDED_MESSAGES);
 
   @BeforeEach
   void setUp() {
@@ -140,38 +140,38 @@ public class ValidatorPerformanceMetricsTest {
   }
 
   @Test
-  void getExpectedSignatures() {
+  void getExpectedMessages() {
     assertThat(
             metricsSystem
-                .getGauge(VALIDATOR_PERFORMANCE, "expected_sync_committee_signatures")
+                .getGauge(VALIDATOR_PERFORMANCE, "expected_sync_committee_messages")
                 .getValue())
-        .isEqualTo(NUMBER_OF_EXPECTED_SIGNATURES);
+        .isEqualTo(NUMBER_OF_EXPECTED_MESSAGES);
   }
 
   @Test
-  void getProducedSignatures() {
+  void getProducedMessages() {
     assertThat(
             metricsSystem
-                .getGauge(VALIDATOR_PERFORMANCE, "produced_sync_committee_signatures")
+                .getGauge(VALIDATOR_PERFORMANCE, "produced_sync_committee_messages")
                 .getValue())
-        .isEqualTo(NUMBER_OF_PRODUCED_SIGNATURES);
+        .isEqualTo(NUMBER_OF_PRODUCED_MESSAGES);
   }
 
   @Test
-  void getCorrectSignatures() {
+  void getCorrectMessages() {
     assertThat(
             metricsSystem
-                .getGauge(VALIDATOR_PERFORMANCE, "correct_sync_committee_signatures")
+                .getGauge(VALIDATOR_PERFORMANCE, "correct_sync_committee_messages")
                 .getValue())
-        .isEqualTo(NUMBER_OF_CORRECT_SIGNATURES);
+        .isEqualTo(NUMBER_OF_CORRECT_MESSAGES);
   }
 
   @Test
-  void getIncludedSignatures() {
+  void getIncludedMessages() {
     assertThat(
             metricsSystem
-                .getGauge(VALIDATOR_PERFORMANCE, "included_sync_committee_signatures")
+                .getGauge(VALIDATOR_PERFORMANCE, "included_sync_committee_messages")
                 .getValue())
-        .isEqualTo(NUMBER_OF_INCLUDED_SIGNATURES);
+        .isEqualTo(NUMBER_OF_INCLUDED_MESSAGES);
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -53,7 +53,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.validator.api.AttesterDuties;
 import tech.pegasys.teku.validator.api.AttesterDuty;
@@ -61,7 +61,7 @@ import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.ProposerDuty;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
-import tech.pegasys.teku.validator.api.SubmitCommitteeSignatureError;
+import tech.pegasys.teku.validator.api.SubmitCommitteeMessageError;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuty;
 import tech.pegasys.teku.validator.api.SyncCommitteeSubnetSubscription;
@@ -274,23 +274,23 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<List<SubmitCommitteeSignatureError>> sendSyncCommitteeSignatures(
-      final List<SyncCommitteeSignature> syncCommitteeSignatures) {
+  public SafeFuture<List<SubmitCommitteeMessageError>> sendSyncCommitteeMessages(
+      final List<SyncCommitteeMessage> syncCommitteeMessages) {
     return sendRequest(
         () ->
             apiClient
-                .sendSyncCommitteeSignatures(
-                    syncCommitteeSignatures.stream()
+                .sendSyncCommitteeMessages(
+                    syncCommitteeMessages.stream()
                         .map(
                             signature ->
-                                new tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature(
+                                new tech.pegasys.teku.api.schema.altair.SyncCommitteeMessage(
                                     signature.getSlot(),
                                     signature.getBeaconBlockRoot(),
                                     signature.getValidatorIndex(),
                                     new tech.pegasys.teku.api.schema.BLSSignature(
                                         signature.getSignature())))
                         .collect(Collectors.toList()))
-                .map(this::responseToSyncCommitteeSignatures)
+                .map(this::responseToSyncCommitteeMessages)
                 .orElse(emptyList()));
   }
 
@@ -331,10 +331,10 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
         new tech.pegasys.teku.api.schema.BLSSignature(contribution.getSignature()));
   }
 
-  private List<SubmitCommitteeSignatureError> responseToSyncCommitteeSignatures(
+  private List<SubmitCommitteeMessageError> responseToSyncCommitteeMessages(
       final PostSyncCommitteeFailureResponse postSyncCommitteeFailureResponse) {
     return postSyncCommitteeFailureResponse.failures.stream()
-        .map(i -> new SubmitCommitteeSignatureError(i.index, i.message))
+        .map(i -> new SubmitCommitteeMessageError(i.index, i.message))
         .collect(Collectors.toList());
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -32,7 +32,7 @@ import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SE
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_ATTESTATION;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_BLOCK;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SIGNED_VOLUNTARY_EXIT;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SYNC_COMMITTEE_SIGNATURES;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_SYNC_COMMITTEE_MESSAGES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_BEACON_COMMITTEE_SUBNET;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_PERSISTENT_SUBNETS;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SUBSCRIBE_TO_SYNC_COMMITTEE_SUBNET;
@@ -255,7 +255,7 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   public Optional<PostSyncCommitteeFailureResponse> sendSyncCommitteeMessages(
       final List<SyncCommitteeMessage> syncCommitteeMessages) {
     return post(
-        SEND_SYNC_COMMITTEE_SIGNATURES,
+        SEND_SYNC_COMMITTEE_MESSAGES,
         syncCommitteeMessages,
         createHandler(PostSyncCommitteeFailureResponse.class));
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -82,7 +82,7 @@ import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.api.schema.SubnetSubscription;
 import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeContribution;
-import tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.api.schema.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
@@ -252,11 +252,11 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   }
 
   @Override
-  public Optional<PostSyncCommitteeFailureResponse> sendSyncCommitteeSignatures(
-      final List<SyncCommitteeSignature> syncCommitteeSignatures) {
+  public Optional<PostSyncCommitteeFailureResponse> sendSyncCommitteeMessages(
+      final List<SyncCommitteeMessage> syncCommitteeMessages) {
     return post(
         SEND_SYNC_COMMITTEE_SIGNATURES,
-        syncCommitteeSignatures,
+        syncCommitteeMessages,
         createHandler(PostSyncCommitteeFailureResponse.class));
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -28,7 +28,7 @@ public enum ValidatorApiMethod {
   GET_ATTESTATION_DATA("eth/v1/validator/attestation_data"),
   SEND_SIGNED_ATTESTATION("eth/v1/beacon/pool/attestations"),
   SEND_SIGNED_VOLUNTARY_EXIT("eth/v1/beacon/pool/voluntary_exits"),
-  SEND_SYNC_COMMITTEE_SIGNATURES("eth/v1/beacon/pool/sync_committees"),
+  SEND_SYNC_COMMITTEE_MESSAGES("eth/v1/beacon/pool/sync_committees"),
   GET_AGGREGATE("eth/v1/validator/aggregate_attestation"),
   SEND_SIGNED_AGGREGATE_AND_PROOF("/eth/v1/validator/aggregate_and_proofs"),
   SEND_CONTRIBUTION_AND_PROOF("eth/v1/validator/contribution_and_proofs"),

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -34,7 +34,7 @@ import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.api.schema.SubnetSubscription;
 import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeContribution;
-import tech.pegasys.teku.api.schema.altair.SyncCommitteeSignature;
+import tech.pegasys.teku.api.schema.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
@@ -70,8 +70,8 @@ public interface ValidatorRestApiClient {
 
   void subscribeToPersistentSubnets(Set<SubnetSubscription> subnetSubscriptions);
 
-  Optional<PostSyncCommitteeFailureResponse> sendSyncCommitteeSignatures(
-      List<SyncCommitteeSignature> syncCommitteeSignatures);
+  Optional<PostSyncCommitteeFailureResponse> sendSyncCommitteeMessages(
+      List<SyncCommitteeMessage> syncCommitteeMessages);
 
   Optional<PostSyncDutiesResponse> getSyncCommitteeDuties(
       UInt64 epoch, Collection<Integer> validatorIndices);


### PR DESCRIPTION
## PR Description
Inline with the changes in alpha.7, rename SyncCommitteeSignature to SyncCommitteeMessage.

Note `SyncAggregate` still contains a `sync_committee_signature` field - it's actually the signature which is part of the confusion that caused the rename.

## Fixed Issue(s)
fixes #4080 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
