### PR TITLE
Disable heap dumps by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -331,7 +331,6 @@ application {
       // We shutdown log4j ourselves, as otherwise his shutdown hook runs before our own and whatever
       // happens during shutdown is not logged.
       "-Dlog4j.shutdownHookEnabled=false",
-      "-XX:+HeapDumpOnOutOfMemoryError",
       // run `jcmd <PID> VM.native_memory` to check JVM native memory consumption
       "-XX:NativeMemoryTracking=summary",
       // 32Mb for Netty Direct ByteBuf


### PR DESCRIPTION
## PR Description
Stop enabling heap dumps by default in Teku.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
