### PR TITLE
Batch requests for validator indices in VoluntaryExitCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@ For information on changes in released versions of Teku, see the [releases page]
 - Fixed issue where discovery did not correctly abort handshake attempts when a request timed out.
 - Downgrade to jbslt 0.3.5 to resolve incompatibility with Windows 10.
 - Fixed issue where `Syncing Completed` message was printing multiple times.
+- Limited the number of validator public keys to lookup per request in `voluntary-exit` subcommand to avoid exceeding maximum URL length limits.


### PR DESCRIPTION
## PR Description
Request validator indices in batches to avoid creating an excessively long URL in the `voluntary-exit` subcommand.

## Fixed Issue(s)
fixes #4583 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
