### PR TITLE
Latest Grafana requires root insider contaioner to run correctly

### DIFF
--- a/test-network/docker-compose.yml
+++ b/test-network/docker-compose.yml
@@ -22,6 +22,7 @@ services:
 
   grafana:
     image: grafana/grafana:latest
+    user: "${USER}:root"
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=pass
     volumes:

--- a/test-network/launch.sh
+++ b/test-network/launch.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd "${DIR}"
 
-mkdir -p data/node1 data/node2 data/node3 data/node4
+mkdir -p data/node1 data/node2 data/node3 data/node4 grafana/data grafana/log
 
 START_DELAY=30
 CURRENT_TIME=$(date +%s)


### PR DESCRIPTION
## PR Description

## Fixed Issue(s)
Starting the test-network with `launch.sh` Grafana stops with the following error:

```txt
GF_PATHS_DATA='/var/lib/grafana' is not writable.
You may have issues with file permissions, more information here: http://docs.grafana.org/installation/docker/#migrate-to-v51-or-later
mkdir: can't create directory '/var/lib/grafana/plugins': Permission denied
```

The problem is due to changes in the permissions inside the container and in particular to the modifications done in [new Grafana docker images](https://grafana.com/docs/grafana/latest/installation/docker/#migrate-to-v73-or-later).

To fix this you can intervene with post start modifications, or you can create grafana folders with `user` permissions (modified `launch.sh`) and set the group as `root`. I applied the latter.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
