### PR TITLE
Disable color output from PicoCLI for options tests

### DIFF
--- a/teku/src/test/java/tech/pegasys/teku/cli/AbstractBeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/AbstractBeaconNodeCommandTest.java
@@ -26,6 +26,8 @@ import java.nio.file.Path;
 import java.util.Collections;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.cli.BeaconNodeCommand.StartAction;
@@ -43,6 +45,16 @@ public abstract class AbstractBeaconNodeCommandTest {
       new BeaconNodeCommand(outputWriter, errorWriter, Collections.emptyMap(), startAction);
 
   @TempDir Path dataPath;
+
+  @BeforeAll
+  static void disablePicocliColors() {
+    System.setProperty("picocli.ansi", "false");
+  }
+
+  @AfterAll
+  static void resetPicocliColors() {
+    System.clearProperty("picocli.ansi");
+  }
 
   public TekuConfiguration getResultingTekuConfiguration() {
     try {


### PR DESCRIPTION
## PR Description
Force disable color output from PicoCLI to improve reliability of tests which check help text output.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
