### PR TITLE
Filter out invalid nodes in ProtoArray.contains

### DIFF
--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
@@ -77,7 +77,7 @@ public class ProtoArray {
   }
 
   public boolean contains(final Bytes32 root) {
-    return indices.contains(root);
+    return getProtoNode(root).filter(protoNode -> !protoNode.isInvalid()).isPresent();
   }
 
   public Optional<Integer> getIndexByRoot(final Bytes32 root) {

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.protoarray;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.protoarray.ProtoNodeValidationStatus.INVALID;
 import static tech.pegasys.teku.protoarray.ProtoNodeValidationStatus.OPTIMISTIC;
 import static tech.pegasys.teku.protoarray.ProtoNodeValidationStatus.VALID;
 
@@ -419,6 +420,24 @@ class ProtoArrayTest {
 
     assertOptimisticHead(block3a);
     assertStrictHead(block3a);
+  }
+
+  @Test
+  void contains_shouldContainValidBlock() {
+    addBlock(1, block1a, GENESIS_CHECKPOINT.getRoot(), VALID);
+    assertThat(protoArray.contains(block1a)).isTrue();
+  }
+
+  @Test
+  void contains_shouldContainOptimisticBlock() {
+    addBlock(1, block1a, GENESIS_CHECKPOINT.getRoot(), OPTIMISTIC);
+    assertThat(protoArray.contains(block1a)).isTrue();
+  }
+
+  @Test
+  void contains_shouldNotContainInvalidBlock() {
+    addBlock(1, block1a, GENESIS_CHECKPOINT.getRoot(), INVALID);
+    assertThat(protoArray.contains(block1a)).isFalse();
   }
 
   private void assertOptimisticHead(final Bytes32 expectedBlockHash) {


### PR DESCRIPTION
## PR Description
Modify ProtoArray.contains to return false when the requested node is invalid.

As with blocks discarded because they no longer descend from the finalized checkpoint, the `ProtoNode` remains but the block root to node index lookup is removed which effectively makes the node inaccessible but doesn't require creating a copy of the protoarray with the actual node removed.

As a result of removing this lookup, if the justified block is found to be invalid we are no longer able to determine the head since the fork choice algorithm starts from the justified block and the valid head must agree with that justified block. Since getting to this point requires 2/3rd of validators to have attested to an invalid block it has the same kind of "oh this is really bad" setup as finalizing an invalid block and requiring user intervention makes sense.

## Fixed Issue(s)
fixes #4652 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
