### PR TITLE
Mark --X execution engine options as hidden

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
@@ -26,7 +26,8 @@ public class ExecutionEngineOptions {
       paramLabel = "<NETWORK>",
       description = "URLs for Execution Engine nodes.",
       split = ",",
-      arity = "0..*")
+      arity = "0..*",
+      hidden = true)
   private List<String> eeEndpoints = new ArrayList<>();
 
   @Option(
@@ -34,7 +35,8 @@ public class ExecutionEngineOptions {
       paramLabel = "<ADDRESS>",
       description =
           "Suggested fee recipient sent to the execution engine, which could use it as coinbase when producing a new execution block.",
-      arity = "0..1")
+      arity = "0..1",
+      hidden = true)
   private String feeRecipient = null;
 
   public void configure(final Builder builder) {

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -101,6 +101,15 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  void helpShouldNotShowUnsupportedOptions() {
+    final String[] args = {"--help"};
+
+    beaconNodeCommand.parse(args);
+    String str = getCommandLineOutput();
+    assertThat(str).doesNotContain("--X");
+  }
+
+  @Test
   public void helpShouldShowDefaultsForBooleanOptions() {
     final Pattern optPattern = Pattern.compile("(?i)--\\S+=<boolean>");
     final Pattern optDefValPattern = Pattern.compile("(?i)Default: (?:true|false)");


### PR DESCRIPTION
## PR Description
New `--X` options for execution engine were incorrectly showing up in help output because they weren't marked as hidden.

Hide them and add a test to ensure all `--X` options are hidden.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
