### PR TITLE
Upgrade discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Fix an issue where deposits for the PoW chain could be loaded out of order on restart.
 - Fix `/eth/v1/validator/contribution_and_proofs` to return errors.
 - Add `SYNC_COMMITTEE_SUBNET_COUNT` to `/eth/v1/config/spec`, as it was missing.
+- Upgraded the discovery library, providing better memory management and standards compliance. 
 
 ### Experimental: New Altair REST APIs
 - implement POST `/eth/v1/beacon/pool/sync_committees` to allow validators to submit sync committee signatures to the beacon node.

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -153,7 +153,7 @@ dependencyManagement {
     dependency "org.testcontainers:testcontainers:1.15.3"
     dependency "org.testcontainers:junit-jupiter:1.15.3"
 
-    dependency 'tech.pegasys.discovery:discovery:0.4.7'
+    dependency 'tech.pegasys.discovery:discovery:0.4.8'
 
     dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.15'
 

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/TekuMetricCategory.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/TekuMetricCategory.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 
 public enum TekuMetricCategory implements MetricCategory {
   BEACON("beacon"),
+  DISCOVERY("discovery"),
   EVENTBUS("eventbus"),
   EXECUTOR("executor"),
   LIBP2P("libp2p"),

--- a/networking/p2p/src/integration-test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkIntegrationTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
@@ -109,6 +110,8 @@ public class DiscoveryNetworkIntegrationTest {
         () -> {
           assertThat(network1.getPeer(network2.getNodeId())).isPresent();
           assertThat(network2.getPeer(network1.getNodeId())).isPresent();
-        });
+        },
+        3,
+        TimeUnit.MINUTES);
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManager.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.p2p.connection;
 
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 import java.time.Duration;
@@ -23,6 +24,7 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -94,18 +96,22 @@ public class ConnectionManager extends Service {
             this::searchForPeers,
             DISCOVERY_INTERVAL,
             error -> LOG.error("Error while searching for peers", error));
-    connectToKnownPeers();
+    connectToBestPeers(emptyList());
     searchForPeers();
     peerConnectedSubscriptionId = network.subscribeConnect(this::onPeerConnected);
     return SafeFuture.COMPLETE;
   }
 
-  private void connectToKnownPeers() {
+  private void connectToBestPeers(final Collection<DiscoveryPeer> additionalPeersToConsider) {
     peerSelectionStrategy
         .selectPeersToConnect(
             network,
             peerPools,
-            () -> discoveryService.streamKnownPeers().filter(this::isPeerValid).collect(toList()))
+            () ->
+                Stream.concat(
+                        additionalPeersToConsider.stream(), discoveryService.streamKnownPeers())
+                    .filter(this::isPeerValid)
+                    .collect(toList()))
         .forEach(this::attemptConnection);
   }
 
@@ -119,10 +125,10 @@ public class ConnectionManager extends Service {
         .searchForPeers()
         .orTimeout(10, TimeUnit.SECONDS)
         .finish(
-            this::connectToKnownPeers,
+            this::connectToBestPeers,
             error -> {
               LOG.debug("Discovery failed", error);
-              connectToKnownPeers();
+              connectToBestPeers(emptyList());
             });
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
@@ -97,6 +97,7 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
       final SchemaDefinitionsSupplier currentSchemaDefinitionsSupplier) {
     final DiscoveryService discoveryService =
         createDiscoveryService(
+            metricsSystem,
             asyncRunner,
             discoveryConfig,
             p2pConfig,
@@ -118,6 +119,7 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
   }
 
   private static DiscoveryService createDiscoveryService(
+      final MetricsSystem metricsSystem,
       final AsyncRunner asyncRunner,
       final DiscoveryConfig discoConfig,
       final NetworkConfig p2pConfig,
@@ -128,6 +130,7 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
     if (discoConfig.isDiscoveryEnabled()) {
       discoveryService =
           new DiscV5Service(
+              metricsSystem,
               asyncRunner,
               discoConfig,
               p2pConfig,

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryService.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryService.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.p2p.discovery;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
@@ -26,7 +27,7 @@ public interface DiscoveryService {
 
   Stream<DiscoveryPeer> streamKnownPeers();
 
-  SafeFuture<Void> searchForPeers();
+  SafeFuture<Collection<DiscoveryPeer>> searchForPeers();
 
   Optional<String> getEnr();
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/noop/NoOpDiscoveryService.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/noop/NoOpDiscoveryService.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.networking.p2p.discovery.noop;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
@@ -38,8 +40,8 @@ public class NoOpDiscoveryService implements DiscoveryService {
   }
 
   @Override
-  public SafeFuture<Void> searchForPeers() {
-    return SafeFuture.COMPLETE;
+  public SafeFuture<Collection<DiscoveryPeer>> searchForPeers() {
+    return SafeFuture.completedFuture(Collections.emptyList());
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Updates discovery to 0.4.8 which is a significant change to how nodes are stored internally.

Node storage is now entirely based on the KBuckets ensuring that there is an upper bound on the number of nodes stored in memory.
Searching for new nodes now returns the list of nodes which are considered for connection even if they don't fit in the KBuckets.

Recursive search for peers also continuously selects the closest peers to the target, resulting in more effective searches.

Added metric to report the number of tracked live nodes in the discovery buckets.

## Fixed Issue(s)
fixes https://github.com/ConsenSys/discovery/issues/103

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
