### PR TITLE
Fix incompatibilies when importing, exporting and repairing slashing protection records

### DIFF
--- a/data/dataexchange/src/main/java/tech/pegasys/teku/data/SlashingProtectionImporter.java
+++ b/data/dataexchange/src/main/java/tech/pegasys/teku/data/SlashingProtectionImporter.java
@@ -26,6 +26,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.data.signingrecord.ValidatorSigningRecord;
@@ -99,23 +100,33 @@ public class SlashingProtectionImporter {
   }
 
   private SigningHistory signingHistoryConverter(final SigningHistory signingHistory) {
-    final Optional<UInt64> lastSlot =
-        signingHistory.signedBlocks.stream().map(SignedBlock::getSlot).max(UInt64::compareTo);
-    final Optional<UInt64> sourceEpoch =
-        signingHistory.signedAttestations.stream()
-            .map(SignedAttestation::getSourceEpoch)
-            .max(UInt64::compareTo);
-    final Optional<UInt64> targetEpoch =
-        signingHistory.signedAttestations.stream()
-            .map(SignedAttestation::getTargetEpoch)
-            .max(UInt64::compareTo);
-    final ValidatorSigningRecord record =
-        new ValidatorSigningRecord(
-            metadata.genesisValidatorsRoot,
-            lastSlot.orElse(UInt64.ZERO),
-            sourceEpoch.orElse(ValidatorSigningRecord.NEVER_SIGNED),
-            targetEpoch.orElse(ValidatorSigningRecord.NEVER_SIGNED));
-    return new SigningHistory(signingHistory.pubkey, record);
+    try {
+      final Optional<UInt64> lastSlot =
+          signingHistory.signedBlocks.stream()
+              .map(SignedBlock::getSlot)
+              .filter(Objects::nonNull)
+              .max(UInt64::compareTo);
+      final Optional<UInt64> sourceEpoch =
+          signingHistory.signedAttestations.stream()
+              .map(SignedAttestation::getSourceEpoch)
+              .filter(Objects::nonNull)
+              .max(UInt64::compareTo);
+      final Optional<UInt64> targetEpoch =
+          signingHistory.signedAttestations.stream()
+              .map(SignedAttestation::getTargetEpoch)
+              .filter(Objects::nonNull)
+              .max(UInt64::compareTo);
+      final ValidatorSigningRecord record =
+          new ValidatorSigningRecord(
+              metadata.genesisValidatorsRoot,
+              lastSlot.orElse(UInt64.ZERO),
+              sourceEpoch.orElse(ValidatorSigningRecord.NEVER_SIGNED),
+              targetEpoch.orElse(ValidatorSigningRecord.NEVER_SIGNED));
+      return new SigningHistory(signingHistory.pubkey, record);
+    } catch (NullPointerException e) {
+      System.out.println(signingHistory.pubkey);
+      throw e;
+    }
   }
 
   public void updateLocalRecords(final Path slashingProtectionPath) {
@@ -134,10 +145,12 @@ public class SlashingProtectionImporter {
       try {
         existingRecord = syncDataAccessor.read(outputFile).map(ValidatorSigningRecord::fromBytes);
       } catch (IOException e) {
-        log.exit(1, "Failed to read existing file: " + outputFile.toString());
+        log.exit(1, "Failed to read existing file: " + outputFile);
       }
     }
     if (existingRecord.isPresent()
+        && existingRecord.get().getGenesisValidatorsRoot() != null
+        && metadata.genesisValidatorsRoot != null
         && metadata.genesisValidatorsRoot.compareTo(existingRecord.get().getGenesisValidatorsRoot())
             != 0) {
       log.exit(

--- a/data/dataexchange/src/test/java/tech/pegasys/teku/data/SlashingProtectionExporterTest.java
+++ b/data/dataexchange/src/test/java/tech/pegasys/teku/data/SlashingProtectionExporterTest.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.cli.OSUtils;
 import tech.pegasys.teku.data.signingrecord.ValidatorSigningRecord;
 import tech.pegasys.teku.data.slashinginterchange.Metadata;
+import tech.pegasys.teku.data.slashinginterchange.SignedBlock;
 import tech.pegasys.teku.data.slashinginterchange.SigningHistory;
 import tech.pegasys.teku.data.slashinginterchange.SlashingProtectionInterchangeFormat;
 import tech.pegasys.teku.infrastructure.logging.SubCommandLogger;
@@ -167,6 +168,35 @@ public class SlashingProtectionExporterTest {
     assertThat(Files.exists(exportedFile)).isFalse();
     exporter.saveToFile(exportedFile.toString());
     assertThat(Files.exists(exportedFile)).isTrue();
+  }
+
+  @Test
+  void shouldHaveNoSignedAttestationsWhenNoAttestationsSigned(@TempDir Path tempDir)
+      throws Exception {
+    final Path exportedFile = tempDir.resolve("exportedFile.json").toAbsolutePath();
+    final SlashingProtectionExporter exporter =
+        new SlashingProtectionExporter(logger, tempDir.toString());
+
+    final UInt64 blockSlot = UInt64.ONE;
+    final ValidatorSigningRecord signingRecord =
+        new ValidatorSigningRecord(validatorsRoot)
+            .maySignBlock(validatorsRoot, blockSlot)
+            .orElseThrow();
+    final Path recordFile = tempDir.resolve(pubkey + ".yml");
+    Files.write(recordFile, signingRecord.toBytes().toArrayUnsafe());
+    exporter.readSlashProtectionFile(recordFile.toFile());
+
+    assertThat(exportedFile).doesNotExist();
+    exporter.saveToFile(exportedFile.toString());
+    assertThat(exportedFile).exists();
+
+    final SlashingProtectionInterchangeFormat exportedRecords =
+        jsonProvider.jsonToObject(
+            Files.readString(exportedFile), SlashingProtectionInterchangeFormat.class);
+    assertThat(exportedRecords.data).hasSize(1);
+    final SigningHistory signingHistory = exportedRecords.data.get(0);
+    assertThat(signingHistory.signedBlocks).containsExactly(new SignedBlock(blockSlot, null));
+    assertThat(signingHistory.signedAttestations).isEmpty();
   }
 
   private File usingResourceFile(final String resourceFileName, final Path tempDir)

--- a/data/dataexchange/src/test/java/tech/pegasys/teku/data/SlashingProtectionImporterTest.java
+++ b/data/dataexchange/src/test/java/tech/pegasys/teku/data/SlashingProtectionImporterTest.java
@@ -14,8 +14,10 @@
 package tech.pegasys.teku.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.io.Resources;
@@ -25,11 +27,14 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
+import tech.pegasys.teku.data.signingrecord.ValidatorSigningRecord;
 import tech.pegasys.teku.data.slashinginterchange.Metadata;
 import tech.pegasys.teku.infrastructure.logging.SubCommandLogger;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class SlashingProtectionImporterTest {
   private final ArgumentCaptor<String> stringArgs = ArgumentCaptor.forClass(String.class);
@@ -87,6 +92,61 @@ public class SlashingProtectionImporterTest {
     assertThat(Files.exists(ruleFile.toPath())).isTrue();
 
     assertThat(originalFileContent).isEqualTo(Files.readString(ruleFile.toPath()));
+  }
+
+  @Test
+  void shouldImportFileOverRepairedRecords(@TempDir Path tempDir) throws Exception {
+    final SubCommandLogger logger = mock(SubCommandLogger.class);
+    final Path initialRecords = tempDir.resolve("initial");
+    final Path repairedRecords = tempDir.resolve("repaired");
+    assertThat(initialRecords.toFile().mkdirs()).isTrue();
+    assertThat(repairedRecords.toFile().mkdirs()).isTrue();
+
+    final Path exportedFile = tempDir.resolve("exportedFile.json").toAbsolutePath();
+    final File initialRuleFile =
+        usingResourceFile("slashProtectionWithGenesisRoot.yml", initialRecords);
+    final File repairedRuleFile =
+        usingResourceFile("slashProtectionWithGenesisRoot.yml", repairedRecords);
+
+    final SlashingProtectionExporter exporter =
+        new SlashingProtectionExporter(logger, tempDir.toString());
+    exporter.readSlashProtectionFile(repairedRuleFile);
+    final String originalFileContent = Files.readString(initialRuleFile.toPath());
+
+    assertThat(exportedFile).doesNotExist();
+    exporter.saveToFile(exportedFile.toString());
+    assertThat(exportedFile).exists();
+
+    final SlashingProtectionRepairer repairer =
+        SlashingProtectionRepairer.create(logger, repairedRecords, true);
+    final UInt64 repairedSlot = UInt64.valueOf(1566);
+    final UInt64 repairedEpoch = UInt64.valueOf(7668);
+    repairer.updateRecords(repairedSlot, repairedEpoch);
+    verify(logger, never()).error(any());
+    verify(logger, never()).error(any(), any());
+    assertThat(Files.readString(repairedRuleFile.toPath())).isNotEqualTo(originalFileContent);
+
+    SlashingProtectionImporter importer =
+        new SlashingProtectionImporter(logger, exportedFile.toString());
+    importer.initialise(exportedFile.toFile());
+    importer.updateLocalRecords(repairedRecords);
+
+    // Should wind up with a file that contains the slot and epochs from the repair, combined with
+    // the genesis root from the initial file
+    final ValidatorSigningRecord initialRecord = loadSigningRecord(initialRuleFile);
+    final ValidatorSigningRecord importedRecord = loadSigningRecord(repairedRuleFile);
+    assertThat(importedRecord)
+        .isEqualTo(
+            new ValidatorSigningRecord(
+                initialRecord.getGenesisValidatorsRoot(),
+                repairedSlot,
+                repairedEpoch,
+                repairedEpoch));
+  }
+
+  private ValidatorSigningRecord loadSigningRecord(final File repairedRuleFile) throws IOException {
+    return ValidatorSigningRecord.fromBytes(
+        Bytes.wrap(Files.readAllBytes(repairedRuleFile.toPath())));
   }
 
   private String loadAndGetErrorText(final String resourceFile)

--- a/data/dataexchange/src/test/resources/slashProtectionNoAttestations.yml
+++ b/data/dataexchange/src/test/resources/slashProtectionNoAttestations.yml
@@ -1,5 +1,4 @@
 ---
-genesisValidatorsRoot: "0x6e2c5d8a89dfe121a92c8812bea69fe9f84ae48f63aafe34ef7e18c7eac9af70"
 lastSignedBlockSlot: 327
 lastSignedAttestationSourceEpoch: 51
 lastSignedAttestationTargetEpoch: 1741


### PR DESCRIPTION
## PR Description
Fixes some corner cases which could lead to exceptions when importing, exporting or repairing slashing protection records.

* `NullPointerException` when importing a slashing protection record that contained a genesis validators root over an existing record that did not (e.g after performing a repair)
* Generated an invalid export for validators that had never signed an attestation - should have had an empty list of attestations but actually had a single, empty object as the signed attestation
* `NullPointerException` when importing an invalid export with an empty object as signed attestation
* `NullPointerException` when repairing the slashing protection record for a validator that had never attested

Generally makes code much more defensive to `null` values.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
