### PR TITLE
Use Optional getter instead of casting state schema

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
@@ -36,7 +36,6 @@ import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateSchemaAltair;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
@@ -147,8 +146,9 @@ public class BeaconStateAccessorsAltair extends BeaconStateAccessors {
             .collect(toList());
     final BLSPublicKey aggregatePubkey = BLSPublicKey.aggregate(pubkeys);
 
-    return ((BeaconStateSchemaAltair) state.getSchema())
-        .getNextSyncCommitteeSchema()
+    return state
+        .getBeaconStateSchema()
+        .getNextSyncCommitteeSchemaOrThrow()
         .create(
             pubkeys.stream().map(SszPublicKey::new).collect(toList()),
             new SszPublicKey(aggregatePubkey));


### PR DESCRIPTION
## PR Description
Fixes sync committee handling in the merge by using `getNextSyncCommitteeSchemaOrThrow` instead of casting to `BeaconStateSchemaAltair`.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
