### PR TITLE
[Merge] fixes SignedBeaconBlockMerge schema in beacon rest api

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBeaconBlockMerge.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBeaconBlockMerge.json
@@ -2,7 +2,7 @@
   "type" : "object",
   "properties" : {
     "message" : {
-      "$ref" : "#/components/schemas/BeaconBlockAltair"
+      "$ref" : "#/components/schemas/BeaconBlockMerge"
     },
     "signature" : {
       "type" : "string",

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/merge/SignedBeaconBlockMerge.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/merge/SignedBeaconBlockMerge.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
-import tech.pegasys.teku.api.schema.altair.BeaconBlockAltair;
 import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
 
 public class SignedBeaconBlockMerge extends SignedBeaconBlock implements SignedBlock {

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/merge/SignedBeaconBlockMerge.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/merge/SignedBeaconBlockMerge.java
@@ -30,7 +30,7 @@ public class SignedBeaconBlockMerge extends SignedBeaconBlock implements SignedB
   }
 
   @Override
-  public BeaconBlockAltair getMessage() {
+  public BeaconBlockMerge getMessage() {
     return message;
   }
 


### PR DESCRIPTION
## PR Description
`SignedBeaconBlockMerge` schema object should refer to the corresponding `Merge` `BeaconBlock` instead of the `Altair` one.

![image](https://user-images.githubusercontent.com/15999009/141830091-2f71235b-f775-48f3-aa6f-33ad616ab722.png)


## Fixed Issue(s)
related to #4504 

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
