### PR TITLE
Ignore SYNC_COMMITTEE_SUBNET_COUNT when parsing spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ For information on changes in released versions of Teku, see the [releases page]
  - Posting aggregates that fail validation to `/eth/v1/validator/aggregate_and_proofs` will now result in `SC_BAD_REQUEST` response, with details of the invalid aggregates in the response body.
  - Use atomic move when writing slashing protection records, if supported by the file system.
  - Increase the batch size when searching for unknown validator indexes from 10 to 50.
+ - Fixed issue with the voluntary-exit subcommand and Altair networks which caused "Failed to retrieve network config" errors.

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
@@ -33,11 +33,7 @@ public class VoluntaryExitAcceptanceTest extends AcceptanceTestBase {
         createTekuDepositSender(networkName).sendValidatorDeposits(eth1Node, 4);
 
     final TekuNode beaconNode =
-        createTekuNode(
-            config ->
-                config
-                    .withNetwork(networkName)
-                    .withDepositsFrom(eth1Node));
+        createTekuNode(config -> config.withNetwork(networkName).withDepositsFrom(eth1Node));
 
     final TekuValidatorNode validatorClient =
         createValidatorNode(

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.test.acceptance;
 
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
 import tech.pegasys.teku.test.acceptance.dsl.BesuNode;
 import tech.pegasys.teku.test.acceptance.dsl.TekuNode;
@@ -38,8 +37,7 @@ public class VoluntaryExitAcceptanceTest extends AcceptanceTestBase {
             config ->
                 config
                     .withNetwork(networkName)
-                    .withDepositsFrom(eth1Node)
-                    .withAltairEpoch(UInt64.ZERO));
+                    .withDepositsFrom(eth1Node));
 
     final TekuValidatorNode validatorClient =
         createValidatorNode(

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.test.acceptance;
 
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
 import tech.pegasys.teku.test.acceptance.dsl.BesuNode;
 import tech.pegasys.teku.test.acceptance.dsl.TekuNode;
@@ -33,7 +34,12 @@ public class VoluntaryExitAcceptanceTest extends AcceptanceTestBase {
         createTekuDepositSender(networkName).sendValidatorDeposits(eth1Node, 4);
 
     final TekuNode beaconNode =
-        createTekuNode(config -> config.withNetwork(networkName).withDepositsFrom(eth1Node));
+        createTekuNode(
+            config ->
+                config
+                    .withNetwork(networkName)
+                    .withDepositsFrom(eth1Node)
+                    .withAltairEpoch(UInt64.ZERO));
 
     final TekuValidatorNode validatorClient =
         createValidatorNode(

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ConfigProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ConfigProviderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.response.v1.config.GetSpecResponse;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.config.SpecConfigLoader;
+
+class ConfigProviderTest {
+  private final Spec spec = SpecFactory.create("prater");
+
+  private final ConfigProvider configProvider = new ConfigProvider(spec);
+
+  @Test
+  void shouldParseResultOfConfig() {
+    final GetSpecResponse response = configProvider.getConfig();
+    final SpecConfig specConfig = SpecConfigLoader.loadConfig(response.data);
+    final SpecConfig expectedConfig = spec.getGenesisSpecConfig();
+    assertThat(specConfig).isEqualToComparingFieldByField(expectedConfig);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigReader.java
@@ -75,7 +75,8 @@ public class SpecConfigReader {
           "DOMAIN_SYNC_COMMITTEE",
           "DOMAIN_CONTRIBUTION_AND_PROOF",
           "TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE",
-          "DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF");
+          "DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF",
+          "SYNC_COMMITTEE_SUBNET_COUNT");
 
   private final ImmutableMap<Class<?>, Function<Object, ?>> parsers =
       ImmutableMap.<Class<?>, Function<Object, ?>>builder()

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -188,7 +188,7 @@ public class VoluntaryExitCommand implements Runnable {
           .orElseThrow();
     } catch (Exception ex) {
       SUB_COMMAND_LOG.error(
-          "Failed to retrieve network config. Check beacon node is accepting REST requests.");
+          "Failed to retrieve network config. Check beacon node is accepting REST requests.", ex);
       System.exit(1);
     }
     return null;


### PR DESCRIPTION
## PR Description
The constant `SYNC_COMMITTEE_SUBNET_COUNT` isn't in the actual config files but is in the REST API config response so we need to ignore it when parsing.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
