### PR TITLE
Ignore unknown values when loading a Spec from remote API

### DIFF
--- a/data/provider/src/test/java/tech/pegasys/teku/api/ConfigProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ConfigProviderTest.java
@@ -30,7 +30,7 @@ class ConfigProviderTest {
   @Test
   void shouldParseResultOfConfig() {
     final GetSpecResponse response = configProvider.getConfig();
-    final SpecConfig specConfig = SpecConfigLoader.loadConfig(response.data);
+    final SpecConfig specConfig = SpecConfigLoader.loadRemoteConfig(response.data);
     final SpecConfig expectedConfig = spec.getGenesisSpecConfig();
     assertThat(specConfig).isEqualToComparingFieldByField(expectedConfig);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigLoader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigLoader.java
@@ -32,20 +32,31 @@ public class SpecConfigLoader {
   private static final String CONFIG_PATH = "configs/";
   private static final String PRESET_PATH = "presets/";
 
+  public static SpecConfig loadConfigStrict(final String configName) {
+    return loadConfig(configName, false, __ -> {});
+  }
+
   public static SpecConfig loadConfig(final String configName) {
     return loadConfig(configName, __ -> {});
   }
 
   public static SpecConfig loadConfig(
       final String configName, final Consumer<SpecConfigBuilder> modifier) {
+    return loadConfig(configName, true, modifier);
+  }
+
+  public static SpecConfig loadConfig(
+      final String configName,
+      final boolean ignoreUnknownConfigItems,
+      final Consumer<SpecConfigBuilder> modifier) {
     final SpecConfigReader reader = new SpecConfigReader();
-    processConfig(configName, reader::read);
+    processConfig(configName, source -> reader.read(source, ignoreUnknownConfigItems));
     return reader.build(modifier);
   }
 
-  public static SpecConfig loadConfig(final Map<String, String> config) {
+  public static SpecConfig loadRemoteConfig(final Map<String, String> config) {
     final SpecConfigReader reader = new SpecConfigReader();
-    reader.loadFromMap(config);
+    reader.loadFromMap(config, true);
     return reader.build();
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
@@ -42,7 +42,7 @@ public class SpecConfigLoaderTest {
   @MethodSource("knownNetworks")
   public void shouldLoadAllKnownNetworks(final String name, final Class<?> configType)
       throws Exception {
-    final SpecConfig config = SpecConfigLoader.loadConfig(name);
+    final SpecConfig config = SpecConfigLoader.loadConfigStrict(name);
     assertAllFieldsSet(config, configType);
   }
 
@@ -123,13 +123,8 @@ public class SpecConfigLoaderTest {
   }
 
   static Stream<Arguments> knownNetworks() {
-    return Stream.of(
-        Arguments.of(Eth2Network.MAINNET.configName(), SpecConfigMerge.class),
-        Arguments.of(Eth2Network.PYRMONT.configName(), SpecConfigMerge.class),
-        Arguments.of(Eth2Network.PRATER.configName(), SpecConfigMerge.class),
-        Arguments.of(Eth2Network.MINIMAL.configName(), SpecConfigMerge.class),
-        Arguments.of(Eth2Network.SWIFT.configName(), SpecConfigMerge.class),
-        Arguments.of(Eth2Network.LESS_SWIFT.configName(), SpecConfigMerge.class));
+    return Stream.of(Eth2Network.values())
+        .map(network -> Arguments.of(network.configName(), SpecConfigMerge.class));
   }
 
   private void writeStreamToFile(final InputStream inputStream, final Path filePath)

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigReaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigReaderTest.java
@@ -25,7 +25,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class SpecConfigReaderTest {
-  private SpecConfigReader reader = new SpecConfigReader();
+  private final SpecConfigReader reader = new SpecConfigReader();
 
   @Test
   public void read_multiFileFormat_mismatchedDuplicateFields() {

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoader.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoader.java
@@ -35,7 +35,7 @@ class RemoteSpecLoader {
     try {
       return apiClient
           .getConfigSpec()
-          .map(response -> SpecConfigLoader.loadConfig(response.data))
+          .map(response -> SpecConfigLoader.loadRemoteConfig(response.data))
           .map(SpecFactory::create)
           .orElseThrow();
     } catch (Exception e) {

--- a/teku/src/test/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoaderTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoaderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.subcommand;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.ConfigProvider;
+import tech.pegasys.teku.api.response.v1.config.GetSpecResponse;
+import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.validator.remote.apiclient.OkHttpValidatorRestApiClient;
+
+class RemoteSpecLoaderTest {
+  private final Spec spec = TestSpecFactory.createDefault();
+
+  private final OkHttpValidatorRestApiClient apiClient = mock(OkHttpValidatorRestApiClient.class);
+
+  @Test
+  void shouldIgnoreUnknownConfigItems() {
+    final Map<String, String> rawConfig = getRawConfigForSpec(spec);
+    rawConfig.put("UNKNOWN_ITEM", "foo");
+    when(apiClient.getConfigSpec()).thenReturn(Optional.of(new GetSpecResponse(rawConfig)));
+    final Spec result = RemoteSpecLoader.getSpec(apiClient);
+    assertThat(getRawConfigForSpec(result)).containsExactlyInAnyOrderEntriesOf(rawConfig);
+    assertThat(result.getGenesisSpecConfig()).isEqualTo(spec.getGenesisSpecConfig());
+  }
+
+  @Test
+  void shouldFailWhenRequiredItemsAreMissing() {
+    final Map<String, String> rawConfig = getRawConfigForSpec(spec);
+    assertThat(rawConfig.remove("GENESIS_FORK_VERSION")).isNotNull();
+
+    when(apiClient.getConfigSpec()).thenReturn(Optional.of(new GetSpecResponse(rawConfig)));
+
+    assertThatThrownBy(() -> RemoteSpecLoader.getSpec(apiClient))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining("GENESIS_FORK_VERSION");
+  }
+
+  private Map<String, String> getRawConfigForSpec(final Spec spec) {
+    return new ConfigProvider(spec).getConfig().data;
+  }
+}


### PR DESCRIPTION
## PR Description
To allow the validator client to work with later versions of the beacon node, ignore any unknown items from the `config/spec` endpoint when loading the schema from the beacon node.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
