### PR TITLE
[Merge] Make Teku Merge capable of running a testnet with a stub Execution Engine 

### DIFF
--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/execution/client/ExecutionEngineClient.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/execution/client/ExecutionEngineClient.java
@@ -92,6 +92,7 @@ public interface ExecutionEngineClient {
         @Override
         public SafeFuture<Response<ExecutePayloadResponse>> executePayload(
             ExecutionPayload request) {
+          number = request.blockNumber;
           return SafeFuture.completedFuture(
               new Response<>(
                   new ExecutePayloadResponse(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- just a minor fix for the `ExecutionEngineClient.Stub` to create valid `ExecutionPayload` when blocks are produced on remote node

### Spinning up testnet: 

1. Generate genesis: 
```bash
> teku genesis mock \
  --output-file ./local-genesis.ssz \ 
  --network=minimal \
  --Xnetwork-altair-fork-epoch=0 \
  --Xnetwork-merge-fork-epoch=0 \
  --validator-count=256
```
2. Create a set of nodes private keys to have persistent `nodeId`s: 
`p2p-privateKey-1.hex`:
```
080212206FD7AF84823661AE4F0FDB05D83BD5569B4270FE94C8AD79CCB7E3F843DEFCB1
```
`p2p-privateKey-2.hex`:
```
080212206FD7AF84823661AE4F0FDB05D83BD5569B4270FE94C8AD79CCB7E3F843DEFCB2
```

3. Start a node `#1` with 1/3 of validators: 
```bash
> teku \
--Xinterop-enabled=true \
--Xinterop-number-of-validators=256 \
--Xinterop-owned-validator-start-index=0 \
--Xinterop-owned-validator-count=90 \
--network=minimal \
--Xnetwork-altair-fork-epoch=0 \
--Xnetwork-merge-fork-epoch=0 \
--initial-state ./local-genesis.ssz \
--p2p-port=9001 \
--p2p-private-key-file=./p2p-privateKey-1.hex \
--p2p-static-peers=/ip4/127.0.0.1/tcp/9002/p2p/16Uiu2HAm7JLKuHchu8TtUwmWvoDzJGH2dsFRA61cvHkw3v98727L \
--data-path=./data.merge.1 \
```

4. Start a node `#2` with the rest 2/3 of validators
```bash
> teku
--Xinterop-enabled=true \
--Xinterop-number-of-validators=256 \
--Xinterop-owned-validator-start-index=90 \
--Xinterop-owned-validator-count=166 \
--network=minimal \
--Xnetwork-altair-fork-epoch=0 \
--Xnetwork-merge-fork-epoch=0 \
--initial-state ./local-genesis.ssz \
--p2p-port=9002 \
--p2p-private-key-file=./p2p-privateKey-2.hex \
--p2p-static-peers=/ip4/127.0.0.1/tcp/9001/p2p/16Uiu2HAmH6m8pE7pXsfzXHg3Z5kLzgwJ5PWSYELaKXc75Bs2utZM \
--data-path=./data.merge.2 \
```
