### PR TITLE
Requesting an attestation for a future slot should not result in a 500 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,4 +27,5 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
  - Fixed `IllegalStateException: New response submitted after closing AsyncResponseProcessor` errors.
  - Get validator from state should return `404` code rather than a `400` code.
+ - Produce attestation data (`/eth/v1/validator/attestation_data`) should return `400` error for future slots, rather than a `500`.
 


### PR DESCRIPTION
When creating a new attestation, any illegal argument exceptions should resolve to a 400 error.

fixes #4269

Signed-off-by: Paul Harris <paul.harris@consensys.net>
## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
