### PR TITLE
[Merge] add `extra_data` field in `ExecutionPayload` and `ExecutionPayloadHeader` Ssz (#4346)

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/merge/BeaconBlockBodyMerge.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/merge/BeaconBlockBodyMerge.java
@@ -76,7 +76,7 @@ public class BeaconBlockBodyMerge extends BeaconBlockBody {
                 () ->
                     new tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload(
                         executionPayload.parent_hash,
-                        executionPayload.miner,
+                        executionPayload.coinbase,
                         executionPayload.state_root,
                         executionPayload.receipt_root,
                         executionPayload.logs_bloom,
@@ -85,6 +85,7 @@ public class BeaconBlockBodyMerge extends BeaconBlockBody {
                         executionPayload.gas_limit,
                         executionPayload.gas_used,
                         executionPayload.timestamp,
+                        executionPayload.extra_data,
                         executionPayload.base_fee_per_gas,
                         executionPayload.block_hash,
                         executionPayload.transactions)));

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/merge/BeaconStateMerge.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/merge/BeaconStateMerge.java
@@ -168,6 +168,7 @@ public class BeaconStateMerge extends BeaconState implements State {
                       latest_execution_payload_header.gas_limit,
                       latest_execution_payload_header.gas_used,
                       latest_execution_payload_header.timestamp,
+                      latest_execution_payload_header.extra_data,
                       latest_execution_payload_header.base_fee_per_gas,
                       latest_execution_payload_header.block_hash,
                       latest_execution_payload_header.transactions_root));

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/merge/ExecutionPayload.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/merge/ExecutionPayload.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.ssz.type.Bytes20;
 public class ExecutionPayload {
 
   public final Bytes32 parent_hash;
-  public final Bytes20 miner;
+  public final Bytes20 coinbase;
   public final Bytes32 state_root;
   public final Bytes32 receipt_root;
   public final Bytes logs_bloom;
@@ -38,13 +38,14 @@ public class ExecutionPayload {
   public final UInt64 gas_limit;
   public final UInt64 gas_used;
   public final UInt64 timestamp;
+  public final Bytes extra_data;
   public final Bytes32 base_fee_per_gas;
   public final Bytes32 block_hash;
   public final List<Bytes> transactions;
 
   public ExecutionPayload(
       @JsonProperty("parent_hash") Bytes32 parent_hash,
-      @JsonProperty("miner") Bytes20 miner,
+      @JsonProperty("coinbase") Bytes20 coinbase,
       @JsonProperty("state_root") Bytes32 state_root,
       @JsonProperty("receipt_root") Bytes32 receipt_root,
       @JsonProperty("logs_bloom") Bytes logs_bloom,
@@ -53,11 +54,12 @@ public class ExecutionPayload {
       @JsonProperty("gas_limit") UInt64 gas_limit,
       @JsonProperty("gas_used") UInt64 gas_used,
       @JsonProperty("timestamp") UInt64 timestamp,
+      @JsonProperty("extra_data") Bytes extra_data,
       @JsonProperty("base_fee_per_gas") Bytes32 base_fee_per_gas,
       @JsonProperty("block_hash") Bytes32 block_hash,
       @JsonProperty("transactions") List<Bytes> transactions) {
     this.parent_hash = parent_hash;
-    this.miner = miner;
+    this.coinbase = coinbase;
     this.state_root = state_root;
     this.receipt_root = receipt_root;
     this.logs_bloom = logs_bloom;
@@ -66,6 +68,7 @@ public class ExecutionPayload {
     this.gas_limit = gas_limit;
     this.gas_used = gas_used;
     this.timestamp = timestamp;
+    this.extra_data = extra_data;
     this.base_fee_per_gas = base_fee_per_gas;
     this.block_hash = block_hash;
     this.transactions = transactions != null ? transactions : Collections.emptyList();
@@ -74,7 +77,7 @@ public class ExecutionPayload {
   public ExecutionPayload(
       tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload executionPayload) {
     this.parent_hash = executionPayload.getParent_hash();
-    this.miner = executionPayload.getCoinbase();
+    this.coinbase = executionPayload.getCoinbase();
     this.state_root = executionPayload.getState_root();
     this.receipt_root = executionPayload.getReceipt_root();
     this.logs_bloom = executionPayload.getLogs_bloom();
@@ -83,6 +86,7 @@ public class ExecutionPayload {
     this.gas_limit = executionPayload.getGas_limit();
     this.gas_used = executionPayload.getGas_used();
     this.timestamp = executionPayload.getTimestamp();
+    this.extra_data = executionPayload.getExtraData();
     this.base_fee_per_gas = executionPayload.getBaseFeePerGas();
     this.block_hash = executionPayload.getBlock_hash();
     this.transactions =
@@ -96,7 +100,7 @@ public class ExecutionPayload {
       asInternalExecutionPayload() {
     return new tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload(
         parent_hash,
-        miner,
+        coinbase,
         state_root,
         receipt_root,
         logs_bloom,
@@ -105,6 +109,7 @@ public class ExecutionPayload {
         gas_limit,
         gas_used,
         timestamp,
+        extra_data,
         base_fee_per_gas,
         block_hash,
         transactions);
@@ -120,7 +125,7 @@ public class ExecutionPayload {
     }
     final ExecutionPayload that = (ExecutionPayload) o;
     return Objects.equals(parent_hash, that.parent_hash)
-        && Objects.equals(miner, that.miner)
+        && Objects.equals(coinbase, that.coinbase)
         && Objects.equals(state_root, that.state_root)
         && Objects.equals(receipt_root, that.receipt_root)
         && Objects.equals(logs_bloom, that.logs_bloom)
@@ -129,6 +134,7 @@ public class ExecutionPayload {
         && Objects.equals(gas_limit, that.gas_limit)
         && Objects.equals(gas_used, that.gas_used)
         && Objects.equals(timestamp, that.timestamp)
+        && Objects.equals(extra_data, that.extra_data)
         && Objects.equals(base_fee_per_gas, that.base_fee_per_gas)
         && Objects.equals(block_hash, that.block_hash)
         && Objects.equals(transactions, that.transactions);
@@ -138,7 +144,7 @@ public class ExecutionPayload {
   public int hashCode() {
     return Objects.hash(
         parent_hash,
-        miner,
+        coinbase,
         state_root,
         receipt_root,
         logs_bloom,
@@ -147,6 +153,7 @@ public class ExecutionPayload {
         gas_limit,
         gas_used,
         timestamp,
+        extra_data,
         base_fee_per_gas,
         block_hash,
         transactions);
@@ -156,7 +163,7 @@ public class ExecutionPayload {
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("parent_hash", parent_hash)
-        .add("miner", miner)
+        .add("coinbase", coinbase)
         .add("state_root", state_root)
         .add("receipt_root", receipt_root)
         .add("logs_bloom", logs_bloom)
@@ -165,6 +172,7 @@ public class ExecutionPayload {
         .add("gas_limit", gas_limit)
         .add("gas_used", gas_used)
         .add("timestamp", timestamp)
+        .add("extra_data", extra_data)
         .add("base_fee_per_gas", base_fee_per_gas)
         .add("block_hash", block_hash)
         .add("transactions", transactions)

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/merge/ExecutionPayloadHeader.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/merge/ExecutionPayloadHeader.java
@@ -33,6 +33,7 @@ public class ExecutionPayloadHeader {
   public final UInt64 gas_limit;
   public final UInt64 gas_used;
   public final UInt64 timestamp;
+  public final Bytes extra_data;
   public final Bytes32 base_fee_per_gas;
   public final Bytes32 block_hash;
   public final Bytes32 transactions_root;
@@ -48,6 +49,7 @@ public class ExecutionPayloadHeader {
       @JsonProperty("gas_limit") UInt64 gas_limit,
       @JsonProperty("gas_used") UInt64 gas_used,
       @JsonProperty("timestamp") UInt64 timestamp,
+      @JsonProperty("extra_data") Bytes extra_data,
       @JsonProperty("base_fee_per_gas") Bytes32 base_fee_per_gas,
       @JsonProperty("block_hash") Bytes32 block_hash,
       @JsonProperty("transactions_root") Bytes32 transactions_root) {
@@ -61,6 +63,7 @@ public class ExecutionPayloadHeader {
     this.gas_limit = gas_limit;
     this.gas_used = gas_used;
     this.timestamp = timestamp;
+    this.extra_data = extra_data;
     this.base_fee_per_gas = base_fee_per_gas;
     this.block_hash = block_hash;
     this.transactions_root = transactions_root;
@@ -79,6 +82,7 @@ public class ExecutionPayloadHeader {
     this.gas_limit = executionPayloadHeader.getGas_limit();
     this.gas_used = executionPayloadHeader.getGas_used();
     this.timestamp = executionPayloadHeader.getTimestamp();
+    this.extra_data = executionPayloadHeader.getExtraData();
     this.base_fee_per_gas = executionPayloadHeader.getBaseFeePerGas();
     this.block_hash = executionPayloadHeader.getBlock_hash();
     this.transactions_root = executionPayloadHeader.getTransactions_root();
@@ -97,6 +101,7 @@ public class ExecutionPayloadHeader {
         gas_limit,
         gas_used,
         timestamp,
+        extra_data,
         base_fee_per_gas,
         block_hash,
         transactions_root);
@@ -121,6 +126,7 @@ public class ExecutionPayloadHeader {
         && Objects.equals(gas_limit, that.gas_limit)
         && Objects.equals(gas_used, that.gas_used)
         && Objects.equals(timestamp, that.timestamp)
+        && Objects.equals(extra_data, that.extra_data)
         && Objects.equals(base_fee_per_gas, that.base_fee_per_gas)
         && Objects.equals(block_hash, that.block_hash)
         && Objects.equals(transactions_root, that.transactions_root);
@@ -139,6 +145,7 @@ public class ExecutionPayloadHeader {
         gas_limit,
         gas_used,
         timestamp,
+        extra_data,
         base_fee_per_gas,
         block_hash,
         transactions_root);
@@ -157,6 +164,7 @@ public class ExecutionPayloadHeader {
         .add("gas_limit", gas_limit)
         .add("gas_used", gas_used)
         .add("timestamp", timestamp)
+        .add("extra_data", extra_data)
         .add("base_fee_per_gas", base_fee_per_gas)
         .add("block_hash", block_hash)
         .add("transactions_root", transactions_root)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
@@ -29,6 +29,7 @@ public interface SpecConfig {
   int BYTES_PER_LOGS_BLOOM = 256;
   int MAX_BYTES_PER_OPAQUE_TRANSACTION = 1048576;
   int MAX_EXECUTION_TRANSACTIONS = 16384;
+  int MAX_EXTRA_DATA_BYTES = 32;
 
   static SpecConfigBuilder builder() {
     return new SpecConfigBuilder();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayload.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayload.java
@@ -91,7 +91,7 @@ public class ExecutionPayload
 
     @SuppressWarnings("unchecked")
     public SszListSchema<Transaction, ?> getTransactionsSchema() {
-      return (SszListSchema<Transaction, ?>) getFieldSchema12();
+      return (SszListSchema<Transaction, ?>) getFieldSchema13();
     }
 
     @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayload.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayload.java
@@ -19,19 +19,21 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.ssz.SszList;
+import tech.pegasys.teku.ssz.collections.SszByteList;
 import tech.pegasys.teku.ssz.collections.SszByteVector;
-import tech.pegasys.teku.ssz.containers.Container13;
-import tech.pegasys.teku.ssz.containers.ContainerSchema13;
+import tech.pegasys.teku.ssz.containers.Container14;
+import tech.pegasys.teku.ssz.containers.ContainerSchema14;
 import tech.pegasys.teku.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.ssz.schema.SszListSchema;
 import tech.pegasys.teku.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.ssz.schema.collections.SszByteListSchema;
 import tech.pegasys.teku.ssz.schema.collections.SszByteVectorSchema;
 import tech.pegasys.teku.ssz.tree.TreeNode;
 import tech.pegasys.teku.ssz.type.Bytes20;
 
 public class ExecutionPayload
-    extends Container13<
+    extends Container14<
         ExecutionPayload,
         SszBytes32,
         SszByteVector,
@@ -43,12 +45,13 @@ public class ExecutionPayload
         SszUInt64,
         SszUInt64,
         SszUInt64,
+        SszByteList,
         SszBytes32,
         SszBytes32,
         SszList<Transaction>> {
 
   public static class ExecutionPayloadSchema
-      extends ContainerSchema13<
+      extends ContainerSchema14<
           ExecutionPayload,
           SszBytes32,
           SszByteVector,
@@ -60,6 +63,7 @@ public class ExecutionPayload
           SszUInt64,
           SszUInt64,
           SszUInt64,
+          SszByteList,
           SszBytes32,
           SszBytes32,
           SszList<Transaction>> {
@@ -77,6 +81,7 @@ public class ExecutionPayload
           namedSchema("gas_limit", SszPrimitiveSchemas.UINT64_SCHEMA),
           namedSchema("gas_used", SszPrimitiveSchemas.UINT64_SCHEMA),
           namedSchema("timestamp", SszPrimitiveSchemas.UINT64_SCHEMA),
+          namedSchema("extra_data", SszByteListSchema.create(SpecConfig.MAX_EXTRA_DATA_BYTES)),
           namedSchema("base_fee_per_gas", SszPrimitiveSchemas.BYTES32_SCHEMA),
           namedSchema("block_hash", SszPrimitiveSchemas.BYTES32_SCHEMA),
           namedSchema(
@@ -102,7 +107,7 @@ public class ExecutionPayload
   }
 
   ExecutionPayload(
-      ContainerSchema13<
+      ContainerSchema14<
               ExecutionPayload,
               SszBytes32,
               SszByteVector,
@@ -114,6 +119,7 @@ public class ExecutionPayload
               SszUInt64,
               SszUInt64,
               SszUInt64,
+              SszByteList,
               SszBytes32,
               SszBytes32,
               SszList<Transaction>>
@@ -133,6 +139,7 @@ public class ExecutionPayload
       UInt64 gas_limit,
       UInt64 gas_used,
       UInt64 timestamp,
+      Bytes extra_data,
       Bytes32 baseFeePerGas,
       Bytes32 block_hash,
       List<Bytes> transactions) {
@@ -148,6 +155,7 @@ public class ExecutionPayload
         SszUInt64.of(gas_limit),
         SszUInt64.of(gas_used),
         SszUInt64.of(timestamp),
+        SszByteList.fromBytes(extra_data),
         SszBytes32.of(baseFeePerGas),
         SszBytes32.of(block_hash),
         transactions.stream()
@@ -201,15 +209,19 @@ public class ExecutionPayload
     return getField9().get();
   }
 
-  public Bytes32 getBaseFeePerGas() {
-    return getField10().get();
+  public Bytes getExtraData() {
+    return getField10().getBytes();
   }
 
-  public Bytes32 getBlock_hash() {
+  public Bytes32 getBaseFeePerGas() {
     return getField11().get();
   }
 
+  public Bytes32 getBlock_hash() {
+    return getField12().get();
+  }
+
   public SszList<Transaction> getTransactions() {
-    return getField12();
+    return getField13();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeader.java
@@ -18,18 +18,21 @@ import static tech.pegasys.teku.spec.config.SpecConfig.BYTES_PER_LOGS_BLOOM;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.ssz.collections.SszByteList;
 import tech.pegasys.teku.ssz.collections.SszByteVector;
-import tech.pegasys.teku.ssz.containers.Container13;
-import tech.pegasys.teku.ssz.containers.ContainerSchema13;
+import tech.pegasys.teku.ssz.containers.Container14;
+import tech.pegasys.teku.ssz.containers.ContainerSchema14;
 import tech.pegasys.teku.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.ssz.schema.collections.SszByteListSchema;
 import tech.pegasys.teku.ssz.schema.collections.SszByteVectorSchema;
 import tech.pegasys.teku.ssz.tree.TreeNode;
 import tech.pegasys.teku.ssz.type.Bytes20;
 
 public class ExecutionPayloadHeader
-    extends Container13<
+    extends Container14<
         ExecutionPayloadHeader,
         SszBytes32,
         SszByteVector,
@@ -41,12 +44,13 @@ public class ExecutionPayloadHeader
         SszUInt64,
         SszUInt64,
         SszUInt64,
+        SszByteList,
         SszBytes32,
         SszBytes32,
         SszBytes32> {
 
   public static class ExecutionPayloadHeaderSchema
-      extends ContainerSchema13<
+      extends ContainerSchema14<
           ExecutionPayloadHeader,
           SszBytes32,
           SszByteVector,
@@ -58,6 +62,7 @@ public class ExecutionPayloadHeader
           SszUInt64,
           SszUInt64,
           SszUInt64,
+          SszByteList,
           SszBytes32,
           SszBytes32,
           SszBytes32> {
@@ -75,6 +80,7 @@ public class ExecutionPayloadHeader
           namedSchema("gas_limit", SszPrimitiveSchemas.UINT64_SCHEMA),
           namedSchema("gas_used", SszPrimitiveSchemas.UINT64_SCHEMA),
           namedSchema("timestamp", SszPrimitiveSchemas.UINT64_SCHEMA),
+          namedSchema("extra_data", SszByteListSchema.create(SpecConfig.MAX_EXTRA_DATA_BYTES)),
           namedSchema("base_fee_per_gas", SszPrimitiveSchemas.BYTES32_SCHEMA),
           namedSchema("block_hash", SszPrimitiveSchemas.BYTES32_SCHEMA),
           namedSchema("transactions_root", SszPrimitiveSchemas.BYTES32_SCHEMA));
@@ -89,7 +95,7 @@ public class ExecutionPayloadHeader
   public static final ExecutionPayloadHeaderSchema SSZ_SCHEMA = new ExecutionPayloadHeaderSchema();
 
   private ExecutionPayloadHeader(
-      ContainerSchema13<
+      ContainerSchema14<
               ExecutionPayloadHeader,
               SszBytes32,
               SszByteVector,
@@ -101,6 +107,7 @@ public class ExecutionPayloadHeader
               SszUInt64,
               SszUInt64,
               SszUInt64,
+              SszByteList,
               SszBytes32,
               SszBytes32,
               SszBytes32>
@@ -120,6 +127,7 @@ public class ExecutionPayloadHeader
       UInt64 gas_limit,
       UInt64 gas_used,
       UInt64 timestamp,
+      Bytes extra_data,
       Bytes32 baseFeePerGas,
       Bytes32 block_hash,
       Bytes32 transactions_root) {
@@ -135,6 +143,7 @@ public class ExecutionPayloadHeader
         SszUInt64.of(gas_limit),
         SszUInt64.of(gas_used),
         SszUInt64.of(timestamp),
+        SszByteList.fromBytes(extra_data),
         SszBytes32.of(baseFeePerGas),
         SszBytes32.of(block_hash),
         SszBytes32.of(transactions_root));
@@ -189,15 +198,19 @@ public class ExecutionPayloadHeader
     return getField9().get();
   }
 
-  public Bytes32 getBaseFeePerGas() {
-    return getField10().get();
+  public Bytes getExtraData() {
+    return getField10().getBytes();
   }
 
-  public Bytes32 getBlock_hash() {
+  public Bytes32 getBaseFeePerGas() {
     return getField11().get();
   }
 
-  public Bytes32 getTransactions_root() {
+  public Bytes32 getBlock_hash() {
     return getField12().get();
+  }
+
+  public Bytes32 getTransactions_root() {
+    return getField13().get();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
@@ -98,7 +98,7 @@ public class GenesisGenerator {
                         UInt64.ZERO,
                         UInt64.ZERO,
                         UInt64.ZERO,
-                        Bytes.wrap(new byte[SpecConfig.MAX_EXTRA_DATA_BYTES]),
+                        Bytes.EMPTY,
                         Bytes32.ZERO,
                         Bytes32.ZERO,
                         Bytes32.ZERO)));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
@@ -98,6 +98,7 @@ public class GenesisGenerator {
                         UInt64.ZERO,
                         UInt64.ZERO,
                         UInt64.ZERO,
+                        Bytes.wrap(new byte[SpecConfig.MAX_EXTRA_DATA_BYTES]),
                         Bytes32.ZERO,
                         Bytes32.ZERO,
                         Bytes32.ZERO)));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/block/BlockProcessorMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/block/BlockProcessorMerge.java
@@ -180,6 +180,7 @@ public class BlockProcessorMerge extends BlockProcessorAltair {
               executionPayload.getGas_limit(),
               executionPayload.getGas_used(),
               executionPayload.getTimestamp(),
+              executionPayload.getExtraData(),
               executionPayload.getBaseFeePerGas(),
               executionPayload.getBlock_hash(),
               executionPayload.getTransactions().hashTreeRoot()));

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderTest.java
@@ -15,8 +15,6 @@ package tech.pegasys.teku.spec.datastructures.execution;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
@@ -25,15 +23,15 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.ssz.type.Bytes20;
 
-public class ExecutionPayloadTest {
+public class ExecutionPayloadHeaderTest {
 
   private final DataStructureUtil dataStructureUtil =
       new DataStructureUtil(TestSpecFactory.createMinimalMerge());
 
   @Test
   public void shouldSszEncodeAndDecode() {
-    ExecutionPayload executionPayload =
-        new ExecutionPayload(
+    ExecutionPayloadHeader executionPayloadHeader =
+        new ExecutionPayloadHeader(
             Bytes32.random(),
             Bytes20.random(),
             Bytes32.random(),
@@ -47,13 +45,12 @@ public class ExecutionPayloadTest {
             Bytes.random(SpecConfig.MAX_EXTRA_DATA_BYTES),
             Bytes32.random(),
             Bytes32.random(),
-            Stream.of(Bytes.random(128), Bytes.random(256), Bytes.random(512))
-                .collect(Collectors.toList()));
+            Bytes32.random());
 
-    Bytes sszExecutionPayload = executionPayload.sszSerialize();
-    ExecutionPayload decodedExecutionPayload =
-        ExecutionPayload.SSZ_SCHEMA.sszDeserialize(sszExecutionPayload);
+    Bytes sszExecutionPayloadHeader = executionPayloadHeader.sszSerialize();
+    ExecutionPayloadHeader decodedExecutionPayloadHeader =
+        ExecutionPayloadHeader.SSZ_SCHEMA.sszDeserialize(sszExecutionPayloadHeader);
 
-    assertEquals(executionPayload, decodedExecutionPayload);
+    assertEquals(executionPayloadHeader, decodedExecutionPayloadHeader);
   }
 }

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/execution/client/ExecutionEngineClient.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/execution/client/ExecutionEngineClient.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.services.powchain.execution.client.schema.GenericRespon
 import tech.pegasys.teku.services.powchain.execution.client.schema.PreparePayloadRequest;
 import tech.pegasys.teku.services.powchain.execution.client.schema.PreparePayloadResponse;
 import tech.pegasys.teku.services.powchain.execution.client.schema.Response;
+import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.ssz.type.Bytes20;
 
@@ -50,6 +51,7 @@ public interface ExecutionEngineClient {
   ExecutionEngineClient Stub =
       new ExecutionEngineClient() {
         private final Bytes ZERO_LOGS_BLOOM = Bytes.wrap(new byte[256]);
+        private final Bytes ZERO_EXTRA_DATA = Bytes.wrap(new byte[SpecConfig.MAX_EXTRA_DATA_BYTES]);
         private UInt64 number = UInt64.ZERO;
         private UInt64 payloadId = UInt64.ZERO;
         private Optional<PreparePayloadRequest> lastPreparePayloadRequest = Optional.empty();
@@ -81,6 +83,7 @@ public interface ExecutionEngineClient {
                       UInt64.ZERO,
                       UInt64.ZERO,
                       preparePayloadRequest.timestamp,
+                      ZERO_EXTRA_DATA,
                       Bytes32.ZERO,
                       Bytes32.random(),
                       Arrays.asList(Bytes.random(128), Bytes.random(256), Bytes.random(512)))));

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/execution/client/schema/ExecutionPayload.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/execution/client/schema/ExecutionPayload.java
@@ -78,6 +78,10 @@ public class ExecutionPayload {
   public final UInt64 timestamp;
 
   @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = BytesDeserializer.class)
+  public final Bytes extraData;
+
+  @JsonSerialize(using = BytesSerializer.class)
   @JsonDeserialize(using = Bytes32Deserializer.class)
   public final Bytes32 baseFeePerGas;
 
@@ -101,6 +105,7 @@ public class ExecutionPayload {
     this.gasLimit = executionPayload.getGas_limit();
     this.gasUsed = executionPayload.getGas_used();
     this.timestamp = executionPayload.getTimestamp();
+    this.extraData = executionPayload.getExtraData();
     this.baseFeePerGas = executionPayload.getBaseFeePerGas();
     this.blockHash = executionPayload.getBlock_hash();
     this.transactions =
@@ -121,6 +126,7 @@ public class ExecutionPayload {
       @JsonProperty("gasLimit") UInt64 gasLimit,
       @JsonProperty("gasUsed") UInt64 gasUsed,
       @JsonProperty("timestamp") UInt64 timestamp,
+      @JsonProperty("extraData") Bytes extraData,
       @JsonProperty("blockHash") Bytes32 baseFeePerGas,
       @JsonProperty("blockHash") Bytes32 blockHash,
       @JsonProperty("transactions") List<Bytes> transactions) {
@@ -134,6 +140,7 @@ public class ExecutionPayload {
     this.gasLimit = gasLimit;
     this.gasUsed = gasUsed;
     this.timestamp = timestamp;
+    this.extraData = extraData;
     this.baseFeePerGas = baseFeePerGas;
     this.blockHash = blockHash;
     this.transactions = transactions != null ? transactions : Collections.emptyList();
@@ -152,6 +159,7 @@ public class ExecutionPayload {
         gasLimit,
         gasUsed,
         timestamp,
+        extraData,
         baseFeePerGas,
         blockHash,
         transactions);

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/execution/client/schema/ExecutionPayload.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/execution/client/schema/ExecutionPayload.java
@@ -43,7 +43,7 @@ public class ExecutionPayload {
 
   @JsonSerialize(using = Bytes20Serializer.class)
   @JsonDeserialize(using = Bytes20Deserializer.class)
-  public final Bytes20 miner;
+  public final Bytes20 coinbase;
 
   @JsonSerialize(using = BytesSerializer.class)
   @JsonDeserialize(using = Bytes32Deserializer.class)
@@ -96,7 +96,7 @@ public class ExecutionPayload {
   public ExecutionPayload(
       tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload executionPayload) {
     this.parentHash = executionPayload.getParent_hash();
-    this.miner = executionPayload.getCoinbase();
+    this.coinbase = executionPayload.getCoinbase();
     this.stateRoot = executionPayload.getState_root();
     this.receiptsRoot = executionPayload.getReceipt_root();
     this.logsBloom = executionPayload.getLogs_bloom();
@@ -117,7 +117,7 @@ public class ExecutionPayload {
 
   public ExecutionPayload(
       @JsonProperty("parentHash") Bytes32 parentHash,
-      @JsonProperty("miner") Bytes20 miner,
+      @JsonProperty("coinbase") Bytes20 coinbase,
       @JsonProperty("stateRoot") Bytes32 stateRoot,
       @JsonProperty("receiptRoot") Bytes32 receiptsRoot,
       @JsonProperty("logsBloom") Bytes logsBloom,
@@ -131,7 +131,7 @@ public class ExecutionPayload {
       @JsonProperty("blockHash") Bytes32 blockHash,
       @JsonProperty("transactions") List<Bytes> transactions) {
     this.parentHash = parentHash;
-    this.miner = miner;
+    this.coinbase = coinbase;
     this.stateRoot = stateRoot;
     this.receiptsRoot = receiptsRoot;
     this.logsBloom = logsBloom;
@@ -150,7 +150,7 @@ public class ExecutionPayload {
       asInternalExecutionPayload() {
     return new tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload(
         parentHash,
-        miner,
+        coinbase,
         stateRoot,
         receiptsRoot,
         logsBloom,
@@ -175,7 +175,7 @@ public class ExecutionPayload {
     }
     final ExecutionPayload that = (ExecutionPayload) o;
     return Objects.equals(parentHash, that.parentHash)
-        && Objects.equals(miner, that.miner)
+        && Objects.equals(coinbase, that.coinbase)
         && Objects.equals(stateRoot, that.stateRoot)
         && Objects.equals(receiptsRoot, that.receiptsRoot)
         && Objects.equals(logsBloom, that.logsBloom)
@@ -193,7 +193,7 @@ public class ExecutionPayload {
   public int hashCode() {
     return Objects.hash(
         parentHash,
-        miner,
+        coinbase,
         stateRoot,
         receiptsRoot,
         logsBloom,
@@ -211,7 +211,7 @@ public class ExecutionPayload {
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("parentHash", parentHash)
-        .add("miner", miner)
+        .add("coinbase", coinbase)
         .add("stateRoot", stateRoot)
         .add("receiptsRoot", receiptsRoot)
         .add("logsBloom", logsBloom)


### PR DESCRIPTION
- adds `extra_data` field in `ExecutionPayload` and `ExecutionPayloadHeader` Ssz(s) as per latest specs (https://github.com/ethereum/consensus-specs/pull/2606)

- adds `ExecutionPayloadHeaderTest`

- renames field `miner` to `coinbase` in APIs
