### PR TITLE
fix name of data-storage-non-canonical-blocks-enabled command line option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ## Unreleased Changes
 
 ### Breaking Changes
+ - If you have `--Xdata-storage-non-canonical-blocks-enabled` set, this option has been renamed to `--data-storage-non-canonical-blocks-enabled`.
 
 ### Additions and Improvements
  - Logged a message to indicate when the node starts and finishes the sync.
@@ -28,4 +29,5 @@ For information on changes in released versions of Teku, see the [releases page]
  - Fixed `IllegalStateException: New response submitted after closing AsyncResponseProcessor` errors.
  - Get validator from state should return `404` code rather than a `400` code.
  - Produce attestation data (`/eth/v1/validator/attestation_data`) should return `400` error for future slots, rather than a `500`.
+ - Fixed command-line option `--Xdata-storage-non-canonical-blocks-enabled` which was marked as a development option (-X) but not hidden.
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DataStorageOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DataStorageOptions.java
@@ -47,7 +47,7 @@ public class DataStorageOptions {
   private String createDbVersion = DatabaseVersion.DEFAULT_VERSION.getValue();
 
   @CommandLine.Option(
-      names = {"--Xdata-storage-non-canonical-blocks-enabled"},
+      names = {"--data-storage-non-canonical-blocks-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
       description = "Store non-canonical blocks",


### PR DESCRIPTION
fixes #4283

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
