### PR TITLE
[Merge] Spec v1.1.1 adoption

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -225,7 +225,7 @@ allprojects {
   }
 }
 
-def refTestVersion = 'v1.1.0'
+def refTestVersion = 'v1.1.1'
 def blsRefTestVersion = 'v0.1.0'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
 def blsRefTestBaseUrl = 'https://github.com/ethereum/bls12-381-tests/releases/download'

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/ForkSchedule.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/ForkSchedule.java
@@ -187,7 +187,9 @@ public class ForkSchedule {
       final Bytes4 forkVersion = maybeForkVersion.get();
       final UInt64 forkSlot = spec.miscHelpers().computeStartSlotAtEpoch(forkEpoch);
       final UInt64 genesisOffset = spec.getForkChoiceUtil().getSlotStartTime(forkSlot, UInt64.ZERO);
-      final Fork fork = new Fork(prevForkVersion.orElse(forkVersion), forkVersion, forkEpoch);
+      final Bytes4 prevForkVersionOrSame =
+          prevForkVersion.isPresent() && !forkEpoch.isZero() ? prevForkVersion.get() : forkVersion;
+      final Fork fork = new Fork(prevForkVersionOrSame, forkVersion, forkEpoch);
 
       // Validate against prev fork
       if (epochToMilestone.isEmpty() && !forkSlot.equals(UInt64.ZERO)) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
@@ -247,8 +248,17 @@ public class Spec {
   // Genesis
   public BeaconState initializeBeaconStateFromEth1(
       Bytes32 eth1BlockHash, UInt64 eth1Timestamp, List<? extends Deposit> deposits) {
+    return initializeBeaconStateFromEth1(eth1BlockHash, eth1Timestamp, deposits, Optional.empty());
+  }
+
+  public BeaconState initializeBeaconStateFromEth1(
+      Bytes32 eth1BlockHash,
+      UInt64 eth1Timestamp,
+      List<? extends Deposit> deposits,
+      Optional<ExecutionPayloadHeader> payloadHeader) {
     final GenesisGenerator genesisGenerator = createGenesisGenerator();
     genesisGenerator.updateCandidateState(eth1BlockHash, eth1Timestamp, deposits);
+    payloadHeader.ifPresent(genesisGenerator::updateExecutionPayloadHeader);
     return genesisGenerator.getGenesisState();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.type.Bytes4;
@@ -675,10 +674,6 @@ public class SpecConfigBuilder {
 
   public class MergeBuilder {
 
-    // Genesis
-    private UInt64 genesisGasLimit;
-    private Bytes32 genesisBaseFeePerGas;
-
     // Fork
     private Bytes4 mergeForkVersion;
     private UInt64 mergeForkEpoch;
@@ -690,32 +685,13 @@ public class SpecConfigBuilder {
 
     SpecConfigMerge build(final SpecConfigAltair specConfig) {
       return new SpecConfigMerge(
-          specConfig,
-          genesisGasLimit,
-          genesisBaseFeePerGas,
-          mergeForkVersion,
-          mergeForkEpoch,
-          terminalTotalDifficulty);
+          specConfig, mergeForkVersion, mergeForkEpoch, terminalTotalDifficulty);
     }
 
     void validate() {
-      validateConstant("genesisGasLimit", genesisGasLimit);
-      validateConstant("genesisBaseFeePerGas", genesisBaseFeePerGas);
       validateConstant("mergeForkVersion", mergeForkVersion);
       validateConstant("mergeForkEpoch", mergeForkEpoch);
       validateConstant("terminalTotalDifficulty", terminalTotalDifficulty);
-    }
-
-    public MergeBuilder genesisGasLimit(UInt64 genesisGasLimit) {
-      checkNotNull(genesisGasLimit);
-      this.genesisGasLimit = genesisGasLimit;
-      return this;
-    }
-
-    public MergeBuilder genesisBaseFeePerGas(Bytes32 genesisBaseFeePerGas) {
-      checkNotNull(genesisBaseFeePerGas);
-      this.genesisBaseFeePerGas = genesisBaseFeePerGas;
-      return this;
     }
 
     public MergeBuilder mergeForkVersion(Bytes4 mergeForkVersion) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigMerge.java
@@ -16,16 +16,11 @@ package tech.pegasys.teku.spec.config;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
-import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.type.Bytes4;
 
 public class SpecConfigMerge extends DelegatingSpecConfigAltair {
-
-  // Genesis
-  private UInt64 genesisGasLimit;
-  private Bytes32 genesisBaseFeePerGas;
 
   // Fork
   private final Bytes4 mergeForkVersion;
@@ -36,8 +31,6 @@ public class SpecConfigMerge extends DelegatingSpecConfigAltair {
 
   public SpecConfigMerge(
       SpecConfigAltair specConfig,
-      UInt64 genesisGasLimit,
-      Bytes32 genesisBaseFeePerGas,
       Bytes4 mergeForkVersion,
       UInt64 mergeForkEpoch,
       UInt256 terminalTotalDifficulty) {
@@ -45,8 +38,6 @@ public class SpecConfigMerge extends DelegatingSpecConfigAltair {
     this.mergeForkVersion = mergeForkVersion;
     this.mergeForkEpoch = mergeForkEpoch;
     this.terminalTotalDifficulty = terminalTotalDifficulty;
-    this.genesisBaseFeePerGas = genesisBaseFeePerGas;
-    this.genesisGasLimit = genesisGasLimit;
   }
 
   public static SpecConfigMerge required(final SpecConfig specConfig) {
@@ -69,14 +60,6 @@ public class SpecConfigMerge extends DelegatingSpecConfigAltair {
                     new IllegalArgumentException(
                         "Expected merge spec config but got: "
                             + specConfig.getClass().getSimpleName())));
-  }
-
-  public UInt64 getGenesisGasLimit() {
-    return genesisGasLimit;
-  }
-
-  public Bytes32 getGenesisBaseFeePerGas() {
-    return genesisBaseFeePerGas;
   }
 
   public Bytes4 getMergeForkVersion() {
@@ -105,20 +88,13 @@ public class SpecConfigMerge extends DelegatingSpecConfigAltair {
       return false;
     }
     SpecConfigMerge that = (SpecConfigMerge) o;
-    return Objects.equals(genesisGasLimit, that.genesisGasLimit)
-        && Objects.equals(genesisBaseFeePerGas, that.genesisBaseFeePerGas)
-        && Objects.equals(mergeForkVersion, that.mergeForkVersion)
+    return Objects.equals(mergeForkVersion, that.mergeForkVersion)
         && Objects.equals(mergeForkEpoch, that.mergeForkEpoch)
         && Objects.equals(terminalTotalDifficulty, that.terminalTotalDifficulty);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(
-        genesisGasLimit,
-        genesisBaseFeePerGas,
-        mergeForkVersion,
-        mergeForkEpoch,
-        terminalTotalDifficulty);
+    return Objects.hash(mergeForkVersion, mergeForkEpoch, terminalTotalDifficulty);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/InteropStartupUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/InteropStartupUtil.java
@@ -14,10 +14,12 @@
 package tech.pegasys.teku.spec.datastructures.interop;
 
 import java.util.List;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.DepositGenerator;
@@ -37,7 +39,7 @@ public final class InteropStartupUtil {
       final long genesisTime,
       List<BLSKeyPair> validatorKeys) {
     return createMockedStartInitialBeaconState(
-        spec, eth1BlockHash, genesisTime, validatorKeys, true);
+        spec, eth1BlockHash, genesisTime, validatorKeys, Optional.empty(), true);
   }
 
   public static BeaconState createMockedStartInitialBeaconState(
@@ -50,6 +52,7 @@ public final class InteropStartupUtil {
         MockStartBeaconStateGenerator.INTEROP_ETH1_BLOCK_HASH,
         genesisTime,
         validatorKeys,
+        Optional.empty(),
         signDeposits);
   }
 
@@ -58,11 +61,13 @@ public final class InteropStartupUtil {
       final Bytes32 eth1BlockHash,
       final long genesisTime,
       List<BLSKeyPair> validatorKeys,
+      Optional<ExecutionPayloadHeader> payloadHeader,
       boolean signDeposits) {
     final List<DepositData> initialDepositData =
         new MockStartDepositGenerator(new DepositGenerator(spec, signDeposits))
             .createDeposits(validatorKeys);
     return new MockStartBeaconStateGenerator(spec)
-        .createInitialBeaconState(eth1BlockHash, UInt64.valueOf(genesisTime), initialDepositData);
+        .createInitialBeaconState(
+            eth1BlockHash, UInt64.valueOf(genesisTime), initialDepositData, payloadHeader);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/MockStartBeaconStateGenerator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/MockStartBeaconStateGenerator.java
@@ -16,9 +16,11 @@ package tech.pegasys.teku.spec.datastructures.interop;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.operations.DepositWithIndex;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -47,6 +49,15 @@ public class MockStartBeaconStateGenerator {
       final Bytes32 eth1BlockHash,
       final UInt64 genesisTime,
       final List<DepositData> initialDepositData) {
+    return createInitialBeaconState(
+        eth1BlockHash, genesisTime, initialDepositData, Optional.empty());
+  }
+
+  public BeaconState createInitialBeaconState(
+      final Bytes32 eth1BlockHash,
+      final UInt64 genesisTime,
+      final List<DepositData> initialDepositData,
+      Optional<ExecutionPayloadHeader> payloadHeader) {
     final List<DepositWithIndex> deposits = new ArrayList<>();
     for (int index = 0; index < initialDepositData.size(); index++) {
       final DepositData data = initialDepositData.get(index);
@@ -54,7 +65,7 @@ public class MockStartBeaconStateGenerator {
       deposits.add(deposit);
     }
     final BeaconState initialState =
-        spec.initializeBeaconStateFromEth1(eth1BlockHash, genesisTime, deposits);
+        spec.initializeBeaconStateFromEth1(eth1BlockHash, genesisTime, deposits, payloadHeader);
     return initialState.updated(state -> state.setGenesis_time(genesisTime));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
@@ -80,26 +80,6 @@ public class GenesisGenerator {
         .ifPresent(stateMerge -> stateMerge.setLatestExecutionPayloadHeader(payloadHeader));
   }
 
-  public void updateExecutionPayloadHeader(
-      Bytes32 eth1BlockHash, UInt64 eth1Timestamp, UInt64 genesisGasLimit, Bytes32 genesisBaseFee) {
-    updateExecutionPayloadHeader(
-        new ExecutionPayloadHeader(
-            Bytes32.ZERO,
-            Bytes20.ZERO,
-            Bytes32.ZERO,
-            Bytes32.ZERO,
-            Bytes.wrap(new byte[SpecConfig.BYTES_PER_LOGS_BLOOM]),
-            eth1BlockHash,
-            UInt64.ZERO,
-            genesisGasLimit,
-            UInt64.ZERO,
-            eth1Timestamp,
-            Bytes.EMPTY,
-            genesisBaseFee,
-            eth1BlockHash,
-            Bytes32.ZERO));
-  }
-
   public void updateCandidateState(
       Bytes32 eth1BlockHash, UInt64 eth1Timestamp, List<? extends Deposit> deposits) {
     updateGenesisTime(eth1Timestamp);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -38,7 +37,6 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconStat
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.ssz.SszMutableList;
 import tech.pegasys.teku.ssz.schema.SszListSchema;
-import tech.pegasys.teku.ssz.type.Bytes20;
 import tech.pegasys.teku.util.config.Constants;
 
 public class GenesisGenerator {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
@@ -74,6 +74,32 @@ public class GenesisGenerator {
             .createWritableCopy();
   }
 
+  public void updateExecutionPayloadHeader(ExecutionPayloadHeader payloadHeader) {
+    state
+        .toMutableVersionMerge()
+        .ifPresent(stateMerge -> stateMerge.setLatestExecutionPayloadHeader(payloadHeader));
+  }
+
+  public void updateExecutionPayloadHeader(
+      Bytes32 eth1BlockHash, UInt64 eth1Timestamp, UInt64 genesisGasLimit, Bytes32 genesisBaseFee) {
+    updateExecutionPayloadHeader(
+        new ExecutionPayloadHeader(
+            Bytes32.ZERO,
+            Bytes20.ZERO,
+            Bytes32.ZERO,
+            Bytes32.ZERO,
+            Bytes.wrap(new byte[SpecConfig.BYTES_PER_LOGS_BLOOM]),
+            eth1BlockHash,
+            UInt64.ZERO,
+            genesisGasLimit,
+            UInt64.ZERO,
+            eth1Timestamp,
+            Bytes.EMPTY,
+            genesisBaseFee,
+            eth1BlockHash,
+            Bytes32.ZERO));
+  }
+
   public void updateCandidateState(
       Bytes32 eth1BlockHash, UInt64 eth1Timestamp, List<? extends Deposit> deposits) {
     updateGenesisTime(eth1Timestamp);
@@ -81,27 +107,6 @@ public class GenesisGenerator {
     state.setEth1_data(
         new Eth1Data(
             Bytes32.ZERO, UInt64.valueOf(depositDataList.size() + deposits.size()), eth1BlockHash));
-
-    state
-        .toMutableVersionMerge()
-        .ifPresent(
-            stateMerge ->
-                stateMerge.setLatestExecutionPayloadHeader(
-                    new ExecutionPayloadHeader(
-                        Bytes32.ZERO,
-                        Bytes20.ZERO,
-                        Bytes32.ZERO,
-                        Bytes32.ZERO,
-                        Bytes.wrap(new byte[SpecConfig.BYTES_PER_LOGS_BLOOM]),
-                        eth1BlockHash,
-                        UInt64.ZERO,
-                        specConfig.toVersionMerge().orElseThrow().getGenesisGasLimit(),
-                        UInt64.ZERO,
-                        eth1Timestamp,
-                        Bytes.EMPTY,
-                        specConfig.toVersionMerge().orElseThrow().getGenesisBaseFeePerGas(),
-                        eth1BlockHash,
-                        Bytes32.ZERO)));
 
     // Process deposits
     deposits.forEach(

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/ForkScheduleTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/ForkScheduleTest.java
@@ -462,7 +462,10 @@ public class ForkScheduleTest {
 
   private Fork getAltairFork(final SpecConfigAltair config) {
     final UInt64 forkEpoch = config.getAltairForkEpoch();
-    return new Fork(config.getGenesisForkVersion(), config.getAltairForkVersion(), forkEpoch);
+    return new Fork(
+        forkEpoch.isZero() ? config.getAltairForkVersion() : config.getGenesisForkVersion(),
+        config.getAltairForkVersion(),
+        forkEpoch);
   }
 
   private Fork getPhase0Fork(final SpecConfig config) {

--- a/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/invalid/invalidPreset_unknown.yaml
+++ b/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/invalid/invalidPreset_unknown.yaml
@@ -14,10 +14,6 @@ GENESIS_FORK_VERSION: 0x00000001
 # [customized] Faster to spin up testnets, but does not give validator reasonable warning time for genesis
 GENESIS_DELAY: 300
 
-# Genesis - Merge
-GENESIS_GAS_LIMIT: 30000000
-GENESIS_BASE_FEE_PER_GAS: 0x00ca9a3b00000000000000000000000000000000000000000000000000000000
-
 # Forking
 # ---------------------------------------------------------------
 # Values provided for illustrative purposes.

--- a/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/invalid/invalidPreset_wrongType.yaml
+++ b/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/invalid/invalidPreset_wrongType.yaml
@@ -14,10 +14,6 @@ GENESIS_FORK_VERSION: 0x00000001
 # [customized] Faster to spin up testnets, but does not give validator reasonable warning time for genesis
 GENESIS_DELAY: 300
 
-# Genesis - Merge
-GENESIS_GAS_LIMIT: 30000000
-GENESIS_BASE_FEE_PER_GAS: 0x00ca9a3b00000000000000000000000000000000000000000000000000000000
-
 # Forking
 # ---------------------------------------------------------------
 # Values provided for illustrative purposes.

--- a/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/invalid/multifile_dupFields/config.yaml
+++ b/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/invalid/multifile_dupFields/config.yaml
@@ -17,10 +17,6 @@ GENESIS_FORK_VERSION: 0x00000000
 # 604800 seconds (7 days)
 GENESIS_DELAY: 604800
 
-# Genesis - Merge
-GENESIS_GAS_LIMIT: 30000000
-GENESIS_BASE_FEE_PER_GAS: 0x00ca9a3b00000000000000000000000000000000000000000000000000000000
-
 # Forking
 # ---------------------------------------------------------------
 # Some forks are disabled for now:

--- a/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/standard/mainnet.yaml
+++ b/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/standard/mainnet.yaml
@@ -14,10 +14,6 @@ GENESIS_FORK_VERSION: 0x00000000
 # 604800 seconds (7 days)
 GENESIS_DELAY: 604800
 
-# Genesis - Merge
-GENESIS_GAS_LIMIT: 30000000
-GENESIS_BASE_FEE_PER_GAS: 0x00ca9a3b00000000000000000000000000000000000000000000000000000000
-
 # Forking
 # ---------------------------------------------------------------
 # Some forks are disabled for now:

--- a/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/standard/minimal.yaml
+++ b/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/standard/minimal.yaml
@@ -14,10 +14,6 @@ GENESIS_FORK_VERSION: 0x00000001
 # [customized] Faster to spin up testnets, but does not give validator reasonable warning time for genesis
 GENESIS_DELAY: 300
 
-# Genesis - Merge
-GENESIS_GAS_LIMIT: 30000000
-GENESIS_BASE_FEE_PER_GAS: 0x00ca9a3b00000000000000000000000000000000000000000000000000000000
-
 # Forking
 # ---------------------------------------------------------------
 # Values provided for illustrative purposes.

--- a/teku/src/integration-test/resources/tech/pegasys/teku/cli/subcommand/test-spec.yaml
+++ b/teku/src/integration-test/resources/tech/pegasys/teku/cli/subcommand/test-spec.yaml
@@ -16,10 +16,6 @@ GENESIS_FORK_VERSION: 0x00001020
 # Customized for Prater: 1919188 seconds (Mar-23-2021 02:00:00 PM +UTC)
 GENESIS_DELAY: 1919188
 
-# Genesis - Merge
-GENESIS_GAS_LIMIT: 30000000
-GENESIS_BASE_FEE_PER_GAS: 0x00ca9a3b00000000000000000000000000000000000000000000000000000000
-
 # Forking
 # ---------------------------------------------------------------
 # Some forks are disabled for now:

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/GenesisCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/GenesisCommand.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
@@ -115,8 +116,7 @@ public class GenesisCommand {
         UInt64.ZERO,
         UInt64.valueOf(genesisParams.genesisTime),
         Bytes.EMPTY,
-        Bytes32.rightPad(
-            Bytes.ofUnsignedLong(genesisParams.genesisBaseFee, ByteOrder.LITTLE_ENDIAN)),
+        UInt256.valueOf(genesisParams.genesisBaseFee),
         blockHash,
         Bytes32.ZERO);
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/GenesisCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/GenesisCommand.java
@@ -18,7 +18,6 @@ import static tech.pegasys.teku.infrastructure.logging.SubCommandLogger.SUB_COMM
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.ByteOrder;
 import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/GenesisCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/GenesisCommand.java
@@ -18,7 +18,10 @@ import static tech.pegasys.teku.infrastructure.logging.SubCommandLogger.SUB_COMM
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteOrder;
 import java.util.List;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
@@ -26,11 +29,15 @@ import picocli.CommandLine.Option;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.cli.converter.PicoCliVersionProvider;
 import tech.pegasys.teku.cli.options.MinimalEth2NetworkOptions;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.interop.InteropStartupUtil;
 import tech.pegasys.teku.spec.datastructures.interop.MockStartBeaconStateGenerator;
 import tech.pegasys.teku.spec.datastructures.interop.MockStartValidatorKeyPairFactory;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.ssz.type.Bytes20;
 
 @Command(
     name = "genesis",
@@ -77,7 +84,12 @@ public class GenesisCommand {
           new MockStartValidatorKeyPairFactory().generateKeyPairs(0, genesisParams.validatorCount);
       final BeaconState genesisState =
           InteropStartupUtil.createMockedStartInitialBeaconState(
-              spec, Bytes32.fromHexString(genesisParams.eth1BlockHash), genesisTime, validatorKeys);
+              spec,
+              Bytes32.fromHexString(genesisParams.eth1BlockHash),
+              genesisTime,
+              validatorKeys,
+              Optional.of(createExecutionPayloadHeader(genesisParams)),
+              true);
 
       if (outputToFile) {
         SUB_COMMAND_LOG.storingGenesis(genesisParams.outputFile, false);
@@ -87,6 +99,26 @@ public class GenesisCommand {
         SUB_COMMAND_LOG.storingGenesis(genesisParams.outputFile, true);
       }
     }
+  }
+
+  private ExecutionPayloadHeader createExecutionPayloadHeader(MockGenesisParams genesisParams) {
+    Bytes32 blockHash = Bytes32.fromHexString(genesisParams.eth1BlockHash);
+    return new ExecutionPayloadHeader(
+        Bytes32.ZERO,
+        Bytes20.ZERO,
+        Bytes32.ZERO,
+        Bytes32.ZERO,
+        Bytes.wrap(new byte[SpecConfig.BYTES_PER_LOGS_BLOOM]),
+        blockHash,
+        UInt64.ZERO,
+        UInt64.valueOf(genesisParams.genesisGasLimit),
+        UInt64.ZERO,
+        UInt64.valueOf(genesisParams.genesisTime),
+        Bytes.EMPTY,
+        Bytes32.rightPad(
+            Bytes.ofUnsignedLong(genesisParams.genesisBaseFee, ByteOrder.LITTLE_ENDIAN)),
+        blockHash,
+        Bytes32.ZERO);
   }
 
   public static class MockGenesisParams {
@@ -114,5 +146,17 @@ public class GenesisCommand {
         description = "The Eth1 block hash")
     private String eth1BlockHash =
         MockStartBeaconStateGenerator.INTEROP_ETH1_BLOCK_HASH.toHexString();
+
+    @Option(
+        names = {"--genesis-gas-limit"},
+        paramLabel = "<GAS_LIMIT>",
+        description = "The Merge genesis gas limit")
+    private long genesisGasLimit = 30_000_000;
+
+    @Option(
+        names = {"--genesis-base-fee"},
+        paramLabel = "<FEE>",
+        description = "The Merge genesis base fee per gas")
+    private long genesisBaseFee = 1_000_000_000;
   }
 }

--- a/util/src/main/java/tech/pegasys/teku/util/config/ConstantsReader.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/ConstantsReader.java
@@ -56,8 +56,6 @@ class ConstantsReader {
           "TRANSITION_TOTAL_DIFFICULTY",
           "MIN_ANCHOR_POW_BLOCK_DIFFICULTY",
           "TERMINAL_TOTAL_DIFFICULTY",
-          "GENESIS_GAS_LIMIT",
-          "GENESIS_BASE_FEE_PER_GAS",
           // Phase0 constants which may exist in legacy config files, but should now be ignored
           "BLS_WITHDRAWAL_PREFIX",
           "TARGET_AGGREGATORS_PER_COMMITTEE",

--- a/util/src/main/resources/tech/pegasys/teku/util/config/configs/mainnet.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/configs/mainnet.yaml
@@ -17,10 +17,6 @@ GENESIS_FORK_VERSION: 0x00000000
 # 604800 seconds (7 days)
 GENESIS_DELAY: 604800
 
-# Genesis - Merge
-GENESIS_GAS_LIMIT: 30000000
-GENESIS_BASE_FEE_PER_GAS: 0x00ca9a3b00000000000000000000000000000000000000000000000000000000
-
 # Forking
 # ---------------------------------------------------------------
 # Some forks are disabled for now:

--- a/util/src/main/resources/tech/pegasys/teku/util/config/configs/minimal.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/configs/minimal.yaml
@@ -14,10 +14,6 @@ GENESIS_FORK_VERSION: 0x00000001
 # [customized] Faster to spin up testnets, but does not give validator reasonable warning time for genesis
 GENESIS_DELAY: 300
 
-# Genesis - Merge
-GENESIS_GAS_LIMIT: 30000000
-GENESIS_BASE_FEE_PER_GAS: 0x00ca9a3b00000000000000000000000000000000000000000000000000000000
-
 # Forking
 # ---------------------------------------------------------------
 # Values provided for illustrative purposes.

--- a/util/src/main/resources/tech/pegasys/teku/util/config/configs/prater.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/configs/prater.yaml
@@ -16,10 +16,6 @@ GENESIS_FORK_VERSION: 0x00001020
 # Customized for Prater: 1919188 seconds (Mar-23-2021 02:00:00 PM +UTC)
 GENESIS_DELAY: 1919188
 
-# Genesis - Merge
-GENESIS_GAS_LIMIT: 30000000
-GENESIS_BASE_FEE_PER_GAS: 0x00ca9a3b00000000000000000000000000000000000000000000000000000000
-
 # Forking
 # ---------------------------------------------------------------
 # Some forks are disabled for now:

--- a/util/src/main/resources/tech/pegasys/teku/util/config/configs/pyrmont.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/configs/pyrmont.yaml
@@ -17,10 +17,6 @@ GENESIS_FORK_VERSION: 0x00002009
 # Customized for Pyrmont: 432000 seconds (5 days)
 GENESIS_DELAY: 432000
 
-# Genesis - Merge
-GENESIS_GAS_LIMIT: 30000000
-GENESIS_BASE_FEE_PER_GAS: 0x00ca9a3b00000000000000000000000000000000000000000000000000000000
-
 # Forking
 # ---------------------------------------------------------------
 # Some forks are disabled for now:

--- a/util/src/test/resources/tech/pegasys/teku/util/config/invalid/invalidPresetType.yaml
+++ b/util/src/test/resources/tech/pegasys/teku/util/config/invalid/invalidPresetType.yaml
@@ -14,10 +14,6 @@ GENESIS_FORK_VERSION: 0x00000001
 # [customized] Faster to spin up testnets, but does not give validator reasonable warning time for genesis
 GENESIS_DELAY: 300
 
-# Genesis - Merge
-GENESIS_GAS_LIMIT: 30000000
-GENESIS_BASE_FEE_PER_GAS: 0x00ca9a3b00000000000000000000000000000000000000000000000000000000
-
 # Forking
 # ---------------------------------------------------------------
 # Values provided for illustrative purposes.

--- a/util/src/test/resources/tech/pegasys/teku/util/config/invalid/unknownPreset.yaml
+++ b/util/src/test/resources/tech/pegasys/teku/util/config/invalid/unknownPreset.yaml
@@ -14,10 +14,6 @@ GENESIS_FORK_VERSION: 0x00000001
 # [customized] Faster to spin up testnets, but does not give validator reasonable warning time for genesis
 GENESIS_DELAY: 300
 
-# Genesis - Merge
-GENESIS_GAS_LIMIT: 30000000
-GENESIS_BASE_FEE_PER_GAS: 0x00ca9a3b00000000000000000000000000000000000000000000000000000000
-
 # Forking
 # ---------------------------------------------------------------
 # Values provided for illustrative purposes.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Adopt Spec v1.1.1 changes:
- Remove `GENESIS_GAS_LIMIT` & `GENESIS_BASE_FEE_PER_GAS` constants
- Instead of spec constants provide values via `--genesis-gas-limit` and `--genesis-base-fee` CLI options when generating `genesis mock` 
-  When `Fork` is scheduled for the genesis epoch use same value for `current/previousVersion`
- Upgrade ref tests to 1.1.1

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Part of the #4226 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
