### PR TITLE
Fix GIndex passed to NodeStore when writing list root node

### DIFF
--- a/ssz/src/main/java/tech/pegasys/teku/ssz/schema/impl/AbstractSszListSchema.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/schema/impl/AbstractSszListSchema.java
@@ -161,7 +161,7 @@ public abstract class AbstractSszListSchema<
     // Store list root node
     nodeStore.storeBranchNode(
         node.hashTreeRoot(),
-        GIndexUtil.gIdxRightGIndex(rootGIndex),
+        rootGIndex,
         1,
         new Bytes32[] {vectorNode.hashTreeRoot(), lengthNode.hashTreeRoot()});
   }


### PR DESCRIPTION
## PR Description
Lists were passing the wrong GIndex to `NodeStore` when storing the top level branch node for the list.  Currently the `NodeStore` doesn't use the GIndex but future optimisations may include it in the key to make writes more sequential so worth getting it right.

Thanks @Nashatyrev for spotting the issue.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
