### PR TITLE
Switch jdk16 docker image to use eclipse-temurin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - The `/eth/v1/debug/beacon/states/:state_id` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/debug/beacon/states/:state_id`
 - The `/eth/v1/beacon/blocks/:block_id` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/beacon/blocks/:block_id`
 - The `/eth/v1/validator/blocks/:slot` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/validator/blocks/:slot`
+- The `-jdk14` and `-jdk15` docker image variants will be removed in a future release. JDK 14 and 15 are no longer receiving security updates from upstream vendors.
+  Note that the default docker image usage JDK 16 and is still receiving security updates.
 
 ## Current Releases
 For information on changes in released versions of Teku, see the [releases page](https://github.com/ConsenSys/teku/releases).
@@ -16,6 +18,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Additions and Improvements
  - Logged a message to indicate when the node is in sync.
  - Upgraded jdk16 and default docker image to use eclipse-tumerin builds of OpenJDK.
+ - jdk14 and jdk15 docker images have been upgraded to use the latest Ubuntu. Note that these images will be removed in future versions.
 
 ### Bug Fixes
  - Fixed `IllegalStateException: New response submitted after closing AsyncResponseProcessor` errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
  - Logged a message to indicate when the node is in sync.
+ - Upgraded jdk16 and default docker image to use eclipse-tumerin builds of OpenJDK.
 
 ### Bug Fixes
  - Fixed `IllegalStateException: New response submitted after closing AsyncResponseProcessor` errors.

--- a/docker/jdk14/Dockerfile
+++ b/docker/jdk14/Dockerfile
@@ -1,4 +1,18 @@
-FROM adoptopenjdk:14-jre-hotspot
+FROM openjdk:14 as jre-build
+
+# Create a custom Java runtime
+RUN $JAVA_HOME/bin/jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-java-debug-attributes \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+FROM ubuntu:latest
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
 
 RUN apt-get -y update
 RUN apt-get -y install curl

--- a/docker/jdk15/Dockerfile
+++ b/docker/jdk15/Dockerfile
@@ -1,4 +1,18 @@
-FROM adoptopenjdk:15-jre-hotspot
+FROM openjdk:15 as jre-build
+
+# Create a custom Java runtime
+RUN $JAVA_HOME/bin/jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-java-debug-attributes \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+FROM ubuntu:latest
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
 
 RUN apt-get -y update
 RUN apt-get -y install curl

--- a/docker/jdk16/Dockerfile
+++ b/docker/jdk16/Dockerfile
@@ -1,4 +1,18 @@
-FROM adoptopenjdk:16-jre-hotspot
+FROM eclipse-temurin:16 as jre-build
+
+# Create a custom Java runtime
+RUN $JAVA_HOME/bin/jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+FROM ubuntu:latest
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
 
 RUN apt-get -y update
 RUN apt-get -y install curl


### PR DESCRIPTION
## PR Description
The jdk16 docker image (which is the default) is now built from eclipse-temurin.

eclipse-temurin doesn't provide a JRE only build so we now use jlink to build one from the JDK. On the plus side, this gives us an even smaller image and we now control the base OS our images use.

There isn't a java 14 or 15 for eclipse-tumerin so they have switched back to OpenJDK, but also use jlink to build a JRE then use ubuntu:latest as the base OS.

Have added a note that the jdk14 and jdk15 images will be removed in a future release. Those JDK versions aren't being supported anymore so there's no reason anyone should be using them.

## Fixed Issue(s)
fixes #4244 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
