### PR TITLE
Log parent block info for onSlot event

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -120,7 +120,7 @@ public class EventLogger {
     }
     final String slotEventLog =
         String.format(
-            "Slot Event  *** Slot: %s, Block: %s <~ %s, Epoch: %s, Finalized checkpoint: %s, Finalized root: %s, Peers: %d",
+            "Slot Event  *** Slot: %s, Block: %s Parent: %s, Epoch: %s, Finalized checkpoint: %s, Finalized root: %s, Peers: %d",
             nodeSlot,
             headBlockRoot,
             bestBlockRootOrParent,

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -104,19 +104,26 @@ public class EventLogger {
       final UInt64 nodeSlot,
       final UInt64 headSlot,
       final Bytes32 bestBlockRoot,
+      final Bytes32 bestBlockParentRoot,
       final UInt64 nodeEpoch,
       final UInt64 finalizedCheckpoint,
       final Bytes32 finalizedRoot,
       final int numPeers) {
-    String blockRoot = "   ... empty";
+    final String headBlockRoot;
+    final String bestBlockRootOrParent;
     if (nodeSlot.equals(headSlot)) {
-      blockRoot = LogFormatter.formatHashRoot(bestBlockRoot);
+      headBlockRoot = LogFormatter.formatHashRoot(bestBlockRoot);
+      bestBlockRootOrParent = LogFormatter.formatHashRoot(bestBlockParentRoot);
+    } else {
+      headBlockRoot = "   ... empty";
+      bestBlockRootOrParent = LogFormatter.formatHashRoot(bestBlockRoot);
     }
     final String slotEventLog =
         String.format(
-            "Slot Event  *** Slot: %s, Block: %s, Epoch: %s, Finalized checkpoint: %s, Finalized root: %s, Peers: %d",
+            "Slot Event  *** Slot: %s, Block: %s <~ %s, Epoch: %s, Finalized checkpoint: %s, Finalized root: %s, Peers: %d",
             nodeSlot,
-            blockRoot,
+            headBlockRoot,
+            bestBlockRootOrParent,
             nodeEpoch,
             finalizedCheckpoint,
             LogFormatter.formatHashRoot(finalizedRoot),

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
@@ -220,6 +220,7 @@ public class SlotProcessor {
                                 nodeSlot.getValue(),
                                 head.getSlot(),
                                 head.getRoot(),
+                                head.getParentRoot(),
                                 nodeEpoch,
                                 finalizedCheckpoint.getEpoch(),
                                 finalizedCheckpoint.getRoot(),

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -219,11 +220,13 @@ public class SlotProcessorTest {
 
     slotProcessor.onTick(beaconState.getGenesis_time().plus(SECONDS_PER_SLOT / 3));
     final Checkpoint finalizedCheckpoint = recentChainData.getStore().getFinalizedCheckpoint();
+    final BeaconBlock headBlock = recentChainData.getHeadBlock().orElseThrow().getMessage();
     verify(eventLogger)
         .slotEvent(
             ZERO,
             recentChainData.getHeadSlot(),
-            recentChainData.getBestBlockRoot().orElseThrow(),
+            headBlock.getRoot(),
+            headBlock.getParentRoot(),
             ZERO,
             finalizedCheckpoint.getEpoch(),
             finalizedCheckpoint.getRoot(),


### PR DESCRIPTION
## PR Description

Make `onSlot` event output a bit more rich. 
When an empty slot happens it's often useful to know what is the current `bestBlock` root 
When headBlock root is printed it is often worth to know its parent root to have sense of forks 

The sample output with this fix: 
```log
19:30:16.237 INFO  - Slot Event  *** Slot: 2536, Block: d7ae5a..6418 <~ b9055e..49d3, Epoch: 317, Finalized checkpoint: 311, Finalized root: fa9501..db2b, Peers: 0
19:30:22.236 INFO  - Slot Event  *** Slot: 2537, Block: ec2488..7d62 <~ d7ae5a..6418, Epoch: 317, Finalized checkpoint: 311, Finalized root: fa9501..db2b, Peers: 0
19:30:28.236 INFO  - Slot Event  *** Slot: 2538, Block:    ... empty <~ ec2488..7d62, Epoch: 317, Finalized checkpoint: 311, Finalized root: fa9501..db2b, Peers: 0
19:30:34.241 INFO  - Slot Event  *** Slot: 2539, Block:    ... empty <~ ec2488..7d62, Epoch: 317, Finalized checkpoint: 311, Finalized root: fa9501..db2b, Peers: 0
19:30:40.234 INFO  - Slot Event  *** Slot: 2540, Block: d2ef66..6f3e <~ ec2488..7d62, Epoch: 317, Finalized checkpoint: 311, Finalized root: fa9501..db2b, Peers: 0
19:30:46.233 INFO  - Slot Event  *** Slot: 2541, Block: 2d3be6..21c0 <~ d2ef66..6f3e, Epoch: 317, Finalized checkpoint: 311, Finalized root: fa9501..db2b, Peers: 0
```
## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

Probably sample console output snapshots need to updated

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
