### PR TITLE
Upgrade discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For information on changes in released versions of Teku, see the [releases page]
  - Added command line option `--validators-early-attestations-enabled`, which defaults to true. 
    When using a load balanced beacon node, this option should be disabled.
  - Added additional bootnodes for the Prater testnet to improve peer discovery.
+ - Improved peer discovery. All authenticated node sessions are evaluated as potential peers to connect.
 
 ### Bug Fixes
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -153,7 +153,7 @@ dependencyManagement {
     dependency "org.testcontainers:testcontainers:1.15.3"
     dependency "org.testcontainers:junit-jupiter:1.15.3"
 
-    dependency 'tech.pegasys.discovery:discovery:0.4.9'
+    dependency 'tech.pegasys.discovery:discovery:0.5.0'
 
     dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.15'
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategy.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.networking.p2p.connection.PeerPools.PeerPool.RAN
 import static tech.pegasys.teku.networking.p2p.connection.PeerPools.PeerPool.SCORE_BASED;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -64,7 +65,7 @@ public class Eth2PeerSelectionStrategy implements PeerSelectionStrategy {
   public List<PeerAddress> selectPeersToConnect(
       final P2PNetwork<?> network,
       final PeerPools peerPools,
-      final Supplier<List<DiscoveryPeer>> candidates) {
+      final Supplier<? extends Collection<DiscoveryPeer>> candidates) {
     final PeerSubnetSubscriptions peerSubnetSubscriptions =
         peerSubnetSubscriptionsFactory.create(network);
     final int peersRequiredForPeerCount =

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManager.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.networking.p2p.connection;
 
 import static java.util.Collections.emptyList;
-import static java.util.stream.Collectors.toList;
 
 import java.time.Duration;
 import java.util.Collection;
@@ -24,6 +23,7 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -111,7 +111,7 @@ public class ConnectionManager extends Service {
                 Stream.concat(
                         additionalPeersToConsider.stream(), discoveryService.streamKnownPeers())
                     .filter(this::isPeerValid)
-                    .collect(toList()))
+                    .collect(Collectors.toSet()))
         .forEach(this::attemptConnection);
   }
 
@@ -123,7 +123,7 @@ public class ConnectionManager extends Service {
     LOG.trace("Searching for peers");
     discoveryService
         .searchForPeers()
-        .orTimeout(10, TimeUnit.SECONDS)
+        .orTimeout(30, TimeUnit.SECONDS)
         .finish(
             this::connectToBestPeers,
             error -> {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/PeerSelectionStrategy.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/PeerSelectionStrategy.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.p2p.connection;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
@@ -22,7 +23,9 @@ import tech.pegasys.teku.networking.p2p.peer.Peer;
 
 public interface PeerSelectionStrategy {
   List<PeerAddress> selectPeersToConnect(
-      P2PNetwork<?> network, PeerPools peerPools, Supplier<List<DiscoveryPeer>> candidates);
+      P2PNetwork<?> network,
+      PeerPools peerPools,
+      Supplier<? extends Collection<DiscoveryPeer>> candidates);
 
   List<Peer> selectPeersToDisconnect(P2PNetwork<?> network, PeerPools peerPools);
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
@@ -102,12 +102,13 @@ public class LibP2PPeer implements Peer {
     disconnectLocallyInitiated = locallyInitiated;
     SafeFuture.of(connection.close())
         .finish(
-            () -> LOG.trace("Disconnected from {}", getId()),
+            () -> LOG.trace("Disconnected from {} because {}", getId(), reason),
             error -> LOG.warn("Failed to disconnect from peer {}", getId(), error));
   }
 
   @Override
   public SafeFuture<Void> disconnectCleanly(final DisconnectReason reason) {
+    LOG.trace("Disconnecting peer {} because {}", getId(), reason);
     connected.set(false);
     disconnectReason = Optional.of(reason);
     disconnectLocallyInitiated = true;

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/ConnectionManagerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/ConnectionManagerTest.java
@@ -79,7 +79,8 @@ class ConnectionManagerTest {
     when(peerSelectionStrategy.selectPeersToConnect(eq(network), any(), any()))
         .thenAnswer(
             invocation -> {
-              final Supplier<List<DiscoveryPeer>> candidateSupplier = invocation.getArgument(2);
+              final Supplier<? extends Collection<DiscoveryPeer>> candidateSupplier =
+                  invocation.getArgument(2);
               return candidateSupplier.get().stream()
                   .map(peer -> new PeerAddress(new MockNodeId(peer.getPublicKey())))
                   .collect(toList());

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/peer/SimplePeerSelectionStrategy.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/peer/SimplePeerSelectionStrategy.java
@@ -17,6 +17,7 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static tech.pegasys.teku.networking.p2p.connection.PeerPools.PeerPool.STATIC;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
 import tech.pegasys.teku.networking.p2p.connection.PeerPools;
@@ -38,7 +39,7 @@ public class SimplePeerSelectionStrategy implements PeerSelectionStrategy {
   public List<PeerAddress> selectPeersToConnect(
       final P2PNetwork<?> network,
       final PeerPools peerPools,
-      final Supplier<List<DiscoveryPeer>> candidates) {
+      final Supplier<? extends Collection<DiscoveryPeer>> candidates) {
     final int peersToAdd = targetPeerRange.getPeersToAdd(network.getPeerCount());
     if (peersToAdd == 0) {
       return emptyList();


### PR DESCRIPTION
## PR Description
Upgrade discovery: Includes improvement to consider all authenticated sessions as potential connection targets instead of only those in the node table.
Add reason to peer disconnect logs.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
