### PR TITLE
More accurately track which attestations have already been included

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidateableAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidateableAttestation.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.attestation;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Suppliers;
 import java.util.Collection;
@@ -184,5 +185,21 @@ public class ValidateableAttestation {
   @Override
   public int hashCode() {
     return Objects.hashCode(getAttestation(), maybeAggregate);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("spec", spec)
+        .add("attestation", attestation)
+        .add("maybeAggregate", maybeAggregate)
+        .add("hashTreeRoot", hashTreeRoot)
+        .add("gossiped", gossiped)
+        .add("producedLocally", producedLocally)
+        .add("isValidIndexedAttestation", isValidIndexedAttestation)
+        .add("indexedAttestation", indexedAttestation)
+        .add("committeeShufflingSeed", committeeShufflingSeed)
+        .add("receivedSubnetId", receivedSubnetId)
+        .toString();
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationsReOrgManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationsReOrgManager.java
@@ -77,6 +77,9 @@ public class OperationsReOrgManager implements ChainHeadChannel {
               recentChainData.getAncestorsOnFork(
                   reorgContext.getCommonAncestorSlot(), bestBlockRoot);
 
+          if (!notCanonicalBlockRoots.isEmpty()) {
+            attestationPool.onReorg(reorgContext.getCommonAncestorSlot());
+          }
           processNonCanonicalBlockOperations(notCanonicalBlockRoots.values());
           processCanonicalBlockOperations(nowCanonicalBlockRoots.values());
         });
@@ -152,7 +155,8 @@ public class OperationsReOrgManager implements ChainHeadChannel {
                             proposerSlashingPool.removeAll(blockBody.getProposer_slashings());
                             attesterSlashingPool.removeAll(blockBody.getAttester_slashings());
                             exitPool.removeAll(blockBody.getVoluntary_exits());
-                            attestationPool.removeAll(blockBody.getAttestations());
+                            attestationPool.onAttestationsIncludedInBlock(
+                                block.getSlot(), blockBody.getAttestations());
                           },
                           () ->
                               LOG.debug(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationsReOrgManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationsReOrgManagerTest.java
@@ -192,7 +192,7 @@ public class OperationsReOrgManagerTest {
 
     verify(recentChainData).getAncestorsOnFork(commonAncestorSlot, block2.hashTreeRoot());
 
-    verify(attestationPool).onReorg(commonAncestorSlot);
+    verify(attestationPool, never()).onReorg(commonAncestorSlot);
     verify(exitOperationPool, never()).addAll(any());
     verify(proposerSlashingOperationPool, never()).addAll(any());
     verify(attesterSlashingOperationPool, never()).addAll(any());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationsReOrgManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationsReOrgManagerTest.java
@@ -117,6 +117,7 @@ public class OperationsReOrgManagerTest {
 
     verify(recentChainData).getAncestorsOnFork(commonAncestorSlot, fork1Block2.hashTreeRoot());
 
+    verify(attestationPool).onReorg(commonAncestorSlot);
     verify(proposerSlashingOperationPool).addAll(fork1Block1.getBody().getProposer_slashings());
     verify(attesterSlashingOperationPool).addAll(fork1Block1.getBody().getAttester_slashings());
     verify(exitOperationPool).addAll(fork1Block1.getBody().getVoluntary_exits());
@@ -143,12 +144,16 @@ public class OperationsReOrgManagerTest {
     verify(proposerSlashingOperationPool).removeAll(fork2Block1.getBody().getProposer_slashings());
     verify(attesterSlashingOperationPool).removeAll(fork2Block1.getBody().getAttester_slashings());
     verify(exitOperationPool).removeAll(fork2Block1.getBody().getVoluntary_exits());
-    verify(attestationPool).removeAll(fork2Block1.getBody().getAttestations());
+    verify(attestationPool)
+        .onAttestationsIncludedInBlock(
+            fork2Block1.getSlot(), fork2Block1.getBody().getAttestations());
 
     verify(proposerSlashingOperationPool).removeAll(fork2Block2.getBody().getProposer_slashings());
     verify(attesterSlashingOperationPool).removeAll(fork2Block2.getBody().getAttester_slashings());
     verify(exitOperationPool).removeAll(fork2Block2.getBody().getVoluntary_exits());
-    verify(attestationPool).removeAll(fork2Block2.getBody().getAttestations());
+    verify(attestationPool)
+        .onAttestationsIncludedInBlock(
+            fork2Block2.getSlot(), fork2Block2.getBody().getAttestations());
   }
 
   @Test
@@ -187,6 +192,7 @@ public class OperationsReOrgManagerTest {
 
     verify(recentChainData).getAncestorsOnFork(commonAncestorSlot, block2.hashTreeRoot());
 
+    verify(attestationPool).onReorg(commonAncestorSlot);
     verify(exitOperationPool, never()).addAll(any());
     verify(proposerSlashingOperationPool, never()).addAll(any());
     verify(attesterSlashingOperationPool, never()).addAll(any());
@@ -195,11 +201,13 @@ public class OperationsReOrgManagerTest {
     verify(proposerSlashingOperationPool).removeAll(block2.getBody().getProposer_slashings());
     verify(attesterSlashingOperationPool).removeAll(block2.getBody().getAttester_slashings());
     verify(exitOperationPool).removeAll(block2.getBody().getVoluntary_exits());
-    verify(attestationPool).removeAll(block2.getBody().getAttestations());
+    verify(attestationPool)
+        .onAttestationsIncludedInBlock(block2.getSlot(), block2.getBody().getAttestations());
 
     verify(proposerSlashingOperationPool).removeAll(block1.getBody().getProposer_slashings());
     verify(attesterSlashingOperationPool).removeAll(block1.getBody().getAttester_slashings());
     verify(exitOperationPool).removeAll(block1.getBody().getVoluntary_exits());
-    verify(attestationPool).removeAll(block1.getBody().getAttestations());
+    verify(attestationPool)
+        .onAttestationsIncludedInBlock(block1.getSlot(), block1.getBody().getAttestations());
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -540,7 +540,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     AggregateAttestationValidator aggregateValidator =
         new AggregateAttestationValidator(recentChainData, attestationValidator, spec);
     blockImporter.subscribeToVerifiedBlockAttestations(
-        (attestations) ->
+        (slot, attestations) ->
             attestations.forEach(
                 attestation ->
                     aggregateValidator.addSeenAggregate(
@@ -687,7 +687,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     LOG.debug("BeaconChainController.initAttestationPool()");
     attestationPool = new AggregatingAttestationPool(spec, metricsSystem);
     eventChannels.subscribe(SlotEventsChannel.class, attestationPool);
-    blockImporter.subscribeToVerifiedBlockAttestations(attestationPool::removeAll);
+    blockImporter.subscribeToVerifiedBlockAttestations(
+        attestationPool::onAttestationsIncludedInBlock);
   }
 
   public void initRestAPI() {


### PR DESCRIPTION
## PR Description
Improve tracking of included attestations by recording which slot they were included in. Allows the accurate handling of re-orgs since some validators may have been included in attestations both before and after the reorg's common ancestor so should remain marked as included whereas others should now be allowed to be added to a block again.

## Fixed Issue(s)
fixes #4308 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
