### PR TITLE
Extend readiness check with peer count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
 - Upgraded to BLST 0.3.5.
+- `/teku/v1/admin/readiness` endpoint now accepts a `target_peer_count` param to require a minimum number of peers before the node is considered ready.
 
 
 ### Bug Fixes

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/RestApiConstants.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/RestApiConstants.java
@@ -96,7 +96,13 @@ public class RestApiConstants {
 
   public static final String SYNCING_STATUS = "syncing_status";
   public static final String SYNCING_STATUS_DESCRIPTION =
-      "Customize syncing status instead of deafult " + SC_PARTIAL_CONTENT;
+      "Customize syncing status instead of default status code (" + SC_PARTIAL_CONTENT + ")";
+
+  public static final String TARGET_PEER_COUNT = "target_peer_count";
+  public static final String TARGET_PEER_COUNT_DESCRIPTION =
+      "Returns "
+          + SC_SERVICE_UNAVAILABLE
+          + " status code when current peer count is below than target";
 
   public static final String HEADER_ACCEPT = "Accept";
   public static final String HEADER_ACCEPT_JSON = "application/json";

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/Readiness.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/Readiness.java
@@ -13,36 +13,54 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin;
 
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.CACHE_NONE;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.RES_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TAG_TEKU;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TARGET_PEER_COUNT;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TARGET_PEER_COUNT_DESCRIPTION;
+import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsLong;
 
 import io.javalin.core.util.Header;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiParam;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.api.SyncDataProvider;
 
 public class Readiness implements Handler {
+  private static final Logger LOG = LogManager.getLogger();
   public static final String ROUTE = "/teku/v1/admin/readiness";
   private final SyncDataProvider syncProvider;
   private final ChainDataProvider chainDataProvider;
+  private final NetworkDataProvider networkDataProvider;
 
   public Readiness(final DataProvider provider) {
     this.syncProvider = provider.getSyncDataProvider();
     this.chainDataProvider = provider.getChainDataProvider();
+    this.networkDataProvider = provider.getNetworkDataProvider();
   }
 
-  Readiness(final SyncDataProvider syncProvider, final ChainDataProvider chainDataProvider) {
+  Readiness(
+      final SyncDataProvider syncProvider,
+      final ChainDataProvider chainDataProvider,
+      final NetworkDataProvider networkDataProvider) {
     this.syncProvider = syncProvider;
     this.chainDataProvider = chainDataProvider;
+    this.networkDataProvider = networkDataProvider;
   }
 
   @OpenApi(
@@ -51,8 +69,14 @@ public class Readiness implements Handler {
       summary = "Get node readiness",
       description = "Returns 200 if the node is ready to accept traffic",
       tags = {TAG_TEKU},
+      queryParams = {
+        @OpenApiParam(name = TARGET_PEER_COUNT, description = TARGET_PEER_COUNT_DESCRIPTION),
+      },
       responses = {
         @OpenApiResponse(status = RES_OK, description = "Node is ready"),
+        @OpenApiResponse(
+            status = RES_BAD_REQUEST,
+            description = "Cannot parse " + TARGET_PEER_COUNT + " parameter passed in request"),
         @OpenApiResponse(
             status = RES_SERVICE_UNAVAILABLE,
             description = "Node not initialized or having issues")
@@ -60,10 +84,35 @@ public class Readiness implements Handler {
   @Override
   public void handle(final Context ctx) throws Exception {
     ctx.header(Header.CACHE_CONTROL, CACHE_NONE);
-    if (!chainDataProvider.isStoreAvailable() || syncProvider.isSyncing()) {
+    if (!canParseTargetPeerCountParameter(ctx)) {
+      ctx.status(SC_BAD_REQUEST);
+    } else if (!chainDataProvider.isStoreAvailable()
+        || syncProvider.isSyncing()
+        || !reachedTargetPeerCount(ctx)) {
       ctx.status(SC_SERVICE_UNAVAILABLE);
     } else {
       ctx.status(SC_OK);
     }
+  }
+
+  private Boolean canParseTargetPeerCountParameter(final Context ctx) {
+    try {
+      final Map<String, List<String>> parameters = ctx.queryParamMap();
+      return parameters.isEmpty() // Backwards compatibility
+          || (parameters.containsKey(TARGET_PEER_COUNT)
+              && getParameterValueAsLong(parameters, TARGET_PEER_COUNT) > 0);
+    } catch (final IllegalArgumentException ex) {
+      LOG.error("Cannot parse {} parameter in Readiness", TARGET_PEER_COUNT, ex);
+      return false;
+    }
+  }
+
+  private boolean reachedTargetPeerCount(final Context ctx) {
+    final Map<String, List<String>> parameters = ctx.queryParamMap();
+    LOG.debug("Current peer count is {}", networkDataProvider.getPeerCount());
+    return parameters.isEmpty() // Backwards compatibility
+        || (parameters.containsKey(TARGET_PEER_COUNT)
+            && networkDataProvider.getPeerCount()
+                > getParameterValueAsLong(parameters, TARGET_PEER_COUNT));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/ReadinessTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/ReadinessTest.java
@@ -13,33 +13,54 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin;
 
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.beaconrestapi.RestApiConstants.CACHE_NONE;
+import static tech.pegasys.teku.beaconrestapi.RestApiConstants.TARGET_PEER_COUNT;
 
-import io.javalin.core.util.Header;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.sync.events.SyncState;
 
 public class ReadinessTest extends AbstractBeaconHandlerTest {
 
   @Test
   public void shouldReturnOkWhenInSyncAndReady() throws Exception {
-    final Readiness handler = new Readiness(syncDataProvider, chainDataProvider);
+    final Readiness handler = new Readiness(syncDataProvider, chainDataProvider, network);
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
 
     handler.handle(context);
-    verify(context).header(Header.CACHE_CONTROL, CACHE_NONE);
-    verify(context).status(SC_OK);
+    verifyCacheStatus(CACHE_NONE);
+    verifyStatusCode(SC_OK);
+  }
+
+  @Test
+  public void shouldReturnOkWhenInSyncAndReadyAndTargetPeerCountReached() throws Exception {
+    final Eth2Peer peer1 = mock(Eth2Peer.class);
+    final Readiness handler = new Readiness(syncDataProvider, chainDataProvider, network);
+    when(chainDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    when(eth2P2PNetwork.streamPeers())
+        .thenReturn(Stream.of(peer1, peer1))
+        .thenReturn(Stream.of(peer1, peer1));
+    when(context.queryParamMap()).thenReturn(Map.of(TARGET_PEER_COUNT, List.of("1")));
+
+    handler.handle(context);
+    verifyCacheStatus(CACHE_NONE);
+    verifyStatusCode(SC_OK);
   }
 
   @Test
   public void shouldReturnUnavailableWhenStoreNotAvailable() throws Exception {
-    final Readiness handler = new Readiness(syncDataProvider, chainDataProvider);
+    final Readiness handler = new Readiness(syncDataProvider, chainDataProvider, network);
     when(chainDataProvider.isStoreAvailable()).thenReturn(false);
 
     handler.handle(context);
@@ -49,7 +70,7 @@ public class ReadinessTest extends AbstractBeaconHandlerTest {
 
   @Test
   public void shouldReturnUnavailableWhenStartingUp() throws Exception {
-    final Readiness handler = new Readiness(syncDataProvider, chainDataProvider);
+    final Readiness handler = new Readiness(syncDataProvider, chainDataProvider, network);
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.START_UP);
 
@@ -60,9 +81,35 @@ public class ReadinessTest extends AbstractBeaconHandlerTest {
 
   @Test
   public void shouldReturnUnavailableWhenSyncing() throws Exception {
-    final Readiness handler = new Readiness(syncDataProvider, chainDataProvider);
+    final Readiness handler = new Readiness(syncDataProvider, chainDataProvider, network);
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.SYNCING);
+
+    handler.handle(context);
+    verifyCacheStatus(CACHE_NONE);
+    verifyStatusCode(SC_SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenWrongTargetPeerCountParam() throws Exception {
+    final Readiness handler = new Readiness(syncDataProvider, chainDataProvider, network);
+    when(chainDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    when(context.queryParamMap()).thenReturn(Map.of(TARGET_PEER_COUNT, List.of("a")));
+
+    handler.handle(context);
+    verifyCacheStatus(CACHE_NONE);
+    verifyStatusCode(SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void shouldReturnUnavailableWhenTargetPeerCountNotReached() throws Exception {
+    final Eth2Peer peer1 = mock(Eth2Peer.class);
+    final Readiness handler = new Readiness(syncDataProvider, chainDataProvider, network);
+    when(chainDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    when(eth2P2PNetwork.streamPeers()).thenReturn(Stream.of(peer1)).thenReturn(Stream.of(peer1));
+    when(context.queryParamMap()).thenReturn(Map.of(TARGET_PEER_COUNT, List.of("10")));
 
     handler.handle(context);
     verifyCacheStatus(CACHE_NONE);


### PR DESCRIPTION
## PR Description
Extend readiness check with peer count:
- get target peer count from request parameters optionally
- return unavailable when peer target not reached
- return bad request when cannot parse parameter
- add tests to cover new scenarios
- fix typos

## Fixed Issue(s)
This new feature aims to improve teku load balancing in Kubernetes.
Currently a beacon is considered ready to accept traffic when is already initialised but this not necessarily means that I connected to a sufficient number of peers. 
Therefore beacon would start receiving traffic from validators but unable to include all the attestations received. 

## Documentation
Readiness probe is enriched with peer count check optionally.
If target peer count is passed as a parameter, then readiness check would return unavailable until target count is reached.
Therefore beacon would be in better position to receive traffic with a target number of peers connected.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
