### PR TITLE
Handle exception when peers send additional responses cleanly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,5 +23,6 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
  - Added a column size and percentage complete to migrate-database command, where columns contain block or state objects, as they can be time consuming to copy.
  - Fixed issue in Altair where sync committee contribution gossip could be incorrectly rejected when received at the very end of the slot.
- - Posting attestations that fail validation to `/eth/v1/beacon/pool/attestations` will now result in `SC_BAD_REQUEST` response, with details of the invalid attestations in the response body. 
+ - Posting attestations that fail validation to `/eth/v1/beacon/pool/attestations` will now result in `SC_BAD_REQUEST` response, with details of the invalid attestations in the response body.
+ - Fixed `IllegalStateException: New response submitted after closing AsyncResponseProcessor` errors.
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/AsyncResponseProcessor.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/AsyncResponseProcessor.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.AdditionalDataReceivedException;
 
 class AsyncResponseProcessor<TResponse> {
   private static final Logger LOG = LogManager.getLogger();
@@ -46,13 +47,9 @@ class AsyncResponseProcessor<TResponse> {
     this.onError = onError;
   }
 
-  public void processResponse(TResponse response) {
+  public void processResponse(TResponse response) throws RpcException {
     if (allResponsesDelivered.get()) {
-      throw new IllegalStateException(
-          "New response submitted after closing "
-              + this.getClass().getSimpleName()
-              + " for new responses: "
-              + response);
+      throw new AdditionalDataReceivedException();
     }
     if (cancelled.get()) {
       LOG.trace("Request cancelled, dropping response: {}", response);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandler.java
@@ -135,7 +135,9 @@ public class Eth2OutgoingRequestHandler<
         throw new ExtraDataAppendedException();
       }
 
-      maybeResponses.forEach(responseProcessor::processResponse);
+      for (TResponse maybeResponse : maybeResponses) {
+        responseProcessor.processResponse(maybeResponse);
+      }
       if (chunksReceived < maximumResponseChunks) {
         if (!maybeResponses.isEmpty()) {
           ensureNextResponseArrivesInTime(rpcStream, chunksReceived, currentChunkCount);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcException.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcException.java
@@ -78,6 +78,12 @@ public class RpcException extends Exception {
     }
   }
 
+  public static class AdditionalDataReceivedException extends RpcException {
+    public AdditionalDataReceivedException() {
+      super(INVALID_REQUEST_CODE, "Received additional response after request completed");
+    }
+  }
+
   // Constraint violation
   public static class ChunkTooLongException extends RpcException {
     public ChunkTooLongException() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcException.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcException.java
@@ -100,7 +100,6 @@ public class RpcException extends Exception {
   // Unavailable data
 
   public static class ResourceUnavailableException extends RpcException {
-
     public ResourceUnavailableException(final String errorMessage) {
       super(RESOURCE_UNAVAILABLE, errorMessage);
     }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/AsyncResponseProcessorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/AsyncResponseProcessorTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.networking.eth2.rpc.core.AsyncResponseProcessor.AsyncProcessingErrorHandler;
+import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.AdditionalDataReceivedException;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 
 public class AsyncResponseProcessorTest {
@@ -45,7 +46,7 @@ public class AsyncResponseProcessorTest {
       new AsyncResponseProcessor<>(asyncRunner, responseStream, errorConsumer);
 
   @Test
-  public void processMultipleResponsesSuccessfully() {
+  public void processMultipleResponsesSuccessfully() throws Exception {
     asyncResponseProcessor.processResponse("a");
     assertThat(asyncResponseProcessor.getResponseCount()).isEqualTo(1);
     asyncResponseProcessor.processResponse("b");
@@ -65,7 +66,7 @@ public class AsyncResponseProcessorTest {
   }
 
   @Test
-  public void dropsRemainingResponsesOnError() {
+  public void dropsRemainingResponsesOnError() throws Exception {
     asyncResponseProcessor.processResponse("a");
     asyncResponseProcessor.processResponse("b");
     asyncResponseProcessor.processResponse("c");
@@ -91,7 +92,7 @@ public class AsyncResponseProcessorTest {
   }
 
   @Test
-  public void finishProcessingWhileSomeResponsesStillQueue() {
+  public void finishProcessingWhileSomeResponsesStillQueue() throws Exception {
     asyncResponseProcessor.processResponse("a");
     asyncResponseProcessor.processResponse("b");
     asyncResponseProcessor.processResponse("c");
@@ -110,7 +111,7 @@ public class AsyncResponseProcessorTest {
   }
 
   @Test
-  public void finishProcessingWhileSomeResponsesStillQueueWhenErrorIsThrown() {
+  public void finishProcessingWhileSomeResponsesStillQueueWhenErrorIsThrown() throws Exception {
     asyncResponseProcessor.processResponse("a");
     asyncResponseProcessor.processResponse("b");
     asyncResponseProcessor.processResponse("c");
@@ -141,7 +142,6 @@ public class AsyncResponseProcessorTest {
   public void shouldThrowIfResponsesSubmittedAfterFinishedProcessing() {
     asyncResponseProcessor.finishProcessing().reportExceptions();
     assertThatThrownBy(() -> asyncResponseProcessor.processResponse("a"))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("New response submitted after closing");
+        .isInstanceOf(AdditionalDataReceivedException.class);
   }
 }


### PR DESCRIPTION
## PR Description
Handle getting additional response messages after a request is expected to be completed.

Previously an IllegalStateException was thrown which is unhandled. Now a RpcException is thrown to indicate that the remote peer has behaved incorrectly. The request is aborted and logged is at debug level.

## Fixed Issue(s)
fixes #3592 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
