### PR TITLE
Use IntList instead of List<Integer>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For information on changes in released versions of Teku, see the [releases page]
  - Upgraded jdk16 and default docker image to use eclipse-tumerin builds of OpenJDK.
  - jdk14 and jdk15 docker images have been upgraded to use the latest Ubuntu. Note that these images will be removed in future versions.
  - Reduced memory usage and GC pressure created while tracking the latest attestations for each validator.
+ - Reduced memory usage and GC pressure created by state caches.
 
 ### Bug Fixes
  - Fixed `IllegalStateException: New response submitted after closing AsyncResponseProcessor` errors.

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionCachesBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionCachesBenchmark.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.benchmarks;
 
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.tuweni.bytes.Bytes;
@@ -40,7 +41,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.Transition
 @Measurement(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 public class TransitionCachesBenchmark {
 
-  private static final List<Integer> SOME_INT_LIST = List.of(1, 2, 3, 43, 4, 5);
+  private static final IntList SOME_INT_LIST = IntList.of(1, 2, 3, 43, 4, 5);
 
   @Param({"1048576"})
   int validatorsCount;
@@ -94,7 +95,7 @@ public class TransitionCachesBenchmark {
     if (counter >= 10064) {
       counter = 10000;
     }
-    Cache<TekuPair<UInt64, UInt64>, List<Integer>> cache = fullCache.getBeaconCommittee();
+    Cache<TekuPair<UInt64, UInt64>, IntList> cache = fullCache.getBeaconCommittee();
     List<Integer> res =
         cache.get(TekuPair.of(UInt64.valueOf(counter), UInt64.ZERO), __ -> SOME_INT_LIST);
     bh.consume(res);
@@ -106,7 +107,7 @@ public class TransitionCachesBenchmark {
       counter = 10064;
     }
     counter++;
-    Cache<TekuPair<UInt64, UInt64>, List<Integer>> cache = fullCache.getBeaconCommittee();
+    Cache<TekuPair<UInt64, UInt64>, IntList> cache = fullCache.getBeaconCommittee();
     List<Integer> res =
         cache.get(TekuPair.of(UInt64.valueOf(counter), UInt64.ZERO), __ -> SOME_INT_LIST);
     bh.consume(res);

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AttestationGenerator.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/AttestationGenerator.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.infrastructure.async.SyncAsyncRunner.SYNC_RUNNER
 import static tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil.compute_epoch_at_slot;
 
 import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -288,7 +289,7 @@ public class AttestationGenerator {
           continue;
         }
 
-        List<Integer> committeeIndices = assignment.getCommittee();
+        IntList committeeIndices = assignment.getCommittee();
         UInt64 committeeIndex = assignment.getCommitteeIndex();
         Committee committee = new Committee(committeeIndex, committeeIndices);
         int indexIntoCommittee = committeeIndices.indexOf(validatorIndex);

--- a/ethereum/spec/build.gradle
+++ b/ethereum/spec/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
+    api 'it.unimi.dsi:fastutil'
+
     implementation project(':ssz')
 
     implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec;
 
 import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -526,7 +527,7 @@ public class Spec {
     return atState(state).beaconStateAccessors().getMaxLookaheadEpoch(state);
   }
 
-  public List<Integer> getActiveValidatorIndices(final BeaconState state, final UInt64 epoch) {
+  public IntList getActiveValidatorIndices(final BeaconState state, final UInt64 epoch) {
     return atEpoch(epoch).beaconStateAccessors().getActiveValidatorIndices(state, epoch);
   }
 
@@ -538,7 +539,7 @@ public class Spec {
     return atState(state).beaconStateAccessors().getPreviousEpochAttestationCapacity(state);
   }
 
-  public List<Integer> getBeaconCommittee(BeaconState state, UInt64 slot, UInt64 index) {
+  public IntList getBeaconCommittee(BeaconState state, UInt64 slot, UInt64 index) {
     return atState(state).beaconStateAccessors().getBeaconCommittee(state, slot, index);
   }
 
@@ -563,8 +564,7 @@ public class Spec {
   }
 
   // Attestation helpers
-  public List<Integer> getAttestingIndices(
-      BeaconState state, AttestationData data, SszBitlist bits) {
+  public IntList getAttestingIndices(BeaconState state, AttestationData data, SszBitlist bits) {
     return atState(state).getAttestationUtil().getAttestingIndices(state, data, bits);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Committee.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Committee.java
@@ -13,15 +13,15 @@
 
 package tech.pegasys.teku.spec.datastructures.state;
 
-import java.util.List;
+import it.unimi.dsi.fastutil.ints.IntList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class Committee {
 
   private final UInt64 index;
-  private final List<Integer> committee;
+  private final IntList committee;
 
-  public Committee(UInt64 index, List<Integer> committee) {
+  public Committee(UInt64 index, IntList committee) {
     this.index = index;
     this.committee = committee;
   }
@@ -31,7 +31,7 @@ public class Committee {
     return index;
   }
 
-  public List<Integer> getCommittee() {
+  public IntList getCommittee() {
     return committee;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/CommitteeAssignment.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/CommitteeAssignment.java
@@ -13,22 +13,22 @@
 
 package tech.pegasys.teku.spec.datastructures.state;
 
-import java.util.List;
+import it.unimi.dsi.fastutil.ints.IntList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class CommitteeAssignment {
 
-  private List<Integer> committee;
+  private IntList committee;
   private UInt64 committeeIndex;
   private UInt64 slot;
 
-  public CommitteeAssignment(List<Integer> committee, UInt64 committeeIndex, UInt64 slot) {
+  public CommitteeAssignment(IntList committee, UInt64 committeeIndex, UInt64 slot) {
     this.committee = committee;
     this.committeeIndex = committeeIndex;
     this.slot = slot;
   }
 
-  public List<Integer> getCommittee() {
+  public IntList getCommittee() {
     return committee;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.state.beaconstate.common;
 
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -66,14 +67,14 @@ public class TransitionCaches {
     return NO_OP_INSTANCE;
   }
 
-  private final Cache<UInt64, List<Integer>> activeValidators;
+  private final Cache<UInt64, IntList> activeValidators;
   private final Cache<UInt64, Integer> beaconProposerIndex;
-  private final Cache<TekuPair<UInt64, UInt64>, List<Integer>> beaconCommittee;
+  private final Cache<TekuPair<UInt64, UInt64>, IntList> beaconCommittee;
   private final Cache<UInt64, UInt64> attestersTotalBalance;
   private final Cache<UInt64, UInt64> totalActiveBalance;
   private final Cache<UInt64, BLSPublicKey> validatorsPubKeys;
   private final ValidatorIndexCache validatorIndexCache;
-  private final Cache<Bytes32, List<Integer>> committeeShuffle;
+  private final Cache<Bytes32, IntList> committeeShuffle;
   private final Cache<UInt64, List<UInt64>> effectiveBalances;
 
   private final Cache<UInt64, Map<UInt64, SyncSubcommitteeAssignments>> syncCommitteeCache;
@@ -94,14 +95,14 @@ public class TransitionCaches {
   }
 
   private TransitionCaches(
-      Cache<UInt64, List<Integer>> activeValidators,
+      Cache<UInt64, IntList> activeValidators,
       Cache<UInt64, Integer> beaconProposerIndex,
-      Cache<TekuPair<UInt64, UInt64>, List<Integer>> beaconCommittee,
+      Cache<TekuPair<UInt64, UInt64>, IntList> beaconCommittee,
       Cache<UInt64, UInt64> attestersTotalBalance,
       Cache<UInt64, UInt64> totalActiveBalance,
       Cache<UInt64, BLSPublicKey> validatorsPubKeys,
       ValidatorIndexCache validatorIndexCache,
-      Cache<Bytes32, List<Integer>> committeeShuffle,
+      Cache<Bytes32, IntList> committeeShuffle,
       Cache<UInt64, List<UInt64>> effectiveBalances,
       Cache<UInt64, Map<UInt64, SyncSubcommitteeAssignments>> syncCommitteeCache) {
     this.activeValidators = activeValidators;
@@ -125,7 +126,7 @@ public class TransitionCaches {
   }
 
   /** (epoch) -> (active validators) cache */
-  public Cache<UInt64, List<Integer>> getActiveValidators() {
+  public Cache<UInt64, IntList> getActiveValidators() {
     return activeValidators;
   }
 
@@ -135,7 +136,7 @@ public class TransitionCaches {
   }
 
   /** (slot, committeeIndex) -> (committee) cache */
-  public Cache<TekuPair<UInt64, UInt64>, List<Integer>> getBeaconCommittee() {
+  public Cache<TekuPair<UInt64, UInt64>, IntList> getBeaconCommittee() {
     return beaconCommittee;
   }
 
@@ -166,7 +167,7 @@ public class TransitionCaches {
   }
 
   /** (epoch committee seed) -> (validators shuffle for epoch) cache */
-  public Cache<Bytes32, List<Integer>> getCommitteeShuffle() {
+  public Cache<Bytes32, IntList> getCommitteeShuffle() {
     return committeeShuffle;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BeaconStateUtil.java
@@ -37,6 +37,7 @@ import static tech.pegasys.teku.util.config.Constants.TARGET_COMMITTEE_SIZE;
 import static tech.pegasys.teku.util.config.Constants.WHISTLEBLOWER_REWARD_QUOTIENT;
 
 import com.google.common.primitives.UnsignedBytes;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.nio.ByteOrder;
 import java.util.Collection;
 import java.util.Collections;
@@ -384,7 +385,7 @@ public class BeaconStateUtil {
    */
   @Deprecated
   public static UInt64 get_committee_count_per_slot(BeaconState state, UInt64 epoch) {
-    List<Integer> active_validator_indices = get_active_validator_indices(state, epoch);
+    IntList active_validator_indices = get_active_validator_indices(state, epoch);
     return get_committee_count_per_slot(active_validator_indices.size());
   }
 
@@ -441,7 +442,7 @@ public class BeaconStateUtil {
                       Bytes.concatenate(
                           get_seed(state, epoch, Domain.BEACON_PROPOSER),
                           uint_to_bytes(slot.longValue(), 8)));
-              List<Integer> indices = get_active_validator_indices(state, epoch);
+              IntList indices = get_active_validator_indices(state, epoch);
               return compute_proposer_index(state, indices, seed);
             });
   }
@@ -712,15 +713,14 @@ public class BeaconStateUtil {
    * @return
    */
   @Deprecated
-  private static int compute_proposer_index(
-      BeaconState state, List<Integer> indices, Bytes32 seed) {
+  private static int compute_proposer_index(BeaconState state, IntList indices, Bytes32 seed) {
     checkArgument(!indices.isEmpty(), "compute_proposer_index indices must not be empty");
     UInt64 MAX_RANDOM_BYTE = UInt64.valueOf(255); // Math.pow(2, 8) - 1;
     int i = 0;
     final int total = indices.size();
     Bytes32 hash = null;
     while (true) {
-      int candidate_index = indices.get(compute_shuffled_index(i % total, total, seed));
+      int candidate_index = indices.getInt(compute_shuffled_index(i % total, total, seed));
       if (i % 32 == 0) {
         hash = Hash.sha2_256(Bytes.concatenate(seed, uint_to_bytes(Math.floorDiv(i, 32), 8)));
       }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/ValidatorsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/ValidatorsUtil.java
@@ -16,9 +16,8 @@ package tech.pegasys.teku.spec.datastructures.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.util.config.Constants.MAX_SEED_LOOKAHEAD;
 
-import java.util.List;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -54,7 +53,7 @@ class ValidatorsUtil {
    * @return A list of indices representing the active validators for the given epoch.
    */
   @Deprecated
-  static List<Integer> get_active_validator_indices(BeaconState state, UInt64 epoch) {
+  static IntList get_active_validator_indices(BeaconState state, UInt64 epoch) {
     final UInt64 stateEpoch = BeaconStateUtil.get_current_epoch(state);
     final UInt64 maxLookaheadEpoch = getMaxLookaheadEpoch(stateEpoch);
     checkArgument(
@@ -68,10 +67,10 @@ class ValidatorsUtil {
             epoch,
             e -> {
               SszList<Validator> validators = state.getValidators();
-              return IntStream.range(0, validators.size())
-                  .filter(index -> is_active_validator(validators.get(index), epoch))
-                  .boxed()
-                  .collect(Collectors.toList());
+              return IntList.of(
+                  IntStream.range(0, validators.size())
+                      .filter(index -> is_active_validator(validators.get(index), epoch))
+                      .toArray());
             });
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Math.toIntExact;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -263,7 +264,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
         "process_attestations: %s",
         invalidReason.map(OperationInvalidReason::describe).orElse(""));
 
-    List<Integer> committee =
+    IntList committee =
         beaconStateAccessors.getBeaconCommittee(state, data.getSlot(), data.getIndex());
     checkArgument(
         attestation.getAggregation_bits().size() == committee.size(),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -17,10 +17,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_EPOCH;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uint64ToBytes;
 
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -97,7 +96,7 @@ public abstract class BeaconStateAccessors {
    * @param epoch - The epoch under consideration.
    * @return A list of indices representing the active validators for the given epoch.
    */
-  public List<Integer> getActiveValidatorIndices(BeaconState state, UInt64 epoch) {
+  public IntList getActiveValidatorIndices(BeaconState state, UInt64 epoch) {
     final UInt64 stateEpoch = getCurrentEpoch(state);
     final UInt64 maxLookaheadEpoch = getMaxLookaheadEpoch(stateEpoch);
     checkArgument(
@@ -111,10 +110,10 @@ public abstract class BeaconStateAccessors {
             epoch,
             e -> {
               SszList<Validator> validators = state.getValidators();
-              return IntStream.range(0, validators.size())
-                  .filter(index -> predicates.isActiveValidator(validators.get(index), epoch))
-                  .boxed()
-                  .collect(Collectors.toList());
+              return IntList.of(
+                  IntStream.range(0, validators.size())
+                      .filter(index -> predicates.isActiveValidator(validators.get(index), epoch))
+                      .toArray());
             });
   }
 
@@ -160,7 +159,7 @@ public abstract class BeaconStateAccessors {
    * @return
    */
   public UInt64 getCommitteeCountPerSlot(BeaconState state, UInt64 epoch) {
-    List<Integer> activeValidatorIndices = getActiveValidatorIndices(state, epoch);
+    IntList activeValidatorIndices = getActiveValidatorIndices(state, epoch);
     return getCommitteeCountPerSlot(activeValidatorIndices.size());
   }
 
@@ -196,7 +195,7 @@ public abstract class BeaconStateAccessors {
                   Hash.sha2_256(
                       Bytes.concatenate(
                           getSeed(state, epoch, Domain.BEACON_PROPOSER), uint64ToBytes(slot)));
-              List<Integer> indices = getActiveValidatorIndices(state, epoch);
+              IntList indices = getActiveValidatorIndices(state, epoch);
               return miscHelpers.computeProposerIndex(state, indices, seed);
             });
   }
@@ -262,7 +261,7 @@ public abstract class BeaconStateAccessors {
     return Integer.MAX_VALUE;
   }
 
-  public List<Integer> getBeaconCommittee(BeaconState state, UInt64 slot, UInt64 index) {
+  public IntList getBeaconCommittee(BeaconState state, UInt64 slot, UInt64 index) {
     // Make sure state is within range of the slot being queried
     validateStateForCommitteeQuery(state, slot);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -19,9 +19,7 @@ import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uint64ToBy
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uintToBytes;
 
 import com.google.common.primitives.UnsignedBytes;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
+import it.unimi.dsi.fastutil.ints.IntList;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.Hash;
@@ -75,14 +73,14 @@ public class MiscHelpers {
     return indexRet;
   }
 
-  public int computeProposerIndex(BeaconState state, List<Integer> indices, Bytes32 seed) {
+  public int computeProposerIndex(BeaconState state, IntList indices, Bytes32 seed) {
     checkArgument(!indices.isEmpty(), "compute_proposer_index indices must not be empty");
     UInt64 MAX_RANDOM_BYTE = UInt64.valueOf(255); // Math.pow(2, 8) - 1;
     int i = 0;
     final int total = indices.size();
     Bytes32 hash = null;
     while (true) {
-      int candidate_index = indices.get(computeShuffledIndex(i % total, total, seed));
+      int candidate_index = indices.getInt(computeShuffledIndex(i % total, total, seed));
       if (i % 32 == 0) {
         hash = Hash.sha2_256(Bytes.concatenate(seed, uint64ToBytes(Math.floorDiv(i, 32))));
       }
@@ -127,15 +125,15 @@ public class MiscHelpers {
     return computeStartSlotAtEpoch(previousEpoch);
   }
 
-  public List<Integer> computeCommittee(
-      BeaconState state, List<Integer> indices, Bytes32 seed, int index, int count) {
+  public IntList computeCommittee(
+      BeaconState state, IntList indices, Bytes32 seed, int index, int count) {
     int start = Math.floorDiv(indices.size() * index, count);
     int end = Math.floorDiv(indices.size() * (index + 1), count);
     return computeCommitteeShuffle(state, indices, seed, start, end);
   }
 
-  private List<Integer> computeCommitteeShuffle(
-      BeaconState state, List<Integer> indices, Bytes32 seed, int fromIndex, int toIndex) {
+  private IntList computeCommitteeShuffle(
+      BeaconState state, IntList indices, Bytes32 seed, int fromIndex, int toIndex) {
     if (fromIndex < toIndex) {
       int indexCount = indices.size();
       checkArgument(fromIndex < indexCount, "CommitteeUtil.getShuffledIndex1");
@@ -147,10 +145,10 @@ public class MiscHelpers {
         .subList(fromIndex, toIndex);
   }
 
-  List<Integer> shuffleList(List<Integer> input, Bytes32 seed) {
-    int[] indexes = input.stream().mapToInt(i -> i).toArray();
+  IntList shuffleList(IntList input, Bytes32 seed) {
+    final int[] indexes = input.toIntArray();
     shuffleList(indexes, seed);
-    return Arrays.stream(indexes).boxed().collect(Collectors.toList());
+    return IntList.of(indexes);
   }
 
   public void shuffleList(int[] input, Bytes32 seed) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -18,6 +18,7 @@ import static java.util.stream.Collectors.toList;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 
 import com.google.common.collect.Comparators;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -107,21 +108,20 @@ public class AttestationUtil {
    * @see
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#get_attesting_indices</a>
    */
-  public List<Integer> getAttestingIndices(
-      BeaconState state, AttestationData data, SszBitlist bits) {
-    return streamAttestingIndices(state, data, bits).boxed().collect(toList());
+  public IntList getAttestingIndices(BeaconState state, AttestationData data, SszBitlist bits) {
+    return IntList.of(streamAttestingIndices(state, data, bits).toArray());
   }
 
   public IntStream streamAttestingIndices(
       BeaconState state, AttestationData data, SszBitlist bits) {
-    List<Integer> committee =
+    IntList committee =
         beaconStateAccessors.getBeaconCommittee(state, data.getSlot(), data.getIndex());
     checkArgument(
         bits.size() == committee.size(),
         "Aggregation bitlist size (%s) does not match committee size (%s)",
         bits.size(),
         committee.size());
-    return IntStream.range(0, committee.size()).filter(bits::getBit).map(committee::get);
+    return IntStream.range(0, committee.size()).filter(bits::getBit).map(committee::getInt);
   }
 
   public AttestationProcessingResult isValidIndexedAttestation(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.spec.logic.common.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.bytesToUInt64;
 
-import java.util.List;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Optional;
 import org.apache.tuweni.crypto.Hash;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -110,7 +110,7 @@ public class ValidatorsUtil {
       for (UInt64 index = UInt64.ZERO;
           index.compareTo(committeeCountPerSlot) < 0;
           index = index.plus(UInt64.ONE)) {
-        final List<Integer> committee = beaconStateAccessors.getBeaconCommittee(state, slot, index);
+        final IntList committee = beaconStateAccessors.getBeaconCommittee(state, slot, index);
         if (committee.contains(validator_index)) {
           return Optional.of(new CommitteeAssignment(committee, index, slot));
         }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/util/BeaconStateUtilTest.java
@@ -25,6 +25,7 @@ import static tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil.compute
 import static tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil.compute_start_slot_at_epoch;
 import static tech.pegasys.teku.util.config.Constants.SLOTS_PER_EPOCH;
 
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -148,7 +149,7 @@ class BeaconStateUtilTest {
   void getTotalBalanceAddsAndReturnsEffectiveTotalBalancesCorrectly() {
     // Data Setup
     BeaconState state = createBeaconState();
-    Committee committee = new Committee(UInt64.ONE, Arrays.asList(0, 1, 2));
+    Committee committee = new Committee(UInt64.ONE, IntList.of(0, 1, 2));
 
     // Calculate Expected Results
     UInt64 expectedBalance = UInt64.ZERO;

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/genesis/GenesisGeneratorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/genesis/GenesisGeneratorTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
@@ -105,7 +106,7 @@ class GenesisGeneratorTest {
 
     final BeaconState actualState = genesisGenerator.getGenesisState();
     assertThat(actualState).isEqualTo(expectedState);
-    assertThat(spec.getActiveValidatorIndices(expectedState, GENESIS_EPOCH))
+    Assertions.<Integer>assertThat(spec.getActiveValidatorIndices(expectedState, GENESIS_EPOCH))
         .hasSize(VALIDATOR_KEYS.size());
     assertThat(genesisGenerator.getActiveValidatorCount()).isEqualTo(VALIDATOR_KEYS.size());
   }
@@ -117,7 +118,8 @@ class GenesisGeneratorTest {
           Bytes32.ZERO, UInt64.ZERO, Collections.singletonList(initialDeposits.get(i)));
 
       final BeaconState state = genesisGenerator.getGenesisState();
-      assertThat(spec.getActiveValidatorIndices(state, GENESIS_EPOCH)).hasSize(i + 1);
+      Assertions.<Integer>assertThat(spec.getActiveValidatorIndices(state, GENESIS_EPOCH))
+          .hasSize(i + 1);
       assertThat(genesisGenerator.getActiveValidatorCount()).isEqualTo(i + 1);
     }
   }
@@ -150,7 +152,7 @@ class GenesisGeneratorTest {
     genesisGenerator.updateCandidateState(Bytes32.ZERO, UInt64.ZERO, INITIAL_DEPOSITS);
 
     final BeaconState state = genesisGenerator.getGenesisState();
-    assertThat(spec.getActiveValidatorIndices(state, GENESIS_EPOCH)).hasSize(1);
+    Assertions.<Integer>assertThat(spec.getActiveValidatorIndices(state, GENESIS_EPOCH)).hasSize(1);
     assertThat(genesisGenerator.getActiveValidatorCount()).isEqualTo(1);
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessorsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessorsTest.java
@@ -20,7 +20,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_EPOCH;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 
-import java.util.Arrays;
+import it.unimi.dsi.fastutil.ints.IntList;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -66,7 +66,7 @@ public class BeaconStateAccessorsTest {
   void getTotalBalanceAddsAndReturnsEffectiveTotalBalancesCorrectly() {
     // Data Setup
     BeaconState state = createBeaconState();
-    Committee committee = new Committee(UInt64.ONE, Arrays.asList(0, 1, 2));
+    Committee committee = new Committee(UInt64.ONE, IntList.of(0, 1, 2));
 
     // Calculate Expected Results
     UInt64 expectedBalance = UInt64.ZERO;

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpersTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpersTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -85,7 +86,7 @@ class MiscHelpersTest {
     int[] indexes = IntStream.range(0, index_count).toArray();
     miscHelpers.shuffleList(indexes, seed);
 
-    List<Integer> indexList = IntStream.range(0, index_count).boxed().collect(Collectors.toList());
+    IntList indexList = IntList.of(IntStream.range(0, index_count).toArray());
     final List<Integer> result = miscHelpers.shuffleList(indexList, seed);
 
     assertThat(result)

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
@@ -22,7 +22,7 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 import static tech.pegasys.teku.util.config.Constants.VALID_AGGREGATE_SET_SIZE;
 
-import java.util.List;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -130,7 +130,7 @@ public class AggregateAttestationValidator {
                           return reject("Rejecting aggregate with incorrect selection proof");
                         }
 
-                        final List<Integer> beaconCommittee =
+                        final IntList beaconCommittee =
                             spec.getBeaconCommittee(
                                 state, aggregateSlot, aggregate.getData().getIndex());
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -21,7 +21,7 @@ import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.
 import static tech.pegasys.teku.util.config.Constants.ATTESTATION_PROPAGATION_SLOT_RANGE;
 import static tech.pegasys.teku.util.config.Constants.VALID_ATTESTATION_SET_SIZE;
 
-import java.util.List;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -180,7 +180,7 @@ public class AttestationValidator {
               // The check below is not specified in the Eth2 networking spec, yet an attestation
               // with aggregation bits size greater/less than the committee size is invalid. So we
               // reject those attestations at the networking layer.
-              final List<Integer> committee =
+              final IntList committee =
                   spec.getBeaconCommittee(state, data.getSlot(), data.getIndex());
               if (committee.size() != attestation.getAggregation_bits().size()) {
                 return completedFuture(

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -86,6 +86,8 @@ dependencyManagement {
     }
     dependency 'io.projectreactor:reactor-core:3.3.7.RELEASE'
 
+    dependency 'it.unimi.dsi:fastutil:8.5.4'
+
     dependency 'javax.annotation:javax.annotation-api:1.3.2'
 
     dependencySet(group: 'org.apache.tuweni', version: '1.0.0') {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Verify.verifyNotNull;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 
 import com.google.common.annotations.VisibleForTesting;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NavigableMap;
@@ -364,7 +365,7 @@ public class CombinedChainDataClient {
       UInt64 slot = startingSlot.plus(i);
       for (int j = 0; j < committeeCount; j++) {
         UInt64 idx = UInt64.valueOf(j);
-        List<Integer> committee = spec.getBeaconCommittee(state, slot, idx);
+        IntList committee = spec.getBeaconCommittee(state, slot, idx);
         result.add(new CommitteeAssignment(committee, idx, slot));
       }
     }


### PR DESCRIPTION
## PR Description
Use fastutil `IntList` instead of `List<Integer>` in some key places. Avoids having to create Integer objects.

Particularly useful for things that go into the state cache like committee allocations as they are longer lived and so may escape the eden generation, increasing cost of GC.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
