### PR TITLE
Suppress performance output when not relevant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - The `/eth/v1/validator/blocks/:slot` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/validator/blocks/:slot`
 - The `-jdk14` and `-jdk15` docker image variants will be removed in a future release. JDK 14 and 15 are no longer receiving security updates from upstream vendors.
   Note that the default docker image usage JDK 16 and is still receiving security updates.
-
+- The commandline option `--validators-performance-tracking-enabled` has been deprecated in favour of `--validators-performance-tracking-mode`
+ 
 ## Current Releases
 For information on changes in released versions of Teku, see the [releases page](https://github.com/ConsenSys/teku/releases).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@ For information on changes in released versions of Teku, see the [releases page]
  - Increase the batch size when searching for unknown validator indexes from 10 to 50.
  - Fixed issue with the voluntary-exit subcommand and Altair networks which caused "Failed to retrieve network config" errors.
  - Fixed issue where redundant attestations were incorrectly included in blocks.
+ - Validator performance is no longer logged when there are no attestations expected.

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -59,7 +59,9 @@ public class ValidatorOptions {
   @Option(
       names = {"--validators-performance-tracking-mode"},
       paramLabel = "<TRACKING_MODE>",
-      description = "Set strategy for handling performance tracking",
+      description =
+          "Set strategy for handling performance tracking."
+              + "Valid values: ${COMPLETION-CANDIDATES}",
       arity = "1")
   private ValidatorPerformanceTrackingMode validatorPerformanceTrackingMode =
       ValidatorPerformanceTrackingMode.ALL;

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -126,14 +126,16 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
       AttestationPerformance attestationPerformance =
           getAttestationPerformanceForEpoch(currentEpoch, analyzedEpoch);
 
-      if (mode.isLoggingEnabled()) {
-        statusLogger.performance(attestationPerformance.toString());
-      }
+      // suppress performance metric output when not relevant
+      if (attestationPerformance.numberOfExpectedAttestations > 0) {
+        if (mode.isLoggingEnabled()) {
+          statusLogger.performance(attestationPerformance.toString());
+        }
 
-      if (mode.isMetricsEnabled()) {
-        validatorPerformanceMetrics.updateAttestationPerformanceMetrics(attestationPerformance);
+        if (mode.isMetricsEnabled()) {
+          validatorPerformanceMetrics.updateAttestationPerformanceMetrics(attestationPerformance);
+        }
       }
-
       producedAttestationsByEpoch.headMap(analyzedEpoch, true).clear();
     }
 

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -127,14 +127,12 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
           getAttestationPerformanceForEpoch(currentEpoch, analyzedEpoch);
 
       // suppress performance metric output when not relevant
-      if (attestationPerformance.numberOfExpectedAttestations > 0) {
-        if (mode.isLoggingEnabled()) {
-          statusLogger.performance(attestationPerformance.toString());
-        }
+      if (mode.isLoggingEnabled() && attestationPerformance.numberOfExpectedAttestations > 0) {
+        statusLogger.performance(attestationPerformance.toString());
+      }
 
-        if (mode.isMetricsEnabled()) {
-          validatorPerformanceMetrics.updateAttestationPerformanceMetrics(attestationPerformance);
-        }
+      if (mode.isMetricsEnabled()) {
+        validatorPerformanceMetrics.updateAttestationPerformanceMetrics(attestationPerformance);
       }
       producedAttestationsByEpoch.headMap(analyzedEpoch, true).clear();
     }

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
@@ -15,7 +15,9 @@ package tech.pegasys.teku.validator.coordinator.performance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker.ATTESTATION_INCLUSION_RANGE;
 import static tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker.BLOCK_PERFORMANCE_EVALUATION_INTERVAL;
 
@@ -327,7 +329,7 @@ public class DefaultPerformanceTrackerTest {
   void shouldNotReportAttestationPerformanceIfNoValidatorsInEpoch() {
     when(validatorTracker.getNumberOfValidatorsForEpoch(UInt64.valueOf(2))).thenReturn(0);
     performanceTracker.onSlot(spec.computeStartSlotAtEpoch(ATTESTATION_INCLUSION_RANGE.plus(2)));
-    verify(log, never()).performance(Mockito.anyString());
+    verify(log, Mockito.never()).performance(Mockito.anyString());
   }
 
   @Test

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
@@ -15,7 +15,9 @@ package tech.pegasys.teku.validator.coordinator.performance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker.ATTESTATION_INCLUSION_RANGE;
@@ -24,7 +26,6 @@ import static tech.pegasys.teku.validator.coordinator.performance.DefaultPerform
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSTestUtil;
@@ -329,7 +330,7 @@ public class DefaultPerformanceTrackerTest {
   void shouldNotReportAttestationPerformanceIfNoValidatorsInEpoch() {
     when(validatorTracker.getNumberOfValidatorsForEpoch(UInt64.valueOf(2))).thenReturn(0);
     performanceTracker.onSlot(spec.computeStartSlotAtEpoch(ATTESTATION_INCLUSION_RANGE.plus(2)));
-    verify(log, Mockito.never()).performance(Mockito.anyString());
+    verify(log, never()).performance(anyString());
   }
 
   @Test

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
@@ -15,15 +15,14 @@ package tech.pegasys.teku.validator.coordinator.performance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker.ATTESTATION_INCLUSION_RANGE;
 import static tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker.BLOCK_PERFORMANCE_EVALUATION_INTERVAL;
 
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSTestUtil;
@@ -322,6 +321,13 @@ public class DefaultPerformanceTrackerTest {
     AttestationPerformance expectedAttestationPerformance =
         new AttestationPerformance(2, 0, 0, 0, 0, 0, 0, 0);
     verify(log).performance(expectedAttestationPerformance.toString());
+  }
+
+  @Test
+  void shouldNotReportAttestationPerformanceIfNoValidatorsInEpoch() {
+    when(validatorTracker.getNumberOfValidatorsForEpoch(UInt64.valueOf(2))).thenReturn(0);
+    performanceTracker.onSlot(spec.computeStartSlotAtEpoch(ATTESTATION_INCLUSION_RANGE.plus(2)));
+    verify(log, never()).performance(Mockito.anyString());
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR addresses a couple of issues raised in #4213, relating to the output of performance metrics.
1. Performance metrics output, should be suppressed when syncing or when there are no local active validators.
2. `—validators-performance-tracking-mode` usage help message should list the set of options that can be specified.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
This PR fixes #4213 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
