### PR TITLE
Relocate signature verification for batch storage

### DIFF
--- a/bls/src/main/java/tech/pegasys/teku/bls/BLSSignatureVerifier.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/BLSSignatureVerifier.java
@@ -45,4 +45,11 @@ public interface BLSSignatureVerifier {
   default boolean verify(BLSPublicKey publicKey, Bytes message, BLSSignature signature) {
     return verify(Collections.singletonList(publicKey), message, signature);
   }
+
+  static boolean verify(
+      final List<List<BLSPublicKey>> publicKeys,
+      final List<Bytes> signingRoots,
+      final List<BLSSignature> signatures) {
+    return BLS.batchVerify(publicKeys, signingRoots, signatures);
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BatchSignatureVerifier.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BatchSignatureVerifier.java
@@ -65,6 +65,19 @@ public class BatchSignatureVerifier implements BLSSignatureVerifier {
     return true;
   }
 
+  @Override
+  public boolean verify(
+      final List<List<BLSPublicKey>> publicKeys,
+      final List<Bytes> messages,
+      final List<BLSSignature> signatures) {
+    for (int i = 0; i < publicKeys.size(); i++) {
+      if (!verify(publicKeys.get(i), messages.get(i), signatures.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /**
    * Performs verification of all the signatures collected with one or more calls to {@link
    * #verify(List, Bytes, BLSSignature)}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AsyncBLSSignatureVerifier.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AsyncBLSSignatureVerifier.java
@@ -21,12 +21,24 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
-@FunctionalInterface
 public interface AsyncBLSSignatureVerifier {
   static AsyncBLSSignatureVerifier wrap(BLSSignatureVerifier syncVerifier) {
-    return (List<BLSPublicKey> publicKeys, Bytes message, BLSSignature signature) -> {
-      final boolean result = syncVerifier.verify(publicKeys, message, signature);
-      return SafeFuture.completedFuture(result);
+    return new AsyncBLSSignatureVerifier() {
+      @Override
+      public SafeFuture<Boolean> verify(
+          final List<BLSPublicKey> publicKeys, final Bytes message, final BLSSignature signature) {
+        final boolean result = syncVerifier.verify(publicKeys, message, signature);
+        return SafeFuture.completedFuture(result);
+      }
+
+      @Override
+      public SafeFuture<Boolean> verify(
+          final List<List<BLSPublicKey>> publicKeys,
+          final List<Bytes> messages,
+          final List<BLSSignature> signatures) {
+        final boolean result = syncVerifier.verify(publicKeys, messages, signatures);
+        return SafeFuture.completedFuture(result);
+      }
     };
   }
 
@@ -46,4 +58,9 @@ public interface AsyncBLSSignatureVerifier {
       BLSPublicKey publicKey, Bytes message, BLSSignature signature) {
     return verify(Collections.singletonList(publicKey), message, signature);
   }
+
+  SafeFuture<Boolean> verify(
+      final List<List<BLSPublicKey>> publicKeys,
+      final List<Bytes> messages,
+      final List<BLSSignature> signatures);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/signatures/AggregatingSignatureVerificationService.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/signatures/AggregatingSignatureVerificationService.java
@@ -185,6 +185,19 @@ class AggregatingSignatureVerificationService extends SignatureVerificationServi
     return batchSignatureTasks.size();
   }
 
+  @Override
+  public SafeFuture<Void> verify(
+      final List<List<BLSPublicKey>> publicKeys,
+      final List<Bytes> signingRoots,
+      final List<BLSSignature> signatures) {
+    final boolean verifyResult = BLSSignatureVerifier.verify(publicKeys, signingRoots, signatures);
+    if (verifyResult) {
+      return SafeFuture.COMPLETE;
+    }
+    return SafeFuture.failedFuture(
+        new IllegalArgumentException("Block signatures are invalid"));
+  }
+
   @VisibleForTesting
   static class SignatureTask {
     final SafeFuture<Boolean> result = new SafeFuture<>();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/signatures/SignatureVerificationService.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/signatures/SignatureVerificationService.java
@@ -13,8 +13,13 @@
 
 package tech.pegasys.teku.statetransition.validation.signatures;
 
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 
@@ -28,4 +33,9 @@ public abstract class SignatureVerificationService extends Service
   public static SignatureVerificationService createSimple() {
     return new SimpleSignatureVerificationService();
   }
+
+  public abstract SafeFuture<Void> verify(
+      final List<List<BLSPublicKey>> publicKeys,
+      final List<Bytes> signingRoots,
+      final List<BLSSignature> signatures);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/signatures/SignatureVerificationService.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/signatures/SignatureVerificationService.java
@@ -13,13 +13,8 @@
 
 package tech.pegasys.teku.statetransition.validation.signatures;
 
-import java.util.List;
-import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.bls.BLSPublicKey;
-import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 
@@ -33,9 +28,4 @@ public abstract class SignatureVerificationService extends Service
   public static SignatureVerificationService createSimple() {
     return new SimpleSignatureVerificationService();
   }
-
-  public abstract SafeFuture<Void> verify(
-      final List<List<BLSPublicKey>> publicKeys,
-      final List<Bytes> signingRoots,
-      final List<BLSSignature> signatures);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/signatures/SimpleSignatureVerificationService.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/signatures/SimpleSignatureVerificationService.java
@@ -29,6 +29,15 @@ class SimpleSignatureVerificationService extends SignatureVerificationService {
   }
 
   @Override
+  public SafeFuture<Boolean> verify(
+      final List<List<BLSPublicKey>> publicKeys,
+      final List<Bytes> messages,
+      final List<BLSSignature> signatures) {
+    return SafeFuture.completedFuture(
+        BLSSignatureVerifier.SIMPLE.verify(publicKeys, messages, signatures));
+  }
+
+  @Override
   protected SafeFuture<?> doStart() {
     return SafeFuture.COMPLETE;
   }
@@ -36,17 +45,5 @@ class SimpleSignatureVerificationService extends SignatureVerificationService {
   @Override
   protected SafeFuture<?> doStop() {
     return SafeFuture.COMPLETE;
-  }
-
-  @Override
-  public SafeFuture<Void> verify(
-      final List<List<BLSPublicKey>> publicKeys,
-      final List<Bytes> signingRoots,
-      final List<BLSSignature> signatures) {
-    final boolean result = BLSSignatureVerifier.verify(publicKeys, signingRoots, signatures);
-    if (result) {
-      return SafeFuture.COMPLETE;
-    }
-    return SafeFuture.failedFuture(new IllegalArgumentException("Block signatures are invalid"));
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/signatures/SimpleSignatureVerificationService.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/signatures/SimpleSignatureVerificationService.java
@@ -37,4 +37,16 @@ class SimpleSignatureVerificationService extends SignatureVerificationService {
   protected SafeFuture<?> doStop() {
     return SafeFuture.COMPLETE;
   }
+
+  @Override
+  public SafeFuture<Void> verify(
+      final List<List<BLSPublicKey>> publicKeys,
+      final List<Bytes> signingRoots,
+      final List<BLSSignature> signatures) {
+    final boolean result = BLSSignatureVerifier.verify(publicKeys, signingRoots, signatures);
+    if (result) {
+      return SafeFuture.COMPLETE;
+    }
+    return SafeFuture.failedFuture(new IllegalArgumentException("Block signatures are invalid"));
+  }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -760,6 +760,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             blockImporter,
             pendingBlocks,
             beaconConfig.eth2NetworkConfig().getStartupTargetPeerCount(),
+            signatureVerificationService,
             Duration.ofSeconds(beaconConfig.eth2NetworkConfig().getStartupTimeoutSeconds()));
 
     syncService.getForwardSync().subscribeToSyncChanges(coalescingChainHeadChannel);

--- a/sync/src/main/java/tech/pegasys/teku/sync/SyncServiceFactory.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/SyncServiceFactory.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.statetransition.validation.signatures.SignatureVerificationService;
@@ -48,7 +49,7 @@ public class SyncServiceFactory {
   private final BlockImporter blockImporter;
   private final PendingPool<SignedBeaconBlock> pendingBlocks;
   private final int getStartupTargetPeerCount;
-  private final SignatureVerificationService signatureVerificationService;
+  private final AsyncBLSSignatureVerifier signatureVerifier;
   private final Duration startupTimeout;
 
   private SyncServiceFactory(
@@ -64,7 +65,7 @@ public class SyncServiceFactory {
       final BlockImporter blockImporter,
       final PendingPool<SignedBeaconBlock> pendingBlocks,
       final int getStartupTargetPeerCount,
-      final SignatureVerificationService signatureVerificationService,
+      final SignatureVerificationService signatureVerifier,
       final Duration startupTimeout) {
     this.syncConfig = syncConfig;
     this.metrics = metrics;
@@ -78,7 +79,7 @@ public class SyncServiceFactory {
     this.blockImporter = blockImporter;
     this.pendingBlocks = pendingBlocks;
     this.getStartupTargetPeerCount = getStartupTargetPeerCount;
-    this.signatureVerificationService = signatureVerificationService;
+    this.signatureVerifier = signatureVerifier;
     this.startupTimeout = startupTimeout;
   }
 
@@ -143,7 +144,7 @@ public class SyncServiceFactory {
         asyncRunner,
         p2pNetwork,
         combinedChainDataClient,
-        signatureVerificationService,
+        signatureVerifier,
         syncStateProvider);
   }
 

--- a/sync/src/main/java/tech/pegasys/teku/sync/SyncServiceFactory.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/SyncServiceFactory.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.util.PendingPool;
+import tech.pegasys.teku.statetransition.validation.signatures.SignatureVerificationService;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -47,6 +48,7 @@ public class SyncServiceFactory {
   private final BlockImporter blockImporter;
   private final PendingPool<SignedBeaconBlock> pendingBlocks;
   private final int getStartupTargetPeerCount;
+  private final SignatureVerificationService signatureVerificationService;
   private final Duration startupTimeout;
 
   private SyncServiceFactory(
@@ -62,6 +64,7 @@ public class SyncServiceFactory {
       final BlockImporter blockImporter,
       final PendingPool<SignedBeaconBlock> pendingBlocks,
       final int getStartupTargetPeerCount,
+      final SignatureVerificationService signatureVerificationService,
       final Duration startupTimeout) {
     this.syncConfig = syncConfig;
     this.metrics = metrics;
@@ -75,6 +78,7 @@ public class SyncServiceFactory {
     this.blockImporter = blockImporter;
     this.pendingBlocks = pendingBlocks;
     this.getStartupTargetPeerCount = getStartupTargetPeerCount;
+    this.signatureVerificationService = signatureVerificationService;
     this.startupTimeout = startupTimeout;
   }
 
@@ -91,6 +95,7 @@ public class SyncServiceFactory {
       final BlockImporter blockImporter,
       final PendingPool<SignedBeaconBlock> pendingBlocks,
       final int getStartupTargetPeerCount,
+      final SignatureVerificationService signatureVerificationService,
       final Duration startupTimeout) {
     final SyncServiceFactory factory =
         new SyncServiceFactory(
@@ -106,6 +111,7 @@ public class SyncServiceFactory {
             blockImporter,
             pendingBlocks,
             getStartupTargetPeerCount,
+            signatureVerificationService,
             startupTimeout);
     return factory.create();
   }
@@ -137,6 +143,7 @@ public class SyncServiceFactory {
         asyncRunner,
         p2pNetwork,
         combinedChainDataClient,
+        signatureVerificationService,
         syncStateProvider);
   }
 

--- a/sync/src/main/java/tech/pegasys/teku/sync/historical/HistoricalBatchFetcher.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/historical/HistoricalBatchFetcher.java
@@ -43,7 +43,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.statetransition.validation.signatures.SignatureVerificationService;
+import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
@@ -63,7 +63,7 @@ public class HistoricalBatchFetcher {
   private final SafeFuture<BeaconBlockSummary> future = new SafeFuture<>();
   private final Deque<SignedBeaconBlock> blocksToImport = new ConcurrentLinkedDeque<>();
   private final AtomicInteger requestCount = new AtomicInteger(0);
-  private final SignatureVerificationService signatureVerificationService;
+  private final AsyncBLSSignatureVerifier signatureVerificationService;
   private final CombinedChainDataClient chainDataClient;
 
   /**
@@ -75,7 +75,7 @@ public class HistoricalBatchFetcher {
    */
   public HistoricalBatchFetcher(
       final StorageUpdateChannel storageUpdateChannel,
-      final SignatureVerificationService signatureVerificationService,
+      final AsyncBLSSignatureVerifier signatureVerifier,
       final CombinedChainDataClient chainDataClient,
       final Spec spec,
       final Eth2Peer peer,
@@ -84,7 +84,7 @@ public class HistoricalBatchFetcher {
       final UInt64 batchSize) {
     this(
         storageUpdateChannel,
-        signatureVerificationService,
+        signatureVerifier,
         chainDataClient,
         spec,
         peer,
@@ -97,7 +97,7 @@ public class HistoricalBatchFetcher {
   @VisibleForTesting
   HistoricalBatchFetcher(
       final StorageUpdateChannel storageUpdateChannel,
-      final SignatureVerificationService signatureVerificationService,
+      final AsyncBLSSignatureVerifier signatureVerifier,
       final CombinedChainDataClient chainDataClient,
       final Spec spec,
       final Eth2Peer peer,
@@ -106,7 +106,7 @@ public class HistoricalBatchFetcher {
       final UInt64 batchSize,
       final int maxRequests) {
     this.storageUpdateChannel = storageUpdateChannel;
-    this.signatureVerificationService = signatureVerificationService;
+    this.signatureVerificationService = signatureVerifier;
     this.chainDataClient = chainDataClient;
     this.spec = spec;
     this.peer = peer;

--- a/sync/src/main/java/tech/pegasys/teku/sync/historical/HistoricalBatchFetcher.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/historical/HistoricalBatchFetcher.java
@@ -15,7 +15,11 @@ package tech.pegasys.teku.sync.historical;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
+
+ import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Deque;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -23,20 +27,30 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.rpc.core.InvalidResponseException;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.constants.Domain;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.statetransition.validation.signatures.SignatureVerificationService;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 /** Fetches a target batch of blocks from a peer. */
 public class HistoricalBatchFetcher {
   private static final Logger LOG = LogManager.getLogger();
-
   private static final int MAX_REQUESTS = 2;
 
   private final StorageUpdateChannel storageUpdateChannel;
@@ -46,9 +60,12 @@ public class HistoricalBatchFetcher {
   private final UInt64 batchSize;
   private final int maxRequests;
 
+  private final Spec spec;
   private final SafeFuture<BeaconBlockSummary> future = new SafeFuture<>();
   private final Deque<SignedBeaconBlock> blocksToImport = new ConcurrentLinkedDeque<>();
   private final AtomicInteger requestCount = new AtomicInteger(0);
+  private final SignatureVerificationService signatureVerificationService;
+  private final CombinedChainDataClient chainDataClient;
 
   /**
    * @param storageUpdateChannel The storage channel where finalized blocks will be imported
@@ -56,32 +73,48 @@ public class HistoricalBatchFetcher {
    * @param maxSlot The maxSlot to pull
    * @param lastBlockRoot The block root that defines the last block in our batch
    * @param batchSize The number of blocks to sync (assuming all slots are filled)
-   * @param maxRequests The number of blocksByRange requests allowed to pull this batch
    */
+  public HistoricalBatchFetcher(
+      final StorageUpdateChannel storageUpdateChannel,
+      final SignatureVerificationService signatureVerificationService,
+      final CombinedChainDataClient chainDataClient,
+      final Spec spec,
+      final Eth2Peer peer,
+      final UInt64 maxSlot,
+      final Bytes32 lastBlockRoot,
+      final UInt64 batchSize) {
+    this(
+        storageUpdateChannel,
+        signatureVerificationService,
+        chainDataClient,
+        spec,
+        peer,
+        maxSlot,
+        lastBlockRoot,
+        batchSize,
+        MAX_REQUESTS);
+  }
+
   @VisibleForTesting
   HistoricalBatchFetcher(
       final StorageUpdateChannel storageUpdateChannel,
+      final SignatureVerificationService signatureVerificationService,
+      final CombinedChainDataClient chainDataClient,
+      final Spec spec,
       final Eth2Peer peer,
       final UInt64 maxSlot,
       final Bytes32 lastBlockRoot,
       final UInt64 batchSize,
       final int maxRequests) {
     this.storageUpdateChannel = storageUpdateChannel;
+    this.signatureVerificationService = signatureVerificationService;
+    this.chainDataClient = chainDataClient;
+    this.spec = spec;
     this.peer = peer;
     this.maxSlot = maxSlot;
     this.lastBlockRoot = lastBlockRoot;
     this.batchSize = batchSize;
     this.maxRequests = maxRequests;
-  }
-
-  public static HistoricalBatchFetcher create(
-      final StorageUpdateChannel storageUpdateChannel,
-      final Eth2Peer peer,
-      final UInt64 maxSlot,
-      final Bytes32 lastBlockRoot,
-      final UInt64 batchSize) {
-    return new HistoricalBatchFetcher(
-        storageUpdateChannel, peer, maxSlot, lastBlockRoot, batchSize, MAX_REQUESTS);
   }
 
   /**
@@ -179,9 +212,53 @@ public class HistoricalBatchFetcher {
 
   private SafeFuture<Void> importBatch() {
     final SignedBeaconBlock newEarliestBlock = blocksToImport.getFirst();
-    return storageUpdateChannel
-        .onFinalizedBlocks(blocksToImport)
-        .thenRun(() -> future.complete(newEarliestBlock));
+
+    return batchVerifyHistoricalBlockSignatures(blocksToImport)
+        .thenCompose(
+            validSignatures ->
+                storageUpdateChannel
+                    // send to signature verification then store
+                    // all pass, or if one fails we reject the entire response
+                    .onFinalizedBlocks(blocksToImport)
+                    .thenRun(
+                        () -> {
+                          LOG.trace(
+                              "Earliest block is now from slot {}", newEarliestBlock.getSlot());
+                          future.complete(newEarliestBlock);
+                        }));
+  }
+
+  SafeFuture<Void> batchVerifyHistoricalBlockSignatures(
+      final Collection<SignedBeaconBlock> blocks) {
+
+    BeaconState bestState = chainDataClient.getBestState().orElseThrow();
+    List<BLSSignature> signatures = new ArrayList<>();
+    List<Bytes> signingRoots = new ArrayList<>();
+    List<List<BLSPublicKey>> proposerPublicKeys = new ArrayList<>();
+
+    final Bytes32 genesisValidatorsRoot = bestState.getForkInfo().getGenesisValidatorsRoot();
+
+    blocks.forEach(
+        signedBlock -> {
+          final BeaconBlock block = signedBlock.getMessage();
+          if (block.getSlot().isGreaterThan(SpecConfig.GENESIS_SLOT)) {
+            final UInt64 epoch = spec.computeEpochAtSlot(block.getSlot());
+            final Fork fork = spec.fork(epoch);
+            final Bytes32 domain =
+                spec.getDomain(Domain.BEACON_PROPOSER, epoch, fork, genesisValidatorsRoot);
+            signatures.add(signedBlock.getSignature());
+            signingRoots.add(spec.computeSigningRoot(block, domain));
+            BLSPublicKey proposerPublicKey =
+                spec.getValidatorPubKey(bestState, block.getProposerIndex())
+                    .orElseThrow(
+                        () ->
+                            new IllegalStateException(
+                                "Proposer has to be in the state since state is more recent than the block proposed"));
+            proposerPublicKeys.add(List.of(proposerPublicKey));
+          }
+        });
+
+    return signatureVerificationService.verify(proposerPublicKeys, signingRoots, signatures);
   }
 
   private RequestParameters calculateRequestParams() {

--- a/sync/src/main/java/tech/pegasys/teku/sync/historical/HistoricalBatchFetcher.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/historical/HistoricalBatchFetcher.java
@@ -15,8 +15,7 @@ package tech.pegasys.teku.sync.historical;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
-
- import java.util.ArrayList;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
@@ -258,7 +257,14 @@ public class HistoricalBatchFetcher {
           }
         });
 
-    return signatureVerificationService.verify(proposerPublicKeys, signingRoots, signatures);
+    return signatureVerificationService
+        .verify(proposerPublicKeys, signingRoots, signatures)
+        .thenAccept(
+            signaturesValid -> {
+              if (!signaturesValid) {
+                throw new IllegalArgumentException("Batch signature verification failed");
+              }
+            });
   }
 
   private RequestParameters calculateRequestParams() {

--- a/sync/src/main/java/tech/pegasys/teku/sync/historical/HistoricalBlockSyncService.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/historical/HistoricalBlockSyncService.java
@@ -36,7 +36,7 @@ import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
-import tech.pegasys.teku.statetransition.validation.signatures.SignatureVerificationService;
+import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.sync.events.SyncStateProvider;
@@ -63,7 +63,7 @@ public class HistoricalBlockSyncService extends Service {
   private final AtomicLong syncStateSubscription = new AtomicLong(-1);
   private final AtomicBoolean requestInProgress = new AtomicBoolean(false);
 
-  private final SignatureVerificationService signatureVerificationService;
+  private final AsyncBLSSignatureVerifier signatureVerifier;
   private volatile BeaconBlockSummary earliestBlock;
   final Set<NodeId> badPeerCache;
 
@@ -76,7 +76,7 @@ public class HistoricalBlockSyncService extends Service {
       final P2PNetwork<Eth2Peer> network,
       final CombinedChainDataClient chainData,
       final SyncStateProvider syncStateProvider,
-      final SignatureVerificationService signatureVerificationService,
+      final AsyncBLSSignatureVerifier signatureVerifier,
       final UInt64 batchSize) {
     this.spec = spec;
     this.storageUpdateChannel = storageUpdateChannel;
@@ -86,7 +86,7 @@ public class HistoricalBlockSyncService extends Service {
     this.chainData = chainData;
     this.syncStateProvider = syncStateProvider;
     this.batchSize = batchSize;
-    this.signatureVerificationService = signatureVerificationService;
+    this.signatureVerifier = signatureVerifier;
 
     this.badPeerCache =
         Collections.newSetFromMap(
@@ -112,7 +112,7 @@ public class HistoricalBlockSyncService extends Service {
       final AsyncRunner asyncRunner,
       final P2PNetwork<Eth2Peer> network,
       final CombinedChainDataClient chainData,
-      final SignatureVerificationService signatureVerificationService,
+      final AsyncBLSSignatureVerifier signatureVerifier,
       final SyncStateProvider syncStateProvider) {
     return new HistoricalBlockSyncService(
         spec,
@@ -122,7 +122,7 @@ public class HistoricalBlockSyncService extends Service {
         network,
         chainData,
         syncStateProvider,
-        signatureVerificationService,
+        signatureVerifier,
         BATCH_SIZE);
   }
 
@@ -224,7 +224,7 @@ public class HistoricalBlockSyncService extends Service {
       final Eth2Peer peer, final MaxMissingBlockParams params) {
     return new HistoricalBatchFetcher(
         storageUpdateChannel,
-        signatureVerificationService,
+        signatureVerifier,
         chainData,
         spec,
         peer,

--- a/sync/src/test/java/tech/pegasys/teku/sync/historical/HistoricalBlockSyncServiceTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/historical/HistoricalBlockSyncServiceTest.java
@@ -103,7 +103,7 @@ public class HistoricalBlockSyncServiceTest {
         .thenAnswer((i) -> syncStateSubscribers.unsubscribe(i.getArgument(0)));
     when(syncStateProvider.getCurrentSyncState()).thenAnswer(i -> currentSyncState.get());
     when(signatureVerificationService.verify(any(), any(), (List<BLSSignature>) any()))
-        .thenReturn(SafeFuture.COMPLETE);
+        .thenReturn(SafeFuture.completedFuture(true));
   }
 
   @Test

--- a/sync/src/test/java/tech/pegasys/teku/sync/historical/HistoricalBlockSyncServiceTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/historical/HistoricalBlockSyncServiceTest.java
@@ -34,6 +34,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
@@ -47,6 +48,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.statetransition.validation.signatures.SignatureVerificationService;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
@@ -61,6 +63,8 @@ public class HistoricalBlockSyncServiceTest {
   private final MetricsSystem metricsSystem = new NoOpMetricsSystem();
   private final StorageUpdateChannel storageUpdateChannel = mock(StorageUpdateChannel.class);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+  private final SignatureVerificationService signatureVerificationService =
+      mock(SignatureVerificationService.class);
 
   @SuppressWarnings("unchecked")
   private final P2PNetwork<Eth2Peer> network = mock(P2PNetwork.class);
@@ -77,6 +81,7 @@ public class HistoricalBlockSyncServiceTest {
           network,
           storageSystem.combinedChainDataClient(),
           syncStateProvider,
+          signatureVerificationService,
           batchSize);
   private final Subscribers<SyncStateProvider.SyncStateSubscriber> syncStateSubscribers =
       Subscribers.create(false);
@@ -88,6 +93,7 @@ public class HistoricalBlockSyncServiceTest {
   private final ArgumentCaptor<Collection<SignedBeaconBlock>> blockCaptor =
       ArgumentCaptor.forClass(Collection.class);
 
+  @SuppressWarnings("unchecked")
   @BeforeEach
   public void setup() {
     when(storageUpdateChannel.onFinalizedBlocks(any())).thenReturn(SafeFuture.COMPLETE);
@@ -96,6 +102,8 @@ public class HistoricalBlockSyncServiceTest {
     when(syncStateProvider.unsubscribeFromSyncStateChanges(anyLong()))
         .thenAnswer((i) -> syncStateSubscribers.unsubscribe(i.getArgument(0)));
     when(syncStateProvider.getCurrentSyncState()).thenAnswer(i -> currentSyncState.get());
+    when(signatureVerificationService.verify(any(), any(), (List<BLSSignature>) any()))
+        .thenReturn(SafeFuture.COMPLETE);
   }
 
   @Test


### PR DESCRIPTION
Signature verification was inside single threaded storage, and slowing down storage.

Now located in the threaded batch fetcher.

fixes #4019

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
