### PR TITLE
Remove invalid sync contribution validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,5 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
  - Added a column size and percentage complete to migrate-database command, where columns contain block or state objects, as they can be time consuming to copy.
+ - Fixed issue in Altair where sync committee contribution gossip could be incorrectly rejected when received at the very end of the slot.
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
@@ -145,12 +145,6 @@ public class SignedContributionAndProofValidator {
       final SyncCommitteeUtil syncCommitteeUtil,
       final UniquenessKey uniquenessKey,
       final BeaconStateAltair state) {
-    if (state.getSlot().isGreaterThan(contribution.getSlot())) {
-      return failureResult(
-          "Rejecting proof because referenced beacon block %s is after contribution slot %s",
-          contribution.getBeaconBlockRoot(), contribution.getSlot());
-    }
-
     final BeaconStateAccessors beaconStateAccessors =
         spec.atSlot(contribution.getSlot()).beaconStateAccessors();
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidatorTest.java
@@ -111,6 +111,22 @@ class SignedContributionAndProofValidatorTest {
   }
 
   @Test
+  void shouldAcceptWhenContributionIsStillValidatingAfterSlotEnds() {
+    final SignedContributionAndProof message =
+        chainBuilder.createValidSignedContributionAndProofBuilder().build();
+    // When we check the current time it's in the right slot
+    // But by the time we request the state it's one slot ahead.
+    final SignedBlockAndState bestBlock =
+        storageSystem
+            .chainUpdater()
+            .advanceChainUntil(message.getMessage().getContribution().getSlot().plus(1));
+    storageSystem.chainUpdater().updateBestBlock(bestBlock);
+
+    final SafeFuture<InternalValidationResult> result = validator.validate(message);
+    assertThat(result).isCompletedWithValue(ACCEPT);
+  }
+
+  @Test
   void shouldRejectWhenAggregationBitsAreEmpty() {
     final SignedContributionAndProof message =
         chainBuilder.createValidSignedContributionAndProofBuilder().removeAllParticipants().build();


### PR DESCRIPTION
## PR Description
SignedContributionAndProofValidator was incorrectly rejecting contribution gossip if the chain head state slot was greater than the contribution slot. This check could fail because of a race condition when contributions were received right at the end of the slot.

Now that there's no requirement for the block to be known, it doesn't make sense to try and check the referenced block root's slot.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
