### PR TITLE
Increase gossip cache timeout to 33 slots

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipConfig.java
@@ -27,11 +27,13 @@ public class GossipConfig {
   public static final int DEFAULT_D_LOW = 6;
   public static final int DEFAULT_D_HIGH = 12;
   public static final int DEFAULT_D_LAZY = 6;
-  public static final Duration DEFAULT_FANOUT_TTL = Duration.ofSeconds(60);
-  public static final int DEFAULT_ADVERTISE = 3;
-  public static final int DEFAULT_HISTORY = 6;
-  public static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(700);
-  public static final Duration DEFAULT_SEEN_TTL = DEFAULT_HEARTBEAT_INTERVAL.multipliedBy(550);
+  private static final Duration DEFAULT_FANOUT_TTL = Duration.ofSeconds(60);
+  private static final int DEFAULT_ADVERTISE = 3;
+  private static final int DEFAULT_HISTORY = 6;
+  static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(700);
+  // ATTESTATION_PROPAGATION_SLOT_RANGE needs to be the last 32 slots, so TTL is 33 slots
+  // 566 * HEARTBEAT == 396.2 seconds, 33 slots is (396 seconds) on mainnet
+  static final Duration DEFAULT_SEEN_TTL = DEFAULT_HEARTBEAT_INTERVAL.multipliedBy(566);
 
   private final int d;
   private final int dLow;

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipConfigTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipConfigTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 class GossipConfigTest {
   @Test
   void shouldUseCorrectSeenTtl() {
-    // Should be heartbeat interval * 567
+    // Should be heartbeat interval * 566
     assertThat(GossipConfig.DEFAULT_SEEN_TTL.toMillis()).isEqualTo(700 * 566);
   }
 }

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipConfigTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipConfigTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 class GossipConfigTest {
   @Test
   void shouldUseCorrectSeenTtl() {
-    // Should be heartbeat interval * 550
-    assertThat(GossipConfig.DEFAULT_SEEN_TTL.toMillis()).isEqualTo(700 * 550);
+    // Should be heartbeat interval * 567
+    assertThat(GossipConfig.DEFAULT_SEEN_TTL.toMillis()).isEqualTo(700 * 566);
   }
 }


### PR DESCRIPTION
Gossip cache is expiring items slightly early, so the timeout has been increased to 33 slots rather than 32.

fixes #4416

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
