### PR TITLE
starts `engine_preparePayload` and `engine_getPayload` API call implementation

### DIFF
--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
@@ -133,7 +133,7 @@ public class BlockProposalTestUtil {
     return spec.atSlot(state.getSlot())
         .getExecutionPayloadUtil()
         .orElseThrow()
-        .produceExecutionPayload(executionParentHash, timestamp);
+        .getExecutionPayload(executionParentHash, timestamp, UInt64.ZERO);
   }
 
   public int getProposerIndexForSlot(final BeaconState preState, final UInt64 slot) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineService.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineService.java
@@ -53,6 +53,10 @@ public class ExecutionEngineService {
     this.executionEngineClient = executionEngineClient;
   }
 
+  public void prepareBlock(Bytes32 parentHash, UInt64 timestamp, UInt64 payloadId) {
+    // TODO CALL execution client
+  }
+
   /**
    * Requests execution-engine to produce a block.
    *

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ExecutionPayloadUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ExecutionPayloadUtil.java
@@ -44,7 +44,8 @@ public class ExecutionPayloadUtil {
     executionEngineService.prepareBlock(parentHash, timestamp, payloadId);
   }
 
-  public ExecutionPayload produceExecutionPayload(Bytes32 parentHash, UInt64 timestamp) {
+  public ExecutionPayload getExecutionPayload(
+      Bytes32 parentHash, UInt64 timestamp, UInt64 payloadId) {
     checkNotNull(executionEngineService);
     return executionEngineService.assembleBlock(parentHash, timestamp).asInternalExecutionPayload();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ExecutionPayloadUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ExecutionPayloadUtil.java
@@ -39,6 +39,11 @@ public class ExecutionPayloadUtil {
             executionPayload));
   }
 
+  public void prepareExecutionPayload(Bytes32 parentHash, UInt64 timestamp, UInt64 payloadId) {
+    checkNotNull(executionEngineService);
+    executionEngineService.prepareBlock(parentHash, timestamp, payloadId);
+  }
+
   public ExecutionPayload produceExecutionPayload(Bytes32 parentHash, UInt64 timestamp) {
     checkNotNull(executionEngineService);
     return executionEngineService.assembleBlock(parentHash, timestamp).asInternalExecutionPayload();

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -55,7 +55,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch);
 
-  SafeFuture<Void> prepareExecutionPayload(UInt64 slot, UInt64 payloadId);
+  SafeFuture<Void> prepareExecutionPayload(UInt64 slot);
 
   SafeFuture<Optional<BeaconBlock>> createUnsignedBlock(
       UInt64 slot, BLSSignature randaoReveal, Optional<Bytes32> graffiti);

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -55,7 +55,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch);
 
-  SafeFuture<Void> prepareExecutionPayload(UInt64 slot, UInt64 requestId);
+  SafeFuture<Void> prepareExecutionPayload(UInt64 slot, UInt64 payloadId);
 
   SafeFuture<Optional<BeaconBlock>> createUnsignedBlock(
       UInt64 slot, BLSSignature randaoReveal, Optional<Bytes32> graffiti);

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -55,6 +55,8 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch);
 
+  SafeFuture<Void> prepareExecutionPayload(UInt64 slot, UInt64 requestId);
+
   SafeFuture<Optional<BeaconBlock>> createUnsignedBlock(
       UInt64 slot, BLSSignature randaoReveal, Optional<Bytes32> graffiti);
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -230,8 +230,8 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> prepareExecutionPayload(UInt64 slot, UInt64 payloadId) {
-    return delegate.prepareExecutionPayload(slot, payloadId);
+  public SafeFuture<Void> prepareExecutionPayload(UInt64 slot) {
+    return delegate.prepareExecutionPayload(slot);
   }
 
   @Override

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -230,6 +230,11 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
+  public SafeFuture<Void> prepareExecutionPayload(UInt64 slot, UInt64 requestId) {
+    return delegate.prepareExecutionPayload(slot, requestId);
+  }
+
+  @Override
   public SafeFuture<Optional<BeaconBlock>> createUnsignedBlock(
       final UInt64 slot, final BLSSignature randaoReveal, Optional<Bytes32> graffiti) {
     return countDataRequest(

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -230,8 +230,8 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> prepareExecutionPayload(UInt64 slot, UInt64 requestId) {
-    return delegate.prepareExecutionPayload(slot, requestId);
+  public SafeFuture<Void> prepareExecutionPayload(UInt64 slot, UInt64 payloadId) {
+    return delegate.prepareExecutionPayload(slot, payloadId);
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -29,7 +29,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   private static final Logger LOG = LogManager.getLogger();
   private final MetricsSystem metricsSystem;
   private final String dutyType;
-  private final Spec spec;
+  protected final Spec spec;
   private final boolean useDependentRoots;
   private final DutyLoader<?> epochDutiesScheduler;
   private final int lookAheadEpochs;
@@ -123,7 +123,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
     invalidateEpochs(dutiesByEpoch);
   }
 
-  private void calculateDuties(final UInt64 epochNumber) {
+  protected void calculateDuties(final UInt64 epochNumber) {
     dutiesByEpoch.computeIfAbsent(epochNumber, this::createEpochDuties);
     for (int i = 1; i <= lookAheadEpochs; i++) {
       dutiesByEpoch.computeIfAbsent(epochNumber.plus(i), this::createEpochDuties);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -44,6 +44,13 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
   }
 
   @Override
+  public void onAttestationCreationDue(final UInt64 slot) {
+    final UInt64 preparationDueSlot = slot.plus(1);
+    calculateDuties(spec.computeEpochAtSlot(preparationDueSlot));
+    notifyEpochDuties(PendingDuties::onProductionDuePreparation, preparationDueSlot);
+  }
+
+  @Override
   protected Bytes32 getExpectedDependentRoot(
       final Bytes32 headBlockRoot,
       final Bytes32 previousTargetRoot,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -47,7 +47,7 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
   public void onAttestationCreationDue(final UInt64 slot) {
     final UInt64 preparationDueSlot = slot.plus(1);
     calculateDuties(spec.computeEpochAtSlot(preparationDueSlot));
-    notifyEpochDuties(PendingDuties::onProductionDuePreparation, preparationDueSlot);
+    notifyEpochDuties(PendingDuties::onProductionPreparationDue, preparationDueSlot);
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/PendingDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/PendingDuties.java
@@ -84,7 +84,7 @@ class PendingDuties {
                     error -> reportDutyFailure(error, duties.getAggregationType(), slot)));
   }
 
-  public void onProductionDuePreparation(final UInt64 slot) {
+  public void onProductionPreparationDue(final UInt64 slot) {
     execute(
         duties ->
             duties

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/PendingDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/PendingDuties.java
@@ -84,6 +84,22 @@ class PendingDuties {
                     error -> reportDutyFailure(error, duties.getAggregationType(), slot)));
   }
 
+  public void onProductionDuePreparation(final UInt64 slot) {
+    execute(
+        duties ->
+            duties
+                .performProductionDutyPreparation(slot)
+                .finish(
+                    error ->
+                        reportDutyPreparationFailure(error, duties.getProductionType(), slot)));
+  }
+
+  private void reportDutyPreparationFailure(
+      final Throwable error, final String producedType, final UInt64 slot) {
+    // TODO handle preparation failure correctly
+    VALIDATOR_LOGGER.dutyFailed("preparation of " + producedType, slot, emptySet(), error);
+  }
+
   private void reportDutyFailure(
       final Throwable error, final String producedType, final UInt64 slot) {
     dutiesPerformedCounter.labels(producedType, "failed").inc();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.validator.client.duties;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.bls.BLSSignature;
@@ -32,13 +31,11 @@ import tech.pegasys.teku.validator.client.Validator;
 
 public class BlockProductionDuty implements Duty {
   private static final Logger LOG = LogManager.getLogger();
-  private static final AtomicLong PAYLOAD_ID_COUNTER = new AtomicLong(0);
   private final Validator validator;
   private final UInt64 slot;
   private final ForkProvider forkProvider;
   private final ValidatorApiChannel validatorApiChannel;
   private final Spec spec;
-  private final UInt64 executionPayloadId;
   private Optional<SafeFuture<Void>> maybePrepareFuture;
 
   public BlockProductionDuty(
@@ -52,7 +49,6 @@ public class BlockProductionDuty implements Duty {
     this.forkProvider = forkProvider;
     this.validatorApiChannel = validatorApiChannel;
     this.spec = spec;
-    this.executionPayloadId = UInt64.fromLongBits(PAYLOAD_ID_COUNTER.incrementAndGet());
     this.maybePrepareFuture = Optional.empty();
   }
 
@@ -71,8 +67,7 @@ public class BlockProductionDuty implements Duty {
   public SafeFuture<Void> prepareDuty() {
     LOG.trace("Preparing block for validator {} at slot {}", validator.getPublicKey(), slot);
 
-    maybePrepareFuture =
-        Optional.of(validatorApiChannel.prepareExecutionPayload(slot, executionPayloadId));
+    maybePrepareFuture = Optional.of(validatorApiChannel.prepareExecutionPayload(slot));
     return maybePrepareFuture.get();
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
@@ -37,7 +37,7 @@ public class BlockProductionDuty implements Duty {
   private final ForkProvider forkProvider;
   private final ValidatorApiChannel validatorApiChannel;
   private final Spec spec;
-  private UInt64 executionPayloadRequestId;
+  private UInt64 executionPayloadId;
 
   public BlockProductionDuty(
       final Validator validator,
@@ -61,9 +61,8 @@ public class BlockProductionDuty implements Duty {
 
   @Override
   public SafeFuture<Void> prepareDuty() {
-    executionPayloadRequestId =
-        UInt64.fromLongBits(SecureRandomProvider.publicSecureRandom().nextLong());
-    return validatorApiChannel.prepareExecutionPayload(slot, executionPayloadRequestId);
+    executionPayloadId = UInt64.fromLongBits(SecureRandomProvider.publicSecureRandom().nextLong());
+    return validatorApiChannel.prepareExecutionPayload(slot, executionPayloadId);
   }
 
   public SafeFuture<DutyResult> produceBlock(final ForkInfo forkInfo) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/Duty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/Duty.java
@@ -16,5 +16,9 @@ package tech.pegasys.teku.validator.client.duties;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
 public interface Duty {
+  default SafeFuture<Void> prepareDuty() {
+    return SafeFuture.COMPLETE;
+  }
+
   SafeFuture<DutyResult> performDuty();
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ScheduledDuties.java
@@ -21,6 +21,8 @@ public interface ScheduledDuties {
 
   boolean requiresRecalculation(Bytes32 newHeadDependentRoot);
 
+  SafeFuture<Void> performProductionDutyPreparation(UInt64 slot);
+
   SafeFuture<DutyResult> performProductionDuty(UInt64 slot);
 
   String getProductionType();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/SlotBasedScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/SlotBasedScheduledDuties.java
@@ -105,4 +105,13 @@ public class SlotBasedScheduledDuties<P extends Duty, A extends Duty> implements
   public boolean requiresRecalculation(final Bytes32 newHeadDependentRoot) {
     return !getDependentRoot().equals(newHeadDependentRoot);
   }
+
+  @Override
+  public SafeFuture<Void> performProductionDutyPreparation(UInt64 slot) {
+    final Duty duty = productionDuties.get(slot);
+    if (duty == null) {
+      return SafeFuture.COMPLETE;
+    }
+    return duty.prepareDuty();
+  }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
@@ -74,6 +74,11 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
   }
 
   @Override
+  public SafeFuture<Void> performProductionDutyPreparation(UInt64 slot) {
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
   public SafeFuture<DutyResult> performProductionDuty(final UInt64 slot) {
     lastSignatureBlockRoot = chainHeadTracker.getCurrentChainHead(slot);
     lastSignatureSlot = Optional.of(slot);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -67,6 +67,7 @@ class BlockProductionDutyTest {
 
   @BeforeEach
   public void setUp() {
+    when(validatorApiChannel.prepareExecutionPayload(SLOT)).thenReturn(SafeFuture.COMPLETE);
     when(forkProvider.getForkInfo(any())).thenReturn(completedFuture(fork));
   }
 
@@ -155,6 +156,7 @@ class BlockProductionDutyTest {
 
   private void performAndReportDuty() {
     final SafeFuture<DutyResult> result = duty.performDuty();
+    verify(validatorApiChannel).prepareExecutionPayload(SLOT);
     assertThat(result).isCompleted();
     result.join().report(TYPE, SLOT, validatorLogger);
   }

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
@@ -83,6 +83,22 @@ public class BlockFactory {
     this.spec = spec;
   }
 
+  public void prepareExecutionPayload(
+      final Optional<BeaconState> maybeCurrentSlotState, UInt64 payloadId) {
+    if (maybeCurrentSlotState.isEmpty()) return;
+    final BeaconState currentState = maybeCurrentSlotState.get();
+    if (currentState instanceof BeaconStateMerge) {
+
+      final ExecutionPayloadUtil executionPayloadUtil =
+          spec.atSlot(currentState.getSlot()).getExecutionPayloadUtil().orElseThrow();
+
+      UInt64 timestamp = spec.computeTimeAtSlot(currentState, currentState.getSlot());
+      final Bytes32 executionParentHash =
+          ((BeaconStateMerge) currentState).getLatest_execution_payload_header().getBlock_hash();
+      executionPayloadUtil.prepareExecutionPayload(executionParentHash, timestamp, payloadId);
+    }
+  }
+
   public BeaconBlock createUnsignedBlock(
       final BeaconState previousState,
       final Optional<BeaconState> maybeBlockSlotState,

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -261,14 +261,15 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> prepareExecutionPayload(UInt64 preparingSlot, UInt64 payloadId) {
+  public SafeFuture<Void> prepareExecutionPayload(UInt64 preparingSlot) {
     // we are preparing for the upcoming slot, lets take current slot state
     final SafeFuture<Optional<BeaconState>> currentSlotStateFuture =
         combinedChainDataClient.getStateAtSlotExact(preparingSlot.decrement());
 
     return currentSlotStateFuture.thenApply(
         preState -> {
-          blockFactory.prepareExecutionPayload(preState, payloadId);
+          blockFactory.prepareExecutionPayload(
+              preState, preparingSlot); // we are using slot number as payloadId
           return null;
         });
   }

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -266,7 +266,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     final SafeFuture<Optional<BeaconState>> currentSlotStateFuture =
         combinedChainDataClient.getStateAtSlotExact(preparingSlot.decrement());
 
-    return currentSlotStateFuture.thenApplyChecked(
+    return currentSlotStateFuture.thenApply(
         preState -> {
           blockFactory.prepareExecutionPayload(preState, payloadId);
           return null;
@@ -311,7 +311,12 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
         "Delegating to block factory. Has block slot state? {}", maybeBlockSlotState.isPresent());
     return Optional.of(
         blockFactory.createUnsignedBlock(
-            maybePreState.get(), maybeBlockSlotState, slot, randaoReveal, graffiti));
+            maybePreState.get(),
+            maybeBlockSlotState,
+            slot,
+            randaoReveal,
+            graffiti,
+            slot)); // we are using slot number as payloadId
   }
 
   @Override

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -261,6 +261,19 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
+  public SafeFuture<Void> prepareExecutionPayload(UInt64 preparingSlot, UInt64 payloadId) {
+    // we are preparing for the upcoming slot, lets take current slot state
+    final SafeFuture<Optional<BeaconState>> currentSlotStateFuture =
+        combinedChainDataClient.getStateAtSlotExact(preparingSlot.decrement());
+
+    return currentSlotStateFuture.thenApplyChecked(
+        preState -> {
+          blockFactory.prepareExecutionPayload(preState, payloadId);
+          return null;
+        });
+  }
+
+  @Override
   public SafeFuture<Optional<BeaconBlock>> createUnsignedBlock(
       final UInt64 slot, final BLSSignature randaoReveal, final Optional<Bytes32> graffiti) {
     LOG.trace("Creating unsigned block for slot {}", slot);

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
@@ -138,7 +138,7 @@ class BlockFactoryTest {
 
     final BeaconBlock block =
         blockFactory.createUnsignedBlock(
-            previousState, Optional.empty(), newSlot, randaoReveal, Optional.empty());
+            previousState, Optional.empty(), newSlot, randaoReveal, Optional.empty(), UInt64.ZERO);
 
     assertThat(block).isNotNull();
     assertThat(block.getSlot()).isEqualTo(newSlot);

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -438,7 +438,7 @@ class ValidatorApiHandlerTest {
             newSlot,
             randaoReveal,
             Optional.empty(),
-            ZERO))
+            newSlot))
         .thenReturn(createdBlock);
 
     final SafeFuture<Optional<BeaconBlock>> result =
@@ -451,7 +451,7 @@ class ValidatorApiHandlerTest {
             newSlot,
             randaoReveal,
             Optional.empty(),
-            ZERO);
+            newSlot);
     assertThat(result).isCompletedWithValue(Optional.of(createdBlock));
   }
 

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -433,7 +433,12 @@ class ValidatorApiHandlerTest {
     when(chainDataClient.getStateAtSlotExact(newSlot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockSlotState)));
     when(blockFactory.createUnsignedBlock(
-            previousState, Optional.of(blockSlotState), newSlot, randaoReveal, Optional.empty()))
+            previousState,
+            Optional.of(blockSlotState),
+            newSlot,
+            randaoReveal,
+            Optional.empty(),
+            ZERO))
         .thenReturn(createdBlock);
 
     final SafeFuture<Optional<BeaconBlock>> result =
@@ -441,7 +446,12 @@ class ValidatorApiHandlerTest {
 
     verify(blockFactory)
         .createUnsignedBlock(
-            previousState, Optional.of(blockSlotState), newSlot, randaoReveal, Optional.empty());
+            previousState,
+            Optional.of(blockSlotState),
+            newSlot,
+            randaoReveal,
+            Optional.empty(),
+            ZERO);
     assertThat(result).isCompletedWithValue(Optional.of(createdBlock));
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -210,7 +210,8 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public SafeFuture<Void> prepareExecutionPayload(UInt64 slot) {
     // TODO implement remote call
-    throw new UnsupportedOperationException("Not implemented");
+    // throw new UnsupportedOperationException("Not implemented");
+    return SafeFuture.COMPLETE;
   }
 
   private ProposerDuty mapToProposerDuties(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -208,8 +208,9 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> prepareExecutionPayload(UInt64 slot, UInt64 requestId) {
-    return SafeFuture.COMPLETE; // TODO implement remote call
+  public SafeFuture<Void> prepareExecutionPayload(UInt64 slot, UInt64 payloadId) {
+    // TODO implement remote call
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   private ProposerDuty mapToProposerDuties(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -207,6 +207,11 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
                                 .collect(toList()))));
   }
 
+  @Override
+  public SafeFuture<Void> prepareExecutionPayload(UInt64 slot, UInt64 requestId) {
+    return SafeFuture.COMPLETE; // TODO implement remote call
+  }
+
   private ProposerDuty mapToProposerDuties(
       final tech.pegasys.teku.api.response.v1.validator.ProposerDuty proposerDuty) {
     return new ProposerDuty(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -208,7 +208,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> prepareExecutionPayload(UInt64 slot, UInt64 payloadId) {
+  public SafeFuture<Void> prepareExecutionPayload(UInt64 slot) {
     // TODO implement remote call
     throw new UnsupportedOperationException("Not implemented");
   }


### PR DESCRIPTION
changelog:
- introduces Duty preparation
- uses Duty preparation in BlockProductionDuty to handle the call to the execution engine to prepare the block
- starts extending other required classes to be able to call the new method
- currently we are using `slot` as `payloadId`