### PR TITLE
Optimise aggregate handling

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.statetransition.attestation;
 
+import static tech.pegasys.teku.util.config.Constants.VALID_AGGREGATE_SET_SIZE;
+
 import java.util.List;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -49,7 +51,8 @@ public class AttestationManager extends Service
 
   private final ForkChoice attestationProcessor;
 
-  private final Set<Bytes32> processedAggregateAttestations = LimitedSet.create(5000);
+  private final Set<Bytes32> processedAggregateAttestations =
+      LimitedSet.create(VALID_AGGREGATE_SET_SIZE);
   private final PendingPool<ValidateableAttestation> pendingAttestations;
   private final FutureItems<ValidateableAttestation> futureAttestations;
   private final AggregatingAttestationPool aggregatingAttestationPool;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
@@ -49,7 +49,7 @@ public class AttestationManager extends Service
 
   private final ForkChoice attestationProcessor;
 
-  private final Set<Bytes32> processedAggregateAttestations = LimitedSet.create(1000);
+  private final Set<Bytes32> processedAggregateAttestations = LimitedSet.create(5000);
   private final PendingPool<ValidateableAttestation> pendingAttestations;
   private final FutureItems<ValidateableAttestation> futureAttestations;
   private final AggregatingAttestationPool aggregatingAttestationPool;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
@@ -14,11 +14,13 @@
 package tech.pegasys.teku.statetransition.attestation;
 
 import java.util.List;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.collections.LimitedSet;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.service.serviceutils.Service;
@@ -47,6 +49,7 @@ public class AttestationManager extends Service
 
   private final ForkChoice attestationProcessor;
 
+  private final Set<Bytes32> processedAggregateAttestations = LimitedSet.create(1000);
   private final PendingPool<ValidateableAttestation> pendingAttestations;
   private final FutureItems<ValidateableAttestation> futureAttestations;
   private final AggregatingAttestationPool aggregatingAttestationPool;
@@ -128,7 +131,11 @@ public class AttestationManager extends Service
   public SafeFuture<InternalValidationResult> addAggregate(ValidateableAttestation attestation) {
     SafeFuture<InternalValidationResult> validationResult =
         aggregateValidator.validate(attestation);
-    processInternallyValidatedAttestation(validationResult, attestation);
+    // We have to validate every aggregate as part of gossip handling since the aggregator may
+    // differ but if we've already processed the wrapped attestation we can skip processing
+    if (processedAggregateAttestations.add(attestation.hash_tree_root())) {
+      processInternallyValidatedAttestation(validationResult, attestation);
+    }
     return validationResult;
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
@@ -23,6 +23,7 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.util.config.Constants.VALID_AGGREGATE_SET_SIZE;
 
 import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -35,6 +36,7 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.collections.LimitedSet;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -51,6 +53,8 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class AggregateAttestationValidator {
   private static final Logger LOG = LogManager.getLogger();
+  private final Map<Bytes32, SafeFuture<InternalValidationResult>> aggregateAttestationResultCache =
+      LimitedMap.create(500);
   private final Set<AggregatorIndexAndEpoch> receivedAggregatorIndexAndEpochs =
       LimitedSet.create(VALID_AGGREGATE_SET_SIZE);
   private final AttestationValidator attestationValidator;
@@ -197,10 +201,15 @@ public class AggregateAttestationValidator {
       final BLSSignatureVerifier signatureVerifier,
       final ValidateableAttestation validateableAttestation,
       final OptionalInt receivedOnSubnetId) {
-    return attestationValidator.singleOrAggregateAttestationChecks(
-        AsyncBLSSignatureVerifier.wrap(signatureVerifier),
-        validateableAttestation,
-        receivedOnSubnetId);
+    // We get a lot of aggregate attestations with the same Attestation but different aggregator
+    // These have to be individually processed but we can skip re-validating the Attestation
+    return aggregateAttestationResultCache.computeIfAbsent(
+        validateableAttestation.hash_tree_root(),
+        __ ->
+            attestationValidator.singleOrAggregateAttestationChecks(
+                AsyncBLSSignatureVerifier.wrap(signatureVerifier),
+                validateableAttestation,
+                receivedOnSubnetId));
   }
 
   private static class AggregatorIndexAndEpoch {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
@@ -54,7 +54,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 public class AggregateAttestationValidator {
   private static final Logger LOG = LogManager.getLogger();
   private final Map<Bytes32, SafeFuture<InternalValidationResult>> aggregateAttestationResultCache =
-      LimitedMap.create(5000);
+      LimitedMap.create(VALID_AGGREGATE_SET_SIZE);
   private final Set<AggregatorIndexAndEpoch> receivedAggregatorIndexAndEpochs =
       LimitedSet.create(VALID_AGGREGATE_SET_SIZE);
   private final AttestationValidator attestationValidator;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
@@ -54,7 +54,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 public class AggregateAttestationValidator {
   private static final Logger LOG = LogManager.getLogger();
   private final Map<Bytes32, SafeFuture<InternalValidationResult>> aggregateAttestationResultCache =
-      LimitedMap.create(500);
+      LimitedMap.create(5000);
   private final Set<AggregatorIndexAndEpoch> receivedAggregatorIndexAndEpochs =
       LimitedSet.create(VALID_AGGREGATE_SET_SIZE);
   private final AttestationValidator attestationValidator;

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -83,7 +83,8 @@ public class Constants {
 
   // Teku Networking Specific
   public static final int VALID_BLOCK_SET_SIZE = 1000;
-  public static final int VALID_AGGREGATE_SET_SIZE = 1000;
+  // Target holding two slots worth of aggregators (16 aggregators, 64 committees and 2 slots)
+  public static final int VALID_AGGREGATE_SET_SIZE = 16 * 64 * 2;
   public static final int VALID_VALIDATOR_SET_SIZE = 10000;
   public static final int VALID_CONTRIBUTION_AND_PROOF_SET_SIZE = 10000;
   public static final int VALID_SYNC_COMMITTEE_MESSAGE_SET_SIZE = 10000;


### PR DESCRIPTION
## PR Description
Optimise aggregate attestation handling now that aggregates from different aggregators that contain the same `Attestation` are no longer ignored by the gossip layer.

Validation result of the internal `Attestation` is cached and reused and processing is skipped for already-seen aggregate attestations.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
