### PR TITLE
Reject sync committee contributions with no participants

### DIFF
--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/synccomittee/SignedContributionAndProofTestBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/synccomittee/SignedContributionAndProofTestBuilder.java
@@ -172,8 +172,15 @@ public class SignedContributionAndProofTestBuilder {
     return addParticipant(aggregatorIndex, aggregatorSigner);
   }
 
+  public SignedContributionAndProofTestBuilder removeAllParticipants() {
+    syncSignatures.clear();
+    subcommitteeParticipationIndices.clear();
+    return this;
+  }
+
   public SignedContributionAndProof build() {
-    final BLSSignature aggregateSignature = BLS.aggregate(syncSignatures);
+    final BLSSignature aggregateSignature =
+        syncSignatures.isEmpty() ? BLSSignature.infinity() : BLS.aggregate(syncSignatures);
 
     final SyncCommitteeContribution syncCommitteeContribution =
         syncCommitteeUtil.createSyncCommitteeContribution(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
@@ -87,6 +87,11 @@ public class SignedContributionAndProofValidator {
     }
     final SyncCommitteeUtil syncCommitteeUtil = maybeSyncCommitteeUtil.get();
 
+    if (proof.getMessage().getContribution().getAggregationBits().getBitCount() == 0) {
+      return SafeFuture.completedFuture(
+          failureResult("Rejecting proof because participant set is empty"));
+    }
+
     // [IGNORE] The contribution's slot is for the current slot (with a
     // `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance), i.e. `contribution.slot == current_slot`.
     if (!slotUtil.isForCurrentSlot(contribution.getSlot())) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidatorTest.java
@@ -111,6 +111,14 @@ class SignedContributionAndProofValidatorTest {
   }
 
   @Test
+  void shouldRejectWhenAggregationBitsAreEmpty() {
+    final SignedContributionAndProof message =
+        chainBuilder.createValidSignedContributionAndProofBuilder().removeAllParticipants().build();
+    final SafeFuture<InternalValidationResult> result = validator.validate(message);
+    assertThat(result).isCompletedWithValueMatching(InternalValidationResult::isReject);
+  }
+
+  @Test
   void shouldAcceptWhenValidButBeaconBlockRootIsUnknown() {
     final SignedContributionAndProof message =
         chainBuilder


### PR DESCRIPTION
## PR Description
Sync committee contributions with no participants are now rejected where they previously threw an exception (which resulted in them being rejected very noisily).

## Fixed Issue(s)
#4168

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
