### PR TITLE
Add jdk16 docker image and curl to docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Breaking Changes
 
 ### Additions and Improvements
+- Updated default docker image to Java 16.
+- Docker images now include `curl` to support adding health checks.
 
 ### Bug Fixes
 - Fixed `ConcurrentModificationException` in validator performance reporting.

--- a/build.gradle
+++ b/build.gradle
@@ -386,6 +386,7 @@ tasks.register("dockerDistUntar") {
 }
 
 def dockerVariants = [
+  "jdk16",
   "jdk15",
   "jdk14",
 ]

--- a/docker/jdk15/Dockerfile
+++ b/docker/jdk15/Dockerfile
@@ -1,5 +1,8 @@
 FROM openjdk:15-slim-buster
 
+RUN apt-get -y update
+RUN apt-get -y install curl
+RUN rm -rf /var/lib/api/lists/*
 RUN adduser --disabled-password --gecos "" --home /opt/teku teku && \
     chown teku:teku /opt/teku
 

--- a/docker/jdk16/Dockerfile
+++ b/docker/jdk16/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:14-slim-buster
+FROM openjdk:16-slim-buster
 
 RUN apt-get -y update
 RUN apt-get -y install curl


### PR DESCRIPTION
## PR Description
Adds curl to the existing docker images and a new jdk16 based docker image.

## Fixed Issue(s)
fixes #4181
fixes #4187 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
