### PR TITLE
Require windows build to pass before publishing artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -531,6 +531,7 @@ workflows:
             - docker
             - extractAPISpec
             - spotless
+            - windowsBuild
           context:
             - cloudsmith-protocols
       - publishDocker:
@@ -549,6 +550,7 @@ workflows:
             - docker
             - extractAPISpec
             - spotless
+            - windowsBuild
           context:
             - dockerhub-quorumengineering-rw
       - publishAPISpec:
@@ -567,6 +569,7 @@ workflows:
             - docker
             - extractAPISpec
             - spotless
+            - windowsBuild
   nightly:
     triggers:
       - schedule:


### PR DESCRIPTION
## PR Description
Require the windows build step to pass before publishing artefacts.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
