### PR TITLE
Add development option to disable early attestation production.

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -81,11 +81,21 @@ public class ValidatorOptions {
       names = {"--Xvalidators-dependent-root-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
-          "Invalidate validator duties based on the dependent root information instead of chain re-org events. Default: false",
+          "Invalidate validator duties based on the dependent root information instead of chain re-org events. Default: true",
       hidden = true,
       fallbackValue = "true",
       arity = "0..1")
   private boolean useDependentRoots = true;
+
+  @Option(
+      names = {"--Xvalidators-early-attestations-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description =
+          "Generate attestations as soon as a block is known, rather than delaying until the attestation is due. Default: true",
+      hidden = true,
+      fallbackValue = "true",
+      arity = "0..1")
+  private boolean generateEarlyAttestations = true;
 
   public void configure(TekuConfiguration.Builder builder) {
     if (validatorPerformanceTrackingEnabled != null) {
@@ -107,7 +117,8 @@ public class ValidatorOptions {
                     .graffitiProvider(
                         new FileBackedGraffitiProvider(
                             Optional.ofNullable(graffiti), Optional.ofNullable(graffitiFile)))
-                    .useDependentRoots(useDependentRoots))
+                    .useDependentRoots(useDependentRoots)
+                    .generateEarlyAttestations(generateEarlyAttestations))
         // We don't need to update head for empty slots when using dependent roots
         .store(b -> b.updateHeadForEmptySlots(!useDependentRoots));
     validatorKeysOptions.configure(builder);

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -452,7 +452,8 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                     .validatorKeystoreLockingEnabled(true)
                     .validatorPerformanceTrackingMode(ValidatorPerformanceTrackingMode.ALL)
                     .graffitiProvider(new FileBackedGraffitiProvider())
-                    .useDependentRoots(true))
+                    .useDependentRoots(true)
+                    .generateEarlyAttestations(true))
         .logging(
             b ->
                 b.colorEnabled(true)

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -142,7 +142,7 @@ public class ValidatorConfig {
     return processor.getFilePairs();
   }
 
-  public boolean isGenerateEarlyAttestations() {
+  public boolean generateEarlyAttestations() {
     return generateEarlyAttestations;
   }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -41,6 +41,7 @@ public class ValidatorConfig {
   private final Optional<URI> beaconNodeApiEndpoint;
   private final int validatorExternalSignerConcurrentRequestLimit;
   private final boolean useDependentRoots;
+  private final boolean generateEarlyAttestations;
 
   private ValidatorConfig(
       final List<String> validatorKeys,
@@ -57,7 +58,8 @@ public class ValidatorConfig {
       final boolean validatorKeystoreLockingEnabled,
       final boolean validatorExternalSignerSlashingProtectionEnabled,
       final int validatorExternalSignerConcurrentRequestLimit,
-      final boolean useDependentRoots) {
+      final boolean useDependentRoots,
+      final boolean generateEarlyAttestations) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
     this.validatorExternalSignerUrl = validatorExternalSignerUrl;
@@ -76,6 +78,7 @@ public class ValidatorConfig {
     this.validatorExternalSignerConcurrentRequestLimit =
         validatorExternalSignerConcurrentRequestLimit;
     this.useDependentRoots = useDependentRoots;
+    this.generateEarlyAttestations = generateEarlyAttestations;
   }
 
   public static Builder builder() {
@@ -139,6 +142,10 @@ public class ValidatorConfig {
     return processor.getFilePairs();
   }
 
+  public boolean isGenerateEarlyAttestations() {
+    return generateEarlyAttestations;
+  }
+
   public boolean useDependentRoots() {
     return useDependentRoots;
   }
@@ -160,6 +167,7 @@ public class ValidatorConfig {
     private Optional<URI> beaconNodeApiEndpoint = Optional.empty();
     private boolean validatorExternalSignerSlashingProtectionEnabled = true;
     private boolean useDependentRoots = false;
+    private boolean generateEarlyAttestations = true;
 
     private Builder() {}
 
@@ -248,6 +256,11 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder generateEarlyAttestations(final boolean generateEarlyAttestations) {
+      this.generateEarlyAttestations = generateEarlyAttestations;
+      return this;
+    }
+
     public ValidatorConfig build() {
       validateExternalSignerUrlAndPublicKeys();
       validateExternalSignerKeystoreAndPasswordFileConfig();
@@ -268,7 +281,8 @@ public class ValidatorConfig {
           validatorKeystoreLockingEnabled,
           validatorExternalSignerSlashingProtectionEnabled,
           validatorExternalSignerConcurrentRequestLimit,
-          useDependentRoots);
+          useDependentRoots,
+          generateEarlyAttestations);
     }
 
     private void validateExternalSignerUrlAndPublicKeys() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -83,7 +83,7 @@ public class ValidatorClientService extends Service {
     final AsyncRunner asyncRunner = services.createAsyncRunner("validator");
     final boolean useDependentRoots = config.getValidatorConfig().useDependentRoots();
     final boolean generateEarlyAttestations =
-        config.getValidatorConfig().isGenerateEarlyAttestations();
+        config.getValidatorConfig().generateEarlyAttestations();
     final BeaconNodeApi beaconNodeApi =
         config
             .getValidatorConfig()

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -91,7 +91,12 @@ public class ValidatorClientService extends Service {
             .map(
                 endpoint ->
                     RemoteBeaconNodeApi.create(
-                        services, asyncRunner, endpoint, config.getSpec(), useDependentRoots, generateEarlyAttestations))
+                        services,
+                        asyncRunner,
+                        endpoint,
+                        config.getSpec(),
+                        useDependentRoots,
+                        generateEarlyAttestations))
             .orElseGet(
                 () ->
                     InProcessBeaconNodeApi.create(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -82,6 +82,8 @@ public class ValidatorClientService extends Service {
     final EventChannels eventChannels = services.getEventChannels();
     final AsyncRunner asyncRunner = services.createAsyncRunner("validator");
     final boolean useDependentRoots = config.getValidatorConfig().useDependentRoots();
+    final boolean generateEarlyAttestations =
+        config.getValidatorConfig().isGenerateEarlyAttestations();
     final BeaconNodeApi beaconNodeApi =
         config
             .getValidatorConfig()
@@ -89,11 +91,15 @@ public class ValidatorClientService extends Service {
             .map(
                 endpoint ->
                     RemoteBeaconNodeApi.create(
-                        services, asyncRunner, endpoint, config.getSpec(), useDependentRoots))
+                        services, asyncRunner, endpoint, config.getSpec(), useDependentRoots, generateEarlyAttestations))
             .orElseGet(
                 () ->
                     InProcessBeaconNodeApi.create(
-                        services, asyncRunner, useDependentRoots, config.getSpec()));
+                        services,
+                        asyncRunner,
+                        useDependentRoots,
+                        generateEarlyAttestations,
+                        config.getSpec()));
     final ValidatorApiChannel validatorApiChannel = beaconNodeApi.getValidatorApi();
     final GenesisDataProvider genesisDataProvider =
         new GenesisDataProvider(asyncRunner, validatorApiChannel);

--- a/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/InProcessBeaconNodeApi.java
+++ b/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/InProcessBeaconNodeApi.java
@@ -44,6 +44,7 @@ public class InProcessBeaconNodeApi implements BeaconNodeApi {
       final ServiceConfig services,
       final AsyncRunner asyncRunner,
       final boolean useIndependentAttestationTiming,
+      final boolean generateEarlyAttestations,
       final Spec spec) {
     final MetricsSystem metricsSystem = services.getMetricsSystem();
     final EventChannels eventChannels = services.getEventChannels();
@@ -62,7 +63,10 @@ public class InProcessBeaconNodeApi implements BeaconNodeApi {
             spec);
     final BeaconChainEventAdapter beaconChainEventAdapter =
         new IndependentTimerEventChannelEventAdapter(
-            eventChannels, timeBasedEventAdapter, validatorTimingChannel);
+            eventChannels,
+            generateEarlyAttestations,
+            timeBasedEventAdapter,
+            validatorTimingChannel);
     return new InProcessBeaconNodeApi(validatorApiChannel, beaconChainEventAdapter);
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/EventSourceBeaconChainEventAdapter.java
@@ -43,7 +43,8 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
       final OkHttpClient okHttpClient,
       final BeaconChainEventAdapter timeBasedEventAdapter,
       final ValidatorTimingChannel validatorTimingChannel,
-      final MetricsSystem metricsSystem) {
+      final MetricsSystem metricsSystem,
+      final boolean generateEarlyAttestations) {
     this.timeBasedEventAdapter = timeBasedEventAdapter;
     final HttpUrl eventSourceUrl =
         baseEndpoint.resolve(
@@ -54,7 +55,7 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
                 + EventType.chain_reorg);
     this.eventSource =
         new EventSource.Builder(
-                new EventSourceHandler(validatorTimingChannel, metricsSystem), eventSourceUrl)
+                new EventSourceHandler(validatorTimingChannel, metricsSystem, generateEarlyAttestations), eventSourceUrl)
             .maxReconnectTime(Duration.ofSeconds(Constants.SECONDS_PER_SLOT))
             .client(okHttpClient)
             .requestTransformer(request -> applyBasicAuthentication(eventSourceUrl, request))

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/EventSourceBeaconChainEventAdapter.java
@@ -55,7 +55,9 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
                 + EventType.chain_reorg);
     this.eventSource =
         new EventSource.Builder(
-                new EventSourceHandler(validatorTimingChannel, metricsSystem, generateEarlyAttestations), eventSourceUrl)
+                new EventSourceHandler(
+                    validatorTimingChannel, metricsSystem, generateEarlyAttestations),
+                eventSourceUrl)
             .maxReconnectTime(Duration.ofSeconds(Constants.SECONDS_PER_SLOT))
             .client(okHttpClient)
             .requestTransformer(request -> applyBasicAuthentication(eventSourceUrl, request))

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/EventSourceHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/EventSourceHandler.java
@@ -42,9 +42,12 @@ class EventSourceHandler implements EventHandler {
   private final Counter invalidEventCounter;
   private final Counter timeoutCounter;
   private final Counter errorCounter;
+  private final boolean generateEarlyAttestations;
 
   public EventSourceHandler(
-      final ValidatorTimingChannel validatorTimingChannel, final MetricsSystem metricsSystem) {
+      final ValidatorTimingChannel validatorTimingChannel,
+      final MetricsSystem metricsSystem,
+      final boolean generateEarlyAttestations) {
     this.validatorTimingChannel = validatorTimingChannel;
     invalidEventCounter =
         metricsSystem.createCounter(
@@ -61,6 +64,7 @@ class EventSourceHandler implements EventHandler {
     disconnectCounter = eventSourceMetrics.labels("disconnect");
     timeoutCounter = eventSourceMetrics.labels("timeout");
     errorCounter = eventSourceMetrics.labels("error");
+    this.generateEarlyAttestations = generateEarlyAttestations;
   }
 
   @Override
@@ -107,7 +111,9 @@ class EventSourceHandler implements EventHandler {
         headEvent.previousDutyDependentRoot,
         headEvent.currentDutyDependentRoot,
         headEvent.block);
-    validatorTimingChannel.onAttestationCreationDue(headEvent.slot);
+    if (generateEarlyAttestations) {
+      validatorTimingChannel.onAttestationCreationDue(headEvent.slot);
+    }
   }
 
   private void handleChainReorgEvent(final MessageEvent messageEvent)

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -51,7 +51,8 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
       final AsyncRunner asyncRunner,
       final URI beaconNodeApiEndpoint,
       final Spec spec,
-      final boolean useIndependentAttestationTiming) {
+      final boolean useIndependentAttestationTiming,
+      final boolean generateEarlyAttestations) {
 
     final int readTimeoutInSeconds = getReadTimeoutInSeconds(spec, useIndependentAttestationTiming);
     final OkHttpClient.Builder httpClientBuilder =
@@ -84,7 +85,8 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
                 useIndependentAttestationTiming,
                 spec),
             validatorTimingChannel,
-            serviceConfig.getMetricsSystem());
+            serviceConfig.getMetricsSystem(),
+            generateEarlyAttestations);
 
     return new RemoteBeaconNodeApi(beaconChainEventAdapter, validatorApiChannel);
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/EventSourceHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/EventSourceHandlerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.launchdarkly.eventsource.MessageEvent;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ class EventSourceHandlerTest {
   final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
   private final EventSourceHandler handler =
-      new EventSourceHandler(validatorTimingChannel, metricsSystem);
+      new EventSourceHandler(validatorTimingChannel, metricsSystem, true);
 
   @Test
   void onOpen_shouldNotifyOfPotentialMissedEvents() {
@@ -115,5 +116,30 @@ class EventSourceHandlerTest {
     final MessageEvent messageEvent = new MessageEvent("{this isn't json!}");
     assertDoesNotThrow(() -> handler.onMessage(EventType.chain_reorg.name(), messageEvent));
     verifyNoInteractions(validatorTimingChannel);
+  }
+
+  @Test
+  void onHeadEvent_shouldNotGenerateEarlyAttestationsIfNotEnabled() throws Exception {
+    final EventSourceHandler onTimeHandler =
+        new EventSourceHandler(validatorTimingChannel, metricsSystem, false);
+
+    final UInt64 slot = UInt64.valueOf(134);
+    final Bytes32 blockRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 previousDutyDependentRoot = dataStructureUtil.randomBytes32();
+    final Bytes32 currentDutyDependentRoot = dataStructureUtil.randomBytes32();
+    final HeadEvent event =
+        new HeadEvent(
+            slot,
+            blockRoot,
+            dataStructureUtil.randomBytes32(),
+            false,
+            previousDutyDependentRoot,
+            currentDutyDependentRoot);
+    onTimeHandler.onMessage(EventType.head.name(), new MessageEvent(jsonProvider.objectToJSON(event)));
+
+    verify(validatorTimingChannel)
+        .onHeadUpdate(
+            eq(slot), eq(previousDutyDependentRoot), eq(currentDutyDependentRoot), eq(blockRoot));
+    verifyNoMoreInteractions(validatorTimingChannel);
   }
 }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/EventSourceHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/EventSourceHandlerTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.launchdarkly.eventsource.MessageEvent;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
@@ -135,7 +134,8 @@ class EventSourceHandlerTest {
             false,
             previousDutyDependentRoot,
             currentDutyDependentRoot);
-    onTimeHandler.onMessage(EventType.head.name(), new MessageEvent(jsonProvider.objectToJSON(event)));
+    onTimeHandler.onMessage(
+        EventType.head.name(), new MessageEvent(jsonProvider.objectToJSON(event)));
 
     verify(validatorTimingChannel)
         .onHeadUpdate(


### PR DESCRIPTION
By default attestation production occurs as soon as a block is produced, but with dependent roots, it is sometimes useful to be able to tweak this default behaviour.

Added internal CLI option `--Xvalidators-early-attestations-enabled` which defaults to true.

fixes #4193

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
