### PR TITLE
Use signature verification service with aggregate attestations and sync contributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Added LevelDB support for Linux/arm64.
 - Switched executor queue size metrics to use labelled gauge.
 - New console message when Teku switches forks. 
+- Reduce CPU usage by using batching signature verification service for aggregate attestation and sync committee contributions.
 
 
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AsyncBatchBLSSignatureVerifier.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AsyncBatchBLSSignatureVerifier.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+public class AsyncBatchBLSSignatureVerifier implements BLSSignatureVerifier {
+
+  public static final SafeFuture<Boolean> TRUE = SafeFuture.completedFuture(true);
+  private final List<List<BLSPublicKey>> publicKeys = new ArrayList<>();
+  private final List<Bytes> messages = new ArrayList<>();
+  private final List<BLSSignature> signatures = new ArrayList<>();
+
+  private final AsyncBLSSignatureVerifier delegate;
+
+  public AsyncBatchBLSSignatureVerifier(final AsyncBLSSignatureVerifier delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public boolean verify(
+      final List<BLSPublicKey> publicKeys, final Bytes message, final BLSSignature signature) {
+    this.publicKeys.add(publicKeys);
+    this.messages.add(message);
+    this.signatures.add(signature);
+    return true;
+  }
+
+  @Override
+  public boolean verify(
+      final List<List<BLSPublicKey>> publicKeys,
+      final List<Bytes> messages,
+      final List<BLSSignature> signatures) {
+    this.publicKeys.addAll(publicKeys);
+    this.messages.addAll(messages);
+    this.signatures.addAll(signatures);
+    return true;
+  }
+
+  public SafeFuture<Boolean> batchVerify() {
+    return delegate.verify(publicKeys, messages, signatures);
+  }
+
+  public AsyncBLSSignatureVerifier asAsyncBSLSSignatureVerifier() {
+    return new AsyncBLSSignatureVerifier() {
+      @Override
+      public SafeFuture<Boolean> verify(
+          final List<BLSPublicKey> publicKeys, final Bytes message, final BLSSignature signature) {
+        AsyncBatchBLSSignatureVerifier.this.verify(publicKeys, message, signature);
+        return TRUE;
+      }
+
+      @Override
+      public SafeFuture<Boolean> verify(
+          final List<List<BLSPublicKey>> publicKeys,
+          final List<Bytes> messages,
+          final List<BLSSignature> signatures) {
+        AsyncBatchBLSSignatureVerifier.this.verify(publicKeys, messages, signatures);
+        return TRUE;
+      }
+    };
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/AsyncBatchBLSSignatureVerifierTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/AsyncBatchBLSSignatureVerifierTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class AsyncBatchBLSSignatureVerifierTest {
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
+
+  private final AsyncBLSSignatureVerifier delegate = mock(AsyncBLSSignatureVerifier.class);
+  private final SafeFuture<Boolean> delegateVerifyResult = new SafeFuture<>();
+
+  private final AsyncBatchBLSSignatureVerifier verifier =
+      new AsyncBatchBLSSignatureVerifier(delegate);
+
+  @BeforeEach
+  void setUp() {
+    when(delegate.verify(anyList(), anyList(), anyList())).thenReturn(delegateVerifyResult);
+  }
+
+  @Test
+  void shouldOnlyVerifySingleAttestationsAtEnd() {
+    final BLSPublicKey publicKey1 = dataStructureUtil.randomPublicKey();
+    final Bytes32 message1 = dataStructureUtil.randomBytes32();
+    final BLSSignature signature1 = dataStructureUtil.randomSignature();
+
+    final BLSPublicKey publicKey2 = dataStructureUtil.randomPublicKey();
+    final Bytes32 message2 = dataStructureUtil.randomBytes32();
+    final BLSSignature signature2 = dataStructureUtil.randomSignature();
+
+    assertThat(verifier.verify(publicKey1, message1, signature1)).isTrue();
+    verifyNoInteractions(delegate);
+
+    assertThat(verifier.verify(publicKey2, message2, signature2)).isTrue();
+    verifyNoInteractions(delegate);
+
+    final SafeFuture<Boolean> result = verifier.batchVerify();
+    assertThat(result).isSameAs(delegateVerifyResult);
+    verify(delegate)
+        .verify(
+            List.of(List.of(publicKey1), List.of(publicKey2)),
+            List.of(message1, message2),
+            List.of(signature1, signature2));
+  }
+
+  @Test
+  void shouldOnlyVerifyCombinedAttestationsAtEnd() {
+    final List<BLSPublicKey> publicKeys1 =
+        List.of(
+            dataStructureUtil.randomPublicKey(),
+            dataStructureUtil.randomPublicKey(),
+            dataStructureUtil.randomPublicKey());
+    final List<Bytes> messages1 =
+        List.of(
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomBytes32());
+    final List<BLSSignature> signatures1 =
+        List.of(
+            dataStructureUtil.randomSignature(),
+            dataStructureUtil.randomSignature(),
+            dataStructureUtil.randomSignature());
+
+    final List<BLSPublicKey> publicKeys2 =
+        List.of(dataStructureUtil.randomPublicKey(), dataStructureUtil.randomPublicKey());
+    final List<Bytes> messages2 =
+        List.of(dataStructureUtil.randomBytes32(), dataStructureUtil.randomBytes32());
+    final List<BLSSignature> signatures2 =
+        List.of(dataStructureUtil.randomSignature(), dataStructureUtil.randomSignature());
+
+    assertThat(verifier.verify(List.of(publicKeys1), messages1, signatures1)).isTrue();
+    verifyNoInteractions(delegate);
+
+    assertThat(verifier.verify(List.of(publicKeys2), messages2, signatures2)).isTrue();
+    verifyNoInteractions(delegate);
+
+    final SafeFuture<Boolean> result = verifier.batchVerify();
+    assertThat(result).isSameAs(delegateVerifyResult);
+    verify(delegate)
+        .verify(
+            concat(List.of(publicKeys1), List.of(publicKeys2)),
+            concat(messages1, messages2),
+            concat(signatures1, signatures2));
+  }
+
+  @Test
+  void shouldVerifySingleAndCombinedAttestationsAtEnd() {
+    final BLSPublicKey publicKey1 = dataStructureUtil.randomPublicKey();
+    final Bytes32 message1 = dataStructureUtil.randomBytes32();
+    final BLSSignature signature1 = dataStructureUtil.randomSignature();
+
+    final List<BLSPublicKey> publicKeys2 =
+        List.of(dataStructureUtil.randomPublicKey(), dataStructureUtil.randomPublicKey());
+    final List<Bytes> messages2 =
+        List.of(dataStructureUtil.randomBytes32(), dataStructureUtil.randomBytes32());
+    final List<BLSSignature> signatures2 =
+        List.of(dataStructureUtil.randomSignature(), dataStructureUtil.randomSignature());
+
+    assertThat(verifier.verify(publicKey1, message1, signature1)).isTrue();
+    verifyNoInteractions(delegate);
+
+    assertThat(verifier.verify(List.of(publicKeys2), messages2, signatures2)).isTrue();
+    verifyNoInteractions(delegate);
+
+    final SafeFuture<Boolean> result = verifier.batchVerify();
+    assertThat(result).isSameAs(delegateVerifyResult);
+    verify(delegate)
+        .verify(
+            concat(List.of(List.of(publicKey1)), List.of(publicKeys2)),
+            concat(List.of(message1), messages2),
+            concat(List.of(signature1), signatures2));
+  }
+
+  @Test
+  void shouldCombineVerificationsMadeViaAsyncBLSSignatureVerifierInterface() {
+    final BLSPublicKey publicKey1 = dataStructureUtil.randomPublicKey();
+    final Bytes32 message1 = dataStructureUtil.randomBytes32();
+    final BLSSignature signature1 = dataStructureUtil.randomSignature();
+
+    final List<BLSPublicKey> publicKeys2 =
+        List.of(dataStructureUtil.randomPublicKey(), dataStructureUtil.randomPublicKey());
+    final List<Bytes> messages2 =
+        List.of(dataStructureUtil.randomBytes32(), dataStructureUtil.randomBytes32());
+    final List<BLSSignature> signatures2 =
+        List.of(dataStructureUtil.randomSignature(), dataStructureUtil.randomSignature());
+
+    final BLSPublicKey publicKey3 = dataStructureUtil.randomPublicKey();
+    final Bytes32 message3 = dataStructureUtil.randomBytes32();
+    final BLSSignature signature3 = dataStructureUtil.randomSignature();
+
+    final AsyncBLSSignatureVerifier asyncVerifier = verifier.asAsyncBSLSSignatureVerifier();
+    assertThat(asyncVerifier.verify(publicKey1, message1, signature1)).isCompletedWithValue(true);
+    assertThat(asyncVerifier.verify(List.of(publicKeys2), messages2, signatures2))
+        .isCompletedWithValue(true);
+    assertThat(verifier.verify(publicKey3, message3, signature3)).isTrue();
+
+    verifyNoInteractions(delegate);
+
+    final SafeFuture<Boolean> result = verifier.batchVerify();
+    assertThat(result).isSameAs(delegateVerifyResult);
+    verify(delegate)
+        .verify(
+            concat(
+                List.of(List.of(publicKey1)), List.of(publicKeys2), List.of(List.of(publicKey3))),
+            concat(List.of(message1), messages2, List.of(message3)),
+            concat(List.of(signature1), signatures2, List.of(signature3)));
+  }
+
+  @SafeVarargs
+  private <T> List<T> concat(final List<T>... lists) {
+    final List<T> result = new ArrayList<>();
+    for (List<T> list : lists) {
+      result.addAll(list);
+    }
+    return result;
+  }
+}

--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -80,7 +80,8 @@ class AttestationManagerIntegrationTest {
           futureAttestations,
           attestationPool,
           attestationValidator,
-          new AggregateAttestationValidator(recentChainData, attestationValidator, spec),
+          new AggregateAttestationValidator(
+              spec, recentChainData, attestationValidator, signatureVerificationService),
           signatureVerificationService,
           activeValidatorChannel);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidatorTest.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedCo
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.statetransition.validation.signatures.SignatureVerificationService;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
@@ -51,7 +52,8 @@ class SignedContributionAndProofValidatorTest {
           spec,
           storageSystem.recentChainData(),
           new SyncCommitteeStateUtils(spec, storageSystem.recentChainData()),
-          timeProvider);
+          timeProvider,
+          SignatureVerificationService.createSimple());
 
   @BeforeEach
   void setUp() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidatorTest.java
@@ -92,7 +92,7 @@ import tech.pegasys.teku.storage.storageSystem.StorageSystem;
  *
  * <p>The signature of aggregate is valid.
  */
-class SignedAggregateAndProofValidatorTest {
+class AggregateAttestationValidatorTest {
 
   private static final List<BLSKeyPair> VALIDATOR_KEYS =
       new MockStartValidatorKeyPairFactory().generateKeyPairs(0, 1024);
@@ -113,7 +113,8 @@ class SignedAggregateAndProofValidatorTest {
   private final AsyncBLSSignatureVerifier signatureVerifier =
       AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.SIMPLE);
   private final AggregateAttestationValidator validator =
-      new AggregateAttestationValidator(recentChainData, attestationValidator, spec);
+      new AggregateAttestationValidator(
+          spec, recentChainData, attestationValidator, signatureVerifier);
   private SignedBlockAndState bestBlock;
   private SignedBlockAndState genesis;
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -559,7 +559,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     AttestationValidator attestationValidator =
         new AttestationValidator(spec, recentChainData, signatureVerificationService);
     AggregateAttestationValidator aggregateValidator =
-        new AggregateAttestationValidator(recentChainData, attestationValidator, spec);
+        new AggregateAttestationValidator(
+            spec, recentChainData, attestationValidator, signatureVerificationService);
     attestationManager =
         AttestationManager.create(
             pendingAttestations,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -585,7 +585,11 @@ public class BeaconChainController extends Service implements TimeTickChannel {
         new SyncCommitteeContributionPool(
             spec,
             new SignedContributionAndProofValidator(
-                spec, recentChainData, syncCommitteeStateUtils, timeProvider));
+                spec,
+                recentChainData,
+                syncCommitteeStateUtils,
+                timeProvider,
+                signatureVerificationService));
 
     syncCommitteeMessagePool =
         new SyncCommitteeMessagePool(


### PR DESCRIPTION
## PR Description
Use signature verification service to batch signature verification for aggregates.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
