### PR TITLE
Increase the seen attestation cache size.

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipConfig.java
@@ -23,8 +23,8 @@ import java.util.function.Consumer;
  * https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/p2p-interface.md#the-gossip-domain-gossipsub
  */
 public class GossipConfig {
-  public static final int DEFAULT_D = 6;
-  public static final int DEFAULT_D_LOW = 5;
+  public static final int DEFAULT_D = 8;
+  public static final int DEFAULT_D_LOW = 6;
   public static final int DEFAULT_D_HIGH = 12;
   public static final int DEFAULT_D_LAZY = 6;
   public static final Duration DEFAULT_FANOUT_TTL = Duration.ofSeconds(60);

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -116,7 +116,7 @@ public class Constants {
 
   // Teku Networking Specific
   public static final int VALID_BLOCK_SET_SIZE = 1000;
-  public static final int VALID_ATTESTATION_SET_SIZE = 1000;
+  public static final int VALID_ATTESTATION_SET_SIZE = 21000;
   public static final int VALID_AGGREGATE_SET_SIZE = 1000;
   public static final int VALID_VALIDATOR_SET_SIZE = 10000;
   public static final int VALID_CONTRIBUTION_AND_PROOF_SET_SIZE = 10000;


### PR DESCRIPTION
The previous cache size was too small to cover the number of attestations being gossiped if all networks were subscribed to.

fixes #4291

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
