### PR TITLE
Support responding to simple requests in validator api

### DIFF
--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApiBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApiBuilder.java
@@ -48,7 +48,7 @@ public class RestApiBuilder {
   private List<String> hostAllowlist = emptyList();
   private final Map<Class<? extends Exception>, RestApiExceptionHandler<?>> exceptionHandlers =
       new HashMap<>();
-  private List<RestApiEndpoint> endpoints = new ArrayList<>();
+  private final List<RestApiEndpoint> endpoints = new ArrayList<>();
 
   private final OpenApiDocBuilder openApiDocBuilder = new OpenApiDocBuilder();
   private boolean openApiDocsEnabled = false;

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApiBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApiBuilder.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.infrastructure.restapi.types.CoreTypes.HTTP_ERRO
 import io.javalin.Javalin;
 import io.javalin.core.JavalinConfig;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,7 @@ import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import tech.pegasys.teku.infrastructure.http.HttpErrorResponse;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.JavalinEndpointAdapter;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.restapi.openapi.OpenApiDocBuilder;
@@ -46,6 +48,7 @@ public class RestApiBuilder {
   private List<String> hostAllowlist = emptyList();
   private final Map<Class<? extends Exception>, RestApiExceptionHandler<?>> exceptionHandlers =
       new HashMap<>();
+  private List<RestApiEndpoint> endpoints = new ArrayList<>();
 
   private final OpenApiDocBuilder openApiDocBuilder = new OpenApiDocBuilder();
   private boolean openApiDocsEnabled = false;
@@ -92,7 +95,8 @@ public class RestApiBuilder {
   }
 
   public RestApiBuilder endpoint(final RestApiEndpoint endpoint) {
-    openApiDocBuilder.endpoint(endpoint);
+    this.openApiDocBuilder.endpoint(endpoint);
+    this.endpoints.add(endpoint);
     return this;
   }
 
@@ -109,6 +113,8 @@ public class RestApiBuilder {
     if (!hostAllowlist.isEmpty()) {
       app.before(new HostAllowlistHandler(hostAllowlist));
     }
+
+    endpoints.forEach(endpoint -> JavalinEndpointAdapter.addEndpoint(app, endpoint));
 
     addExceptionHandlers(app);
 

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.infrastructure.restapi.endpoints;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Collections.emptyMap;
+import static tech.pegasys.teku.infrastructure.restapi.json.JsonUtil.JSON_CONTENT_TYPE;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import io.javalin.http.HandlerType;
@@ -63,6 +64,17 @@ public class EndpointMetadata {
 
   public String getPath() {
     return path;
+  }
+
+  public SerializableTypeDefinition<?> getResponseType(
+      final int statusCode, final String contentType) {
+    final OpenApiResponse response = responses.get(Integer.toString(statusCode));
+    checkNotNull(response, "Unexpected response for status code %s", statusCode);
+
+    final SerializableTypeDefinition<?> responseType = response.getType(contentType);
+    checkNotNull(
+        responseType, "Unexpected content type %s for status code %s", contentType, statusCode);
+    return responseType;
   }
 
   public void writeOpenApi(final JsonGenerator gen) throws IOException {
@@ -127,7 +139,7 @@ public class EndpointMetadata {
         final int responseCode,
         final String description,
         final SerializableTypeDefinition<?> content) {
-      return response(responseCode, description, Map.of("application/json", content));
+      return response(responseCode, description, Map.of(JSON_CONTENT_TYPE, content));
     }
 
     public EndpointMetaDataBuilder response(

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.infrastructure.restapi.endpoints;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Collections.emptyMap;
@@ -69,11 +70,14 @@ public class EndpointMetadata {
   public SerializableTypeDefinition<?> getResponseType(
       final int statusCode, final String contentType) {
     final OpenApiResponse response = responses.get(Integer.toString(statusCode));
-    checkNotNull(response, "Unexpected response for status code %s", statusCode);
+    checkArgument(response != null, "Unexpected response for status code %s", statusCode);
 
     final SerializableTypeDefinition<?> responseType = response.getType(contentType);
-    checkNotNull(
-        responseType, "Unexpected content type %s for status code %s", contentType, statusCode);
+    checkArgument(
+        responseType != null,
+        "Unexpected content type %s for status code %s",
+        contentType,
+        statusCode);
     return responseType;
   }
 

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/JavalinEndpointAdapter.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/JavalinEndpointAdapter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.endpoints;
+
+import io.javalin.Javalin;
+import io.javalin.http.Context;
+import io.javalin.http.Handler;
+
+public class JavalinEndpointAdapter implements Handler {
+
+  private final RestApiEndpoint endpoint;
+
+  private JavalinEndpointAdapter(final RestApiEndpoint endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public static void addEndpoint(final Javalin app, final RestApiEndpoint endpoint) {
+    final EndpointMetadata metadata = endpoint.getMetadata();
+    app.addHandler(metadata.getMethod(), metadata.getPath(), new JavalinEndpointAdapter(endpoint));
+  }
+
+  @Override
+  public void handle(final Context ctx) throws Exception {
+    final RestApiRequest request = new RestApiRequest(ctx, endpoint.getMetadata());
+    endpoint.handle(request);
+  }
+}

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiEndpoint.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiEndpoint.java
@@ -13,7 +13,9 @@
 
 package tech.pegasys.teku.infrastructure.restapi.endpoints;
 
-public class RestApiEndpoint {
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public abstract class RestApiEndpoint {
 
   private final EndpointMetadata metadata;
 
@@ -24,4 +26,6 @@ public class RestApiEndpoint {
   public EndpointMetadata getMetadata() {
     return metadata;
   }
+
+  public abstract void handle(RestApiRequest request) throws JsonProcessingException;
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
@@ -43,8 +43,7 @@ public class RestApiRequest {
   @SuppressWarnings({"rawtypes", "unchecked"})
   private void respond(final int statusCode, final String contentType, final Object response)
       throws JsonProcessingException {
-    context.status(statusCode);
     final SerializableTypeDefinition type = metadata.getResponseType(statusCode, contentType);
-    context.result(JsonUtil.serialize(response, type));
+    context.status(statusCode).result(JsonUtil.serialize(response, type));
   }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.endpoints;
+
+import static tech.pegasys.teku.infrastructure.restapi.json.JsonUtil.JSON_CONTENT_TYPE;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.javalin.http.Context;
+import tech.pegasys.teku.infrastructure.http.HttpErrorResponse;
+import tech.pegasys.teku.infrastructure.http.HttpStatusCodes;
+import tech.pegasys.teku.infrastructure.restapi.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.restapi.types.SerializableTypeDefinition;
+
+public class RestApiRequest {
+  private final Context context;
+  private final EndpointMetadata metadata;
+
+  public RestApiRequest(final Context context, final EndpointMetadata metadata) {
+    this.context = context;
+    this.metadata = metadata;
+  }
+
+  public void respondOk(final Object response) throws JsonProcessingException {
+    respond(HttpStatusCodes.SC_OK, JSON_CONTENT_TYPE, response);
+  }
+
+  public void respondError(final int statusCode, final String message)
+      throws JsonProcessingException {
+    respond(statusCode, JSON_CONTENT_TYPE, new HttpErrorResponse(statusCode, message));
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private void respond(final int statusCode, final String contentType, final Object response)
+      throws JsonProcessingException {
+    context.status(statusCode);
+    final SerializableTypeDefinition type = metadata.getResponseType(statusCode, contentType);
+    context.result(JsonUtil.serialize(response, type));
+  }
+}

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/json/JsonUtil.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/json/JsonUtil.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.infrastructure.restapi.types.DeserializableTypeDefiniti
 import tech.pegasys.teku.infrastructure.restapi.types.SerializableTypeDefinition;
 
 public class JsonUtil {
+  public static final String JSON_CONTENT_TYPE = "application/json";
 
   public static final JsonFactory FACTORY = new JsonFactory();
 

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiResponse.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiResponse.java
@@ -33,6 +33,10 @@ public class OpenApiResponse {
     this.content = content;
   }
 
+  public SerializableTypeDefinition<?> getType(final String contentType) {
+    return content.get(contentType);
+  }
+
   public void writeOpenApi(final JsonGenerator gen) throws IOException {
     gen.writeStartObject();
     gen.writeStringField("description", description);

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiDocBuilderTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiDocBuilderTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.restapi.JsonTestUtil;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.infrastructure.restapi.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.restapi.types.CoreTypes;
 
@@ -158,6 +159,9 @@ class OpenApiDocBuilderTest {
   }
 
   private RestApiEndpoint endpoint(final EndpointMetadata metadata) {
-    return new RestApiEndpoint(metadata) {};
+    return new RestApiEndpoint(metadata) {
+      @Override
+      public void handle(final RestApiRequest request) {}
+    };
   }
 }

--- a/validator/restapi/src/main/java/tech/pegasys/teku/validator/restapi/ValidatorTypes.java
+++ b/validator/restapi/src/main/java/tech/pegasys/teku/validator/restapi/ValidatorTypes.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.validator.restapi;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes48;
 import tech.pegasys.teku.api.schema.PublicKeyException;
@@ -48,10 +47,10 @@ public class ValidatorTypes {
   public static SerializableTypeDefinition<BLSPublicKey> VALIDATOR_KEY_TYPE =
       SerializableTypeDefinition.object(BLSPublicKey.class)
           .withField("validating_pubkey", PUBKEY_TYPE, Function.identity())
-          .withOptionalField(
+          .withField(
               "derivation_path",
               CoreTypes.string("The derivation path (if present in the imported keystore)."),
-              __ -> Optional.empty())
+              __ -> null)
           .build();
 
   public static SerializableTypeDefinition<List<BLSPublicKey>> LIST_KEYS_RESPONSE_TYPE =

--- a/validator/restapi/src/main/java/tech/pegasys/teku/validator/restapi/apis/GetKeys.java
+++ b/validator/restapi/src/main/java/tech/pegasys/teku/validator/restapi/apis/GetKeys.java
@@ -18,8 +18,10 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_UNAUTHORIZED;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.infrastructure.restapi.types.CoreTypes;
 import tech.pegasys.teku.validator.restapi.ValidatorTypes;
 
@@ -48,5 +50,10 @@ public class GetKeys extends RestApiEndpoint {
                 "Internal server error",
                 CoreTypes.HTTP_ERROR_RESPONSE_TYPE)
             .build());
+  }
+
+  @Override
+  public void handle(final RestApiRequest request) throws JsonProcessingException {
+    request.respondError(SC_INTERNAL_SERVER_ERROR, "Not implemented");
   }
 }

--- a/validator/restapi/src/test/java/tech/pegasys/teku/validator/restapi/ValidatorTypesTest.java
+++ b/validator/restapi/src/test/java/tech/pegasys/teku/validator/restapi/ValidatorTypesTest.java
@@ -47,7 +47,9 @@ class ValidatorTypesTest {
     assertThat(keysList).hasSize(keys.size());
     for (int i = 0; i < keys.size(); i++) {
       assertThat(keysList.get(i))
-          .containsOnly(entry("validating_pubkey", keys.get(i).toBytesCompressed().toHexString()));
+          .containsOnly(
+              entry("validating_pubkey", keys.get(i).toBytesCompressed().toHexString()),
+              entry("derivation_path", null));
     }
   }
 

--- a/validator/restapi/src/test/java/tech/pegasys/teku/validator/restapi/apis/GetKeysTest.java
+++ b/validator/restapi/src/test/java/tech/pegasys/teku/validator/restapi/apis/GetKeysTest.java
@@ -14,10 +14,14 @@
 package tech.pegasys.teku.validator.restapi.apis;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.restapi.JsonTestUtil;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 
 class GetKeysTest {
   @Test
@@ -30,5 +34,14 @@ class GetKeysTest {
         JsonTestUtil.parseJsonResource(GetKeysTest.class, "GetKeys.json");
 
     assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldBeNotImplemented() throws Exception {
+    final GetKeys endpoint = new GetKeys();
+    final RestApiRequest request = mock(RestApiRequest.class);
+    endpoint.handle(request);
+
+    verify(request).respondError(SC_INTERNAL_SERVER_ERROR, "Not implemented");
   }
 }


### PR DESCRIPTION
## PR Description
Adds endpoints as handlers in javelin and supports returning OK and error responses.

## Fixed Issue(s)
#4525 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
