### PR TITLE
add contribution_and_proof events in the rest api.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@ For information on changes in released versions of Teku, see the [releases page]
 - implement GET `/eth/v1/beacon/states/{state_id}/sync_committees` for Altair fork.
 - `/eth/v1/validator/blocks/{slot}` will now produce an altair block if an altair slot is requested.
 - `/eth/v1/node/identity` will now include syncnets in metadata
+- implement event channel for `/eth/v1/events&topic=contribution_and_proof` for Altair fork.

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractBeaconRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractBeaconRestAPIIntegrationTest.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockManager;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -79,6 +80,8 @@ public abstract class AbstractBeaconRestAPIIntegrationTest {
   private final OperationPool<AttesterSlashing> attesterSlashingPool = mock(OperationPool.class);
   private final OperationPool<ProposerSlashing> proposerSlashingPool = mock(OperationPool.class);
   private final OperationPool<SignedVoluntaryExit> voluntaryExitPool = mock(OperationPool.class);
+  protected final SyncCommitteeContributionPool syncCommitteeContributionPool =
+      mock(SyncCommitteeContributionPool.class);
   protected final EventChannels eventChannels = mock(EventChannels.class);
 
   protected CombinedChainDataClient combinedChainDataClient =
@@ -102,7 +105,8 @@ public abstract class AbstractBeaconRestAPIIntegrationTest {
             attestationManager,
             attesterSlashingPool,
             proposerSlashingPool,
-            voluntaryExitPool);
+            voluntaryExitPool,
+            syncCommitteeContributionPool);
 
     beaconRestApi =
         new BeaconRestApi(dataProvider, restApiConfig, eventChannels, SyncAsyncRunner.SYNC_RUNNER);

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -61,6 +61,7 @@ import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.storage.client.ChainUpdater;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -107,6 +108,8 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
   protected final OperationPool<AttesterSlashing> attesterSlashingPool = mock(OperationPool.class);
   protected final OperationPool<ProposerSlashing> proposerSlashingPool = mock(OperationPool.class);
   protected final OperationPool<SignedVoluntaryExit> voluntaryExitPool = mock(OperationPool.class);
+  protected final SyncCommitteeContributionPool syncCommitteeContributionPool =
+      mock(SyncCommitteeContributionPool.class);
 
   private StorageSystem storageSystem;
 
@@ -170,7 +173,8 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
             attestationManager,
             attesterSlashingPool,
             proposerSlashingPool,
-            voluntaryExitPool);
+            voluntaryExitPool,
+            syncCommitteeContributionPool);
     beaconRestApi =
         new BeaconRestApi(dataProvider, config, eventChannels, SyncAsyncRunner.SYNC_RUNNER);
     beaconRestApi.start();

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.api.response.v1.HeadEvent;
 import tech.pegasys.teku.api.response.v1.SyncStateChangeEvent;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
+import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
 import tech.pegasys.teku.beaconrestapi.ListQueryParameterUtils;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
@@ -81,6 +82,7 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
     nodeDataProvider.subscribeToReceivedBlocks(this::onNewBlock);
     nodeDataProvider.subscribeToValidAttestations(this::onNewAttestation);
     nodeDataProvider.subscribeToNewVoluntaryExits(this::onNewVoluntaryExit);
+    nodeDataProvider.subscribeToSyncCommitteeContributions(this::onSyncCommitteeContribution);
   }
 
   public void registerClient(final SseClient sseClient) {
@@ -140,6 +142,18 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
       final InternalValidationResult result) {
     final SignedVoluntaryExit voluntaryExitEvent = new SignedVoluntaryExit(exit);
     notifySubscribersOfEvent(EventType.voluntary_exit, voluntaryExitEvent);
+  }
+
+  protected void onSyncCommitteeContribution(
+      final tech.pegasys.teku.spec.datastructures.operations.versions.altair
+              .SignedContributionAndProof
+          proof,
+      final InternalValidationResult result) {
+    if (result.isAccept()) {
+      final SignedContributionAndProof signedContributionAndProof =
+          new SignedContributionAndProof(proof);
+      notifySubscribersOfEvent(EventType.contribution_and_proof, signedContributionAndProof);
+    }
   }
 
   protected void onNewAttestation(final ValidateableAttestation attestation) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/GetEvents.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/GetEvents.java
@@ -104,7 +104,8 @@ public class GetEvents implements Handler {
             required = true,
             description =
                 "Event types to subscribe to."
-                    + " Available values include: [`head`, `finalized_checkpoint`, `chain_reorg`, `block`, `attestation`, `voluntary_exit`]\n\n"),
+                    + " Available values include: [`head`, `finalized_checkpoint`, `chain_reorg`, `block`, "
+                    + "`attestation`, `voluntary_exit`, `contribution_and_proof`]\n\n"),
       },
       responses = {
         @OpenApiResponse(

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockManager;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -59,6 +60,8 @@ class BeaconRestApiTest {
   private final OperationPool<AttesterSlashing> attesterSlashingPool = mock(OperationPool.class);
   private final OperationPool<ProposerSlashing> proposerSlashingPool = mock(OperationPool.class);
   private final OperationPool<SignedVoluntaryExit> voluntaryExitPool = mock(OperationPool.class);
+  private final SyncCommitteeContributionPool syncCommitteeContributionPool =
+      mock(SyncCommitteeContributionPool.class);
 
   @BeforeEach
   public void setup() {
@@ -83,7 +86,8 @@ class BeaconRestApiTest {
             attestationManager,
             attesterSlashingPool,
             proposerSlashingPool,
-            voluntaryExitPool),
+            voluntaryExitPool,
+            syncCommitteeContributionPool),
         beaconRestApiConfig,
         eventChannels,
         new StubAsyncRunner(),

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -91,6 +91,7 @@ import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockManager;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -112,6 +113,8 @@ public class BeaconRestApiV1Test {
   private final OperationPool<AttesterSlashing> attesterSlashingPool = mock(OperationPool.class);
   private final OperationPool<ProposerSlashing> proposerSlashingPool = mock(OperationPool.class);
   private final OperationPool<SignedVoluntaryExit> voluntaryExitPool = mock(OperationPool.class);
+  private final SyncCommitteeContributionPool syncCommitteeContributionPool =
+      mock(SyncCommitteeContributionPool.class);
 
   @BeforeEach
   public void setup() {
@@ -137,7 +140,8 @@ public class BeaconRestApiV1Test {
             attestationManager,
             attesterSlashingPool,
             proposerSlashingPool,
-            voluntaryExitPool),
+            voluntaryExitPool,
+            syncCommitteeContributionPool),
         beaconRestApiConfig,
         eventChannels,
         new StubAsyncRunner(),

--- a/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockManager;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.sync.SyncService;
@@ -47,7 +48,8 @@ public class DataProvider {
       final AttestationManager attestationManager,
       final OperationPool<AttesterSlashing> attesterSlashingPool,
       final OperationPool<ProposerSlashing> proposerSlashingPool,
-      final OperationPool<SignedVoluntaryExit> voluntaryExitPool) {
+      final OperationPool<SignedVoluntaryExit> voluntaryExitPool,
+      final SyncCommitteeContributionPool syncCommitteeContributionPool) {
     this.configProvider = new ConfigProvider(spec);
     networkDataProvider = new NetworkDataProvider(p2pNetwork);
     nodeDataProvider =
@@ -56,6 +58,7 @@ public class DataProvider {
             attesterSlashingPool,
             proposerSlashingPool,
             voluntaryExitPool,
+            syncCommitteeContributionPool,
             blockManager,
             attestationManager);
     chainDataProvider = new ChainDataProvider(spec, recentChainData, combinedChainDataClient);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -24,10 +24,12 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.attestation.ProcessedAttestationListener;
 import tech.pegasys.teku.spec.datastructures.blocks.ReceivedBlockListener;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockManager;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class NodeDataProvider {
@@ -39,6 +41,7 @@ public class NodeDataProvider {
       proposerSlashingPool;
   private final OperationPool<tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit>
       voluntaryExitPool;
+  private final SyncCommitteeContributionPool syncCommitteeContributionPool;
   private final BlockManager blockManager;
   private final AttestationManager attestationManager;
 
@@ -50,12 +53,14 @@ public class NodeDataProvider {
           proposerSlashingPool,
       OperationPool<tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit>
           voluntaryExitPool,
+      final SyncCommitteeContributionPool syncCommitteeContributionPool,
       BlockManager blockManager,
       AttestationManager attestationManager) {
     this.attestationPool = attestationPool;
     this.attesterSlashingPool = attesterSlashingsPool;
     this.proposerSlashingPool = proposerSlashingPool;
     this.voluntaryExitPool = voluntaryExitPool;
+    this.syncCommitteeContributionPool = syncCommitteeContributionPool;
     this.blockManager = blockManager;
     this.attestationManager = attestationManager;
   }
@@ -111,5 +116,10 @@ public class NodeDataProvider {
               tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit>
           listener) {
     voluntaryExitPool.subscribeOperationAdded(listener);
+  }
+
+  public void subscribeToSyncCommitteeContributions(
+      OperationPool.OperationAddedSubscriber<SignedContributionAndProof> listener) {
+    syncCommitteeContributionPool.subscribeOperationAdded(listener);
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/EventType.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/EventType.java
@@ -23,7 +23,8 @@ public enum EventType {
   voluntary_exit,
   finalized_checkpoint,
   chain_reorg,
-  sync_state;
+  sync_state,
+  contribution_and_proof;
 
   public static List<EventType> getTopics(List<String> topics) {
     return topics.stream().map(EventType::valueOf).collect(Collectors.toList());

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SignedContributionAndProof.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SignedContributionAndProof.java
@@ -38,6 +38,14 @@ public class SignedContributionAndProof {
     this.signature = signature;
   }
 
+  public SignedContributionAndProof(
+      final tech.pegasys.teku.spec.datastructures.operations.versions.altair
+              .SignedContributionAndProof
+          proof) {
+    this.message = new ContributionAndProof(proof.getMessage());
+    this.signature = new BLSSignature(proof.getSignature());
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) return true;

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -705,7 +705,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             attestationManager,
             attesterSlashingPool,
             proposerSlashingPool,
-            voluntaryExitPool);
+            voluntaryExitPool,
+            syncCommitteeContributionPool);
     if (beaconConfig.beaconRestApiConfig().isRestApiEnabled()) {
 
       beaconRestAPI =


### PR DESCRIPTION
When in Altair, contribution_and_proof events are now able to be distributed in the rest api events.

fixes #4178

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
