### PR TITLE
Fix block performance reporting

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -109,8 +109,7 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
     }
 
     UInt64 currentEpoch = spec.computeEpochAtSlot(slot);
-    if (!latestAnalyzedEpoch.get().isZero()
-        && currentEpoch.isLessThanOrEqualTo(
+    if (currentEpoch.isLessThanOrEqualTo(
             latestAnalyzedEpoch.getAndUpdate(
                 val -> val.isLessThan(currentEpoch) ? currentEpoch : val))) {
       return;
@@ -135,18 +134,22 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
       producedAttestationsByEpoch.headMap(analyzedEpoch, true).clear();
     }
 
-    BlockPerformance blockPerformance = getBlockPerformanceForEpoch(currentEpoch);
-    if (blockPerformance.numberOfExpectedBlocks > 0) {
-      if (mode.isLoggingEnabled()) {
-        statusLogger.performance(blockPerformance.toString());
-      }
+    // Nothing to report until epoch 0 is complete
+    if (!currentEpoch.isZero()) {
+      final UInt64 blockProductionEpoch = currentEpoch.minus(1);
+      BlockPerformance blockPerformance = getBlockPerformanceForEpoch(blockProductionEpoch);
+      if (blockPerformance.numberOfExpectedBlocks > 0) {
+        if (mode.isLoggingEnabled()) {
+          statusLogger.performance(blockPerformance.toString());
+        }
 
-      if (mode.isMetricsEnabled()) {
-        validatorPerformanceMetrics.updateBlockPerformanceMetrics(blockPerformance);
-      }
+        if (mode.isMetricsEnabled()) {
+          validatorPerformanceMetrics.updateBlockPerformanceMetrics(blockPerformance);
+        }
 
-      producedBlocksByEpoch.headMap(currentEpoch, true).clear();
-      blockProductionAttemptsByEpoch.headMap(currentEpoch, true).clear();
+      }
+      producedBlocksByEpoch.headMap(blockProductionEpoch, true).clear();
+      blockProductionAttemptsByEpoch.headMap(blockProductionEpoch, true).clear();
     }
 
     // Nothing to report until epoch 0 is complete

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -110,8 +110,8 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
 
     UInt64 currentEpoch = spec.computeEpochAtSlot(slot);
     if (currentEpoch.isLessThanOrEqualTo(
-            latestAnalyzedEpoch.getAndUpdate(
-                val -> val.isLessThan(currentEpoch) ? currentEpoch : val))) {
+        latestAnalyzedEpoch.getAndUpdate(
+            val -> val.isLessThan(currentEpoch) ? currentEpoch : val))) {
       return;
     }
 
@@ -146,7 +146,6 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
         if (mode.isMetricsEnabled()) {
           validatorPerformanceMetrics.updateBlockPerformanceMetrics(blockPerformance);
         }
-
       }
       producedBlocksByEpoch.headMap(blockProductionEpoch, true).clear();
       blockProductionAttemptsByEpoch.headMap(blockProductionEpoch, true).clear();

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
@@ -46,7 +46,6 @@ import tech.pegasys.teku.validator.coordinator.ActiveValidatorTracker;
 
 public class DefaultPerformanceTrackerTest {
 
-  private static final UInt64 EPOCH = UInt64.ZERO;
   private static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(64);
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
   protected StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
@@ -89,21 +88,20 @@ public class DefaultPerformanceTrackerTest {
     performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(UInt64.valueOf(2)));
     performanceTracker.saveProducedBlock(chainUpdater.chainBuilder.getBlockAtSlot(1));
     performanceTracker.saveProducedBlock(chainUpdater.chainBuilder.getBlockAtSlot(2));
-    performanceTracker.onSlot(spec.computeEpochAtSlot(UInt64.ONE));
-    BlockPerformance expectedBlockPerformance =
-        new BlockPerformance(spec.computeEpochAtSlot(UInt64.ONE), 2, 2, 2);
+    performanceTracker.onSlot(spec.computeStartSlotAtEpoch(UInt64.ONE));
+    BlockPerformance expectedBlockPerformance = new BlockPerformance(UInt64.ZERO, 2, 2, 2);
     verify(log).performance(expectedBlockPerformance.toString());
   }
 
   @Test
   void shouldDisplayBlockInclusionWhenProducedBlockIsChainHead() {
-    final UInt64 lastSlot = spec.computeStartSlotAtEpoch(EPOCH);
+    final UInt64 lastSlot = spec.computeStartSlotAtEpoch(UInt64.ONE);
     final SignedBlockAndState bestBlock = chainUpdater.advanceChainUntil(2);
     chainUpdater.updateBestBlock(bestBlock);
     performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(bestBlock.getSlot()));
     performanceTracker.saveProducedBlock(bestBlock.getBlock());
     performanceTracker.onSlot(lastSlot);
-    BlockPerformance expectedBlockPerformance = new BlockPerformance(EPOCH, 1, 1, 1);
+    BlockPerformance expectedBlockPerformance = new BlockPerformance(UInt64.ZERO, 1, 1, 1);
     verify(log).performance(expectedBlockPerformance.toString());
   }
 
@@ -116,8 +114,8 @@ public class DefaultPerformanceTrackerTest {
     performanceTracker.saveProducedBlock(chainUpdater.chainBuilder.getBlockAtSlot(1));
     performanceTracker.saveProducedBlock(chainUpdater.chainBuilder.getBlockAtSlot(2));
     performanceTracker.saveProducedBlock(dataStructureUtil.randomSignedBeaconBlock(3));
-    performanceTracker.onSlot(spec.computeStartSlotAtEpoch(EPOCH));
-    BlockPerformance expectedBlockPerformance = new BlockPerformance(EPOCH, 3, 2, 3);
+    performanceTracker.onSlot(spec.computeStartSlotAtEpoch(UInt64.ONE));
+    BlockPerformance expectedBlockPerformance = new BlockPerformance(UInt64.ZERO, 3, 2, 3);
     verify(log).performance(expectedBlockPerformance.toString());
   }
 
@@ -253,11 +251,11 @@ public class DefaultPerformanceTrackerTest {
 
   @Test
   void shouldClearOldSentObjects() {
-    chainUpdater.updateBestBlock(chainUpdater.advanceChainUntil(22));
-    performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(UInt64.valueOf(16)));
-    performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(UInt64.valueOf(17)));
-    performanceTracker.saveProducedBlock(chainUpdater.chainBuilder.getBlockAtSlot(16));
-    performanceTracker.saveProducedBlock(chainUpdater.chainBuilder.getBlockAtSlot(17));
+    chainUpdater.updateBestBlock(chainUpdater.advanceChainUntil(10));
+    performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(UInt64.valueOf(1)));
+    performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(UInt64.valueOf(2)));
+    performanceTracker.saveProducedBlock(chainUpdater.chainBuilder.getBlockAtSlot(1));
+    performanceTracker.saveProducedBlock(chainUpdater.chainBuilder.getBlockAtSlot(2));
     performanceTracker.saveProducedAttestation(
         new Attestation(
             dataStructureUtil.randomBitlist(),


### PR DESCRIPTION
## PR Description
Block performance was being reported for the just started epoch instead of the just completed one, resulting in incorrect or missing data.

## Fixed Issue(s)
fixes #4581 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
