### PR TITLE
Exclude attestations made redundant by previous aggreagtions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ For information on changes in released versions of Teku, see the [releases page]
  - Use atomic move when writing slashing protection records, if supported by the file system.
  - Increase the batch size when searching for unknown validator indexes from 10 to 50.
  - Fixed issue with the voluntary-exit subcommand and Altair networks which caused "Failed to retrieve network config" errors.
+ - Fixed issue where redundant attestations were incorrectly included in blocks.

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -171,9 +171,6 @@ class MatchingDataAttestationGroup implements Iterable<ValidateableAttestation> 
               candidate -> {
                 final SszBitlist candidateAggregationBits =
                     candidate.getAttestation().getAggregation_bits();
-                if (includedValidators.isSuperSetOf(candidateAggregationBits)) {
-                  return;
-                }
                 if (builder.canAggregate(candidate)) {
                   builder.aggregate(candidate);
                   includedValidators = includedValidators.or(candidateAggregationBits);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -155,7 +155,7 @@ class MatchingDataAttestationGroup implements Iterable<ValidateableAttestation> 
   }
 
   private class AggregatingIterator implements Iterator<ValidateableAttestation> {
-    private final Set<ValidateableAttestation> includedAttestations = new HashSet<>();
+    private SszBitlist includedValidators = Attestation.createEmptyAggregationBits();
 
     @Override
     public boolean hasNext() {
@@ -169,20 +169,26 @@ class MatchingDataAttestationGroup implements Iterable<ValidateableAttestation> 
       streamRemainingAttestations()
           .forEach(
               candidate -> {
+                final SszBitlist candidateAggregationBits =
+                    candidate.getAttestation().getAggregation_bits();
+                if (includedValidators.isSuperSetOf(candidateAggregationBits)) {
+                  return;
+                }
                 if (builder.canAggregate(candidate)) {
                   builder.aggregate(candidate);
-                } else if (builder.isFullyIncluded(candidate)) {
-                  includedAttestations.add(candidate);
+                  includedValidators = includedValidators.or(candidateAggregationBits);
                 }
               });
-      includedAttestations.addAll(builder.getIncludedAttestations());
       return builder.buildAggregate();
     }
 
     public Stream<ValidateableAttestation> streamRemainingAttestations() {
       return attestationsByValidatorCount.values().stream()
           .flatMap(Set::stream)
-          .filter(candidate -> !includedAttestations.contains(candidate));
+          .filter(
+              candidate ->
+                  !includedValidators.isSuperSetOf(
+                      candidate.getAttestation().getAggregation_bits()));
     }
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupTest.java
@@ -169,6 +169,20 @@ class MatchingDataAttestationGroupTest {
   }
 
   @Test
+  void iterator_shouldOmitAttestationsThatOverlapWithFirstAttestationAndAreRedundantWithCombined() {
+    // First aggregate created will have validators 1,2,3,4 which makes the 2,4 attestation
+    // redundant, but iteration will have already passed it before it becomes redundant
+    final ValidateableAttestation useful1 = addAttestation(1, 2, 3);
+    addAttestation(2, 4);
+    final ValidateableAttestation useful2 = addAttestation(4);
+
+    assertThat(group)
+        .containsExactly(
+            ValidateableAttestation.from(
+                spec, aggregateAttestations(useful1.getAttestation(), useful2.getAttestation())));
+  }
+
+  @Test
   public void size() {
     assertThat(group.size()).isEqualTo(0);
     final ValidateableAttestation attestation1 = addAttestation(1);


### PR DESCRIPTION
## PR Description
When aggregating, track included validators rather than included attestations.  Closes a loop-hole which could result in redundant attestations being included in the same block because the attestation was checked against the aggregate being built when it overlapped but wasn't entirely redundant but then attestations that were later added to that aggregate made it fully redundant.

## Fixed Issue(s)
#4308 - Further fixes will be required to ensure attestations included in previous blocks are correctly excluded.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
