### PR TITLE
Fix InvalidDepositEventsException after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
 - Fixed `ConcurrentModificationException` and `NoSuchElementException` in validator performance reporting.
 - Upgraded the discovery library, providing better memory management and standards compliance.
+- Fixed `InvalidDepositEventsException` error after restart.
 
 ### Experimental: New Altair REST APIs
 - implement POST `/eth/v1/beacon/pool/sync_committees` to allow validators to submit sync committee signatures to the beacon node.

--- a/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/DepositFetcher.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.pow;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
@@ -72,7 +73,11 @@ public class DepositFetcher {
   // Inclusive on both sides
   public synchronized SafeFuture<Void> fetchDepositsInRange(
       BigInteger fromBlockNumber, BigInteger toBlockNumber) {
-
+    checkArgument(
+        fromBlockNumber.compareTo(toBlockNumber) <= 0,
+        "From block number (%s) must be less than or equal to block number (%s)",
+        fromBlockNumber,
+        toBlockNumber);
     LOG.trace(
         "Attempting to fetch deposit events for block numbers in the range ({}, {})",
         fromBlockNumber,

--- a/pow/src/main/java/tech/pegasys/teku/pow/ValidatingEth1EventsPublisher.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/ValidatingEth1EventsPublisher.java
@@ -33,7 +33,7 @@ public class ValidatingEth1EventsPublisher extends DelegatingEth1EventsChannel {
 
   public synchronized void setLatestPublishedDeposit(final UInt64 latestPublishedDeposit) {
     checkNotNull(latestPublishedDeposit);
-    if (!lastPublishedDeposit.isEmpty()) {
+    if (lastPublishedDeposit.isPresent()) {
       throw new IllegalStateException("Latest published deposit is already set");
     }
     this.lastPublishedDeposit = Optional.of(latestPublishedDeposit);


### PR DESCRIPTION
## PR Description
Handles the case where the current canonical head is prior to the last deposit replayed from storage. Previously we're re-request deposits from the last deposit back to the canonical head.

## Fixed Issue(s)
fixes #4202

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
