### PR TITLE
use event topics to show contribution gossip

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -27,4 +27,5 @@ dependencies {
   testFixturesImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   testFixturesImplementation 'org.web3j:core'
   testFixturesImplementation 'org.apache.logging.log4j:log4j-core'
+  testFixturesImplementation 'com.launchdarkly:okhttp-eventsource'
 }

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
   acceptanceTestImplementation project(":bls")
   acceptanceTestImplementation project(':infrastructure:time')
-  acceptanceTestImplementation project(':data:serializer')
 
   testFixturesImplementation project(':bls')
   testFixturesImplementation project(':data:provider')

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
   acceptanceTestImplementation project(":bls")
   acceptanceTestImplementation project(':infrastructure:time')
+  acceptanceTestImplementation project(':data:serializer')
 
   testFixturesImplementation project(':bls')
   testFixturesImplementation project(':data:provider')

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
   acceptanceTestImplementation project(":bls")
   acceptanceTestImplementation project(':infrastructure:time')
+  acceptanceTestImplementation project(':data:serializer')
 
   testFixturesImplementation project(':bls')
   testFixturesImplementation project(':data:provider')
-  testFixturesImplementation project(':data:serializer')
   testFixturesImplementation project(':ethereum:spec')
   testFixturesImplementation testFixtures(project(':ethereum:spec'))
   testFixturesImplementation project(':ethereum:networks')

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 
   testFixturesImplementation project(':bls')
   testFixturesImplementation project(':data:provider')
+  testFixturesImplementation project(':data:serializer')
   testFixturesImplementation project(':ethereum:spec')
   testFixturesImplementation testFixtures(project(':ethereum:spec'))
   testFixturesImplementation project(':ethereum:networks')

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SyncCommitteeGossipAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SyncCommitteeGossipAcceptanceTest.java
@@ -73,14 +73,14 @@ public class SyncCommitteeGossipAcceptanceTest extends AcceptanceTestBase {
 
     // primary node has validators 1-7, expect gossip from aggregators 8-15 coming through
     assertThat(
-            primaryNode.getContributionAndProofEvents().stream()
-                .filter(proof -> proof.message.aggregatorIndex.isGreaterThanOrEqualTo(8))
+            primaryNode.getContributionAndProofAggregators().stream()
+                .filter(aggregatorIndex -> aggregatorIndex.isGreaterThanOrEqualTo(8))
                 .count())
         .isGreaterThan(0);
     // secondary node has remote validators 8-15, expect gossip from aggregators 1-7
     assertThat(
-            secondaryNode.getContributionAndProofEvents().stream()
-                .filter(proof -> proof.message.aggregatorIndex.isLessThan(8))
+            secondaryNode.getContributionAndProofAggregators().stream()
+                .filter(aggregatorIndex -> aggregatorIndex.isLessThan(8))
                 .count())
         .isGreaterThan(0);
   }

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SyncCommitteeGossipAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SyncCommitteeGossipAcceptanceTest.java
@@ -73,14 +73,14 @@ public class SyncCommitteeGossipAcceptanceTest extends AcceptanceTestBase {
 
     // primary node has validators 1-7, expect gossip from aggregators 8-15 coming through
     assertThat(
-            primaryNode.getContributionAndProofAggregators().stream()
-                .filter(aggregatorIndex -> aggregatorIndex.isGreaterThanOrEqualTo(8))
+            primaryNode.getContributionAndProofEvents().stream()
+                .filter(proof -> proof.message.aggregatorIndex.isGreaterThanOrEqualTo(8))
                 .count())
         .isGreaterThan(0);
     // secondary node has remote validators 8-15, expect gossip from aggregators 1-7
     assertThat(
-            secondaryNode.getContributionAndProofAggregators().stream()
-                .filter(aggregatorIndex -> aggregatorIndex.isLessThan(8))
+            secondaryNode.getContributionAndProofEvents().stream()
+                .filter(proof -> proof.message.aggregatorIndex.isLessThan(8))
                 .count())
         .isGreaterThan(0);
   }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Eth2EventHandler.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Eth2EventHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.test.acceptance.dsl;
+
+import com.launchdarkly.eventsource.EventHandler;
+import com.launchdarkly.eventsource.MessageEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Eth2EventHandler implements EventHandler {
+  private final List<PackedMessage> eventList = new ArrayList<>();
+
+  @Override
+  public void onOpen() {}
+
+  @Override
+  public void onClosed() {}
+
+  @Override
+  public void onMessage(final String event, final MessageEvent messageEvent) {
+    eventList.add(new PackedMessage(event, messageEvent));
+  }
+
+  public List<PackedMessage> getMessages() {
+    return eventList;
+  }
+
+  @Override
+  public void onComment(final String comment) {}
+
+  @Override
+  public void onError(final Throwable t) {}
+
+  public static class PackedMessage {
+    private String event;
+    private MessageEvent messageEvent;
+
+    public PackedMessage(final String event, final MessageEvent messageEvent) {
+      this.event = event;
+      this.messageEvent = messageEvent;
+    }
+
+    public String getEvent() {
+      return event;
+    }
+
+    public MessageEvent getMessageEvent() {
+      return messageEvent;
+    }
+  }
+}

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/EventStreamListener.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/EventStreamListener.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.test.acceptance.dsl;
+
+import com.launchdarkly.eventsource.EventSource;
+import java.net.URI;
+import java.util.List;
+
+public class EventStreamListener {
+  EventSource eventSource;
+  final Eth2EventHandler handler = new Eth2EventHandler();
+
+  public EventStreamListener(final String url) {
+    eventSource = new EventSource.Builder(handler, URI.create(url)).build();
+    eventSource.start();
+  }
+
+  public List<Eth2EventHandler.PackedMessage> getMessages() {
+    return handler.getMessages();
+  }
+
+  public void close() {
+    eventSource.close();
+  }
+}

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -140,7 +140,7 @@ public class TekuNode extends Node {
     maybeEventStreamListener = Optional.of(new EventStreamListener(getEventUrl(eventTypes)));
   }
 
-  public List<SignedContributionAndProof> getContributionAndProofEvents() {
+  public List<UInt64> getContributionAndProofAggregators() {
     if (maybeEventStreamListener.isEmpty()) {
       return Collections.emptyList();
     }
@@ -150,6 +150,7 @@ public class TekuNode extends Node {
                 packedMessage.getEvent().equals(EventType.contribution_and_proof.name()))
         .map(this::optionalProof)
         .flatMap(Optional::stream)
+        .map(proof -> proof.message.aggregatorIndex)
         .collect(Collectors.toList());
   }
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.libp2p.core.PeerId;
 import io.libp2p.core.crypto.KEY_TYPE;
 import io.libp2p.core.crypto.KeyKt;
@@ -31,6 +32,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +50,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.MountableFile;
+import tech.pegasys.teku.api.response.v1.EventType;
 import tech.pegasys.teku.api.response.v1.beacon.FinalityCheckpointsResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetBlockRootResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
@@ -57,6 +60,7 @@ import tech.pegasys.teku.api.response.v2.beacon.GetBlockResponseV2;
 import tech.pegasys.teku.api.schema.BeaconState;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
+import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
 import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
@@ -75,6 +79,7 @@ public class TekuNode extends Node {
   private final Config config;
   private final JsonProvider jsonProvider = new JsonProvider();
   private final Spec spec;
+  private Optional<EventStreamListener> maybeEventStreamListener;
 
   private boolean started = false;
   private Set<File> configFiles;
@@ -131,6 +136,34 @@ public class TekuNode extends Node {
     container.start();
   }
 
+  public void startEventListener(final List<EventType> eventTypes) {
+    maybeEventStreamListener = Optional.of(new EventStreamListener(getEventUrl(eventTypes)));
+  }
+
+  public List<SignedContributionAndProof> getContributionAndProofEvents() {
+    if (maybeEventStreamListener.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return maybeEventStreamListener.get().getMessages().stream()
+        .filter(
+            packedMessage ->
+                packedMessage.getEvent().equals(EventType.contribution_and_proof.name()))
+        .map(this::optionalProof)
+        .flatMap(Optional::stream)
+        .collect(Collectors.toList());
+  }
+
+  private Optional<SignedContributionAndProof> optionalProof(
+      final Eth2EventHandler.PackedMessage packedMessage) {
+    try {
+      return Optional.of(
+          jsonProvider.jsonToObject(
+              packedMessage.getMessageEvent().getData(), SignedContributionAndProof.class));
+    } catch (JsonProcessingException e) {
+      return Optional.empty();
+    }
+  }
+
   public void waitForGenesis() {
     LOG.debug("Wait for genesis");
     waitFor(this::fetchGenesisTime);
@@ -138,6 +171,15 @@ public class TekuNode extends Node {
 
   public void waitForGenesisTime(final UInt64 expectedGenesisTime) {
     waitFor(() -> assertThat(fetchGenesisTime()).isEqualTo(expectedGenesisTime));
+  }
+
+  private String getEventUrl(List<EventType> events) {
+    String eventTypes = "";
+    if (events.size() > 0) {
+      eventTypes =
+          "?topics=" + events.stream().map(EventType::name).collect(Collectors.joining(","));
+    }
+    return getRestApiUrl() + "/eth/v1/events" + eventTypes;
   }
 
   private UInt64 fetchGenesisTime() throws IOException {
@@ -425,6 +467,7 @@ public class TekuNode extends Node {
       return;
     }
     LOG.debug("Shutting down");
+    maybeEventStreamListener.ifPresent(EventStreamListener::close);
     configFiles.forEach(
         configFile -> {
           if (!configFile.delete() && configFile.exists()) {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -79,7 +79,7 @@ public class TekuNode extends Node {
   private final Config config;
   private final JsonProvider jsonProvider = new JsonProvider();
   private final Spec spec;
-  private Optional<EventStreamListener> maybeEventStreamListener;
+  private Optional<EventStreamListener> maybeEventStreamListener = Optional.empty();
 
   private boolean started = false;
   private Set<File> configFiles;

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -140,7 +140,7 @@ public class TekuNode extends Node {
     maybeEventStreamListener = Optional.of(new EventStreamListener(getEventUrl(eventTypes)));
   }
 
-  public List<UInt64> getContributionAndProofAggregators() {
+  public List<SignedContributionAndProof> getContributionAndProofEvents() {
     if (maybeEventStreamListener.isEmpty()) {
       return Collections.emptyList();
     }
@@ -150,7 +150,6 @@ public class TekuNode extends Node {
                 packedMessage.getEvent().equals(EventType.contribution_and_proof.name()))
         .map(this::optionalProof)
         .flatMap(Optional::stream)
-        .map(proof -> proof.message.aggregatorIndex)
         .collect(Collectors.toList());
   }
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -21,7 +21,7 @@ dependencyManagement {
     dependency 'com.googlecode.json-simple:json-simple:1.1.1'
     dependency 'org.jsoup:jsoup:1.13.1'
 
-    dependency 'com.launchdarkly:okhttp-eventsource:2.3.1'
+    dependency 'com.launchdarkly:okhttp-eventsource:2.3.2'
     
     dependency 'com.squareup.okhttp3:okhttp:4.8.1'
     dependency 'com.squareup.okhttp3:mockwebserver:4.8.1'


### PR DESCRIPTION
Now that there is a contribution_and_proof http event, listen for it during an acceptance test to show that contribution_and_proof objects are coming from validators remote to the beacon node, indicating that the contributions are being successfully gossipped.

fixes #4191

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
