### PR TITLE
Include named types in the schemas section of open api docs

### DIFF
--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
@@ -20,11 +20,14 @@ import static java.util.Collections.emptyMap;
 import com.fasterxml.jackson.core.JsonGenerator;
 import io.javalin.http.HandlerType;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import tech.pegasys.teku.infrastructure.restapi.openapi.OpenApiResponse;
+import tech.pegasys.teku.infrastructure.restapi.types.OpenApiTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.types.SerializableTypeDefinition;
 
 public class EndpointMetadata {
@@ -75,6 +78,12 @@ public class EndpointMetadata {
     }
     gen.writeEndObject();
     gen.writeEndObject();
+  }
+
+  public Collection<OpenApiTypeDefinition> getReferencedTypeDefinitions() {
+    return responses.values().stream()
+        .flatMap(response -> response.getReferencedTypeDefinitions().stream())
+        .collect(Collectors.toSet());
   }
 
   public static class EndpointMetaDataBuilder {

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiDocBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiDocBuilder.java
@@ -135,7 +135,7 @@ public class OpenApiDocBuilder {
             .collect(toSet());
     gen.writeObjectFieldStart("schemas");
     for (OpenApiTypeDefinition type : typeDefinitions) {
-      gen.writeFieldName(type.getTypeName().get());
+      gen.writeFieldName(type.getTypeName().orElseThrow());
       type.serializeOpenApiType(gen);
     }
     gen.writeEndObject();

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiResponse.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiResponse.java
@@ -13,10 +13,14 @@
 
 package tech.pegasys.teku.infrastructure.restapi.openapi;
 
+import static java.util.stream.Collectors.toSet;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
+import tech.pegasys.teku.infrastructure.restapi.types.OpenApiTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.types.SerializableTypeDefinition;
 
 public class OpenApiResponse {
@@ -42,5 +46,11 @@ public class OpenApiResponse {
 
     gen.writeEndObject();
     gen.writeEndObject();
+  }
+
+  public Collection<OpenApiTypeDefinition> getReferencedTypeDefinitions() {
+    return content.values().stream()
+        .flatMap(type -> type.getSelfAndReferencedTypeDefinitions().stream())
+        .collect(toSet());
   }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/OpenApiTypeDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/OpenApiTypeDefinition.java
@@ -13,9 +13,14 @@
 
 package tech.pegasys.teku.infrastructure.restapi.types;
 
+import static java.util.stream.Collectors.toSet;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 public interface OpenApiTypeDefinition {
   default Optional<String> getTypeName() {
@@ -23,6 +28,14 @@ public interface OpenApiTypeDefinition {
   }
 
   void serializeOpenApiType(JsonGenerator gen) throws IOException;
+
+  default Collection<OpenApiTypeDefinition> getReferencedTypeDefinitions() {
+    return Collections.emptySet();
+  }
+
+  default Collection<OpenApiTypeDefinition> getSelfAndReferencedTypeDefinitions() {
+    return Stream.concat(Stream.of(this), getReferencedTypeDefinitions().stream()).collect(toSet());
+  }
 
   default void serializeOpenApiTypeOrReference(final JsonGenerator gen) throws IOException {
     if (getTypeName().isPresent()) {

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableArrayTypeDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableArrayTypeDefinition.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.infrastructure.restapi.types;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 
 public class SerializableArrayTypeDefinition<T> implements SerializableTypeDefinition<List<T>> {
@@ -40,5 +41,10 @@ public class SerializableArrayTypeDefinition<T> implements SerializableTypeDefin
     gen.writeFieldName("items");
     itemType.serializeOpenApiTypeOrReference(gen);
     gen.writeEndObject();
+  }
+
+  @Override
+  public Collection<OpenApiTypeDefinition> getReferencedTypeDefinitions() {
+    return itemType.getSelfAndReferencedTypeDefinitions();
   }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableObjectTypeDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableObjectTypeDefinition.java
@@ -13,8 +13,12 @@
 
 package tech.pegasys.teku.infrastructure.restapi.types;
 
+import static java.util.stream.Collectors.toSet;
+
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.base.MoreObjects;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 
@@ -58,9 +62,23 @@ class SerializableObjectTypeDefinition<TObject> implements SerializableTypeDefin
     gen.writeEndObject();
   }
 
+  @Override
+  public Collection<OpenApiTypeDefinition> getReferencedTypeDefinitions() {
+    return fields.values().stream()
+        .flatMap(field -> field.getReferencedTypeDefinitions().stream())
+        .collect(toSet());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("name", name).add("fields", fields).toString();
+  }
+
   interface FieldDefinition<TObject> {
     void writeField(final TObject source, JsonGenerator gen) throws IOException;
 
     void writeOpenApiField(JsonGenerator gen) throws IOException;
+
+    Collection<OpenApiTypeDefinition> getReferencedTypeDefinitions();
   }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableObjectTypeDefinitionBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableObjectTypeDefinitionBuilder.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.infrastructure.restapi.types;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -79,6 +80,11 @@ public class SerializableObjectTypeDefinitionBuilder<TObject> {
       gen.writeFieldName(name);
       type.serializeOpenApiTypeOrReference(gen);
     }
+
+    @Override
+    public Collection<OpenApiTypeDefinition> getReferencedTypeDefinitions() {
+      return type.getSelfAndReferencedTypeDefinitions();
+    }
   }
 
   private static class OptionalFieldDefinition<TObject, TField>
@@ -109,6 +115,11 @@ public class SerializableObjectTypeDefinitionBuilder<TObject> {
     public void writeOpenApiField(final JsonGenerator gen) throws IOException {
       gen.writeFieldName(name);
       type.serializeOpenApiTypeOrReference(gen);
+    }
+
+    @Override
+    public Collection<OpenApiTypeDefinition> getReferencedTypeDefinitions() {
+      return type.getSelfAndReferencedTypeDefinitions();
     }
   }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/StringBasedPrimitiveTypeDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/StringBasedPrimitiveTypeDefinition.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.google.common.base.MoreObjects;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Function;
@@ -83,6 +84,17 @@ public class StringBasedPrimitiveTypeDefinition<T> implements DeserializableType
       gen.writeStringField("format", format.get());
     }
     gen.writeEndObject();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .add("description", description)
+        .add("example", example)
+        .add("format", format)
+        .add("pattern", pattern)
+        .toString();
   }
 
   public static class StringTypeBuilder<T> {

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadataTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadataTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.endpoints;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.javalin.http.HandlerType;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata.EndpointMetaDataBuilder;
+import tech.pegasys.teku.infrastructure.restapi.types.CoreTypes;
+import tech.pegasys.teku.infrastructure.restapi.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.restapi.types.SerializableTypeDefinition;
+
+class EndpointMetadataTest {
+  @Test
+  void shouldGetAllReferencedTypeDefinitions() {
+    final DeserializableTypeDefinition<String> describedStringType =
+        CoreTypes.string("describedString");
+    final SerializableTypeDefinition<String> objectType1 =
+        SerializableTypeDefinition.object(String.class).name("Test1").build();
+    final SerializableTypeDefinition<String> objectType2 =
+        SerializableTypeDefinition.object(String.class).name("Test2").build();
+    final SerializableTypeDefinition<String> objectType3 =
+        SerializableTypeDefinition.object(String.class)
+            .name("Test4")
+            .withField("type3", objectType2, __ -> null)
+            .build();
+    final EndpointMetadata metadata =
+        new EndpointMetaDataBuilder()
+            .method(HandlerType.GET)
+            .path("/foo")
+            .summary("foo")
+            .description("foo")
+            .operationId("foo")
+            .response(200, "foo", CoreTypes.HTTP_ERROR_RESPONSE_TYPE)
+            .response(404, "foo", describedStringType)
+            .response(
+                500,
+                "foo",
+                Map.of(
+                    "application/json", objectType1,
+                    "application/ssz", objectType3))
+            .build();
+
+    assertThat(metadata.getReferencedTypeDefinitions())
+        .containsExactlyInAnyOrder(
+            describedStringType,
+            objectType1,
+            objectType2,
+            objectType3,
+            CoreTypes.HTTP_ERROR_RESPONSE_TYPE,
+            CoreTypes.STRING_TYPE,
+            CoreTypes.INTEGER_TYPE);
+  }
+}

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiDocBuilderTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiDocBuilderTest.java
@@ -21,8 +21,10 @@ import static tech.pegasys.teku.infrastructure.restapi.JsonTestUtil.parse;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.restapi.JsonTestUtil;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
+import tech.pegasys.teku.infrastructure.restapi.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.restapi.types.CoreTypes;
 
 class OpenApiDocBuilderTest {
@@ -140,6 +142,15 @@ class OpenApiDocBuilderTest {
                     "$ref",
                     "#/components/schemas/"
                         + CoreTypes.HTTP_ERROR_RESPONSE_TYPE.getTypeName().orElseThrow())));
+
+    // Should include referenced types as schemas
+    final Map<String, Object> schemas = getObject(result, "components", "schemas");
+    assertThat(schemas).containsOnlyKeys("HttpErrorResponse");
+    // Full type should be serialized in schemas
+    assertThat(getObject(schemas, "HttpErrorResponse"))
+        .isEqualTo(
+            JsonTestUtil.parse(
+                JsonUtil.serialize(CoreTypes.HTTP_ERROR_RESPONSE_TYPE::serializeOpenApiType)));
   }
 
   private OpenApiDocBuilder validBuilder() {

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableArrayTypeDefinitionTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableArrayTypeDefinitionTest.java
@@ -39,4 +39,18 @@ public class SerializableArrayTypeDefinitionTest {
         JsonTestUtil.parseList(JsonUtil.serialize(List.of("a", "b", "c"), stringListType));
     assertThat(result).containsExactly("a", "b", "c");
   }
+
+  @Test
+  void shouldGetReferencedTypesRecursively() {
+    final SerializableTypeDefinition<String> type1 =
+        SerializableTypeDefinition.object(String.class).name("Type1").build();
+    final SerializableTypeDefinition<String> type2 =
+        SerializableTypeDefinition.object(String.class)
+            .name("Type2")
+            .withField("type1", type1, __ -> null)
+            .build();
+
+    assertThat(SerializableTypeDefinition.listOf(type2).getReferencedTypeDefinitions())
+        .containsExactlyInAnyOrder(type1, type2);
+  }
 }

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableObjectTypeDefinitionBuilderTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/SerializableObjectTypeDefinitionBuilderTest.java
@@ -63,6 +63,24 @@ class SerializableObjectTypeDefinitionBuilderTest {
     assertThat(JsonTestUtil.parse(json)).isEmpty();
   }
 
+  @Test
+  void shouldGetReferencedTypesRecursively() {
+    final SerializableTypeDefinition<String> type1 =
+        SerializableTypeDefinition.object(String.class).name("Type1").build();
+    final SerializableTypeDefinition<String> type2 =
+        SerializableTypeDefinition.object(String.class)
+            .name("Type2")
+            .withField("type1", type1, __ -> null)
+            .build();
+    final SerializableTypeDefinition<String> type3 =
+        SerializableTypeDefinition.object(String.class)
+            .name("Type3")
+            .withField("type2", type2, __ -> null)
+            .build();
+
+    assertThat(type3.getReferencedTypeDefinitions()).containsExactlyInAnyOrder(type1, type2);
+  }
+
   private static class WithOptionalValue {
     private final Optional<String> value;
 


### PR DESCRIPTION
## PR Description
Recursively find named type definitions and include them in the components/schemas section of the open api doc since they are included by reference inline.

## Fixed Issue(s)
#4525 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
