### PR TITLE
Remove unused validatorIndex param for sendSignedAttestation

### DIFF
--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -73,8 +73,6 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   void sendSignedAttestation(Attestation attestation);
 
-  void sendSignedAttestation(Attestation attestation, Optional<Integer> validatorIndex);
-
   void sendAggregateAndProof(SignedAggregateAndProof aggregateAndProof);
 
   SafeFuture<SendSignedBlockResult> sendSignedBlock(SignedBeaconBlock block);

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -284,13 +284,6 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public void sendSignedAttestation(
-      final Attestation attestation, Optional<Integer> validatorIndex) {
-    sendAttestationRequestCounter.inc();
-    delegate.sendSignedAttestation(attestation, validatorIndex);
-  }
-
-  @Override
   public void sendAggregateAndProof(final SignedAggregateAndProof aggregateAndProof) {
     sendAggregateRequestCounter.inc();
     delegate.sendAggregateAndProof(aggregateAndProof);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDuty.java
@@ -148,10 +148,7 @@ public class AttestationProductionDuty implements Duty {
         .getSigner()
         .signAttestationData(attestationData, forkInfo)
         .thenApply(signature -> createSignedAttestation(attestationData, validator, signature))
-        .thenAccept(
-            signedAttestation ->
-                validatorApiChannel.sendSignedAttestation(
-                    signedAttestation, Optional.of(validator.getValidatorIndex())))
+        .thenAccept(validatorApiChannel::sendSignedAttestation)
         .thenApply(__ -> DutyResult.success(attestationData.getBeacon_block_root()));
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
@@ -126,7 +126,7 @@ class AttestationProductionDutyTest {
     assertThat(attestationResult1).isCompletedWithValue(Optional.empty());
     assertThat(attestationResult2).isCompletedWithValue(Optional.of(attestationData));
 
-    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation, Optional.of(10));
+    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation);
     verify(validatorLogger)
         .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
     verify(validatorLogger)
@@ -172,7 +172,7 @@ class AttestationProductionDutyTest {
     assertThatThrownBy(attestationResult1::join).hasRootCause(failure);
     assertThat(attestationResult2).isCompletedWithValue(Optional.of(attestationData));
 
-    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation, Optional.of(10));
+    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation);
 
     verify(validatorLogger)
         .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
@@ -209,7 +209,7 @@ class AttestationProductionDutyTest {
     assertThat(attestationResult1).isCompletedWithValue(Optional.of(attestationData));
     assertThat(attestationResult2).isCompletedWithValue(Optional.of(attestationData));
 
-    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation, Optional.of(10));
+    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation);
 
     verify(validatorLogger)
         .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
@@ -235,7 +235,7 @@ class AttestationProductionDutyTest {
     performAndReportDuty();
     assertThat(attestationResult).isCompletedWithValue(Optional.of(attestationData));
 
-    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation, Optional.of(10));
+    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation);
     verify(validatorLogger)
         .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeacon_block_root()));
     verifyNoMoreInteractions(validatorLogger);
@@ -277,9 +277,9 @@ class AttestationProductionDutyTest {
     assertThat(attestationResult2).isCompletedWithValue(Optional.of(attestationData));
     assertThat(attestationResult3).isCompletedWithValue(Optional.of(attestationData));
 
-    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation1, Optional.of(10));
-    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation2, Optional.of(10));
-    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation3, Optional.of(10));
+    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation1);
+    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation2);
+    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation3);
 
     // Should have only needed to create one unsigned attestation and reused it for each validator
     verify(validatorApiChannel, times(1)).createAttestationData(any(), anyInt());
@@ -328,9 +328,9 @@ class AttestationProductionDutyTest {
     assertThat(attestationResult2).isCompletedWithValue(Optional.of(unsignedAttestation2));
     assertThat(attestationResult3).isCompletedWithValue(Optional.of(unsignedAttestation1));
 
-    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation1, Optional.of(10));
-    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation2, Optional.of(10));
-    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation3, Optional.of(10));
+    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation1);
+    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation2);
+    verify(validatorApiChannel).sendSignedAttestation(expectedAttestation3);
 
     // Need to create an unsigned attestation for each committee
     verify(validatorApiChannel, times(2)).createAttestationData(any(), anyInt());
@@ -372,10 +372,10 @@ class AttestationProductionDutyTest {
   public Attestation createExpectedAttestation(
       final AttestationData attestationData,
       final int committeePosition,
-      final int commiteeSize,
+      final int committeeSize,
       final BLSSignature signature) {
     final SszBitlist expectedAggregationBits =
-        Attestation.SSZ_SCHEMA.getAggregationBitsSchema().ofBits(commiteeSize, committeePosition);
+        Attestation.SSZ_SCHEMA.getAggregationBitsSchema().ofBits(committeeSize, committeePosition);
     return new Attestation(expectedAggregationBits, attestationData, signature);
   }
 

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -442,8 +442,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public void sendSignedAttestation(
-      final Attestation attestation, final Optional<Integer> expectedValidatorIndex) {
+  public void sendSignedAttestation(final Attestation attestation) {
     attestationManager
         .onAttestation(ValidateableAttestation.fromValidator(spec, attestation))
         .finish(
@@ -461,11 +460,6 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                     "Failed to send signed attestation for slot {}, block {}",
                     attestation.getData().getSlot(),
                     attestation.getData().getBeacon_block_root()));
-  }
-
-  @Override
-  public void sendSignedAttestation(final Attestation attestation) {
-    sendSignedAttestation(attestation, Optional.empty());
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -248,12 +248,6 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public void sendSignedAttestation(
-      final Attestation attestation, final Optional<Integer> validatorIndex) {
-    sendSignedAttestation(attestation);
-  }
-
-  @Override
   public SafeFuture<Optional<BeaconBlock>> createUnsignedBlock(
       final UInt64 slot, final BLSSignature randaoReveal, final Optional<Bytes32> graffiti) {
     return sendRequest(

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -354,22 +354,6 @@ class RemoteValidatorApiHandlerTest {
   }
 
   @Test
-  public void sendSignedAttestation_IgnoresValidatorIndexParameter_AndInvokeApi() {
-    final Attestation attestation = dataStructureUtil.randomAttestation();
-    final tech.pegasys.teku.api.schema.Attestation schemaAttestation =
-        new tech.pegasys.teku.api.schema.Attestation(attestation);
-
-    ArgumentCaptor<tech.pegasys.teku.api.schema.Attestation> argumentCaptor =
-        ArgumentCaptor.forClass(tech.pegasys.teku.api.schema.Attestation.class);
-
-    apiHandler.sendSignedAttestation(attestation, Optional.of(1));
-    asyncRunner.executeQueuedActions();
-
-    verify(apiClient).sendSignedAttestation(argumentCaptor.capture());
-    assertThat(argumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(schemaAttestation);
-  }
-
-  @Test
   public void createUnsignedBlock_WhenNoneFound_ReturnsEmpty() {
     final BLSSignature blsSignature = dataStructureUtil.randomSignature();
 


### PR DESCRIPTION
## PR Description
Remove unused validatorIndex param for sendSignedAttestation. Was previously used for some extra debug logging but that has long since been removed.  Simplifies the API in preparation for other work.

## Fixed Issue(s)
#3908

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
