### PR TITLE
add metrics to OperationPool

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationPool.java
@@ -52,11 +52,12 @@ public class OperationPool<T extends SszData> {
     this.operationValidator = operationValidator;
 
     metricsSystem.createIntegerGauge(
-        TekuMetricCategory.BEACON, OPERATION_POOL_SIZE_METRIC + metricType, "result", this::size);
+        TekuMetricCategory.BEACON, OPERATION_POOL_SIZE_METRIC + metricType, "Current number of operations in the pool", this::size);
     validationReasonCounter =
         metricsSystem.createLabelledCounter(
             TekuMetricCategory.BEACON,
             OPERATION_POOL_SIZE_VALIDATION_REASON + metricType,
+                "Total number of attempts to add an operation to the pool, broken down by validation result",
             "result");
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationPool.java
@@ -16,8 +16,12 @@ package tech.pegasys.teku.statetransition;
 import java.util.Collections;
 import java.util.Set;
 import java.util.function.Function;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.collections.LimitedSet;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -31,16 +35,29 @@ import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
 
 public class OperationPool<T extends SszData> {
   private static final int OPERATION_POOL_SIZE = 1000;
+  private static final String OPERATION_POOL_SIZE_METRIC = "operation_pool_size_";
+  private static final String OPERATION_POOL_SIZE_VALIDATION_REASON = "operation_pool_validation_";
   private final Set<T> operations = LimitedSet.create(OPERATION_POOL_SIZE);
   private final Function<UInt64, SszListSchema<T, ?>> slotToSszListSchemaSupplier;
   private final OperationValidator<T> operationValidator;
   private final Subscribers<OperationAddedSubscriber<T>> subscribers = Subscribers.create(true);
+  private final LabelledMetric<Counter> validationReasonCounter;
 
   public OperationPool(
+      String metricType,
+      MetricsSystem metricsSystem,
       Function<UInt64, SszListSchema<T, ?>> slotToSszListSchemaSupplier,
       OperationValidator<T> operationValidator) {
     this.slotToSszListSchemaSupplier = slotToSszListSchemaSupplier;
     this.operationValidator = operationValidator;
+
+    metricsSystem.createIntegerGauge(
+        TekuMetricCategory.BEACON, OPERATION_POOL_SIZE_METRIC + metricType, "result", this::size);
+    validationReasonCounter =
+        metricsSystem.createLabelledCounter(
+            TekuMetricCategory.BEACON,
+            OPERATION_POOL_SIZE_VALIDATION_REASON + metricType,
+            "result");
   }
 
   public void subscribeOperationAdded(OperationAddedSubscriber<T> subscriber) {
@@ -60,6 +77,7 @@ public class OperationPool<T extends SszData> {
 
   public SafeFuture<InternalValidationResult> add(T item) {
     InternalValidationResult result = operationValidator.validateFully(item);
+    validationReasonCounter.labels(result.code().toString()).inc();
     if (result.code().equals(ValidationResultCode.ACCEPT)
         || result.code().equals(ValidationResultCode.SAVE_FOR_FUTURE)) {
       operations.add(item);
@@ -83,5 +101,9 @@ public class OperationPool<T extends SszData> {
 
   public interface OperationAddedSubscriber<T> {
     void onOperationAdded(T operation, InternalValidationResult validationStatus);
+  }
+
+  private int size() {
+    return operations.size();
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationPoolTest.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -50,6 +51,7 @@ public class OperationPoolTest {
   Function<UInt64, BeaconBlockBodySchema<?>> beaconBlockSchemaSupplier =
       slot -> spec.atSlot(slot).getSchemaDefinitions().getBeaconBlockBodySchema();
   BeaconState state = mock(BeaconState.class);
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
   @BeforeEach
   void init() {
@@ -62,6 +64,8 @@ public class OperationPoolTest {
 
     OperationPool<ProposerSlashing> pool =
         new OperationPool<>(
+            "ProposerSlashingPool",
+            metricsSystem,
             beaconBlockSchemaSupplier.andThen(BeaconBlockBodySchema::getProposerSlashingsSchema),
             validator);
     assertThat(pool.getItemsForBlock(state)).isEmpty();
@@ -72,6 +76,8 @@ public class OperationPoolTest {
     OperationValidator<SignedVoluntaryExit> validator = mock(OperationValidator.class);
     OperationPool<SignedVoluntaryExit> pool =
         new OperationPool<>(
+            "SignedVoluntaryExitPool",
+            metricsSystem,
             beaconBlockSchemaSupplier.andThen(BeaconBlockBodySchema::getVoluntaryExitsSchema),
             validator);
     when(validator.validateFully(any())).thenReturn(InternalValidationResult.ACCEPT);
@@ -90,7 +96,8 @@ public class OperationPoolTest {
             .andThen(BeaconBlockBodySchema::getAttesterSlashingsSchema)
             .apply(state.getSlot());
     OperationPool<AttesterSlashing> pool =
-        new OperationPool<>(__ -> attesterSlashingsSchema, validator);
+        new OperationPool<>(
+            "AttesterSlashingPool", metricsSystem, __ -> attesterSlashingsSchema, validator);
     when(validator.validateFully(any())).thenReturn(InternalValidationResult.ACCEPT);
     when(validator.validateForStateTransition(any(), any())).thenReturn(Optional.empty());
     SszList<AttesterSlashing> attesterSlashings =
@@ -106,6 +113,8 @@ public class OperationPoolTest {
     OperationValidator<ProposerSlashing> validator = mock(OperationValidator.class);
     OperationPool<ProposerSlashing> pool =
         new OperationPool<>(
+            "ProposerSlashingPool",
+            metricsSystem,
             beaconBlockSchemaSupplier.andThen(BeaconBlockBodySchema::getProposerSlashingsSchema),
             validator);
 
@@ -129,6 +138,8 @@ public class OperationPoolTest {
     OperationValidator<ProposerSlashing> validator = mock(OperationValidator.class);
     OperationPool<ProposerSlashing> pool =
         new OperationPool<>(
+            "ProposerSlashingPool",
+            metricsSystem,
             beaconBlockSchemaSupplier.andThen(BeaconBlockBodySchema::getProposerSlashingsSchema),
             validator);
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -354,6 +354,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     LOG.debug("BeaconChainController.initAttesterSlashingPool()");
     attesterSlashingPool =
         new OperationPool<>(
+            "AttesterSlashingPool",
+            metricsSystem,
             beaconBlockSchemaSupplier.andThen(BeaconBlockBodySchema::getAttesterSlashingsSchema),
             new AttesterSlashingValidator(recentChainData, spec));
     blockImporter.subscribeToVerifiedBlockAttesterSlashings(attesterSlashingPool::removeAll);
@@ -364,6 +366,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     ProposerSlashingValidator validator = new ProposerSlashingValidator(spec, recentChainData);
     proposerSlashingPool =
         new OperationPool<>(
+            "ProposerSlashingPool",
+            metricsSystem,
             beaconBlockSchemaSupplier.andThen(BeaconBlockBodySchema::getProposerSlashingsSchema),
             validator);
     blockImporter.subscribeToVerifiedBlockProposerSlashings(proposerSlashingPool::removeAll);
@@ -374,6 +378,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     VoluntaryExitValidator validator = new VoluntaryExitValidator(spec, recentChainData);
     voluntaryExitPool =
         new OperationPool<>(
+            "VoluntaryExitPool",
+            metricsSystem,
             beaconBlockSchemaSupplier.andThen(BeaconBlockBodySchema::getVoluntaryExitsSchema),
             validator);
     blockImporter.subscribeToVerifiedBlockVoluntaryExits(voluntaryExitPool::removeAll);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fix for issue #3917 (Metrics for operation pool size and usage), creating a new PR because the old one(https://github.com/ConsenSys/teku/pull/4295) had issue with CLA signing 
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
