### PR TITLE
Sync committee duties should not perform aggregates if there are no validators active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
 - Fix `NoSuchElementException` reported at startup by validator performance tracking module. 
+- Fix `IllegalStateException` reported on altair networks, when none of your validators are in a sync committee for the current epoch.

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -66,6 +66,9 @@ public class AttestationDutyLoader
   @Override
   protected SafeFuture<Optional<AttesterDuties>> requestDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndices) {
+    if (validatorIndices.isEmpty()) {
+      return SafeFuture.completedFuture(Optional.empty());
+    }
     return validatorApiChannel.getAttestationDuties(epoch, validatorIndices);
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
@@ -48,6 +48,9 @@ public class BlockProductionDutyLoader
   @Override
   protected SafeFuture<Optional<ProposerDuties>> requestDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndices) {
+    if (validatorIndices.isEmpty()) {
+      return SafeFuture.completedFuture(Optional.empty());
+    }
     return validatorApiChannel.getProposerDuties(epoch);
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
@@ -110,6 +110,9 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
 
   @Override
   public SafeFuture<DutyResult> performAggregationDuty(final UInt64 slot) {
+    if (getAllValidatorKeys().isEmpty()) {
+      return SafeFuture.completedFuture(DutyResult.NO_OP);
+    }
     if (lastSignatureSlot.isEmpty()
         || lastSignatureBlockRoot.isEmpty()
         || !lastSignatureSlot.get().equals(slot)) {


### PR DESCRIPTION

There were actually 2 duties performed in sync committee, and the previous PR addressed only 1.

Also don't request attestation or block duties if there are no keys, as the result will be empty, and for remote validators that are services, it is just adding to the request count for no value.

fixes #4370

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
