### PR TITLE
Make use of abstract unit tests for BLST implementation

### DIFF
--- a/bls/src/main/java/tech/pegasys/teku/bls/BLS.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/BLS.java
@@ -18,7 +18,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
-import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -146,8 +145,7 @@ public class BLS {
         publicKeys.size() == messages.size(),
         "Number of public keys and number of messages differs.");
     if (publicKeys.isEmpty()) return false;
-    // Check that there are no duplicate messages
-    if (new HashSet<>(messages).size() != messages.size()) return false;
+
     List<PublicKeyMessagePair> publicKeyMessagePairs =
         Streams.zip(
                 publicKeys.stream(),

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstBLS12381.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstBLS12381.java
@@ -156,6 +156,10 @@ public class BlstBLS12381 implements BLS12381 {
   @Override
   public boolean completeBatchVerify(List<? extends BatchSemiAggregate> preparedList) {
     try {
+      if (preparedList.isEmpty()) {
+        return true;
+      }
+
       List<BlstSemiAggregate> blstList =
           preparedList.stream().map(b -> (BlstSemiAggregate) b).collect(Collectors.toList());
 

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstSignature.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstSignature.java
@@ -109,13 +109,6 @@ public class BlstSignature implements Signature {
   @Override
   public boolean verify(List<PublicKeyMessagePair> keysToMessages) {
 
-    // according to BLS spec aggregateVerify allows only distinct messages
-    // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-3.1.1
-    if (keysToMessages.stream().map(PublicKeyMessagePair::getMessage).distinct().count()
-        < keysToMessages.size()) {
-      return false;
-    }
-
     boolean isAnyPublicKeyInfinity =
         keysToMessages.stream()
             .anyMatch(pair -> ((BlstPublicKey) pair.getPublicKey()).isInfinity());

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstSignature.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstSignature.java
@@ -109,6 +109,13 @@ public class BlstSignature implements Signature {
   @Override
   public boolean verify(List<PublicKeyMessagePair> keysToMessages) {
 
+    // according to BLS spec aggregateVerify allows only distinct messages
+    // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-3.1.1
+    if (keysToMessages.stream().map(PublicKeyMessagePair::getMessage).distinct().count()
+        < keysToMessages.size()) {
+      return false;
+    }
+
     boolean isAnyPublicKeyInfinity =
         keysToMessages.stream()
             .anyMatch(pair -> ((BlstPublicKey) pair.getPublicKey()).isInfinity());

--- a/bls/src/test/java/tech/pegasys/teku/bls/BLSTest.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/BLSTest.java
@@ -127,27 +127,6 @@ public abstract class BLSTest {
   }
 
   @Test
-  void succeedsWhenAggregateVerifyWithRepeatedMessagesReturnsFalse() {
-    Bytes message1 = Bytes.wrap("Hello, world 1!".getBytes(UTF_8));
-    Bytes message2 = Bytes.wrap("Hello, world 2!".getBytes(UTF_8));
-    BLSKeyPair keyPair1 = BLSTestUtil.randomKeyPair(1);
-    BLSKeyPair keyPair2 = BLSTestUtil.randomKeyPair(2);
-    BLSKeyPair keyPair3 = BLSTestUtil.randomKeyPair(3);
-
-    List<BLSPublicKey> publicKeys =
-        Arrays.asList(keyPair1.getPublicKey(), keyPair2.getPublicKey(), keyPair3.getPublicKey());
-    List<Bytes> messages = Arrays.asList(message1, message2, message2);
-    List<BLSSignature> signatures =
-        Arrays.asList(
-            BLS.sign(keyPair1.getSecretKey(), message1),
-            BLS.sign(keyPair2.getSecretKey(), message2),
-            BLS.sign(keyPair3.getSecretKey(), message2));
-    BLSSignature aggregatedSignature = BLS.aggregate(signatures);
-
-    assertFalse(BLS.aggregateVerify(publicKeys, messages, aggregatedSignature));
-  }
-
-  @Test
   void succeedsWhenAggregateVerifyWithDistinctMessagesReturnsTrue() {
     Bytes message1 = Bytes.wrap("Hello, world 1!".getBytes(UTF_8));
     Bytes message2 = Bytes.wrap("Hello, world 2!".getBytes(UTF_8));

--- a/bls/src/test/java/tech/pegasys/teku/bls/impl/AbstractBLS12381Test.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/impl/AbstractBLS12381Test.java
@@ -117,6 +117,27 @@ public abstract class AbstractBLS12381Test {
   }
 
   @Test
+  void aggregateVerifyDuplicateMessages() {
+    Bytes message1 = Bytes.wrap("Hello, world 1!".getBytes(UTF_8));
+    Bytes message2 = Bytes.wrap("Hello, world 2!".getBytes(UTF_8));
+    KeyPair keyPair1 = getBls().generateKeyPair(1);
+    KeyPair keyPair2 = getBls().generateKeyPair(2);
+    KeyPair keyPair3 = getBls().generateKeyPair(3);
+
+    List<PublicKey> publicKeys =
+        Arrays.asList(keyPair1.getPublicKey(), keyPair2.getPublicKey(), keyPair3.getPublicKey());
+    List<Bytes> messages = Arrays.asList(message1, message2, message2);
+    List<Signature> signatures =
+        Arrays.asList(
+            keyPair1.getSecretKey().sign(message1),
+            keyPair2.getSecretKey().sign(message2),
+            keyPair3.getSecretKey().sign(message2));
+    Signature aggregatedSignature = getBls().aggregateSignatures(signatures);
+
+    assertFalse(aggregatedSignature.verify(PublicKeyMessagePair.fromLists(publicKeys, messages)));
+  }
+
+  @Test
   void batchVerifyPositiveSimpleTest() {
     // positive simple case
     for (int sigCnt = 0; sigCnt < 6; sigCnt++) {

--- a/bls/src/test/java/tech/pegasys/teku/bls/impl/AbstractBLS12381Test.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/impl/AbstractBLS12381Test.java
@@ -117,27 +117,6 @@ public abstract class AbstractBLS12381Test {
   }
 
   @Test
-  void aggregateVerifyDuplicateMessages() {
-    Bytes message1 = Bytes.wrap("Hello, world 1!".getBytes(UTF_8));
-    Bytes message2 = Bytes.wrap("Hello, world 2!".getBytes(UTF_8));
-    KeyPair keyPair1 = getBls().generateKeyPair(1);
-    KeyPair keyPair2 = getBls().generateKeyPair(2);
-    KeyPair keyPair3 = getBls().generateKeyPair(3);
-
-    List<PublicKey> publicKeys =
-        Arrays.asList(keyPair1.getPublicKey(), keyPair2.getPublicKey(), keyPair3.getPublicKey());
-    List<Bytes> messages = Arrays.asList(message1, message2, message2);
-    List<Signature> signatures =
-        Arrays.asList(
-            keyPair1.getSecretKey().sign(message1),
-            keyPair2.getSecretKey().sign(message2),
-            keyPair3.getSecretKey().sign(message2));
-    Signature aggregatedSignature = getBls().aggregateSignatures(signatures);
-
-    assertFalse(aggregatedSignature.verify(PublicKeyMessagePair.fromLists(publicKeys, messages)));
-  }
-
-  @Test
   void batchVerifyPositiveSimpleTest() {
     // positive simple case
     for (int sigCnt = 0; sigCnt < 6; sigCnt++) {

--- a/bls/src/test/java/tech/pegasys/teku/bls/impl/AbstractBLS12381Test.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/impl/AbstractBLS12381Test.java
@@ -29,7 +29,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BatchSemiAggregate;
 
-public abstract class BLS12381Test {
+public abstract class AbstractBLS12381Test {
 
   private final List<KeyPair> keys =
       IntStream.range(0, 8).mapToObj(getBls()::generateKeyPair).collect(Collectors.toList());
@@ -57,7 +57,7 @@ public abstract class BLS12381Test {
   private final int aggrIndex;
   private final int invalidIndex;
 
-  protected BLS12381Test() {
+  protected AbstractBLS12381Test() {
     aggrIndex = pubKeys.size();
     pubKeys.add(aggrSigPubkeys);
     messages.add(aggrSigMsg);
@@ -114,27 +114,6 @@ public abstract class BLS12381Test {
     Signature aggregatedSignature = getBls().aggregateSignatures(signatures);
 
     assertTrue(aggregatedSignature.verify(publicKeys, message));
-  }
-
-  @Test
-  void aggregateVerifyDuplicateMessages() {
-    Bytes message1 = Bytes.wrap("Hello, world 1!".getBytes(UTF_8));
-    Bytes message2 = Bytes.wrap("Hello, world 2!".getBytes(UTF_8));
-    KeyPair keyPair1 = getBls().generateKeyPair(1);
-    KeyPair keyPair2 = getBls().generateKeyPair(2);
-    KeyPair keyPair3 = getBls().generateKeyPair(3);
-
-    List<PublicKey> publicKeys =
-        Arrays.asList(keyPair1.getPublicKey(), keyPair2.getPublicKey(), keyPair3.getPublicKey());
-    List<Bytes> messages = Arrays.asList(message1, message2, message2);
-    List<Signature> signatures =
-        Arrays.asList(
-            keyPair1.getSecretKey().sign(message1),
-            keyPair2.getSecretKey().sign(message2),
-            keyPair3.getSecretKey().sign(message2));
-    Signature aggregatedSignature = getBls().aggregateSignatures(signatures);
-
-    assertFalse(aggregatedSignature.verify(PublicKeyMessagePair.fromLists(publicKeys, messages)));
   }
 
   @Test

--- a/bls/src/test/java/tech/pegasys/teku/bls/impl/AbstractPublicKeyTest.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/impl/AbstractPublicKeyTest.java
@@ -13,21 +13,14 @@
 
 package tech.pegasys.teku.bls.impl;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Collections;
 import org.apache.tuweni.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
 
-public abstract class PublicKeyTest {
+public abstract class AbstractPublicKeyTest {
 
   protected abstract BLS12381 getBls();
-
-  @Test
-  void succeedsWhenPassingEmptyListToAggregatePublicKeysDoesNotThrowException() {
-    assertDoesNotThrow(() -> getBls().aggregatePublicKeys(Collections.emptyList()));
-  }
 
   @Test
   public void shouldHaveConsistentHashCodeAndEquals() {

--- a/bls/src/test/java/tech/pegasys/teku/bls/impl/AbstractSignatureTest.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/impl/AbstractSignatureTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
-public abstract class SignatureTest {
+public abstract class AbstractSignatureTest {
 
   protected abstract BLS12381 getBls();
 

--- a/bls/src/test/java/tech/pegasys/teku/bls/impl/blst/BlstPublicKeyTest.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/impl/blst/BlstPublicKeyTest.java
@@ -13,18 +13,26 @@
 
 package tech.pegasys.teku.bls.impl.blst;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.tuweni.bytes.Bytes48;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.impl.AbstractPublicKeyTest;
+import tech.pegasys.teku.bls.impl.BLS12381;
 
-public class BlstPublicKeyTest {
+public class BlstPublicKeyTest extends AbstractPublicKeyTest {
+
+  private static BLS12381 BLS;
 
   @BeforeAll
   static void setup() {
-    assertThat(BlstLoader.INSTANCE).isNotEmpty();
+    BLS = BlstLoader.INSTANCE.orElseThrow();
+  }
+
+  @Override
+  protected BLS12381 getBls() {
+    return BLS;
   }
 
   // The infinite public key is now considered to be invalid

--- a/bls/src/test/java/tech/pegasys/teku/bls/impl/blst/BlstSignatureTest.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/impl/blst/BlstSignatureTest.java
@@ -1,9 +1,5 @@
 /*
-<<<<<<< HEAD
  * Copyright 2020 ConsenSys AG.
-=======
- * Copyright 2021 ConsenSys AG.
->>>>>>> Make use of abstract unit tests for BLST implementation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -17,16 +13,14 @@
 
 package tech.pegasys.teku.bls.impl.blst;
 
-<<<<<<< HEAD
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.bls.impl.blst.BlstSignature.INFINITY;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.impl.AbstractSignatureTest;
 import tech.pegasys.teku.bls.impl.BLS12381;
-
-import org.apache.tuweni.bytes.Bytes;
-import org.junit.jupiter.api.Test;
 
 public class BlstSignatureTest extends AbstractSignatureTest {
   private static BLS12381 BLS;

--- a/bls/src/test/java/tech/pegasys/teku/bls/impl/blst/BlstSignatureTest.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/impl/blst/BlstSignatureTest.java
@@ -1,5 +1,9 @@
 /*
+<<<<<<< HEAD
  * Copyright 2020 ConsenSys AG.
+=======
+ * Copyright 2021 ConsenSys AG.
+>>>>>>> Make use of abstract unit tests for BLST implementation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,18 +17,28 @@
 
 package tech.pegasys.teku.bls.impl.blst;
 
+<<<<<<< HEAD
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.bls.impl.blst.BlstSignature.INFINITY;
 
-import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeAll;
+import tech.pegasys.teku.bls.impl.AbstractSignatureTest;
+import tech.pegasys.teku.bls.impl.BLS12381;
+
+import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 
-public class BlstSignatureTest {
+public class BlstSignatureTest extends AbstractSignatureTest {
+  private static BLS12381 BLS;
 
   @BeforeAll
   static void setup() {
-    assertThat(BlstLoader.INSTANCE).isNotEmpty();
+    BLS = BlstLoader.INSTANCE.orElseThrow();
+  }
+
+  @Override
+  protected BLS12381 getBls() {
+    return BLS;
   }
 
   private static final Bytes INFINITY_BYTES =

--- a/bls/src/test/java/tech/pegasys/teku/bls/impl/blst/BlstTest.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/impl/blst/BlstTest.java
@@ -22,9 +22,10 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BatchSemiAggregate;
+import tech.pegasys.teku.bls.impl.AbstractBLS12381Test;
 import tech.pegasys.teku.bls.impl.BLS12381;
 
-public class BlstTest {
+public class BlstTest extends AbstractBLS12381Test {
   private static final Random random = new Random(1);
 
   private static BLS12381 BLS;
@@ -32,6 +33,11 @@ public class BlstTest {
   @BeforeAll
   static void setup() {
     BLS = BlstLoader.INSTANCE.orElseThrow();
+  }
+
+  @Override
+  protected BLS12381 getBls() {
+    return BLS;
   }
 
   @Test

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BatchSignatureVerifierTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BatchSignatureVerifierTest.java
@@ -42,8 +42,7 @@ public class BatchSignatureVerifierTest {
         Bytes.wrap("Hello, world!".getBytes(UTF_8)),
         BLSTestUtil.randomSignature(43));
 
-    // a case that should probably be handled differently, but equally doesnt seem to occur
-    assertThatThrownBy(verifier::batchVerify).isInstanceOf(IndexOutOfBoundsException.class);
+    assertThat(verifier.batchVerify()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## PR Description

Turned out that there are 3 BLST abstract unit tests which were formerly derived just by the Mikuli implementation tests, but were actually intended to test BLST implementation as well. 


- Remove `succeedsWhenPassingEmptyListToAggregatePublicKeysDoesNotThrowException` : aggregating empty set of public keys should formerly return 'infinite point' public key. Don't think this is a case any more as the spec now explicitly prohibits 'infinite points' 
- Return 'true' for `batchVerify` with empty batches list
- ~~`aggregateVerifyDuplicateMessages`: for some reasons in Mikuli we prohibited duplicate messages when doing `aggregateVerify`. That [condition](https://github.com/ConsenSys/teku/pull/1100/files?file-filters%5B%5D=.java&hide-deleted-files=true#diff-43cbcb21d01ad4a2e674e5d30fcf4533e4d9460ea0d4ee83b875bc73d10f609bR101-R106) was added in #1100. @benjaminion could you please check this if you by any chance remember what was the reason behind this check?~~
- fix `BatchSignatureVerifierTest#shouldRaiseExceptionIfNoValidPublicKeys`: throwing `IndexOutOfBoundsException` was just a side effect. Returning `false` from `batchVerify()` is the expected behavior 
- Prohibit duplicate messages for `aggregateVerify` as per [BLS spec](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-3.1.1).

## Fixed Issue(s)

Fix #4240

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
