### PR TITLE
Improved debug messages

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -201,7 +201,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   @Override
   public void onAttestationAggregationDue(final UInt64 slot) {
     if (!isAbleToVerifyEpoch(slot)) {
-      LOG.info("Not performing {} duties for slot {}, unable to verify its epoch", dutyType, slot);
+      LOG.info("Not performing {} aggregation duties for slot {}, unable to verify its epoch", dutyType, slot);
       return;
     }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -201,7 +201,10 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   @Override
   public void onAttestationAggregationDue(final UInt64 slot) {
     if (!isAbleToVerifyEpoch(slot)) {
-      LOG.info("Not performing {} aggregation duties for slot {}, unable to verify its epoch", dutyType, slot);
+      LOG.info(
+          "Not performing {} aggregation duties for slot {}, unable to verify its epoch",
+          dutyType,
+          slot);
       return;
     }
 


### PR DESCRIPTION
## PR Description

While debugging the validator to investigate some missing attestations, I enabled the `DEBUG` log level and I found this kind of messages:

```log
2021-08-21 01:14:58.706+02:00 | ValidatorTimingChannel-0 | INFO  | AbstractDutyScheduler | Not performing attestation duties for slot 1889773 because it is too far ahead of the current slot UNDEFINED
2021-08-21 01:15:15.003+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889774 because last production slot 1889774 is beyond that.
2021-08-21 01:15:27.002+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889775 because last production slot 1889775 is beyond that.
2021-08-21 01:15:39.003+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889776 because last production slot 1889776 is beyond that.
2021-08-21 01:15:51.003+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889777 because last production slot 1889777 is beyond that.
2021-08-21 01:16:03.003+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889778 because last production slot 1889778 is beyond that.
2021-08-21 01:16:15.002+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889779 because last production slot 1889779 is beyond that.
2021-08-21 01:16:27.007+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889780 because last production slot 1889780 is beyond that.
2021-08-21 01:16:34.989+02:00 | validator-async-0 | INFO  | teku-validator-log | Validator   *** Published attestation        Count: 1, Slot: 1889781, Root: 15b158..6304
2021-08-21 01:16:39.002+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889781 because last production slot 1889781 is beyond that.
2021-08-21 01:16:51.001+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889782 because last production slot 1889782 is beyond that.
2021-08-21 01:17:03.001+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889783 because last production slot 1889783 is beyond that.
```

I found these messages a bit misleading, especially when they say *not performing attestation duties...* just after publishing one correctly. And also, the current slot is almost always equal to the last production slot, so again the message is not very clear, I never seen it *beyond that*. So I have needed to look into the code to really understand what was happening.

I improved those messages for me, maybe this is useful also for others. Merging this PR the log will look like this:

```log
2021-08-21 04:50:35.087+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Performing block duties for slot 1890851, last production slot null
2021-08-21 04:50:35.422+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Performing attestation duties for slot 1890851, last production slot null
2021-08-21 04:50:39.003+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Attestation duties for slot 1890851 already performed, last production slot 1890851
[...]
2021-08-21 04:51:31.706+02:00 | ValidatorTimingChannel-0 | INFO  | AbstractDutyScheduler | Not performing attestation duties for slot 1890856, unable to verify its epoch
[...]
2021-08-21 04:51:47.150+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Performing attestation duties for slot 1890857, last production slot 1890856
2021-08-21 04:51:51.001+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Attestation duties for slot 1890857 already performed, last production slot 1890857
2021-08-21 04:51:59.004+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Performing block duties for slot 1890858, last production slot 1890857
2021-08-21 04:51:59.105+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Performing attestation duties for slot 1890858, last production slot 1890857
2021-08-21 04:52:03.003+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Attestation duties for slot 1890858 already performed, last production slot 1890858
2021-08-21 04:52:10.670+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Performing attestation duties for slot 1890859, last production slot 1890858
2021-08-21 04:52:11.004+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Performing block duties for slot 1890859, last production slot 1890858
2021-08-21 04:52:12.786+02:00 | validator-async-0 | INFO  | teku-validator-log | Validator   *** Published attestation        Count: 1, Slot: 1890859, Root: 11a59c..b2b9
2021-08-21 04:52:15.003+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Attestation duties for slot 1890859 already performed, last production slot 1890859
2021-08-21 04:52:23.003+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Performing block duties for slot 1890860, last production slot 1890859
2021-08-21 04:52:24.247+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Performing attestation duties for slot 1890860, last production slot 1890859
2021-08-21 04:52:27.003+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Attestation duties for slot 1890860 already performed, last production slot 1890860
```

## Fixed Issue(s)

None.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
