### PR TITLE
Make validators-early-attestations-enabled a public option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Breaking Changes
 
 ### Additions and Improvements
+ - added command line option `--validators-early-attestations-enabled`, which defaults to true. For validator clients that are having low effectiveness when using a remote beacon node, consider disabling this option.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
  - Added command line option `--validators-early-attestations-enabled`, which defaults to true. 
-   For validator clients that are having low effectiveness when using a load balanced beacon 
-   nodes such as Infura, consider disabling this option.
+   When using a load balanced beacon node, this option should be disabled.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Breaking Changes
 
 ### Additions and Improvements
- - added command line option `--validators-early-attestations-enabled`, which defaults to true. For validator clients that are having low effectiveness when using a remote beacon node, consider disabling this option.
+ - Added command line option `--validators-early-attestations-enabled`, which defaults to true. 
+   For validator clients that are having low effectiveness when using a load balanced beacon 
+   nodes such as Infura, consider disabling this option.
 
 ### Bug Fixes
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -88,11 +88,10 @@ public class ValidatorOptions {
   private boolean useDependentRoots = true;
 
   @Option(
-      names = {"--Xvalidators-early-attestations-enabled"},
+      names = {"--validators-early-attestations-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
           "Generate attestations as soon as a block is known, rather than delaying until the attestation is due. Default: true",
-      hidden = true,
       fallbackValue = "true",
       arity = "0..1")
   private boolean generateEarlyAttestations = true;


### PR DESCRIPTION
fixes #4225

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
