### PR TITLE
cleanup a failure condition for the openapi lib that was missed in initial pr

### DIFF
--- a/infrastructure/restapi/src/testFixtures/java/tech/pegasys/teku/infrastructure/restapi/OpenApiTestUtil.java
+++ b/infrastructure/restapi/src/testFixtures/java/tech/pegasys/teku/infrastructure/restapi/OpenApiTestUtil.java
@@ -146,6 +146,9 @@ public class OpenApiTestUtil<TObject> {
     final List<String> expectedFileListing = IOUtils.readLines(resourcesAsStream, UTF_8);
 
     for (String file : expectedFileListing) {
+      if (!file.endsWith(".json")) {
+        continue;
+      }
       // Notes:
       //  * If a path has been deleted, just delete the reference file to make this test pass.
       //  * If this path shouldn't have been changed and the error appears, check changes.

--- a/infrastructure/restapi/src/testFixtures/java/tech/pegasys/teku/infrastructure/restapi/OpenApiTestUtil.java
+++ b/infrastructure/restapi/src/testFixtures/java/tech/pegasys/teku/infrastructure/restapi/OpenApiTestUtil.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Fail;
@@ -146,7 +147,7 @@ public class OpenApiTestUtil<TObject> {
     final List<String> expectedFileListing = IOUtils.readLines(resourcesAsStream, UTF_8);
 
     for (String file : expectedFileListing) {
-      if (!file.endsWith(".json")) {
+      if (!file.toLowerCase(Locale.ROOT).endsWith(".json")) {
         continue;
       }
       // Notes:


### PR DESCRIPTION


Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
