### PR TITLE
Fix potential race condition in DefaultPerformanceTracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ For information on changes in released versions of Teku, see the [releases page]
 - Docker images now include `curl` to support adding health checks.
 
 ### Bug Fixes
-- Fixed `ConcurrentModificationException` in validator performance reporting.
-- Upgraded the discovery library, providing better memory management and standards compliance. 
+- Fixed `ConcurrentModificationException` and `NoSuchElementException` in validator performance reporting.
+- Upgraded the discovery library, providing better memory management and standards compliance.
 
 ### Experimental: New Altair REST APIs
 - implement POST `/eth/v1/beacon/pool/sync_committees` to allow validators to submit sync committee signatures to the beacon node.

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -74,7 +74,7 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
   private final SyncCommitteePerformanceTracker syncCommitteePerformanceTracker;
   private final Spec spec;
 
-  private Optional<UInt64> nodeStartEpoch = Optional.empty();
+  private volatile Optional<UInt64> nodeStartEpoch = Optional.empty();
   private final AtomicReference<UInt64> latestAnalyzedEpoch = new AtomicReference<>(UInt64.ZERO);
 
   public DefaultPerformanceTracker(
@@ -101,6 +101,8 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
 
   @Override
   public void onSlot(UInt64 slot) {
+    // Ensure a consistent view as the field is volatile.
+    final Optional<UInt64> nodeStartEpoch = this.nodeStartEpoch;
     if (nodeStartEpoch.isEmpty()) {
       return;
     }


### PR DESCRIPTION
## PR Description
start is called from a different thread to onSlot so need to ensure a consistent view of nodeStartEpoch. Most of the time we'd get away with it but sometimes it's possible for the method to start on one CPU and pass the `nodeStartEpoch.isEmpty` check and enter the main logic in the method but to then wind up on a different core and see an empty value for `nodeStartEpoch` (no memory barrier means no ordering guarantees).

Making `nodeStartEpoch` volatile and using a consistent immutable reference to it inserts the required memory barriers and avoids the race condition.

## Fixed Issue(s)
fixes #4200

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
