### PR TITLE
Justified block is always a viable head

### DIFF
--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
@@ -178,7 +178,7 @@ public class ProtoArray {
     }
 
     // Perform a sanity check that the node is indeed valid to be the head.
-    if (bestNode != justifiedNode && !nodeIsViableForHead(bestNode)) {
+    if (!nodeIsViableForHead(bestNode) && !bestNode.equals(justifiedNode)) {
       throw new RuntimeException("ProtoArray: Best node is not viable for head");
     }
 

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
@@ -178,7 +178,7 @@ public class ProtoArray {
     }
 
     // Perform a sanity check that the node is indeed valid to be the head.
-    if (!nodeIsViableForHead(bestNode)) {
+    if (bestNode != justifiedNode && !nodeIsViableForHead(bestNode)) {
       throw new RuntimeException("ProtoArray: Best node is not viable for head");
     }
 

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/FFGUpdatesTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/FFGUpdatesTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.protoarray;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.protoarray.ProtoArrayTestUtil.createProtoArrayForkChoiceStrategy;
@@ -182,12 +181,11 @@ public class FFGUpdatesTest {
                 store, unsigned(2), getHash(0), unsigned(0), balances, proposerWeightings))
         .isEqualTo(getHash(10));
 
-    // Same as above, but with justified epoch 3 (should be invalid).
-    assertThatThrownBy(
-            () ->
-                forkChoice.applyPendingVotes(
-                    store, unsigned(3), getHash(0), unsigned(0), balances, proposerWeightings))
-        .hasMessage("ProtoArray: Best node is not viable for head");
+    // Same as above, but with justified epoch 3 (should invalidate all nodes so return justified).
+    assertThat(
+            forkChoice.applyPendingVotes(
+                store, unsigned(3), getHash(0), unsigned(0), balances, proposerWeightings))
+        .isEqualTo(getHash(0));
 
     // Add a vote to 1.
     //
@@ -228,12 +226,11 @@ public class FFGUpdatesTest {
                 store, unsigned(2), getHash(0), unsigned(0), balances, proposerWeightings))
         .isEqualTo(getHash(9));
 
-    // Same as above but justified epoch 3 (should fail).
-    assertThatThrownBy(
-            () ->
-                forkChoice.applyPendingVotes(
-                    store, unsigned(3), getHash(0), unsigned(0), balances, proposerWeightings))
-        .hasMessage("ProtoArray: Best node is not viable for head");
+    // Same as above but justified epoch 3 (should invalidate all and return justified).
+    assertThat(
+            forkChoice.applyPendingVotes(
+                store, unsigned(3), getHash(0), unsigned(0), balances, proposerWeightings))
+        .isEqualTo(getHash(0));
 
     // Add a vote to 2.
     //
@@ -274,12 +271,11 @@ public class FFGUpdatesTest {
                 store, unsigned(2), getHash(0), unsigned(0), balances, proposerWeightings))
         .isEqualTo(getHash(10));
 
-    // Same as above but justified epoch 3 (should fail).
-    assertThatThrownBy(
-            () ->
-                forkChoice.applyPendingVotes(
-                    store, unsigned(3), getHash(0), unsigned(0), balances, proposerWeightings))
-        .hasMessage("ProtoArray: Best node is not viable for head");
+    // Same as above but justified epoch 3 (should invalidate all and return justified).
+    assertThat(
+            forkChoice.applyPendingVotes(
+                store, unsigned(3), getHash(0), unsigned(0), balances, proposerWeightings))
+        .isEqualTo(getHash(0));
 
     // Ensure that if we start at 1 we find 9 (just: 0, fin: 0).
     //
@@ -305,12 +301,11 @@ public class FFGUpdatesTest {
                 store, unsigned(2), getHash(1), unsigned(0), balances, proposerWeightings))
         .isEqualTo(getHash(9));
 
-    // Same as above but justified epoch 3 (should fail).
-    assertThatThrownBy(
-            () ->
-                forkChoice.applyPendingVotes(
-                    store, unsigned(3), getHash(1), unsigned(0), balances, proposerWeightings))
-        .hasMessage("ProtoArray: Best node is not viable for head");
+    // Same as above but justified epoch 3 (should invalidate all so return justified).
+    assertThat(
+            forkChoice.applyPendingVotes(
+                store, unsigned(3), getHash(1), unsigned(0), balances, proposerWeightings))
+        .isEqualTo(getHash(1));
 
     // Ensure that if we start at 2 we find 10 (just: 0, fin: 0).
     //
@@ -336,12 +331,11 @@ public class FFGUpdatesTest {
                 store, unsigned(2), getHash(2), unsigned(0), balances, proposerWeightings))
         .isEqualTo(getHash(10));
 
-    // Same as above but justified epoch 3 (should fail).
-    assertThatThrownBy(
-            () ->
-                forkChoice.applyPendingVotes(
-                    store, unsigned(3), getHash(2), unsigned(0), balances, proposerWeightings))
-        .hasMessage("ProtoArray: Best node is not viable for head");
+    // Same as above but justified epoch 3 (should invalidate all so return justified).
+    assertThat(
+            forkChoice.applyPendingVotes(
+                store, unsigned(3), getHash(2), unsigned(0), balances, proposerWeightings))
+        .isEqualTo(getHash(2));
   }
 
   private UInt64 unsigned(final int i) {

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/NoVotesTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/NoVotesTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.protoarray;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.protoarray.ProtoArrayTestUtil.createProtoArrayForkChoiceStrategy;
@@ -148,7 +147,7 @@ public class NoVotesTest {
                 store, unsigned(1), getHash(0), unsigned(1), balances, proposerWeightings))
         .isEqualTo(getHash(4));
 
-    // Ensure there is an error when starting from a block that has the wrong justified epoch.
+    // Ensure there is no error when starting from a block that has the wrong justified epoch.
     //
     //      0
     //     / \
@@ -156,12 +155,11 @@ public class NoVotesTest {
     //     |  |
     //     4  3
     //     |
-    //     5 <- starting from 5 with justified epoch 0 should error.
-    assertThatThrownBy(
-            () ->
-                forkChoice.applyPendingVotes(
-                    store, unsigned(1), getHash(5), unsigned(1), balances, proposerWeightings))
-        .hasMessage("ProtoArray: Best node is not viable for head");
+    //     5 <- starting from 5 with justified epoch 0 should return justified.
+    assertThat(
+            forkChoice.applyPendingVotes(
+                store, unsigned(1), getHash(5), unsigned(1), balances, proposerWeightings))
+        .isEqualTo(getHash(5));
 
     // Set the justified epoch to 2 and the start block to 5 and ensure 5 is the head.
     //


### PR DESCRIPTION
## PR Description
Fix sanity check in `ProtoArray` to always allow returning the justified block as the head. There are some interesting corner cases with how the justified and finalized checkpoints can update which result in all blocks failing the viable head conditions. In that case the head block should be the justified block itself, but Teku previously threw an exception in that case because the sanity check failed.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
