### PR TITLE
[Merge] ExecutionEngineOptions added

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainConfiguration.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainConfiguration.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.infrastructure.logging.LoggingConfig;
 import tech.pegasys.teku.networking.eth2.P2PConfig;
 import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
 import tech.pegasys.teku.services.powchain.PowchainConfiguration;
+import tech.pegasys.teku.services.powchain.execution.ExecutionEngineConfiguration;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.storage.store.StoreConfig;
 import tech.pegasys.teku.sync.SyncConfig;
@@ -36,6 +37,7 @@ public class BeaconChainConfiguration {
   private final LoggingConfig loggingConfig;
   private final StoreConfig storeConfig;
   private final PowchainConfiguration powchainConfiguration;
+  private final ExecutionEngineConfiguration executionEngineConfiguration;
   private final Spec spec;
 
   public BeaconChainConfiguration(
@@ -47,6 +49,7 @@ public class BeaconChainConfiguration {
       final SyncConfig syncConfig,
       final BeaconRestApiConfig beaconRestApiConfig,
       final PowchainConfiguration powchainConfiguration,
+      final ExecutionEngineConfiguration executionEngineConfiguration,
       final LoggingConfig loggingConfig,
       final StoreConfig storeConfig,
       final Spec spec) {
@@ -58,6 +61,7 @@ public class BeaconChainConfiguration {
     this.syncConfig = syncConfig;
     this.beaconRestApiConfig = beaconRestApiConfig;
     this.powchainConfiguration = powchainConfiguration;
+    this.executionEngineConfiguration = executionEngineConfiguration;
     this.loggingConfig = loggingConfig;
     this.storeConfig = storeConfig;
     this.spec = spec;
@@ -97,6 +101,10 @@ public class BeaconChainConfiguration {
 
   public PowchainConfiguration powchainConfig() {
     return powchainConfiguration;
+  }
+
+  public ExecutionEngineConfiguration executionEngineConfiguration() {
+    return executionEngineConfiguration;
   }
 
   public LoggingConfig loggingConfig() {

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/execution/ExecutionEngineChannelImpl.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/execution/ExecutionEngineChannelImpl.java
@@ -43,9 +43,11 @@ public class ExecutionEngineChannelImpl implements ExecutionEngineChannel {
 
   private final ExecutionEngineClient executionEngineClient;
 
-  public static ExecutionEngineChannelImpl create(String eth1EngineEndpoint) {
-    checkNotNull(eth1EngineEndpoint);
-    return new ExecutionEngineChannelImpl(new Web3JExecutionEngineClient(eth1EngineEndpoint));
+  public static ExecutionEngineChannelImpl create(
+      String eth1Endpoint, Optional<String> eeEndpoint) {
+    checkNotNull(eth1Endpoint);
+    checkNotNull(eeEndpoint);
+    return new ExecutionEngineChannelImpl(new Web3JExecutionEngineClient(eth1Endpoint, eeEndpoint));
   }
 
   public static ExecutionEngineChannelImpl createStub() {

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/execution/ExecutionEngineConfiguration.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/execution/ExecutionEngineConfiguration.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.services.powchain.execution;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
+
+public class ExecutionEngineConfiguration {
+
+  private final Spec spec;
+  private final List<String> endpoints;
+  private final Optional<Eth1Address> feeRecipient;
+
+  private ExecutionEngineConfiguration(
+      final Spec spec, final List<String> endpoints, final Optional<Eth1Address> feeRecipient) {
+    this.spec = spec;
+    this.endpoints = endpoints;
+    this.feeRecipient = feeRecipient;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public boolean isEnabled() {
+    return !endpoints.isEmpty();
+  }
+
+  public Spec getSpec() {
+    return spec;
+  }
+
+  public List<String> getEndpoints() {
+    return endpoints;
+  }
+
+  public Optional<Eth1Address> getFeeRecipient() {
+    return feeRecipient;
+  }
+
+  public static class Builder {
+    private Spec spec;
+    private List<String> endpoints = new ArrayList<>();
+    private Optional<Eth1Address> feeRecipient;
+
+    private Builder() {}
+
+    public ExecutionEngineConfiguration build() {
+      validate();
+      return new ExecutionEngineConfiguration(spec, endpoints, feeRecipient);
+    }
+
+    private void validate() {
+      checkNotNull(spec, "Must specify a spec");
+    }
+
+    public Builder endpoints(final List<String> endpoints) {
+      checkNotNull(endpoints);
+      this.endpoints = endpoints.stream().filter(s -> !s.isBlank()).collect(Collectors.toList());
+      return this;
+    }
+
+    public Builder feeRecipient(final Eth1Address feeRecipient) {
+      this.feeRecipient = Optional.ofNullable(feeRecipient);
+      return this;
+    }
+
+    public Builder feeRecipient(final String feeRecipient) {
+      if (feeRecipient == null) {
+        this.feeRecipient = Optional.empty();
+      } else {
+        this.feeRecipient = Optional.of(Eth1Address.fromHexString(feeRecipient));
+      }
+      return this;
+    }
+
+    public Builder specProvider(final Spec spec) {
+      this.spec = spec;
+      return this;
+    }
+  }
+}

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/execution/client/Web3JExecutionEngineClient.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/execution/client/Web3JExecutionEngineClient.java
@@ -96,7 +96,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
         new Request<>(
             "engine_consensusValidated",
             List.of(blockHash.toHexString(), validationResult),
-            web3jService,
+            eeWeb3jService,
             GenericWeb3jResponse.class);
     return doRequest(web3jRequest);
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.cli.options.BeaconRestApiOptions;
 import tech.pegasys.teku.cli.options.DataStorageOptions;
 import tech.pegasys.teku.cli.options.DepositOptions;
 import tech.pegasys.teku.cli.options.Eth2NetworkOptions;
+import tech.pegasys.teku.cli.options.ExecutionEngineOptions;
 import tech.pegasys.teku.cli.options.InteropOptions;
 import tech.pegasys.teku.cli.options.LoggingOptions;
 import tech.pegasys.teku.cli.options.MetricsOptions;
@@ -156,6 +157,9 @@ public class BeaconNodeCommand implements Callable<Integer> {
 
   @Mixin(name = "Deposit")
   private DepositOptions depositOptions;
+
+  @Mixin(name = "Execution Engine")
+  private ExecutionEngineOptions executionEngineOptionsptions;
 
   @Mixin(name = "Logging")
   private LoggingOptions loggingOptions;
@@ -343,6 +347,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
       // Eth2NetworkOptions configures network defaults across builders, so configure this first
       eth2NetworkOptions.configure(builder);
       depositOptions.configure(builder);
+      executionEngineOptionsptions.configure(builder);
       weakSubjectivityOptions.configure(builder);
       validatorOptions.configure(builder);
       dataOptions.configure(builder);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
@@ -34,6 +34,7 @@ public class ExecutionEngineOptions {
       paramLabel = "<ADDRESS>",
       description =
           "Suggested fee recipient sent to the execution engine, which could use it as coinbase when producing a new execution block.",
+      hidden = true,
       arity = "0..1")
   private String feeRecipient = null;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.options;
+
+import java.util.ArrayList;
+import java.util.List;
+import picocli.CommandLine.Option;
+import tech.pegasys.teku.config.TekuConfiguration;
+
+public class ExecutionEngineOptions {
+
+  @Option(
+      names = {"--ee-endpoints", "--ee-endpoint"},
+      paramLabel = "<NETWORK>",
+      description = "URLs for Execution Engine nodes.",
+      hidden = true,
+      split = ",",
+      arity = "0..*")
+  private List<String> eeEndpoints = new ArrayList<>();
+
+  @Option(
+      names = {"--ee-fee-recipient-address"},
+      paramLabel = "<ADDRESS>",
+      description =
+          "Suggested fee recipient sent to the execution engine, which could use it as coinbase when producing a new execution block.",
+      arity = "0..1")
+  private String feeRecipient = null;
+
+  public void configure(final TekuConfiguration.Builder builder) {
+    builder.executionEngine(b -> b.endpoints(eeEndpoints).feeRecipient(feeRecipient));
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.service.serviceutils.layout.DataConfig;
 import tech.pegasys.teku.services.beaconchain.BeaconChainConfiguration;
 import tech.pegasys.teku.services.chainstorage.StorageConfiguration;
 import tech.pegasys.teku.services.powchain.PowchainConfiguration;
+import tech.pegasys.teku.services.powchain.execution.ExecutionEngineConfiguration;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.storage.store.StoreConfig;
 import tech.pegasys.teku.sync.SyncConfig;
@@ -48,6 +49,7 @@ public class TekuConfiguration {
   private final BeaconChainConfiguration beaconChainConfig;
   private final ValidatorClientConfiguration validatorClientConfig;
   private final PowchainConfiguration powchainConfiguration;
+  private final ExecutionEngineConfiguration executionEngineConfiguration;
   private final NatConfiguration natConfiguration;
 
   private TekuConfiguration(
@@ -57,6 +59,7 @@ public class TekuConfiguration {
       final WeakSubjectivityConfig weakSubjectivityConfig,
       final ValidatorConfig validatorConfig,
       final PowchainConfiguration powchainConfiguration,
+      final ExecutionEngineConfiguration executionEngineConfiguration,
       final InteropConfig interopConfig,
       final DataConfig dataConfig,
       final P2PConfig p2PConfig,
@@ -70,6 +73,7 @@ public class TekuConfiguration {
     this.storageConfiguration = storageConfiguration;
     this.weakSubjectivityConfig = weakSubjectivityConfig;
     this.powchainConfiguration = powchainConfiguration;
+    this.executionEngineConfiguration = executionEngineConfiguration;
     this.dataConfig = dataConfig;
     this.loggingConfig = loggingConfig;
     this.metricsConfig = metricsConfig;
@@ -83,6 +87,7 @@ public class TekuConfiguration {
             syncConfig,
             beaconRestApiConfig,
             powchainConfiguration,
+            executionEngineConfiguration,
             loggingConfig,
             storeConfig,
             spec);
@@ -135,6 +140,10 @@ public class TekuConfiguration {
     return powchainConfiguration;
   }
 
+  public ExecutionEngineConfiguration executionEngine() {
+    return executionEngineConfiguration;
+  }
+
   public DataConfig dataConfig() {
     return dataConfig;
   }
@@ -161,6 +170,8 @@ public class TekuConfiguration {
     private final ValidatorConfig.Builder validatorConfigBuilder = ValidatorConfig.builder();
     private final PowchainConfiguration.Builder powchainConfigBuilder =
         PowchainConfiguration.builder();
+    private final ExecutionEngineConfiguration.Builder executionEngineConfigBuilder =
+        ExecutionEngineConfiguration.builder();
     private final InteropConfig.InteropConfigBuilder interopConfigBuilder = InteropConfig.builder();
     private final DataConfig.Builder dataConfigBuilder = DataConfig.builder();
     private final P2PConfig.Builder p2pConfigBuilder = P2PConfig.builder();
@@ -186,6 +197,7 @@ public class TekuConfiguration {
       weakSubjectivityBuilder.specProvider(spec);
       p2pConfigBuilder.specProvider(spec);
       powchainConfigBuilder.specProvider(spec);
+      executionEngineConfigBuilder.specProvider(spec);
 
       return new TekuConfiguration(
           eth2NetworkConfiguration,
@@ -194,6 +206,7 @@ public class TekuConfiguration {
           weakSubjectivityBuilder.build(),
           validatorConfigBuilder.build(),
           powchainConfigBuilder.build(),
+          executionEngineConfigBuilder.build(),
           interopConfigBuilder.build(),
           dataConfigBuilder.build(),
           p2pConfigBuilder.build(),
@@ -233,6 +246,11 @@ public class TekuConfiguration {
 
     public Builder powchain(final Consumer<PowchainConfiguration.Builder> consumer) {
       consumer.accept(powchainConfigBuilder);
+      return this;
+    }
+
+    public Builder executionEngine(final Consumer<ExecutionEngineConfiguration.Builder> consumer) {
+      consumer.accept(executionEngineConfigBuilder);
       return this;
     }
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -386,6 +386,10 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
       "0x77f7bED277449F51505a4C54550B074030d989bC",
       "--eth1-endpoint",
       "http://localhost:8545",
+      "--ee-endpoint",
+      "http://localhost:8550",
+      "--ee-fee-recipient-address",
+      "0x00220204f295DbB79fbBe619dd1B94463800F9D9",
       "--metrics-enabled",
       "false",
       "--metrics-port",
@@ -421,6 +425,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
 
     return expectedConfigurationBuilder()
         .eth2NetworkConfig(b -> b.applyNetworkDefaults("mainnet"))
+        .executionEngine(b -> b.feeRecipient((String) null).endpoints(new ArrayList<String>()))
         .powchain(
             b -> {
               b.depositContract(networkConfig.getEth1DepositContractAddress());
@@ -465,6 +470,10 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   private TekuConfiguration.Builder expectedConfigurationBuilder() {
     return TekuConfiguration.builder()
         .eth2NetworkConfig(b -> b.applyMinimalNetworkDefaults().eth1DepositContractAddress(address))
+        .executionEngine(
+            b ->
+                b.feeRecipient("0x00220204f295DbB79fbBe619dd1B94463800F9D9")
+                    .endpoints(List.of("http://localhost:8550")))
         .powchain(
             b ->
                 b.eth1Endpoints(List.of("http://localhost:8545"))

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionEngineOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionEngineOptionsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.options;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
+import tech.pegasys.teku.config.TekuConfiguration;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
+
+public class ExecutionEngineOptionsTest extends AbstractBeaconNodeCommandTest {
+
+  @Test
+  public void shouldReadExecutionEngineOptionsFromConfigurationFile() {
+    final TekuConfiguration config =
+        getTekuConfigurationFromFile("executionEngineOptions_config.yaml");
+
+    assertThat(config.executionEngine().isEnabled()).isTrue();
+    assertThat(config.executionEngine().getEndpoints())
+        .containsExactly("http://example.com:1234/path/", "http://example2.com:1234/path/");
+  }
+
+  @Test
+  public void shouldReportEEEnabledIfEndpointSpecified() {
+    final String[] args = {"--ee-endpoint", "http://example.com:1234/path/"};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.executionEngine().isEnabled()).isTrue();
+  }
+
+  @Test
+  public void shouldReportEEDisabledIfEndpointNotSpecified() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    assertThat(config.executionEngine().isEnabled()).isFalse();
+  }
+
+  @Test
+  public void shouldReportEEDisabledIfEndpointIsEmpty() {
+    final String[] args = {"--ee-endpoint", "   "};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.executionEngine().isEnabled()).isFalse();
+  }
+
+  @Test
+  public void multiple_eeEndpoints_areSupported() {
+    final String[] args = {
+      "--ee-endpoints",
+      "http://example.com:1234/path/,http://example-2.com:1234/path/",
+      "http://example-3.com:1234/path/"
+    };
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.executionEngine().getEndpoints())
+        .containsExactlyInAnyOrder(
+            "http://example.com:1234/path/",
+            "http://example-2.com:1234/path/",
+            "http://example-3.com:1234/path/");
+    assertThat(config.executionEngine().isEnabled()).isTrue();
+  }
+
+  @Test
+  public void multiple_eeEndpoints_areSupported_mixedParams() {
+    final String[] args = {
+      "--ee-endpoint",
+      "http://example-single.com:1234/path/",
+      "--ee-endpoints",
+      "http://example.com:1234/path/,http://example-2.com:1234/path/",
+      "http://example-3.com:1234/path/"
+    };
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.executionEngine().getEndpoints())
+        .containsExactlyInAnyOrder(
+            "http://example-single.com:1234/path/",
+            "http://example.com:1234/path/",
+            "http://example-2.com:1234/path/",
+            "http://example-3.com:1234/path/");
+    assertThat(config.executionEngine().isEnabled()).isTrue();
+  }
+
+  @Test
+  public void ShouldReportEmptyIfFeeRecipientNotSpecified() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    assertThat(config.executionEngine().getFeeRecipient()).isEmpty();
+  }
+
+  @Test
+  public void ShouldReportAddressIfFeeRecipientSpecified() {
+    final String[] args = {
+      "--ee-fee-recipient-address", "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73"
+    };
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.executionEngine().getFeeRecipient())
+        .isEqualTo(
+            Optional.of(Eth1Address.fromHexString("0xfe3b557e8fb62b89f4916b721be55ceb828dbd73")));
+  }
+}

--- a/teku/src/test/resources/complete_config.yaml
+++ b/teku/src/test/resources/complete_config.yaml
@@ -24,6 +24,10 @@ eth1-deposit-contract-address: "0x77f7bED277449F51505a4C54550B074030d989bC"
 eth1-endpoint: "http://localhost:8545"
 #Xeth1-deposits-from-storage-enabled: true
 
+# execution engine
+ee-endpoint: "http://localhost:8550"
+ee-fee-recipient-address: "0x00220204f295dbb79fbbe619dd1b94463800f9d9"
+
 # output
 #Xtransaction-record-directory: "/tmp/teku"
 

--- a/teku/src/test/resources/executionEngineOptions_config.yaml
+++ b/teku/src/test/resources/executionEngineOptions_config.yaml
@@ -1,0 +1,4 @@
+# execution engine
+ee-endpoint:
+  - "http://example.com:1234/path/"
+  - "http://example2.com:1234/path/"

--- a/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
+++ b/validator/coordinator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
@@ -63,6 +63,7 @@ public class BlockFactory {
   private final DepositProvider depositProvider;
   private final Eth1DataCache eth1DataCache;
   private final Bytes32 graffiti;
+  private final Bytes20 feeRecipient;
   private final Spec spec;
   private final ExecutionEngineChannel executionEngineChannel;
 
@@ -79,6 +80,7 @@ public class BlockFactory {
       final DepositProvider depositProvider,
       final Eth1DataCache eth1DataCache,
       final Bytes32 graffiti,
+      final Bytes20 feeRecipient,
       final Spec spec,
       final ExecutionEngineChannel executionEngineChannel) {
     this.attestationPool = attestationPool;
@@ -89,6 +91,7 @@ public class BlockFactory {
     this.depositProvider = depositProvider;
     this.eth1DataCache = eth1DataCache;
     this.graffiti = graffiti;
+    this.feeRecipient = feeRecipient;
     this.spec = spec;
     this.executionEngineChannel = executionEngineChannel;
 
@@ -146,11 +149,7 @@ public class BlockFactory {
 
     final UInt64 payloadId =
         executionPayloadUtil.prepareExecutionPayload(
-            executionEngineChannel,
-            executionParentHash,
-            timestamp,
-            random,
-            Bytes20.ZERO); // TODO let's burn fees for now!
+            executionEngineChannel, executionParentHash, timestamp, random, feeRecipient);
 
     slotToPayloadIdMap.invalidateWithNewValue(slot, payloadId);
   }

--- a/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
+++ b/validator/coordinator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProces
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.ssz.SszList;
+import tech.pegasys.teku.ssz.type.Bytes20;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
@@ -119,6 +120,7 @@ class BlockFactoryTest {
             depositProvider,
             eth1DataCache,
             graffiti,
+            Bytes20.ZERO,
             spec,
             executionEngineChannel);
 


### PR DESCRIPTION
## PR Description

introduces new ExecutionEngine Options:
--ee-endpoints
--ee-endpoint
--ee-fee-recipient-address

- The endpoint options work like the corresponding `--eth1-*` options. It supports multiple endpoints, but we currently use only the first one.
- in case no `ee-endpont(s)` are specified, it fallbacks using the first endpoint specified in `eth1-endpoint(s)`
- `--ee-fee-recipient-address` support the feeRecipient param described here: https://github.com/ethereum/execution-apis/blob/fd116bf4b34fd2526b8f2fbe561627995d14fcb2/src/engine/interop/specification.md

## Fixed Issue(s)

related to #4346 

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
