### PR TITLE
Create a labelled gauge to report connected peers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Updated to Javalin 4 for the rest api.
 - Added relevant epoch to attestation and sync committee performance log message.
 - Removed ignore rule for aggregate attestation gossip where the attestation root has previously been seen.
-- add metrics to report client type - `libp2p_connected_peers_current`, with client tag `Teku`, `Lighthouse`, `Prysm`, `Nimbus`, `Unknown`.
+- Added metrics to report client type of connected peers - `libp2p_connected_peers_current`, with client tag `Teku`, `Lighthouse`, `Prysm`, `Nimbus`, `Unknown`.
 - Added support for Apple Silicon (M1 chips).
 - Added LevelDB support for Linux/arm64.
 - New console message when Teku switches forks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Attestations are now sent to the beacon node in batches by default when using the validator-client.
 - Updated to Javalin 4 for the rest api.
 - Removed ignore rule for aggregate attestation gossip where the attestation root has previously been seen.
+- add metrics to report client type - `libp2p_connected_peers_current`, with client tag `Teku`, `Lighthouse`, `Prysm`, `Nimbus`, `Unknown`.
 
 ### Bug Fixes
 - Fixed issue where discovery did not correctly abort handshake attempts when a request timed out.

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -95,6 +95,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
               if (valid) {
                 remoteStatus = Optional.of(status);
                 initialStatus.complete(status);
+                checkPeerIdentity();
                 statusSubscribers.deliver(PeerStatusSubscriber::onPeerStatus, status);
               } // Otherwise will have already been disconnected.
             },

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
@@ -29,10 +29,13 @@ import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.MetadataMessage
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class Eth2PeerTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Spec spec = TestSpecFactory.createMinimalAltair();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final Peer delegate = mock(Peer.class);
   private final BeaconChainMethods rpcMethods = mock(BeaconChainMethods.class);
   private final StatusMessageFactory statusMessageFactory = mock(StatusMessageFactory.class);
@@ -71,6 +74,15 @@ class Eth2PeerTest {
     assertThat(peer.hasStatus()).isTrue();
     assertThat(peer.getStatus()).isEqualTo(randomPeerStatus);
     verify(peerStatusSubscriber).onPeerStatus(randomPeerStatus);
+  }
+
+  @Test
+  void shouldCallCheckPeerIdentity() {
+    final SafeFuture<Boolean> validationResult = new SafeFuture<>();
+    when(peerChainValidator.validate(peer, randomPeerStatus)).thenReturn(validationResult);
+    peer.updateStatus(randomPeerStatus);
+    validationResult.complete(true);
+    verify(delegate).checkPeerIdentity();
   }
 
   @Test

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
@@ -13,14 +13,17 @@
 
 package tech.pegasys.teku.networking.p2p.libp2p;
 
+import identify.pb.IdentifyOuterClass;
 import io.libp2p.core.Connection;
 import io.libp2p.core.PeerId;
+import io.libp2p.protocol.Identify;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -48,6 +51,8 @@ public class LibP2PPeer implements Peer {
   private final AtomicBoolean connected = new AtomicBoolean(true);
   private final MultiaddrPeerAddress peerAddress;
   private final PeerId peerId;
+  private volatile PeerClientType peerClient = PeerClientType.UNKNOWN;
+  private volatile Optional<String> peerClientType = Optional.empty();
 
   private volatile Optional<DisconnectReason> disconnectReason = Optional.empty();
   private volatile boolean disconnectLocallyInitiated = false;
@@ -80,6 +85,34 @@ public class LibP2PPeer implements Peer {
   }
 
   @Override
+  public void checkPeerIdentity() {
+    if (isConnected()) {
+      getClientFromIdentity()
+          .thenAccept(
+              maybeClientIdentity -> {
+                LOG.debug("Connected peer has identity: {}", maybeClientIdentity.orElse("Unknown"));
+                peerClientType = maybeClientIdentity;
+                if (maybeClientIdentity.isPresent()) {
+                  peerClient = getPeerClientFromIdentity(maybeClientIdentity.get());
+                }
+              })
+          .finish(error -> LOG.error("Failed to retrieve client identity", error));
+    }
+  }
+
+  private PeerClientType getPeerClientFromIdentity(final String agentVersion) {
+    String agent = agentVersion;
+    if (agentVersion.contains("/")) {
+      agent = agentVersion.substring(0, agentVersion.indexOf("/"));
+    }
+    return EnumUtils.getEnumIgnoreCase(PeerClientType.class, agent, PeerClientType.UNKNOWN);
+  }
+
+  public Optional<String> getPeerClientType() {
+    return peerClientType;
+  }
+
+  @Override
   public PeerAddress getAddress() {
     return peerAddress;
   }
@@ -95,6 +128,11 @@ public class LibP2PPeer implements Peer {
   }
 
   @Override
+  public PeerClientType getPeerClient() {
+    return peerClient;
+  }
+
+  @Override
   public void disconnectImmediately(
       final Optional<DisconnectReason> reason, final boolean locallyInitiated) {
     connected.set(false);
@@ -104,6 +142,26 @@ public class LibP2PPeer implements Peer {
         .finish(
             () -> LOG.trace("Disconnected from {} because {}", getId(), reason),
             error -> LOG.warn("Failed to disconnect from peer {}", getId(), error));
+  }
+
+  private SafeFuture<Optional<String>> getClientFromIdentity() {
+    return getIdentify()
+        .thenApply(
+            id -> id.hasAgentVersion() ? Optional.of(id.getAgentVersion()) : Optional.empty());
+  }
+
+  private SafeFuture<IdentifyOuterClass.Identify> getIdentify() {
+    return SafeFuture.of(
+            connection
+                .muxerSession()
+                .createStream(new Identify())
+                .getController()
+                .thenCompose(controller -> SafeFuture.of(controller.id())))
+        .exceptionallyCompose(
+            error -> {
+              LOG.debug("Failed to get peer identity", error);
+              return SafeFuture.failedFuture(error);
+            });
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
@@ -86,18 +86,16 @@ public class LibP2PPeer implements Peer {
 
   @Override
   public void checkPeerIdentity() {
-    if (isConnected()) {
-      getAgentVersionFromIdentity()
-          .thenAccept(
-              maybeAgent -> {
-                LOG.debug("Connected peer has agent string: {}", maybeAgent.orElse("Unknown"));
-                maybeAgentString = maybeAgent;
-                if (maybeAgent.isPresent()) {
-                  peerClientType = getPeerTypeFromAgentString(maybeAgent.get());
-                }
-              })
-          .finish(error -> LOG.error("Failed to retrieve client identity", error));
-    }
+    getAgentVersionFromIdentity()
+        .thenAccept(
+            maybeAgent -> {
+              LOG.debug("Connected peer has agent string: {}", maybeAgent.orElse("Unknown"));
+              maybeAgentString = maybeAgent;
+              if (maybeAgent.isPresent()) {
+                peerClientType = getPeerTypeFromAgentString(maybeAgent.get());
+              }
+            })
+        .finish(error -> LOG.debug("Failed to retrieve client identity", error));
   }
 
   private PeerClientType getPeerTypeFromAgentString(final String agentVersion) {
@@ -156,7 +154,7 @@ public class LibP2PPeer implements Peer {
                 .muxerSession()
                 .createStream(new Identify())
                 .getController()
-                .thenCompose(controller -> SafeFuture.of(controller.id())))
+                .thenCompose(controller -> controller.id()))
         .exceptionallyCompose(
             error -> {
               LOG.debug("Failed to get peer identity", error);

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/PeerClientType.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/PeerClientType.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.p2p.libp2p;
+
+public enum PeerClientType {
+  UNKNOWN("Unknown"),
+  LIGHTHOUSE("Lighthouse"),
+  NIMBUS("Nimbus"),
+  PRYSM("Prysm"),
+  TEKU("Teku");
+
+  private final String displayName;
+
+  PeerClientType(final String displayName) {
+    this.displayName = displayName;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+}

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/PeerManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/PeerManager.java
@@ -54,7 +54,6 @@ public class PeerManager implements ConnectionHandler {
       new ConcurrentHashMap<>();
   private final ReputationManager reputationManager;
   private final List<PeerHandler> peerHandlers;
-  private final LabelledGauge peersLabelledGauge;
 
   private final Subscribers<PeerConnectedSubscriber<Peer>> connectSubscribers =
       Subscribers.create(true);
@@ -71,7 +70,7 @@ public class PeerManager implements ConnectionHandler {
     this.peerScoreFunction = peerScoreFunction;
     metricsSystem.createGauge(
         TekuMetricCategory.LIBP2P, "peers", "Tracks number of libp2p peers", this::getPeerCount);
-    peersLabelledGauge =
+    final LabelledGauge peersLabelledGauge =
         metricsSystem.createLabelledGauge(
             TekuMetricCategory.LIBP2P,
             "connected_peers_current",

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/PeerManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/PeerManager.java
@@ -92,7 +92,7 @@ public class PeerManager implements ConnectionHandler {
   double countConnectedPeersOfType(final PeerClientType type) {
     return connectedPeerMap.values().stream()
         .filter(Peer::isConnected)
-        .filter(peer -> type.equals(peer.getPeerClient()))
+        .filter(peer -> type.equals(peer.getPeerClientType()))
         .count();
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/DelegatingPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/DelegatingPeer.java
@@ -51,6 +51,11 @@ public class DelegatingPeer implements Peer {
   }
 
   @Override
+  public void checkPeerIdentity() {
+    peer.checkPeerIdentity();
+  }
+
+  @Override
   public <
           TOutgoingHandler extends RpcRequestHandler,
           TRequest,

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Peer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Peer.java
@@ -36,7 +36,7 @@ public interface Peer {
 
   boolean isConnected();
 
-  default PeerClientType getPeerClient() {
+  default PeerClientType getPeerClientType() {
     return PeerClientType.UNKNOWN;
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Peer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Peer.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.p2p.peer;
 import java.util.Objects;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.networking.p2p.libp2p.PeerClientType;
 import tech.pegasys.teku.networking.p2p.network.PeerAddress;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment;
 import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
@@ -34,6 +35,12 @@ public interface Peer {
   Double getGossipScore();
 
   boolean isConnected();
+
+  default PeerClientType getPeerClient() {
+    return PeerClientType.UNKNOWN;
+  }
+
+  default void checkPeerIdentity() {}
 
   void disconnectImmediately(Optional<DisconnectReason> reason, boolean locallyInitiated);
 


### PR DESCRIPTION
Peers will be logged by their client type (eg. teku, lighthouse, prysm) without version number so that the reporting is relatively clean.

Once the initial status is determined, an 'identify' request will be made to the peer, and it will be persisted on the peer object for reporting.

Also stored the peer client type on the peer object, but we don't currently do anything with it, so it could be removed arguably.

fixes #2764

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
