### PR TITLE
Enable more merge reference tests

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -68,12 +68,8 @@ public abstract class Eth2ReferenceTestCase {
           .putAll(ForkUpgradeTestExecutor.FORK_UPGRADE_TEST_TYPES)
           .putAll(RewardsTestExecutorMerge.REWARDS_TEST_TYPES)
 
-          // Disabled while work continues to bring over the merge work
-          .put("sanity/blocks", TestExecutor.IGNORE_TESTS)
+          // We don't yet support on_merge_block reference tests
           .put("fork_choice/on_merge_block", TestExecutor.IGNORE_TESTS)
-          .put("fork_choice/on_block", TestExecutor.IGNORE_TESTS)
-          .put("fork_choice/get_head", TestExecutor.IGNORE_TESTS)
-          .put("finality/finality", TestExecutor.IGNORE_TESTS)
           .build();
 
   protected void runReferenceTest(final TestDefinition testDefinition) throws Throwable {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.ethtests.TestFork;
 import tech.pegasys.teku.ethtests.finder.ReferenceTestFinder;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
 
@@ -39,13 +40,13 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    * <p>e.g. set to "ssz_static" to run only ssz static tests or "ssz_static/Attestation" for only
    * attestation ssz tests.
    */
-  private static final String TEST_TYPE = "operations/execution_payload";
+  private static final String TEST_TYPE = "sanity/blocks";
 
   /** Filter test to run to those from the specified spec. One of general, minimal or mainnet */
-  private static final String SPEC = "";
+  private static final String SPEC = "minimal";
 
   /** Filter test to run only those for a specific milestone. Use values from TestFork. */
-  private static final String MILESTONE = null;
+  private static final String MILESTONE = TestFork.MERGE;
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("loadReferenceTests")

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.teku.ethtests.TestFork;
 import tech.pegasys.teku.ethtests.finder.ReferenceTestFinder;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
 
@@ -40,13 +39,13 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    * <p>e.g. set to "ssz_static" to run only ssz static tests or "ssz_static/Attestation" for only
    * attestation ssz tests.
    */
-  private static final String TEST_TYPE = "sanity/blocks";
+  private static final String TEST_TYPE = "operations/execution_payload";
 
   /** Filter test to run to those from the specified spec. One of general, minimal or mainnet */
-  private static final String SPEC = "minimal";
+  private static final String SPEC = "";
 
   /** Filter test to run only those for a specific milestone. Use values from TestFork. */
-  private static final String MILESTONE = TestFork.MERGE;
+  private static final String MILESTONE = null;
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("loadReferenceTests")

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/fork/TransitionTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/fork/TransitionTestExecutor.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigLoader;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.NonValidatingExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 
 public class TransitionTestExecutor implements TestExecutor {
@@ -77,7 +77,9 @@ public class TransitionTestExecutor implements TestExecutor {
 
         final BLSSignatureVerifier signatureVerifier =
             metadata.blsSetting == 2 ? BLSSignatureVerifier.NO_OP : BLSSignatureVerifier.SIMPLE;
-        result = spec.processBlock(result, block, signatureVerifier, ExecutionEngineChannel.NOOP);
+        result =
+            spec.processBlock(
+                result, block, signatureVerifier, new NonValidatingExecutionEngineChannel());
       } catch (final StateTransitionException e) {
         Assertions.fail(
             "Failed to process block " + i + " at slot " + block.getSlot() + ": " + e.getMessage(),

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -37,7 +37,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.NonValidatingExecutionEngineChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -154,7 +154,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
         TestDataUtils.loadSsz(
             testDefinition, blockName + ".ssz_snappy", spec::deserializeSignedBeaconBlock);
     LOG.info("Importing block {} at slot {}", block.getRoot(), block.getSlot());
-    assertThat(forkChoice.onBlock(block, ExecutionEngineChannel.NOOP)).isCompleted();
+    assertThat(forkChoice.onBlock(block, new NonValidatingExecutionEngineChannel())).isCompleted();
   }
 
   @SuppressWarnings("unchecked")

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityBlocksTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityBlocksTestExecutor.java
@@ -32,7 +32,7 @@ import tech.pegasys.teku.reference.TestExecutor;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.NonValidatingExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 
 public class SanityBlocksTestExecutor implements TestExecutor {
@@ -95,7 +95,7 @@ public class SanityBlocksTestExecutor implements TestExecutor {
                 metaData.getBlsSetting() == IGNORED
                     ? BLSSignatureVerifier.NO_OP
                     : BLSSignatureVerifier.SIMPLE,
-                ExecutionEngineChannel.NOOP);
+                new NonValidatingExecutionEngineChannel());
       }
       return result;
     } catch (StateTransitionException e) {

--- a/ethereum/spec/build.gradle
+++ b/ethereum/spec/build.gradle
@@ -62,4 +62,5 @@ dependencies {
     testFixturesImplementation testFixtures(project(':bls'))
     testFixturesImplementation project(':util')
     testFixturesImplementation project(':infrastructure:async')
+    testFixturesImplementation project(':infrastructure:events')
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/executionengine/NonValidatingExecutionEngineChannel.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/executionengine/NonValidatingExecutionEngineChannel.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.executionengine;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.ssz.type.Bytes8;
+
+public class NonValidatingExecutionEngineChannel implements ExecutionEngineChannel {
+
+  @Override
+  public SafeFuture<Optional<PowBlock>> getPowBlock(final Bytes32 blockHash) {
+    return SafeFuture.completedFuture(Optional.empty());
+  }
+
+  @Override
+  public SafeFuture<PowBlock> getPowChainHead() {
+    return SafeFuture.failedFuture(
+        new UnsupportedOperationException("getPowChainHead not supported"));
+  }
+
+  @Override
+  public SafeFuture<Void> forkChoiceUpdated(
+      final ForkChoiceState forkChoiceState, final Optional<PayloadAttributes> payloadAttributes) {
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
+  public SafeFuture<ExecutionPayload> getPayload(final Bytes8 payloadId) {
+    return SafeFuture.failedFuture(new UnsupportedOperationException("getPayload not supported"));
+  }
+
+  @Override
+  public SafeFuture<ExecutePayloadResult> executePayload(final ExecutionPayload executionPayload) {
+    return SafeFuture.completedFuture(
+        new ExecutePayloadResult(ExecutionPayloadStatus.VALID, Optional.empty(), Optional.empty()));
+  }
+}

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -42,7 +42,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.NonValidatingExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.ssz.SszList;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -237,7 +237,7 @@ public class BeaconChainUtil {
         createBlockAndStateAtSlot(slot, true, attestations, deposits, exits, eth1Data).getBlock();
     setSlot(slot);
     final BlockImportResult importResult =
-        forkChoice.onBlock(block, ExecutionEngineChannel.NOOP).join();
+        forkChoice.onBlock(block, new NonValidatingExecutionEngineChannel()).join();
     if (!importResult.isSuccessful()) {
       throw new IllegalStateException(
           "Produced an invalid block ( reason "

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceTestExecutor.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceTestExecutor.java
@@ -45,7 +45,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
-import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.NonValidatingExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.ssz.SszData;
@@ -264,7 +264,8 @@ public class ForkChoiceTestExecutor {
   }
 
   private boolean processBlock(ForkChoice fc, SignedBeaconBlock block) {
-    BlockImportResult blockImportResult = fc.onBlock(block, ExecutionEngineChannel.NOOP).join();
+    BlockImportResult blockImportResult =
+        fc.onBlock(block, new NonValidatingExecutionEngineChannel()).join();
     return blockImportResult.isSuccessful();
   }
 

--- a/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
+++ b/sync/src/testFixtures/java/tech/pegasys/teku/sync/SyncingNodeManager.java
@@ -34,7 +34,7 @@ import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.NonValidatingExecutionEngineChannel;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.block.BlockImportNotifications;
@@ -98,7 +98,7 @@ public class SyncingNodeManager {
             recentChainData,
             forkChoice,
             WeakSubjectivityFactory.lenientValidator(),
-            ExecutionEngineChannel.NOOP);
+            new NonValidatingExecutionEngineChannel());
 
     BlockValidator blockValidator = new BlockValidator(spec, recentChainData);
     final PendingPool<SignedBeaconBlock> pendingBlocks = PendingPool.createForBlocks(spec);


### PR DESCRIPTION
## PR Description
Enables remaining merge reference tests except `fork_choice/on_merge_block`.

Introduces a NonValidatingExecutionEngineChannel to textFixtures that treats all payloads as valid.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
