### PR TITLE
Fix loadSource() in Windows when invalid path is passed

### DIFF
--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/resource/FileResourceLoader.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/resource/FileResourceLoader.java
@@ -13,10 +13,11 @@
 
 package tech.pegasys.teku.infrastructure.io.resource;
 
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -28,10 +29,10 @@ public class FileResourceLoader extends ResourceLoader {
 
   @Override
   Optional<InputStream> loadSource(final String source) throws IOException {
-    final Path path = Path.of(source);
-    if (!path.toFile().exists()) {
+    final File file = new File(source);
+    if (!file.exists()) {
       return Optional.empty();
     }
-    return Optional.of(Files.newInputStream(path));
+    return Optional.of(new BufferedInputStream(new FileInputStream(file)));
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Many tests (e.g. `tech.pegasys.teku.spec.SpecVersionTest`) fails in Windows due to the exception below: 

```
java.lang.IllegalArgumentException: Failed to load spec config: file:/E:/ws/teku/ethereum/spec/out/test/resources/tech/pegasys/teku/spec/config/legacy/minimal.yaml

	at tech.pegasys.teku.spec.config.SpecConfigLoader.processConfig(SpecConfigLoader.java:72)
	at tech.pegasys.teku.spec.config.TestConfigLoader.loadPhase0Config(TestConfigLoader.java:38)
	at tech.pegasys.teku.spec.config.TestConfigLoader.loadPhase0Config(TestConfigLoader.java:31)
	at tech.pegasys.teku.spec.SpecVersionTest.<init>(SpecVersionTest.java:29)
Caused by: java.nio.file.InvalidPathException: Illegal char <:> at index 12: configs/file:/E:/ws/teku/ethereum/spec/out/test/resources/tech/pegasys/teku/spec/config/legacy/minimal.yaml.yaml
	at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
	at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
	at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
	at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
	at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:229)
	at java.base/java.nio.file.Path.of(Path.java:147)
	at tech.pegasys.teku.infrastructure.io.resource.FileResourceLoader.loadSource(FileResourceLoader.java:31)
	at tech.pegasys.teku.infrastructure.io.resource.FallbackResourceLoader.loadSource(FallbackResourceLoader.java:33)
	at tech.pegasys.teku.infrastructure.io.resource.ResourceLoader.load(ResourceLoader.java:71)
	at tech.pegasys.teku.spec.config.SpecConfigLoader.loadConfigurationFile(SpecConfigLoader.java:78)
	at tech.pegasys.teku.spec.config.SpecConfigLoader.processConfig(SpecConfigLoader.java:52)
	... 66 more
```

Suggested change fixes this behavior 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
