### PR TITLE
Fix handling of sendSyncCommitteeMessage responses

### DIFF
--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -257,7 +257,8 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
     return post(
         SEND_SYNC_COMMITTEE_MESSAGES,
         syncCommitteeMessages,
-        createHandler(PostSyncCommitteeFailureResponse.class));
+        ResponseHandler.createForEmptyOkAndContentInBadResponse(
+            jsonProvider, PostSyncCommitteeFailureResponse.class));
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Fixes handling of responses when sending sync committee messages from a remote validator.
Ok responses are expected to be empty and bad request responses are expected to have the failure response content.

Previously both OK and bad request responses were reported as an error and the bad request response had a much more complex error message than necessary.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
