### PR TITLE
Add warning with full details for invalid blocks

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.statetransition.forkchoice;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.infrastructure.logging.P2PLogger.P2P_LOG;
 import static tech.pegasys.teku.statetransition.forkchoice.StateRootCollector.addParentStateRoots;
 
 import com.google.common.base.Throwables;
@@ -190,6 +191,12 @@ public class ForkChoice {
               spec.onBlock(transaction, block, blockSlotState.get(), indexedAttestationCache);
 
           if (!result.isSuccessful()) {
+            P2P_LOG.onInvalidBlock(
+                block.getSlot(),
+                block.getRoot(),
+                block.sszSerialize(),
+                result.getFailureReason().name(),
+                result.getFailureCause());
             return result;
           }
           // Note: not using thenRun here because we want to ensure each step is on the event thread

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/P2PLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/P2PLogger.java
@@ -17,6 +17,8 @@ import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class P2PLogger {
   public static final P2PLogger P2P_LOG = new P2PLogger(LoggingConfigurator.P2P_LOGGER_NAME);
@@ -44,5 +46,20 @@ public class P2PLogger {
         topic,
         description.orElse("failed validation"),
         decodedMessage);
+  }
+
+  public void onInvalidBlock(
+      final UInt64 slot,
+      final Bytes32 blockRoot,
+      final Bytes blockSsz,
+      final String failureReason,
+      final Optional<Throwable> failureCause) {
+    log.warn(
+        "Rejecting invalid block at slot {} with root {} because {}. Full block data: {}",
+        slot,
+        blockRoot,
+        failureReason,
+        blockSsz,
+        failureCause.orElse(null));
   }
 }


### PR DESCRIPTION
## PR Description
When additional logging is enabled, report invalid blocks with full content as a warning.

## Fixed Issue(s)
fixes #4166 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
