### PR TITLE
Fix race conditions in AggregatingAttestationPool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,15 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
  - Updated BLST library.
+ - Use atomic move when writing slashing protection records, if supported by the file system.
 
 
 ### Bug Fixes
  - Posting aggregates that fail validation to `/eth/v1/validator/aggregate_and_proofs` will now result in `SC_BAD_REQUEST` response, with details of the invalid aggregates in the response body.
- - Use atomic move when writing slashing protection records, if supported by the file system.
- - Increase the batch size when searching for unknown validator indexes from 10 to 50.
+ - Increase the validator client batch size when searching for unknown validator indexes from 10 to 50.
  - Fixed issue with the voluntary-exit subcommand and Altair networks which caused "Failed to retrieve network config" errors.
  - Fixed issue where redundant attestations were incorrectly included in blocks.
  - Validator performance is no longer logged when there are no attestations expected.
  - Updated sync committee subscriptions to use untilEpoch as an exclusive field.
  - Fixed an issue where invalid attestations could be incorrectly added to blocks in the epoch immediately after the Altair fork.
+ - Fixed `ConcurrentModificationException` in `AggregatingAttestationPool`.

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -126,7 +126,7 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
     sizeGauge.set(currentSize);
   }
 
-  public int getSize() {
+  public synchronized int getSize() {
     return size.get();
   }
 
@@ -156,7 +156,7 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
         .collect(ATTESTATIONS_SCHEMA.collector());
   }
 
-  public Stream<Attestation> getAttestations(
+  public synchronized Stream<Attestation> getAttestations(
       final Optional<UInt64> maybeSlot, final Optional<UInt64> maybeCommitteeIndex) {
     final Predicate<Map.Entry<UInt64, Set<Bytes>>> filterForSlot =
         (entry) -> maybeSlot.map(slot -> entry.getKey().equals(slot)).orElse(true);
@@ -189,7 +189,7 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
         .flatMap(attestations -> attestations.stream().findFirst());
   }
 
-  public void onReorg(final UInt64 commonAncestorSlot) {
+  public synchronized void onReorg(final UInt64 commonAncestorSlot) {
     attestationGroupByDataHash.values().forEach(group -> group.onReorg(commonAncestorSlot));
   }
 }


### PR DESCRIPTION
## PR Description
Add missing `synchronised` to public methods in `AggregatingAttestationPool` to avoid race conditions.

## Fixed Issue(s)
fixes #4336 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
