### PR TITLE
Remove the requirement to cache seen attestations

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
@@ -232,8 +232,6 @@ public class AttestationManager extends Service
 
     if (attestation.isAggregate()) {
       aggregateValidator.addSeenAggregate(attestation);
-    } else {
-      attestationValidator.addSeenAttestation(attestation);
     }
 
     notifyAttestationsToSendSubscribers(attestation);

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -116,7 +116,6 @@ public class Constants {
 
   // Teku Networking Specific
   public static final int VALID_BLOCK_SET_SIZE = 1000;
-  public static final int VALID_ATTESTATION_SET_SIZE = 21000;
   public static final int VALID_AGGREGATE_SET_SIZE = 1000;
   public static final int VALID_VALIDATOR_SET_SIZE = 10000;
   public static final int VALID_CONTRIBUTION_AND_PROOF_SET_SIZE = 10000;


### PR DESCRIPTION
 - AttestationValidator no longer looks for attestations that have been seen, as it is filtered by the gossip cache

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
