### PR TITLE
Fix JSON content sent and expected by the send signed block endpoint

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -63,7 +63,7 @@ import tech.pegasys.teku.api.response.v1.validator.ValidatorLivenessAtEpoch;
 import tech.pegasys.teku.api.response.v2.beacon.GetBlockResponseV2;
 import tech.pegasys.teku.api.schema.BeaconState;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockAltair;
+import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
 import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
 import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -417,7 +417,7 @@ public class TekuNode extends Node {
           final Optional<BeaconState> maybeState = fetchHeadState();
           assertThat(maybeBlock).isPresent();
           assertThat(maybeState).isPresent();
-          SignedBeaconBlock<?> block = (SignedBeaconBlock<?>) maybeBlock.get();
+          SignedBeaconBlock block = (SignedBeaconBlock) maybeBlock.get();
           BeaconState state = maybeState.get();
 
           // Check that the fetched block and state are in sync

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -248,7 +248,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
   public List<SignedBeaconBlock> createBlocksAtSlotsAndMapToApiResult(UInt64... slots) {
     return createBlocksAtSlots(slots).stream()
         .map(SignedBlockAndState::getBlock)
-        .map(SignedBeaconBlock::new)
+        .map(SignedBeaconBlock::create)
         .collect(Collectors.toList());
   }
 

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -77,11 +77,8 @@ import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 public abstract class AbstractDataBackedRestAPIIntegrationTest {
   protected static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(16);
 
-  protected Spec spec = TestSpecFactory.createMinimalPhase0();
-  protected SpecConfig specConfig = spec.getGenesisSpecConfig();
-
-  protected final ActiveValidatorChannel activeValidatorChannel =
-      new ActiveValidatorCache(spec, 10);
+  protected Spec spec;
+  protected SpecConfig specConfig;
 
   private static final okhttp3.MediaType JSON =
       okhttp3.MediaType.parse("application/json; charset=utf-8");
@@ -96,11 +93,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
           .eth1DepositContractAddress(Eth1Address.ZERO)
           .build();
 
-  protected static final UInt64 SIX = UInt64.valueOf(6);
-  protected static final UInt64 SEVEN = UInt64.valueOf(7);
-  protected static final UInt64 EIGHT = UInt64.valueOf(8);
-  protected static final UInt64 NINE = UInt64.valueOf(9);
-  protected static final UInt64 TEN = UInt64.valueOf(10);
+  protected ActiveValidatorChannel activeValidatorChannel;
 
   // Mocks
   protected final Eth2P2PNetwork eth2P2PNetwork = mock(Eth2P2PNetwork.class);
@@ -141,17 +134,11 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
       final StateStorageMode storageMode,
       final boolean useMockForkChoice,
       final SpecMilestone specMilestone) {
-    setupStorage(
-        InMemoryStorageSystemBuilder.buildDefault(storageMode), useMockForkChoice, specMilestone);
-  }
-
-  private void setupStorage(
-      final StorageSystem storageSystem,
-      final boolean useMockForkChoice,
-      final SpecMilestone specMilestone) {
     this.spec = TestSpecFactory.createMinimal(specMilestone);
     this.specConfig = spec.getGenesisSpecConfig();
-    this.storageSystem = storageSystem;
+    this.storageSystem =
+        InMemoryStorageSystemBuilder.create().specProvider(spec).storageMode(storageMode).build();
+    activeValidatorChannel = new ActiveValidatorCache(spec, 10);
     recentChainData = storageSystem.recentChainData();
     chainBuilder = ChainBuilder.create(spec, VALIDATOR_KEYS);
     chainUpdater = new ChainUpdater(recentChainData, chainBuilder, spec);
@@ -191,23 +178,6 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
 
   private void setupAndStartRestAPI() {
     setupAndStartRestAPI(CONFIG);
-  }
-
-  protected void startPreForkChoiceRestAPI() {
-    // Initialize genesis
-    setupStorage(StateStorageMode.ARCHIVE, true, SpecMilestone.PHASE0);
-    chainUpdater.initializeGenesis();
-    // Restart storage system without running fork choice
-    storageSystem = storageSystem.restarted(StateStorageMode.ARCHIVE);
-    setupStorage(storageSystem, true, SpecMilestone.PHASE0);
-    // Start API
-    setupAndStartRestAPI();
-  }
-
-  protected void startPreGenesisRestAPI() {
-    setupStorage(StateStorageMode.ARCHIVE, false, SpecMilestone.PHASE0);
-    // Start API
-    setupAndStartRestAPI();
   }
 
   protected void startPreGenesisRestAPIWithConfig(BeaconRestApiConfig config) {

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -269,16 +269,16 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
     return results;
   }
 
-  public List<SignedBeaconBlock<?>> createBlocksAtSlotsAndMapToApiResult(long... slots) {
+  public List<SignedBeaconBlock> createBlocksAtSlotsAndMapToApiResult(long... slots) {
     final UInt64[] unsignedSlots =
         Arrays.stream(slots).mapToObj(UInt64::valueOf).toArray(UInt64[]::new);
     return createBlocksAtSlotsAndMapToApiResult(unsignedSlots);
   }
 
-  public List<SignedBeaconBlock<?>> createBlocksAtSlotsAndMapToApiResult(UInt64... slots) {
+  public List<SignedBeaconBlock> createBlocksAtSlotsAndMapToApiResult(UInt64... slots) {
     return createBlocksAtSlots(slots).stream()
         .map(SignedBlockAndState::getBlock)
-        .map(SignedBeaconBlock::create)
+        .map(SignedBeaconBlock::new)
         .collect(Collectors.toList());
   }
 

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetBlockIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetBlockIntegrationTest.java
@@ -36,9 +36,9 @@ public class GetBlockIntegrationTest extends AbstractDataBackedRestAPIIntegratio
 
     final GetBlockResponse body =
         jsonProvider.jsonToObject(response.body().string(), GetBlockResponse.class);
-    final SignedBeaconBlock<?> data = body.data;
+    final SignedBeaconBlock data = body.data;
     final SignedBlockAndState block = created.get(0);
-    assertThat(data).isEqualTo(SignedBeaconBlock.create(block.getBlock()));
+    assertThat(data).isEqualTo(new SignedBeaconBlock(block.getBlock()));
   }
 
   @Test

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetBlockIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetBlockIntegrationTest.java
@@ -38,7 +38,7 @@ public class GetBlockIntegrationTest extends AbstractDataBackedRestAPIIntegratio
         jsonProvider.jsonToObject(response.body().string(), GetBlockResponse.class);
     final SignedBeaconBlock data = body.data;
     final SignedBlockAndState block = created.get(0);
-    assertThat(data).isEqualTo(new SignedBeaconBlock(block.getBlock()));
+    assertThat(data).isEqualTo(SignedBeaconBlock.create(block.getBlock()));
   }
 
   @Test

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/GetBlockV2IntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/GetBlockV2IntegrationTest.java
@@ -25,9 +25,9 @@ import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.response.v2.beacon.GetBlockResponseV2;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockAltair;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockPhase0;
 import tech.pegasys.teku.api.schema.Version;
+import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
+import tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v2.beacon.GetBlock;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -47,7 +47,7 @@ public class GetBlockV2IntegrationTest extends AbstractDataBackedRestAPIIntegrat
     assertThat(body.data).isInstanceOf(SignedBeaconBlockPhase0.class);
     final SignedBeaconBlockPhase0 data = (SignedBeaconBlockPhase0) body.getData();
     final SignedBlockAndState block = created.get(0);
-    assertThat(data).isEqualTo(SignedBeaconBlock.create(block.getBlock()));
+    assertThat(data).isEqualTo(new SignedBeaconBlock(block.getBlock()));
 
     assertThat(response.header(HEADER_CONSENSUS_VERSION)).isEqualTo(Version.phase0.name());
   }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/GetBlockV2IntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/GetBlockV2IntegrationTest.java
@@ -47,7 +47,7 @@ public class GetBlockV2IntegrationTest extends AbstractDataBackedRestAPIIntegrat
     assertThat(body.data).isInstanceOf(SignedBeaconBlockPhase0.class);
     final SignedBeaconBlockPhase0 data = (SignedBeaconBlockPhase0) body.getData();
     final SignedBlockAndState block = created.get(0);
-    assertThat(data).isEqualTo(new SignedBeaconBlock(block.getBlock()));
+    assertThat(data).isEqualTo(SignedBeaconBlock.create(block.getBlock()));
 
     assertThat(response.header(HEADER_CONSENSUS_VERSION)).isEqualTo(Version.phase0.name());
   }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetAllBlocksAtSlot.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetAllBlocksAtSlot.java
@@ -85,7 +85,7 @@ public class GetAllBlocksAtSlot implements Handler {
     ctx.header(Header.CACHE_CONTROL, CACHE_NONE);
 
     try {
-      SafeFuture<Set<SignedBeaconBlock<?>>> future =
+      SafeFuture<Set<SignedBeaconBlock>> future =
           chainDataProvider.getAllBlocksAtSlot(pathParamMap.get(SLOT));
       ctx.future(
           future.thenApplyChecked(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlock.java
@@ -77,12 +77,12 @@ public class GetBlock extends AbstractHandler implements Handler {
   @Override
   public void handle(@NotNull final Context ctx) throws Exception {
     final Map<String, String> pathParams = ctx.pathParamMap();
-    final SafeFuture<Optional<SignedBeaconBlock<?>>> future =
+    final SafeFuture<Optional<SignedBeaconBlock>> future =
         chainDataProvider.getBlock(pathParams.get(PARAM_BLOCK_ID));
     handleOptionalResult(ctx, future, this::handleResult, SC_NOT_FOUND);
   }
 
-  private Optional<String> handleResult(Context ctx, final SignedBeaconBlock<?> response)
+  private Optional<String> handleResult(Context ctx, final SignedBeaconBlock response)
       throws JsonProcessingException {
     if (!chainDataProvider
         .getMilestoneAtSlot(response.getMessage().slot)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlock.java
@@ -102,7 +102,7 @@ public class PostBlock implements Handler {
         return;
       }
 
-      final SignedBeaconBlock<?> signedBeaconBlock =
+      final SignedBeaconBlock signedBeaconBlock =
           validatorDataProvider.parseBlock(jsonProvider, ctx.body());
 
       ctx.future(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetBlock.java
@@ -92,13 +92,13 @@ public class GetBlock extends AbstractHandler implements Handler {
           ctx, future, this::handleSszResult, this::resultFilename, SC_NOT_FOUND);
 
     } else {
-      final SafeFuture<Optional<SignedBeaconBlock<?>>> future =
+      final SafeFuture<Optional<SignedBeaconBlock>> future =
           chainDataProvider.getBlockV2(blockIdentifier);
       handleOptionalResult(ctx, future, this::handleJsonResult, SC_NOT_FOUND);
     }
   }
 
-  private Optional<String> handleJsonResult(Context ctx, final SignedBeaconBlock<?> response)
+  private Optional<String> handleJsonResult(Context ctx, final SignedBeaconBlock response)
       throws JsonProcessingException {
     final Version version = chainDataProvider.getVersionAtSlot(response.getMessage().slot);
     ctx.header(HEADER_CONSENSUS_VERSION, version.name());

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlockTest.java
@@ -130,8 +130,7 @@ class PostBlockTest {
   }
 
   private String buildSignedBeaconBlock() throws JsonProcessingException {
-    SignedBeaconBlock<?> block =
-        SignedBeaconBlock.create(dataStructureUtil.randomSignedBeaconBlock(3));
+    SignedBeaconBlock block = new SignedBeaconBlock(dataStructureUtil.randomSignedBeaconBlock(3));
     return jsonProvider.objectToJSON(block);
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlockTest.java
@@ -130,7 +130,8 @@ class PostBlockTest {
   }
 
   private String buildSignedBeaconBlock() throws JsonProcessingException {
-    SignedBeaconBlock block = new SignedBeaconBlock(dataStructureUtil.randomSignedBeaconBlock(3));
+    SignedBeaconBlock block =
+        SignedBeaconBlock.create(dataStructureUtil.randomSignedBeaconBlock(3));
     return jsonProvider.objectToJSON(block);
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.api.response.v1.SyncStateChangeEvent;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
+import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -96,7 +97,7 @@ public class EventSubscriptionManagerTest {
 
   private final SyncState sampleSyncState = SyncState.IN_SYNC;
   private final SignedBeaconBlock sampleBlock =
-      new SignedBeaconBlock(data.randomSignedBeaconBlock(0));
+      new SignedBeaconBlockAltair(data.randomSignedBeaconBlock(0));
   private final Attestation sampleAttestation = new Attestation(data.randomAttestation(0));
   private final SignedVoluntaryExit sampleVoluntaryExit =
       new SignedVoluntaryExit(data.randomSignedVoluntaryExit());

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -42,7 +42,6 @@ import tech.pegasys.teku.api.response.v1.SyncStateChangeEvent;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
-import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -97,7 +96,7 @@ public class EventSubscriptionManagerTest {
 
   private final SyncState sampleSyncState = SyncState.IN_SYNC;
   private final SignedBeaconBlock sampleBlock =
-      new SignedBeaconBlockAltair(data.randomSignedBeaconBlock(0));
+      SignedBeaconBlock.create(data.randomSignedBeaconBlock(0));
   private final Attestation sampleAttestation = new Attestation(data.randomAttestation(0));
   private final SignedVoluntaryExit sampleVoluntaryExit =
       new SignedVoluntaryExit(data.randomSignedVoluntaryExit());

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -95,8 +95,8 @@ public class EventSubscriptionManagerTest {
       new FinalizedCheckpointEvent(data.randomBytes32(), data.randomBytes32(), epoch);
 
   private final SyncState sampleSyncState = SyncState.IN_SYNC;
-  private final SignedBeaconBlock<?> sampleBlock =
-      SignedBeaconBlock.create(data.randomSignedBeaconBlock(0));
+  private final SignedBeaconBlock sampleBlock =
+      new SignedBeaconBlock(data.randomSignedBeaconBlock(0));
   private final Attestation sampleAttestation = new Attestation(data.randomAttestation(0));
   private final SignedVoluntaryExit sampleVoluntaryExit =
       new SignedVoluntaryExit(data.randomSignedVoluntaryExit());

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -113,14 +113,14 @@ public class ChainDataProvider {
         .thenApply(maybeBlock -> maybeBlock.map(block -> new BlockHeader(block, true)));
   }
 
-  public SafeFuture<Optional<SignedBeaconBlock<?>>> getBlock(final String slotParameter) {
+  public SafeFuture<Optional<SignedBeaconBlock>> getBlock(final String slotParameter) {
     return defaultBlockSelectorFactory
         .defaultBlockSelector(slotParameter)
         .getSingleBlock()
         .thenApply(maybeBlock -> maybeBlock.map(schemaObjectProvider::getSignedBeaconBlock));
   }
 
-  public SafeFuture<Optional<SignedBeaconBlock<?>>> getBlockV2(final String slotParameter) {
+  public SafeFuture<Optional<SignedBeaconBlock>> getBlockV2(final String slotParameter) {
     return defaultBlockSelectorFactory
         .defaultBlockSelector(slotParameter)
         .getSingleBlock()
@@ -201,7 +201,7 @@ public class ChainDataProvider {
                             spec.atSlot(state.getSlot()).getMilestone())));
   }
 
-  public SafeFuture<Set<SignedBeaconBlock<?>>> getAllBlocksAtSlot(final String slot) {
+  public SafeFuture<Set<SignedBeaconBlock>> getAllBlocksAtSlot(final String slot) {
     if (slot.startsWith("0x")) {
       throw new BadRequestException(
           String.format("block roots are not currently supported: %s", slot));
@@ -232,7 +232,7 @@ public class ChainDataProvider {
                             spec.atSlot(state.getSlot()).getMilestone())));
   }
 
-  public boolean isFinalized(final SignedBeaconBlock<?> signedBeaconBlock) {
+  public boolean isFinalized(final SignedBeaconBlock signedBeaconBlock) {
     return combinedChainDataClient.isFinalized(signedBeaconBlock.getMessage().slot);
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/SchemaObjectProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/SchemaObjectProvider.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.api;
 
+import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.BeaconBlockBody;
 import tech.pegasys.teku.api.schema.BeaconState;
@@ -40,10 +41,11 @@ public class SchemaObjectProvider {
     this.spec = spec;
   }
 
-  public SignedBeaconBlock<?> getSignedBeaconBlock(
+  public SignedBeaconBlock getSignedBeaconBlock(
       final tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock) {
 
-    return SignedBeaconBlock.create(internalBlock);
+    return new SignedBeaconBlock(
+        getBeaconBlock(internalBlock.getMessage()), new BLSSignature(internalBlock.getSignature()));
   }
 
   public BeaconBlock getBeaconBlock(

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -41,13 +41,13 @@ import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockAltair;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockMerge;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockPhase0;
 import tech.pegasys.teku.api.schema.ValidatorBlockResult;
+import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
 import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSubnetSubscription;
+import tech.pegasys.teku.api.schema.merge.SignedBeaconBlockMerge;
+import tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.http.HttpStatusCodes;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -156,12 +156,12 @@ public class ValidatorDataProvider {
         .thenApply(this::convertToPostDataFailureResponse);
   }
 
-  public SignedBeaconBlock<?> parseBlock(final JsonProvider jsonProvider, final String jsonBlock)
+  public SignedBeaconBlock parseBlock(final JsonProvider jsonProvider, final String jsonBlock)
       throws JsonProcessingException {
     final ObjectMapper mapper = jsonProvider.getObjectMapper();
     final JsonNode jsonNode = mapper.readTree(jsonBlock);
     final UInt64 slot = mapper.treeToValue(jsonNode.findValue("slot"), UInt64.class);
-    final SignedBeaconBlock<?> signedBeaconBlock;
+    final SignedBeaconBlock signedBeaconBlock;
     checkNotNull(slot, "Slot was not found in json block");
     switch (spec.atSlot(slot).getMilestone()) {
       case PHASE0:
@@ -180,7 +180,7 @@ public class ValidatorDataProvider {
   }
 
   public SafeFuture<ValidatorBlockResult> submitSignedBlock(
-      final SignedBeaconBlock<?> signedBeaconBlock) {
+      final SignedBeaconBlock signedBeaconBlock) {
     return validatorApiChannel
         .sendSignedBlock(signedBeaconBlock.asInternalSignedBeaconBlock(spec))
         .thenApply(

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -257,7 +257,7 @@ public class ValidatorDataProviderTest {
     final SignedBeaconBlock internalSignedBeaconBlock =
         dataStructureUtil.randomSignedBeaconBlock(1);
     final tech.pegasys.teku.api.schema.SignedBeaconBlock signedBeaconBlock =
-        new tech.pegasys.teku.api.schema.SignedBeaconBlock(internalSignedBeaconBlock);
+        tech.pegasys.teku.api.schema.SignedBeaconBlock.create(internalSignedBeaconBlock);
 
     final SafeFuture<SendSignedBlockResult> successImportResult =
         completedFuture(SendSignedBlockResult.success(internalSignedBeaconBlock.getRoot()));
@@ -275,7 +275,7 @@ public class ValidatorDataProviderTest {
     final SignedBeaconBlock internalSignedBeaconBlock =
         dataStructureUtil.randomSignedBeaconBlock(1);
     final tech.pegasys.teku.api.schema.SignedBeaconBlock signedBeaconBlock =
-        new tech.pegasys.teku.api.schema.SignedBeaconBlock(internalSignedBeaconBlock);
+        tech.pegasys.teku.api.schema.SignedBeaconBlock.create(internalSignedBeaconBlock);
     final AtomicInteger failReasonCount = new AtomicInteger();
 
     Stream.of(FailureReason.values())
@@ -309,7 +309,7 @@ public class ValidatorDataProviderTest {
     final SignedBeaconBlock internalSignedBeaconBlock =
         dataStructureUtil.randomSignedBeaconBlock(1);
     final tech.pegasys.teku.api.schema.SignedBeaconBlock signedBeaconBlock =
-        new tech.pegasys.teku.api.schema.SignedBeaconBlock(internalSignedBeaconBlock);
+        tech.pegasys.teku.api.schema.SignedBeaconBlock.create(internalSignedBeaconBlock);
 
     final SafeFuture<SendSignedBlockResult> failImportResult =
         completedFuture(SendSignedBlockResult.rejected(FailureReason.INTERNAL_ERROR.name()));

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -49,8 +49,8 @@ import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.api.schema.BeaconBlock;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockAltair;
 import tech.pegasys.teku.api.schema.ValidatorBlockResult;
+import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
 import tech.pegasys.teku.api.schema.phase0.BeaconBlockPhase0;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -186,11 +186,11 @@ public class ValidatorDataProviderTest {
   @TestTemplate
   void parseBlock_shouldParseBlocks() throws JsonProcessingException {
     final SignedBeaconBlock internalSignedBlock = dataStructureUtil.randomSignedBeaconBlock(ONE);
-    final tech.pegasys.teku.api.schema.SignedBeaconBlock<?> signedBlock =
+    final tech.pegasys.teku.api.schema.SignedBeaconBlock signedBlock =
         schemaProvider.getSignedBeaconBlock(internalSignedBlock);
     final String signedBlockJson = jsonProvider.objectToJSON(signedBlock);
 
-    final tech.pegasys.teku.api.schema.SignedBeaconBlock<?> parsedBlock =
+    final tech.pegasys.teku.api.schema.SignedBeaconBlock parsedBlock =
         provider.parseBlock(jsonProvider, signedBlockJson);
 
     assertThat(parsedBlock).isEqualTo(signedBlock);
@@ -202,11 +202,11 @@ public class ValidatorDataProviderTest {
     SpecContextExecutionHelper.only(specContext, SpecMilestone.ALTAIR);
 
     final SignedBeaconBlock internalSignedBlock = dataStructureUtil.randomSignedBeaconBlock(ONE);
-    final tech.pegasys.teku.api.schema.SignedBeaconBlock<?> signedBlock =
+    final tech.pegasys.teku.api.schema.SignedBeaconBlock signedBlock =
         schemaProvider.getSignedBeaconBlock(internalSignedBlock);
     final String signedBlockJson = jsonProvider.objectToJSON(signedBlock);
 
-    final tech.pegasys.teku.api.schema.SignedBeaconBlock<?> parsedBlock =
+    final tech.pegasys.teku.api.schema.SignedBeaconBlock parsedBlock =
         provider.parseBlock(jsonProvider, signedBlockJson);
 
     assertThat(parsedBlock).isEqualTo(signedBlock);
@@ -256,8 +256,8 @@ public class ValidatorDataProviderTest {
       throws ExecutionException, InterruptedException {
     final SignedBeaconBlock internalSignedBeaconBlock =
         dataStructureUtil.randomSignedBeaconBlock(1);
-    final tech.pegasys.teku.api.schema.SignedBeaconBlock<?> signedBeaconBlock =
-        tech.pegasys.teku.api.schema.SignedBeaconBlock.create(internalSignedBeaconBlock);
+    final tech.pegasys.teku.api.schema.SignedBeaconBlock signedBeaconBlock =
+        new tech.pegasys.teku.api.schema.SignedBeaconBlock(internalSignedBeaconBlock);
 
     final SafeFuture<SendSignedBlockResult> successImportResult =
         completedFuture(SendSignedBlockResult.success(internalSignedBeaconBlock.getRoot()));
@@ -274,8 +274,8 @@ public class ValidatorDataProviderTest {
   public void submitSignedBlock_shouldReturn202ForInvalidBlock() {
     final SignedBeaconBlock internalSignedBeaconBlock =
         dataStructureUtil.randomSignedBeaconBlock(1);
-    final tech.pegasys.teku.api.schema.SignedBeaconBlock<?> signedBeaconBlock =
-        tech.pegasys.teku.api.schema.SignedBeaconBlock.create(internalSignedBeaconBlock);
+    final tech.pegasys.teku.api.schema.SignedBeaconBlock signedBeaconBlock =
+        new tech.pegasys.teku.api.schema.SignedBeaconBlock(internalSignedBeaconBlock);
     final AtomicInteger failReasonCount = new AtomicInteger();
 
     Stream.of(FailureReason.values())
@@ -308,8 +308,8 @@ public class ValidatorDataProviderTest {
       throws ExecutionException, InterruptedException {
     final SignedBeaconBlock internalSignedBeaconBlock =
         dataStructureUtil.randomSignedBeaconBlock(1);
-    final tech.pegasys.teku.api.schema.SignedBeaconBlock<?> signedBeaconBlock =
-        tech.pegasys.teku.api.schema.SignedBeaconBlock.create(internalSignedBeaconBlock);
+    final tech.pegasys.teku.api.schema.SignedBeaconBlock signedBeaconBlock =
+        new tech.pegasys.teku.api.schema.SignedBeaconBlock(internalSignedBeaconBlock);
 
     final SafeFuture<SendSignedBlockResult> failImportResult =
         completedFuture(SendSignedBlockResult.rejected(FailureReason.INTERNAL_ERROR.name()));

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/GetBlockResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/GetBlockResponse.java
@@ -18,10 +18,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 
 public class GetBlockResponse {
-  public final SignedBeaconBlock<?> data;
+  public final SignedBeaconBlock data;
 
   @JsonCreator
-  public GetBlockResponse(@JsonProperty("data") final SignedBeaconBlock<?> data) {
+  public GetBlockResponse(@JsonProperty("data") final SignedBeaconBlock data) {
     this.data = data;
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v2/beacon/GetBlockResponseV2.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v2/beacon/GetBlockResponseV2.java
@@ -18,11 +18,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockAltair;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockMerge;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockPhase0;
 import tech.pegasys.teku.api.schema.Version;
+import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
 import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
+import tech.pegasys.teku.api.schema.merge.SignedBeaconBlockMerge;
+import tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0;
 
 public class GetBlockResponseV2 {
   private final Version version;
@@ -49,7 +49,7 @@ public class GetBlockResponseV2 {
   @JsonCreator
   public GetBlockResponseV2(
       @JsonProperty("version") final Version version,
-      @JsonProperty("data") final SignedBeaconBlock<?> data) {
+      @JsonProperty("data") final SignedBeaconBlock data) {
     this.version = version;
     this.data = data;
   }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v2/debug/GetStateResponseV2.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v2/debug/GetStateResponseV2.java
@@ -17,11 +17,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockAltair;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockMerge;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockPhase0;
 import tech.pegasys.teku.api.schema.Version;
+import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
 import tech.pegasys.teku.api.schema.interfaces.State;
+import tech.pegasys.teku.api.schema.merge.SignedBeaconBlockMerge;
+import tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0;
 
 public class GetStateResponseV2 {
   public final Version version;

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SignedBeaconBlock.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SignedBeaconBlock.java
@@ -17,42 +17,31 @@ import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES96;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
-import tech.pegasys.teku.api.schema.altair.BeaconBlockAltair;
 import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
-import tech.pegasys.teku.api.schema.merge.BeaconBlockMerge;
-import tech.pegasys.teku.api.schema.phase0.BeaconBlockPhase0;
 import tech.pegasys.teku.spec.Spec;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
-@JsonSubTypes({
-  @JsonSubTypes.Type(value = SignedBeaconBlock.SignedBeaconBlockMerge.class),
-  @JsonSubTypes.Type(value = SignedBeaconBlock.SignedBeaconBlockAltair.class),
-  @JsonSubTypes.Type(value = SignedBeaconBlock.SignedBeaconBlockPhase0.class),
-})
-public abstract class SignedBeaconBlock<T extends BeaconBlock> implements SignedBlock {
-  private final T message;
+public class SignedBeaconBlock implements SignedBlock {
+  private final BeaconBlock message;
 
   @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES96)
   public final BLSSignature signature;
 
-  public T getMessage() {
+  public BeaconBlock getMessage() {
     return message;
   }
 
-  private SignedBeaconBlock(
-      tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock, T block) {
+  public SignedBeaconBlock(
+      tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock) {
     this.signature = new BLSSignature(internalBlock.getSignature());
-    this.message = block;
+    this.message = new BeaconBlock(internalBlock.getMessage());
   }
 
-  private SignedBeaconBlock(final T message, final BLSSignature signature) {
+  @JsonCreator
+  public SignedBeaconBlock(
+      @JsonProperty("message") final BeaconBlock message,
+      @JsonProperty("signature") final BLSSignature signature) {
     this.message = message;
     this.signature = signature;
   }
@@ -65,76 +54,16 @@ public abstract class SignedBeaconBlock<T extends BeaconBlock> implements Signed
         spec, beaconBlock, signature.asInternalBLSSignature());
   }
 
-  public static SignedBeaconBlock<?> create(
-      tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock) {
-    tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody beaconBlock =
-        internalBlock.getMessage().getBody();
-
-    return Stream.of(
-            () -> beaconBlock.toVersionMerge().map(__ -> new SignedBeaconBlockMerge(internalBlock)),
-            () ->
-                beaconBlock.toVersionAltair().map(__ -> new SignedBeaconBlockAltair(internalBlock)),
-            (Supplier<Optional<SignedBeaconBlock<?>>>)
-                () ->
-                    Optional.of((SignedBeaconBlock<?>) new SignedBeaconBlockPhase0(internalBlock)))
-        .map(Supplier::get)
-        .flatMap(Optional::stream)
-        .findFirst()
-        .orElseThrow();
-  }
-
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof SignedBeaconBlock<?>)) return false;
-    SignedBeaconBlock<?> that = (SignedBeaconBlock<?>) o;
+    if (!(o instanceof SignedBeaconBlock)) return false;
+    SignedBeaconBlock that = (SignedBeaconBlock) o;
     return Objects.equals(message, that.message) && Objects.equals(signature, that.signature);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(message, signature);
-  }
-
-  public static class SignedBeaconBlockMerge extends SignedBeaconBlock<BeaconBlockMerge> {
-    @JsonCreator
-    private SignedBeaconBlockMerge(
-        @JsonProperty("message") final BeaconBlockMerge message,
-        @JsonProperty("signature") final BLSSignature signature) {
-      super(message, signature);
-    }
-
-    private SignedBeaconBlockMerge(
-        tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock) {
-      super(internalBlock, new BeaconBlockMerge(internalBlock.getMessage()));
-    }
-  }
-
-  public static class SignedBeaconBlockAltair extends SignedBeaconBlock<BeaconBlockAltair> {
-    @JsonCreator
-    private SignedBeaconBlockAltair(
-        @JsonProperty("message") final BeaconBlockAltair message,
-        @JsonProperty("signature") final BLSSignature signature) {
-      super(message, signature);
-    }
-
-    private SignedBeaconBlockAltair(
-        tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock) {
-      super(internalBlock, new BeaconBlockAltair(internalBlock.getMessage()));
-    }
-  }
-
-  public static class SignedBeaconBlockPhase0 extends SignedBeaconBlock<BeaconBlockPhase0> {
-    @JsonCreator
-    private SignedBeaconBlockPhase0(
-        @JsonProperty("message") final BeaconBlockPhase0 message,
-        @JsonProperty("signature") final BLSSignature signature) {
-      super(message, signature);
-    }
-
-    private SignedBeaconBlockPhase0(
-        tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock) {
-      super(internalBlock, new BeaconBlockPhase0(internalBlock.getMessage()));
-    }
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SignedBeaconBlockAltair.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SignedBeaconBlockAltair.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.schema.altair;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import tech.pegasys.teku.api.schema.BLSSignature;
+import tech.pegasys.teku.api.schema.SignedBeaconBlock;
+import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
+
+public class SignedBeaconBlockAltair extends SignedBeaconBlock implements SignedBlock {
+  private final BeaconBlockAltair message;
+
+  public SignedBeaconBlockAltair(
+      tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock) {
+    super(internalBlock);
+    this.message = new BeaconBlockAltair(internalBlock.getMessage());
+  }
+
+  @Override
+  public BeaconBlockAltair getMessage() {
+    return message;
+  }
+
+  @JsonCreator
+  public SignedBeaconBlockAltair(
+      @JsonProperty("message") final BeaconBlockAltair message,
+      @JsonProperty("signature") final BLSSignature signature) {
+    super(message, signature);
+    this.message = message;
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/SignedBlock.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/SignedBlock.java
@@ -14,9 +14,9 @@
 package tech.pegasys.teku.api.schema.interfaces;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockAltair;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockMerge;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockPhase0;
+import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
+import tech.pegasys.teku.api.schema.merge.SignedBeaconBlockMerge;
+import tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0;
 
 @Schema(
     oneOf = {

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/merge/SignedBeaconBlockMerge.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/merge/SignedBeaconBlockMerge.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.schema.merge;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import tech.pegasys.teku.api.schema.BLSSignature;
+import tech.pegasys.teku.api.schema.SignedBeaconBlock;
+import tech.pegasys.teku.api.schema.altair.BeaconBlockAltair;
+import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
+
+public class SignedBeaconBlockMerge extends SignedBeaconBlock implements SignedBlock {
+  private final BeaconBlockMerge message;
+
+  public SignedBeaconBlockMerge(
+      tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock) {
+    super(internalBlock);
+    this.message = new BeaconBlockMerge(internalBlock.getMessage());
+  }
+
+  @Override
+  public BeaconBlockAltair getMessage() {
+    return message;
+  }
+
+  @JsonCreator
+  public SignedBeaconBlockMerge(
+      @JsonProperty("message") final BeaconBlockMerge message,
+      @JsonProperty("signature") final BLSSignature signature) {
+    super(message, signature);
+    this.message = message;
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/phase0/SignedBeaconBlockPhase0.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/phase0/SignedBeaconBlockPhase0.java
@@ -21,6 +21,12 @@ import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
 
 public class SignedBeaconBlockPhase0 extends SignedBeaconBlock implements SignedBlock {
+
+  public SignedBeaconBlockPhase0(
+      tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock) {
+    super(internalBlock);
+  }
+
   @JsonCreator
   public SignedBeaconBlockPhase0(
       @JsonProperty("message") final BeaconBlock message,

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/phase0/SignedBeaconBlockPhase0.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/phase0/SignedBeaconBlockPhase0.java
@@ -11,32 +11,20 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.api.response.v1.teku;
+package tech.pegasys.teku.api.schema.phase0;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Set;
+import tech.pegasys.teku.api.schema.BLSSignature;
+import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
-import tech.pegasys.teku.api.schema.Version;
+import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
 
-public class GetAllBlocksAtSlotResponse {
-  private final Version version;
-
-  private final Set<SignedBeaconBlock> data;
-
-  public Set<SignedBeaconBlock> getData() {
-    return data;
-  }
-
-  public Version getVersion() {
-    return version;
-  }
-
+public class SignedBeaconBlockPhase0 extends SignedBeaconBlock implements SignedBlock {
   @JsonCreator
-  public GetAllBlocksAtSlotResponse(
-      @JsonProperty("version") final Version version,
-      @JsonProperty("data") final Set<SignedBeaconBlock> data) {
-    this.version = version;
-    this.data = data;
+  public SignedBeaconBlockPhase0(
+      @JsonProperty("message") final BeaconBlock message,
+      @JsonProperty("signature") final BLSSignature signature) {
+    super(message, signature);
   }
 }

--- a/data/serializer/src/test/java/tech/pegasys/teku/api/schema/SignedBeaconBlockTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/api/schema/SignedBeaconBlockTest.java
@@ -27,7 +27,7 @@ class SignedBeaconBlockTest {
 
     final tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock =
         ctx.getDataStructureUtil().randomSignedBeaconBlock(1);
-    final SignedBeaconBlock<?> apiBlock = SignedBeaconBlock.create(internalBlock);
+    final SignedBeaconBlock apiBlock = new SignedBeaconBlock(internalBlock);
     assertThatSszData(apiBlock.asInternalSignedBeaconBlock(ctx.getSpec()))
         .isEqualByAllMeansTo(internalBlock);
   }

--- a/data/serializer/src/test/java/tech/pegasys/teku/api/schema/SignedBeaconBlockTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/api/schema/SignedBeaconBlockTest.java
@@ -27,7 +27,7 @@ class SignedBeaconBlockTest {
 
     final tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock =
         ctx.getDataStructureUtil().randomSignedBeaconBlock(1);
-    final SignedBeaconBlock apiBlock = new SignedBeaconBlock(internalBlock);
+    final SignedBeaconBlock apiBlock = SignedBeaconBlock.create(internalBlock);
     assertThatSszData(apiBlock.asInternalSignedBeaconBlock(ctx.getSpec()))
         .isEqualByAllMeansTo(internalBlock);
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -184,7 +184,7 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   }
 
   @Override
-  public SendSignedBlockResult sendSignedBlock(final SignedBeaconBlock<?> beaconBlock) {
+  public SendSignedBlockResult sendSignedBlock(final SignedBeaconBlock beaconBlock) {
     return post(SEND_SIGNED_BLOCK, beaconBlock, createHandler())
         .map(__ -> SendSignedBlockResult.success(Bytes32.ZERO))
         .orElseGet(() -> SendSignedBlockResult.notImported("UNKNOWN"));

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ResponseHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ResponseHandler.java
@@ -108,7 +108,7 @@ public class ResponseHandler<T> {
     LOG.debug(
         "Invalid params response from Beacon Node API (url = {}, response = {})",
         request.url(),
-        response.body());
+        response.body().string());
     throw new IllegalArgumentException(
         "Invalid params response from Beacon Node API (url = " + request.url() + ")");
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -54,7 +54,7 @@ public interface ValidatorRestApiClient {
   Optional<BeaconBlock> createUnsignedBlock(
       UInt64 slot, BLSSignature randaoReveal, Optional<Bytes32> graffiti);
 
-  SendSignedBlockResult sendSignedBlock(SignedBeaconBlock<?> beaconBlock);
+  SendSignedBlockResult sendSignedBlock(SignedBeaconBlock beaconBlock);
 
   Optional<AttestationData> createAttestationData(UInt64 slot, int committeeIndex);
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -407,14 +407,13 @@ class RemoteValidatorApiHandlerTest {
         dataStructureUtil.signedBlock(beaconBlock, signature);
     final SendSignedBlockResult expectedResult = SendSignedBlockResult.success(Bytes32.ZERO);
 
-    final tech.pegasys.teku.api.schema.SignedBeaconBlock<?> schemaSignedBlock =
-        tech.pegasys.teku.api.schema.SignedBeaconBlock.create(signedBeaconBlock);
+    final tech.pegasys.teku.api.schema.SignedBeaconBlock schemaSignedBlock =
+        new tech.pegasys.teku.api.schema.SignedBeaconBlock(signedBeaconBlock);
 
     when(apiClient.sendSignedBlock(any())).thenReturn(expectedResult);
 
-    ArgumentCaptor<tech.pegasys.teku.api.schema.SignedBeaconBlock<?>> argumentCaptor =
-        ArgumentCaptor.forClass(
-            tech.pegasys.teku.api.schema.SignedBeaconBlock.SignedBeaconBlockPhase0.class);
+    ArgumentCaptor<tech.pegasys.teku.api.schema.SignedBeaconBlock> argumentCaptor =
+        ArgumentCaptor.forClass(tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0.class);
 
     final SafeFuture<SendSignedBlockResult> result = apiHandler.sendSignedBlock(signedBeaconBlock);
     asyncRunner.executeQueuedActions();

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -408,7 +408,7 @@ class RemoteValidatorApiHandlerTest {
     final SendSignedBlockResult expectedResult = SendSignedBlockResult.success(Bytes32.ZERO);
 
     final tech.pegasys.teku.api.schema.SignedBeaconBlock schemaSignedBlock =
-        new tech.pegasys.teku.api.schema.SignedBeaconBlock(signedBeaconBlock);
+        tech.pegasys.teku.api.schema.SignedBeaconBlock.create(signedBeaconBlock);
 
     when(apiClient.sendSignedBlock(any())).thenReturn(expectedResult);
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -254,7 +254,7 @@ class OkHttpValidatorRestApiClientTest {
   @Test
   public void sendSignedBlock_MakesExpectedRequest() throws Exception {
     final Bytes32 blockRoot = Bytes32.fromHexStringLenient("0x1234");
-    final SignedBeaconBlock<?> signedBeaconBlock = schemaObjects.signedBeaconBlock();
+    final SignedBeaconBlock signedBeaconBlock = schemaObjects.signedBeaconBlock();
 
     // Block has been successfully broadcast, validated and imported
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_OK).setBody(asJson(blockRoot)));
@@ -272,7 +272,7 @@ class OkHttpValidatorRestApiClientTest {
 
   @Test
   public void sendSignedBlock_WhenAccepted_DoesNotFailHandlingResponse() {
-    final SignedBeaconBlock<?> signedBeaconBlock = schemaObjects.signedBeaconBlock();
+    final SignedBeaconBlock signedBeaconBlock = schemaObjects.signedBeaconBlock();
 
     // Block has been successfully broadcast, but failed validation and has not been imported
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_ACCEPTED));
@@ -282,7 +282,7 @@ class OkHttpValidatorRestApiClientTest {
 
   @Test
   public void sendSignedBlock_WhenBadParameters_ThrowsIllegalArgumentException() {
-    final SignedBeaconBlock<?> signedBeaconBlock = schemaObjects.signedBeaconBlock();
+    final SignedBeaconBlock signedBeaconBlock = schemaObjects.signedBeaconBlock();
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_BAD_REQUEST));
 
@@ -292,7 +292,7 @@ class OkHttpValidatorRestApiClientTest {
 
   @Test
   public void sendSignedBlock_WhenServiceUnavailable_ThrowsServiceNotAvailableResponse() {
-    final SignedBeaconBlock<?> signedBeaconBlock = schemaObjects.signedBeaconBlock();
+    final SignedBeaconBlock signedBeaconBlock = schemaObjects.signedBeaconBlock();
 
     // node is syncing
     mockWebServer.enqueue(new MockResponse().setResponseCode(503));
@@ -304,7 +304,7 @@ class OkHttpValidatorRestApiClientTest {
 
   @Test
   public void sendSignedBlock_WhenServerError_ThrowsRuntimeException() {
-    final SignedBeaconBlock<?> signedBeaconBlock = schemaObjects.signedBeaconBlock();
+    final SignedBeaconBlock signedBeaconBlock = schemaObjects.signedBeaconBlock();
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_INTERNAL_SERVER_ERROR));
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/SchemaObjectsTestFixture.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/SchemaObjectsTestFixture.java
@@ -105,8 +105,8 @@ public class SchemaObjectsTestFixture {
     return new SyncCommitteeContribution(altairData.randomSyncCommitteeContribution(slot));
   }
 
-  public SignedBeaconBlock<?> signedBeaconBlock() {
-    return SignedBeaconBlock.create(dataStructureUtil.randomSignedBeaconBlock(UInt64.ONE));
+  public SignedBeaconBlock signedBeaconBlock() {
+    return new SignedBeaconBlock(dataStructureUtil.randomSignedBeaconBlock(UInt64.ONE));
   }
 
   public Attestation attestation() {

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/SchemaObjectsTestFixture.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/SchemaObjectsTestFixture.java
@@ -106,7 +106,7 @@ public class SchemaObjectsTestFixture {
   }
 
   public SignedBeaconBlock signedBeaconBlock() {
-    return new SignedBeaconBlock(dataStructureUtil.randomSignedBeaconBlock(UInt64.ONE));
+    return SignedBeaconBlock.create(dataStructureUtil.randomSignedBeaconBlock(UInt64.ONE));
   }
 
   public Attestation attestation() {


### PR DESCRIPTION
## PR Description
Fix JSON content when sending signed blocks to the beacon node.  Both serialisation and deserialisation used the same incorrect format with a `$class` attribute so it works with the same version of Teku but doesn't follow the standard correctly.

#4600

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
