### PR TITLE
Fix "Failed to produce sync_signature" errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ For information on changes in released versions of Teku, see the [releases page]
 - Fix `NoSuchElementException` reported at startup by validator performance tracking module. 
 - Fix `IllegalStateException` reported on altair networks, when none of your validators are in a sync committee for the current epoch.
 - Fix failed to export/import slashing protection data.
+- Fix incorrect gossip validation when processing duplicate sync committee messages which could lead to an error being reported instead of ignoring the duplicate.

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -37,7 +37,6 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.logic.common.helpers.MathHelpers;
 import tech.pegasys.teku.ssz.SszList;
 import tech.pegasys.teku.ssz.schema.SszListSchema;
 import tech.pegasys.teku.util.config.Constants;
@@ -141,9 +140,8 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
         .flatMap(Collection::stream)
         .map(attestationGroupByDataHash::get)
         .filter(Objects::nonNull)
-        .filter(group -> earnsRewards(stateAtBlockSlot, group.getAttestationData()))
-        .filter(forkChecker::areAttestationsFromCorrectFork)
         .filter(group -> isValid(stateAtBlockSlot, group.getAttestationData()))
+        .filter(forkChecker::areAttestationsFromCorrectFork)
         .flatMap(MatchingDataAttestationGroup::stream)
         .limit(ATTESTATIONS_SCHEMA.getMaxLength())
         .map(ValidateableAttestation::getAttestation)
@@ -156,25 +154,6 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
               return true;
             })
         .collect(ATTESTATIONS_SCHEMA.collector());
-  }
-
-  private boolean earnsRewards(
-      final BeaconState stateAtBlockSlot, final AttestationData attestationData) {
-    final UInt64 attestationSlot = attestationData.getSlot();
-    final UInt64 blockSlot = stateAtBlockSlot.getSlot();
-    final int slotsPerEpoch = spec.getSlotsPerEpoch(attestationSlot);
-    if (attestationSlot.plus(slotsPerEpoch).isLessThan(blockSlot)) {
-      return false;
-    }
-    if (attestationSlot
-        .plus(MathHelpers.integerSquareRoot(slotsPerEpoch))
-        .isGreaterThanOrEqualTo(blockSlot)) {
-      return true;
-    }
-
-    final Bytes32 correctTargetRoot =
-        spec.getBlockRoot(stateAtBlockSlot, attestationData.getTarget().getEpoch());
-    return correctTargetRoot.equals(attestationData.getTarget().getRoot());
   }
 
   public synchronized Stream<Attestation> getAttestations(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidator.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.statetransition.synccommittee;
 import static java.util.stream.Collectors.toList;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.IGNORE;
+import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ignore;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 import static tech.pegasys.teku.util.config.Constants.VALID_SYNC_COMMITTEE_MESSAGE_SET_SIZE;
 
@@ -187,7 +188,7 @@ public class SyncCommitteeMessageValidator {
                 return reject("Rejecting sync committee message because the signature is invalid");
               }
               if (!seenIndices.addAll(uniquenessKeys)) {
-                return reject(
+                return ignore(
                     "Ignoring sync committee message as a duplicate was processed during validation");
               }
               return ACCEPT;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.validator.client;
 
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -35,6 +37,7 @@ import tech.pegasys.teku.validator.client.duties.synccommittee.SyncCommitteeSche
  * subnet subscriptions are renewed if the reconnection was because the beacon chain restarted.
  */
 public class SyncCommitteeScheduler implements ValidatorTimingChannel {
+  private static final Logger LOG = LogManager.getLogger();
 
   private final MetricsSystem metricsSystem;
   private final Spec spec;
@@ -43,6 +46,7 @@ public class SyncCommitteeScheduler implements ValidatorTimingChannel {
 
   private Optional<SyncCommitteePeriod> currentSyncCommitteePeriod = Optional.empty();
   private Optional<SyncCommitteePeriod> nextSyncCommitteePeriod = Optional.empty();
+  private UInt64 lastProductionSlot;
 
   public SyncCommitteeScheduler(
       final MetricsSystem metricsSystem,
@@ -109,6 +113,16 @@ public class SyncCommitteeScheduler implements ValidatorTimingChannel {
 
   @Override
   public void onAttestationCreationDue(final UInt64 slot) {
+    // Check slot being null for the edge case of genesis slot (i.e. slot 0)
+    if (lastProductionSlot != null && slot.compareTo(lastProductionSlot) <= 0) {
+      LOG.debug(
+          "Not producing sync committee message for slot {} because last production slot {} is beyond that.",
+          slot,
+          lastProductionSlot);
+      return;
+    }
+
+    lastProductionSlot = slot;
     getDutiesForSlot(slot).ifPresent(duties -> duties.onProductionDue(slot));
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeSchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeSchedulerTest.java
@@ -99,6 +99,31 @@ class SyncCommitteeSchedulerTest {
   }
 
   @Test
+  void shouldNotPerformProductionMultipleTimesForSameSlot() {
+    scheduler.onSlot(UInt64.ONE);
+
+    getRequestedDutiesForSyncCommitteePeriod(0).complete(Optional.of(duties));
+
+    scheduler.onAttestationCreationDue(UInt64.ONE);
+    scheduler.onAttestationCreationDue(UInt64.ONE);
+
+    verify(duties, times(1)).performProductionDuty(UInt64.ONE);
+  }
+
+  @Test
+  void shouldNotPerformProductionForEarlierSlot() {
+    scheduler.onSlot(UInt64.ONE);
+
+    getRequestedDutiesForSyncCommitteePeriod(0).complete(Optional.of(duties));
+
+    scheduler.onAttestationCreationDue(UInt64.valueOf(2));
+    scheduler.onAttestationCreationDue(UInt64.ONE);
+
+    verify(duties).performProductionDuty(UInt64.valueOf(2));
+    verify(duties, never()).performProductionDuty(UInt64.ONE);
+  }
+
+  @Test
   void shouldPerformAggregationForEachSlotWhenAttestationAggregationDue() {
     scheduler.onSlot(UInt64.ONE);
 


### PR DESCRIPTION
## PR Description
The validation result for sync committee messages which are initially found to be new, but are duplicates by the time the validation completes was incorrectly changed from IGNORE to REJECT in commit e4fe8301db0ffcc74a2a811982f2344696d451e8.  Change it back to ignore.

Update the validator client to avoid creating multiple sync committee messages for the same slot (at the 4 second mark and when the block is received). Normally these would be ignored as duplicates by the beacon chain but the above bug could lead to one of these being reported as a failure in the logs if the two messages were produced at almost the same time.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
