### PR TITLE
Start enabling reference tests for the merge

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.reference.altair.fork.ForkUpgradeTestExecutor;
 import tech.pegasys.teku.reference.altair.fork.TransitionTestExecutor;
 import tech.pegasys.teku.reference.altair.rewards.RewardsTestExecutorAltair;
+import tech.pegasys.teku.reference.altair.rewards.RewardsTestExecutorMerge;
 import tech.pegasys.teku.reference.common.epoch_processing.EpochProcessingTestExecutor;
 import tech.pegasys.teku.reference.common.operations.OperationsTestExecutor;
 import tech.pegasys.teku.reference.phase0.bls.BlsTests;
@@ -65,12 +66,10 @@ public abstract class Eth2ReferenceTestCase {
       ImmutableMap.<String, TestExecutor>builder()
           .putAll(TransitionTestExecutor.TRANSITION_TEST_TYPES)
           .putAll(ForkUpgradeTestExecutor.FORK_UPGRADE_TEST_TYPES)
+          .putAll(RewardsTestExecutorMerge.REWARDS_TEST_TYPES)
 
           // Disabled while work continues to bring over the merge work
           .put("sanity/blocks", TestExecutor.IGNORE_TESTS)
-          .put("rewards/leak", TestExecutor.IGNORE_TESTS)
-          .put("rewards/basic", TestExecutor.IGNORE_TESTS)
-          .put("rewards/random", TestExecutor.IGNORE_TESTS)
           .put("operations/proposer_slashing", TestExecutor.IGNORE_TESTS)
           .put("operations/attester_slashing", TestExecutor.IGNORE_TESTS)
           .put("operations/execution_payload", TestExecutor.IGNORE_TESTS)

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -70,16 +70,12 @@ public abstract class Eth2ReferenceTestCase {
 
           // Disabled while work continues to bring over the merge work
           .put("sanity/blocks", TestExecutor.IGNORE_TESTS)
-          .put("operations/proposer_slashing", TestExecutor.IGNORE_TESTS)
-          .put("operations/attester_slashing", TestExecutor.IGNORE_TESTS)
           .put("operations/execution_payload", TestExecutor.IGNORE_TESTS)
           .put("genesis/initialization", TestExecutor.IGNORE_TESTS)
           .put("fork_choice/on_merge_block", TestExecutor.IGNORE_TESTS)
           .put("fork_choice/on_block", TestExecutor.IGNORE_TESTS)
           .put("fork_choice/get_head", TestExecutor.IGNORE_TESTS)
           .put("finality/finality", TestExecutor.IGNORE_TESTS)
-          .put("epoch_processing/slashings", TestExecutor.IGNORE_TESTS)
-          .put("epoch_processing/rewards_and_penalties", TestExecutor.IGNORE_TESTS)
           .put("epoch_processing/sync_committee_updates", TestExecutor.IGNORE_TESTS)
           .build();
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -39,10 +39,13 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    * <p>e.g. set to "ssz_static" to run only ssz static tests or "ssz_static/Attestation" for only
    * attestation ssz tests.
    */
-  private static final String TEST_TYPE = "fork_choice/on_block";
+  private static final String TEST_TYPE = "ssz_static";
 
   /** Filter test to run to those from the specified spec. One of general, minimal or mainnet */
-  private static final String SPEC = "minimal";
+  private static final String SPEC = "";
+
+  /** Filter test to run only those for a specific milestone. Use values from TestFork. */
+  private static final String MILESTONE = null;
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("loadReferenceTests")
@@ -59,6 +62,12 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
             testDefinition ->
                 SPEC.isBlank() || testDefinition.getConfigName().equalsIgnoreCase(SPEC))
         .filter(testDefinition -> testDefinition.getTestType().startsWith(TEST_TYPE))
+        .filter(ManualReferenceTestRunner::isSelectedMilestone)
         .map(testDefinition -> Arguments.of(testDefinition.getDisplayName(), testDefinition));
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  private static boolean isSelectedMilestone(final TestDefinition testDefinition) {
+    return MILESTONE == null || MILESTONE.equals(testDefinition.getFork());
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/rewards/RewardsTestExecutorAltair.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/rewards/RewardsTestExecutorAltair.java
@@ -53,13 +53,20 @@ public class RewardsTestExecutorAltair implements TestExecutor {
 
     final SpecVersion spec = testDefinition.getSpec().getGenesisSpec();
     final RewardsAndPenaltiesCalculatorAltair calculator =
-        new RewardsAndPenaltiesCalculatorAltair(
-            SpecConfigAltair.required(spec.getConfig()),
-            BeaconStateAltair.required(preState),
-            validatorStatuses,
-            (MiscHelpersAltair) spec.miscHelpers(),
-            (BeaconStateAccessorsAltair) spec.beaconStateAccessors());
+        createRewardsAndPenaltiesCalculator(preState, validatorStatuses, spec);
     runTest(testDefinition, calculator, validatorStatuses);
+  }
+
+  protected RewardsAndPenaltiesCalculatorAltair createRewardsAndPenaltiesCalculator(
+      final BeaconState preState,
+      final ValidatorStatuses validatorStatuses,
+      final SpecVersion spec) {
+    return new RewardsAndPenaltiesCalculatorAltair(
+        SpecConfigAltair.required(spec.getConfig()),
+        BeaconStateAltair.required(preState),
+        validatorStatuses,
+        (MiscHelpersAltair) spec.miscHelpers(),
+        (BeaconStateAccessorsAltair) spec.beaconStateAccessors());
   }
 
   private void runTest(

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/rewards/RewardsTestExecutorMerge.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/rewards/RewardsTestExecutorMerge.java
@@ -1,0 +1,35 @@
+package tech.pegasys.teku.reference.altair.rewards;
+
+import com.google.common.collect.ImmutableMap;
+import tech.pegasys.teku.reference.TestExecutor;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.config.SpecConfigMerge;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.merge.BeaconStateMerge;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatuses;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.RewardsAndPenaltiesCalculatorAltair;
+import tech.pegasys.teku.spec.logic.versions.merge.statetransition.epoch.RewardsAndPenaltiesCalculatorMerge;
+
+public class RewardsTestExecutorMerge extends RewardsTestExecutorAltair {
+
+  public static final ImmutableMap<String, TestExecutor> REWARDS_TEST_TYPES =
+      ImmutableMap.of(
+          "rewards/basic", new RewardsTestExecutorMerge(),
+          "rewards/leak", new RewardsTestExecutorMerge(),
+          "rewards/random", new RewardsTestExecutorMerge());
+
+  @Override
+  protected RewardsAndPenaltiesCalculatorAltair createRewardsAndPenaltiesCalculator(
+      final BeaconState preState,
+      final ValidatorStatuses validatorStatuses,
+      final SpecVersion spec) {
+    return new RewardsAndPenaltiesCalculatorMerge(
+        SpecConfigMerge.required(spec.getConfig()),
+        BeaconStateMerge.required(preState),
+        validatorStatuses,
+        (MiscHelpersAltair) spec.miscHelpers(),
+        (BeaconStateAccessorsAltair) spec.beaconStateAccessors());
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/rewards/RewardsTestExecutorMerge.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/rewards/RewardsTestExecutorMerge.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.reference.altair.rewards;
 
 import com.google.common.collect.ImmutableMap;

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
@@ -22,9 +22,9 @@ import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.reference.TestDataUtils;
 import tech.pegasys.teku.reference.TestExecutor;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateSchemaAltair;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsMerge;
 import tech.pegasys.teku.ssz.SszData;
 import tech.pegasys.teku.ssz.schema.SszSchema;
 
@@ -49,9 +49,7 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
           .put(
               "ssz_static/SyncCommittee",
               new SszTestExecutor<>(
-                  schemas ->
-                      BeaconStateSchemaAltair.required(schemas.getBeaconStateSchema())
-                          .getCurrentSyncCommitteeSchema()))
+                  schemas -> schemas.getBeaconStateSchema().getCurrentSyncCommitteeSchemaOrThrow()))
           .put(
               "ssz_static/SyncAggregate",
               new SszTestExecutor<>(
@@ -89,6 +87,18 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
           .put("ssz_static/LightClientStore", IGNORE_TESTS)
           .put("ssz_static/LightClientSnapshot", IGNORE_TESTS)
           .put("ssz_static/LightClientUpdate", IGNORE_TESTS)
+
+          // Merge types
+          .put(
+              "ssz_static/ExecutionPayloadHeader",
+              new SszTestExecutor<>(
+                  schemas ->
+                      SchemaDefinitionsMerge.required(schemas).getExecutionPayloadHeaderSchema()))
+          .put(
+              "ssz_static/ExecutionPayload",
+              new SszTestExecutor<>(
+                  schemas -> SchemaDefinitionsMerge.required(schemas).getExecutionPayloadSchema()))
+          .put("ssz_static/PowBlock", IGNORE_TESTS)
 
           // SSZ Generic
           .put("ssz_generic/basic_vector", IGNORE_TESTS)

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/TestFork.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/TestFork.java
@@ -16,4 +16,5 @@ package tech.pegasys.teku.ethtests;
 public class TestFork {
   public static String PHASE0 = "phase0";
   public static String ALTAIR = "altair";
+  public static String MERGE = "merge";
 }

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -28,7 +28,8 @@ public class ReferenceTestFinder {
 
   private static final Path TEST_PATH_FROM_MODULE =
       Path.of("src", "referenceTest", "resources", "eth2.0-spec-tests", "tests");
-  private static final List<String> SUPPORTED_FORKS = List.of(TestFork.PHASE0, TestFork.ALTAIR);
+  private static final List<String> SUPPORTED_FORKS =
+      List.of(TestFork.PHASE0, TestFork.ALTAIR, TestFork.MERGE);
 
   @MustBeClosed
   public static Stream<TestDefinition> findReferenceTests() throws IOException {

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -54,10 +54,14 @@ public class TestDefinition {
         spec = TestSpecFactory.createMainnetPhase0();
       } else if (configName.equals(TestSpecConfig.MAINNET) && fork.equals(TestFork.ALTAIR)) {
         spec = TestSpecFactory.createMainnetAltair();
+      } else if (configName.equals(TestSpecConfig.MAINNET) && fork.equals(TestFork.MERGE)) {
+        spec = TestSpecFactory.createMainnetMerge();
       } else if (configName.equals(TestSpecConfig.MINIMAL) && fork.equals(TestFork.PHASE0)) {
         spec = TestSpecFactory.createMinimalPhase0();
       } else if (configName.equals(TestSpecConfig.MINIMAL) && fork.equals(TestFork.ALTAIR)) {
         spec = TestSpecFactory.createMinimalAltair();
+      } else if (configName.equals(TestSpecConfig.MINIMAL) && fork.equals(TestFork.MERGE)) {
+        spec = TestSpecFactory.createMinimalMerge();
       } else {
         // Set generic value
         spec = TestSpecFactory.createMinimalPhase0();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateInvariants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateInvariants.java
@@ -118,6 +118,6 @@ public class BeaconStateInvariants {
             .add("finalized_checkpoint", state.getFinalized_checkpoint());
 
     modifier.accept(builder);
-    return builder.toString().replace(",", "\n");
+    return builder.toString();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateInvariants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateInvariants.java
@@ -118,6 +118,6 @@ public class BeaconStateInvariants {
             .add("finalized_checkpoint", state.getFinalized_checkpoint());
 
     modifier.accept(builder);
-    return builder.toString();
+    return builder.toString().replace(",", "\n");
   }
 }


### PR DESCRIPTION
## PR Description
Add support for running MERGE reference tests but disable most of them until we implement that part of the merge.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
