### PR TITLE
Implement ExecutionPayload processing

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenaltyDeltas;
@@ -109,7 +110,12 @@ public class EpochTransitionBenchmark {
     localChain.initializeStorage();
 
     blockImporter =
-        new BlockImporter(blockImportNotifications, recentChainData, forkChoice, wsValidator);
+        new BlockImporter(
+            blockImportNotifications,
+            recentChainData,
+            forkChoice,
+            wsValidator,
+            ExecutionEngineChannel.NOOP);
     blockIterator = BlockIO.createResourceReader(spec, blocksFile).iterator();
     System.out.println("Importing 63 blocks from " + blocksFile);
 

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.spec.datastructures.interop.InteropStartupUtil;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -92,7 +93,12 @@ public class ProfilingRun {
       BeaconChainUtil localChain =
           BeaconChainUtil.create(spec, recentChainData, validatorKeys, false);
       BlockImporter blockImporter =
-          new BlockImporter(blockImportNotifications, recentChainData, forkChoice, wsValidator);
+          new BlockImporter(
+              blockImportNotifications,
+              recentChainData,
+              forkChoice,
+              wsValidator,
+              ExecutionEngineChannel.NOOP);
 
       System.out.println("Start blocks import from " + blocksFile);
       int blockCount = 0;
@@ -165,7 +171,12 @@ public class ProfilingRun {
       initialState = null;
       ForkChoice forkChoice = ForkChoice.create(spec, new InlineEventThread(), recentChainData);
       BlockImporter blockImporter =
-          new BlockImporter(blockImportNotifications, recentChainData, forkChoice, wsValidator);
+          new BlockImporter(
+              blockImportNotifications,
+              recentChainData,
+              forkChoice,
+              wsValidator,
+              ExecutionEngineChannel.NOOP);
 
       System.out.println("Start blocks import from " + blocksFile);
       int counter = 1;

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
@@ -91,7 +92,12 @@ public abstract class TransitionBenchmark {
     localChain.initializeStorage();
 
     blockImporter =
-        new BlockImporter(blockImportNotifications, recentChainData, forkChoice, wsValidator);
+        new BlockImporter(
+            blockImportNotifications,
+            recentChainData,
+            forkChoice,
+            wsValidator,
+            ExecutionEngineChannel.NOOP);
     blockIterator = BlockIO.createResourceReader(spec, blocksFile).iterator();
     System.out.println("Importing blocks from " + blocksFile);
   }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -70,7 +70,6 @@ public abstract class Eth2ReferenceTestCase {
 
           // Disabled while work continues to bring over the merge work
           .put("sanity/blocks", TestExecutor.IGNORE_TESTS)
-          .put("operations/execution_payload", TestExecutor.IGNORE_TESTS)
           .put("fork_choice/on_merge_block", TestExecutor.IGNORE_TESTS)
           .put("fork_choice/on_block", TestExecutor.IGNORE_TESTS)
           .put("fork_choice/get_head", TestExecutor.IGNORE_TESTS)

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -39,7 +39,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    * <p>e.g. set to "ssz_static" to run only ssz static tests or "ssz_static/Attestation" for only
    * attestation ssz tests.
    */
-  private static final String TEST_TYPE = "ssz_static";
+  private static final String TEST_TYPE = "operations/execution_payload";
 
   /** Filter test to run to those from the specified spec. One of general, minimal or mainnet */
   private static final String SPEC = "";

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/fork/TransitionTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/fork/TransitionTestExecutor.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigLoader;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 
 public class TransitionTestExecutor implements TestExecutor {
@@ -76,7 +77,7 @@ public class TransitionTestExecutor implements TestExecutor {
 
         final BLSSignatureVerifier signatureVerifier =
             metadata.blsSetting == 2 ? BLSSignatureVerifier.NO_OP : BLSSignatureVerifier.SIMPLE;
-        result = spec.processBlock(result, block, signatureVerifier);
+        result = spec.processBlock(result, block, signatureVerifier, ExecutionEngineChannel.NOOP);
       } catch (final StateTransitionException e) {
         Assertions.fail(
             "Failed to process block " + i + " at slot " + block.getSlot() + ": " + e.getMessage(),

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
@@ -18,12 +18,14 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 
 public class DefaultOperationProcessor implements OperationProcessor {
@@ -96,5 +98,15 @@ public class DefaultOperationProcessor implements OperationProcessor {
       throws BlockProcessingException {
     spec.getBlockProcessor(state.getSlot())
         .processSyncAggregate(state, aggregate, BLSSignatureVerifier.SIMPLE);
+  }
+
+  @Override
+  public void processExecutionPayload(
+      final MutableBeaconState state,
+      final ExecutionPayload executionPayload,
+      final ExecutionEngineChannel executionEngine)
+      throws BlockProcessingException {
+    spec.getBlockProcessor(state.getSlot())
+        .processExecutionPayload(state, executionPayload, executionEngine);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
@@ -15,12 +15,14 @@ package tech.pegasys.teku.reference.common.operations;
 
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 
 public interface OperationProcessor {
@@ -39,9 +41,15 @@ public interface OperationProcessor {
   void processVoluntaryExit(MutableBeaconState state, SignedVoluntaryExit voluntaryExit)
       throws BlockProcessingException;
 
-  void processAttestation(MutableBeaconState state, final Attestation attestation)
+  void processAttestation(MutableBeaconState state, Attestation attestation)
       throws BlockProcessingException;
 
-  void processSyncCommittee(final MutableBeaconState state, final SyncAggregate aggregate)
+  void processSyncCommittee(MutableBeaconState state, SyncAggregate aggregate)
+      throws BlockProcessingException;
+
+  void processExecutionPayload(
+      MutableBeaconState state,
+      ExecutionPayload executionPayload,
+      ExecutionEngineChannel executionEngine)
       throws BlockProcessingException;
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -15,15 +15,22 @@ package tech.pegasys.teku.reference.common.operations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.reference.TestDataUtils.loadSsz;
 import static tech.pegasys.teku.reference.TestDataUtils.loadStateFromSsz;
+import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
+import java.util.Optional;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.reference.TestExecutor;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
@@ -31,6 +38,9 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutePayloadResult;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.ssz.SszData;
 
@@ -45,7 +55,8 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
     DEPOSIT,
     VOLUNTARY_EXIT,
     ATTESTATION,
-    SYNC_AGGREGATE
+    SYNC_AGGREGATE,
+    EXECUTION_PAYLOAD
   }
 
   public static ImmutableMap<String, TestExecutor> OPERATIONS_TEST_TYPES =
@@ -76,6 +87,10 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
           .put(
               "operations/sync_aggregate_random",
               new OperationsTestExecutor<>("sync_aggregate.ssz_snappy", Operation.SYNC_AGGREGATE))
+          .put(
+              "operations/execution_payload",
+              new OperationsTestExecutor<>(
+                  "execution_payload.ssz_snappy", Operation.EXECUTION_PAYLOAD))
           .build();
 
   private final String dataFileName;
@@ -184,6 +199,36 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
                     .getSyncAggregateSchema());
         processor.processSyncCommittee(state, syncAggregate);
         break;
+      case EXECUTION_PAYLOAD:
+        final ExecutionEngineChannel executionEngine = mock(ExecutionEngineChannel.class);
+        final ExecutionMeta executionMeta =
+            loadYaml(testDefinition, "execution.yaml", ExecutionMeta.class);
+        final ExecutionPayload payload =
+            loadSsz(
+                testDefinition,
+                dataFileName,
+                testDefinition
+                    .getSpec()
+                    .getGenesisSchemaDefinitions()
+                    .toVersionMerge()
+                    .orElseThrow()
+                    .getExecutionPayloadSchema());
+        when(executionEngine.executePayload(payload))
+            .thenReturn(
+                SafeFuture.completedFuture(
+                    new ExecutePayloadResult(
+                        executionMeta.executionValid
+                            ? ExecutionPayloadStatus.VALID
+                            : ExecutionPayloadStatus.INVALID,
+                        Optional.empty(),
+                        Optional.empty())));
+        processor.processExecutionPayload(state, payload, executionEngine);
+        break;
     }
+  }
+
+  private static class ExecutionMeta {
+    @JsonProperty(value = "execution_valid", required = true)
+    private boolean executionValid;
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -153,7 +154,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
         TestDataUtils.loadSsz(
             testDefinition, blockName + ".ssz_snappy", spec::deserializeSignedBeaconBlock);
     LOG.info("Importing block {} at slot {}", block.getRoot(), block.getSlot());
-    assertThat(forkChoice.onBlock(block)).isCompleted();
+    assertThat(forkChoice.onBlock(block, ExecutionEngineChannel.NOOP)).isCompleted();
   }
 
   @SuppressWarnings("unchecked")

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityBlocksTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityBlocksTestExecutor.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.reference.TestExecutor;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 
 public class SanityBlocksTestExecutor implements TestExecutor {
@@ -93,7 +94,8 @@ public class SanityBlocksTestExecutor implements TestExecutor {
                 block,
                 metaData.getBlsSetting() == IGNORED
                     ? BLSSignatureVerifier.NO_OP
-                    : BLSSignatureVerifier.SIMPLE);
+                    : BLSSignatureVerifier.SIMPLE,
+                ExecutionEngineChannel.NOOP);
       }
       return result;
     } catch (StateTransitionException e) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutePayloadResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutePayloadResult.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.executionengine;
 
+import com.google.common.base.MoreObjects;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 
@@ -38,5 +39,14 @@ public class ExecutePayloadResult {
 
   public Optional<String> getMessage() {
     return message;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("status", status)
+        .add("latestValidHash", latestValidHash)
+        .add("message", message)
+        .toString();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -31,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
@@ -43,7 +45,8 @@ public interface BlockProcessor {
   BeaconState processAndValidateBlock(
       SignedBeaconBlock signedBlock,
       BeaconState blockSlotState,
-      IndexedAttestationCache indexedAttestationCache)
+      IndexedAttestationCache indexedAttestationCache,
+      ExecutionEngineChannel executionEngine)
       throws StateTransitionException;
 
   /**
@@ -53,6 +56,8 @@ public interface BlockProcessor {
    * @param blockSlotState The preState on which this block should be procssed, this preState must
    *     already be advanced to the block's slot
    * @param indexedAttestationCache A cache of indexed attestations
+   * @param signatureVerifier The signature verifier to use
+   * @param executionEngine The execution engine to verify payloads via
    * @return The post state after processing the block on top of {@code blockSlotState}
    * @throws StateTransitionException If the block is invalid or cannot be processed
    */
@@ -60,14 +65,16 @@ public interface BlockProcessor {
       SignedBeaconBlock signedBlock,
       BeaconState blockSlotState,
       IndexedAttestationCache indexedAttestationCache,
-      BLSSignatureVerifier signatureVerifier)
+      BLSSignatureVerifier signatureVerifier,
+      ExecutionEngineChannel executionEngine)
       throws StateTransitionException;
 
   BeaconState processUnsignedBlock(
       BeaconState preState,
       BeaconBlock block,
       IndexedAttestationCache indexedAttestationCache,
-      BLSSignatureVerifier signatureVerifier)
+      BLSSignatureVerifier signatureVerifier,
+      ExecutionEngineChannel executionEngine)
       throws BlockProcessingException;
 
   void processBlockHeader(MutableBeaconState state, BeaconBlockSummary blockHeader)
@@ -109,5 +116,11 @@ public interface BlockProcessor {
 
   void processSyncAggregate(
       MutableBeaconState state, SyncAggregate syncAggregate, BLSSignatureVerifier signatureVerifier)
+      throws BlockProcessingException;
+
+  void processExecutionPayload(
+      MutableBeaconState state,
+      ExecutionPayload executionPayload,
+      ExecutionEngineChannel executionEngine)
       throws BlockProcessingException;
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockProposalUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockProposalUtil.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
@@ -75,7 +76,11 @@ public class BlockProposalUtil {
     try {
       final BeaconState newState =
           blockProcessor.processUnsignedBlock(
-              blockSlotState, newBlock, IndexedAttestationCache.NOOP, BLSSignatureVerifier.NO_OP);
+              blockSlotState,
+              newBlock,
+              IndexedAttestationCache.NOOP,
+              BLSSignatureVerifier.NO_OP,
+              ExecutionEngineChannel.NOOP);
 
       Bytes32 stateRoot = newState.hashTreeRoot();
       BeaconBlock newCompleteBlock = newBlock.withStateRoot(stateRoot);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
@@ -315,7 +316,8 @@ public class ForkChoiceUtil {
       final MutableStore store,
       final SignedBeaconBlock signedBlock,
       final BeaconState blockSlotState,
-      final IndexedAttestationCache indexedAttestationCache) {
+      final IndexedAttestationCache indexedAttestationCache,
+      final ExecutionEngineChannel executionEngine) {
     checkArgument(
         blockSlotState.getSlot().equals(signedBlock.getSlot()),
         "State must have slots processed up to the block slot");
@@ -335,7 +337,7 @@ public class ForkChoiceUtil {
     try {
       state =
           blockProcessor.processAndValidateBlock(
-              signedBlock, blockSlotState, indexedAttestationCache);
+              signedBlock, blockSlotState, indexedAttestationCache, executionEngine);
     } catch (StateTransitionException e) {
       return BlockImportResult.failedStateTransition(e);
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -31,12 +31,14 @@ import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.MutableBeaconStateAltair;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
@@ -92,12 +94,13 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
       final MutableBeaconState genericState,
       final BeaconBlock block,
       final IndexedAttestationCache indexedAttestationCache,
-      final BLSSignatureVerifier signatureVerifier)
+      final BLSSignatureVerifier signatureVerifier,
+      final ExecutionEngineChannel executionEngine)
       throws BlockProcessingException {
     final MutableBeaconStateAltair state = MutableBeaconStateAltair.required(genericState);
     final BeaconBlockBodyAltair blockBody = BeaconBlockBodyAltair.required(block.getBody());
 
-    super.processBlock(state, block, indexedAttestationCache, signatureVerifier);
+    super.processBlock(state, block, indexedAttestationCache, signatureVerifier, executionEngine);
     processSyncAggregate(state, blockBody.getSyncAggregate(), signatureVerifier);
   }
 
@@ -240,6 +243,15 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
         .forEach(
             participantIndex ->
                 beaconStateMutators.decreaseBalance(state, participantIndex, participantReward));
+  }
+
+  @Override
+  public void processExecutionPayload(
+      final MutableBeaconState state,
+      final ExecutionPayload executionPayload,
+      final ExecutionEngineChannel executionEngine)
+      throws BlockProcessingException {
+    throw new UnsupportedOperationException("No ExecutionPayload in phase0");
   }
 
   public static boolean eth2FastAggregateVerify(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -251,7 +251,7 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
       final ExecutionPayload executionPayload,
       final ExecutionEngineChannel executionEngine)
       throws BlockProcessingException {
-    throw new UnsupportedOperationException("No ExecutionPayload in phase0");
+    throw new UnsupportedOperationException("No ExecutionPayload in Altair");
   }
 
   public static boolean eth2FastAggregateVerify(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/SpecLogicMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/SpecLogicMerge.java
@@ -33,12 +33,12 @@ import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
-import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.forktransition.AltairStateUpgrade;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.attestation.AttestationWorthinessCheckerAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.EpochProcessorAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.ValidatorStatusFactoryAltair;
+import tech.pegasys.teku.spec.logic.versions.merge.block.BlockProcessorMerge;
 import tech.pegasys.teku.spec.logic.versions.merge.helpers.BeaconStateAccessorsMerge;
 import tech.pegasys.teku.spec.logic.versions.merge.helpers.BeaconStateMutatorsMerge;
 import tech.pegasys.teku.spec.logic.versions.merge.helpers.MergeTransitionHelpers;
@@ -67,7 +67,7 @@ public class SpecLogicMerge extends AbstractSpecLogic {
       final OperationValidator operationValidator,
       final ValidatorStatusFactoryAltair validatorStatusFactory,
       final EpochProcessorAltair epochProcessor,
-      final BlockProcessorAltair blockProcessor,
+      final BlockProcessorMerge blockProcessor,
       final ForkChoiceUtil forkChoiceUtil,
       final BlockProposalUtil blockProposalUtil,
       final SyncCommitteeUtil syncCommitteeUtil,
@@ -137,8 +137,8 @@ public class SpecLogicMerge extends AbstractSpecLogic {
             validatorsUtil,
             beaconStateUtil,
             validatorStatusFactory);
-    final BlockProcessorAltair blockProcessor =
-        new BlockProcessorAltair(
+    final BlockProcessorMerge blockProcessor =
+        new BlockProcessorMerge(
             config,
             predicates,
             miscHelpers,
@@ -148,7 +148,8 @@ public class SpecLogicMerge extends AbstractSpecLogic {
             beaconStateUtil,
             attestationUtil,
             validatorsUtil,
-            operationValidator);
+            operationValidator,
+            schemaDefinitions);
     final ForkChoiceUtil forkChoiceUtil =
         new ForkChoiceUtil(
             config, beaconStateAccessors, attestationUtil, blockProcessor, miscHelpers);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/block/BlockProcessorMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/block/BlockProcessorMerge.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.merge.block;
+
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
+import tech.pegasys.teku.spec.config.SpecConfigMerge;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.merge.BeaconBlockBodyMerge;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeaderSchema;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.merge.MutableBeaconStateMerge;
+import tech.pegasys.teku.spec.executionengine.ExecutePayloadResult;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.ExecutionPayloadStatus;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
+import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
+import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
+import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
+import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair;
+import tech.pegasys.teku.spec.logic.versions.merge.helpers.BeaconStateAccessorsMerge;
+import tech.pegasys.teku.spec.logic.versions.merge.helpers.MiscHelpersMerge;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsMerge;
+
+public class BlockProcessorMerge extends BlockProcessorAltair {
+
+  private final MiscHelpersMerge miscHelpers;
+  private final SchemaDefinitionsMerge schemaDefinitions;
+
+  public BlockProcessorMerge(
+      final SpecConfigMerge specConfig,
+      final Predicates predicates,
+      final MiscHelpersMerge miscHelpers,
+      final BeaconStateAccessorsMerge beaconStateAccessors,
+      final BeaconStateMutators beaconStateMutators,
+      final OperationSignatureVerifier operationSignatureVerifier,
+      final BeaconStateUtil beaconStateUtil,
+      final AttestationUtil attestationUtil,
+      final ValidatorsUtil validatorsUtil,
+      final OperationValidator operationValidator,
+      final SchemaDefinitionsMerge schemaDefinitions) {
+    super(
+        specConfig,
+        predicates,
+        miscHelpers,
+        beaconStateAccessors,
+        beaconStateMutators,
+        operationSignatureVerifier,
+        beaconStateUtil,
+        attestationUtil,
+        validatorsUtil,
+        operationValidator);
+    this.miscHelpers = miscHelpers;
+    this.schemaDefinitions = schemaDefinitions;
+  }
+
+  @Override
+  public void processBlock(
+      final MutableBeaconState genericState,
+      final BeaconBlock block,
+      final IndexedAttestationCache indexedAttestationCache,
+      final BLSSignatureVerifier signatureVerifier,
+      final ExecutionEngineChannel executionEngine)
+      throws BlockProcessingException {
+    final MutableBeaconStateMerge state = MutableBeaconStateMerge.required(genericState);
+    final BeaconBlockBodyMerge blockBody = BeaconBlockBodyMerge.required(block.getBody());
+    processBlockHeader(state, block);
+    if (miscHelpers.isExecutionEnabled(genericState, block)) {
+      processExecutionPayload(state, blockBody.getExecutionPayload(), executionEngine);
+    }
+    processRandaoNoValidation(state, block.getBody());
+    processEth1Data(state, block.getBody());
+    processOperationsNoValidation(state, block.getBody(), indexedAttestationCache);
+    processSyncAggregate(state, blockBody.getSyncAggregate(), signatureVerifier);
+  }
+
+  @Override
+  public void processExecutionPayload(
+      final MutableBeaconState genericState,
+      final ExecutionPayload payload,
+      final ExecutionEngineChannel executionEngine)
+      throws BlockProcessingException {
+    final MutableBeaconStateMerge state = MutableBeaconStateMerge.required(genericState);
+    if (miscHelpers.isMergeComplete(state)) {
+      if (!payload.getParentHash().equals(state.getLatestExecutionPayloadHeader().getBlockHash())) {
+        throw new BlockProcessingException(
+            "Execution payload parent hash does not match previous execution payload header");
+      }
+    }
+
+    if (!beaconStateAccessors
+        .getRandaoMix(state, beaconStateAccessors.getCurrentEpoch(state))
+        .equals(payload.getRandom())) {
+      throw new BlockProcessingException("Execution payload random does not match state randao");
+    }
+
+    if (!miscHelpers
+        .computeTimestampAtSlot(state, state.getSlot())
+        .equals(payload.getTimestamp())) {
+      throw new BlockProcessingException(
+          "Execution payload timestamp does not match time for state slot");
+    }
+
+    final ExecutePayloadResult payloadResult = executionEngine.executePayload(payload).join();
+    if (payloadResult.getStatus() != ExecutionPayloadStatus.VALID) {
+      throw new BlockProcessingException(
+          "Execution payload was not valid: " + payloadResult.getMessage());
+    }
+
+    final ExecutionPayloadHeaderSchema executionPayloadHeaderSchema =
+        schemaDefinitions.getExecutionPayloadHeaderSchema();
+    state.setLatestExecutionPayloadHeader(
+        executionPayloadHeaderSchema.create(
+            payload.getParentHash(),
+            payload.getCoinbase(),
+            payload.getStateRoot(),
+            payload.getReceiptRoot(),
+            payload.getLogsBloom(),
+            payload.getRandom(),
+            payload.getBlockNumber(),
+            payload.getGasLimit(),
+            payload.getGasUsed(),
+            payload.getTimestamp(),
+            payload.getExtraData(),
+            payload.getBaseFeePerGas(),
+            payload.getBlockHash(),
+            payload.getTransactions().hashTreeRoot()));
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/block/BlockProcessorMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/block/BlockProcessorMerge.java
@@ -40,7 +40,7 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsMerge;
 
 public class BlockProcessorMerge extends BlockProcessorAltair {
 
-  private final MiscHelpersMerge miscHelpers;
+  private final MiscHelpersMerge miscHelpersMerge;
   private final SchemaDefinitionsMerge schemaDefinitions;
 
   public BlockProcessorMerge(
@@ -66,7 +66,7 @@ public class BlockProcessorMerge extends BlockProcessorAltair {
         attestationUtil,
         validatorsUtil,
         operationValidator);
-    this.miscHelpers = miscHelpers;
+    this.miscHelpersMerge = miscHelpers;
     this.schemaDefinitions = schemaDefinitions;
   }
 
@@ -81,7 +81,7 @@ public class BlockProcessorMerge extends BlockProcessorAltair {
     final MutableBeaconStateMerge state = MutableBeaconStateMerge.required(genericState);
     final BeaconBlockBodyMerge blockBody = BeaconBlockBodyMerge.required(block.getBody());
     processBlockHeader(state, block);
-    if (miscHelpers.isExecutionEnabled(genericState, block)) {
+    if (miscHelpersMerge.isExecutionEnabled(genericState, block)) {
       processExecutionPayload(state, blockBody.getExecutionPayload(), executionEngine);
     }
     processRandaoNoValidation(state, block.getBody());
@@ -97,7 +97,7 @@ public class BlockProcessorMerge extends BlockProcessorAltair {
       final ExecutionEngineChannel executionEngine)
       throws BlockProcessingException {
     final MutableBeaconStateMerge state = MutableBeaconStateMerge.required(genericState);
-    if (miscHelpers.isMergeComplete(state)) {
+    if (miscHelpersMerge.isMergeComplete(state)) {
       if (!payload.getParentHash().equals(state.getLatestExecutionPayloadHeader().getBlockHash())) {
         throw new BlockProcessingException(
             "Execution payload parent hash does not match previous execution payload header");
@@ -110,7 +110,7 @@ public class BlockProcessorMerge extends BlockProcessorAltair {
       throw new BlockProcessingException("Execution payload random does not match state randao");
     }
 
-    if (!miscHelpers
+    if (!miscHelpersMerge
         .computeTimestampAtSlot(state, state.getSlot())
         .equals(payload.getTimestamp())) {
       throw new BlockProcessingException(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/helpers/MiscHelpersMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/helpers/MiscHelpersMerge.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.logic.versions.merge.helpers;
 
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.merge.BeaconBlockBodyMerge;
@@ -39,5 +40,9 @@ public class MiscHelpersMerge extends MiscHelpersAltair {
 
   public boolean isExecutionEnabled(final BeaconState genericState, final BeaconBlock block) {
     return isMergeBlock(genericState, block) || isMergeComplete(genericState);
+  }
+
+  public UInt64 computeTimestampAtSlot(final BeaconState state, final UInt64 slot) {
+    return state.getGenesis_time().plus(slot.times(specConfig.getSecondsPerSlot()));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
@@ -17,11 +17,13 @@ import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.MutableBeaconStatePhase0;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
@@ -89,5 +91,14 @@ public final class BlockProcessorPhase0 extends AbstractBlockProcessor {
       final BLSSignatureVerifier signatureVerifier)
       throws BlockProcessingException {
     throw new UnsupportedOperationException("No SyncAggregates in phase0");
+  }
+
+  @Override
+  public void processExecutionPayload(
+      final MutableBeaconState state,
+      final ExecutionPayload executionPayload,
+      final ExecutionEngineChannel executionEngine)
+      throws BlockProcessingException {
+    throw new UnsupportedOperationException("No ExecutionPayload in phase0");
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.CheckpointState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.ssz.SszList;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -45,6 +46,7 @@ public class BlockImporter {
   private final RecentChainData recentChainData;
   private final ForkChoice forkChoice;
   private final WeakSubjectivityValidator weakSubjectivityValidator;
+  private final ExecutionEngineChannel executionEngine;
 
   private final Subscribers<VerifiedBlockAttestationListener> attestationSubscribers =
       Subscribers.create(true);
@@ -62,11 +64,13 @@ public class BlockImporter {
       final BlockImportNotifications blockImportNotifications,
       final RecentChainData recentChainData,
       final ForkChoice forkChoice,
-      final WeakSubjectivityValidator weakSubjectivityValidator) {
+      final WeakSubjectivityValidator weakSubjectivityValidator,
+      final ExecutionEngineChannel executionEngine) {
     this.blockImportNotifications = blockImportNotifications;
     this.recentChainData = recentChainData;
     this.forkChoice = forkChoice;
     this.weakSubjectivityValidator = weakSubjectivityValidator;
+    this.executionEngine = executionEngine;
   }
 
   @CheckReturnValue
@@ -84,7 +88,7 @@ public class BlockImporter {
     }
 
     return validateWeakSubjectivityPeriod()
-        .thenCompose(__ -> forkChoice.onBlock(block))
+        .thenCompose(__ -> forkChoice.onBlock(block, executionEngine))
         .thenApply(
             result -> {
               if (!result.isSuccessful()) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -48,6 +48,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.CheckpointState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
@@ -82,7 +83,11 @@ public class BlockImporterTest {
 
   private final BlockImporter blockImporter =
       new BlockImporter(
-          blockImportNotifications, recentChainData, forkChoice, weakSubjectivityValidator);
+          blockImportNotifications,
+          recentChainData,
+          forkChoice,
+          weakSubjectivityValidator,
+          ExecutionEngineChannel.NOOP);
 
   @BeforeAll
   public static void init() {
@@ -354,7 +359,11 @@ public class BlockImporterTest {
         WeakSubjectivityValidator.lenient(wsConfig);
     final BlockImporter blockImporter =
         new BlockImporter(
-            blockImportNotifications, recentChainData, forkChoice, weakSubjectivityValidator);
+            blockImportNotifications,
+            recentChainData,
+            forkChoice,
+            weakSubjectivityValidator,
+            ExecutionEngineChannel.NOOP);
 
     final BlockImportResult result = blockImporter.importBlock(otherBlock).get();
     assertImportFailed(result, FailureReason.FAILED_WEAK_SUBJECTIVITY_CHECKS);
@@ -379,7 +388,11 @@ public class BlockImporterTest {
         WeakSubjectivityValidator.lenient(wsConfig);
     final BlockImporter blockImporter =
         new BlockImporter(
-            blockImportNotifications, recentChainData, forkChoice, weakSubjectivityValidator);
+            blockImportNotifications,
+            recentChainData,
+            forkChoice,
+            weakSubjectivityValidator,
+            ExecutionEngineChannel.NOOP);
 
     // Import wsBlock
     final BlockImportResult result = blockImporter.importBlock(wsBlock).get();
@@ -400,7 +413,8 @@ public class BlockImporterTest {
             blockImportNotifications,
             storageSystem.recentChainData(),
             forkChoice,
-            weakSubjectivityValidator);
+            weakSubjectivityValidator,
+            ExecutionEngineChannel.NOOP);
 
     // The current slot is far ahead of the block being imported
     final UInt64 wsPeriod = UInt64.valueOf(10);
@@ -436,7 +450,8 @@ public class BlockImporterTest {
             blockImportNotifications,
             storageSystem.recentChainData(),
             forkChoice,
-            weakSubjectivityValidator);
+            weakSubjectivityValidator,
+            ExecutionEngineChannel.NOOP);
 
     // Set current time to be several WSP's ahead of finalized checkpoint
     final UInt64 wsPeriod = UInt64.valueOf(10);
@@ -480,7 +495,8 @@ public class BlockImporterTest {
             blockImportNotifications,
             storageSystem.recentChainData(),
             forkChoice,
-            weakSubjectivityValidator);
+            weakSubjectivityValidator,
+            ExecutionEngineChannel.NOOP);
 
     // Set current time to be several WSP's ahead of finalized checkpoint
     final UInt64 wsPeriod = UInt64.valueOf(10);
@@ -516,7 +532,8 @@ public class BlockImporterTest {
             blockImportNotifications,
             storageSystem.recentChainData(),
             forkChoice,
-            weakSubjectivityValidator);
+            weakSubjectivityValidator,
+            ExecutionEngineChannel.NOOP);
 
     final SignedBlockAndState genesis = storageSystem.chainUpdater().initializeGenesis();
 
@@ -540,7 +557,8 @@ public class BlockImporterTest {
             blockImportNotifications,
             storageSystem.recentChainData(),
             forkChoice,
-            weakSubjectivityValidator);
+            weakSubjectivityValidator,
+            ExecutionEngineChannel.NOOP);
 
     final SignedBlockAndState genesis = storageSystem.chainUpdater().initializeGenesis();
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
@@ -80,7 +81,8 @@ public class BlockManagerTest {
           blockImportNotifications,
           localRecentChainData,
           forkChoice,
-          WeakSubjectivityFactory.lenientValidator());
+          WeakSubjectivityFactory.lenientValidator(),
+          ExecutionEngineChannel.NOOP);
   private final BlockManager blockManager =
       new BlockManager(
           localRecentChainData,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.api.TrackingChainHeadChannel.ReorgEvent;
@@ -92,7 +93,8 @@ class ForkChoiceTest {
   @Test
   void onBlock_shouldImmediatelyMakeChildOfCurrentHeadTheNewHead() {
     final SignedBlockAndState blockAndState = chainBuilder.generateBlockAtSlot(ONE);
-    final SafeFuture<BlockImportResult> importResult = forkChoice.onBlock(blockAndState.getBlock());
+    final SafeFuture<BlockImportResult> importResult =
+        forkChoice.onBlock(blockAndState.getBlock(), ExecutionEngineChannel.NOOP);
     assertBlockImportedSuccessfully(importResult);
 
     assertThat(recentChainData.getHeadBlock()).contains(blockAndState.getBlock());
@@ -106,7 +108,8 @@ class ForkChoiceTest {
     processHead(nodeSlot);
 
     final SignedBlockAndState blockAndState = chainBuilder.generateBlockAtSlot(ONE);
-    final SafeFuture<BlockImportResult> importResult = forkChoice.onBlock(blockAndState.getBlock());
+    final SafeFuture<BlockImportResult> importResult =
+        forkChoice.onBlock(blockAndState.getBlock(), ExecutionEngineChannel.NOOP);
     assertBlockImportedSuccessfully(importResult);
 
     assertThat(recentChainData.getHeadBlock()).contains(blockAndState.getBlock());
@@ -404,7 +407,8 @@ class ForkChoiceTest {
   }
 
   private void importBlock(final SignedBlockAndState block) {
-    final SafeFuture<BlockImportResult> result = forkChoice.onBlock(block.getBlock());
+    final SafeFuture<BlockImportResult> result =
+        forkChoice.onBlock(block.getBlock(), ExecutionEngineChannel.NOOP);
     assertBlockImportedSuccessfully(result);
   }
 

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.ssz.SszList;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -235,7 +236,8 @@ public class BeaconChainUtil {
     final SignedBeaconBlock block =
         createBlockAndStateAtSlot(slot, true, attestations, deposits, exits, eth1Data).getBlock();
     setSlot(slot);
-    final BlockImportResult importResult = forkChoice.onBlock(block).join();
+    final BlockImportResult importResult =
+        forkChoice.onBlock(block, ExecutionEngineChannel.NOOP).join();
     if (!importResult.isSuccessful()) {
       throw new IllegalStateException(
           "Produced an invalid block ( reason "

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceTestExecutor.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceTestExecutor.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.ssz.SszData;
@@ -263,7 +264,7 @@ public class ForkChoiceTestExecutor {
   }
 
   private boolean processBlock(ForkChoice fc, SignedBeaconBlock block) {
-    BlockImportResult blockImportResult = fc.onBlock(block).join();
+    BlockImportResult blockImportResult = fc.onBlock(block, ExecutionEngineChannel.NOOP).join();
     return blockImportResult.isSuccessful();
   }
 

--- a/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
+++ b/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.ssz.SszData;
@@ -58,6 +59,7 @@ public class FuzzUtil {
   private static final int OUTPUT_INDEX_BYTES = Long.BYTES;
 
   private final BLSSignatureVerifier signatureVerifier;
+  private final ExecutionEngineChannel executionEngineChannel = ExecutionEngineChannel.NOOP;
 
   // NOTE: this uses primitive values as parameters to more easily call via JNI
   public FuzzUtil(final boolean useMainnetConfig, final boolean disable_bls) {
@@ -139,7 +141,10 @@ public class FuzzUtil {
     try {
       BeaconState postState =
           spec.processBlock(
-              structuredInput.getState(), structuredInput.getSigned_block(), signatureVerifier);
+              structuredInput.getState(),
+              structuredInput.getSigned_block(),
+              signatureVerifier,
+              executionEngineChannel);
       Bytes output = postState.sszSerialize();
       return Optional.of(output.toArrayUnsafe());
     } catch (StateTransitionException e) {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -73,6 +73,7 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedCo
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.statetransition.EpochCachePrimer;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.OperationsReOrgManager;
@@ -766,7 +767,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             eventChannels.getPublisher(BlockImportNotifications.class),
             recentChainData,
             forkChoice,
-            weakSubjectivityValidator);
+            weakSubjectivityValidator,
+            ExecutionEngineChannel.NOOP);
   }
 
   public void initBlockManager() {

--- a/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
+++ b/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.block.BlockImportNotifications;
@@ -96,7 +97,8 @@ public class SyncingNodeManager {
             eventChannels.getPublisher(BlockImportNotifications.class),
             recentChainData,
             forkChoice,
-            WeakSubjectivityFactory.lenientValidator());
+            WeakSubjectivityFactory.lenientValidator(),
+            ExecutionEngineChannel.NOOP);
 
     BlockValidator blockValidator = new BlockValidator(spec, recentChainData);
     final PendingPool<SignedBeaconBlock> pendingBlocks = PendingPool.createForBlocks(spec);

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/TransitionCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/TransitionCommand.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
@@ -78,7 +79,9 @@ public class TransitionCommand implements Runnable {
           if (blocks != null) {
             for (String blockPath : blocks) {
               SignedBeaconBlock block = readBlock(spec, blockPath);
-              state = spec.processBlock(state, block, BLSSignatureVerifier.SIMPLE);
+              state =
+                  spec.processBlock(
+                      state, block, BLSSignatureVerifier.SIMPLE, ExecutionEngineChannel.NOOP);
             }
           }
           return state;


### PR DESCRIPTION
## PR Description
Implements the spec version of execution payload processing during block processing.

As per the spec, assumes the execution engine is available separately so while this is enough to get reference tests passing we will need an actual ExecutionEngineChannel implementation before it works in the real world. Currently everything is passing in `ExecutionEngineChannel.NOOP`.

Also hasn't implemented optimistic sync which will need to be done separately.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
