### PR TITLE
Update to beta.3 reference tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -225,7 +225,7 @@ allprojects {
   }
 }
 
-def refTestVersion = 'v1.1.0-beta.2'
+def refTestVersion = 'v1.1.0-beta.3'
 def blsRefTestVersion = 'v0.1.0'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
 def blsRefTestBaseUrl = 'https://github.com/ethereum/bls12-381-tests/releases/download'

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -73,6 +73,9 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
           .put(
               "operations/sync_aggregate",
               new OperationsTestExecutor<>("sync_aggregate.ssz_snappy", Operation.SYNC_AGGREGATE))
+          .put(
+              "operations/sync_aggregate_random",
+              new OperationsTestExecutor<>("sync_aggregate.ssz_snappy", Operation.SYNC_AGGREGATE))
           .build();
 
   private final String dataFileName;

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/bls/BlsTests.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/bls/BlsTests.java
@@ -28,6 +28,8 @@ public class BlsTests {
           .put("bls/aggregate_verify", new BlsAggregateVerifyTestExecutor())
           .put("bls/sign", new BlsSignTestExecutor())
           .put("bls/fast_aggregate_verify", new BlsFastAggregateVerifyTestExecutor())
+          .put("bls/eth_aggregate_pubkeys", TestExecutor.IGNORE_TESTS)
+          .put("bls/eth_fast_aggregate_verify", TestExecutor.IGNORE_TESTS)
           .put("bls/deserialization_G1", new BlsDeserializationG1TestExecutor())
           .put("bls/deserialization_G2", new BlsDeserializationG2TestExecutor())
           // Hash to G2 is an internal detail of our BLS library so we can't run these tests

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -44,7 +44,10 @@ import tech.pegasys.teku.storage.store.UpdatableStore;
 public class ForkChoiceTestExecutor implements TestExecutor {
   private static final Logger LOG = LogManager.getLogger();
   public static final ImmutableMap<String, TestExecutor> FORK_CHOICE_TEST_TYPES =
-      ImmutableMap.of("fork_choice/get_head", new ForkChoiceTestExecutor());
+      ImmutableMap.<String, TestExecutor>builder()
+          .put("fork_choice/get_head", new ForkChoiceTestExecutor())
+          .put("fork_choice/on_block", TestExecutor.IGNORE_TESTS)
+          .build();
 
   @Override
   public void runTest(final TestDefinition testDefinition) throws Throwable {
@@ -134,6 +137,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
     final SignedBeaconBlock block =
         TestDataUtils.loadSsz(
             testDefinition, blockName + ".ssz_snappy", spec::deserializeSignedBeaconBlock);
+    LOG.info("Importing block {} at slot {}", block.getRoot(), block.getSlot());
     assertThat(forkChoice.onBlock(block)).isCompleted();
   }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityTests.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityTests.java
@@ -21,6 +21,7 @@ public class SanityTests {
   public static final ImmutableMap<String, TestExecutor> SANITY_TEST_TYPES =
       ImmutableMap.<String, TestExecutor>builder()
           .put("sanity/blocks", new SanityBlocksTestExecutor())
+          .put("random/random", new SanityBlocksTestExecutor())
           .put("sanity/slots", new SanitySlotsTestExecutor())
           .put("finality/finality", new SanityBlocksTestExecutor())
           .build();


### PR DESCRIPTION

## PR Description
Still ignoring some new test formats which need new test executors implemented. 
Upgrading now because the new random block tests significantly improve coverage using existing executors.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
