### PR TITLE
Test SpecContext provider

### DIFF
--- a/ethereum/spec/build.gradle
+++ b/ethereum/spec/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     testFixturesImplementation testFixtures(project(':bls'))
     testFixturesImplementation project(':infrastructure:io')
     testFixturesImplementation 'org.apache.tuweni:tuweni-units'
+    testFixturesImplementation 'org.junit.jupiter:junit-jupiter-api'
 
     testFixturesApi project(':ethereum:pow:api')
     testFixturesApi 'com.google.guava:guava'

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecContext.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecContext.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(TestSpecInvocationContextProvider.class)
+public @interface TestSpecContext {
+
+  SpecMilestone[] milestone() default SpecMilestone.PHASE0;
+
+  Eth2Network[] network() default Eth2Network.MINIMAL;
+
+  boolean allMilestones() default false;
+
+  boolean allNetworks() default false;
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -110,6 +110,19 @@ public class TestSpecFactory {
     return create(config, SpecMilestone.MERGE);
   }
 
+  public static Spec create(final SpecMilestone specMilestone, final Eth2Network network) {
+    switch (specMilestone) {
+      case PHASE0:
+        return create(SpecConfigLoader.loadConfig(network.configName()), specMilestone);
+      case ALTAIR:
+        return create(getAltairSpecConfig(network), specMilestone);
+      case MERGE:
+        return create(getMergeSpecConfig(network), specMilestone);
+      default:
+        throw new IllegalStateException("unsupported milestone");
+    }
+  }
+
   private static Spec create(
       final SpecConfig config, final SpecMilestone highestSupportedMilestone) {
     return Spec.create(config, highestSupportedMilestone);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecInvocationContextProvider.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecInvocationContextProvider.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class TestSpecInvocationContextProvider implements TestTemplateInvocationContextProvider {
+
+  @Override
+  public boolean supportsTestTemplate(ExtensionContext extensionContext) {
+    return true;
+  }
+
+  @Override
+  public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+      ExtensionContext extensionContext) {
+
+    Class<?> clazz = extensionContext.getRequiredTestClass();
+    TestSpecContext testSpecContext = clazz.getAnnotation(TestSpecContext.class);
+
+    Set<SpecMilestone> milestones;
+    Set<Eth2Network> networks;
+
+    if (testSpecContext.allMilestones()) {
+      milestones = Set.of(SpecMilestone.values());
+    } else {
+      milestones = Set.of(testSpecContext.milestone());
+    }
+
+    if (testSpecContext.allNetworks()) {
+      networks = Set.of(Eth2Network.values());
+    } else {
+      networks = Set.of(testSpecContext.network());
+    }
+
+    List<TestTemplateInvocationContext> invocations = new ArrayList<>();
+
+    milestones.forEach(
+        specMilestone -> {
+          networks.forEach(
+              eth2Network -> {
+                invocations.add(generateContext(new SpecContext(specMilestone, eth2Network)));
+              });
+        });
+
+    return invocations.stream();
+  }
+
+  private TestTemplateInvocationContext generateContext(SpecContext specContext) {
+    return new TestTemplateInvocationContext() {
+      @Override
+      public String getDisplayName(int invocationIndex) {
+        return specContext.getDisplayName();
+      }
+
+      @Override
+      public List<Extension> getAdditionalExtensions() {
+        return List.of(new SpecContextParameterResolver<>(specContext));
+      }
+    };
+  }
+
+  public static class SpecContext {
+    private final String displayName;
+    private final Spec spec;
+    private final DataStructureUtil dataStructureUtil;
+
+    private final SpecMilestone specMilestone;
+    private final Eth2Network network;
+
+    SpecContext(SpecMilestone specMilestone, Eth2Network network) {
+      this.spec = TestSpecFactory.create(specMilestone, network);
+      this.dataStructureUtil = new DataStructureUtil(spec);
+      this.displayName = specMilestone.name() + ' ' + network.name();
+
+      this.specMilestone = specMilestone;
+      this.network = network;
+    }
+
+    public String getDisplayName() {
+      return displayName;
+    }
+
+    public Spec getSpec() {
+      return spec;
+    }
+
+    public DataStructureUtil getDataStructureUtil() {
+      return dataStructureUtil;
+    }
+
+    public SpecMilestone getSpecMilestone() {
+      return specMilestone;
+    }
+
+    public Eth2Network getNetwork() {
+      return network;
+    }
+  }
+
+  public static class SpecContextParameterResolver<T> implements ParameterResolver {
+    T data;
+
+    public SpecContextParameterResolver(T data) {
+      this.data = data;
+    }
+
+    @Override
+    public boolean supportsParameter(
+        ParameterContext parameterContext, ExtensionContext extensionContext)
+        throws ParameterResolutionException {
+      return parameterContext.getParameter().getType().isInstance(data);
+    }
+
+    @Override
+    public Object resolveParameter(
+        ParameterContext parameterContext, ExtensionContext extensionContext)
+        throws ParameterResolutionException {
+      return data;
+    }
+  }
+
+  public static class SpecContextExecutionHelper {
+    public static void skip(SpecContext specContext, SpecMilestone... milestones) {
+      Assumptions.assumeFalse(
+          List.of(milestones).contains(specContext.getSpecMilestone()), "Milestone skipped");
+    }
+
+    public static void only(SpecContext specContext, SpecMilestone... milestones) {
+      Assumptions.assumeTrue(
+          List.of(milestones).contains(specContext.getSpecMilestone()), "Milestone skipped");
+    }
+
+    public static void skip(SpecContext specContext, Eth2Network... networks) {
+      Assumptions.assumeFalse(
+          List.of(networks).contains(specContext.getNetwork()), "Network skipped");
+    }
+
+    public static void only(SpecContext specContext, Eth2Network... networks) {
+      Assumptions.assumeTrue(
+          List.of(networks).contains(specContext.getNetwork()), "Network skipped");
+    }
+  }
+}


### PR DESCRIPTION
## PR Description

related to #4504

Introduces a convenient way to run systematic unit tests on all possible combination of `SpecMilestone` and\or `Eth2Network`


### minimal example
```Java
import tech.pegasys.teku.spec.TestSpecContext;
import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;

@TestSpecContext(allMilestones = true)
public class ExampleTest {

  @TestTemplate
  void shouldDo(SpecContext specContext) {
     final Spec spec = specContext.getSpec();
    final DataStructureUtil dataStructureUtil = specContext.getDataStructureUtil();
   // do test
 }
}
```

### `TestSpecContext` examples options:
```Java
// run for all milestones on default network (MINIMAL)
@TestSpecContext(allMilestones = true)
public class ExampleTest {
...

// run for all networks on default milestone (PHASE0)
@TestSpecContext(allNetworks = true)
public class ExampleTest {
...

// run for all combinations of MERGE\ALTAIR and MAINNET\MINIMAL
@TestSpecContext(
    milestone = {SpecMilestone.MERGE, SpecMilestone.ALTAIR},
    network = {Eth2Network.MAINNET, Eth2Network.MINIMAL})
public class ExampleTest {
...

// run for all combinations
@TestSpecContext(allMilestones = true, allNetworks = true)
public class ExampleTest {
...
```

### usage in combination with `@BeforeEach`
```Java
@TestSpecContext(allMilestones = true)
public class ExampleTest {

  private Spec spec;
  private DataStructureUtil dataStructureUtil;

  @BeforeEach
  @TestTemplate
  public void setup(SpecContext specContext) {
    spec = specContext.getSpec();
    dataStructureUtil = specContext.getDataStructureUtil();
   // additional setup
  }

  // if you prepare all context in setup you dont need to use SpecContext parameter
  @TestTemplate
  void shouldDo() {
   // do test
 }

```

### usage of `SpecContextExecutionHelper`
i provided some helpers to restrict or skip specific configurations for a specific method
```Java
import tech.pegasys.teku.spec.TestSpecContext;
import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContextExecutionHelper;
import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;

@TestSpecContext(
    milestone = {SpecMilestone.MERGE, SpecMilestone.ALTAIR},
    allNetworks = true)
public class ExampleTest {

  @TestTemplate
  void shouldDoOnlyMerge(SpecContext specContext) {
    SpecContextExecutionHelper.only(specContext, SpecMilestone.MERGE);
   // do test
 }

  @TestTemplate
  void shouldOnlyAltairSkippingSwift(SpecContext specContext) {
   SpecContextExecutionHelper.only(specContext, SpecMilestone.ALTAIR);
    SpecContextExecutionHelper.skip(specContext, Eth2Network.SWIFT, Eth2Network.LESS_SWIFT);
   // do test
 }
}
```

![image](https://user-images.githubusercontent.com/15999009/140095076-3810371f-2e7f-4e16-9e99-9900496c8342.png)


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
