### PR TITLE
Track seen validators in AggregatingAttestationPool correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ For information on changes in released versions of Teku, see the [releases page]
  - Use atomic move when writing slashing protection records, if supported by the file system.
  - Increase the batch size when searching for unknown validator indexes from 10 to 50.
  - Fixed issue with the voluntary-exit subcommand and Altair networks which caused "Failed to retrieve network config" errors.
+ - Fixed issue where redundant attestations were held in the attestation pool and included in blocks.

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/collections/SszBitlist.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/collections/SszBitlist.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.ssz.collections;
 
+import java.util.BitSet;
 import java.util.List;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
@@ -75,6 +76,8 @@ public interface SszBitlist extends SszPrimitiveList<Boolean, SszBit> {
   default IntStream streamAllSetBits() {
     return getAllSetBits().stream().mapToInt(i -> i);
   }
+
+  BitSet asBitSet();
 
   @Override
   default Boolean getElement(int index) {

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/collections/impl/BitlistImpl.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/collections/impl/BitlistImpl.java
@@ -122,6 +122,10 @@ class BitlistImpl {
     return Bytes.wrap(array);
   }
 
+  public BitSet asBitSet() {
+    return (BitSet) data.clone();
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/collections/impl/SszBitlistImpl.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/collections/impl/SszBitlistImpl.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.ssz.collections.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.util.BitSet;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.tuweni.bytes.Bytes;
@@ -130,6 +131,11 @@ public class SszBitlistImpl extends SszListImpl<SszBit> implements SszBitlist {
   @Override
   public List<Integer> getAllSetBits() {
     return value.getAllSetBits();
+  }
+
+  @Override
+  public BitSet asBitSet() {
+    return value.asBitSet();
   }
 
   @Override


### PR DESCRIPTION
## PR Description
The set of seen aggregators for an attestation wasn't being updated correctly, leading to including redundant attestations in blocks.

## Fixed Issue(s)
#4308 - Not sure if it's a complete fix, but should make a major improvement and at minimum stop us from including redundant attestations in the same block. Need to do further investigation into how reorgs may factor in.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
