### PR TITLE
clean up migrate-database command line arguments

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
@@ -135,11 +135,9 @@ public class MigrateDatabaseCommand implements Runnable {
               + ", review this folder and remove before continuing.");
     }
 
-    DataConfig.Builder dataConfigBuilder = DataConfig.builder().dataBasePath(dataPath);
-    if (dataBeaconPath != null) {
-      dataConfigBuilder.beaconDataPath(dataBeaconPath);
-    }
-    dataDirLayout = DataDirLayout.createFrom(dataConfigBuilder.build());
+    dataDirLayout =
+        DataDirLayout.createFrom(
+            DataConfig.builder().dataBasePath(dataPath).beaconDataPath(dataBeaconPath).build());
 
     // validate source database exists
     final DatabaseVersion sourceDatabaseVersion =

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
@@ -17,18 +17,18 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Scanner;
 import picocli.CommandLine;
 import tech.pegasys.teku.cli.converter.PicoCliVersionProvider;
-import tech.pegasys.teku.cli.options.DataStorageOptions;
-import tech.pegasys.teku.cli.options.Eth2NetworkOptions;
-import tech.pegasys.teku.cli.options.ValidatorClientDataOptions;
 import tech.pegasys.teku.cli.util.DatabaseMigrater;
 import tech.pegasys.teku.cli.util.DatabaseMigraterError;
 import tech.pegasys.teku.infrastructure.logging.SubCommandLogger;
+import tech.pegasys.teku.service.serviceutils.layout.DataConfig;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.storage.server.DatabaseVersion;
+import tech.pegasys.teku.storage.server.StateStorageMode;
 
 @CommandLine.Command(
     name = "migrate-database",
@@ -44,14 +44,36 @@ import tech.pegasys.teku.storage.server.DatabaseVersion;
 public class MigrateDatabaseCommand implements Runnable {
   public static final SubCommandLogger SUB_COMMAND_LOG = new SubCommandLogger();
 
-  @CommandLine.Mixin(name = "Data Storage")
-  private DataStorageOptions dataStorageOptions;
+  @CommandLine.Option(
+      names = {"--data-base-path", "--data-path"},
+      paramLabel = "<string>",
+      required = true,
+      description = "The path to the teku database.",
+      arity = "1")
+  private Path dataPath;
 
-  @CommandLine.Mixin(name = "Network")
-  private Eth2NetworkOptions eth2NetworkOptions;
+  @CommandLine.Option(
+      names = {"--data-beacon-path"},
+      paramLabel = "<FILENAME>",
+      description = "Path to beacon node data\n  Default: <data-base-path>/beacon",
+      arity = "1")
+  private Path dataBeaconPath;
 
-  @CommandLine.Mixin(name = "Data")
-  private ValidatorClientDataOptions dataOptions;
+  @CommandLine.Option(
+      names = {"--Xdata-storage-mode"},
+      paramLabel = "<STORAGE_MODE>",
+      hidden = true,
+      description =
+          "Sets the strategy for handling historical chain data.  (Valid values: ${COMPLETION-CANDIDATES})",
+      arity = "1")
+  private StateStorageMode dataStorageMode = StateStorageMode.ARCHIVE;
+
+  @CommandLine.Option(
+      names = {"-n", "--network"},
+      paramLabel = "<NETWORK>",
+      description = "Represents which network to use. (default: mainnet)",
+      arity = "1")
+  private String network = "mainnet";
 
   // Use Cases
   // - I have a rocksdb database and want to update to the latest leveldb database version
@@ -78,6 +100,8 @@ public class MigrateDatabaseCommand implements Runnable {
       arity = "1")
   private Integer batchSize = 100;
 
+  private DataDirLayout dataDirLayout;
+
   // OVERVIEW
   // teku folder has a 'beacon' folder
   // If the user wants to change the type of database stored in 'beacon',
@@ -103,22 +127,29 @@ public class MigrateDatabaseCommand implements Runnable {
     // validate there is no old database instance present
     // If a previous migrate-data was run, the 'beacon' would have been renamed to 'beacon.old'
     // and advice given to the user to cleanup 'beacon.old' manually.
-    if (Files.isDirectory(dataOptions.getDataBasePath().resolve("beacon.old"))) {
+    if (Files.isDirectory(dataPath.resolve("beacon.old"))) {
       SUB_COMMAND_LOG.exit(
           1,
           "There is an existing folder in "
-              + dataOptions.getDataBasePath().resolve("beacon.old").toFile()
+              + dataPath.resolve("beacon.old").toFile()
               + ", review this folder and remove before continuing.");
     }
+
+    DataConfig.Builder dataConfigBuilder = DataConfig.builder().dataBasePath(dataPath);
+    if (dataBeaconPath != null) {
+      dataConfigBuilder.beaconDataPath(dataBeaconPath);
+    }
+    dataDirLayout = DataDirLayout.createFrom(dataConfigBuilder.build());
+
     // validate source database exists
     final DatabaseVersion sourceDatabaseVersion =
         confirmAndCheckOriginalDb(maybeOutputVersion.get());
 
     final DatabaseMigrater dbMigrater =
         DatabaseMigrater.builder()
-            .dataOptions(dataOptions)
-            .dataStorageOptions(dataStorageOptions)
-            .eth2NetworkOptions(eth2NetworkOptions)
+            .dataDirLayout(dataDirLayout)
+            .network(network)
+            .storageMode(dataStorageMode)
             .batchSize(batchSize)
             .statusUpdater(SUB_COMMAND_LOG::display)
             .build();
@@ -168,18 +199,13 @@ public class MigrateDatabaseCommand implements Runnable {
   }
 
   private void displaySourceDatabaseDetails(final DatabaseVersion sourceDatabaseVersion) {
-    final DataDirLayout dataDirLayout = DataDirLayout.createFrom(dataOptions.getDataConfig());
-
     SUB_COMMAND_LOG.display("Current database path: " + dataDirLayout.getBeaconDataDirectory());
     SUB_COMMAND_LOG.display("Current Database Version: " + sourceDatabaseVersion.getValue());
   }
 
   private DatabaseVersion validateSourceDatabase(final DatabaseVersion databaseVersion) {
     final File currentDatabasePath =
-        DataDirLayout.createFrom(dataOptions.getDataConfig())
-            .getBeaconDataDirectory()
-            .toAbsolutePath()
-            .toFile();
+        dataDirLayout.getBeaconDataDirectory().toAbsolutePath().toFile();
     if (!currentDatabasePath.isDirectory()) {
       SUB_COMMAND_LOG.exit(
           1, "Could not locate the existing database to migrate from: " + currentDatabasePath);

--- a/teku/src/main/java/tech/pegasys/teku/cli/util/DatabaseMigrater.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/util/DatabaseMigrater.java
@@ -24,23 +24,23 @@ import java.util.List;
 import java.util.function.Consumer;
 import org.apache.commons.io.FileUtils;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
-import tech.pegasys.teku.cli.options.DataStorageOptions;
-import tech.pegasys.teku.cli.options.Eth2NetworkOptions;
 import tech.pegasys.teku.cli.options.ValidatorClientDataOptions;
+import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.server.DatabaseVersion;
+import tech.pegasys.teku.storage.server.StateStorageMode;
 import tech.pegasys.teku.storage.server.VersionedDatabaseFactory;
 import tech.pegasys.teku.storage.server.kvstore.KvStoreDatabase;
 
 public class DatabaseMigrater {
   private final DataDirLayout dataDirLayout;
   private final Consumer<String> statusUpdater;
-  private final DataStorageOptions dataStorageOptions;
-  private final Eth2NetworkOptions eth2NetworkOptions;
   private final int batchSize;
   private final Spec spec;
+  private final String network;
+  private final StateStorageMode storageMode;
   private KvStoreDatabase originalDatabase;
 
   KvStoreDatabase getOriginalDatabase() {
@@ -55,14 +55,14 @@ public class DatabaseMigrater {
 
   private DatabaseMigrater(
       final DataDirLayout dataDirLayout,
-      final DataStorageOptions dataStorageOptions,
-      final Eth2NetworkOptions eth2NetworkOptions,
+      final String network,
+      final StateStorageMode storageMode,
       final Spec spec,
       final int batchSize,
       final Consumer<String> statusUpdater) {
     this.dataDirLayout = dataDirLayout;
-    this.dataStorageOptions = dataStorageOptions;
-    this.eth2NetworkOptions = eth2NetworkOptions;
+    this.network = network;
+    this.storageMode = storageMode;
     this.spec = spec;
     this.batchSize = batchSize;
     this.statusUpdater = statusUpdater;
@@ -173,15 +173,16 @@ public class DatabaseMigrater {
   @VisibleForTesting
   KvStoreDatabase createDatabase(final Path databasePath, DatabaseVersion databaseVersion)
       throws DatabaseMigraterError {
+    final Eth2NetworkConfiguration config = Eth2NetworkConfiguration.builder(network).build();
     final VersionedDatabaseFactory databaseFactory =
         new VersionedDatabaseFactory(
             new NoOpMetricsSystem(),
             databasePath,
-            dataStorageOptions.getDataStorageMode(),
+            storageMode,
             databaseVersion,
             DEFAULT_STORAGE_FREQUENCY,
-            eth2NetworkOptions.getNetworkConfiguration().getEth1DepositContractAddress(),
-            dataStorageOptions.isStoreNonCanonicalBlocks(),
+            config.getEth1DepositContractAddress(),
+            true,
             spec);
     final Database database = databaseFactory.createDatabase();
     if (!(database instanceof KvStoreDatabase)) {
@@ -205,8 +206,8 @@ public class DatabaseMigrater {
     private int batchSize = 500;
     private DataDirLayout dataDirLayout;
     private Consumer<String> statusUpdater;
-    private DataStorageOptions dataStorageOptions;
-    private Eth2NetworkOptions eth2NetworkOptions;
+    private String network;
+    private StateStorageMode storageMode = StateStorageMode.ARCHIVE;
     private Spec spec;
 
     public Builder dataOptions(final ValidatorClientDataOptions dataOptions) {
@@ -226,21 +227,21 @@ public class DatabaseMigrater {
       return this;
     }
 
+    public Builder network(final String network) {
+      this.network = network;
+      if (spec == null) {
+        spec = Eth2NetworkConfiguration.builder().applyNetworkDefaults(network).build().getSpec();
+      }
+      return this;
+    }
+
+    public Builder storageMode(final StateStorageMode storageMode) {
+      this.storageMode = storageMode;
+      return this;
+    }
+
     public Builder statusUpdater(final Consumer<String> statusUpdater) {
       this.statusUpdater = statusUpdater;
-      return this;
-    }
-
-    public Builder dataStorageOptions(final DataStorageOptions dataStorageOptions) {
-      this.dataStorageOptions = dataStorageOptions;
-      return this;
-    }
-
-    public Builder eth2NetworkOptions(final Eth2NetworkOptions eth2NetworkOptions) {
-      this.eth2NetworkOptions = eth2NetworkOptions;
-      if (spec == null) {
-        spec = this.eth2NetworkOptions.getNetworkConfiguration().getSpec();
-      }
       return this;
     }
 
@@ -251,8 +252,9 @@ public class DatabaseMigrater {
 
     public DatabaseMigrater build() {
       checkNotNull(dataDirLayout);
+      checkNotNull(spec);
       return new DatabaseMigrater(
-          dataDirLayout, dataStorageOptions, eth2NetworkOptions, spec, batchSize, statusUpdater);
+          dataDirLayout, network, storageMode, spec, batchSize, statusUpdater);
     }
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/util/DatabaseMigraterTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/util/DatabaseMigraterTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.cli.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.google.common.io.Resources;
 import java.io.IOException;
@@ -24,41 +23,26 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import tech.pegasys.teku.cli.options.DataStorageOptions;
-import tech.pegasys.teku.cli.options.Eth2NetworkOptions;
 import tech.pegasys.teku.infrastructure.logging.SubCommandLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
-import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.server.DatabaseVersion;
+import tech.pegasys.teku.storage.server.StateStorageMode;
 import tech.pegasys.teku.storage.server.kvstore.TestKvStoreDatabase;
 import tech.pegasys.teku.storage.server.kvstore.dataaccess.KvStoreHotDao;
 
 public class DatabaseMigraterTest {
-  private final Eth2NetworkOptions eth2NetworkOptions = mock(Eth2NetworkOptions.class);
-  private final DataStorageOptions dataStorageOptions = mock(DataStorageOptions.class);
-  private final Eth2NetworkConfiguration networkConfiguration =
-      mock(Eth2NetworkConfiguration.class);
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final SubCommandLogger subCommandLogger = mock(SubCommandLogger.class);
   private final Consumer<String> logger = subCommandLogger::display;
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-
-  @BeforeEach
-  void setup() {
-    when(eth2NetworkOptions.getNetworkConfiguration()).thenReturn(networkConfiguration);
-    when(networkConfiguration.getEth1DepositContractAddress())
-        .thenReturn(Eth1Address.fromHexString("0x1234567890123456789012345678901234567890"));
-  }
 
   @Test
   void shouldSupplyOriginalDatabasePath(@TempDir Path tmpDir) throws IOException {
@@ -190,9 +174,9 @@ public class DatabaseMigraterTest {
   private DatabaseMigrater getDatabaseMigrater(final DataDirLayout dataDirLayout) {
     return DatabaseMigrater.builder()
         .dataDirLayout(dataDirLayout)
-        .dataStorageOptions(dataStorageOptions)
+        .storageMode(StateStorageMode.ARCHIVE)
+        .network("minimal")
         .spec(spec)
-        .eth2NetworkOptions(eth2NetworkOptions)
         .statusUpdater(logger)
         .build();
   }


### PR DESCRIPTION
It was difficult to determine the command line arguments actually required for the migrate-database command, and several listed options were completely ignored.

migrate-database got manually re-tested because of the scope of the changes needed to change the reporting of arguments.

CLI is now:

```
teku migrate-database [OPTIONS]

Description:

Migrate the database to a specified version.

Options:
  -c, --config-file=<FILENAME>
                            Path/filename of the yaml config file (default:
                              none)
      --data-beacon-path=<FILENAME>
                            Path to beacon node data
                              Default: <data-base-path>/beacon
      --data-path, --data-base-path=<string>
                            The path to the teku database.
  -h, --help                Show this help message and exit.
  -n, --network=<NETWORK>   Represents which network to use. (Default: mainnet)
  -V, --version             Print version information and exit.

Teku is licensed under the Apache License 2.0
```

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
