### PR TITLE
Don't update performance metrics if chain head is not yet set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ For information on changes in released versions of Teku, see the [releases page]
 ## Unreleased Changes
 
 ### Additions and Improvements
-- Upgraded to BLST 0.3.5
+- Upgraded to BLST 0.3.5.
 
 
 ### Bug Fixes
+- Fix `NoSuchElementException` reported at startup by validator performance tracking module. 

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -103,7 +103,7 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
   public void onSlot(UInt64 slot) {
     // Ensure a consistent view as the field is volatile.
     final Optional<UInt64> nodeStartEpoch = this.nodeStartEpoch;
-    if (nodeStartEpoch.isEmpty()) {
+    if (nodeStartEpoch.isEmpty() || combinedChainDataClient.getChainHead().isEmpty()) {
       return;
     }
 


### PR DESCRIPTION
## PR Description
Skip processing performance metrics if the chain head has not yet been set.  Avoids `NoSuchElementException`.

## Fixed Issue(s)
fixes #4373

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
