### PR TITLE
Add notify task to master build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,6 +333,7 @@ jobs:
           name: Publish to Cloudsmith
           command: |
             ./gradlew --no-daemon --parallel cloudsmithUpload publish
+      - notify
 
   publishDocker:
     executor: medium_executor
@@ -347,6 +348,7 @@ jobs:
           command: |
             docker login --username "${DOCKER_USER_RW}" --password "${DOCKER_PASSWORD_RW}"
             ./gradlew --no-daemon --parallel "-Pbranch=${CIRCLE_BRANCH}" dockerUpload
+      - notify
 
   extractAPISpec:
     executor: medium_executor
@@ -517,7 +519,6 @@ workflows:
             - docker
             - extractAPISpec
             - spotless
-      - notify
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,7 @@ jobs:
           name: Assemble
           command: |
             ./gradlew --no-daemon --parallel clean compileJava compileTestJava compileJmhJava compileIntegrationTestJava compileAcceptanceTestJava assemble
+      - notify
       - save_cache:
           name: Caching gradle dependencies
           key: deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
@@ -153,6 +154,7 @@ jobs:
           name: Spotless
           command: |
             ./gradlew --no-daemon --parallel checkMavenCoordinateCollisions spotlessCheck
+      - notify
 
   dockerScan:
     executor: trivy_executor
@@ -200,6 +202,7 @@ jobs:
               exit 1
             fi
             ./gradlew --no-daemon --parallel test $GRADLE_ARGS
+      - notify
       - capture_test_results
 
   integrationTests:
@@ -213,6 +216,7 @@ jobs:
           no_output_timeout: 20m
           command: |
             ./gradlew --no-daemon --parallel integrationTest
+      - notify
       - capture_test_results
       - store_artifacts:
           path: build/test-results
@@ -241,6 +245,7 @@ jobs:
               exit 1
             fi
             ./gradlew --no-daemon --parallel acceptanceTest $GRADLE_ARGS
+      - notify
       - capture_test_results
       - capture_test_artifacts
       - store_artifacts:
@@ -268,6 +273,7 @@ jobs:
           name: CompileReferenceTests
           command: |
             ./gradlew --no-daemon --parallel compileReferenceTestJava
+      - notify
       - save_cache:
           name: Caching reference tests
           key: reftests-{{ checksum "build.gradle" }}
@@ -303,6 +309,7 @@ jobs:
               exit 1
             fi
             ./gradlew --no-daemon --parallel -x generateReferenceTestClasses -x processReferenceTestResources -x cleanReferenceTestClasses referenceTest $GRADLE_ARGS
+      - notify
       - capture_test_results
 
   docker:
@@ -317,6 +324,7 @@ jobs:
           name: Docker
           command: |
             ./gradlew --no-daemon --parallel distDocker
+      - notify
 
   publish-cloudsmith:
     executor: small_executor
@@ -376,6 +384,7 @@ jobs:
 
             kill $TEKU_PID
             exit $EXIT_CODE
+      - notify
       - store_artifacts:
           path: .openapidoc/spec/teku.json
       - store_artifacts:
@@ -408,6 +417,7 @@ jobs:
           working_directory: .openapidoc
           command: |
             OA_GIT_USERNAME=$CIRCLE_USERNAME OA_GIT_EMAIL="${CIRCLE_USERNAME}@users.noreply.github.com" OA_GIT_URL=$CIRCLE_REPOSITORY_URL OA_GH_PAGES_BRANCH="gh-pages" node publish.js
+      - notify
       - save_cache:
           paths:
             - ~/.npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
           command: |
             for FILE in $(ls docker)
             do
-              trivy -q image --exit-code 1 --no-progress --severity MEDIUM,HIGH,CRITICAL "consensys/teku:develop-$FILE"
+              trivy -q image --exit-code 1 --no-progress --severity HIGH,CRITICAL "consensys/teku:develop-$FILE"
             done
       - notify
 
@@ -517,10 +517,11 @@ workflows:
             - docker
             - extractAPISpec
             - spotless
+      - notify
   nightly:
     triggers:
       - schedule:
-          cron: "0 02 * * *"
+          cron: "0 19 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
Also change nightly task to run before standups in the morning, and we only want trivy warnings on high,critical issues.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
