### PR TITLE
Add testing for the SlashingProtectionExporter to exercise file reading

### DIFF
--- a/data/dataexchange/src/main/java/tech/pegasys/teku/data/SlashingProtectionExporter.java
+++ b/data/dataexchange/src/main/java/tech/pegasys/teku/data/SlashingProtectionExporter.java
@@ -56,7 +56,7 @@ public class SlashingProtectionExporter {
         .forEach(this::readSlashProtectionFile);
   }
 
-  private void readSlashProtectionFile(final File file) {
+  void readSlashProtectionFile(final File file) {
     try {
       Optional<ValidatorSigningRecord> maybeRecord =
           syncDataAccessor.read(file.toPath()).map(ValidatorSigningRecord::fromBytes);
@@ -69,7 +69,6 @@ public class SlashingProtectionExporter {
           && validatorSigningRecord.getGenesisValidatorsRoot() != null) {
         this.genesisValidatorsRoot = validatorSigningRecord.getGenesisValidatorsRoot();
       } else if (validatorSigningRecord.getGenesisValidatorsRoot() != null
-          && genesisValidatorsRoot != null
           && !genesisValidatorsRoot.equals(validatorSigningRecord.getGenesisValidatorsRoot())) {
         log.exit(
             1,
@@ -99,10 +98,12 @@ public class SlashingProtectionExporter {
   }
 
   private Bytes getJsonByteData() throws JsonProcessingException {
-    final String prettyJson =
-        jsonProvider.objectToPrettyJSON(
-            new SlashingProtectionInterchangeFormat(
-                new Metadata(INTERCHANGE_VERSION, genesisValidatorsRoot), signingHistoryList));
-    return Bytes.of(prettyJson.getBytes(StandardCharsets.UTF_8));
+    return Bytes.of(getPrettyJson().getBytes(StandardCharsets.UTF_8));
+  }
+
+  String getPrettyJson() throws JsonProcessingException {
+    return jsonProvider.objectToPrettyJSON(
+        new SlashingProtectionInterchangeFormat(
+            new Metadata(INTERCHANGE_VERSION, genesisValidatorsRoot), signingHistoryList));
   }
 }

--- a/data/dataexchange/src/main/java/tech/pegasys/teku/data/SlashingProtectionExporter.java
+++ b/data/dataexchange/src/main/java/tech/pegasys/teku/data/SlashingProtectionExporter.java
@@ -65,18 +65,20 @@ public class SlashingProtectionExporter {
       }
       ValidatorSigningRecord validatorSigningRecord = maybeRecord.get();
 
-      if (genesisValidatorsRoot == null
-          && validatorSigningRecord.getGenesisValidatorsRoot() != null) {
-        this.genesisValidatorsRoot = validatorSigningRecord.getGenesisValidatorsRoot();
-      } else if (validatorSigningRecord.getGenesisValidatorsRoot() != null
-          && !validatorSigningRecord.getGenesisValidatorsRoot().equals(genesisValidatorsRoot)) {
-        log.exit(
-            1,
-            "The genesisValidatorsRoot of "
-                + file.getName()
-                + " does not match the expected "
-                + genesisValidatorsRoot.toHexString());
+      if (validatorSigningRecord.getGenesisValidatorsRoot() != null) {
+        if (genesisValidatorsRoot == null) {
+          this.genesisValidatorsRoot = validatorSigningRecord.getGenesisValidatorsRoot();
+        } else if (!genesisValidatorsRoot.equals(
+            validatorSigningRecord.getGenesisValidatorsRoot())) {
+          log.exit(
+              1,
+              "The genesisValidatorsRoot of "
+                  + file.getName()
+                  + " does not match the expected "
+                  + genesisValidatorsRoot.toHexString());
+        }
       }
+
       final String pubkey = file.getName().substring(0, file.getName().length() - ".yml".length());
       log.display("Exporting " + pubkey);
       signingHistoryList.add(

--- a/data/dataexchange/src/main/java/tech/pegasys/teku/data/SlashingProtectionExporter.java
+++ b/data/dataexchange/src/main/java/tech/pegasys/teku/data/SlashingProtectionExporter.java
@@ -69,7 +69,7 @@ public class SlashingProtectionExporter {
           && validatorSigningRecord.getGenesisValidatorsRoot() != null) {
         this.genesisValidatorsRoot = validatorSigningRecord.getGenesisValidatorsRoot();
       } else if (validatorSigningRecord.getGenesisValidatorsRoot() != null
-          && !genesisValidatorsRoot.equals(validatorSigningRecord.getGenesisValidatorsRoot())) {
+          && !validatorSigningRecord.getGenesisValidatorsRoot().equals(genesisValidatorsRoot)) {
         log.exit(
             1,
             "The genesisValidatorsRoot of "

--- a/data/dataexchange/src/main/java/tech/pegasys/teku/data/slashinginterchange/Metadata.java
+++ b/data/dataexchange/src/main/java/tech/pegasys/teku/data/slashinginterchange/Metadata.java
@@ -16,16 +16,17 @@ package tech.pegasys.teku.data.slashinginterchange;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Metadata {
 
   public static final UInt64 INTERCHANGE_VERSION = UInt64.valueOf(5);
 
   @JsonProperty("interchange_format")
-  @JsonInclude(JsonInclude.Include.NON_NULL)
   public final String interchangeFormat;
 
   @JsonProperty("interchange_format_version")
@@ -62,5 +63,14 @@ public class Metadata {
   @Override
   public int hashCode() {
     return Objects.hash(interchangeFormatVersion, genesisValidatorsRoot);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("interchangeFormat", interchangeFormat)
+        .add("interchangeFormatVersion", interchangeFormatVersion)
+        .add("genesisValidatorsRoot", genesisValidatorsRoot)
+        .toString();
   }
 }

--- a/data/dataexchange/src/main/java/tech/pegasys/teku/data/slashinginterchange/SlashingProtectionInterchangeFormat.java
+++ b/data/dataexchange/src/main/java/tech/pegasys/teku/data/slashinginterchange/SlashingProtectionInterchangeFormat.java
@@ -14,7 +14,10 @@
 package tech.pegasys.teku.data.slashinginterchange;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import java.util.List;
+import java.util.Objects;
 
 public class SlashingProtectionInterchangeFormat {
   public final Metadata metadata;
@@ -22,8 +25,27 @@ public class SlashingProtectionInterchangeFormat {
 
   @JsonCreator
   public SlashingProtectionInterchangeFormat(
-      final Metadata metadata, final List<SigningHistory> data) {
+      @JsonProperty("metadata") final Metadata metadata,
+      @JsonProperty("data") final List<SigningHistory> data) {
     this.metadata = metadata;
     this.data = data;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final SlashingProtectionInterchangeFormat that = (SlashingProtectionInterchangeFormat) o;
+    return Objects.equals(metadata, that.metadata) && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(metadata, data);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("metadata", metadata).add("data", data).toString();
   }
 }

--- a/data/dataexchange/src/test/java/tech/pegasys/teku/data/SlashingProtectionExporterTest.java
+++ b/data/dataexchange/src/test/java/tech/pegasys/teku/data/SlashingProtectionExporterTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static tech.pegasys.teku.data.slashinginterchange.Metadata.INTERCHANGE_VERSION;
+
+import com.google.common.io.Resources;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.List;
+import java.util.Set;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import tech.pegasys.teku.api.schema.BLSPubKey;
+import tech.pegasys.teku.data.signingrecord.ValidatorSigningRecord;
+import tech.pegasys.teku.data.slashinginterchange.Metadata;
+import tech.pegasys.teku.data.slashinginterchange.SigningHistory;
+import tech.pegasys.teku.data.slashinginterchange.SlashingProtectionInterchangeFormat;
+import tech.pegasys.teku.infrastructure.logging.SubCommandLogger;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.provider.JsonProvider;
+
+public class SlashingProtectionExporterTest {
+  private final ArgumentCaptor<String> stringArgs = ArgumentCaptor.forClass(String.class);
+  final SubCommandLogger logger = mock(SubCommandLogger.class);
+  private final JsonProvider jsonProvider = new JsonProvider();
+  private final String pubkey =
+      "b845089a1457f811bfc000588fbb4e713669be8ce060ea6be3c6ece09afc3794106c91ca73acda5e5457122d58723bed";
+  private final Bytes32 validatorsRoot =
+      Bytes32.fromHexString("0x6e2c5d8a89dfe121a92c8812bea69fe9f84ae48f63aafe34ef7e18c7eac9af70");
+
+  @Test
+  public void shouldReadSlashingProtectionFile_withEmptyGenesisValidatorsRoot(@TempDir Path tempDir)
+      throws IOException, URISyntaxException {
+    final SlashingProtectionExporter exporter =
+        new SlashingProtectionExporter(logger, tempDir.toString());
+    exporter.readSlashProtectionFile(usingResourceFile("slashProtection.yml", tempDir));
+    verify(logger, times(1)).display("Exporting " + pubkey);
+
+    final SlashingProtectionInterchangeFormat parsedData =
+        jsonProvider.jsonToObject(
+            exporter.getPrettyJson(), SlashingProtectionInterchangeFormat.class);
+    final SlashingProtectionInterchangeFormat expectedData = getExportData(null, 327, 51, 1741);
+    assertThat(parsedData).isEqualTo(expectedData);
+
+    verify(logger, never()).exit(eq(1), stringArgs.capture());
+  }
+
+  @Test
+  public void shouldReadSlashingProtectionFile_withGenesisValidatorsRoot(@TempDir Path tempDir)
+      throws IOException, URISyntaxException {
+    final SlashingProtectionExporter exporter =
+        new SlashingProtectionExporter(logger, tempDir.toString());
+    exporter.readSlashProtectionFile(
+        usingResourceFile("slashProtectionWithGenesisRoot.yml", tempDir));
+    verify(logger, times(1)).display("Exporting " + pubkey);
+
+    final SlashingProtectionInterchangeFormat parsedData =
+        jsonProvider.jsonToObject(
+            exporter.getPrettyJson(), SlashingProtectionInterchangeFormat.class);
+    final SlashingProtectionInterchangeFormat expectedData =
+        getExportData(validatorsRoot, 327, 51, 1741);
+    assertThat(parsedData).isEqualTo(expectedData);
+
+    verify(logger, never()).exit(eq(1), stringArgs.capture());
+  }
+
+  @Test
+  public void shouldReadFilesWithEmptyRootAfterGenesisRootIsDefined(@TempDir Path tempDir)
+      throws URISyntaxException, IOException {
+    final SlashingProtectionExporter exporter =
+        new SlashingProtectionExporter(logger, tempDir.toString());
+    exporter.readSlashProtectionFile(
+        usingResourceFile("slashProtectionWithGenesisRoot.yml", tempDir));
+    exporter.readSlashProtectionFile(usingResourceFile("slashProtection.yml", tempDir));
+
+    verify(logger, never()).exit(eq(1), stringArgs.capture());
+    verify(logger, times(2)).display("Exporting " + pubkey);
+  }
+
+  @Test
+  public void shouldReadFileWithGenesisRootDefinedSecond(@TempDir Path tempDir)
+      throws URISyntaxException, IOException {
+    final SlashingProtectionExporter exporter =
+        new SlashingProtectionExporter(logger, tempDir.toString());
+    exporter.readSlashProtectionFile(usingResourceFile("slashProtection.yml", tempDir));
+    exporter.readSlashProtectionFile(
+        usingResourceFile("slashProtectionWithGenesisRoot.yml", tempDir));
+
+    verify(logger, never()).exit(eq(1), stringArgs.capture());
+    verify(logger, times(2)).display("Exporting " + pubkey);
+  }
+
+  @Test
+  public void shouldNotAcceptDifferentGenesisValidatorsRoot(@TempDir Path tempDir)
+      throws URISyntaxException, IOException {
+    final SlashingProtectionExporter exporter =
+        new SlashingProtectionExporter(logger, tempDir.toString());
+    exporter.readSlashProtectionFile(
+        usingResourceFile("slashProtectionWithGenesisRoot2.yml", tempDir));
+    exporter.readSlashProtectionFile(
+        usingResourceFile("slashProtectionWithGenesisRoot.yml", tempDir));
+
+    verify(logger).exit(eq(1), stringArgs.capture());
+    assertThat(stringArgs.getValue()).startsWith("The genesisValidatorsRoot of");
+  }
+
+  @Test
+  public void shouldRequirePubkeyInFilename(@TempDir Path tempDir)
+      throws URISyntaxException, IOException {
+    final SlashingProtectionExporter exporter =
+        new SlashingProtectionExporter(logger, tempDir.toString());
+    exporter.readSlashProtectionFile(
+        new File(Resources.getResource("slashProtectionWithGenesisRoot.yml").toURI()));
+
+    verify(logger).exit(eq(1), stringArgs.capture());
+    assertThat(stringArgs.getValue())
+        .contains("Public key in file slashProtectionWithGenesisRoot.yml does not appear valid.");
+  }
+
+  @Test
+  public void shouldPrintIfFileCannotBeRead(@TempDir Path tempDir)
+      throws URISyntaxException, IOException {
+    final SlashingProtectionExporter exporter =
+        new SlashingProtectionExporter(logger, tempDir.toString());
+    final File file = usingResourceFile("slashProtection.yml", tempDir);
+    Files.setPosixFilePermissions(file.toPath(), Set.of(PosixFilePermission.OTHERS_EXECUTE));
+    exporter.readSlashProtectionFile(file);
+    verify(logger).exit(eq(1), stringArgs.capture(), any(AccessDeniedException.class));
+    assertThat(stringArgs.getValue()).startsWith("Failed to read from file");
+  }
+
+  private File usingResourceFile(final String resourceFileName, final Path tempDir)
+      throws URISyntaxException, IOException {
+    final Path tempFile = tempDir.resolve(pubkey + ".yml").toAbsolutePath();
+    Files.copy(
+        new File(Resources.getResource(resourceFileName).toURI()).toPath(),
+        tempFile,
+        StandardCopyOption.REPLACE_EXISTING);
+    return tempFile.toFile();
+  }
+
+  private SlashingProtectionInterchangeFormat getExportData(
+      final Bytes32 genesisValidatorsRoot,
+      final int lastSignedBlockSlot,
+      final int lastSignedAttestationSourceEpoch,
+      final int lastSignedAttestationTargetEpoch) {
+    return new SlashingProtectionInterchangeFormat(
+        new Metadata(INTERCHANGE_VERSION, genesisValidatorsRoot),
+        List.of(
+            new SigningHistory(
+                BLSPubKey.fromHexString(pubkey),
+                new ValidatorSigningRecord(
+                    genesisValidatorsRoot,
+                    UInt64.valueOf(lastSignedBlockSlot),
+                    UInt64.valueOf(lastSignedAttestationSourceEpoch),
+                    UInt64.valueOf(lastSignedAttestationTargetEpoch)))));
+  }
+}

--- a/data/dataexchange/src/test/java/tech/pegasys/teku/data/SlashingProtectionImporterTest.java
+++ b/data/dataexchange/src/test/java/tech/pegasys/teku/data/SlashingProtectionImporterTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.data.slashinginterchange;
+package tech.pegasys.teku.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import tech.pegasys.teku.data.SlashingProtectionImporter;
+import tech.pegasys.teku.data.slashinginterchange.Metadata;
 import tech.pegasys.teku.infrastructure.logging.SubCommandLogger;
 
 public class SlashingProtectionImporterTest {

--- a/data/dataexchange/src/test/java/tech/pegasys/teku/data/slashinginterchange/MetadataTest.java
+++ b/data/dataexchange/src/test/java/tech/pegasys/teku/data/slashinginterchange/MetadataTest.java
@@ -47,6 +47,13 @@ public class MetadataTest {
   }
 
   @Test
+  public void shouldSerializeWithoutRoot() throws JsonProcessingException {
+    final Metadata metadata = new Metadata(INTERCHANGE_VERSION, null);
+    assertThat(jsonProvider.objectToPrettyJSON(metadata))
+        .isEqualToIgnoringWhitespace("{\"interchange_format_version\":\"5\"}");
+  }
+
+  @Test
   public void shouldSerializeCompleteFormat() throws JsonProcessingException {
     final Metadata metadata = new Metadata(INTERCHANGE_VERSION, root);
     assertThat(jsonProvider.objectToPrettyJSON(metadata)).isEqualTo(jsonData);

--- a/data/dataexchange/src/test/resources/slashProtectionWithGenesisRoot2.yml
+++ b/data/dataexchange/src/test/resources/slashProtectionWithGenesisRoot2.yml
@@ -1,0 +1,5 @@
+---
+lastSignedBlockSlot: 327
+lastSignedAttestationSourceEpoch: 51
+lastSignedAttestationTargetEpoch: 1741
+genesisValidatorsRoot: "0x6e2c5d8a89dfe121a92c8812bea69fe9f84ae48f63aafe34ef7e18c7eac9af71"


### PR DESCRIPTION
 - Show failure conditions
 - Show different reading orders with genesisValidatorsRoot and without

Couldn't find a scenario where the export would need to re-check genesisValidatorsRoot, so removed that check. Also followed up with previous PR to ensure I haven't missed something that actually happened at runtime. I'll wait to hear back from contributor on that before merging this.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
