### PR TITLE
Switch to AdoptOpenJDK, Ubuntu docker base images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Breaking Changes
 
 ### Additions and Improvements
-- Updated default docker image to Java 16.
+- Updated default docker image to Java 16 using AdoptOpenJDK Ubuntu based images.
 - Docker images now include `curl` to support adding health checks.
 
 ### Bug Fixes

--- a/docker/jdk14/Dockerfile
+++ b/docker/jdk14/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:14-slim-buster
+FROM adoptopenjdk:14-jre-hotspot
 
 RUN apt-get -y update
 RUN apt-get -y install curl

--- a/docker/jdk15/Dockerfile
+++ b/docker/jdk15/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:15-slim-buster
+FROM adoptopenjdk:15-jre-hotspot
 
 RUN apt-get -y update
 RUN apt-get -y install curl

--- a/docker/jdk16/Dockerfile
+++ b/docker/jdk16/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:16-slim-buster
+FROM adoptopenjdk:16-jre-hotspot
 
 RUN apt-get -y update
 RUN apt-get -y install curl


### PR DESCRIPTION
## PR Description
Switch Docker images to use the Ubuntu based AdoptOpenJDK images as a base instead of the Debian based OpenJDK images.  They're both more up to date and smaller.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
