### PR TITLE
Empty body should return bad request

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostAttesterSlashingIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostAttesterSlashingIntegrationTest.java
@@ -17,8 +17,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 
 import okhttp3.Response;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.schema.AttesterSlashing;
@@ -35,6 +37,12 @@ public class PostAttesterSlashingIntegrationTest extends AbstractDataBackedRestA
   @BeforeEach
   public void setup() {
     startRestAPIAtGenesis();
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenRequestBodyIsEmpty() throws Exception {
+    Response response = post(PostAttesterSlashing.ROUTE, jsonProvider.objectToJSON(""));
+    Assertions.assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
   }
 
   @Test

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostProposerSlashingIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostProposerSlashingIntegrationTest.java
@@ -17,8 +17,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 
 import okhttp3.Response;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.schema.ProposerSlashing;
@@ -35,6 +37,12 @@ public class PostProposerSlashingIntegrationTest extends AbstractDataBackedRestA
   @BeforeEach
   public void setup() {
     startRestAPIAtGenesis();
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenRequestBodyIsEmpty() throws Exception {
+    Response response = post(PostProposerSlashing.ROUTE, jsonProvider.objectToJSON(""));
+    Assertions.assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
   }
 
   @Test

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostVoluntaryExitIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostVoluntaryExitIntegrationTest.java
@@ -17,6 +17,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 
 import okhttp3.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +44,13 @@ public class PostVoluntaryExitIntegrationTest extends AbstractDataBackedRestAPII
   public void shouldReturnBadRequestWhenRequestBodyIsInvalid() throws Exception {
     Response response =
         post(PostVoluntaryExit.ROUTE, jsonProvider.objectToJSON("{\"foo\": \"bar\"}"));
-    assertThat(response.code()).isEqualTo(400);
+    assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenRequestBodyIsEmpty() throws Exception {
+    Response response = post(PostVoluntaryExit.ROUTE, jsonProvider.objectToJSON(""));
+    assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
   }
 
   @Test
@@ -54,7 +63,7 @@ public class PostVoluntaryExitIntegrationTest extends AbstractDataBackedRestAPII
     doThrow(new RuntimeException()).when(voluntaryExitPool).add(signedVoluntaryExit);
 
     Response response = post(PostVoluntaryExit.ROUTE, jsonProvider.objectToJSON(schemaExit));
-    assertThat(response.code()).isEqualTo(500);
+    assertThat(response.code()).isEqualTo(SC_INTERNAL_SERVER_ERROR);
   }
 
   @Test
@@ -71,6 +80,6 @@ public class PostVoluntaryExitIntegrationTest extends AbstractDataBackedRestAPII
 
     verify(voluntaryExitPool).add(signedVoluntaryExit);
 
-    assertThat(response.code()).isEqualTo(200);
+    assertThat(response.code()).isEqualTo(SC_OK);
   }
 }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostAttesterDutiesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostAttesterDutiesIntegrationTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.v1.validator;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+
+import java.io.IOException;
+import okhttp3.Response;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostAttesterDuties;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.sync.events.SyncState;
+
+public class PostAttesterDutiesIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
+
+  @Test
+  void shouldGiveDecentErrorIfNoBody() throws IOException {
+    startRestAPIAtGenesis(SpecMilestone.ALTAIR);
+
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+
+    Response response = post(PostAttesterDuties.ROUTE.replace(":epoch", "1"), "");
+
+    assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
+    assertThat(response.body().string()).contains("Could read request body to get required data.");
+  }
+}

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostSyncCommitteeSubscriptionsIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostSyncCommitteeSubscriptionsIntegrationTest.java
@@ -14,12 +14,14 @@
 package tech.pegasys.teku.beaconrestapi.v1.validator;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
 import java.io.IOException;
 import java.util.List;
 import okhttp3.Response;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
@@ -28,6 +30,14 @@ import tech.pegasys.teku.spec.SpecMilestone;
 
 public class PostSyncCommitteeSubscriptionsIntegrationTest
     extends AbstractDataBackedRestAPIIntegrationTest {
+
+  @Test
+  public void shouldReturnBadRequestWhenRequestBodyIsEmpty() throws Exception {
+    startRestAPIAtGenesis(SpecMilestone.ALTAIR);
+    Response response = post(PostSyncCommitteeSubscriptions.ROUTE, jsonProvider.objectToJSON(""));
+    Assertions.assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
+  }
+
   @Test
   void shouldPostSubscriptions() throws IOException {
     final List<SyncCommitteeSubnetSubscription> validators =

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostSyncDutiesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostSyncDutiesIntegrationTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.beaconrestapi.v1.validator;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
@@ -37,6 +38,15 @@ import tech.pegasys.teku.validator.api.SyncCommitteeDuty;
 
 public class PostSyncDutiesIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
   final List<Integer> validators = List.of(1);
+
+  @Test
+  public void shouldReturnBadRequestWhenRequestBodyIsEmpty() throws Exception {
+    startRestAPIAtGenesis(SpecMilestone.ALTAIR);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    Response response =
+        post(PostSyncDuties.ROUTE.replace(":epoch", "1"), jsonProvider.objectToJSON(""));
+    Assertions.assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
+  }
 
   @Test
   void shouldGetSyncCommitteeDuties() throws IOException {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandler.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
 import java.io.ByteArrayInputStream;
@@ -26,6 +27,15 @@ public abstract class AbstractHandler implements Handler {
 
   protected AbstractHandler(final JsonProvider jsonProvider) {
     this.jsonProvider = jsonProvider;
+  }
+
+  public <T> T parseRequestBody(String json, Class<T> clazz) {
+    try {
+      return jsonProvider.jsonToObject(json, clazz);
+    } catch (JsonProcessingException ex) {
+      throw new IllegalArgumentException(
+          "Could read request body to get required data. " + ex.getMessage());
+    }
   }
 
   protected <T> void handleOptionalResult(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandler.java
@@ -29,7 +29,7 @@ public abstract class AbstractHandler implements Handler {
     this.jsonProvider = jsonProvider;
   }
 
-  public <T> T parseRequestBody(String json, Class<T> clazz) {
+  protected <T> T parseRequestBody(String json, Class<T> clazz) {
     try {
       return jsonProvider.jsonToObject(json, clazz);
     } catch (JsonProcessingException ex) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/PutLogLevel.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/PutLogLevel.java
@@ -21,7 +21,6 @@ import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERRO
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_NO_CONTENT;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_TEKU;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
@@ -30,18 +29,17 @@ import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
 import tech.pegasys.teku.api.schema.LogLevel;
+import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfigurator;
 import tech.pegasys.teku.provider.JsonProvider;
 
-public class PutLogLevel implements Handler {
+public class PutLogLevel extends AbstractHandler implements Handler {
 
   public static final String ROUTE = "/teku/v1/admin/log_level";
 
-  private final JsonProvider jsonProvider;
-
   public PutLogLevel(final JsonProvider jsonProvider) {
-    this.jsonProvider = jsonProvider;
+    super(jsonProvider);
   }
 
   @OpenApi(
@@ -66,9 +64,8 @@ public class PutLogLevel implements Handler {
       })
   @Override
   public void handle(final Context ctx) throws Exception {
-
     try {
-      final LogLevel params = jsonProvider.jsonToObject(ctx.body(), LogLevel.class);
+      final LogLevel params = parseRequestBody(ctx.body(), LogLevel.class);
 
       final String[] logFilters = params.getLogFilter().orElseGet(() -> new String[] {""});
 
@@ -77,7 +74,7 @@ public class PutLogLevel implements Handler {
       }
 
       ctx.status(SC_NO_CONTENT);
-    } catch (final IllegalArgumentException | JsonMappingException e) {
+    } catch (final IllegalArgumentException e) {
       ctx.result(jsonProvider.objectToJSON(new BadRequest(e.getMessage())));
       ctx.status(SC_BAD_REQUEST);
     }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttestation.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttestation.java
@@ -22,7 +22,6 @@ import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_BEACON;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR_REQUIRED;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import io.javalin.http.Context;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
@@ -72,12 +71,11 @@ public class PostAttestation extends AbstractHandler {
   @Override
   public void handle(final Context ctx) throws Exception {
     try {
-      final String body = ctx.body();
       final List<Attestation> attestations =
-          Arrays.asList(jsonProvider.jsonToObject(body, Attestation[].class));
+          Arrays.asList(parseRequestBody(ctx.body(), Attestation[].class));
       provider.submitAttestations(attestations);
       ctx.status(SC_OK);
-    } catch (final IllegalArgumentException | JsonMappingException e) {
+    } catch (final IllegalArgumentException e) {
       ctx.result(BadRequest.badRequest(jsonProvider, e.getMessage()));
       ctx.status(SC_BAD_REQUEST);
     }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttesterSlashing.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttesterSlashing.java
@@ -72,7 +72,7 @@ public class PostAttesterSlashing extends AbstractHandler {
   public void handle(final Context ctx) throws Exception {
     try {
       final AttesterSlashing attesterSlashing =
-          jsonProvider.jsonToObject(ctx.body(), AttesterSlashing.class);
+          parseRequestBody(ctx.body(), AttesterSlashing.class);
       InternalValidationResult result =
           nodeDataProvider.postAttesterSlashing(attesterSlashing).join();
       if (result.code().equals(ValidationResultCode.IGNORE)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostProposerSlashing.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostProposerSlashing.java
@@ -72,7 +72,7 @@ public class PostProposerSlashing extends AbstractHandler {
   public void handle(final Context ctx) throws Exception {
     try {
       final ProposerSlashing proposerSlashing =
-          jsonProvider.jsonToObject(ctx.body(), ProposerSlashing.class);
+          parseRequestBody(ctx.body(), ProposerSlashing.class);
       InternalValidationResult result =
           nodeDataProvider.postProposerSlashing(proposerSlashing).join();
       if (result.code().equals(ValidationResultCode.IGNORE)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostSyncCommittees.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostSyncCommittees.java
@@ -22,7 +22,6 @@ import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.base.Throwables;
 import io.javalin.http.Context;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
@@ -84,9 +83,8 @@ public class PostSyncCommittees extends AbstractHandler {
   @Override
   public void handle(final Context ctx) throws Exception {
     try {
-      final String body = ctx.body();
       final List<SyncCommitteeMessage> messages =
-          Arrays.asList(jsonProvider.jsonToObject(body, SyncCommitteeMessage[].class));
+          Arrays.asList(parseRequestBody(ctx.body(), SyncCommitteeMessage[].class));
       final SafeFuture<SubmitCommitteeMessagesResult> future =
           provider.submitCommitteeSignatures(messages);
 
@@ -95,7 +93,7 @@ public class PostSyncCommittees extends AbstractHandler {
               .thenApplyChecked(response -> handleResult(ctx, response))
               .exceptionallyCompose(error -> handleError(ctx, error)));
 
-    } catch (final IllegalArgumentException | JsonMappingException e) {
+    } catch (final IllegalArgumentException e) {
       ctx.result(BadRequest.badRequest(jsonProvider, e.getMessage()));
       ctx.status(SC_BAD_REQUEST);
     }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostVoluntaryExit.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostVoluntaryExit.java
@@ -71,8 +71,7 @@ public class PostVoluntaryExit extends AbstractHandler {
   @Override
   public void handle(final Context ctx) throws Exception {
     try {
-      final SignedVoluntaryExit exit =
-          jsonProvider.jsonToObject(ctx.body(), SignedVoluntaryExit.class);
+      final SignedVoluntaryExit exit = parseRequestBody(ctx.body(), SignedVoluntaryExit.class);
       InternalValidationResult result = nodeDataProvider.postVoluntaryExit(exit).join();
       if (result.code().equals(ValidationResultCode.IGNORE)
           || result.code().equals(ValidationResultCode.REJECT)) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAggregateAndProofs.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAggregateAndProofs.java
@@ -14,15 +14,14 @@
 package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
 import static java.util.Arrays.asList;
-import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR_REQUIRED;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
@@ -33,15 +32,15 @@ import io.javalin.plugin.openapi.annotations.OpenApiResponse;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
+import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.provider.JsonProvider;
 
-public class PostAggregateAndProofs implements Handler {
+public class PostAggregateAndProofs extends AbstractHandler implements Handler {
 
   public static final String ROUTE = "/eth/v1/validator/aggregate_and_proofs";
 
   private final ValidatorDataProvider provider;
-  private final JsonProvider jsonProvider;
 
   public PostAggregateAndProofs(final DataProvider provider, final JsonProvider jsonProvider) {
     this(provider.getValidatorDataProvider(), jsonProvider);
@@ -49,7 +48,7 @@ public class PostAggregateAndProofs implements Handler {
 
   public PostAggregateAndProofs(
       final ValidatorDataProvider provider, final JsonProvider jsonProvider) {
-    this.jsonProvider = jsonProvider;
+    super(jsonProvider);
     this.provider = provider;
   }
 
@@ -72,12 +71,12 @@ public class PostAggregateAndProofs implements Handler {
   public void handle(Context ctx) throws Exception {
     try {
       final SignedAggregateAndProof[] signedAggregateAndProofs =
-          jsonProvider.jsonToObject(ctx.body(), SignedAggregateAndProof[].class);
+          parseRequestBody(ctx.body(), SignedAggregateAndProof[].class);
 
       provider.sendAggregateAndProofs(asList(signedAggregateAndProofs));
       ctx.status(SC_OK);
-    } catch (final JsonMappingException e) {
-      ctx.result(jsonProvider.objectToJSON(new BadRequest(e.getMessage())));
+    } catch (IllegalArgumentException e) {
+      ctx.result(BadRequest.badRequest(jsonProvider, e.getMessage()));
       ctx.status(SC_BAD_REQUEST);
     }
   }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
@@ -113,7 +113,7 @@ public class PostAttesterDuties extends AbstractHandler implements Handler {
     final Map<String, String> parameters = ctx.pathParamMap();
     try {
       final UInt64 epoch = UInt64.valueOf(parameters.get(EPOCH));
-      final UInt64[] indexes = jsonProvider.jsonToObject(ctx.body(), UInt64[].class);
+      final UInt64[] indexes = parseRequestBody(ctx.body(), UInt64[].class);
 
       SafeFuture<Optional<PostAttesterDutiesResponse>> future =
           validatorDataProvider.getAttesterDuties(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostContributionAndProofs.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostContributionAndProofs.java
@@ -76,8 +76,8 @@ public class PostContributionAndProofs extends AbstractHandler implements Handle
     final SignedContributionAndProof[] signedContributionAndProofs;
     try {
       signedContributionAndProofs =
-        parseRequestBody(ctx.body(), SignedContributionAndProof[].class);
-    } catch(IllegalArgumentException e) {
+          parseRequestBody(ctx.body(), SignedContributionAndProof[].class);
+    } catch (IllegalArgumentException e) {
       ctx.result(BadRequest.badRequest(jsonProvider, e.getMessage()));
       ctx.status(HttpStatusCodes.SC_BAD_REQUEST);
       return;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostContributionAndProofs.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostContributionAndProofs.java
@@ -20,7 +20,6 @@ import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERRO
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_EXPERIMENTAL;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.base.Throwables;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
@@ -33,16 +32,16 @@ import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
 import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
+import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.provider.JsonProvider;
 
-public class PostContributionAndProofs implements Handler {
+public class PostContributionAndProofs extends AbstractHandler implements Handler {
 
   public static final String ROUTE = "/eth/v1/validator/contribution_and_proofs";
 
   private final ValidatorDataProvider provider;
-  private final JsonProvider jsonProvider;
 
   public PostContributionAndProofs(final DataProvider provider, final JsonProvider jsonProvider) {
     this(provider.getValidatorDataProvider(), jsonProvider);
@@ -50,8 +49,8 @@ public class PostContributionAndProofs implements Handler {
 
   public PostContributionAndProofs(
       final ValidatorDataProvider provider, final JsonProvider jsonProvider) {
+    super(jsonProvider);
     this.provider = provider;
-    this.jsonProvider = jsonProvider;
   }
 
   @OpenApi(
@@ -73,21 +72,15 @@ public class PostContributionAndProofs implements Handler {
       })
   @Override
   public void handle(@NotNull final Context ctx) throws Exception {
-    try {
-      final SignedContributionAndProof[] signedContributionAndProofs =
-          jsonProvider.jsonToObject(ctx.body(), SignedContributionAndProof[].class);
+    final SignedContributionAndProof[] signedContributionAndProofs =
+        parseRequestBody(ctx.body(), SignedContributionAndProof[].class);
+    final SafeFuture<Void> future =
+        provider.sendContributionAndProofs(asList(signedContributionAndProofs));
 
-      final SafeFuture<Void> future =
-          provider.sendContributionAndProofs(asList(signedContributionAndProofs));
-
-      ctx.result(
-          future
-              .thenApplyChecked(result -> "")
-              .exceptionallyCompose(error -> handleError(ctx, error)));
-    } catch (final JsonMappingException e) {
-      ctx.result(jsonProvider.objectToJSON(new BadRequest(e.getMessage())));
-      ctx.status(SC_BAD_REQUEST);
-    }
+    ctx.result(
+        future
+            .thenApplyChecked(result -> "")
+            .exceptionallyCompose(error -> handleError(ctx, error)));
   }
 
   private SafeFuture<String> handleError(final Context ctx, final Throwable error) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostContributionAndProofs.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostContributionAndProofs.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
 import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.http.HttpStatusCodes;
 import tech.pegasys.teku.provider.JsonProvider;
 
 public class PostContributionAndProofs extends AbstractHandler implements Handler {
@@ -72,8 +73,15 @@ public class PostContributionAndProofs extends AbstractHandler implements Handle
       })
   @Override
   public void handle(@NotNull final Context ctx) throws Exception {
-    final SignedContributionAndProof[] signedContributionAndProofs =
+    final SignedContributionAndProof[] signedContributionAndProofs;
+    try {
+      signedContributionAndProofs =
         parseRequestBody(ctx.body(), SignedContributionAndProof[].class);
+    } catch(IllegalArgumentException e) {
+      ctx.result(BadRequest.badRequest(jsonProvider, e.getMessage()));
+      ctx.status(HttpStatusCodes.SC_BAD_REQUEST);
+      return;
+    }
     final SafeFuture<Void> future =
         provider.sendContributionAndProofs(asList(signedContributionAndProofs));
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSubscribeToBeaconCommitteeSubnet.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSubscribeToBeaconCommitteeSubnet.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
 import static java.util.Arrays.asList;
-import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_INTERNAL_ERROR;
@@ -23,8 +22,8 @@ import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_SERVICE_UNAVA
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_VALIDATOR_REQUIRED;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import io.javalin.http.Context;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
@@ -80,13 +79,13 @@ public class PostSubscribeToBeaconCommitteeSubnet extends AbstractHandler {
   public void handle(final Context ctx) throws Exception {
     try {
       final BeaconCommitteeSubscriptionRequest[] request =
-          jsonProvider.jsonToObject(ctx.body(), BeaconCommitteeSubscriptionRequest[].class);
+          parseRequestBody(ctx.body(), BeaconCommitteeSubscriptionRequest[].class);
 
       provider.subscribeToBeaconCommittee(asList(request));
       ctx.status(SC_OK);
-    } catch (final JsonMappingException e) {
-      ctx.status(SC_BAD_REQUEST);
+    } catch (IllegalArgumentException e) {
       ctx.result(BadRequest.badRequest(jsonProvider, e.getMessage()));
+      ctx.status(SC_BAD_REQUEST);
     }
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncCommitteeSubscriptions.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncCommitteeSubscriptions.java
@@ -20,7 +20,6 @@ import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_EXPERIMENTAL;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import io.javalin.http.Context;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
@@ -69,12 +68,11 @@ public class PostSyncCommitteeSubscriptions extends AbstractHandler {
   @Override
   public void handle(@NotNull final Context ctx) throws Exception {
     try {
-      final String body = ctx.body();
       final List<SyncCommitteeSubnetSubscription> subscriptions =
-          Arrays.asList(jsonProvider.jsonToObject(body, SyncCommitteeSubnetSubscription[].class));
+          Arrays.asList(parseRequestBody(ctx.body(), SyncCommitteeSubnetSubscription[].class));
       provider.subscribeToSyncCommitteeSubnets(subscriptions);
       ctx.status(SC_OK);
-    } catch (final IllegalArgumentException | JsonMappingException e) {
+    } catch (final IllegalArgumentException e) {
       ctx.result(BadRequest.badRequest(jsonProvider, e.getMessage()));
       ctx.status(SC_BAD_REQUEST);
     }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncDuties.java
@@ -99,8 +99,7 @@ public class PostSyncDuties extends AbstractHandler implements Handler {
     final Map<String, String> parameters = ctx.pathParamMap();
     try {
       final UInt64 epoch = UInt64.valueOf(parameters.get(EPOCH));
-      final List<Integer> indexes =
-          Arrays.asList(jsonProvider.jsonToObject(ctx.body(), Integer[].class));
+      final List<Integer> indexes = Arrays.asList(parseRequestBody(ctx.body(), Integer[].class));
 
       SafeFuture<Optional<PostSyncDutiesResponse>> future =
           validatorDataProvider.getSyncDuties(epoch, indexes);


### PR DESCRIPTION
When an empty body is received for an endpoint requiring a body of data, a bad request should be the result, rather than a 500 error.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
