### PR TITLE
Publish multi-arch docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,8 +358,12 @@ jobs:
       - run: mkdir -vp ~/.docker/cli-plugins/
       - run: curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
       - run: chmod a+x ~/.docker/cli-plugins/docker-buildx
-      - run: docker buildx inspect
-      - run: docker buildx create --use --driver docker-container
+      - run: |
+          ssh remote-docker \<<EOF
+            sudo bash -c 'echo "{\"experimental\": true}" > /etc/docker/daemon.json'
+            sudo systemctl restart docker
+            sudo docker info
+          EOF
       - run: docker buildx inspect
       - run:
           name: Docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,8 @@ jobs:
       - run: chmod a+x ~/.docker/cli-plugins/docker-buildx
       - run: docker run --rm --privileged tonistiigi/binfmt:latest --install "linux/amd64,linux/arm64"
       - run: docker buildx inspect
+      - run: docker buildx create --use --driver docker-container
+      - run: docker buildx inspect
       - run:
           name: Docker
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,14 +347,14 @@ jobs:
       - capture_test_results
 
   docker:
-    executor: machine_executor
+    executor: medium_executor
     steps:
       - prepare
       - attach_workspace:
           at: ~/project
-#      - setup_remote_docker:
-#          docker_layer_caching: false
-#          version: 20.10.7
+      - setup_remote_docker:
+          docker_layer_caching: false
+          version: 20.10.7
       - run: mkdir -vp ~/.docker/cli-plugins/
       - run: curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
       - run: chmod a+x ~/.docker/cli-plugins/docker-buildx

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,16 @@ commands:
       - store_artifacts:
           path: build/test-artifacts
 
+  install_docker_buildx:
+    description: "Install Docker buildx plugin"
+    steps:
+      - run:
+          name: "Install Docker buildx plugin"
+          command: |
+            mkdir -vp ~/.docker/cli-plugins/
+            curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+
   notify:
     description: "Notify Slack"
     steps:
@@ -355,13 +365,10 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: false
           version: 20.10.7
+      - install_docker_buildx
       - run:
           name: Configure Buildx
-          command: |
-            mkdir -vp ~/.docker/cli-plugins/
-            curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
-            docker buildx install
+          command: docker buildx install
       - run:
           name: Docker
           command: |
@@ -391,15 +398,12 @@ jobs:
       - prepare
       - attach_workspace:
           at: ~/project
+      - install_docker_buildx
       - run:
-          name: Setup Buildx
+          name: Configure Buildx for Multi-Arch
           command: |
-            mkdir -vp ~/.docker/cli-plugins/
-            curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
             docker run --rm --privileged tonistiigi/binfmt:latest --install "linux/amd64,linux/arm64"
             docker buildx create --use --driver docker-container
-            docker buildx inspect
       - run:
           name: Publish Docker
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,6 +354,12 @@ jobs:
           at: ~/project
       - setup_remote_docker:
           docker_layer_caching: false
+          version: 18.09.3
+      - run: apk add make curl
+      - run: mkdir -vp ~/.docker/cli-plugins/
+      - run: curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
+      - run: chmod a+x ~/.docker/cli-plugins/docker-buildx
+      - run: docker buildx version
       - run:
           name: Docker
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,21 +347,21 @@ jobs:
       - capture_test_results
 
   docker:
-    executor: machine_executor
+    executor: medium_executor
     steps:
       - prepare
       - attach_workspace:
           at: ~/project
-#      - setup_remote_docker:
-#          docker_layer_caching: false
-#          version: 20.10.7
-      - run: mkdir -vp ~/.docker/cli-plugins/
-      - run: curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
-      - run: chmod a+x ~/.docker/cli-plugins/docker-buildx
-      - run: docker run --rm --privileged tonistiigi/binfmt:latest --install "linux/amd64,linux/arm64"
-      - run: docker buildx inspect
-      - run: docker buildx create --use --driver docker-container
-      - run: docker buildx inspect
+      - setup_remote_docker:
+          docker_layer_caching: false
+          version: 20.10.7
+      - run:
+          name: Configure Buildx
+          command: |
+            mkdir -vp ~/.docker/cli-plugins/
+            curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx install
       - run:
           name: Docker
           command: |
@@ -386,13 +386,20 @@ jobs:
       - notify
 
   publishDocker:
-    executor: medium_executor
+    executor: machine_executor
     steps:
       - prepare
       - attach_workspace:
           at: ~/project
-      - setup_remote_docker:
-          docker_layer_caching: false
+      - run:
+          name: Setup Buildx
+          command: |
+            mkdir -vp ~/.docker/cli-plugins/
+            curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker run --rm --privileged tonistiigi/binfmt:latest --install "linux/amd64,linux/arm64"
+            docker buildx create --use --driver docker-container
+            docker buildx inspect
       - run:
           name: Publish Docker
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,11 +355,6 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: false
           version: 18.09.3
-      - run: apk add make curl
-      - run: mkdir -vp ~/.docker/cli-plugins/
-      - run: curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
-      - run: chmod a+x ~/.docker/cli-plugins/docker-buildx
-      - run: docker buildx version
       - run:
           name: Docker
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,112 +479,112 @@ workflows:
           filters:
             tags: &filters-release-tags
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?/
-#      - spotless:
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#      - windowsBuild:
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#      - referenceTestsPrep:
-#          requires:
-#            - assemble
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#      - referenceTests:
-#          requires:
-#            - assemble
-#            - referenceTestsPrep
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#      - unitTests:
-#          requires:
-#            - assemble
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#      - integrationTests:
-#          requires:
-#            - assemble
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#      - acceptanceTests:
-#          requires:
-#            - assemble
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
+      - spotless:
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - windowsBuild:
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - referenceTestsPrep:
+          requires:
+            - assemble
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - referenceTests:
+          requires:
+            - assemble
+            - referenceTestsPrep
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - unitTests:
+          requires:
+            - assemble
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - integrationTests:
+          requires:
+            - assemble
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - acceptanceTests:
+          requires:
+            - assemble
+          filters:
+            tags:
+              <<: *filters-release-tags
       - docker:
           requires:
             - assemble
           filters:
             tags:
               <<: *filters-release-tags
-#      - extractAPISpec:
-#          requires:
-#            - assemble
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#      - publish-cloudsmith:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - /^release-.*/
-#            tags:
-#              <<: *filters-release-tags
-#          requires:
-#            - unitTests
-#            - integrationTests
-#            - acceptanceTests
-#            - referenceTests
-#            - docker
-#            - extractAPISpec
-#            - spotless
-#            - windowsBuild
-#          context:
-#            - cloudsmith-protocols
-#      - publishDocker:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - /^release-.*/
-#            tags:
-#              <<: *filters-release-tags
-#          requires:
-#            - unitTests
-#            - integrationTests
-#            - acceptanceTests
-#            - referenceTests
-#            - docker
-#            - extractAPISpec
-#            - spotless
-#            - windowsBuild
-#          context:
-#            - dockerhub-quorumengineering-rw
-#      - publishAPISpec:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - /^release-.*/
-#            tags: # stable doc is published only on tags to prevent confusion on the doc site.
-#              <<: *filters-release-tags
-#          requires:
-#            - unitTests
-#            - integrationTests
-#            - acceptanceTests
-#            - referenceTests
-#            - docker
-#            - extractAPISpec
-#            - spotless
-#            - windowsBuild
+      - extractAPISpec:
+          requires:
+            - assemble
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - publish-cloudsmith:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+            tags:
+              <<: *filters-release-tags
+          requires:
+            - unitTests
+            - integrationTests
+            - acceptanceTests
+            - referenceTests
+            - docker
+            - extractAPISpec
+            - spotless
+            - windowsBuild
+          context:
+            - cloudsmith-protocols
+      - publishDocker:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+            tags:
+              <<: *filters-release-tags
+          requires:
+            - unitTests
+            - integrationTests
+            - acceptanceTests
+            - referenceTests
+            - docker
+            - extractAPISpec
+            - spotless
+            - windowsBuild
+          context:
+            - dockerhub-quorumengineering-rw
+      - publishAPISpec:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+            tags: # stable doc is published only on tags to prevent confusion on the doc site.
+              <<: *filters-release-tags
+          requires:
+            - unitTests
+            - integrationTests
+            - acceptanceTests
+            - referenceTests
+            - docker
+            - extractAPISpec
+            - spotless
+            - windowsBuild
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,6 +272,10 @@ jobs:
       - prepare
       - attach_workspace:
           at: ~/project
+      - install_docker_buildx
+      - run:
+          name: Configure Buildx
+          command: docker buildx install
       - run:
           name: AcceptanceTests
           command: |
@@ -355,25 +359,6 @@ jobs:
             ./gradlew --no-daemon --parallel -x generateReferenceTestClasses -x processReferenceTestResources -x cleanReferenceTestClasses referenceTest $GRADLE_ARGS
       - notify
       - capture_test_results
-
-  docker:
-    executor: medium_executor
-    steps:
-      - prepare
-      - attach_workspace:
-          at: ~/project
-      - setup_remote_docker:
-          docker_layer_caching: false
-          version: 20.10.7
-      - install_docker_buildx
-      - run:
-          name: Configure Buildx
-          command: docker buildx install
-      - run:
-          name: Docker
-          command: |
-            ./gradlew --no-daemon --parallel distDocker
-      - notify
 
   publish-cloudsmith:
     executor: small_executor
@@ -522,12 +507,6 @@ workflows:
           filters:
             tags:
               <<: *filters-release-tags
-      - docker:
-          requires:
-            - assemble
-          filters:
-            tags:
-              <<: *filters-release-tags
       - extractAPISpec:
           requires:
             - assemble
@@ -547,7 +526,6 @@ workflows:
             - integrationTests
             - acceptanceTests
             - referenceTests
-            - docker
             - extractAPISpec
             - spotless
             - windowsBuild
@@ -566,7 +544,6 @@ workflows:
             - integrationTests
             - acceptanceTests
             - referenceTests
-            - docker
             - extractAPISpec
             - spotless
             - windowsBuild
@@ -585,7 +562,6 @@ workflows:
             - integrationTests
             - acceptanceTests
             - referenceTests
-            - docker
             - extractAPISpec
             - spotless
             - windowsBuild

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,12 +358,8 @@ jobs:
       - run: mkdir -vp ~/.docker/cli-plugins/
       - run: curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
       - run: chmod a+x ~/.docker/cli-plugins/docker-buildx
-      - run: |
-          ssh remote-docker \<<EOF
-            sudo bash -c 'echo "{\"experimental\": true}" > /etc/docker/daemon.json'
-            sudo systemctl restart docker
-            sudo docker info
-          EOF
+      - run: docker buildx inspect
+      - run: docker buildx create --use --driver docker-container
       - run: docker buildx inspect
       - run:
           name: Docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,7 +354,11 @@ jobs:
           at: ~/project
       - setup_remote_docker:
           docker_layer_caching: false
-          version: 18.09.3
+          version: 20.10.7
+      - run: mkdir -vp ~/.docker/cli-plugins/
+      - run: curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
+      - run: chmod a+x ~/.docker/cli-plugins/docker-buildx
+      - run: docker buildx version
       - run:
           name: Docker
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,8 +358,7 @@ jobs:
       - run: mkdir -vp ~/.docker/cli-plugins/
       - run: curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
       - run: chmod a+x ~/.docker/cli-plugins/docker-buildx
-      - run: docker buildx inspect
-      - run: docker buildx create --use --driver docker-container
+      - run: docker run --rm --privileged tonistiigi/binfmt:latest --install "linux/amd64,linux/arm64"
       - run: docker buildx inspect
       - run:
           name: Docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,9 @@ jobs:
       - run: mkdir -vp ~/.docker/cli-plugins/
       - run: curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
       - run: chmod a+x ~/.docker/cli-plugins/docker-buildx
-      - run: docker buildx version
+      - run: docker buildx inspect
+      - run: docker buildx create --use --driver docker-container
+      - run: docker buildx inspect
       - run:
           name: Docker
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,14 +347,14 @@ jobs:
       - capture_test_results
 
   docker:
-    executor: medium_executor
+    executor: machine_executor
     steps:
       - prepare
       - attach_workspace:
           at: ~/project
-      - setup_remote_docker:
-          docker_layer_caching: false
-          version: 20.10.7
+#      - setup_remote_docker:
+#          docker_layer_caching: false
+#          version: 20.10.7
       - run: mkdir -vp ~/.docker/cli-plugins/
       - run: curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
       - run: chmod a+x ~/.docker/cli-plugins/docker-buildx

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,112 +465,112 @@ workflows:
           filters:
             tags: &filters-release-tags
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?/
-      - spotless:
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - windowsBuild:
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - referenceTestsPrep:
-          requires:
-            - assemble
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - referenceTests:
-          requires:
-            - assemble
-            - referenceTestsPrep
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - unitTests:
-          requires:
-            - assemble
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - integrationTests:
-          requires:
-            - assemble
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - acceptanceTests:
-          requires:
-            - assemble
-          filters:
-            tags:
-              <<: *filters-release-tags
+#      - spotless:
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#      - windowsBuild:
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#      - referenceTestsPrep:
+#          requires:
+#            - assemble
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#      - referenceTests:
+#          requires:
+#            - assemble
+#            - referenceTestsPrep
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#      - unitTests:
+#          requires:
+#            - assemble
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#      - integrationTests:
+#          requires:
+#            - assemble
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#      - acceptanceTests:
+#          requires:
+#            - assemble
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
       - docker:
           requires:
             - assemble
           filters:
             tags:
               <<: *filters-release-tags
-      - extractAPISpec:
-          requires:
-            - assemble
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - publish-cloudsmith:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release-.*/
-            tags:
-              <<: *filters-release-tags
-          requires:
-            - unitTests
-            - integrationTests
-            - acceptanceTests
-            - referenceTests
-            - docker
-            - extractAPISpec
-            - spotless
-            - windowsBuild
-          context:
-            - cloudsmith-protocols
-      - publishDocker:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release-.*/
-            tags:
-              <<: *filters-release-tags
-          requires:
-            - unitTests
-            - integrationTests
-            - acceptanceTests
-            - referenceTests
-            - docker
-            - extractAPISpec
-            - spotless
-            - windowsBuild
-          context:
-            - dockerhub-quorumengineering-rw
-      - publishAPISpec:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release-.*/
-            tags: # stable doc is published only on tags to prevent confusion on the doc site.
-              <<: *filters-release-tags
-          requires:
-            - unitTests
-            - integrationTests
-            - acceptanceTests
-            - referenceTests
-            - docker
-            - extractAPISpec
-            - spotless
-            - windowsBuild
+#      - extractAPISpec:
+#          requires:
+#            - assemble
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#      - publish-cloudsmith:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - /^release-.*/
+#            tags:
+#              <<: *filters-release-tags
+#          requires:
+#            - unitTests
+#            - integrationTests
+#            - acceptanceTests
+#            - referenceTests
+#            - docker
+#            - extractAPISpec
+#            - spotless
+#            - windowsBuild
+#          context:
+#            - cloudsmith-protocols
+#      - publishDocker:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - /^release-.*/
+#            tags:
+#              <<: *filters-release-tags
+#          requires:
+#            - unitTests
+#            - integrationTests
+#            - acceptanceTests
+#            - referenceTests
+#            - docker
+#            - extractAPISpec
+#            - spotless
+#            - windowsBuild
+#          context:
+#            - dockerhub-quorumengineering-rw
+#      - publishAPISpec:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - /^release-.*/
+#            tags: # stable doc is published only on tags to prevent confusion on the doc site.
+#              <<: *filters-release-tags
+#          requires:
+#            - unitTests
+#            - integrationTests
+#            - acceptanceTests
+#            - referenceTests
+#            - docker
+#            - extractAPISpec
+#            - spotless
+#            - windowsBuild
   nightly:
     triggers:
       - schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Additions and Improvements
 - Introduces a new database format for archive nodes that significantly improves response times for queries that require historic state data.
     Existing databases and nodes using the default PRUNE storage mode are unchanged. Archive nodes wishing to take advantage of this will need to perform a full resync.
+- Docker images are now published with multi-arch support including Linux/amd64 and Linux/arm64 
 - The default docker image now uses JDK 17 instead of 16. The JDK 16 image is still available with the version suffix `-jdk16`
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ plugins {
 rootProject.version = calculatePublishVersion()
 def specificVersion = calculateVersion()
 def isDevelopBuild = rootProject.version.contains('develop')
-def dockerImageName = "consensys/teku"
 
 apply plugin: 'application'
 
@@ -406,11 +405,11 @@ tasks.register("dockerDistUntar") {
   }
 }
 
+def dockerImageName = "consensys/teku"
 def dockerVariants = [
   "jdk17",
   "jdk16",
 ]
-
 def dockerPlatforms = "linux/amd64,linux/arm64"
 def dockerBuildDir = "build/docker-teku/"
 

--- a/build.gradle
+++ b/build.gradle
@@ -423,9 +423,7 @@ task distDocker  {
         from file("${projectDir}/docker/${variant}/Dockerfile")
         into(dockerBuildDir)
       }
-      def images = ""
       def image = "${dockerImageName}:${dockerBuildVersion}-${variant}"
-      images += "${image} "
       exec {
         workingDir dockerBuildDir
         executable "sh"

--- a/build.gradle
+++ b/build.gradle
@@ -743,22 +743,22 @@ task dockerUpload {
   dependsOn([distDocker])
   def dockerBuildVersion = "${rootProject.version}".replace('+', '-')
 
-  def additionalTags = [dockerBuildVersion]
+  def versionPrefixes = [dockerBuildVersion]
   if (project.hasProperty('branch') && project.property('branch') == 'master') {
-    additionalTags.add('develop')
+    versionPrefixes.add('develop')
   }
 
   if (!isDevelopBuild) {
-    additionalTags.add('latest')
-    additionalTags.add(dockerBuildVersion.split(/\./)[0..1].join('.'))
+    versionPrefixes.add('latest')
+    versionPrefixes.add(dockerBuildVersion.split(/\./)[0..1].join('.'))
   }
 
   doLast {
     for (def variant in dockerVariants) {
       def tags = ""
-      additionalTags.forEach { tag -> tags += "-t ${dockerImageName}:${tag.trim()}-${variant} "}
+      versionPrefixes.forEach { prefix -> tags += "-t ${dockerImageName}:${prefix.trim()}-${variant} "}
       if (variant == dockerVariants[0]) {
-        additionalTags.forEach { tag -> tags += "-t ${dockerImageName}:${tag.trim()} "}
+        versionPrefixes.forEach { prefix -> tags += "-t ${dockerImageName}:${prefix.trim()} "}
       }
 
       exec {

--- a/build.gradle
+++ b/build.gradle
@@ -412,12 +412,12 @@ def dockerVariants = [
 ]
 
 def dockerPlatforms = "linux/amd64,linux/arm64"
+def dockerBuildDir = "build/docker-teku/"
 
 task distDocker  {
   dependsOn dockerDistUntar
 
   def dockerBuildVersion = 'develop'
-  def dockerBuildDir = "build/docker-teku/"
   doLast {
     for (def variant in dockerVariants) {
       copy {
@@ -426,12 +426,11 @@ task distDocker  {
       }
       def images = ""
       def image = "${dockerImageName}:${dockerBuildVersion}-${variant}"
-      println("Building ${image}")
       images += "${image} "
       exec {
         workingDir dockerBuildDir
         executable "sh"
-        args "-c", "docker buildx build --platform ${dockerPlatforms} --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
+        args "-c", "docker build --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
       }
     }
     // tag the "default" (which is the variant in the zero position)
@@ -743,25 +742,11 @@ task cloudsmithUpload {
   }
 }
 
-
-def createManifest(String manifestName, String includedImages) {
-  logger.info("Creating manifest ${manifestName} with images ${includedImages}")
-  exec {
-    executable "sh"
-    args "-c", "docker manifest rm ${manifestName} || true"
-  }
-  exec {
-    executable "sh"
-    args "-c", "docker manifest create ${manifestName} ${includedImages} && docker manifest push ${manifestName}"
-  }
-}
-
 task dockerUpload {
   dependsOn([distDocker])
   def dockerBuildVersion = "${rootProject.version}".replace('+', '-')
-  def image = "${dockerImageName}:${dockerBuildVersion}"
 
-  def additionalTags = []
+  def additionalTags = [dockerBuildVersion]
   if (project.hasProperty('branch') && project.property('branch') == 'master') {
     additionalTags.add('develop')
   }
@@ -773,35 +758,17 @@ task dockerUpload {
 
   doLast {
     for (def variant in dockerVariants) {
-      def manifestImages = ""
-      for (def platform in dockerPlatforms) {
-        def variantImage = "${image}-${platform}-${variant}"
-        manifestImages += "${variantImage} "
-        def variantBuildImage = "${dockerImageName}:develop-${platform}-${variant}"
-        def cmd = "docker tag '${variantBuildImage}' '${variantImage}' && docker push '${variantImage}'"
-        exec {
-          additionalTags.each { tag -> cmd += " && docker tag '${variantBuildImage}' '${dockerImageName}:${tag.trim()}-${platform}-${variant}' && docker push '${dockerImageName}:${tag.trim()}-${platform}-${variant}'" }
-          executable "sh"
-          args '-c', cmd
-        }
+      def tags = ""
+      additionalTags.forEach { tag -> tags += "-t ${dockerImageName}:${tag.trim()}-${variant} "}
+      if (variant == dockerVariants[0]) {
+        additionalTags.forEach { tag -> tags += "-t ${dockerImageName}:${tag.trim()} "}
       }
 
-      createManifest("${image}-${variant}", manifestImages)
-      additionalTags.each { tag ->
-        createManifest("${dockerImageName}:${tag.trim()}-${variant}", manifestImages)
+      exec {
+        workingDir dockerBuildDir
+        executable "sh"
+        args "-c", "docker buildx build --platform ${dockerPlatforms} --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} --push ${tags} ."
       }
-    }
-
-    // Publish default version without variant suffix
-    var defaultVariant = dockerVariants[0]
-    for (def tag in additionalTags) {
-      def manifestName = "${dockerImageName}:${tag.trim()}"
-      def imageList = ""
-      for (def platform in dockerPlatforms) {
-        imageList += "${dockerImageName}:develop-${platform}-${defaultVariant} "
-      }
-
-      createManifest(manifestName, imageList);
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -411,10 +411,7 @@ def dockerVariants = [
   "jdk16",
 ]
 
-def dockerPlatforms = [
-    "arm64",
-    "amd64",
-]
+def dockerPlatforms = "linux/amd64,linux/arm64"
 
 task distDocker  {
   dependsOn dockerDistUntar
@@ -428,21 +425,19 @@ task distDocker  {
         into(dockerBuildDir)
       }
       def images = ""
-      for (def platform in dockerPlatforms) {
-        def image = "${dockerImageName}:${dockerBuildVersion}-${platform}-${variant}"
-        println("Building ${image}")
-        images += "${image} "
-        exec {
-          workingDir dockerBuildDir
-          executable "sh"
-          args "-c", "docker build --platform linux/${platform} --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
-        }
+      def image = "${dockerImageName}:${dockerBuildVersion}-${variant}"
+      println("Building ${image}")
+      images += "${image} "
+      exec {
+        workingDir dockerBuildDir
+        executable "sh"
+        args "-c", "docker buildx build --platform ${dockerPlatforms} --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
       }
     }
     // tag the "default" (which is the variant in the zero position)
     exec {
       executable "sh"
-      args "-c", "docker tag '${dockerImageName}:${dockerBuildVersion}-${dockerPlatforms[0]}-${dockerVariants[0]}' '${dockerImageName}:${dockerBuildVersion}'"
+      args "-c", "docker tag '${dockerImageName}:${dockerBuildVersion}-${dockerVariants[0]}' '${dockerImageName}:${dockerBuildVersion}'"
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -430,6 +430,7 @@ task distDocker  {
       def images = ""
       for (def platform in dockerPlatforms) {
         def image = "${dockerImageName}:${dockerBuildVersion}-${platform}-${variant}"
+        println("Building ${image}")
         images += "${image} "
         exec {
           workingDir dockerBuildDir

--- a/build.gradle
+++ b/build.gradle
@@ -423,8 +423,8 @@ task distDocker  {
         from file("${projectDir}/docker/${variant}/Dockerfile")
         into(dockerBuildDir)
       }
-      def image = "${dockerImageName}:${dockerBuildVersion}-${variant}"
       exec {
+        def image = "${dockerImageName}:${dockerBuildVersion}-${variant}"
         workingDir dockerBuildDir
         executable "sh"
         args "-c", "docker build --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ plugins {
 rootProject.version = calculatePublishVersion()
 def specificVersion = calculateVersion()
 def isDevelopBuild = rootProject.version.contains('develop')
+def dockerImageName = "consensys/teku"
 
 apply plugin: 'application'
 
@@ -410,30 +411,37 @@ def dockerVariants = [
   "jdk16",
 ]
 
+def dockerPlatforms = [
+    "arm64",
+    "amd64",
+]
+
 task distDocker  {
   dependsOn dockerDistUntar
 
   def dockerBuildVersion = 'develop'
   def dockerBuildDir = "build/docker-teku/"
-  def imageName = "consensys/teku"
-  
   doLast {
     for (def variant in dockerVariants) {
       copy {
         from file("${projectDir}/docker/${variant}/Dockerfile")
         into(dockerBuildDir)
       }
-      exec {
-        def image = "${imageName}:${dockerBuildVersion}-${variant}"
-        workingDir dockerBuildDir
-        executable "sh"
-        args "-c", "docker build --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
+      def images = ""
+      for (def platform in dockerPlatforms) {
+        def image = "${dockerImageName}:${dockerBuildVersion}-${platform}-${variant}"
+        images += "${image} "
+        exec {
+          workingDir dockerBuildDir
+          executable "sh"
+          args "-c", "docker build --platform linux/${platform} --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
+        }
       }
     }
     // tag the "default" (which is the variant in the zero position)
     exec {
       executable "sh"
-      args "-c", "docker tag '${imageName}:${dockerBuildVersion}-${dockerVariants[0]}' '${imageName}:${dockerBuildVersion}'"
+      args "-c", "docker tag '${dockerImageName}:${dockerBuildVersion}-${dockerPlatforms[0]}-${dockerVariants[0]}' '${dockerImageName}:${dockerBuildVersion}'"
     }
   }
 }
@@ -739,11 +747,23 @@ task cloudsmithUpload {
   }
 }
 
+
+def createManifest(String manifestName, String includedImages) {
+  logger.info("Creating manifest ${manifestName} with images ${includedImages}")
+  exec {
+    executable "sh"
+    args "-c", "docker manifest rm ${manifestName} || true"
+  }
+  exec {
+    executable "sh"
+    args "-c", "docker manifest create ${manifestName} ${includedImages} && docker manifest push ${manifestName}"
+  }
+}
+
 task dockerUpload {
   dependsOn([distDocker])
   def dockerBuildVersion = "${rootProject.version}".replace('+', '-')
-  def imageName = "consensys/teku"
-  def image = "${imageName}:${dockerBuildVersion}"
+  def image = "${dockerImageName}:${dockerBuildVersion}"
 
   def additionalTags = []
   if (project.hasProperty('branch') && project.property('branch') == 'master') {
@@ -757,22 +777,35 @@ task dockerUpload {
 
   doLast {
     for (def variant in dockerVariants) {
-      def variantImage = "${image}-${variant}"
-      def variantBuildImage = "${imageName}:develop-${variant}"
-      def cmd = "docker tag '${variantBuildImage}' '${variantImage}' && docker push '${variantImage}'"
-      exec {
-        additionalTags.each { tag -> cmd += " && docker tag '${variantBuildImage}' '${imageName}:${tag.trim()}-${variant}' && docker push '${imageName}:${tag.trim()}-${variant}'" }
-        executable "sh"
-        args '-c', cmd
+      def manifestImages = ""
+      for (def platform in dockerPlatforms) {
+        def variantImage = "${image}-${platform}-${variant}"
+        manifestImages += "${variantImage} "
+        def variantBuildImage = "${dockerImageName}:develop-${platform}-${variant}"
+        def cmd = "docker tag '${variantBuildImage}' '${variantImage}' && docker push '${variantImage}'"
+        exec {
+          additionalTags.each { tag -> cmd += " && docker tag '${variantBuildImage}' '${dockerImageName}:${tag.trim()}-${platform}-${variant}' && docker push '${dockerImageName}:${tag.trim()}-${platform}-${variant}'" }
+          executable "sh"
+          args '-c', cmd
+        }
+      }
+
+      createManifest("${image}-${variant}", manifestImages)
+      additionalTags.each { tag ->
+        createManifest("${dockerImageName}:${tag.trim()}-${variant}", manifestImages)
       }
     }
 
     // Publish default version without variant suffix
-    exec {
-      def cmd = "docker tag '${imageName}:develop' '${image}' && docker push '${image}'"
-      additionalTags.each { tag -> cmd += " && docker tag '${image}' '${imageName}:${tag.trim()}' && docker push '${imageName}:${tag.trim()}'" }
-      executable "sh"
-      args '-c', cmd
+    var defaultVariant = dockerVariants[0]
+    for (def tag in additionalTags) {
+      def manifestName = "${dockerImageName}:${tag.trim()}"
+      def imageList = ""
+      for (def platform in dockerPlatforms) {
+        imageList += "${dockerImageName}:develop-${platform}-${defaultVariant} "
+      }
+
+      createManifest(manifestName, imageList);
     }
   }
 }

--- a/docker/jdk16/Dockerfile
+++ b/docker/jdk16/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:16 as jre-build
 
 # Create a custom Java runtime
-RUN $JAVA_HOME/bin/jlink \
+RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/jlink \
          --add-modules ALL-MODULE-PATH \
          --strip-debug \
          --no-man-pages \

--- a/docker/jdk16/Dockerfile
+++ b/docker/jdk16/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:16 as jre-build
 
 # Create a custom Java runtime
-RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/jlink \
+RUN $JAVA_HOME/bin/jlink \
          --add-modules ALL-MODULE-PATH \
          --strip-debug \
          --no-man-pages \

--- a/docker/jdk17/Dockerfile
+++ b/docker/jdk17/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:17 as jre-build
 
 # Create a custom Java runtime
-RUN $JAVA_HOME/bin/jlink \
+RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/jlink \
          --add-modules ALL-MODULE-PATH \
          --strip-debug \
          --no-man-pages \

--- a/docker/jdk17/Dockerfile
+++ b/docker/jdk17/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:17 as jre-build
 
 # Create a custom Java runtime
-RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/jlink \
+RUN $JAVA_HOME/bin/jlink \
          --add-modules ALL-MODULE-PATH \
          --strip-debug \
          --no-man-pages \


### PR DESCRIPTION
## PR Description
Configure CircleCI to publish multi-arch docker images. This isn't the ideal approach but it threads the needle between significant limitations in Docker's multi-arch support and CircleCI's support for ARM docker instances.

We want to be able to build the docker images locally, test them and then publish, but Docker can't make multi-arch images locally, it has to publish the single-arch versions to a repo then create a multi-arch manifest pointing at them. And while we can use the docker buildx plugin to build multi-arch images it isn't capable of loading the multi-arch image back into the local docker - it can only do that for single-arch images. So we have to do the multi-arch build and publish them in the dockerUpload step.

To ensure the docker build process used for testing is as similar as possible to the final build we publish, we install and use the `buildx` plugin when building the single-arch docker image for ATs, even though it doesn't strictly need buildx.

Also removes the separate `docker` step to the build and just lets the docker images be built as part of the acceptance test step. Looking at the logs for previous runs, only the base layers for the built docker images were being reused anyway with the Teku specific steps still executing again as part of the acceptance test step. Plus the acceptance test step runs on the same machine_executor type as the final publish so building the images there brings the two build setups closer.


Testing-wise it's obviously hard to check how this works in CircleCI since the upload step only runs once merged. So testing has been done in two ways:
1. Initially the buildx multi-arch build ran as part of the `docker` step which confirmed it does work and builds images successfully (though they don't get published anywhere)
2. I've been testing the publish by running locally and publishing under a different alias (https://hub.docker.com/repository/docker/ajsutton/tekua/tags). From there I can confirm that I can run the images on both intel and arm devices and it pulls the right image. I've since deleted the repo but have also run tests of building when there is a release tag for that commit to check it publishes under the right release versions still.


fixes #4062 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
