### PR TITLE
Always use v2 api for create block

### DIFF
--- a/infrastructure/logging/src/testFixtures/resources/log4j2-test.xml
+++ b/infrastructure/logging/src/testFixtures/resources/log4j2-test.xml
@@ -8,7 +8,7 @@
     </Appenders>
     <Loggers>
         <Logger name="io.netty" level="INFO"/>
-        <Logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="INFO"/>
+        <Logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http" level="INFO"/>
         <Root level="DEBUG">
             <AppenderRef ref="Console"/>
         </Root>

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -24,7 +24,6 @@ import tech.pegasys.teku.infrastructure.async.timed.RepeatingTaskScheduler;
 import tech.pegasys.teku.infrastructure.http.UrlSanitizer;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
@@ -70,8 +69,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
     apiEndpoint = apiEndpoint.newBuilder().username("").password("").build();
     final OkHttpClient okHttpClient = httpClientBuilder.build();
     final OkHttpValidatorRestApiClient apiClient =
-        new OkHttpValidatorRestApiClient(
-            apiEndpoint, okHttpClient, spec.isMilestoneSupported(SpecMilestone.ALTAIR));
+        new OkHttpValidatorRestApiClient(apiEndpoint, okHttpClient);
 
     final ValidatorApiChannel validatorApiChannel =
         new MetricRecordingValidatorApiChannel(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -24,7 +24,6 @@ import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GE
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_PROPOSER_DUTIES;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_SYNC_COMMITTEE_CONTRIBUTION;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_SYNC_COMMITTEE_DUTIES;
-import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK_V2;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_VALIDATORS;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.SEND_CONTRIBUTION_AND_PROOF;
@@ -67,7 +66,6 @@ import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.config.GetSpecResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
-import tech.pegasys.teku.api.response.v1.validator.GetNewBlockResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetProposerDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetSyncCommitteeContributionResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
@@ -101,17 +99,10 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   private final JsonProvider jsonProvider = new JsonProvider();
   private final OkHttpClient httpClient;
   private final HttpUrl baseEndpoint;
-  private final boolean useV2CreateBlock;
 
   public OkHttpValidatorRestApiClient(final HttpUrl baseEndpoint, final OkHttpClient okHttpClient) {
-    this(baseEndpoint, okHttpClient, false);
-  }
-
-  public OkHttpValidatorRestApiClient(
-      final HttpUrl baseEndpoint, final OkHttpClient okHttpClient, final boolean useV2CreateBlock) {
     this.baseEndpoint = baseEndpoint;
     this.httpClient = okHttpClient;
-    this.useV2CreateBlock = useV2CreateBlock;
   }
 
   public Optional<GetSpecResponse> getConfigSpec() {
@@ -170,16 +161,11 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
     queryParams.put("randao_reveal", encodeQueryParam(randaoReveal));
     graffiti.ifPresent(bytes32 -> queryParams.put("graffiti", encodeQueryParam(bytes32)));
 
-    if (useV2CreateBlock) {
-      return get(
-              GET_UNSIGNED_BLOCK_V2,
-              pathParams,
-              queryParams,
-              createHandler(GetNewBlockResponseV2.class))
-          .map(response -> (BeaconBlock) response.data);
-    }
     return get(
-            GET_UNSIGNED_BLOCK, pathParams, queryParams, createHandler(GetNewBlockResponse.class))
+            GET_UNSIGNED_BLOCK_V2,
+            pathParams,
+            queryParams,
+            createHandler(GetNewBlockResponseV2.class))
         .map(response -> (BeaconBlock) response.data);
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorApiMethod.java
@@ -22,7 +22,6 @@ public enum ValidatorApiMethod {
   GET_GENESIS("eth/v1/beacon/genesis"),
   GET_VALIDATORS("eth/v1/beacon/states/head/validators"),
   GET_DUTIES("validator/duties"),
-  GET_UNSIGNED_BLOCK("eth/v1/validator/blocks/:slot"),
   GET_UNSIGNED_BLOCK_V2("eth/v2/validator/blocks/:slot"),
   SEND_SIGNED_BLOCK("eth/v1/beacon/blocks"),
   GET_ATTESTATION_DATA("eth/v1/validator/attestation_data"),

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -49,7 +49,6 @@ import tech.pegasys.teku.api.response.v1.beacon.PostDataFailureResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAggregatedAttestationResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetAttestationDataResponse;
-import tech.pegasys.teku.api.response.v1.validator.GetNewBlockResponse;
 import tech.pegasys.teku.api.response.v1.validator.GetSyncCommitteeContributionResponse;
 import tech.pegasys.teku.api.response.v2.validator.GetNewBlockResponseV2;
 import tech.pegasys.teku.api.schema.Attestation;
@@ -184,7 +183,7 @@ class OkHttpValidatorRestApiClientTest {
 
     assertThat(request.getMethod()).isEqualTo("GET");
     assertThat(request.getPath())
-        .contains(ValidatorApiMethod.GET_UNSIGNED_BLOCK.getPath(Map.of("slot", "1")));
+        .contains(ValidatorApiMethod.GET_UNSIGNED_BLOCK_V2.getPath(Map.of("slot", "1")));
     assertThat(request.getRequestUrl().queryParameter("randao_reveal"))
         .isEqualTo(blsSignature.toHexString());
     assertThat(request.getRequestUrl().queryParameter("graffiti"))
@@ -224,7 +223,7 @@ class OkHttpValidatorRestApiClientTest {
     mockWebServer.enqueue(
         new MockResponse()
             .setResponseCode(SC_OK)
-            .setBody(asJson(new GetNewBlockResponse(expectedBeaconBlock))));
+            .setBody(asJson(new GetNewBlockResponseV2(SpecMilestone.PHASE0, expectedBeaconBlock))));
 
     Optional<BeaconBlock> beaconBlock = apiClient.createUnsignedBlock(slot, blsSignature, graffiti);
 
@@ -234,7 +233,6 @@ class OkHttpValidatorRestApiClientTest {
 
   @Test
   public void createUnsignedBlock_Altair_ReturnsBeaconBlock() {
-    apiClient = new OkHttpValidatorRestApiClient(mockWebServer.url("/"), okHttpClient, true);
     final UInt64 slot = UInt64.ONE;
     final BLSSignature blsSignature = schemaObjects.BLSSignature();
     final Optional<Bytes32> graffiti = Optional.of(Bytes32.random());


### PR DESCRIPTION
## PR Description
Change validator client to always use the v2 api for create block even if only phase0 is enabled.  Previously it used v1 if altair wasn't enable to preserve backwards compatibility while the v2 change rolled out but it is now available everyone (and required for all real networks).

## Fixed Issue(s)
fixes #4622

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
