### PR TITLE
[Merge] Fix reference tests

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -61,9 +61,7 @@ public abstract class Eth2ReferenceTestCase {
           .build();
 
   private final ImmutableMap<String, TestExecutor> MERGE_TEST_TYPES =
-      ImmutableMap.<String, TestExecutor>builder()
-          .putAll(RewardsTestExecutorPhase0.REWARDS_TEST_TYPES)
-          .build();
+      ImmutableMap.<String, TestExecutor>builder().putAll(ALTAIR_TEST_TYPES).build();
 
   protected void runReferenceTest(final TestDefinition testDefinition) throws Throwable {
     setConstants(testDefinition.getConfigName());

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -39,7 +39,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    * <p>e.g. set to "ssz_static" to run only ssz static tests or "ssz_static/Attestation" for only
    * attestation ssz tests.
    */
-  private static final String TEST_TYPE = "ssz_static/ExecutionPayload";
+  private static final String TEST_TYPE = "";
 
   /** Filter test to run to those from the specified spec. One of general, minimal or mainnet */
   private static final String SPEC = "";
@@ -59,7 +59,6 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
             testDefinition ->
                 SPEC.isBlank() || testDefinition.getConfigName().equalsIgnoreCase(SPEC))
         .filter(testDefinition -> testDefinition.getTestType().startsWith(TEST_TYPE))
-        .filter(testDefinition -> testDefinition.getDisplayName().contains("merge"))
         .map(testDefinition -> Arguments.of(testDefinition.getDisplayName(), testDefinition));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.spec.config;
 
 import java.util.Map;
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.type.Bytes4;
@@ -289,15 +288,5 @@ public class DelegatingSpecConfig implements SpecConfig {
   @Override
   public Bytes getDepositContractAddress() {
     return specConfig.getDepositContractAddress();
-  }
-
-  @Override
-  public Optional<SpecConfigAltair> toVersionAltair() {
-    return specConfig.toVersionAltair();
-  }
-
-  @Override
-  public Optional<SpecConfigMerge> toVersionMerge() {
-    return specConfig.toVersionMerge();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfigAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfigAltair.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.config;
+
+import java.util.Optional;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.ssz.type.Bytes4;
+
+public class DelegatingSpecConfigAltair extends DelegatingSpecConfig implements SpecConfigAltair {
+
+  private final SpecConfigAltair specConfigAltair;
+
+  public DelegatingSpecConfigAltair(final SpecConfigAltair specConfig) {
+    super(specConfig);
+    this.specConfigAltair = specConfig;
+  }
+
+  @Override
+  public Bytes4 getAltairForkVersion() {
+    return specConfigAltair.getAltairForkVersion();
+  }
+
+  @Override
+  public UInt64 getAltairForkEpoch() {
+    return specConfigAltair.getAltairForkEpoch();
+  }
+
+  @Override
+  public UInt64 getInactivityPenaltyQuotientAltair() {
+    return specConfigAltair.getInactivityPenaltyQuotientAltair();
+  }
+
+  @Override
+  public int getMinSlashingPenaltyQuotientAltair() {
+    return specConfigAltair.getMinSlashingPenaltyQuotientAltair();
+  }
+
+  @Override
+  public int getProportionalSlashingMultiplierAltair() {
+    return specConfigAltair.getProportionalSlashingMultiplierAltair();
+  }
+
+  @Override
+  public int getSyncCommitteeSize() {
+    return specConfigAltair.getSyncCommitteeSize();
+  }
+
+  @Override
+  public UInt64 getInactivityScoreBias() {
+    return specConfigAltair.getInactivityScoreBias();
+  }
+
+  @Override
+  public UInt64 getInactivityScoreRecoveryRate() {
+    return specConfigAltair.getInactivityScoreRecoveryRate();
+  }
+
+  @Override
+  public int getEpochsPerSyncCommitteePeriod() {
+    return specConfigAltair.getEpochsPerSyncCommitteePeriod();
+  }
+
+  @Override
+  public int getMinSyncCommitteeParticipants() {
+    return specConfigAltair.getMinSyncCommitteeParticipants();
+  }
+
+  @Override
+  public Optional<SpecConfigAltair> toVersionAltair() {
+    return Optional.of(this);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigAltair.java
@@ -13,59 +13,13 @@
 
 package tech.pegasys.teku.spec.config;
 
-import java.util.Objects;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.type.Bytes4;
 
-public class SpecConfigAltair extends DelegatingSpecConfig {
+public interface SpecConfigAltair extends SpecConfig {
 
-  // Updated penalties
-  private final UInt64 inactivityPenaltyQuotientAltair;
-  private final int minSlashingPenaltyQuotientAltair;
-  private final int proportionalSlashingMultiplierAltair;
-
-  // Misc
-  private final int syncCommitteeSize;
-  private final UInt64 inactivityScoreBias;
-  private final UInt64 inactivityScoreRecoveryRate;
-
-  // Time
-  private final int epochsPerSyncCommitteePeriod;
-
-  // Fork
-  private final Bytes4 altairForkVersion;
-  private final UInt64 altairForkEpoch;
-
-  // Sync protocol
-  private final int minSyncCommitteeParticipants;
-
-  public SpecConfigAltair(
-      final SpecConfig specConfig,
-      final UInt64 inactivityPenaltyQuotientAltair,
-      final int altairMinSlashingPenaltyQuotient,
-      final int proportionalSlashingMultiplierAltair,
-      final int syncCommitteeSize,
-      final UInt64 inactivityScoreBias,
-      final UInt64 inactivityScoreRecoveryRate,
-      final int epochsPerSyncCommitteePeriod,
-      final Bytes4 altairForkVersion,
-      final UInt64 altairForkEpoch,
-      final int minSyncCommitteeParticipants) {
-    super(specConfig);
-    this.inactivityPenaltyQuotientAltair = inactivityPenaltyQuotientAltair;
-    this.minSlashingPenaltyQuotientAltair = altairMinSlashingPenaltyQuotient;
-    this.proportionalSlashingMultiplierAltair = proportionalSlashingMultiplierAltair;
-    this.syncCommitteeSize = syncCommitteeSize;
-    this.inactivityScoreBias = inactivityScoreBias;
-    this.inactivityScoreRecoveryRate = inactivityScoreRecoveryRate;
-    this.epochsPerSyncCommitteePeriod = epochsPerSyncCommitteePeriod;
-    this.altairForkVersion = altairForkVersion;
-    this.altairForkEpoch = altairForkEpoch;
-    this.minSyncCommitteeParticipants = minSyncCommitteeParticipants;
-  }
-
-  public static SpecConfigAltair required(final SpecConfig specConfig) {
+  static SpecConfigAltair required(SpecConfig specConfig) {
     return specConfig
         .toVersionAltair()
         .orElseThrow(
@@ -75,82 +29,26 @@ public class SpecConfigAltair extends DelegatingSpecConfig {
                         + specConfig.getClass().getSimpleName()));
   }
 
-  public Bytes4 getAltairForkVersion() {
-    return altairForkVersion;
-  }
+  Bytes4 getAltairForkVersion();
 
-  public UInt64 getAltairForkEpoch() {
-    return altairForkEpoch;
-  }
+  UInt64 getAltairForkEpoch();
 
-  public UInt64 getInactivityPenaltyQuotientAltair() {
-    return inactivityPenaltyQuotientAltair;
-  }
+  UInt64 getInactivityPenaltyQuotientAltair();
 
-  public int getMinSlashingPenaltyQuotientAltair() {
-    return minSlashingPenaltyQuotientAltair;
-  }
+  int getMinSlashingPenaltyQuotientAltair();
 
-  public int getProportionalSlashingMultiplierAltair() {
-    return proportionalSlashingMultiplierAltair;
-  }
+  int getProportionalSlashingMultiplierAltair();
 
-  public int getSyncCommitteeSize() {
-    return syncCommitteeSize;
-  }
+  int getSyncCommitteeSize();
 
-  public UInt64 getInactivityScoreBias() {
-    return inactivityScoreBias;
-  }
+  UInt64 getInactivityScoreBias();
 
-  public UInt64 getInactivityScoreRecoveryRate() {
-    return inactivityScoreRecoveryRate;
-  }
+  UInt64 getInactivityScoreRecoveryRate();
 
-  public int getEpochsPerSyncCommitteePeriod() {
-    return epochsPerSyncCommitteePeriod;
-  }
+  int getEpochsPerSyncCommitteePeriod();
 
-  public int getMinSyncCommitteeParticipants() {
-    return minSyncCommitteeParticipants;
-  }
+  int getMinSyncCommitteeParticipants();
 
   @Override
-  public Optional<SpecConfigAltair> toVersionAltair() {
-    return Optional.of(this);
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    final SpecConfigAltair that = (SpecConfigAltair) o;
-    return Objects.equals(specConfig, that.specConfig)
-        && minSlashingPenaltyQuotientAltair == that.minSlashingPenaltyQuotientAltair
-        && proportionalSlashingMultiplierAltair == that.proportionalSlashingMultiplierAltair
-        && syncCommitteeSize == that.syncCommitteeSize
-        && Objects.equals(inactivityScoreBias, that.inactivityScoreBias)
-        && Objects.equals(inactivityScoreRecoveryRate, that.inactivityScoreRecoveryRate)
-        && epochsPerSyncCommitteePeriod == that.epochsPerSyncCommitteePeriod
-        && minSyncCommitteeParticipants == that.minSyncCommitteeParticipants
-        && Objects.equals(inactivityPenaltyQuotientAltair, that.inactivityPenaltyQuotientAltair)
-        && Objects.equals(altairForkVersion, that.altairForkVersion)
-        && Objects.equals(altairForkEpoch, that.altairForkEpoch);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        specConfig,
-        inactivityPenaltyQuotientAltair,
-        minSlashingPenaltyQuotientAltair,
-        proportionalSlashingMultiplierAltair,
-        syncCommitteeSize,
-        inactivityScoreBias,
-        inactivityScoreRecoveryRate,
-        epochsPerSyncCommitteePeriod,
-        altairForkVersion,
-        altairForkEpoch,
-        minSyncCommitteeParticipants);
-  }
+  Optional<SpecConfigAltair> toVersionAltair();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigAltairImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigAltairImpl.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.config;
+
+import java.util.Objects;
+import java.util.Optional;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.ssz.type.Bytes4;
+
+public class SpecConfigAltairImpl extends DelegatingSpecConfig implements SpecConfigAltair {
+
+  // Updated penalties
+  private final UInt64 inactivityPenaltyQuotientAltair;
+  private final int minSlashingPenaltyQuotientAltair;
+  private final int proportionalSlashingMultiplierAltair;
+
+  // Misc
+  private final int syncCommitteeSize;
+  private final UInt64 inactivityScoreBias;
+  private final UInt64 inactivityScoreRecoveryRate;
+
+  // Time
+  private final int epochsPerSyncCommitteePeriod;
+
+  // Fork
+  private final Bytes4 altairForkVersion;
+  private final UInt64 altairForkEpoch;
+
+  // Sync protocol
+  private final int minSyncCommitteeParticipants;
+
+  public SpecConfigAltairImpl(
+      final SpecConfig specConfig,
+      final UInt64 inactivityPenaltyQuotientAltair,
+      final int altairMinSlashingPenaltyQuotient,
+      final int proportionalSlashingMultiplierAltair,
+      final int syncCommitteeSize,
+      final UInt64 inactivityScoreBias,
+      final UInt64 inactivityScoreRecoveryRate,
+      final int epochsPerSyncCommitteePeriod,
+      final Bytes4 altairForkVersion,
+      final UInt64 altairForkEpoch,
+      final int minSyncCommitteeParticipants) {
+    super(specConfig);
+    this.inactivityPenaltyQuotientAltair = inactivityPenaltyQuotientAltair;
+    this.minSlashingPenaltyQuotientAltair = altairMinSlashingPenaltyQuotient;
+    this.proportionalSlashingMultiplierAltair = proportionalSlashingMultiplierAltair;
+    this.syncCommitteeSize = syncCommitteeSize;
+    this.inactivityScoreBias = inactivityScoreBias;
+    this.inactivityScoreRecoveryRate = inactivityScoreRecoveryRate;
+    this.epochsPerSyncCommitteePeriod = epochsPerSyncCommitteePeriod;
+    this.altairForkVersion = altairForkVersion;
+    this.altairForkEpoch = altairForkEpoch;
+    this.minSyncCommitteeParticipants = minSyncCommitteeParticipants;
+  }
+
+  @Override
+  public Bytes4 getAltairForkVersion() {
+    return altairForkVersion;
+  }
+
+  @Override
+  public UInt64 getAltairForkEpoch() {
+    return altairForkEpoch;
+  }
+
+  @Override
+  public UInt64 getInactivityPenaltyQuotientAltair() {
+    return inactivityPenaltyQuotientAltair;
+  }
+
+  @Override
+  public int getMinSlashingPenaltyQuotientAltair() {
+    return minSlashingPenaltyQuotientAltair;
+  }
+
+  @Override
+  public int getProportionalSlashingMultiplierAltair() {
+    return proportionalSlashingMultiplierAltair;
+  }
+
+  @Override
+  public int getSyncCommitteeSize() {
+    return syncCommitteeSize;
+  }
+
+  @Override
+  public UInt64 getInactivityScoreBias() {
+    return inactivityScoreBias;
+  }
+
+  @Override
+  public UInt64 getInactivityScoreRecoveryRate() {
+    return inactivityScoreRecoveryRate;
+  }
+
+  @Override
+  public int getEpochsPerSyncCommitteePeriod() {
+    return epochsPerSyncCommitteePeriod;
+  }
+
+  @Override
+  public int getMinSyncCommitteeParticipants() {
+    return minSyncCommitteeParticipants;
+  }
+
+  @Override
+  public Optional<SpecConfigAltair> toVersionAltair() {
+    return Optional.of(this);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final SpecConfigAltairImpl that = (SpecConfigAltairImpl) o;
+    return Objects.equals(specConfig, that.specConfig)
+        && minSlashingPenaltyQuotientAltair == that.minSlashingPenaltyQuotientAltair
+        && proportionalSlashingMultiplierAltair == that.proportionalSlashingMultiplierAltair
+        && syncCommitteeSize == that.syncCommitteeSize
+        && Objects.equals(inactivityScoreBias, that.inactivityScoreBias)
+        && Objects.equals(inactivityScoreRecoveryRate, that.inactivityScoreRecoveryRate)
+        && epochsPerSyncCommitteePeriod == that.epochsPerSyncCommitteePeriod
+        && minSyncCommitteeParticipants == that.minSyncCommitteeParticipants
+        && Objects.equals(inactivityPenaltyQuotientAltair, that.inactivityPenaltyQuotientAltair)
+        && Objects.equals(altairForkVersion, that.altairForkVersion)
+        && Objects.equals(altairForkEpoch, that.altairForkEpoch);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        specConfig,
+        inactivityPenaltyQuotientAltair,
+        minSlashingPenaltyQuotientAltair,
+        proportionalSlashingMultiplierAltair,
+        syncCommitteeSize,
+        inactivityScoreBias,
+        inactivityScoreRecoveryRate,
+        epochsPerSyncCommitteePeriod,
+        altairForkVersion,
+        altairForkEpoch,
+        minSyncCommitteeParticipants);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
@@ -158,10 +158,11 @@ public class SpecConfigBuilder {
             depositContractAddress);
 
     if (altairBuilder.isPresent()) {
-      config = altairBuilder.get().build(config);
-    }
-    if (mergeBuilder.isPresent()) {
-      config = mergeBuilder.get().build(config);
+      final SpecConfigAltair altairConfig = altairBuilder.get().build(config);
+      config = altairConfig;
+      if (mergeBuilder.isPresent()) {
+        config = mergeBuilder.get().build(altairConfig);
+      }
     }
     return config;
   }
@@ -570,7 +571,7 @@ public class SpecConfigBuilder {
     private AltairBuilder() {}
 
     SpecConfigAltair build(final SpecConfig specConfig) {
-      return new SpecConfigAltair(
+      return new SpecConfigAltairImpl(
           specConfig,
           inactivityPenaltyQuotientAltair,
           minSlashingPenaltyQuotientAltair,
@@ -683,7 +684,7 @@ public class SpecConfigBuilder {
 
     private MergeBuilder() {}
 
-    SpecConfigMerge build(final SpecConfig specConfig) {
+    SpecConfigMerge build(final SpecConfigAltair specConfig) {
       return new SpecConfigMerge(
           specConfig,
           mergeForkVersion,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigMerge.java
@@ -20,7 +20,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.type.Bytes4;
 
-public class SpecConfigMerge extends DelegatingSpecConfig {
+public class SpecConfigMerge extends DelegatingSpecConfigAltair {
 
   // Fork
   private final Bytes4 mergeForkVersion;
@@ -31,7 +31,7 @@ public class SpecConfigMerge extends DelegatingSpecConfig {
   private final UInt256 minAnchorPowBlockDifficulty;
 
   public SpecConfigMerge(
-      SpecConfig specConfig,
+      SpecConfigAltair specConfig,
       Bytes4 mergeForkVersion,
       UInt64 mergeForkEpoch,
       UInt64 targetSecondsToMerge,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchema.java
@@ -91,6 +91,10 @@ public interface BeaconStateSchema<T extends BeaconState, TMutable extends Mutab
     return (SyncCommitteeSchema) getSchemaOrThrow(BeaconStateFields.CURRENT_SYNC_COMMITTEE);
   }
 
+  default SyncCommitteeSchema getNextSyncCommitteeSchemaOrThrow() {
+    return (SyncCommitteeSchema) getSchemaOrThrow(BeaconStateFields.NEXT_SYNC_COMMITTEE);
+  }
+
   private SszSchema<?> getSchemaOrThrow(final BeaconStateFields field) {
     final String fieldName = field.name();
     final int fieldIndex = getFieldIndex(fieldName);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
@@ -36,7 +36,6 @@ import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateSchemaAltair;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
@@ -146,8 +145,9 @@ public class BeaconStateAccessorsAltair extends BeaconStateAccessors {
             .collect(toList());
     final BLSPublicKey aggregatePubkey = BLSPublicKey.aggregate(pubkeys);
 
-    return ((BeaconStateSchemaAltair) state.getSchema())
-        .getNextSyncCommitteeSchema()
+    return state
+        .getBeaconStateSchema()
+        .getNextSyncCommitteeSchemaOrThrow()
         .create(
             pubkeys.stream().map(SszPublicKey::new).collect(toList()),
             new SszPublicKey(aggregatePubkey));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/SpecLogicMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/SpecLogicMerge.java
@@ -20,8 +20,6 @@ import tech.pegasys.teku.spec.config.SpecConfigMerge;
 import tech.pegasys.teku.spec.datastructures.forkchoice.TransitionStore;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
-import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
-import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MergeTransitionHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.PowBlock;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
@@ -34,6 +32,7 @@ import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateMutatorsAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.EpochProcessorAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.ValidatorStatusFactoryAltair;
 import tech.pegasys.teku.spec.logic.versions.merge.block.BlockProcessorMerge;
@@ -54,8 +53,8 @@ public class SpecLogicMerge extends AbstractSpecLogic {
   private SpecLogicMerge(
       final Predicates predicates,
       final MiscHelpersMerge miscHelpers,
-      final BeaconStateAccessors beaconStateAccessors,
-      final BeaconStateMutators beaconStateMutators,
+      final BeaconStateAccessorsMerge beaconStateAccessors,
+      final BeaconStateMutatorsAltair beaconStateMutators,
       final OperationSignatureVerifier operationSignatureVerifier,
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
@@ -101,8 +100,8 @@ public class SpecLogicMerge extends AbstractSpecLogic {
     final MiscHelpersMerge miscHelpers = new MiscHelpersMerge(config);
     final BeaconStateAccessorsMerge beaconStateAccessors =
         new BeaconStateAccessorsMerge(config, predicates, miscHelpers);
-    final BeaconStateMutators beaconStateMutators =
-        new BeaconStateMutators(config, miscHelpers, beaconStateAccessors);
+    final BeaconStateMutatorsAltair beaconStateMutators =
+        new BeaconStateMutatorsAltair(config, miscHelpers, beaconStateAccessors);
 
     // Operation validaton
     final OperationSignatureVerifier operationSignatureVerifier =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/block/BlockProcessorMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/block/BlockProcessorMerge.java
@@ -26,7 +26,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
 import tech.pegasys.teku.spec.config.SpecConfigMerge;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.merge.BeaconBlockBodyMerge;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
@@ -94,13 +93,6 @@ public class BlockProcessorMerge extends BlockProcessorAltair {
         "Expected merge block processor but got %s",
         blockProcessor.getClass());
     return (BlockProcessorMerge) blockProcessor;
-  }
-
-  @Override
-  public void processSyncAggregate(
-      MutableBeaconState state, SyncAggregate syncAggregate, BLSSignatureVerifier signatureVerifier)
-      throws BlockProcessingException {
-    throw new UnsupportedOperationException("No SyncCommittee in merge");
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigAltairTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigAltairTest.java
@@ -69,7 +69,7 @@ public class SpecConfigAltairTest {
   private SpecConfigAltair createRandomAltairConfig(final SpecConfig phase0Config, final int seed) {
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
 
-    return new SpecConfigAltair(
+    return new SpecConfigAltairImpl(
         phase0Config,
         dataStructureUtil.randomUInt64(),
         dataStructureUtil.randomPositiveInt(),

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigAssertions.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigAssertions.java
@@ -28,7 +28,7 @@ public class SpecConfigAssertions {
   }
 
   static void assertAllAltairFieldsSet(final SpecConfig config) throws Exception {
-    assertAllFieldsSet(config, SpecConfigAltair.class);
+    assertAllFieldsSet(config, SpecConfigAltairImpl.class);
   }
 
   static void assertAllMergeFieldsSet(final SpecConfig config) throws Exception {


### PR DESCRIPTION
## PR Description
Makes progress fixing failing merge reference tests.

 * Fix SpecConfigMerge so it implements SpecConfigAltair and doesn't get unwrapped when calling toVersionAltair()
 * Suport sync aggregates in merge block processor
 * Use altair versions of beacon chain accessor and mutator
 * Use altair version of rewards & penalties reference test executor

Combined with https://github.com/ConsenSys/teku/pull/4362 this gets all reference tests passing.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
