### PR TITLE
Don't assume all MatchingDataAttestationGroup instances have a known shuffling seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
  - Fixed `ConcurrentModificationException` in `AggregatingAttestationPool`.
+ - Fixed potential `IllegalStateException` during block production.

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -76,13 +76,13 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
     if (add) {
       updateSize(1);
     }
-    dataHashBySlot
-        .computeIfAbsent(attestationData.getSlot(), slot -> new HashSet<>())
-        .add(attestationData.hashTreeRoot());
   }
 
   private MatchingDataAttestationGroup getOrCreateAttestationGroup(
       final AttestationData attestationData) {
+    dataHashBySlot
+        .computeIfAbsent(attestationData.getSlot(), slot -> new HashSet<>())
+        .add(attestationData.hashTreeRoot());
     return attestationGroupByDataHash.computeIfAbsent(
         attestationData.hashTreeRoot(),
         key -> new MatchingDataAttestationGroup(spec, attestationData));

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationForkChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationForkChecker.java
@@ -40,6 +40,6 @@ public class AttestationForkChecker {
 
   public boolean areAttestationsFromCorrectFork(
       final MatchingDataAttestationGroup attestationGroup) {
-    return validCommitteeShufflingSeeds.contains(attestationGroup.getCommitteeShufflingSeed());
+    return attestationGroup.matchesCommitteeShufflingSeed(validCommitteeShufflingSeeds);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroup.java
@@ -186,10 +186,8 @@ class MatchingDataAttestationGroup implements Iterable<ValidateableAttestation> 
             .reduce(Attestation.createEmptyAggregationBits(), SszBitlist::or);
   }
 
-  public Bytes32 getCommitteeShufflingSeed() {
-    return committeeShufflingSeed.orElseThrow(
-        () ->
-            new IllegalStateException("Attestations added with unknown committee shuffling seed"));
+  public boolean matchesCommitteeShufflingSeed(final Set<Bytes32> validSeeds) {
+    return committeeShufflingSeed.map(validSeeds::contains).orElse(false);
   }
 
   private class AggregatingIterator implements Iterator<ValidateableAttestation> {


### PR DESCRIPTION
## PR Description
Fixes an `IllegalStateException` during block production in a particular corner case. Specifically:

 * A block is imported to the canonical chain containing an attestation with `AttestationData` that has never been seen via gossip.
 * Then an attestation with that same `AttestationData` is received via gossip with a subset of the already included validators.
 * Block production is requested before any attestations with not-included validators are received for that `AttestationData`.

It was assumed that all `MatchingDataAttestationPool` instances held would have, at some point, had an attestation added to them from which the committee shuffling seed could be retrieved.  As part of filtering for inclusion in the block the group is checked to ensure that stored seed matches one of the valid seeds for the block.  In this corner case the seed has never been stored and so an `IllegalStateException` is thrown.

The fix is to consider any `MatchingDataAttestationPool` that doesn't have a stored seed as not matching and simply skip over it (it won't have any attestations in it anyway).

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
