### PR TITLE
Only advertise address in ENR when external address is known

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Fixed `ConcurrentModificationException` and `NoSuchElementException` in validator performance reporting.
 - Upgraded the discovery library, providing better memory management and standards compliance.
 - Fixed `InvalidDepositEventsException` error after restart.
+- Improve compatibility with Lighthouse bootnodes by not including the local address in the local ENR until the external address has been determined.
 
 ### Experimental: New Altair REST APIs
 - implement POST `/eth/v1/beacon/pool/sync_committees` to allow validators to submit sync committee signatures to the beacon node.

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -153,7 +153,7 @@ dependencyManagement {
     dependency "org.testcontainers:testcontainers:1.15.3"
     dependency "org.testcontainers:junit-jupiter:1.15.3"
 
-    dependency 'tech.pegasys.discovery:discovery:0.4.8'
+    dependency 'tech.pegasys.discovery:discovery:0.4.9'
 
     dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.15'
 

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
@@ -17,6 +17,7 @@ import java.net.BindException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -87,7 +88,11 @@ public class DiscoveryNetworkFactory {
         final DiscoveryConfig discoveryConfig =
             DiscoveryConfig.builder().staticPeers(staticPeers).bootnodes(bootnodes).build();
         final NetworkConfig config =
-            NetworkConfig.builder().listenPort(port).networkInterface("127.0.0.1").build();
+            NetworkConfig.builder()
+                .listenPort(port)
+                .advertisedIp(Optional.of("127.0.0.1"))
+                .networkInterface("127.0.0.1")
+                .build();
         final NoOpMetricsSystem metricsSystem = new NoOpMetricsSystem();
         final ReputationManager reputationManager =
             new ReputationManager(


### PR DESCRIPTION
## PR Description
Delay adding the local address info to the node ENR until the external IP is known.  The external address is considered known either when an explicit advertised IP is specified or when the discovery system has determined it from PONG responses.

Requires https://github.com/ConsenSys/discovery/pull/120 to be in a release before build will pass.

## Fixed Issue(s)
fixes https://github.com/ConsenSys/discovery/issues/116

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
