### PR TITLE
Add option to log warnings when P2P messages are invalid/rejected

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfig.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfig.java
@@ -18,6 +18,7 @@ public class LoggingConfig {
   private final boolean colorEnabled;
   private final boolean includeEventsEnabled;
   private final boolean includeValidatorDutiesEnabled;
+  private final boolean includeP2pWarningsEnabled;
   private final LoggingDestination destination;
   private final String logFile;
   private final String logFileNamePattern;
@@ -26,12 +27,14 @@ public class LoggingConfig {
       final boolean colorEnabled,
       final boolean includeEventsEnabled,
       final boolean includeValidatorDutiesEnabled,
+      final boolean includeP2pWarningsEnabled,
       final LoggingDestination destination,
       final String logFile,
       final String logFileNamePattern) {
     this.colorEnabled = colorEnabled;
     this.includeEventsEnabled = includeEventsEnabled;
     this.includeValidatorDutiesEnabled = includeValidatorDutiesEnabled;
+    this.includeP2pWarningsEnabled = includeP2pWarningsEnabled;
     this.destination = destination;
     this.logFile = logFile;
     this.logFileNamePattern = logFileNamePattern;
@@ -53,6 +56,10 @@ public class LoggingConfig {
     return includeValidatorDutiesEnabled;
   }
 
+  public boolean isIncludeP2pWarningsEnabled() {
+    return includeP2pWarningsEnabled;
+  }
+
   public LoggingDestination getDestination() {
     return destination;
   }
@@ -70,6 +77,7 @@ public class LoggingConfig {
     private boolean colorEnabled;
     private boolean includeEventsEnabled;
     private boolean includeValidatorDutiesEnabled;
+    private boolean includeP2pWarningsEnabled;
     private LoggingDestination destination;
     private String logFile;
     private String logFileNamePattern;
@@ -89,6 +97,11 @@ public class LoggingConfig {
     public LoggingConfigBuilder includeValidatorDutiesEnabled(
         boolean includeValidatorDutiesEnabled) {
       this.includeValidatorDutiesEnabled = includeValidatorDutiesEnabled;
+      return this;
+    }
+
+    public LoggingConfigBuilder includeP2pWarningsEnabled(final boolean includeP2pWarningsEnabled) {
+      this.includeP2pWarningsEnabled = includeP2pWarningsEnabled;
       return this;
     }
 
@@ -112,6 +125,7 @@ public class LoggingConfig {
           colorEnabled,
           includeEventsEnabled,
           includeValidatorDutiesEnabled,
+          includeP2pWarningsEnabled,
           destination,
           logFile,
           logFileNamePattern);

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
@@ -35,6 +35,7 @@ public class LoggingConfigurator {
   static final String EVENT_LOGGER_NAME = "teku-event-log";
   static final String STATUS_LOGGER_NAME = "teku-status-log";
   static final String VALIDATOR_LOGGER_NAME = "teku-validator-log";
+  static final String P2P_LOGGER_NAME = "teku-p2p-log";
 
   private static final String LOG4J_CONFIG_FILE_KEY = "LOG4J_CONFIGURATION_FILE";
   private static final String LOG4J_LEGACY_CONFIG_FILE_KEY = "log4j.configurationFile";
@@ -47,6 +48,7 @@ public class LoggingConfigurator {
   private static LoggingDestination DESTINATION;
   private static boolean INCLUDE_EVENTS;
   private static boolean INCLUDE_VALIDATOR_DUTIES;
+  private static boolean INCLUDE_P2P_WARNINGS;
   private static String FILE;
   private static String FILE_PATTERN;
   private static Level ROOT_LOG_LEVEL = Level.INFO;
@@ -79,6 +81,7 @@ public class LoggingConfigurator {
     DESTINATION = configuration.getDestination();
     INCLUDE_EVENTS = configuration.isIncludeEventsEnabled();
     INCLUDE_VALIDATOR_DUTIES = configuration.isIncludeValidatorDutiesEnabled();
+    INCLUDE_P2P_WARNINGS = configuration.isIncludeP2pWarningsEnabled();
     FILE = configuration.getLogFile();
     FILE_PATTERN = configuration.getLogFileNamePattern();
 
@@ -115,6 +118,7 @@ public class LoggingConfigurator {
         setUpStatusLogger(consoleAppender);
         setUpEventsLogger(consoleAppender);
         setUpValidatorLogger(consoleAppender);
+        setUpP2pLogger(consoleAppender);
 
         addAppenderToRootLogger(configuration, consoleAppender);
         break;
@@ -124,6 +128,7 @@ public class LoggingConfigurator {
         setUpStatusLogger(fileAppender);
         setUpEventsLogger(fileAppender);
         setUpValidatorLogger(fileAppender);
+        setUpP2pLogger(fileAppender);
 
         addAppenderToRootLogger(configuration, fileAppender);
         break;
@@ -137,9 +142,11 @@ public class LoggingConfigurator {
         final LoggerConfig eventsLogger = setUpEventsLogger(consoleAppender);
         final LoggerConfig statusLogger = setUpStatusLogger(consoleAppender);
         final LoggerConfig validatorLogger = setUpValidatorLogger(consoleAppender);
+        final LoggerConfig p2pLogger = setUpP2pLogger(consoleAppender);
         configuration.addLogger(eventsLogger.getName(), eventsLogger);
         configuration.addLogger(statusLogger.getName(), statusLogger);
         configuration.addLogger(validatorLogger.getName(), validatorLogger);
+        configuration.addLogger(p2pLogger.getName(), p2pLogger);
 
         fileAppender = fileAppender(configuration);
 
@@ -234,6 +241,17 @@ public class LoggingConfigurator {
             ? ROOT_LOG_LEVEL
             : Level.ERROR;
     final LoggerConfig logger = new LoggerConfig(VALIDATOR_LOGGER_NAME, validatorLogLevel, true);
+    logger.addAppender(appender, ROOT_LOG_LEVEL, null);
+    return logger;
+  }
+
+  private static LoggerConfig setUpP2pLogger(final Appender appender) {
+    // Don't disable p2p error logs unless the root log level disables error.
+    final Level p2pLogLevel =
+        INCLUDE_P2P_WARNINGS || ROOT_LOG_LEVEL.isMoreSpecificThan(Level.ERROR)
+            ? ROOT_LOG_LEVEL
+            : Level.ERROR;
+    final LoggerConfig logger = new LoggerConfig(P2P_LOGGER_NAME, p2pLogLevel, true);
     logger.addAppender(appender, ROOT_LOG_LEVEL, null);
     return logger;
   }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/P2PLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/P2PLogger.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.logging;
+
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+
+public class P2PLogger {
+  public static final P2PLogger P2P_LOG = new P2PLogger(LoggingConfigurator.P2P_LOGGER_NAME);
+
+  private final Logger log;
+
+  public P2PLogger(final String name) {
+    this.log = LogManager.getLogger(name);
+  }
+
+  public void onGossipMessageDecodingError(
+      final String topic, final Bytes originalMessage, final Throwable error) {
+    log.warn(
+        "Failed to decode gossip message on topic {}, raw message: {}",
+        topic,
+        originalMessage,
+        error);
+  }
+
+  public void onGossipRejected(
+      final String topic, final Bytes decodedMessage, final Optional<String> description) {
+    log.warn(
+        "Rejecting gossip message on topic {}, reason: {}, decoded message: {}",
+        topic,
+        description.orElse("failed validation"),
+        decodedMessage);
+  }
+}

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/P2PLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/P2PLogger.java
@@ -21,6 +21,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class P2PLogger {
   public static final P2PLogger P2P_LOG = new P2PLogger(LoggingConfigurator.P2P_LOGGER_NAME);
 
+  @SuppressWarnings("PrivateStaticFinalLoggers")
   private final Logger log;
 
   public P2PLogger(final String name) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/encoding/SnappyPreparedGossipMessage.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/encoding/SnappyPreparedGossipMessage.java
@@ -109,6 +109,11 @@ class SnappyPreparedGossipMessage implements PreparedGossipMessage {
     }
   }
 
+  @Override
+  public Bytes getOriginalMessage() {
+    return compressedData;
+  }
+
   private Optional<Bytes> getUncompressed() {
     return decodedResult.get().getDecodedMessage();
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/PreparedGossipMessage.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/PreparedGossipMessage.java
@@ -32,6 +32,8 @@ public interface PreparedGossipMessage {
   /** @return Returns the decoded message content */
   DecodedMessageResult getDecodedMessage();
 
+  Bytes getOriginalMessage();
+
   class DecodedMessageResult {
     private final Optional<Bytes> decodedMessage;
     private final Optional<Throwable> decodingException;

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/jvmlibp2p/MockMessageApi.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/jvmlibp2p/MockMessageApi.java
@@ -83,6 +83,11 @@ public class MockMessageApi implements MessageApi {
             final Bytes decoded = Bytes.of(protoMessage.getData().toByteArray());
             return DecodedMessageResult.successful(decoded);
           }
+
+          @Override
+          public Bytes getOriginalMessage() {
+            return Bytes.wrapByteBuf(data);
+          }
         };
     return new PreparedPubsubMessage(protoMessage, preparedMessage);
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
@@ -48,6 +48,15 @@ public class LoggingOptions {
   private boolean logIncludeValidatorDutiesEnabled = true;
 
   @CommandLine.Option(
+      names = {"--Xlog-include-p2p-warnings-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Whether warnings are logged for invalid P2P messages",
+      hidden = true,
+      fallbackValue = "true",
+      arity = "0..1")
+  private boolean logIncludeP2pWarningsEnabled = false;
+
+  @CommandLine.Option(
       names = {"--log-destination"},
       paramLabel = "<LOG_DESTINATION>",
       description =
@@ -111,44 +120,12 @@ public class LoggingOptions {
       arity = "0..1")
   private boolean logWireGossipEnabled = false;
 
-  public boolean isLogColorEnabled() {
-    return logColorEnabled;
-  }
-
-  public boolean isLogIncludeEventsEnabled() {
-    return logIncludeEventsEnabled;
-  }
-
-  public boolean isLogIncludeValidatorDutiesEnabled() {
-    return logIncludeValidatorDutiesEnabled;
-  }
-
-  public LoggingDestination getLogDestination() {
-    return logDestination;
-  }
-
   public Optional<String> getMaybeLogFile() {
     return Optional.ofNullable(logFile);
   }
 
   public Optional<String> getMaybeLogPattern() {
     return Optional.ofNullable(logFileNamePattern);
-  }
-
-  public boolean isLogWireCipherEnabled() {
-    return logWireCipherEnabled;
-  }
-
-  public boolean isLogWirePlainEnabled() {
-    return logWirePlainEnabled;
-  }
-
-  public boolean isLogWireMuxEnabled() {
-    return logWireMuxEnabled;
-  }
-
-  public boolean isLogWireGossipEnabled() {
-    return logWireGossipEnabled;
   }
 
   public TekuConfiguration.Builder configure(
@@ -178,6 +155,7 @@ public class LoggingOptions {
                     .colorEnabled(logColorEnabled)
                     .includeEventsEnabled(logIncludeEventsEnabled)
                     .includeValidatorDutiesEnabled(logIncludeValidatorDutiesEnabled)
+                    .includeP2pWarningsEnabled(logIncludeP2pWarningsEnabled)
                     .destination(logDestination)
                     .logFile(logFile)
                     .logFileNamePattern(logFileNamePattern))


### PR DESCRIPTION
## PR Description
Add a hidden `--Xlog-include-p2p-warnings-enabled` option that logs any invalid P2P messages at WARN level, including the full message content.  This would potentially generate too much noise for most users but will aid in monitoring and debugging interop issues between clients.

Doesn't currently include blocks that fail state transition checks (only if they are rejected based on P2P validation rules).

## Fixed Issue(s)
#4166

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
