### PR TITLE
Fix running acceptance tests in IntelliJ.

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   testFixturesImplementation 'org.apache.tuweni:tuweni-toml'
   testFixturesImplementation 'org.junit.jupiter:junit-jupiter-api'
   testFixturesImplementation 'org.testcontainers:testcontainers'
+  testFixturesImplementation 'org.testcontainers:junit-jupiter'
   testFixturesImplementation 'com.fasterxml.jackson.core:jackson-databind'
   testFixturesImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   testFixturesImplementation 'org.web3j:core'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -111,7 +111,7 @@ dependencyManagement {
 
     dependency 'org.java-websocket:Java-WebSocket:1.5.2'
 
-    dependencySet(group: 'org.junit.jupiter', version: '5.6.2') {
+    dependencySet(group: 'org.junit.jupiter', version: '5.8.1') {
       entry 'junit-jupiter-api'
       entry 'junit-jupiter-engine'
       entry 'junit-jupiter-params'
@@ -148,8 +148,10 @@ dependencyManagement {
     }
     dependency 'org.hyperledger.besu:plugin-api:21.7.4'
 
-    dependency "org.testcontainers:testcontainers:1.15.3"
-    dependency "org.testcontainers:junit-jupiter:1.15.3"
+    dependencySet(group: 'org.testcontainers', version: '1.16.2') {
+      entry "testcontainers"
+      entry "junit-jupiter"
+    }
 
     dependency 'tech.pegasys.discovery:discovery:21.10.0'
 


### PR DESCRIPTION
## PR Description
Upgrades junit and testcontainers to fix an issue where acceptance tests couldn't be run in IntelliJ because the unit version failed to parse.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
