### PR TITLE
Verify SSZ bit is padded to byte boundary with zeros

### DIFF
--- a/ssz/src/main/java/tech/pegasys/teku/ssz/schema/SszPrimitiveSchemas.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/schema/SszPrimitiveSchemas.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.ssz.primitive.SszBytes4;
 import tech.pegasys.teku.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.ssz.schema.impl.AbstractSszPrimitiveSchema;
+import tech.pegasys.teku.ssz.sos.SszDeserializeException;
 import tech.pegasys.teku.ssz.tree.LeafDataNode;
 import tech.pegasys.teku.ssz.tree.LeafNode;
 import tech.pegasys.teku.ssz.tree.TreeNode;
@@ -67,6 +68,15 @@ public interface SszPrimitiveSchemas {
         @Override
         public TreeNode getDefaultTree() {
           return LeafNode.ZERO_LEAVES[1];
+        }
+
+        @Override
+        protected LeafNode createNodeFromSszBytes(final Bytes bytes) {
+          final byte data = bytes.get(0);
+          if (data != 0 && data != 1) {
+            throw new SszDeserializeException("Invalid bit value: " + bytes);
+          }
+          return super.createNodeFromSszBytes(bytes);
         }
 
         @Override

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/schema/impl/AbstractSszPrimitiveSchema.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/schema/impl/AbstractSszPrimitiveSchema.java
@@ -106,7 +106,6 @@ public abstract class AbstractSszPrimitiveSchema<
 
   @Override
   public int sszSerializeTree(TreeNode node, SszWriter writer) {
-    int sszBytesSize = getSSZBytesSize();
     final Bytes nodeData;
     if (node instanceof LeafDataNode) {
       // small perf optimization
@@ -114,16 +113,20 @@ public abstract class AbstractSszPrimitiveSchema<
     } else {
       nodeData = node.hashTreeRoot();
     }
-    writer.write(nodeData.toArrayUnsafe(), 0, sszBytesSize);
-    return sszBytesSize;
+    writer.write(nodeData.toArrayUnsafe(), 0, sszSize);
+    return sszSize;
   }
 
   @Override
   public TreeNode sszDeserializeTree(SszReader reader) {
-    Bytes bytes = reader.read(getSSZBytesSize());
+    Bytes bytes = reader.read(sszSize);
     if (reader.getAvailableBytes() > 0) {
       throw new SszDeserializeException("Extra " + reader.getAvailableBytes() + " bytes found");
     }
+    return createNodeFromSszBytes(bytes);
+  }
+
+  protected LeafNode createNodeFromSszBytes(final Bytes bytes) {
     return LeafNode.create(bytes);
   }
 

--- a/ssz/src/test/java/tech/pegasys/teku/ssz/schema/SszPrimitiveSchemaTest.java
+++ b/ssz/src/test/java/tech/pegasys/teku/ssz/schema/SszPrimitiveSchemaTest.java
@@ -14,14 +14,18 @@
 package tech.pegasys.teku.ssz.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.ssz.RandomSszDataGenerator;
 import tech.pegasys.teku.ssz.SszDataAssert;
 import tech.pegasys.teku.ssz.SszPrimitive;
+import tech.pegasys.teku.ssz.primitive.SszBit;
+import tech.pegasys.teku.ssz.sos.SszDeserializeException;
 import tech.pegasys.teku.ssz.tree.LeafNode;
 
 public class SszPrimitiveSchemaTest implements SszSchemaTestBase {
@@ -71,5 +75,20 @@ public class SszPrimitiveSchemaTest implements SszSchemaTestBase {
     assertThat(SszPrimitiveSchemas.UINT64_SCHEMA.getBitsSize()).isEqualTo(64);
     assertThat(SszPrimitiveSchemas.BYTES4_SCHEMA.getBitsSize()).isEqualTo(32);
     assertThat(SszPrimitiveSchemas.BYTES32_SCHEMA.getBitsSize()).isEqualTo(256);
+  }
+
+  @Test
+  void sszDeserializeTree_shouldRejectValuesPaddedWithNonZero() {
+    assertThatThrownBy(
+            () -> SszPrimitiveSchemas.BIT_SCHEMA.sszDeserialize(Bytes.fromHexString("0xda")))
+        .isInstanceOf(SszDeserializeException.class);
+  }
+
+  @Test
+  void sszDeserializeTree_shouldAcceptValuesPaddedWithZero() {
+    assertThat(SszPrimitiveSchemas.BIT_SCHEMA.sszDeserialize(Bytes.fromHexString("0x01")))
+        .isSameAs(SszBit.of(true));
+    assertThat(SszPrimitiveSchemas.BIT_SCHEMA.sszDeserialize(Bytes.fromHexString("0x00")))
+        .isSameAs(SszBit.of(false));
   }
 }


### PR DESCRIPTION
## PR Description
Verify SSZ bit is padded to byte boundary with zeros when deserializing.

SSZ bits, when not packed as part of a list or vector, should be either 0x00 or 0x01 but Teku previously wasn't verifying the leading bits padding out the byte were all zero.

This is really just future proofing as the only place a bit is used outside a list or vector currently is in `BeaconState.Validator.slashed` and we use the `SszSuperNode` optimisation for validators so don't parse individual field during deserialisation.  However this change ensures that if a bit is ever added to something transferred over the network that our parsing will be compatible with other clients.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
