### PR TITLE
Support voting for eth1 blocks prior to the first deposit

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1Data.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1Data.java
@@ -43,6 +43,12 @@ public class Eth1Data extends Container3<Eth1Data, SszBytes32, SszUInt64, SszByt
 
   public static final Eth1DataSchema SSZ_SCHEMA = new Eth1DataSchema();
 
+  /**
+   * The output of `get_deposit_root` from the deposit contract prior to any deposits being made.
+   */
+  public static final Bytes32 EMPTY_DEPOSIT_ROOT =
+      Bytes32.fromHexString("0xd70a234731285c6804c2a4f56711ddb8c82c99740f207854891028af34e27e5e");
+
   private Eth1Data(Eth1DataSchema type, TreeNode backingNode) {
     super(type, backingNode);
   }

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/Eth1DataCacheTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/Eth1DataCacheTest.java
@@ -99,11 +99,15 @@ public class Eth1DataCacheTest {
   }
 
   @Test
-  void shouldIgnoreEmptyBlocksWithNoEarlierDeposits() {
+  void shouldUseEmptyMerkleTrieRootForBlocksWithNoEarlierDeposits() {
     final Bytes32 emptyBlockHash = dataStructureUtil.randomBytes32();
     eth1DataCache.onEth1Block(emptyBlockHash, IN_RANGE_TIMESTAMP_1);
 
-    assertThat(getCacheSize()).isZero();
+    final BeaconState beaconState = createBeaconStateWithVotes();
+    when(beaconState.getEth1_data()).thenReturn(new Eth1Data(Bytes32.ZERO, ZERO, Bytes32.ZERO));
+
+    final Eth1Data eth1Vote = eth1DataCache.getEth1Vote(beaconState);
+    assertThat(eth1Vote).isEqualTo(new Eth1Data(Eth1Data.EMPTY_DEPOSIT_ROOT, ZERO, emptyBlockHash));
   }
 
   @Test


### PR DESCRIPTION
## PR Description
On testnets, it's common for a genesis state to be generated that already includes validators, so the chain can start without having any deposits received.

Eth1 blocks are now added to cache even if they are before the first deposit and simply use the hash for the empty deposit merkle tree.

## Fixed Issue(s)
fixes #4113

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
