### PR TITLE
Precompute SszLengthBounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For information on changes in released versions of Teku, see the [releases page]
  - jdk14 and jdk15 docker images have been upgraded to use the latest Ubuntu. Note that these images will be removed in future versions.
  - Reduced memory usage and GC pressure created while tracking the latest attestations for each validator.
  - Reduced memory usage and GC pressure created by state caches.
+ - Optimised length validation of gossip and RPC messages.
 
 ### Bug Fixes
  - Fixed `IllegalStateException: New response submitted after closing AsyncResponseProcessor` errors.

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/schema/impl/AbstractSszPrimitiveSchema.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/schema/impl/AbstractSszPrimitiveSchema.java
@@ -40,12 +40,14 @@ public abstract class AbstractSszPrimitiveSchema<
 
   private final int bitsSize;
   private final int sszSize;
+  private final SszLengthBounds sszLengthBounds;
 
   protected AbstractSszPrimitiveSchema(int bitsSize) {
     checkArgument(
         bitsSize > 0 && bitsSize <= 256 && 256 % bitsSize == 0, "Invalid bitsize: %s", bitsSize);
     this.bitsSize = bitsSize;
     this.sszSize = getSSZBytesSize();
+    this.sszLengthBounds = SszLengthBounds.ofBits(bitsSize);
   }
 
   @Override
@@ -127,6 +129,6 @@ public abstract class AbstractSszPrimitiveSchema<
 
   @Override
   public SszLengthBounds getSszLengthBounds() {
-    return SszLengthBounds.ofBits(getBitsSize());
+    return sszLengthBounds;
   }
 }

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/schema/impl/AbstractSszVectorSchema.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/schema/impl/AbstractSszVectorSchema.java
@@ -43,6 +43,7 @@ public abstract class AbstractSszVectorSchema<
 
   private final boolean isListBacking;
   private final int fixedPartSize;
+  private SszLengthBounds sszLengthBounds;
 
   protected AbstractSszVectorSchema(SszSchema<SszElementT> elementType, long vectorLength) {
     this(elementType, vectorLength, false);
@@ -61,6 +62,7 @@ public abstract class AbstractSszVectorSchema<
     super(vectorLength, elementSchema, hints);
     this.isListBacking = isListBacking;
     this.fixedPartSize = calcSszFixedPartSize();
+    this.sszLengthBounds = computeSszLengthBounds(elementSchema, vectorLength);
   }
 
   @Override
@@ -164,11 +166,16 @@ public abstract class AbstractSszVectorSchema<
 
   @Override
   public SszLengthBounds getSszLengthBounds() {
-    return getElementSchema()
+    return sszLengthBounds;
+  }
+
+  private static SszLengthBounds computeSszLengthBounds(
+      final SszSchema<?> elementSchema, final long length) {
+    return elementSchema
         .getSszLengthBounds()
         // if elements are of dynamic size the offset size should be added for every element
-        .addBytes(getElementSchema().isFixedSize() ? 0 : SSZ_LENGTH_SIZE)
-        .mul(getLength())
+        .addBytes(elementSchema.isFixedSize() ? 0 : SSZ_LENGTH_SIZE)
+        .mul(length)
         .ceilToBytes();
   }
 


### PR DESCRIPTION
## PR Description
Precompute `SszLengthBounds` in the schema definition. Previously these were calculated for every message which generates a surprisingly large amount of gossip.  While they don't live long so likely don't cause a lot of GC, it's simple to avoid and the calculation itself isn't straight forward as it requires walking the whole SSZ type tree which is fairly large for things like blocks.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
