### PR TITLE
[Merge] ExecutionPayload preparation via PreparableDuty 

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_prepare_beacon_proposer.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_prepare_beacon_proposer.json
@@ -1,0 +1,31 @@
+{
+  "post" : {
+    "tags" : [ "Validator", "Validator Required Api" ],
+    "summary" : "Provide beacon node with proposals for the given validators.",
+    "description" : "Prepares the beacon node for potential proposers by supplying information required when proposing blocks for the given validators. The information supplied for each validator index is considered persistent until overwritten by new information for the given validator index, or until the beacon node restarts.\n\nNote that because the information is not persistent across beacon node restarts it is recommended that either the beacon node is monitored for restarts or this information is refreshed by resending this request periodically (for example, each epoch).\n\nAlso note that requests containing currently inactive or unknown validator indices will be accepted, as they may become active at a later epoch.",
+    "operationId" : "postEthV1ValidatorPrepare_beacon_proposer",
+    "requestBody" : {
+      "content" : {
+        "application/json" : {
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/BeaconPreparableProposer"
+            }
+          }
+        }
+      }
+    },
+    "responses" : {
+      "200" : {
+        "description" : "Preparation information has been received."
+      },
+      "400" : {
+        "description" : "Invalid parameter supplied."
+      },
+      "500" : {
+        "description" : "Beacon node internal error."
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconPreparableProposer.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconPreparableProposer.json
@@ -1,0 +1,16 @@
+{
+  "type" : "object",
+  "properties" : {
+    "validator_index" : {
+      "type" : "string",
+      "format" : "uint64",
+      "example" : "1"
+    },
+    "fee_recipient" : {
+      "pattern" : "^0x[a-fA-F0-9]{40}$",
+      "type" : "string",
+      "description" : "Bytes20 hexadecimal",
+      "format" : "byte"
+    }
+  }
+}

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -94,7 +94,6 @@ public class ValidatorDataProviderTest {
   private final BLSSignature signature = new BLSSignature(signatureInternal);
 
   @BeforeEach
-  @TestTemplate
   public void setup(SpecContext specContext) {
     spec = specContext.getSpec();
     dataStructureUtil = specContext.getDataStructureUtil();

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecInvocationContextProvider.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecInvocationContextProvider.java
@@ -164,5 +164,20 @@ public class TestSpecInvocationContextProvider implements TestTemplateInvocation
       Assumptions.assumeTrue(
           List.of(networks).contains(specContext.getNetwork()), "Network skipped");
     }
+
+    public static void onlyPhase0(SpecContext specContext) {
+      Assumptions.assumeTrue(
+          specContext.getSpecMilestone().equals(SpecMilestone.PHASE0), "Milestone skipped");
+    }
+
+    public static void onlyAltair(SpecContext specContext) {
+      Assumptions.assumeTrue(
+          specContext.getSpecMilestone().equals(SpecMilestone.ALTAIR), "Milestone skipped");
+    }
+
+    public static void onlyMerge(SpecContext specContext) {
+      Assumptions.assumeTrue(
+          specContext.getSpecMilestone().equals(SpecMilestone.MERGE), "Milestone skipped");
+    }
   }
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorTimingChannel.java
@@ -32,6 +32,8 @@ public interface ValidatorTimingChannel extends VoidReturningChannelInterface {
 
   void onBlockProductionDue(UInt64 slot);
 
+  void onExecutionPayloadPreparationDue(UInt64 slot);
+
   void onAttestationCreationDue(UInt64 slot);
 
   void onAttestationAggregationDue(UInt64 slot);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -29,7 +29,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   private static final Logger LOG = LogManager.getLogger();
   private final MetricsSystem metricsSystem;
   private final String dutyType;
-  private final Spec spec;
+  protected final Spec spec;
   private final boolean useDependentRoots;
   private final DutyLoader<?> epochDutiesScheduler;
   private final int lookAheadEpochs;
@@ -123,7 +123,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
     invalidateEpochs(dutiesByEpoch);
   }
 
-  private void calculateDuties(final UInt64 epochNumber) {
+  protected void calculateDuties(final UInt64 epochNumber) {
     dutiesByEpoch.computeIfAbsent(epochNumber, this::createEpochDuties);
     for (int i = 1; i <= lookAheadEpochs; i++) {
       dutiesByEpoch.computeIfAbsent(epochNumber.plus(i), this::createEpochDuties);
@@ -159,6 +159,9 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
 
   @Override
   public void onBlockProductionDue(final UInt64 slot) {}
+
+  @Override
+  public void onExecutionPayloadPreparationDue(UInt64 slot) {}
 
   @Override
   public void onAttestationCreationDue(final UInt64 slot) {}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -44,6 +44,23 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
   }
 
   @Override
+  public void onExecutionPayloadPreparationDue(UInt64 slot) {
+    ensureDutiesCalculationAndRunPreparation(slot);
+  }
+
+  @Override
+  public void onChainReorg(UInt64 newSlot, UInt64 commonAncestorSlot) {
+    super.onChainReorg(newSlot, commonAncestorSlot);
+    ensureDutiesCalculationAndRunPreparation(newSlot);
+  }
+
+  private void ensureDutiesCalculationAndRunPreparation(UInt64 slot) {
+    final UInt64 preparationDueSlot = slot.plus(1);
+    calculateDuties(spec.computeEpochAtSlot(preparationDueSlot));
+    notifyEpochDuties(PendingDuties::onProductionPreparationDue, preparationDueSlot);
+  }
+
+  @Override
   protected Bytes32 getExpectedDependentRoot(
       final Bytes32 headBlockRoot,
       final Bytes32 previousTargetRoot,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/PendingDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/PendingDuties.java
@@ -84,6 +84,23 @@ class PendingDuties {
                     error -> reportDutyFailure(error, duties.getAggregationType(), slot)));
   }
 
+  public void onProductionPreparationDue(final UInt64 slot) {
+    execute(
+        duties ->
+            duties
+                .performProductionDutyPreparation(slot)
+                .finish(
+                    result -> reportDutySuccess(result, duties.getPreparationType(), slot),
+                    error ->
+                        reportDutyPreparationFailure(error, duties.getPreparationType(), slot)));
+  }
+
+  private void reportDutyPreparationFailure(
+      final Throwable error, final String preparationType, final UInt64 slot) {
+    dutiesPerformedCounter.labels(preparationType, "failed").inc();
+    VALIDATOR_LOGGER.dutyFailed(preparationType, slot, emptySet(), error);
+  }
+
   private void reportDutyFailure(
       final Throwable error, final String producedType, final UInt64 slot) {
     dutiesPerformedCounter.labels(producedType, "failed").inc();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
@@ -171,6 +171,9 @@ public class SyncCommitteeScheduler implements ValidatorTimingChannel {
   @Override
   public void onBlockProductionDue(final UInt64 slot) {}
 
+  @Override
+  public void onExecutionPayloadPreparationDue(UInt64 slot) {}
+
   private class SyncCommitteePeriod {
     private Optional<PendingDuties> duties = Optional.empty();
     private final UInt64 periodStartEpoch;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -89,6 +89,11 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
   }
 
   @Override
+  public void onExecutionPayloadPreparationDue(UInt64 slot) {
+    delegates.forEach(delegate -> delegate.onExecutionPayloadPreparationDue(slot));
+  }
+
+  @Override
   public void onAttestationCreationDue(final UInt64 slot) {
     delegates.forEach(delegate -> delegate.onAttestationCreationDue(slot));
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockDutyFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockDutyFactory.java
@@ -46,6 +46,11 @@ public class BlockDutyFactory implements DutyFactory<BlockProductionDuty, Duty> 
   }
 
   @Override
+  public String getPreparationType() {
+    return "execution_payload_preparation";
+  }
+
+  @Override
   public String getProductionType() {
     return "block";
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/DutyFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/DutyFactory.java
@@ -22,6 +22,8 @@ public interface DutyFactory<P extends Duty, A extends Duty> {
 
   A createAggregationDuty(UInt64 slot, Validator validator);
 
+  String getPreparationType();
+
   String getProductionType();
 
   String getAggregationType();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/PreparableDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/PreparableDuty.java
@@ -16,10 +16,11 @@ package tech.pegasys.teku.validator.client.duties;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
-public interface Duty {
-  SafeFuture<DutyResult> performDuty();
+public interface PreparableDuty extends Duty {
+  SafeFuture<DutyResult> prepareDuty();
 
+  @Override
   default Optional<PreparableDuty> toPreparableDuty() {
-    return Optional.empty();
+    return Optional.of(this);
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ScheduledDuties.java
@@ -21,6 +21,10 @@ public interface ScheduledDuties {
 
   boolean requiresRecalculation(Bytes32 newHeadDependentRoot);
 
+  SafeFuture<DutyResult> performProductionDutyPreparation(UInt64 slot);
+
+  String getPreparationType();
+
   SafeFuture<DutyResult> performProductionDuty(UInt64 slot);
 
   String getProductionType();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/SlotBasedScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/SlotBasedScheduledDuties.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.client.duties;
 
 import java.util.NavigableMap;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -61,8 +62,28 @@ public class SlotBasedScheduledDuties<P extends Duty, A extends Duty> implements
   }
 
   @Override
+  public SafeFuture<DutyResult> performProductionDutyPreparation(UInt64 slot) {
+    final Duty duty = productionDuties.get(slot);
+    if (duty == null) {
+      return SafeFuture.completedFuture(DutyResult.NO_OP);
+    }
+
+    final Optional<PreparableDuty> maybePreparableDuty = duty.toPreparableDuty();
+    if (maybePreparableDuty.isEmpty()) {
+      return SafeFuture.completedFuture(DutyResult.NO_OP);
+    }
+
+    return maybePreparableDuty.get().prepareDuty();
+  }
+
+  @Override
   public synchronized SafeFuture<DutyResult> performProductionDuty(final UInt64 slot) {
     return performDutyForSlot(productionDuties, slot);
+  }
+
+  @Override
+  public String getPreparationType() {
+    return dutyFactory.getPreparationType();
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/AttestationDutyFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/AttestationDutyFactory.java
@@ -62,6 +62,12 @@ public class AttestationDutyFactory
   }
 
   @Override
+  public String getPreparationType() {
+    // Preparation is never used but getters should be safe to call so return a placeholder
+    return "";
+  }
+
+  @Override
   public String getProductionType() {
     return "attestation";
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
@@ -54,6 +54,9 @@ public class ChainHeadTracker implements ValidatorTimingChannel {
   public void onBlockProductionDue(final UInt64 slot) {}
 
   @Override
+  public void onExecutionPayloadPreparationDue(UInt64 slot) {}
+
+  @Override
   public void onAttestationCreationDue(final UInt64 slot) {}
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
@@ -76,6 +76,11 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
   }
 
   @Override
+  public SafeFuture<DutyResult> performProductionDutyPreparation(UInt64 slot) {
+    return SafeFuture.completedFuture(DutyResult.NO_OP);
+  }
+
+  @Override
   public SafeFuture<DutyResult> performProductionDuty(final UInt64 slot) {
     LOG.trace(
         "Performing sync committee duties at slot {}, {} assignments", slot, assignments.size());
@@ -101,6 +106,12 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
     return assignments.stream()
         .map(assignment -> assignment.getValidator().getPublicKey())
         .collect(Collectors.toSet());
+  }
+
+  @Override
+  public String getPreparationType() {
+    // Preparation is never used but getters should be safe to call so return a placeholder
+    return "";
   }
 
   @Override


### PR DESCRIPTION
## PR Description

introduces:
- new event `onExecutionPayloadPreparationDue` in `ValidatorTimingChannel`, called in `TimeBasedEventAdapter`
- new duty type `PreparableDuty`

The idea is to run execution payload preparation on:
- slotTime + 4s at one slot prior to each slot where we have a Block Production duty.
- on each reorg event (late block) occurring on a slot prior to a slot where we have a Block Production duty

TODO: unit tests

## Fixed Issue(s)
related to #4504

## Documentation

- [ ] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
