### PR TITLE
Apply increased penalties in the merge

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecVersion.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecVersion.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.spec.config.SpecConfigMerge;
 import tech.pegasys.teku.spec.logic.DelegatingSpecLogic;
 import tech.pegasys.teku.spec.logic.SpecLogic;
 import tech.pegasys.teku.spec.logic.versions.altair.SpecLogicAltair;
+import tech.pegasys.teku.spec.logic.versions.merge.SpecLogicMerge;
 import tech.pegasys.teku.spec.logic.versions.phase0.SpecLogicPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
@@ -69,7 +70,7 @@ public class SpecVersion extends DelegatingSpecLogic {
 
   static SpecVersion createMerge(final SpecConfigMerge specConfig) {
     final SchemaDefinitionsMerge schemaDefinitions = new SchemaDefinitionsMerge(specConfig);
-    final SpecLogic specLogic = SpecLogicAltair.create(specConfig, schemaDefinitions);
+    final SpecLogic specLogic = SpecLogicMerge.create(specConfig, schemaDefinitions);
     return new SpecVersion(SpecMilestone.MERGE, specConfig, schemaDefinitions, specLogic);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
@@ -37,8 +37,8 @@ import tech.pegasys.teku.ssz.primitive.SszByte;
 public class EpochProcessorAltair extends AbstractEpochProcessor {
 
   private final SpecConfigAltair specConfigAltair;
-  private final MiscHelpersAltair miscHelpersAltair;
-  private final BeaconStateAccessorsAltair beaconStateAccessorsAltair;
+  protected final MiscHelpersAltair miscHelpersAltair;
+  protected final BeaconStateAccessorsAltair beaconStateAccessorsAltair;
 
   public EpochProcessorAltair(
       final SpecConfigAltair specConfig,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/RewardsAndPenaltiesCalculatorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/RewardsAndPenaltiesCalculatorAltair.java
@@ -137,12 +137,14 @@ public class RewardsAndPenaltiesCalculatorAltair extends RewardsAndPenaltiesCalc
               .getCurrentEpochEffectiveBalance()
               .times(stateAltair.getInactivityScores().get(i).get());
       final UInt64 penaltyDenominator =
-          specConfigAltair
-              .getInactivityScoreBias()
-              .times(specConfigAltair.getInactivityPenaltyQuotientAltair());
+          specConfigAltair.getInactivityScoreBias().times(getInactivityPenaltyQuotient());
       final UInt64 penalty = penaltyNumerator.dividedBy(penaltyDenominator);
       deltas.getDelta(i).penalize(penalty);
     }
+  }
+
+  protected UInt64 getInactivityPenaltyQuotient() {
+    return specConfigAltair.getInactivityPenaltyQuotientAltair();
   }
 
   private boolean validatorHasPrevEpochParticipationFlag(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/SpecLogicMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/SpecLogicMerge.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.merge;
+
+import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.integerSquareRoot;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfigAltair;
+import tech.pegasys.teku.spec.config.SpecConfigMerge;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
+import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
+import tech.pegasys.teku.spec.logic.common.statetransition.attestation.AttestationWorthinessChecker;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
+import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
+import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
+import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
+import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.forktransition.AltairStateUpgrade;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateMutatorsAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.statetransition.attestation.AttestationWorthinessCheckerAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.EpochProcessorAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.ValidatorStatusFactoryAltair;
+import tech.pegasys.teku.spec.logic.versions.merge.statetransition.epoch.EpochProcessorMerge;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsMerge;
+
+public class SpecLogicMerge extends AbstractSpecLogic {
+
+  private final SpecConfigAltair specConfig;
+  private final Optional<SyncCommitteeUtil> syncCommitteeUtil;
+
+  private SpecLogicMerge(
+      final SpecConfigAltair specConfig,
+      final Predicates predicates,
+      final MiscHelpersAltair miscHelpers,
+      final BeaconStateAccessorsAltair beaconStateAccessors,
+      final BeaconStateMutators beaconStateMutators,
+      final OperationSignatureVerifier operationSignatureVerifier,
+      final ValidatorsUtil validatorsUtil,
+      final BeaconStateUtil beaconStateUtil,
+      final AttestationUtil attestationUtil,
+      final OperationValidator operationValidator,
+      final ValidatorStatusFactoryAltair validatorStatusFactory,
+      final EpochProcessorAltair epochProcessor,
+      final BlockProcessorAltair blockProcessor,
+      final ForkChoiceUtil forkChoiceUtil,
+      final BlockProposalUtil blockProposalUtil,
+      final SyncCommitteeUtil syncCommitteeUtil,
+      final AltairStateUpgrade stateUpgrade) {
+    super(
+        predicates,
+        miscHelpers,
+        beaconStateAccessors,
+        beaconStateMutators,
+        operationSignatureVerifier,
+        validatorsUtil,
+        beaconStateUtil,
+        attestationUtil,
+        operationValidator,
+        validatorStatusFactory,
+        epochProcessor,
+        blockProcessor,
+        forkChoiceUtil,
+        blockProposalUtil,
+        Optional.of(stateUpgrade));
+    this.specConfig = specConfig;
+    this.syncCommitteeUtil = Optional.of(syncCommitteeUtil);
+  }
+
+  public static SpecLogicMerge create(
+      final SpecConfigMerge config, final SchemaDefinitionsMerge schemaDefinitions) {
+    // Helpers
+    final Predicates predicates = new Predicates();
+    final MiscHelpersAltair miscHelpers = new MiscHelpersAltair(config);
+    final BeaconStateAccessorsAltair beaconStateAccessors =
+        new BeaconStateAccessorsAltair(config, predicates, miscHelpers);
+    final BeaconStateMutatorsAltair beaconStateMutators =
+        new BeaconStateMutatorsAltair(config, miscHelpers, beaconStateAccessors);
+
+    // Operation validaton
+    final OperationSignatureVerifier operationSignatureVerifier =
+        new OperationSignatureVerifier(miscHelpers, beaconStateAccessors);
+
+    // Util
+    final ValidatorsUtil validatorsUtil =
+        new ValidatorsUtil(config, miscHelpers, beaconStateAccessors);
+    final BeaconStateUtil beaconStateUtil =
+        new BeaconStateUtil(
+            config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
+    final AttestationUtil attestationUtil = new AttestationUtil(beaconStateAccessors, miscHelpers);
+    final OperationValidator operationValidator =
+        OperationValidator.create(
+            config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
+    final ValidatorStatusFactoryAltair validatorStatusFactory =
+        new ValidatorStatusFactoryAltair(
+            config,
+            beaconStateUtil,
+            attestationUtil,
+            predicates,
+            miscHelpers,
+            beaconStateAccessors);
+    final EpochProcessorMerge epochProcessor =
+        new EpochProcessorMerge(
+            config,
+            miscHelpers,
+            beaconStateAccessors,
+            beaconStateMutators,
+            validatorsUtil,
+            beaconStateUtil,
+            validatorStatusFactory);
+    final BlockProcessorAltair blockProcessor =
+        new BlockProcessorAltair(
+            config,
+            predicates,
+            miscHelpers,
+            beaconStateAccessors,
+            beaconStateMutators,
+            operationSignatureVerifier,
+            beaconStateUtil,
+            attestationUtil,
+            validatorsUtil,
+            operationValidator);
+    final ForkChoiceUtil forkChoiceUtil =
+        new ForkChoiceUtil(
+            config, beaconStateAccessors, attestationUtil, blockProcessor, miscHelpers);
+    final BlockProposalUtil blockProposalUtil =
+        new BlockProposalUtil(schemaDefinitions, blockProcessor);
+    final SyncCommitteeUtil syncCommitteeUtil =
+        new SyncCommitteeUtil(
+            beaconStateAccessors, validatorsUtil, config, miscHelpers, schemaDefinitions);
+
+    // State upgrade
+    final AltairStateUpgrade stateUpgrade =
+        new AltairStateUpgrade(
+            config, schemaDefinitions, beaconStateAccessors, attestationUtil, miscHelpers);
+
+    return new SpecLogicMerge(
+        config,
+        predicates,
+        miscHelpers,
+        beaconStateAccessors,
+        beaconStateMutators,
+        operationSignatureVerifier,
+        validatorsUtil,
+        beaconStateUtil,
+        attestationUtil,
+        operationValidator,
+        validatorStatusFactory,
+        epochProcessor,
+        blockProcessor,
+        forkChoiceUtil,
+        blockProposalUtil,
+        syncCommitteeUtil,
+        stateUpgrade);
+  }
+
+  @Override
+  public Optional<SyncCommitteeUtil> getSyncCommitteeUtil() {
+    return syncCommitteeUtil;
+  }
+
+  @Override
+  public AttestationWorthinessChecker createAttestationWorthinessChecker(final BeaconState state) {
+    final UInt64 currentSlot = state.getSlot();
+    final UInt64 startSlot =
+        miscHelpers.computeStartSlotAtEpoch(miscHelpers.computeEpochAtSlot(currentSlot));
+
+    final Bytes32 expectedAttestationTarget =
+        startSlot.compareTo(currentSlot) == 0 || currentSlot.compareTo(startSlot) <= 0
+            ? state.getLatest_block_header().getRoot()
+            : beaconStateAccessors.getBlockRootAtSlot(state, startSlot);
+
+    final UInt64 oldestWorthySlotForSourceReward =
+        state.getSlot().minusMinZero(integerSquareRoot(specConfig.getSlotsPerEpoch()));
+    return new AttestationWorthinessCheckerAltair(
+        expectedAttestationTarget, oldestWorthySlotForSourceReward);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/SpecLogicMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/SpecLogicMerge.java
@@ -36,11 +36,11 @@ import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.forktransition.AltairStateUpgrade;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
-import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateMutatorsAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.attestation.AttestationWorthinessCheckerAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.EpochProcessorAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.ValidatorStatusFactoryAltair;
+import tech.pegasys.teku.spec.logic.versions.merge.helpers.BeaconStateMutatorsMerge;
 import tech.pegasys.teku.spec.logic.versions.merge.statetransition.epoch.EpochProcessorMerge;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsMerge;
 
@@ -94,8 +94,8 @@ public class SpecLogicMerge extends AbstractSpecLogic {
     final MiscHelpersAltair miscHelpers = new MiscHelpersAltair(config);
     final BeaconStateAccessorsAltair beaconStateAccessors =
         new BeaconStateAccessorsAltair(config, predicates, miscHelpers);
-    final BeaconStateMutatorsAltair beaconStateMutators =
-        new BeaconStateMutatorsAltair(config, miscHelpers, beaconStateAccessors);
+    final BeaconStateMutatorsMerge beaconStateMutators =
+        new BeaconStateMutatorsMerge(config, miscHelpers, beaconStateAccessors);
 
     // Operation validaton
     final OperationSignatureVerifier operationSignatureVerifier =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/helpers/BeaconStateMutatorsMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/helpers/BeaconStateMutatorsMerge.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.merge.helpers;
+
+import tech.pegasys.teku.spec.config.SpecConfigMerge;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateMutatorsAltair;
+
+public class BeaconStateMutatorsMerge extends BeaconStateMutatorsAltair {
+
+  private final SpecConfigMerge specConfigMerge;
+
+  public BeaconStateMutatorsMerge(
+      final SpecConfigMerge specConfig,
+      final MiscHelpers miscHelpers,
+      final BeaconStateAccessors beaconStateAccessors) {
+    super(specConfig, miscHelpers, beaconStateAccessors);
+    specConfigMerge = specConfig;
+  }
+
+  @Override
+  protected int getMinSlashingPenaltyQuotient() {
+    return specConfigMerge.getMinSlashingPenaltyQuotient();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/helpers/BeaconStateMutatorsMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/helpers/BeaconStateMutatorsMerge.java
@@ -32,6 +32,6 @@ public class BeaconStateMutatorsMerge extends BeaconStateMutatorsAltair {
 
   @Override
   protected int getMinSlashingPenaltyQuotient() {
-    return specConfigMerge.getMinSlashingPenaltyQuotient();
+    return specConfigMerge.getMinSlashingPenaltyQuotientMerge();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/statetransition/epoch/EpochProcessorMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/statetransition/epoch/EpochProcessorMerge.java
@@ -66,6 +66,6 @@ public class EpochProcessorMerge extends EpochProcessorAltair {
 
   @Override
   protected int getProportionalSlashingMultiplier() {
-    return specConfigMerge.getProportionalSlashingMultiplier();
+    return specConfigMerge.getProportionalSlashingMultiplierMerge();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/statetransition/epoch/EpochProcessorMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/statetransition/epoch/EpochProcessorMerge.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.merge.statetransition.epoch;
+
+import tech.pegasys.teku.spec.config.SpecConfigMerge;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.merge.BeaconStateMerge;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenaltyDeltas;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatusFactory;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatuses;
+import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
+import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.EpochProcessorAltair;
+
+public class EpochProcessorMerge extends EpochProcessorAltair {
+
+  private final SpecConfigMerge specConfigMerge;
+
+  public EpochProcessorMerge(
+      final SpecConfigMerge specConfig,
+      final MiscHelpersAltair miscHelpers,
+      final BeaconStateAccessorsAltair beaconStateAccessors,
+      final BeaconStateMutators beaconStateMutators,
+      final ValidatorsUtil validatorsUtil,
+      final BeaconStateUtil beaconStateUtil,
+      final ValidatorStatusFactory validatorStatusFactory) {
+    super(
+        specConfig,
+        miscHelpers,
+        beaconStateAccessors,
+        beaconStateMutators,
+        validatorsUtil,
+        beaconStateUtil,
+        validatorStatusFactory);
+    specConfigMerge = specConfig;
+  }
+
+  @Override
+  public RewardAndPenaltyDeltas getRewardAndPenaltyDeltas(
+      final BeaconState genericState, final ValidatorStatuses validatorStatuses) {
+    final BeaconStateMerge state = BeaconStateMerge.required(genericState);
+    final RewardsAndPenaltiesCalculatorMerge calculator =
+        new RewardsAndPenaltiesCalculatorMerge(
+            specConfigMerge,
+            state,
+            validatorStatuses,
+            miscHelpersAltair,
+            beaconStateAccessorsAltair);
+
+    return calculator.getDeltas();
+  }
+
+  @Override
+  protected int getProportionalSlashingMultiplier() {
+    return specConfigMerge.getProportionalSlashingMultiplier();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/statetransition/epoch/RewardsAndPenaltiesCalculatorMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/statetransition/epoch/RewardsAndPenaltiesCalculatorMerge.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.merge.statetransition.epoch;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfigMerge;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.merge.BeaconStateMerge;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatuses;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.RewardsAndPenaltiesCalculatorAltair;
+
+public class RewardsAndPenaltiesCalculatorMerge extends RewardsAndPenaltiesCalculatorAltair {
+
+  private final SpecConfigMerge specConfigMerge;
+
+  public RewardsAndPenaltiesCalculatorMerge(
+      final SpecConfigMerge specConfig,
+      final BeaconStateMerge state,
+      final ValidatorStatuses validatorStatuses,
+      final MiscHelpersAltair miscHelpers,
+      final BeaconStateAccessorsAltair beaconStateAccessors) {
+    super(specConfig, state, validatorStatuses, miscHelpers, beaconStateAccessors);
+    specConfigMerge = specConfig;
+  }
+
+  @Override
+  protected UInt64 getInactivityPenaltyQuotient() {
+    return specConfigMerge.getInactivityPenaltyQuotientMerge();
+  }
+}


### PR DESCRIPTION
## PR Description
Apply the increased penalties from the merge fork.

Involves introducing `SpecLogicMerge` which uses a custom `EpochProcessorMerge`, `BeaconStateMutatorsMerge` and `RewardsAndPenaltiesCalculatorMerge` all of which differ from the Altair versions only by the config values they use. Hence they extend the Altair implementations.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
