### PR TITLE
Always serialize double with a dot decimal separator

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/provider/DoubleSerializer.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/provider/DoubleSerializer.java
@@ -19,8 +19,12 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 public class DoubleSerializer extends JsonSerializer<Double> {
+  private static final DecimalFormatSymbols US_SYMBOLS = new DecimalFormatSymbols(Locale.US);
+
   @Override
   public void serialize(Double value, JsonGenerator gen, SerializerProvider serializers)
       throws IOException {
@@ -28,7 +32,7 @@ public class DoubleSerializer extends JsonSerializer<Double> {
   }
 
   private String formatValue(Double value) {
-    DecimalFormat df = new DecimalFormat("#.####");
+    DecimalFormat df = new DecimalFormat("#.####", US_SYMBOLS);
     df.setRoundingMode(RoundingMode.HALF_UP);
     return df.format(value);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

`GetPeersScoreTest` fails on machine with system locale where decimal separator is different from `.` (e.g. Italy or Russian locales)
I believe we should always serialize doubles with dot separator in JSON irrespectful to system locale 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
