### PR TITLE
Add additional verification of snappy data sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@ For information on changes in released versions of Teku, see the [releases page]
 - Fix `IllegalStateException` reported on altair networks, when none of your validators are in a sync committee for the current epoch.
 - Fix failed to export/import slashing protection data.
 - Fix incorrect gossip validation when processing duplicate sync committee messages which could lead to an error being reported instead of ignoring the duplicate.
+- Added additional verification of message lengths when decoding snappy messages.

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/snappy/SnappyFrameDecoder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/snappy/SnappyFrameDecoder.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.s
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.compression.DecompressionException;
 import io.netty.handler.codec.compression.Snappy;
 import java.util.Optional;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.AbstractByteBufDecoder;
@@ -43,7 +44,12 @@ public class SnappyFrameDecoder extends AbstractByteBufDecoder<ByteBuf, Compress
   }
 
   private static final int SNAPPY_IDENTIFIER_LEN = 6;
+  // See https://github.com/google/snappy/blob/1.1.9/framing_format.txt#L95
   private static final int MAX_UNCOMPRESSED_DATA_SIZE = 65536 + 4;
+  // See https://github.com/google/snappy/blob/1.1.9/framing_format.txt#L82
+  private static final int MAX_DECOMPRESSED_DATA_SIZE = 65536;
+  // See https://github.com/google/snappy/blob/1.1.9/framing_format.txt#L82
+  private static final int MAX_COMPRESSED_CHUNK_SIZE = 16777216 - 1;
 
   private final Snappy snappy = new Snappy();
   private final boolean validateChecksums;
@@ -164,13 +170,21 @@ public class SnappyFrameDecoder extends AbstractByteBufDecoder<ByteBuf, Compress
             throw new CompressionException("Received COMPRESSED_DATA tag before STREAM_IDENTIFIER");
           }
 
+          if (chunkLength > MAX_COMPRESSED_CHUNK_SIZE) {
+            throw new DecompressionException(
+                "Received COMPRESSED_DATA that contains"
+                    + " chunk that exceeds "
+                    + MAX_COMPRESSED_CHUNK_SIZE
+                    + " bytes");
+          }
+
           if (inSize < 4 + chunkLength) {
             return Optional.empty();
           }
 
           in.skipBytes(4);
           int checksum = in.readIntLE();
-          ByteBuf uncompressed = Unpooled.buffer();
+          ByteBuf uncompressed = Unpooled.buffer(chunkLength, MAX_DECOMPRESSED_DATA_SIZE);
           try {
             if (validateChecksums) {
               int oldWriterIndex = in.writerIndex();


### PR DESCRIPTION
## PR Description
Add additional verification of snappy compressed and decompressed data lengths for frame decoding to more strictly enforce the specification.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
