### PR TITLE
Add OpenAPI endpoint definition for GetKeys

### DIFF
--- a/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/HttpStatusCodes.java
+++ b/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/HttpStatusCodes.java
@@ -20,6 +20,7 @@ public class HttpStatusCodes {
   public static final int SC_NO_CONTENT = 204;
   public static final int SC_PARTIAL_CONTENT = 206;
   public static final int SC_BAD_REQUEST = 400;
+  public static final int SC_UNAUTHORIZED = 401;
   public static final int SC_FORBIDDEN = 403;
   public static final int SC_NOT_FOUND = 404;
   public static final int SC_PRECONDITION_FAILED = 412;

--- a/infrastructure/restapi/build.gradle
+++ b/infrastructure/restapi/build.gradle
@@ -19,4 +19,5 @@ dependencies {
   testImplementation testFixtures(project(':infrastructure:async'))
 
   testFixturesImplementation 'com.fasterxml.jackson.core:jackson-databind'
+  testFixturesImplementation 'com.google.guava:guava'
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApiBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApiBuilder.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import tech.pegasys.teku.infrastructure.http.HttpErrorResponse;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.restapi.openapi.OpenApiDocBuilder;
 
@@ -87,6 +88,11 @@ public class RestApiBuilder {
 
   public RestApiBuilder openApiInfo(final Consumer<OpenApiDocBuilder> handler) {
     handler.accept(openApiDocBuilder);
+    return this;
+  }
+
+  public RestApiBuilder endpoint(final RestApiEndpoint endpoint) {
+    openApiDocBuilder.endpoint(endpoint);
     return this;
   }
 

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.endpoints;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Collections.emptyMap;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import io.javalin.http.HandlerType;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import tech.pegasys.teku.infrastructure.restapi.openapi.OpenApiResponse;
+import tech.pegasys.teku.infrastructure.restapi.types.SerializableTypeDefinition;
+
+public class EndpointMetadata {
+  private final HandlerType method;
+  private final String path;
+  private final String operationId;
+  private final String summary;
+  private final String description;
+  private final Map<String, OpenApiResponse> responses;
+
+  private EndpointMetadata(
+      final HandlerType method,
+      final String path,
+      final String operationId,
+      final String summary,
+      final String description,
+      final Map<String, OpenApiResponse> responses) {
+    this.method = method;
+    this.path = path;
+    this.operationId = operationId;
+    this.summary = summary;
+    this.description = description;
+    this.responses = responses;
+  }
+
+  public static EndpointMetaDataBuilder get(final String path) {
+    return new EndpointMetaDataBuilder().method(HandlerType.GET).path(path);
+  }
+
+  public HandlerType getMethod() {
+    return method;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void writeOpenApi(final JsonGenerator gen) throws IOException {
+    gen.writeObjectFieldStart(method.name().toLowerCase(Locale.ROOT));
+    gen.writeStringField("operationId", operationId);
+    gen.writeStringField("summary", summary);
+    gen.writeStringField("description", description);
+
+    gen.writeObjectFieldStart("responses");
+    for (Entry<String, OpenApiResponse> responseEntry : responses.entrySet()) {
+      gen.writeFieldName(responseEntry.getKey());
+      responseEntry.getValue().writeOpenApi(gen);
+    }
+    gen.writeEndObject();
+    gen.writeEndObject();
+  }
+
+  public static class EndpointMetaDataBuilder {
+    private HandlerType method;
+    private String path;
+    private String operationId;
+    private String summary;
+    private String description;
+    private final Map<String, OpenApiResponse> responses = new LinkedHashMap<>();
+
+    public EndpointMetaDataBuilder method(final HandlerType method) {
+      this.method = method;
+      return this;
+    }
+
+    public EndpointMetaDataBuilder path(final String path) {
+      this.path = path;
+      return this;
+    }
+
+    public EndpointMetaDataBuilder operationId(final String operationId) {
+      this.operationId = operationId;
+      return this;
+    }
+
+    public EndpointMetaDataBuilder summary(final String summary) {
+      this.summary = summary;
+      return this;
+    }
+
+    public EndpointMetaDataBuilder description(final String description) {
+      this.description = description;
+      return this;
+    }
+
+    public EndpointMetaDataBuilder response(final int responseCode, final String description) {
+      return response(responseCode, description, emptyMap());
+    }
+
+    public EndpointMetaDataBuilder response(
+        final int responseCode,
+        final String description,
+        final SerializableTypeDefinition<?> content) {
+      return response(responseCode, description, Map.of("application/json", content));
+    }
+
+    public EndpointMetaDataBuilder response(
+        final int responseCode,
+        final String description,
+        final Map<String, SerializableTypeDefinition<?>> content) {
+      this.responses.put(Integer.toString(responseCode), new OpenApiResponse(description, content));
+      return this;
+    }
+
+    public EndpointMetadata build() {
+      checkNotNull(method, "method must be specified");
+      checkNotNull(path, "path must be specified");
+      checkNotNull(operationId, "operationId must be specified");
+      checkNotNull(summary, "summary must be specified");
+      checkNotNull(description, "description must be specified");
+      checkState(!responses.isEmpty(), "Must specify at least one response");
+      return new EndpointMetadata(method, path, operationId, summary, description, responses);
+    }
+  }
+}

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiEndpoint.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiEndpoint.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.endpoints;
+
+public class RestApiEndpoint {
+
+  private final EndpointMetadata metadata;
+
+  protected RestApiEndpoint(final EndpointMetadata metadata) {
+    this.metadata = metadata;
+  }
+
+  public EndpointMetadata getMetadata() {
+    return metadata;
+  }
+}

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiDocBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiDocBuilder.java
@@ -17,9 +17,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.javalin.http.HandlerType;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 
 public class OpenApiDocBuilder {
 
@@ -31,6 +37,8 @@ public class OpenApiDocBuilder {
   private String description;
   private String licenseName;
   private String licenseUrl;
+
+  private final Map<String, Map<HandlerType, RestApiEndpoint>> endpoints = new LinkedHashMap<>();
 
   public OpenApiDocBuilder title(final String title) {
     this.title = title;
@@ -53,6 +61,13 @@ public class OpenApiDocBuilder {
     return this;
   }
 
+  public OpenApiDocBuilder endpoint(final RestApiEndpoint endpoint) {
+    this.endpoints
+        .computeIfAbsent(endpoint.getMetadata().getPath(), __ -> new LinkedHashMap<>())
+        .put(endpoint.getMetadata().getMethod(), endpoint);
+    return this;
+  }
+
   public String build() {
     checkNotNull(title, "title must be supplied");
     checkNotNull(version, "version must be supplied");
@@ -61,8 +76,8 @@ public class OpenApiDocBuilder {
 
       gen.writeStartObject();
       gen.writeStringField("openapi", OPENAPI_VERSION);
-      gen.writeFieldName("info");
       writeInfo(gen);
+      writePaths(gen);
       gen.writeEndObject();
 
     } catch (IOException e) {
@@ -72,7 +87,7 @@ public class OpenApiDocBuilder {
   }
 
   private void writeInfo(final JsonGenerator gen) throws IOException {
-    gen.writeStartObject();
+    gen.writeObjectFieldStart("info");
     gen.writeStringField("title", title);
     if (description != null) {
       gen.writeStringField("description", description);
@@ -84,6 +99,19 @@ public class OpenApiDocBuilder {
       gen.writeEndObject();
     }
     gen.writeStringField("version", version);
+    gen.writeEndObject();
+  }
+
+  private void writePaths(final JsonGenerator gen) throws IOException {
+    gen.writeObjectFieldStart("paths");
+    for (final Entry<String, Map<HandlerType, RestApiEndpoint>> pathEntry : endpoints.entrySet()) {
+      gen.writeObjectFieldStart(pathEntry.getKey());
+      for (RestApiEndpoint endpoint : pathEntry.getValue().values()) {
+        final EndpointMetadata metadata = endpoint.getMetadata();
+        metadata.writeOpenApi(gen);
+      }
+      gen.writeEndObject();
+    }
     gen.writeEndObject();
   }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiResponse.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.openapi;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Map.Entry;
+import tech.pegasys.teku.infrastructure.restapi.types.SerializableTypeDefinition;
+
+public class OpenApiResponse {
+  private final String description;
+  private final Map<String, SerializableTypeDefinition<?>> content;
+
+  public OpenApiResponse(
+      final String description, final Map<String, SerializableTypeDefinition<?>> content) {
+    this.description = description;
+    this.content = content;
+  }
+
+  public void writeOpenApi(final JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField("description", description);
+    gen.writeObjectFieldStart("content");
+    for (Entry<String, SerializableTypeDefinition<?>> contentEntry : content.entrySet()) {
+      gen.writeObjectFieldStart(contentEntry.getKey());
+      gen.writeFieldName("schema");
+      contentEntry.getValue().serializeOpenApiTypeOrReference(gen);
+      gen.writeEndObject();
+    }
+
+    gen.writeEndObject();
+    gen.writeEndObject();
+  }
+}

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiDocBuilderTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiDocBuilderTest.java
@@ -21,6 +21,9 @@ import static tech.pegasys.teku.infrastructure.restapi.JsonTestUtil.parse;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
+import tech.pegasys.teku.infrastructure.restapi.types.CoreTypes;
 
 class OpenApiDocBuilderTest {
 
@@ -63,7 +66,87 @@ class OpenApiDocBuilderTest {
     assertThat(getObject(result, "info")).containsEntry("description", "Some description");
   }
 
+  @Test
+  void shouldIncludeSimpleEndpoint() throws Exception {
+    final RestApiEndpoint endpoint =
+        endpoint(
+            EndpointMetadata.get("/test/endpoint")
+                .operationId("myOperationId")
+                .summary("The summary")
+                .description("The description")
+                .response(200, "A simple string", CoreTypes.STRING_TYPE)
+                .build());
+    final Map<String, Object> result = parse(validBuilder().endpoint(endpoint).build());
+    final Map<String, Object> endpointDefinition = getObject(result, "paths", "/test/endpoint");
+    assertThat(endpointDefinition).containsOnlyKeys("get");
+
+    final Map<String, Object> getHandler = getObject(endpointDefinition, "get");
+    assertThat(getHandler).containsOnlyKeys("operationId", "summary", "description", "responses");
+    assertThat(getHandler)
+        .contains(
+            entry("operationId", "myOperationId"),
+            entry("summary", "The summary"),
+            entry("description", "The description"));
+
+    final Map<String, Object> responses = getObject(getHandler, "responses");
+    assertThat(responses).containsOnlyKeys("200");
+    final Map<String, Object> okResponses = getObject(responses, "200");
+    assertThat(okResponses).containsOnlyKeys("description", "content");
+    assertThat(okResponses).containsEntry("description", "A simple string");
+
+    final Map<String, Object> okResponseContent = getObject(okResponses, "content");
+    assertThat(okResponseContent).containsOnlyKeys("application/json");
+    final Map<String, Object> jsonContent = getObject(okResponseContent, "application/json");
+    assertThat(jsonContent).containsOnly(entry("schema", Map.of("type", "string")));
+  }
+
+  @Test
+  void shouldIncludeEndpointWithMultipleResponseTypes() throws Exception {
+    final RestApiEndpoint endpoint =
+        endpoint(
+            EndpointMetadata.get("/test/endpoint")
+                .operationId("myOperationId")
+                .summary("The summary")
+                .description("The description")
+                .response(
+                    200,
+                    "It depends",
+                    Map.of(
+                        "application/json", CoreTypes.STRING_TYPE, "uint", CoreTypes.UINT64_TYPE))
+                .response(404, "Not 'ere gov", CoreTypes.HTTP_ERROR_RESPONSE_TYPE)
+                .build());
+    final Map<String, Object> result = parse(validBuilder().endpoint(endpoint).build());
+    final Map<String, Object> responses =
+        getObject(result, "paths", "/test/endpoint", "get", "responses");
+    assertThat(responses).containsOnlyKeys("200", "404");
+
+    final Map<String, Object> okResponses = getObject(responses, "200");
+    assertThat(okResponses).containsEntry("description", "It depends");
+    final Map<String, Object> okContent = getObject(okResponses, "content");
+    assertThat(okContent).containsOnlyKeys("application/json", "uint");
+    assertThat(getObject(okContent, "application/json", "schema"))
+        .containsOnly(entry("type", "string"));
+    assertThat(getObject(okContent, "uint", "schema")).containsEntry("format", "uint64");
+
+    final Map<String, Object> notFoundResponses = getObject(responses, "404");
+    assertThat(notFoundResponses).containsEntry("description", "Not 'ere gov");
+    final Map<String, Object> notFoundContent = getObject(notFoundResponses, "content");
+    assertThat(notFoundContent).containsOnlyKeys("application/json");
+    assertThat(getObject(notFoundContent, "application/json"))
+        .containsOnly(
+            entry(
+                "schema",
+                Map.of(
+                    "$ref",
+                    "#/components/schemas/"
+                        + CoreTypes.HTTP_ERROR_RESPONSE_TYPE.getTypeName().orElseThrow())));
+  }
+
   private OpenApiDocBuilder validBuilder() {
     return new OpenApiDocBuilder().title("My Title").version("My Version");
+  }
+
+  private RestApiEndpoint endpoint(final EndpointMetadata metadata) {
+    return new RestApiEndpoint(metadata) {};
   }
 }

--- a/infrastructure/restapi/src/testFixtures/java/tech/pegasys/teku/infrastructure/restapi/JsonTestUtil.java
+++ b/infrastructure/restapi/src/testFixtures/java/tech/pegasys/teku/infrastructure/restapi/JsonTestUtil.java
@@ -17,10 +17,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.google.common.io.Resources;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
+import tech.pegasys.teku.infrastructure.restapi.json.JsonUtil;
 
 public class JsonTestUtil {
 
@@ -58,5 +62,22 @@ public class JsonTestUtil {
             TypeFactory.defaultInstance()
                 .constructCollectionLikeType(ArrayList.class, Object.class))
         .readValue(json);
+  }
+
+  public static String serializeEndpointMetadata(final RestApiEndpoint endpoint) throws Exception {
+    return JsonUtil.serialize(
+        gen -> {
+          gen.writeStartObject();
+          endpoint.getMetadata().writeOpenApi(gen);
+          gen.writeEndObject();
+        });
+  }
+
+  public static Map<String, Object> parseJsonResource(
+      final Class<?> contextClass, final String resourceName) throws Exception {
+    final String expected =
+        Resources.toString(
+            Resources.getResource(contextClass, resourceName), StandardCharsets.UTF_8);
+    return JsonTestUtil.parse(expected);
   }
 }

--- a/validator/restapi/src/main/java/tech/pegasys/teku/validator/restapi/ValidatorRestApi.java
+++ b/validator/restapi/src/main/java/tech/pegasys/teku/validator/restapi/ValidatorRestApi.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.infrastructure.http.HttpErrorResponse;
 import tech.pegasys.teku.infrastructure.restapi.RestApi;
 import tech.pegasys.teku.infrastructure.restapi.RestApiBuilder;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
+import tech.pegasys.teku.validator.restapi.apis.GetKeys;
 
 public class ValidatorRestApi {
 
@@ -50,6 +51,7 @@ public class ValidatorRestApi {
         .exceptionHandler(
             BadRequestException.class,
             (throwable, url) -> new HttpErrorResponse(SC_BAD_REQUEST, throwable.getMessage()))
+        .endpoint(new GetKeys())
         .build();
   }
 }

--- a/validator/restapi/src/main/java/tech/pegasys/teku/validator/restapi/apis/GetKeys.java
+++ b/validator/restapi/src/main/java/tech/pegasys/teku/validator/restapi/apis/GetKeys.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.restapi.apis;
+
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_FORBIDDEN;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_UNAUTHORIZED;
+
+import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
+import tech.pegasys.teku.infrastructure.restapi.types.CoreTypes;
+import tech.pegasys.teku.validator.restapi.ValidatorTypes;
+
+public class GetKeys extends RestApiEndpoint {
+
+  public static final String ROUTE = "/eth/v1/keystores";
+
+  public GetKeys() {
+    super(
+        EndpointMetadata.get(ROUTE)
+            .operationId("ListKeys")
+            .summary("List Keys.")
+            .description(
+                "List all validating pubkeys known to and decrypted by this keymanager binary")
+            .response(SC_OK, "Success response", ValidatorTypes.LIST_KEYS_RESPONSE_TYPE)
+            .response(
+                SC_UNAUTHORIZED,
+                "Unauthorized, no token is found",
+                CoreTypes.HTTP_ERROR_RESPONSE_TYPE)
+            .response(
+                SC_FORBIDDEN,
+                "Forbidden, a token is found but is invalid",
+                CoreTypes.HTTP_ERROR_RESPONSE_TYPE)
+            .response(
+                SC_INTERNAL_SERVER_ERROR,
+                "Internal server error",
+                CoreTypes.HTTP_ERROR_RESPONSE_TYPE)
+            .build());
+  }
+}

--- a/validator/restapi/src/test/java/tech/pegasys/teku/validator/restapi/ValidatorTypesTest.java
+++ b/validator/restapi/src/test/java/tech/pegasys/teku/validator/restapi/ValidatorTypesTest.java
@@ -16,8 +16,6 @@ package tech.pegasys.teku.validator.restapi;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
-import com.google.common.io.Resources;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -72,9 +70,6 @@ class ValidatorTypesTest {
   }
 
   private Map<String, Object> parseJsonResource(final String resourceName) throws Exception {
-    final String expected =
-        Resources.toString(
-            Resources.getResource(ValidatorTypesTest.class, resourceName), StandardCharsets.UTF_8);
-    return JsonTestUtil.parse(expected);
+    return JsonTestUtil.parseJsonResource(ValidatorTypesTest.class, resourceName);
   }
 }

--- a/validator/restapi/src/test/java/tech/pegasys/teku/validator/restapi/apis/GetKeysTest.java
+++ b/validator/restapi/src/test/java/tech/pegasys/teku/validator/restapi/apis/GetKeysTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.restapi.apis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.restapi.JsonTestUtil;
+
+class GetKeysTest {
+  @Test
+  void metadata_shouldProduceCorrectOpenApi() throws Exception {
+    final GetKeys endpoint = new GetKeys();
+    final String json = JsonTestUtil.serializeEndpointMetadata(endpoint);
+    final Map<String, Object> result = JsonTestUtil.parse(json);
+
+    final Map<String, Object> expected =
+        JsonTestUtil.parseJsonResource(GetKeysTest.class, "GetKeys.json");
+
+    assertThat(result).isEqualTo(expected);
+  }
+}

--- a/validator/restapi/src/test/resources/tech/pegasys/teku/validator/restapi/apis/GetKeys.json
+++ b/validator/restapi/src/test/resources/tech/pegasys/teku/validator/restapi/apis/GetKeys.json
@@ -1,0 +1,49 @@
+{
+  "get": {
+    "operationId": "ListKeys",
+    "summary": "List Keys.",
+    "description": "List all validating pubkeys known to and decrypted by this keymanager binary",
+    "responses": {
+      "200": {
+        "description": "Success response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ListKeysResponse"
+            }
+          }
+        }
+      },
+      "401": {
+        "description": "Unauthorized, no token is found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "403": {
+        "description": "Forbidden, a token is found but is invalid",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "500": {
+        "description": "Internal server error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## PR Description
Adds the list keys endpoint to OpenApi docs.

Not yet done:
 * Adding endpoint to Javalin so it actually works
 * Including the referenced types in the OpenApi docs.

## Fixed Issue(s)
#4525 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
