### PR TITLE
Add response type definition for list keys API

### DIFF
--- a/infrastructure/restapi/build.gradle
+++ b/infrastructure/restapi/build.gradle
@@ -17,4 +17,6 @@ dependencies {
   implementation 'it.unimi.dsi:fastutil'
 
   testImplementation testFixtures(project(':infrastructure:async'))
+
+  testFixturesImplementation 'com.fasterxml.jackson.core:jackson-databind'
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApiBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApiBuilder.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.infrastructure.restapi;
 
 import static java.util.Collections.emptyList;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
-import static tech.pegasys.teku.infrastructure.restapi.types.CommonTypeDefinitions.HTTP_ERROR_RESPONSE_TYPE;
+import static tech.pegasys.teku.infrastructure.restapi.types.CoreTypes.HTTP_ERROR_RESPONSE_TYPE;
 
 import io.javalin.Javalin;
 import io.javalin.core.JavalinConfig;

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/CoreTypes.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/CoreTypes.java
@@ -15,15 +15,11 @@ package tech.pegasys.teku.infrastructure.restapi.types;
 
 import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.http.HttpErrorResponse;
+import tech.pegasys.teku.infrastructure.restapi.types.StringBasedPrimitiveTypeDefinition.StringTypeBuilder;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class CommonTypeDefinitions {
-  public static final DeserializableTypeDefinition<String> STRING_TYPE =
-      DeserializableTypeDefinition.string(String.class)
-          .formatter(Function.identity())
-          .parser(Function.identity())
-          .example("value")
-          .build();
+public class CoreTypes {
+  public static final DeserializableTypeDefinition<String> STRING_TYPE = stringBuilder().build();
 
   public static final DeserializableTypeDefinition<UInt64> UINT64_TYPE =
       DeserializableTypeDefinition.string(UInt64.class)
@@ -39,7 +35,18 @@ public class CommonTypeDefinitions {
 
   public static final SerializableTypeDefinition<HttpErrorResponse> HTTP_ERROR_RESPONSE_TYPE =
       SerializableTypeDefinition.object(HttpErrorResponse.class)
+          .name("HttpErrorResponse")
           .withField("status", INTEGER_TYPE, HttpErrorResponse::getStatus)
           .withField("message", STRING_TYPE, HttpErrorResponse::getMessage)
           .build();
+
+  public static DeserializableTypeDefinition<String> string(final String description) {
+    return stringBuilder().description(description).build();
+  }
+
+  private static StringTypeBuilder<String> stringBuilder() {
+    return DeserializableTypeDefinition.string(String.class)
+        .formatter(Function.identity())
+        .parser(Function.identity());
+  }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/DeserializableArrayTypeDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/DeserializableArrayTypeDefinition.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.types;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DeserializableArrayTypeDefinition<T> extends SerializableArrayTypeDefinition<T>
+    implements DeserializableTypeDefinition<List<T>> {
+
+  private final DeserializableTypeDefinition<T> itemType;
+
+  public DeserializableArrayTypeDefinition(final DeserializableTypeDefinition<T> itemType) {
+    super(itemType);
+    this.itemType = itemType;
+  }
+
+  @Override
+  public List<T> deserialize(final JsonParser parser) throws IOException {
+    if (!parser.isExpectedStartArrayToken()) {
+      throw MismatchedInputException.from(
+          parser, (Class<?>) null, "Array expected but got " + parser.getCurrentToken());
+    }
+    final List<T> result = new ArrayList<>();
+    while (parser.nextToken() != JsonToken.END_ARRAY) {
+      result.add(itemType.deserialize(parser));
+    }
+    return result;
+  }
+}

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/DeserializableTypeDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/DeserializableTypeDefinition.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.infrastructure.restapi.types;
 
 import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
+import java.util.List;
 import tech.pegasys.teku.infrastructure.restapi.types.StringBasedPrimitiveTypeDefinition.StringTypeBuilder;
 
 public interface DeserializableTypeDefinition<T> extends SerializableTypeDefinition<T> {
@@ -23,5 +24,10 @@ public interface DeserializableTypeDefinition<T> extends SerializableTypeDefinit
 
   static <T> StringTypeBuilder<T> string(@SuppressWarnings("unused") final Class<T> clazz) {
     return new StringTypeBuilder<>();
+  }
+
+  static <T> DeserializableTypeDefinition<List<T>> listOf(
+      final DeserializableTypeDefinition<T> itemType) {
+    return new DeserializableArrayTypeDefinition<>(itemType);
   }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableArrayTypeDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableArrayTypeDefinition.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.types;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.IOException;
+import java.util.List;
+
+public class SerializableArrayTypeDefinition<T> implements SerializableTypeDefinition<List<T>> {
+  private final SerializableTypeDefinition<T> itemType;
+
+  public SerializableArrayTypeDefinition(final SerializableTypeDefinition<T> itemType) {
+    this.itemType = itemType;
+  }
+
+  @Override
+  public void serialize(final List<T> values, final JsonGenerator gen) throws IOException {
+    gen.writeStartArray();
+    for (T value : values) {
+      itemType.serialize(value, gen);
+    }
+    gen.writeEndArray();
+  }
+
+  @Override
+  public void serializeOpenApiType(final JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField("type", "array");
+    gen.writeFieldName("items");
+    itemType.serializeOpenApiTypeOrReference(gen);
+    gen.writeEndObject();
+  }
+}

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableObjectTypeDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableObjectTypeDefinition.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.types;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+class SerializableObjectTypeDefinition<TObject> implements SerializableTypeDefinition<TObject> {
+
+  private final Optional<String> name;
+  private final Map<String, FieldDefinition<TObject>> fields;
+
+  SerializableObjectTypeDefinition(
+      final Optional<String> name, final Map<String, FieldDefinition<TObject>> fields) {
+    this.name = name;
+    this.fields = fields;
+  }
+
+  @Override
+  public Optional<String> getTypeName() {
+    return name;
+  }
+
+  @Override
+  public void serialize(final TObject value, final JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+    for (FieldDefinition<TObject> field : fields.values()) {
+      field.writeField(value, gen);
+    }
+    gen.writeEndObject();
+  }
+
+  @Override
+  public void serializeOpenApiType(final JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+    if (name.isPresent()) {
+      gen.writeStringField("title", name.get());
+    }
+    gen.writeStringField("type", "object");
+    gen.writeObjectFieldStart("properties");
+    for (FieldDefinition<TObject> field : fields.values()) {
+      field.writeOpenApiField(gen);
+    }
+    gen.writeEndObject();
+    gen.writeEndObject();
+  }
+
+  interface FieldDefinition<TObject> {
+    void writeField(final TObject source, JsonGenerator gen) throws IOException;
+
+    void writeOpenApiField(JsonGenerator gen) throws IOException;
+  }
+}

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableObjectTypeDefinitionBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableObjectTypeDefinitionBuilder.java
@@ -68,6 +68,7 @@ public class SerializableObjectTypeDefinitionBuilder<TObject> {
       this.type = type;
     }
 
+    @Override
     public void writeField(final TObject source, final JsonGenerator gen) throws IOException {
       gen.writeFieldName(name);
       type.serialize(getter.apply(source), gen);
@@ -95,6 +96,7 @@ public class SerializableObjectTypeDefinitionBuilder<TObject> {
       this.type = type;
     }
 
+    @Override
     public void writeField(final TObject source, final JsonGenerator gen) throws IOException {
       final Optional<TField> maybeValue = getter.apply(source);
       if (maybeValue.isPresent()) {

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableObjectTypeDefinitionBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableObjectTypeDefinitionBuilder.java
@@ -17,66 +17,49 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
+import tech.pegasys.teku.infrastructure.restapi.types.SerializableObjectTypeDefinition.FieldDefinition;
 
 public class SerializableObjectTypeDefinitionBuilder<TObject> {
 
-  private final Map<String, ObjectFieldDefinition<TObject, ?>> fields = new LinkedHashMap<>();
+  private final Map<String, FieldDefinition<TObject>> fields = new LinkedHashMap<>();
+  private Optional<String> name = Optional.empty();
 
   SerializableObjectTypeDefinitionBuilder() {}
+
+  public SerializableObjectTypeDefinitionBuilder<TObject> name(final String name) {
+    this.name = Optional.of(name);
+    return this;
+  }
 
   public <TField> SerializableObjectTypeDefinitionBuilder<TObject> withField(
       final String name,
       final SerializableTypeDefinition<TField> type,
       final Function<TObject, TField> getter) {
-    this.fields.put(name, new ObjectFieldDefinition<>(name, getter, type));
+    this.fields.put(name, new RequiredFieldDefinition<>(name, getter, type));
+    return this;
+  }
+
+  public <TField> SerializableObjectTypeDefinitionBuilder<TObject> withOptionalField(
+      final String name,
+      final SerializableTypeDefinition<TField> type,
+      final Function<TObject, Optional<TField>> getter) {
+    this.fields.put(name, new OptionalFieldDefinition<>(name, getter, type));
     return this;
   }
 
   public SerializableTypeDefinition<TObject> build() {
-    return new SerializableObjectTypeDefinition<>(fields);
+    return new SerializableObjectTypeDefinition<>(name, fields);
   }
 
-  private static class SerializableObjectTypeDefinition<TObject>
-      implements SerializableTypeDefinition<TObject> {
-    private final Map<String, ObjectFieldDefinition<TObject, ?>> fields;
-
-    private SerializableObjectTypeDefinition(
-        final Map<String, ObjectFieldDefinition<TObject, ?>> fields) {
-      this.fields = fields;
-    }
-
-    @Override
-    public void serialize(final TObject value, final JsonGenerator gen) throws IOException {
-      gen.writeStartObject();
-      for (ObjectFieldDefinition<TObject, ?> field : fields.values()) {
-        gen.writeFieldName(field.name);
-        field.serialize(value, gen);
-      }
-      gen.writeEndObject();
-    }
-
-    @Override
-    public void serializeOpenApiType(final JsonGenerator gen) throws IOException {
-      gen.writeStartObject();
-      gen.writeStringField("type", "object");
-      gen.writeObjectFieldStart("properties");
-      for (ObjectFieldDefinition<?, ?> field : fields.values()) {
-        gen.writeFieldName(field.name);
-        field.type.serializeOpenApiTypeOrReference(gen);
-      }
-      gen.writeEndObject();
-      gen.writeEndObject();
-    }
-  }
-
-  private static class ObjectFieldDefinition<TObject, TField> {
+  private static class RequiredFieldDefinition<TObject, TField>
+      implements FieldDefinition<TObject> {
     private final String name;
-
     private final Function<TObject, TField> getter;
     private final SerializableTypeDefinition<TField> type;
 
-    private ObjectFieldDefinition(
+    private RequiredFieldDefinition(
         final String name,
         final Function<TObject, TField> getter,
         final SerializableTypeDefinition<TField> type) {
@@ -85,8 +68,45 @@ public class SerializableObjectTypeDefinitionBuilder<TObject> {
       this.type = type;
     }
 
-    public void serialize(final TObject source, final JsonGenerator gen) throws IOException {
+    public void writeField(final TObject source, final JsonGenerator gen) throws IOException {
+      gen.writeFieldName(name);
       type.serialize(getter.apply(source), gen);
+    }
+
+    @Override
+    public void writeOpenApiField(final JsonGenerator gen) throws IOException {
+      gen.writeFieldName(name);
+      type.serializeOpenApiTypeOrReference(gen);
+    }
+  }
+
+  private static class OptionalFieldDefinition<TObject, TField>
+      implements FieldDefinition<TObject> {
+    private final String name;
+    private final Function<TObject, Optional<TField>> getter;
+    private final SerializableTypeDefinition<TField> type;
+
+    private OptionalFieldDefinition(
+        final String name,
+        final Function<TObject, Optional<TField>> getter,
+        final SerializableTypeDefinition<TField> type) {
+      this.name = name;
+      this.getter = getter;
+      this.type = type;
+    }
+
+    public void writeField(final TObject source, final JsonGenerator gen) throws IOException {
+      final Optional<TField> maybeValue = getter.apply(source);
+      if (maybeValue.isPresent()) {
+        gen.writeFieldName(name);
+        type.serialize(maybeValue.get(), gen);
+      }
+    }
+
+    @Override
+    public void writeOpenApiField(final JsonGenerator gen) throws IOException {
+      gen.writeFieldName(name);
+      type.serializeOpenApiTypeOrReference(gen);
     }
   }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableTypeDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableTypeDefinition.java
@@ -15,12 +15,21 @@ package tech.pegasys.teku.infrastructure.restapi.types;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
+import java.util.List;
 
 public interface SerializableTypeDefinition<T> extends OpenApiTypeDefinition {
   void serialize(T value, JsonGenerator gen) throws IOException;
 
   static <T> SerializableObjectTypeDefinitionBuilder<T> object(
       @SuppressWarnings("unused") final Class<T> type) {
+    return object();
+  }
+
+  static <T> SerializableObjectTypeDefinitionBuilder<T> object() {
     return new SerializableObjectTypeDefinitionBuilder<>();
+  }
+
+  static <T> SerializableTypeDefinition<List<T>> listOf(SerializableTypeDefinition<T> itemType) {
+    return new SerializableArrayTypeDefinition<>(itemType);
   }
 }

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/CoreTypesTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/CoreTypesTest.java
@@ -25,27 +25,27 @@ import tech.pegasys.teku.infrastructure.http.HttpErrorResponse;
 import tech.pegasys.teku.infrastructure.restapi.JsonTestUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-class CommonTypeDefinitionsTest {
+class CoreTypesTest {
   @Test
   void uint64_shouldRoundTrip() throws Exception {
-    assertRoundTrip(UInt64.valueOf(200), CommonTypeDefinitions.UINT64_TYPE);
+    assertRoundTrip(UInt64.valueOf(200), CoreTypes.UINT64_TYPE);
   }
 
   @Test
   void string_shouldRoundTrip() throws Exception {
-    assertRoundTrip("some string", CommonTypeDefinitions.STRING_TYPE);
+    assertRoundTrip("some string", CoreTypes.STRING_TYPE);
   }
 
   @Test
   void integer_shouldRoundTrip() throws Exception {
-    assertRoundTrip(458, CommonTypeDefinitions.INTEGER_TYPE);
+    assertRoundTrip(458, CoreTypes.INTEGER_TYPE);
   }
 
   @Test
   void httpErrorResponse_shouldSerialize() throws Exception {
     final HttpErrorResponse value = new HttpErrorResponse(442, "No good");
     final Map<String, Object> result =
-        JsonTestUtil.parse(serialize(value, CommonTypeDefinitions.HTTP_ERROR_RESPONSE_TYPE));
+        JsonTestUtil.parse(serialize(value, CoreTypes.HTTP_ERROR_RESPONSE_TYPE));
 
     assertThat(result).containsOnly(entry("status", 442), entry("message", "No good"));
   }

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/DeserializableArrayTypeDefinitionTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/DeserializableArrayTypeDefinitionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.types;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.restapi.types.CoreTypes.STRING_TYPE;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.restapi.json.JsonUtil;
+
+class DeserializableArrayTypeDefinitionTest {
+
+  private final DeserializableTypeDefinition<List<String>> stringListType =
+      DeserializableTypeDefinition.listOf(STRING_TYPE);
+
+  @Test
+  void shouldRoundTripEmptyList() throws Exception {
+    final List<String> result =
+        JsonUtil.parse(JsonUtil.serialize(emptyList(), stringListType), stringListType);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldRoundTripNonEmptyList() throws Exception {
+    final List<String> value = List.of("x", "y", "z", "x");
+    final List<String> result =
+        JsonUtil.parse(JsonUtil.serialize(value, stringListType), stringListType);
+
+    assertThat(result).isEqualTo(value);
+  }
+}

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableArrayTypeDefinitionTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableArrayTypeDefinitionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.types;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.restapi.types.CoreTypes.STRING_TYPE;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.restapi.JsonTestUtil;
+import tech.pegasys.teku.infrastructure.restapi.json.JsonUtil;
+
+public class SerializableArrayTypeDefinitionTest {
+  private final SerializableTypeDefinition<List<String>> stringListType =
+      SerializableTypeDefinition.listOf(STRING_TYPE);
+
+  @Test
+  void serialize_shouldSerializeEmptyArray() throws Exception {
+    final List<Object> result =
+        JsonTestUtil.parseList(JsonUtil.serialize(emptyList(), stringListType));
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void serialize_shouldSerializeArrayWithValues() throws Exception {
+    final List<Object> result =
+        JsonTestUtil.parseList(JsonUtil.serialize(List.of("a", "b", "c"), stringListType));
+    assertThat(result).containsExactly("a", "b", "c");
+  }
+}

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableObjectTypeDefinitionBuilderTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableObjectTypeDefinitionBuilderTest.java
@@ -15,11 +15,12 @@ package tech.pegasys.teku.infrastructure.restapi.types;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
-import static tech.pegasys.teku.infrastructure.restapi.types.CommonTypeDefinitions.STRING_TYPE;
-import static tech.pegasys.teku.infrastructure.restapi.types.CommonTypeDefinitions.UINT64_TYPE;
+import static tech.pegasys.teku.infrastructure.restapi.types.CoreTypes.STRING_TYPE;
+import static tech.pegasys.teku.infrastructure.restapi.types.CoreTypes.UINT64_TYPE;
 
 import com.google.common.base.MoreObjects;
 import java.util.Objects;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.restapi.JsonTestUtil;
 import tech.pegasys.teku.infrastructure.restapi.json.JsonUtil;
@@ -38,6 +39,62 @@ class SerializableObjectTypeDefinitionBuilderTest {
     final String json = JsonUtil.serialize(new SimpleValue("abc", UInt64.valueOf(300)), type);
     assertThat(JsonTestUtil.parse(json))
         .containsExactly(entry("value1", "abc"), entry("value2", "300"));
+  }
+
+  @Test
+  void shouldNotIncludeOptionalFieldWithValue() throws Exception {
+    final SerializableTypeDefinition<WithOptionalValue> type =
+        SerializableTypeDefinition.object(WithOptionalValue.class)
+            .withOptionalField("optional", STRING_TYPE, WithOptionalValue::getValue)
+            .build();
+
+    final String json = JsonUtil.serialize(new WithOptionalValue(Optional.of("foo")), type);
+    assertThat(JsonTestUtil.parse(json)).containsExactly(entry("optional", "foo"));
+  }
+
+  @Test
+  void shouldNotIncludeOptionalFieldWithNoValue() throws Exception {
+    final SerializableTypeDefinition<WithOptionalValue> type =
+        SerializableTypeDefinition.object(WithOptionalValue.class)
+            .withOptionalField("optional", STRING_TYPE, WithOptionalValue::getValue)
+            .build();
+
+    final String json = JsonUtil.serialize(new WithOptionalValue(Optional.empty()), type);
+    assertThat(JsonTestUtil.parse(json)).isEmpty();
+  }
+
+  private static class WithOptionalValue {
+    private final Optional<String> value;
+
+    private WithOptionalValue(final Optional<String> value) {
+      this.value = value;
+    }
+
+    public Optional<String> getValue() {
+      return value;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final WithOptionalValue that = (WithOptionalValue) o;
+      return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this).add("value", value).toString();
+    }
   }
 
   private static class SimpleValue {

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/StringBasedPrimitiveTypeDefinitionTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/StringBasedPrimitiveTypeDefinitionTest.java
@@ -72,6 +72,22 @@ class StringBasedPrimitiveTypeDefinitionTest {
   }
 
   @Test
+  void serializeOpenApiType_withName() throws Exception {
+    final DeserializableTypeDefinition<String> type =
+        DeserializableTypeDefinition.string(String.class)
+            .name("TestName")
+            .formatter(Function.identity())
+            .parser(Function.identity())
+            .example("ex")
+            .build();
+
+    final Map<String, Object> result = parse(serialize(type::serializeOpenApiType));
+    assertThat(result)
+        .containsOnly(entry("type", "string"), entry("title", "TestName"), entry("example", "ex"));
+    assertThat(type.getTypeName()).contains("TestName");
+  }
+
+  @Test
   void serialize_shouldApplyConverter() throws Exception {
     final DeserializableTypeDefinition<String> type =
         DeserializableTypeDefinition.string(String.class)

--- a/infrastructure/restapi/src/testFixtures/java/tech/pegasys/teku/infrastructure/restapi/JsonTestUtil.java
+++ b/infrastructure/restapi/src/testFixtures/java/tech/pegasys/teku/infrastructure/restapi/JsonTestUtil.java
@@ -17,7 +17,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 public class JsonTestUtil {
@@ -33,6 +35,11 @@ public class JsonTestUtil {
     return current;
   }
 
+  @SuppressWarnings("unchecked")
+  public static <T> List<T> getList(final Map<String, Object> input, final String name) {
+    return (List<T>) input.get(name);
+  }
+
   public static Map<String, Object> parse(final String json) throws Exception {
     return new ObjectMapper()
         .readerFor(
@@ -43,5 +50,13 @@ public class JsonTestUtil {
 
   public static String parseString(final String json) throws Exception {
     return new ObjectMapper().readerFor(String.class).readValue(json);
+  }
+
+  public static List<Object> parseList(final String json) throws Exception {
+    return new ObjectMapper()
+        .readerFor(
+            TypeFactory.defaultInstance()
+                .constructCollectionLikeType(ArrayList.class, Object.class))
+        .readValue(json);
   }
 }

--- a/validator/restapi/build.gradle
+++ b/validator/restapi/build.gradle
@@ -22,5 +22,7 @@ dependencies {
   implementation 'org.webjars:swagger-ui'
 
   testImplementation testFixtures(project(':bls'))
+  testImplementation testFixtures(project(':ethereum:spec'))
+  testImplementation testFixtures(project(':infrastructure:restapi'))
 }
 

--- a/validator/restapi/src/main/java/tech/pegasys/teku/validator/restapi/ValidatorRestApi.java
+++ b/validator/restapi/src/main/java/tech/pegasys/teku/validator/restapi/ValidatorRestApi.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.infrastructure.restapi.RestApiBuilder;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
 
 public class ValidatorRestApi {
+
   public static RestApi create(final ValidatorRestApiConfig config) {
     return new RestApiBuilder()
         .openApiInfo(

--- a/validator/restapi/src/main/java/tech/pegasys/teku/validator/restapi/ValidatorTypes.java
+++ b/validator/restapi/src/main/java/tech/pegasys/teku/validator/restapi/ValidatorTypes.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.restapi;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.tuweni.bytes.Bytes48;
+import tech.pegasys.teku.api.schema.PublicKeyException;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.restapi.types.CoreTypes;
+import tech.pegasys.teku.infrastructure.restapi.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.restapi.types.SerializableTypeDefinition;
+
+public class ValidatorTypes {
+
+  public static DeserializableTypeDefinition<BLSPublicKey> PUBKEY_TYPE =
+      DeserializableTypeDefinition.string(BLSPublicKey.class)
+          .name("PubKey")
+          .formatter(BLSPublicKey::toString)
+          .parser(
+              value -> {
+                try {
+                  return BLSPublicKey.fromBytesCompressedValidate(Bytes48.fromHexString(value));
+                } catch (final IllegalArgumentException e) {
+                  throw new PublicKeyException(
+                      "Public key " + value + " is invalid: " + e.getMessage(), e);
+                }
+              })
+          .pattern("^0x[a-fA-F0-9]{96}$")
+          .example(
+              "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a")
+          .description(
+              "The validator's BLS public key, uniquely identifying them. _48-bytes, hex encoded with 0x prefix, case insensitive._")
+          .build();
+
+  public static SerializableTypeDefinition<BLSPublicKey> VALIDATOR_KEY_TYPE =
+      SerializableTypeDefinition.object(BLSPublicKey.class)
+          .withField("validating_pubkey", PUBKEY_TYPE, Function.identity())
+          .withOptionalField(
+              "derivation_path",
+              CoreTypes.string("The derivation path (if present in the imported keystore)."),
+              __ -> Optional.empty())
+          .build();
+
+  public static SerializableTypeDefinition<List<BLSPublicKey>> LIST_KEYS_RESPONSE_TYPE =
+      SerializableTypeDefinition.<List<BLSPublicKey>>object()
+          .name("ListKeysResponse")
+          .withField(
+              "keys", SerializableTypeDefinition.listOf(VALIDATOR_KEY_TYPE), Function.identity())
+          .build();
+}

--- a/validator/restapi/src/test/java/tech/pegasys/teku/validator/restapi/ValidatorTypesTest.java
+++ b/validator/restapi/src/test/java/tech/pegasys/teku/validator/restapi/ValidatorTypesTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.restapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import com.google.common.io.Resources;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.restapi.JsonTestUtil;
+import tech.pegasys.teku.infrastructure.restapi.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.restapi.types.SerializableTypeDefinition;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class ValidatorTypesTest {
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
+
+  @Test
+  void listKeysResponse_shouldFormatListOfPublicKeys() throws Exception {
+    final List<BLSPublicKey> keys =
+        List.of(
+            dataStructureUtil.randomPublicKey(),
+            dataStructureUtil.randomPublicKey(),
+            dataStructureUtil.randomPublicKey(),
+            dataStructureUtil.randomPublicKey());
+
+    final Map<String, Object> result =
+        JsonTestUtil.parse(JsonUtil.serialize(keys, ValidatorTypes.LIST_KEYS_RESPONSE_TYPE));
+
+    assertThat(result).containsOnlyKeys("keys");
+    final List<Map<String, Object>> keysList = JsonTestUtil.getList(result, "keys");
+    assertThat(keysList).hasSize(keys.size());
+    for (int i = 0; i < keys.size(); i++) {
+      assertThat(keysList.get(i))
+          .containsOnly(entry("validating_pubkey", keys.get(i).toBytesCompressed().toHexString()));
+    }
+  }
+
+  @Test
+  void listKeysResponse_shouldSerializeOpenApi() throws Exception {
+    assertOpenApi(ValidatorTypes.LIST_KEYS_RESPONSE_TYPE, "ListKeysResponse.json");
+  }
+
+  @Test
+  void pubkey_shouldSerializeOpenApi() throws Exception {
+    assertOpenApi(ValidatorTypes.PUBKEY_TYPE, "PubKey.json");
+  }
+
+  private void assertOpenApi(final SerializableTypeDefinition<?> type, final String resourceName)
+      throws Exception {
+    final Map<String, Object> expectedParsed = parseJsonResource(resourceName);
+    final String json = JsonUtil.serialize(type::serializeOpenApiType);
+    final Map<String, Object> result = JsonTestUtil.parse(json);
+    assertThat(result).isEqualTo(expectedParsed);
+  }
+
+  private Map<String, Object> parseJsonResource(final String resourceName) throws Exception {
+    final String expected =
+        Resources.toString(
+            Resources.getResource(ValidatorTypesTest.class, resourceName), StandardCharsets.UTF_8);
+    return JsonTestUtil.parse(expected);
+  }
+}

--- a/validator/restapi/src/test/resources/tech/pegasys/teku/validator/restapi/ListKeysResponse.json
+++ b/validator/restapi/src/test/resources/tech/pegasys/teku/validator/restapi/ListKeysResponse.json
@@ -1,0 +1,21 @@
+{
+  "title": "ListKeysResponse",
+  "type": "object",
+  "properties": {
+    "keys": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "validating_pubkey": {
+            "$ref": "#/components/schemas/PubKey"
+          },
+          "derivation_path": {
+            "type": "string",
+            "description": "The derivation path (if present in the imported keystore)."
+          }
+        }
+      }
+    }
+  }
+}

--- a/validator/restapi/src/test/resources/tech/pegasys/teku/validator/restapi/PubKey.json
+++ b/validator/restapi/src/test/resources/tech/pegasys/teku/validator/restapi/PubKey.json
@@ -1,0 +1,7 @@
+{
+  "title": "PubKey",
+  "type": "string",
+  "pattern": "^0x[a-fA-F0-9]{96}$",
+  "description": "The validator's BLS public key, uniquely identifying them. _48-bytes, hex encoded with 0x prefix, case insensitive._",
+  "example": "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a"
+}


### PR DESCRIPTION
## PR Description
Add the type definitions required for the list keys API response. Includes support for array types and various tweaks to open api doc formatting to match the standard, including supporting custom descriptions on string types.

## Fixed Issue(s)
#4525 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
