### PR TITLE
feat(task-queue): updating task queue metrics to use labelled gauge

### DIFF
--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/CachingTaskQueue.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/CachingTaskQueue.java
@@ -26,6 +26,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -87,21 +88,15 @@ public class CachingTaskQueue<K, V> {
   }
 
   public void startMetrics() {
-    metricsSystem.createIntegerGauge(
-        TekuMetricCategory.STORAGE,
-        metricsPrefix + "_tasks_requested",
-        "Number of tasks requested but not yet completed",
-        pendingTasks::size);
-    metricsSystem.createIntegerGauge(
-        TekuMetricCategory.STORAGE,
-        metricsPrefix + "_tasks_active",
-        "Number of tasks actively being processed",
-        activeTasks::get);
-    metricsSystem.createIntegerGauge(
-        TekuMetricCategory.STORAGE,
-        metricsPrefix + "_tasks_queued",
-        "Number of tasks queued for later processing",
-        queuedTasks::size);
+    final LabelledGauge taskQueueMetrics =
+        metricsSystem.createLabelledGauge(
+            TekuMetricCategory.STORAGE,
+            metricsPrefix + "_tasks",
+            "Labelled task queue metrics",
+            "status");
+    taskQueueMetrics.labels(pendingTasks::size, "requested");
+    taskQueueMetrics.labels(activeTasks::get, "active");
+    taskQueueMetrics.labels(queuedTasks::size, "queued");
     metricsSystem.createIntegerGauge(
         TekuMetricCategory.STORAGE,
         metricsPrefix + "_cache_size",

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/CachingTaskQueueTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/CachingTaskQueueTest.java
@@ -307,8 +307,7 @@ class CachingTaskQueueTest {
         metricsSystem
             .getLabelledGauge(TekuMetricCategory.STORAGE, METRICS_PREFIX + "_tasks")
             .getValue("requested");
-    final double value = optionalValue.orElseThrow();
-    assertThat(value).isEqualTo(expectedCount);
+    assertThat(optionalValue).hasValue(expectedCount);
   }
 
   private void assertActiveTaskCount(final int expectedCount) {
@@ -316,8 +315,7 @@ class CachingTaskQueueTest {
         metricsSystem
             .getLabelledGauge(TekuMetricCategory.STORAGE, METRICS_PREFIX + "_tasks")
             .getValue("active");
-    final double value = optionalValue.orElseThrow();
-    assertThat(value).isEqualTo(expectedCount);
+    assertThat(optionalValue).hasValue(expectedCount);
   }
 
   private void assertQueuedTaskCount(final int expectedCount) {
@@ -325,8 +323,7 @@ class CachingTaskQueueTest {
         metricsSystem
             .getLabelledGauge(TekuMetricCategory.STORAGE, METRICS_PREFIX + "_tasks")
             .getValue("queued");
-    final double value = optionalValue.orElseThrow();
-    assertThat(value).isEqualTo(expectedCount);
+    assertThat(optionalValue).hasValue(expectedCount);
   }
 
   public static class StubTask implements CacheableTask<Integer, String> {


### PR DESCRIPTION
## PR Description

1. Updated task queue metrics to use a labelled gauge in place of individual gauges
2. Affected metrics `storage_memory_states_tasks_requested`, `storage_memory_states_tasks_active`, `storage_memory_states_tasks_queued`, `storage_memory_checkpoint_states_tasks_requested`, `storage_memory_checkpoint_states_tasks_active` and `storage_memory_checkpoint_states_tasks_queued`
3. Updated metric names `storage_memory_states_tasks` and `storage_memory_checkpoint_states_tasks` with label `status` (`requested`/`active`/`queued`)
4. Contains UT

## Fixed Issue(s)
1. Closes #4465

## Documentation

## Changelog
