### PR TITLE
Add progress counter to some of the migrate-database columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,5 @@ For information on changes in released versions of Teku, see the [releases page]
  - Added additional bootnodes for the Prater testnet to improve peer discovery.
 
 ### Bug Fixes
+ - Added a column size and percentage complete to migrate-database command columns that contain large amounts of data.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,5 @@ For information on changes in released versions of Teku, see the [releases page]
  - Improved peer discovery. All authenticated node sessions are evaluated as potential peers to connect.
 
 ### Bug Fixes
- - Added a column size and percentage complete to migrate-database command columns that contain large amounts of data.
+ - Added a column size and percentage complete to migrate-database command, where columns contain block or state objects, as they can be time consuming to copy.
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -147,13 +147,50 @@ public class V4FinalizedKvStoreDao implements KvStoreFinalizedDao {
     if (newColumns.size() > 0) {
       final Map<String, KvStoreColumn<?, ?>> oldColumns = dao.schema.getColumnMap();
       for (String key : newColumns.keySet()) {
-        logger.accept(String.format("Copy column %s", key));
+        final Optional<UInt64> maybeCount = displayCopyColumnMessage(key, oldColumns, dao, logger);
         try (final Stream<ColumnEntry<Bytes, Bytes>> oldEntryStream =
                 dao.streamRawColumn(oldColumns.get(key));
-            BatchWriter batchWriter = new BatchWriter(batchSize, logger, db)) {
+            BatchWriter batchWriter = new BatchWriter(batchSize, logger, db, maybeCount)) {
           oldEntryStream.forEach(entry -> batchWriter.add(newColumns.get(key), entry));
         }
       }
+    }
+  }
+
+  private Optional<UInt64> displayCopyColumnMessage(
+      final String key,
+      final Map<String, KvStoreColumn<?, ?>> oldColumns,
+      final V4FinalizedKvStoreDao dao,
+      final Consumer<String> logger) {
+    final Optional<UInt64> maybeCount = getObjectCountForColumn(key, oldColumns, dao);
+    maybeCount.ifPresentOrElse(
+        (count) -> logger.accept(String.format("Copy column %s - %s objects", key, count)),
+        () -> logger.accept(String.format("Copy column %s", key)));
+
+    return maybeCount;
+  }
+
+  private Optional<UInt64> getObjectCountForColumn(
+      final String key,
+      final Map<String, KvStoreColumn<?, ?>> oldColumns,
+      final V4FinalizedKvStoreDao dao) {
+    switch (key) {
+      case ("FINALIZED_STATES_BY_SLOT"):
+      case ("SLOTS_BY_FINALIZED_STATE_ROOT"):
+      case ("SLOTS_BY_FINALIZED_ROOT"):
+        return getEntityCountFromColumn(oldColumns.get(key), dao);
+      case ("FINALIZED_BLOCKS_BY_SLOT"):
+        return getEntityCountFromColumn(oldColumns.get("SLOTS_BY_FINALIZED_ROOT"), dao);
+      default:
+        break;
+    }
+    return Optional.empty();
+  }
+
+  Optional<UInt64> getEntityCountFromColumn(
+      final KvStoreColumn<?, ?> column, final V4FinalizedKvStoreDao dao) {
+    try (final Stream<ColumnEntry<Bytes, Bytes>> oldEntryStream = dao.streamRawColumn(column)) {
+      return Optional.of(UInt64.valueOf(oldEntryStream.count()));
     }
   }
 
@@ -186,10 +223,6 @@ public class V4FinalizedKvStoreDao implements KvStoreFinalizedDao {
     private final UInt64 stateStorageFrequency;
     private Optional<UInt64> lastStateStoredSlot = Optional.empty();
     private boolean loadedLastStoreState = false;
-
-    KvStoreTransaction getTransaction() {
-      return transaction;
-    }
 
     V4FinalizedUpdater(
         final KvStoreAccessor db,


### PR DESCRIPTION
Particularly finalized state and block columns can be time consuming to copy, so providing some context of the number of elements and percentage completed is helpful to understand how long is likely to be remaining in the process.

fixes #4229

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
