### PR TITLE
Support storing and loading SSZ structures using supernodes

### DIFF
--- a/ssz/src/main/java/tech/pegasys/teku/ssz/schema/SszSchemaHints.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/schema/SszSchemaHints.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.ssz.schema;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import tech.pegasys.teku.ssz.tree.SszSuperNode;
 
 /**
@@ -25,6 +26,13 @@ import tech.pegasys.teku.ssz.tree.SszSuperNode;
 public class SszSchemaHints {
 
   private static class SszSchemaHint {}
+
+  @Override
+  public String toString() {
+    return hints.stream()
+        .map(hint -> hint.getClass().getSimpleName())
+        .collect(Collectors.joining(", ", "(", ")"));
+  }
 
   /**
    * Hint to use {@link SszSuperNode} for lists/vectors to save the memory when the list content is

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/tree/SszSuperNode.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/tree/SszSuperNode.java
@@ -15,8 +15,8 @@ package tech.pegasys.teku.ssz.tree;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes;

--- a/ssz/src/test/java/tech/pegasys/teku/ssz/schema/TreeNodeAssert.java
+++ b/ssz/src/test/java/tech/pegasys/teku/ssz/schema/TreeNodeAssert.java
@@ -22,6 +22,7 @@ import org.assertj.core.api.AbstractAssert;
 import tech.pegasys.teku.ssz.tree.BranchNode;
 import tech.pegasys.teku.ssz.tree.GIndexUtil;
 import tech.pegasys.teku.ssz.tree.LeafDataNode;
+import tech.pegasys.teku.ssz.tree.SszSuperNode;
 import tech.pegasys.teku.ssz.tree.TreeNode;
 import tech.pegasys.teku.ssz.tree.TreeUtil.ZeroBranchNode;
 import tech.pegasys.teku.ssz.tree.TreeUtil.ZeroLeafNode;
@@ -41,7 +42,7 @@ public class TreeNodeAssert extends AbstractAssert<TreeNodeAssert, TreeNode> {
       assertTreeEqual(actual, expected, GIndexUtil.SELF_G_INDEX);
     } catch (final Throwable t) {
       failWithActualExpectedAndMessage(
-          printTree(actual), printTree(expected), "Trees did not match", t);
+          printTree(actual), printTree(expected), "Trees did not match: " + t.getMessage(), t);
     }
     return this;
   }
@@ -58,6 +59,9 @@ public class TreeNodeAssert extends AbstractAssert<TreeNodeAssert, TreeNode> {
     if (node instanceof ZeroLeafNode) {
       out.println(
           prefix + node.hashTreeRoot() + ": " + ((LeafDataNode) node).getData() + " (zero)");
+    } else if (node instanceof SszSuperNode) {
+      out.println(
+          prefix + node.hashTreeRoot() + ": " + ((LeafDataNode) node).getData() + " (supernode)");
     } else if (node instanceof LeafDataNode) {
       out.println(prefix + node.hashTreeRoot() + ": " + ((LeafDataNode) node).getData());
     } else if (node instanceof ZeroBranchNode) {
@@ -94,6 +98,13 @@ public class TreeNodeAssert extends AbstractAssert<TreeNodeAssert, TreeNode> {
           actualBranch.left(), expectedBranch.left(), GIndexUtil.gIdxLeftGIndex(gIndex));
       assertTreeEqual(
           actualBranch.right(), expectedBranch.right(), GIndexUtil.gIdxRightGIndex(gIndex));
+    } else if (expected instanceof SszSuperNode) {
+      assertThat(((LeafDataNode) actual).getData())
+          .describedAs("leaf data at gIndex %s", gIndex)
+          .isEqualTo(((LeafDataNode) expected).getData());
+      assertThat(actual)
+          .describedAs("node at gIndex %s should be supernode but wasn't", gIndex)
+          .isInstanceOf(SszSuperNode.class);
     } else if (actual instanceof LeafDataNode) {
       assertThat(((LeafDataNode) actual).getData())
           .describedAs("leaf data at gIndex %s", gIndex)

--- a/ssz/src/test/java/tech/pegasys/teku/ssz/schema/collections/SszListSchemaTestBase.java
+++ b/ssz/src/test/java/tech/pegasys/teku/ssz/schema/collections/SszListSchemaTestBase.java
@@ -17,6 +17,8 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.ssz.schema.SszListSchema;
+import tech.pegasys.teku.ssz.schema.SszSchema;
+import tech.pegasys.teku.ssz.schema.SszSchemaHints;
 
 public abstract class SszListSchemaTestBase extends SszCollectionSchemaTestBase {
 
@@ -24,13 +26,23 @@ public abstract class SszListSchemaTestBase extends SszCollectionSchemaTestBase 
     return SszCollectionSchemaTestBase.complexElementSchemas()
         .flatMap(
             elementSchema ->
-                Stream.of(
-                    SszListSchema.create(elementSchema, 0),
-                    SszListSchema.create(elementSchema, 1),
-                    SszListSchema.create(elementSchema, 2),
-                    SszListSchema.create(elementSchema, 3),
-                    SszListSchema.create(elementSchema, 10),
-                    SszListSchema.create(elementSchema, 1L << 33)));
+                Stream.concat(
+                    Stream.of(
+                        SszListSchema.create(elementSchema, 0),
+                        SszListSchema.create(elementSchema, 1),
+                        SszListSchema.create(elementSchema, 2),
+                        SszListSchema.create(elementSchema, 3),
+                        SszListSchema.create(elementSchema, 10),
+                        SszListSchema.create(elementSchema, 1L << 33)),
+                    createSuperNodeVariant(elementSchema)));
+  }
+
+  private static Stream<? extends SszListSchema<?, ?>> createSuperNodeVariant(
+      final SszSchema<?> elementSchema) {
+    // SuperNodes only support fixed sized content
+    return elementSchema.isFixedSize()
+        ? Stream.of(SszListSchema.create(elementSchema, 1L << 16, SszSchemaHints.sszSuperNode(8)))
+        : Stream.empty();
   }
 
   @MethodSource("testSchemaArguments")


### PR DESCRIPTION
## PR Description
Support loading and storing SSZ structures that use `SszSuperNode`.

## Fixed Issue(s)
#4173 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
