### PR TITLE
Fix gossip validation around a network upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ For information on changes in released versions of Teku, see the [releases page]
  - Increase the batch size when searching for unknown validator indexes from 10 to 50.
  - Fixed issue with the voluntary-exit subcommand and Altair networks which caused "Failed to retrieve network config" errors.
  - Fixed issue where redundant attestations were incorrectly included in blocks.
+ - Fixed an issue where invalid attestations could be incorrectly added to blocks in the epoch immediately after the Altair fork.

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
@@ -297,13 +298,8 @@ public abstract class BeaconStateAccessors {
         oldestQueryableSlot);
   }
 
-  public Bytes32 getDomain(BeaconState state, Bytes4 domainType, UInt64 messageEpoch) {
-    UInt64 epoch = (messageEpoch == null) ? getCurrentEpoch(state) : messageEpoch;
-    return getDomain(domainType, epoch, state.getFork(), state.getGenesis_validators_root());
-  }
-
-  public Bytes32 getDomain(BeaconState state, Bytes4 domainType) {
-    return getDomain(state, domainType, null);
+  public Bytes32 getDomain(final ForkInfo forkInfo, final Bytes4 domainType, final UInt64 epoch) {
+    return getDomain(domainType, epoch, forkInfo.getFork(), forkInfo.getGenesisValidatorsRoot());
   }
 
   public Bytes32 getDomain(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/AttestationDataValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/AttestationDataValidator.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.spec.logic.common.operations.validation.Operatio
 import java.util.Optional;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
@@ -42,7 +43,7 @@ public class AttestationDataValidator
 
   @Override
   public Optional<OperationInvalidReason> validate(
-      final BeaconState state, final AttestationData data) {
+      final Fork fork, final BeaconState state, final AttestationData data) {
     return firstOf(
         () ->
             check(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/AttesterSlashingValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/AttesterSlashingValidator.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
@@ -45,11 +46,12 @@ public class AttesterSlashingValidator
 
   @Override
   public Optional<OperationInvalidReason> validate(
-      final BeaconState state, final AttesterSlashing attesterSlashing) {
-    return validate(state, attesterSlashing, SlashedIndicesCaptor.NOOP);
+      final Fork fork, final BeaconState state, final AttesterSlashing attesterSlashing) {
+    return validate(fork, state, attesterSlashing, SlashedIndicesCaptor.NOOP);
   }
 
   public Optional<OperationInvalidReason> validate(
+      final Fork fork,
       final BeaconState state,
       final AttesterSlashing attesterSlashing,
       final SlashedIndicesCaptor slashedIndicesCaptor) {
@@ -63,11 +65,15 @@ public class AttesterSlashingValidator
                 AttesterSlashingInvalidReason.ATTESTATIONS_NOT_SLASHABLE),
         () ->
             check(
-                attestationUtil.isValidIndexedAttestation(state, attestation_1).isSuccessful(),
+                attestationUtil
+                    .isValidIndexedAttestation(fork, state, attestation_1)
+                    .isSuccessful(),
                 AttesterSlashingInvalidReason.ATTESTATION_1_INVALID),
         () ->
             check(
-                attestationUtil.isValidIndexedAttestation(state, attestation_2).isSuccessful(),
+                attestationUtil
+                    .isValidIndexedAttestation(fork, state, attestation_2)
+                    .isSuccessful(),
                 AttesterSlashingInvalidReason.ATTESTATION_2_INVALID),
         () -> {
           boolean slashed_any = false;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/OperationStateTransitionValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/OperationStateTransitionValidator.java
@@ -14,10 +14,11 @@
 package tech.pegasys.teku.spec.logic.common.operations.validation;
 
 import java.util.Optional;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 @FunctionalInterface
 public interface OperationStateTransitionValidator<T> {
 
-  Optional<OperationInvalidReason> validate(final BeaconState state, final T operation);
+  Optional<OperationInvalidReason> validate(Fork fork, BeaconState state, T operation);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/OperationValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/OperationValidator.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
@@ -65,29 +66,30 @@ public class OperationValidator {
   }
 
   public Optional<OperationInvalidReason> validateAttestationData(
-      final BeaconState state, final AttestationData data) {
-    return attestationDataValidator.validate(state, data);
+      final Fork fork, final BeaconState state, final AttestationData data) {
+    return attestationDataValidator.validate(fork, state, data);
   }
 
   public Optional<OperationInvalidReason> validateAttesterSlashing(
-      final BeaconState state, final AttesterSlashing attesterSlashing) {
-    return attesterSlashingValidator.validate(state, attesterSlashing);
+      final Fork fork, final BeaconState state, final AttesterSlashing attesterSlashing) {
+    return attesterSlashingValidator.validate(fork, state, attesterSlashing);
   }
 
   public Optional<OperationInvalidReason> validateAttesterSlashing(
+      final Fork fork,
       final BeaconState state,
       final AttesterSlashing attesterSlashing,
       SlashedIndicesCaptor slashedIndicesCaptor) {
-    return attesterSlashingValidator.validate(state, attesterSlashing, slashedIndicesCaptor);
+    return attesterSlashingValidator.validate(fork, state, attesterSlashing, slashedIndicesCaptor);
   }
 
   public Optional<OperationInvalidReason> validateProposerSlashing(
-      final BeaconState state, final ProposerSlashing proposerSlashing) {
-    return proposerSlashingValidator.validate(state, proposerSlashing);
+      final Fork fork, final BeaconState state, final ProposerSlashing proposerSlashing) {
+    return proposerSlashingValidator.validate(fork, state, proposerSlashing);
   }
 
   public Optional<OperationInvalidReason> validateVoluntaryExit(
-      final BeaconState state, final SignedVoluntaryExit signedExit) {
-    return voluntaryExitValidator.validate(state, signedExit);
+      final Fork fork, final BeaconState state, final SignedVoluntaryExit signedExit) {
+    return voluntaryExitValidator.validate(fork, state, signedExit);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/ProposerSlashingValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/ProposerSlashingValidator.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
@@ -40,7 +41,7 @@ public class ProposerSlashingValidator
 
   @Override
   public Optional<OperationInvalidReason> validate(
-      final BeaconState state, final ProposerSlashing proposerSlashing) {
+      final Fork fork, final BeaconState state, final ProposerSlashing proposerSlashing) {
     final BeaconBlockHeader header1 = proposerSlashing.getHeader_1().getMessage();
     final BeaconBlockHeader header2 = proposerSlashing.getHeader_2().getMessage();
     return firstOf(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/VoluntaryExitValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/VoluntaryExitValidator.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
@@ -46,7 +47,7 @@ public class VoluntaryExitValidator
 
   @Override
   public Optional<OperationInvalidReason> validate(
-      final BeaconState state, final SignedVoluntaryExit signedExit) {
+      final Fork fork, final BeaconState state, final SignedVoluntaryExit signedExit) {
     VoluntaryExit exit = signedExit.getMessage();
     return firstOf(
         () ->

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -204,7 +204,7 @@ public class ForkChoiceUtil {
 
   @CheckReturnValue
   public AttestationProcessingResult validate(
-      final Fork forkInfo,
+      final Fork fork,
       final ReadOnlyStore store,
       final ValidateableAttestation validateableAttestation,
       final Optional<BeaconState> maybeTargetState) {
@@ -216,7 +216,7 @@ public class ForkChoiceUtil {
                 return AttestationProcessingResult.UNKNOWN_BLOCK;
               } else {
                 return attestationUtil.isValidIndexedAttestation(
-                    forkInfo, maybeTargetState.get(), validateableAttestation);
+                    fork, maybeTargetState.get(), validateableAttestation);
               }
             })
         .ifSuccessful(() -> checkIfAttestationShouldBeSavedForFuture(store, attestation));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
@@ -203,6 +204,7 @@ public class ForkChoiceUtil {
 
   @CheckReturnValue
   public AttestationProcessingResult validate(
+      final Fork forkInfo,
       final ReadOnlyStore store,
       final ValidateableAttestation validateableAttestation,
       final Optional<BeaconState> maybeTargetState) {
@@ -214,7 +216,7 @@ public class ForkChoiceUtil {
                 return AttestationProcessingResult.UNKNOWN_BLOCK;
               } else {
                 return attestationUtil.isValidIndexedAttestation(
-                    maybeTargetState.get(), validateableAttestation);
+                    forkInfo, maybeTargetState.get(), validateableAttestation);
               }
             })
         .ifSuccessful(() -> checkIfAttestationShouldBeSavedForFuture(store, attestation));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -190,7 +190,9 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
     final UInt64 previousSlot = state.getSlot().minusMinZero(1);
     final Bytes32 domain =
         beaconStateAccessors.getDomain(
-            state, Domain.SYNC_COMMITTEE, miscHelpers.computeEpochAtSlot(previousSlot));
+            state.getForkInfo(),
+            Domain.SYNC_COMMITTEE,
+            miscHelpers.computeEpochAtSlot(previousSlot));
     final Bytes32 signingRoot =
         miscHelpersAltair.computeSigningRoot(
             beaconStateAccessors.getBlockRootAtSlot(state, previousSlot), domain);
@@ -236,9 +238,8 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
     idlePubkeys.stream()
         .map(pubkey -> validatorsUtil.getValidatorIndex(state, pubkey).orElseThrow())
         .forEach(
-            participantIndex -> {
-              beaconStateMutators.decreaseBalance(state, participantIndex, participantReward);
-            });
+            participantIndex ->
+                beaconStateMutators.decreaseBalance(state, participantIndex, participantReward));
   }
 
   public static boolean eth2FastAggregateVerify(

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtilTest.java
@@ -114,15 +114,6 @@ public class BeaconStateUtilTest {
                 .getElement((int) GENESIS_SLOT.plus(SLOTS_PER_EPOCH).decrement().longValue()));
   }
 
-  private BeaconState createBeaconState() {
-    return new BeaconStateTestBuilder(dataStructureUtil)
-        .forkVersion(specConfig.getGenesisForkVersion())
-        .validator(dataStructureUtil.randomValidator())
-        .validator(dataStructureUtil.randomValidator())
-        .validator(dataStructureUtil.randomValidator())
-        .build();
-  }
-
   @Test
   public void isSlotAtNthEpochBoundary_invalidNParameter_zero() {
     assertThatThrownBy(

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtilTest.java
@@ -15,29 +15,18 @@ package tech.pegasys.teku.spec.logic.common.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_EPOCH;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 
-import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.junit.BouncyCastleExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import tech.pegasys.teku.bls.BLS;
-import tech.pegasys.teku.bls.BLSPublicKey;
-import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.constants.ValidatorConstants;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.operations.Deposit;
-import tech.pegasys.teku.spec.datastructures.operations.DepositData;
-import tech.pegasys.teku.spec.datastructures.operations.DepositMessage;
 import tech.pegasys.teku.spec.datastructures.state.BeaconStateTestBuilder;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -132,25 +121,6 @@ public class BeaconStateUtilTest {
         .validator(dataStructureUtil.randomValidator())
         .validator(dataStructureUtil.randomValidator())
         .build();
-  }
-
-  @Test
-  void validateProofOfPossessionReturnsFalseIfTheBLSSignatureIsNotValidForGivenDepositInputData() {
-    Deposit deposit = dataStructureUtil.newDeposits(1).get(0);
-    BLSPublicKey pubkey = BLSTestUtil.randomPublicKey(42);
-    DepositData depositData = deposit.getData();
-    DepositMessage depositMessage =
-        new DepositMessage(
-            depositData.getPubkey(),
-            depositData.getWithdrawal_credentials(),
-            depositData.getAmount());
-    Bytes32 domain =
-        genesisSpec
-            .beaconStateAccessors()
-            .getDomain(createBeaconState(), Domain.DEPOSIT, GENESIS_EPOCH);
-    Bytes signing_root = genesisSpec.miscHelpers().computeSigningRoot(depositMessage, domain);
-
-    assertFalse(BLS.verify(pubkey, signing_root, depositData.getSignature()));
   }
 
   @Test

--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.attestation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import it.unimi.dsi.fastutil.ints.IntList;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.ssz.collections.SszBitlist;
+import tech.pegasys.teku.ssz.type.Bytes4;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.util.FutureItems;
+import tech.pegasys.teku.statetransition.util.PendingPool;
+import tech.pegasys.teku.statetransition.validation.AggregateAttestationValidator;
+import tech.pegasys.teku.statetransition.validation.AttestationValidator;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.statetransition.validation.signatures.SignatureVerificationService;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
+
+class AttestationManagerIntegrationTest {
+
+  public static final UInt64 COMMITTEE_INDEX = UInt64.ZERO;
+  private final Spec spec = TestSpecFactory.createMinimalWithAltairForkEpoch(UInt64.ONE);
+  private final StorageSystem storageSystem =
+      InMemoryStorageSystemBuilder.create()
+          .specProvider(spec)
+          .numberOfValidators(spec.getSlotsPerEpoch(UInt64.ZERO))
+          .build();
+  private final RecentChainData recentChainData = storageSystem.recentChainData();
+
+  private final AggregatingAttestationPool attestationPool =
+      new AggregatingAttestationPool(spec, new NoOpMetricsSystem());
+  private final ForkChoice forkChoice =
+      ForkChoice.create(spec, new InlineEventThread(), recentChainData);
+
+  private final PendingPool<ValidateableAttestation> pendingAttestations =
+      PendingPool.createForAttestations(spec);
+  private final FutureItems<ValidateableAttestation> futureAttestations =
+      FutureItems.create(ValidateableAttestation::getEarliestSlotForForkChoiceProcessing);
+  private final SignatureVerificationService signatureVerificationService =
+      SignatureVerificationService.createSimple();
+  private final AttestationValidator attestationValidator =
+      new AttestationValidator(spec, recentChainData, signatureVerificationService);
+
+  private final AttestationManager attestationManager =
+      new AttestationManager(
+          forkChoice,
+          pendingAttestations,
+          futureAttestations,
+          attestationPool,
+          attestationValidator,
+          new AggregateAttestationValidator(recentChainData, attestationValidator, spec),
+          signatureVerificationService);
+
+  // Version of forks with same fork version for previous and current
+  // Guarantees that's the version used for signing regardless of slot
+  private final Fork altairFork = createForkWithVersion(spec.fork(UInt64.ONE).getCurrent_version());
+  private final Fork phase0Fork =
+      createForkWithVersion(spec.fork(UInt64.ZERO).getCurrent_version());
+
+  @BeforeEach
+  public void setup() {
+    storageSystem.chainUpdater().initializeGenesis();
+    assertThat(attestationManager.start()).isCompleted();
+  }
+
+  private Fork createForkWithVersion(final Bytes4 version) {
+    return new Fork(version, version, UInt64.ZERO);
+  }
+
+  @AfterEach
+  public void cleanup() {
+    assertThat(attestationManager.stop()).isCompleted();
+  }
+
+  @Test
+  void shouldAcceptAttestationsBeforeForkWithOriginalForkId() {
+    final UInt64 attestationSlot = UInt64.ONE;
+
+    // Fork choice only runs attestations one slot after they're sent.
+    storageSystem.chainUpdater().setCurrentSlot(attestationSlot.plus(1));
+
+    final SignedBlockAndState targetBlockAndState =
+        storageSystem.chainBuilder().getLatestBlockAndStateAtSlot(attestationSlot);
+    final ValidateableAttestation attestation =
+        createAttestation(attestationSlot, targetBlockAndState, phase0Fork);
+
+    final SafeFuture<InternalValidationResult> result =
+        attestationManager.addAttestation(attestation);
+    assertThat(result).isCompletedWithValue(InternalValidationResult.ACCEPT);
+  }
+
+  @Test
+  void shouldRejectAttestationsBeforeForkWithNewForkId() {
+    final UInt64 attestationSlot = UInt64.ONE;
+
+    // Fork choice only runs attestations one slot after they're sent.
+    storageSystem.chainUpdater().setCurrentSlot(attestationSlot.plus(1));
+
+    final SignedBlockAndState targetBlockAndState =
+        storageSystem.chainBuilder().getLatestBlockAndStateAtSlot(attestationSlot);
+    final ValidateableAttestation attestation =
+        createAttestation(attestationSlot, targetBlockAndState, altairFork);
+
+    final SafeFuture<InternalValidationResult> result =
+        attestationManager.addAttestation(attestation);
+    assertThat(result)
+        .isCompletedWithValueMatching(InternalValidationResult::isReject, "is rejected");
+  }
+
+  @Test
+  void shouldRejectAttestationsAfterForkWithOldForkId() {
+    final UInt64 attestationSlot = spec.computeStartSlotAtEpoch(UInt64.ONE);
+
+    // Fork choice only runs attestations one slot after they're sent.
+    storageSystem.chainUpdater().setCurrentSlot(attestationSlot.plus(1));
+
+    final SignedBlockAndState targetBlockAndState =
+        storageSystem.chainBuilder().getLatestBlockAndStateAtSlot(attestationSlot);
+    final ValidateableAttestation attestation =
+        createAttestation(attestationSlot, targetBlockAndState, phase0Fork);
+
+    final SafeFuture<InternalValidationResult> result =
+        attestationManager.addAttestation(attestation);
+    assertThat(result)
+        .isCompletedWithValueMatching(InternalValidationResult::isReject, "is rejected");
+  }
+
+  @Test
+  void shouldAcceptAttestationsAfterForkWithNewForkId_emptySlots() {
+    final UInt64 attestationSlot = spec.computeStartSlotAtEpoch(UInt64.ONE);
+
+    // Fork choice only runs attestations one slot after they're sent.
+    storageSystem.chainUpdater().setCurrentSlot(attestationSlot.plus(1));
+
+    final SignedBlockAndState targetBlockAndState =
+        storageSystem.chainBuilder().getLatestBlockAndStateAtSlot(attestationSlot);
+    final ValidateableAttestation attestation =
+        createAttestation(attestationSlot, targetBlockAndState, altairFork);
+
+    final SafeFuture<InternalValidationResult> result =
+        attestationManager.addAttestation(attestation);
+    assertThat(result).isCompletedWithValue(InternalValidationResult.ACCEPT);
+  }
+
+  @Test
+  void shouldAcceptAttestationsAfterForkWithNewForkId_filledSlots() {
+    final UInt64 attestationSlot = spec.computeStartSlotAtEpoch(UInt64.ONE);
+    final SignedBlockAndState chainHead =
+        storageSystem.chainUpdater().advanceChainUntil(attestationSlot);
+    storageSystem.chainUpdater().updateBestBlock(chainHead);
+
+    // Fork choice only runs attestations one slot after they're sent.
+    storageSystem.chainUpdater().setCurrentSlot(attestationSlot.plus(1));
+
+    final SignedBlockAndState targetBlockAndState =
+        storageSystem.chainBuilder().getLatestBlockAndStateAtSlot(attestationSlot);
+    final ValidateableAttestation attestation =
+        createAttestation(attestationSlot, targetBlockAndState, altairFork);
+
+    final SafeFuture<InternalValidationResult> result =
+        attestationManager.addAttestation(attestation);
+    assertThat(result).isCompletedWithValue(InternalValidationResult.ACCEPT);
+  }
+
+  private ValidateableAttestation createAttestation(
+      final UInt64 attestationSlot,
+      final SignedBlockAndState targetBlockAndState,
+      final Fork fork) {
+    final int validatorCommitteePosition = 0;
+    final IntList committee =
+        spec.getBeaconCommittee(targetBlockAndState.getState(), attestationSlot, COMMITTEE_INDEX);
+    final int validatorId = committee.getInt(validatorCommitteePosition);
+
+    final AttestationData attestationData =
+        spec.getGenericAttestationData(
+            attestationSlot, targetBlockAndState.getState(), targetBlockAndState, COMMITTEE_INDEX);
+
+    final ForkInfo forkInfo =
+        new ForkInfo(fork, targetBlockAndState.getState().getGenesis_validators_root());
+    final BLSSignature signature =
+        storageSystem
+            .chainBuilder()
+            .sign(validatorId, signer -> signer.signAttestationData(attestationData, forkInfo));
+
+    SszBitlist aggregationBits =
+        Attestation.SSZ_SCHEMA
+            .getAggregationBitsSchema()
+            .ofBits(committee.size(), validatorCommitteePosition);
+    final Attestation attestation = new Attestation(aggregationBits, attestationData, signature);
+    return ValidateableAttestation.fromNetwork(
+        spec,
+        attestation,
+        spec.computeSubnetForAttestation(targetBlockAndState.getState(), attestation));
+  }
+}


### PR DESCRIPTION
## PR Description
Remove get_domain variants that get the fork from the state and explicitly pass in the fork to use instead.
Resolves an issue where attestations (and potentially other types) from after the fork are published by a node that did not follow the fork, but validated against a state from prior to the fork.  The older state may be used either because it is within the look-ahead period for attestation committees or because there were empty slots immediately after the fork epoch. The old state does not contain info on the fork as it only contains previous and current fork info, so the gossiped signature verifies even though it is incorrectly from the old fork.

More complete write up at https://hackmd.io/n54L4BRoTP2l3OVrrSXszg

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
