### PR TITLE
Optimise validator index checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
  - Posting aggregates that fail validation to `/eth/v1/validator/aggregate_and_proofs` will now result in `SC_BAD_REQUEST` response, with details of the invalid aggregates in the response body.
  - Use atomic move when writing slashing protection records, if supported by the file system.
+ - Increase the batch size when searching for unknown validator indexes from 10 to 50.

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -51,12 +51,12 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
 
   @Override
   public void onSlot(final UInt64 slot) {
-    validatorIndexProvider.lookupValidators();
     delegates.forEach(delegate -> delegate.onSlot(slot));
     final UInt64 epoch = spec.computeEpochAtSlot(slot);
     validatorCurrentEpoch.set(epoch.doubleValue());
     final UInt64 firstSlotOfEpoch = spec.computeStartSlotAtEpoch(epoch);
     if (slot.equals(firstSlotOfEpoch.plus(1))) {
+      validatorIndexProvider.lookupValidators();
       statusLogger.checkValidatorStatusChanges();
     }
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -73,7 +73,7 @@ import tech.pegasys.teku.validator.remote.apiclient.ValidatorRestApiClient;
 public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 
   private static final Logger LOG = LogManager.getLogger();
-  static final int MAX_PUBLIC_KEY_BATCH_SIZE = 10;
+  static final int MAX_PUBLIC_KEY_BATCH_SIZE = 50;
   static final int MAX_RATE_LIMITING_RETRIES = 3;
 
   private final Spec spec;


### PR DESCRIPTION
Also increase batch size to 50 validator keys from 10, to reduce remote calls.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
