### PR TITLE
[Merge] call prepareBeaconProposer on every new epoch

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/eth1/Eth1Address.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/eth1/Eth1Address.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.ssz.type.Bytes20;
 
 public class Eth1Address {
   /** The number of bytes in this value - i.e. 20 */
@@ -70,5 +71,9 @@ public class Eth1Address {
 
   public Bytes toBytes() {
     return bytes;
+  }
+
+  public Bytes20 toBytes20() {
+    return new Bytes20(bytes);
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecInvocationContextProvider.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecInvocationContextProvider.java
@@ -172,5 +172,20 @@ public class TestSpecInvocationContextProvider implements TestTemplateInvocation
       Assumptions.assumeTrue(
           List.of(networks).contains(specContext.getNetwork()), "Network skipped");
     }
+
+    public static void onlyPhase0(SpecContext specContext) {
+      Assumptions.assumeTrue(
+          specContext.getSpecMilestone().equals(SpecMilestone.PHASE0), "Milestone skipped");
+    }
+
+    public static void onlyAltair(SpecContext specContext) {
+      Assumptions.assumeTrue(
+          specContext.getSpecMilestone().equals(SpecMilestone.ALTAIR), "Milestone skipped");
+    }
+
+    public static void onlyMerge(SpecContext specContext) {
+      Assumptions.assumeTrue(
+          specContext.getSpecMilestone().equals(SpecMilestone.MERGE), "Milestone skipped");
+    }
   }
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -144,4 +144,9 @@ public class ValidatorLogger {
         ColorConsolePrinter.print(
             PREFIX + "Produced invalid aggregate for slot " + slot + ": " + reason, Color.RED));
   }
+
+  public void beaconProposerPreparationFailed(final Throwable error) {
+    final String errorString = String.format("%sFailed to send proposers to Beacon Node", PREFIX);
+    log.error(ColorConsolePrinter.print(errorString, Color.RED), error);
+  }
 }

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfiguration.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfiguration.java
@@ -17,22 +17,17 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 
 public class ExecutionEngineConfiguration {
 
   private final Spec spec;
   private final List<String> endpoints;
-  private final Optional<Eth1Address> feeRecipient;
 
-  private ExecutionEngineConfiguration(
-      final Spec spec, final List<String> endpoints, final Optional<Eth1Address> feeRecipient) {
+  private ExecutionEngineConfiguration(final Spec spec, final List<String> endpoints) {
     this.spec = spec;
     this.endpoints = endpoints;
-    this.feeRecipient = feeRecipient;
   }
 
   public static Builder builder() {
@@ -51,20 +46,15 @@ public class ExecutionEngineConfiguration {
     return endpoints;
   }
 
-  public Optional<Eth1Address> getFeeRecipient() {
-    return feeRecipient;
-  }
-
   public static class Builder {
     private Spec spec;
     private List<String> endpoints = new ArrayList<>();
-    private Optional<Eth1Address> feeRecipient = Optional.empty();
 
     private Builder() {}
 
     public ExecutionEngineConfiguration build() {
       validate();
-      return new ExecutionEngineConfiguration(spec, endpoints, feeRecipient);
+      return new ExecutionEngineConfiguration(spec, endpoints);
     }
 
     private void validate() {
@@ -74,20 +64,6 @@ public class ExecutionEngineConfiguration {
     public Builder endpoints(final List<String> endpoints) {
       checkNotNull(endpoints);
       this.endpoints = endpoints.stream().filter(s -> !s.isBlank()).collect(Collectors.toList());
-      return this;
-    }
-
-    public Builder feeRecipient(final Eth1Address feeRecipient) {
-      this.feeRecipient = Optional.ofNullable(feeRecipient);
-      return this;
-    }
-
-    public Builder feeRecipient(final String feeRecipient) {
-      if (feeRecipient == null) {
-        this.feeRecipient = Optional.empty();
-      } else {
-        this.feeRecipient = Optional.of(Eth1Address.fromHexString(feeRecipient));
-      }
       return this;
     }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
@@ -30,16 +30,7 @@ public class ExecutionEngineOptions {
       hidden = true)
   private List<String> eeEndpoints = new ArrayList<>();
 
-  @Option(
-      names = {"--Xee-fee-recipient-address"},
-      paramLabel = "<ADDRESS>",
-      description =
-          "Suggested fee recipient sent to the execution engine, which could use it as coinbase when producing a new execution block.",
-      arity = "0..1",
-      hidden = true)
-  private String feeRecipient = null;
-
   public void configure(final Builder builder) {
-    builder.executionEngine(b -> b.endpoints(eeEndpoints).feeRecipient(feeRecipient));
+    builder.executionEngine(b -> b.endpoints(eeEndpoints));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -125,6 +125,15 @@ public class ValidatorOptions {
       arity = "1..*")
   private List<URI> additionalPublishUrls = new ArrayList<>();
 
+  @Option(
+      names = {"--Xvalidators-fee-recipient-address"},
+      paramLabel = "<ADDRESS>",
+      description =
+          "Suggested fee recipient sent to the execution engine, which could use it as coinbase when producing a new execution block.",
+      arity = "0..1",
+      hidden = true)
+  private String feeRecipient = null;
+
   public void configure(TekuConfiguration.Builder builder) {
     if (validatorPerformanceTrackingEnabled != null) {
       if (validatorPerformanceTrackingEnabled) {
@@ -148,7 +157,8 @@ public class ValidatorOptions {
                     .useDependentRoots(useDependentRoots)
                     .generateEarlyAttestations(generateEarlyAttestations)
                     .sendAttestationsAsBatch(sendAttestationsAsBatch)
-                    .additionalPublishUrls(additionalPublishUrls))
+                    .additionalPublishUrls(additionalPublishUrls)
+                    .feeRecipient(feeRecipient))
         // We don't need to update head for empty slots when using dependent roots
         .store(b -> b.updateHeadForEmptySlots(!useDependentRoots));
     validatorKeysOptions.configure(builder);

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -409,8 +409,6 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
       "http://localhost:8545",
       "--Xee-endpoint",
       "http://localhost:8550",
-      "--Xee-fee-recipient-address",
-      "0x00220204f295DbB79fbBe619dd1B94463800F9D9",
       "--metrics-enabled",
       "false",
       "--metrics-port",

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -446,7 +446,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
 
     return expectedConfigurationBuilder()
         .eth2NetworkConfig(b -> b.applyNetworkDefaults("mainnet"))
-        .executionEngine(b -> b.feeRecipient((String) null).endpoints(new ArrayList<String>()))
+        .executionEngine(b -> b.endpoints(new ArrayList<String>()))
         .powchain(
             b -> {
               b.depositContract(networkConfig.getEth1DepositContractAddress());
@@ -496,10 +496,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   private TekuConfiguration.Builder expectedConfigurationBuilder() {
     return TekuConfiguration.builder()
         .eth2NetworkConfig(b -> b.applyMinimalNetworkDefaults().eth1DepositContractAddress(address))
-        .executionEngine(
-            b ->
-                b.feeRecipient("0x00220204f295DbB79fbBe619dd1B94463800F9D9")
-                    .endpoints(List.of("http://localhost:8550")))
+        .executionEngine(b -> b.endpoints(List.of("http://localhost:8550")))
         .powchain(
             b ->
                 b.eth1Endpoints(List.of("http://localhost:8545"))

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionEngineOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionEngineOptionsTest.java
@@ -15,11 +15,9 @@ package tech.pegasys.teku.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.teku.config.TekuConfiguration;
-import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 
 public class ExecutionEngineOptionsTest extends AbstractBeaconNodeCommandTest {
 
@@ -86,22 +84,5 @@ public class ExecutionEngineOptionsTest extends AbstractBeaconNodeCommandTest {
             "http://example-2.com:1234/path/",
             "http://example-3.com:1234/path/");
     assertThat(config.executionEngine().isEnabled()).isTrue();
-  }
-
-  @Test
-  public void ShouldReportEmptyIfFeeRecipientNotSpecified() {
-    final TekuConfiguration config = getTekuConfigurationFromArguments();
-    assertThat(config.executionEngine().getFeeRecipient()).isEmpty();
-  }
-
-  @Test
-  public void ShouldReportAddressIfFeeRecipientSpecified() {
-    final String[] args = {
-      "--Xee-fee-recipient-address", "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73"
-    };
-    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(config.executionEngine().getFeeRecipient())
-        .isEqualTo(
-            Optional.of(Eth1Address.fromHexString("0xfe3b557e8fb62b89f4916b721be55ceb828dbd73")));
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
+import tech.pegasys.teku.config.TekuConfiguration;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
 
 public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
@@ -136,5 +138,22 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
                 getTekuConfigurationFromArguments(
                     "--Xvalidators-publish-to-additional-nodes=invalid-{url}"))
         .hasMessageContaining("cannot convert 'invalid-{url}' to URI");
+  }
+
+  @Test
+  public void ShouldReportEmptyIfFeeRecipientNotSpecified() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    assertThat(config.validatorClient().getValidatorConfig().getFeeRecipient()).isEmpty();
+  }
+
+  @Test
+  public void ShouldReportAddressIfFeeRecipientSpecified() {
+    final String[] args = {
+      "--Xvalidators-fee-recipient-address", "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73"
+    };
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.validatorClient().getValidatorConfig().getFeeRecipient())
+        .isEqualTo(
+            Optional.of(Eth1Address.fromHexString("0xfe3b557e8fb62b89f4916b721be55ceb828dbd73")));
   }
 }

--- a/teku/src/test/resources/complete_config.yaml
+++ b/teku/src/test/resources/complete_config.yaml
@@ -26,7 +26,6 @@ eth1-endpoint: "http://localhost:8545"
 
 # execution engine
 Xee-endpoint: "http://localhost:8550"
-Xee-fee-recipient-address: "0x00220204f295dbb79fbbe619dd1b94463800f9d9"
 
 # output
 #Xtransaction-record-directory: "/tmp/teku"

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 
 public class ValidatorConfig {
 
@@ -44,6 +45,7 @@ public class ValidatorConfig {
   private final boolean useDependentRoots;
   private final boolean generateEarlyAttestations;
   private final boolean sendAttestationsAsBatch;
+  private final Optional<Eth1Address> feeRecipient;
 
   private ValidatorConfig(
       final List<String> validatorKeys,
@@ -63,7 +65,8 @@ public class ValidatorConfig {
       final boolean useDependentRoots,
       final boolean generateEarlyAttestations,
       final boolean sendAttestationsAsBatch,
-      final List<URI> additionalPublishUrls) {
+      final List<URI> additionalPublishUrls,
+      final Optional<Eth1Address> feeRecipient) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
     this.validatorExternalSignerUrl = validatorExternalSignerUrl;
@@ -85,6 +88,7 @@ public class ValidatorConfig {
     this.generateEarlyAttestations = generateEarlyAttestations;
     this.sendAttestationsAsBatch = sendAttestationsAsBatch;
     this.additionalPublishUrls = additionalPublishUrls;
+    this.feeRecipient = feeRecipient;
   }
 
   public static Builder builder() {
@@ -164,6 +168,10 @@ public class ValidatorConfig {
     return additionalPublishUrls;
   }
 
+  public Optional<Eth1Address> getFeeRecipient() {
+    return feeRecipient;
+  }
+
   public static final class Builder {
 
     private List<String> validatorKeys = new ArrayList<>();
@@ -184,6 +192,7 @@ public class ValidatorConfig {
     private boolean useDependentRoots = false;
     private boolean generateEarlyAttestations = true;
     private boolean sendAttestationsAsBatch = true;
+    private Optional<Eth1Address> feeRecipient = Optional.empty();
 
     private Builder() {}
 
@@ -287,6 +296,20 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder feeRecipient(final Eth1Address feeRecipient) {
+      this.feeRecipient = Optional.ofNullable(feeRecipient);
+      return this;
+    }
+
+    public Builder feeRecipient(final String feeRecipient) {
+      if (feeRecipient == null) {
+        this.feeRecipient = Optional.empty();
+      } else {
+        this.feeRecipient = Optional.of(Eth1Address.fromHexString(feeRecipient));
+      }
+      return this;
+    }
+
     public ValidatorConfig build() {
       validateExternalSignerUrlAndPublicKeys();
       validateExternalSignerKeystoreAndPasswordFileConfig();
@@ -310,7 +333,8 @@ public class ValidatorConfig {
           useDependentRoots,
           generateEarlyAttestations,
           sendAttestationsAsBatch,
-          additionalPublishUrls);
+          additionalPublishUrls,
+          feeRecipient);
     }
 
     private void validateExternalSignerUrlAndPublicKeys() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.ssz.type.Bytes20;
 import tech.pegasys.teku.validator.api.BeaconPreparableProposer;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
@@ -27,15 +28,18 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
   private final ValidatorIndexProvider validatorIndexProvider;
   private final OwnedValidators validators;
   private final Spec spec;
+  private final Bytes20 feeRecipient;
 
   public BeaconProposerPreparer(
       ValidatorApiChannel validatorApiChannel,
       ValidatorIndexProvider validatorIndexProvider,
+      Bytes20 feeRecipient,
       OwnedValidators validators,
       Spec spec) {
     this.validatorApiChannel = validatorApiChannel;
     this.validatorIndexProvider = validatorIndexProvider;
     this.validators = validators;
+    this.feeRecipient = feeRecipient;
     this.spec = spec;
   }
 
@@ -48,7 +52,9 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
           .thenApply(
               integers ->
                   integers.stream()
-                      .map(index -> new BeaconPreparableProposer(UInt64.valueOf(index), null))
+                      .map(
+                          index ->
+                              new BeaconPreparableProposer(UInt64.valueOf(index), feeRecipient))
                       .collect(Collectors.toList()))
           .thenAccept(validatorApiChannel::prepareBeaconProposer)
           .reportExceptions();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -17,8 +17,6 @@ import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR
 
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -29,8 +27,6 @@ import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
 public class BeaconProposerPreparer implements ValidatorTimingChannel {
-  private static final Logger LOG = LogManager.getLogger();
-
   private final ValidatorApiChannel validatorApiChannel;
   private final ValidatorIndexProvider validatorIndexProvider;
   private final OwnedValidators validators;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import java.util.stream.Collectors;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.validator.api.BeaconPreparableProposer;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
+import tech.pegasys.teku.validator.client.loader.OwnedValidators;
+
+public class BeaconProposerPreparer implements ValidatorTimingChannel {
+  private final ValidatorApiChannel validatorApiChannel;
+  private final ValidatorIndexProvider validatorIndexProvider;
+  private final OwnedValidators validators;
+  private final Spec spec;
+
+  public BeaconProposerPreparer(
+      ValidatorApiChannel validatorApiChannel,
+      ValidatorIndexProvider validatorIndexProvider,
+      OwnedValidators validators,
+      Spec spec) {
+    this.validatorApiChannel = validatorApiChannel;
+    this.validatorIndexProvider = validatorIndexProvider;
+    this.validators = validators;
+    this.spec = spec;
+  }
+
+  @Override
+  public void onSlot(UInt64 slot) {
+    if (spec.atSlot(slot).getExecutionPayloadUtil().isPresent()
+        && slot.mod(spec.getSlotsPerEpoch(slot)).isZero()) {
+      validatorIndexProvider
+          .getValidatorIndices(validators.getPublicKeys())
+          .thenApply(
+              integers ->
+                  integers.stream()
+                      .map(index -> new BeaconPreparableProposer(UInt64.valueOf(index), null))
+                      .collect(Collectors.toList()))
+          .thenAccept(validatorApiChannel::prepareBeaconProposer)
+          .reportExceptions();
+    }
+  }
+
+  @Override
+  public void onHeadUpdate(
+      UInt64 slot,
+      Bytes32 previousDutyDependentRoot,
+      Bytes32 currentDutyDependentRoot,
+      Bytes32 headBlockRoot) {}
+
+  @Override
+  public void onChainReorg(UInt64 newSlot, UInt64 commonAncestorSlot) {}
+
+  @Override
+  public void onPossibleMissedEvents() {}
+
+  @Override
+  public void onBlockProductionDue(UInt64 slot) {}
+
+  @Override
+  public void onAttestationCreationDue(UInt64 slot) {}
+
+  @Override
+  public void onAttestationAggregationDue(UInt64 slot) {}
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.client;
 
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -33,13 +34,13 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
   public BeaconProposerPreparer(
       ValidatorApiChannel validatorApiChannel,
       ValidatorIndexProvider validatorIndexProvider,
-      Bytes20 feeRecipient,
+      Optional<Bytes20> feeRecipient,
       OwnedValidators validators,
       Spec spec) {
     this.validatorApiChannel = validatorApiChannel;
     this.validatorIndexProvider = validatorIndexProvider;
     this.validators = validators;
-    this.feeRecipient = feeRecipient;
+    this.feeRecipient = feeRecipient.orElse(null);
     this.spec = spec;
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -214,6 +214,9 @@ public class ValidatorClientService extends Service {
       validatorTimingChannels.add(
           new SyncCommitteeScheduler(
               metricsSystem, spec, syncCommitteeDutyLoader, new Random()::nextInt));
+      validatorTimingChannels.add(
+          new BeaconProposerPreparer(
+              validatorApiChannel, validatorIndexProvider, validators, spec));
     }
     addValidatorCountMetric(metricsSystem, validators);
     this.validatorStatusLogger =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -36,7 +36,6 @@ import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
-import tech.pegasys.teku.ssz.type.Bytes20;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.beaconnode.BeaconNodeApi;
@@ -223,12 +222,7 @@ public class ValidatorClientService extends Service {
           new BeaconProposerPreparer(
               validatorApiChannel,
               validatorIndexProvider,
-              config
-                  .getValidatorConfig()
-                  .getFeeRecipient()
-                  .map(Eth1Address::toBytes)
-                  .map(Bytes20::new)
-                  .orElse(null),
+              config.getValidatorConfig().getFeeRecipient().map(Eth1Address::toBytes20),
               validators,
               spec));
     }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -35,6 +35,8 @@ import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
+import tech.pegasys.teku.ssz.type.Bytes20;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.beaconnode.BeaconNodeApi;
@@ -214,9 +216,21 @@ public class ValidatorClientService extends Service {
       validatorTimingChannels.add(
           new SyncCommitteeScheduler(
               metricsSystem, spec, syncCommitteeDutyLoader, new Random()::nextInt));
+    }
+
+    if (spec.isMilestoneSupported(SpecMilestone.MERGE)) {
       validatorTimingChannels.add(
           new BeaconProposerPreparer(
-              validatorApiChannel, validatorIndexProvider, validators, spec));
+              validatorApiChannel,
+              validatorIndexProvider,
+              config
+                  .getValidatorConfig()
+                  .getFeeRecipient()
+                  .map(Eth1Address::toBytes)
+                  .map(Bytes20::new)
+                  .orElse(null),
+              validators,
+              spec));
     }
     addValidatorCountMetric(metricsSystem, validators);
     this.validatorStatusLogger =

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
@@ -73,7 +73,7 @@ public class BeaconProposerPreparerTest {
         new BeaconProposerPreparer(
             validatorApiChannel,
             validatorIndexProvider,
-            feeRecipient,
+            Optional.of(feeRecipient),
             validators,
             specContext.getSpec());
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
+import tech.pegasys.teku.ssz.type.Bytes20;
 import tech.pegasys.teku.validator.api.BeaconPreparableProposer;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
@@ -44,6 +45,7 @@ public class BeaconProposerPreparerTest {
   private final ValidatorIndexProvider validatorIndexProvider = mock(ValidatorIndexProvider.class);
   private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
   private BeaconProposerPreparer beaconProposerPreparer;
+  private Bytes20 feeRecipient;
 
   private long slotsPerEpoch;
 
@@ -65,9 +67,15 @@ public class BeaconProposerPreparerTest {
         new OwnedValidators(
             Map.of(validator1.getPublicKey(), validator1, validator2.getPublicKey(), validator2));
 
+    feeRecipient = specContext.getDataStructureUtil().randomBytes20();
+
     beaconProposerPreparer =
         new BeaconProposerPreparer(
-            validatorApiChannel, validatorIndexProvider, validators, specContext.getSpec());
+            validatorApiChannel,
+            validatorIndexProvider,
+            feeRecipient,
+            validators,
+            specContext.getSpec());
 
     slotsPerEpoch = specContext.getSpec().getSlotsPerEpoch(UInt64.ZERO);
 
@@ -87,8 +95,8 @@ public class BeaconProposerPreparerTest {
 
       assertThat(captor.getValue())
           .containsExactlyInAnyOrder(
-              new BeaconPreparableProposer(UInt64.valueOf(validator1Index), null),
-              new BeaconPreparableProposer(UInt64.valueOf(validator2Index), null));
+              new BeaconPreparableProposer(UInt64.valueOf(validator1Index), feeRecipient),
+              new BeaconPreparableProposer(UInt64.valueOf(validator2Index), feeRecipient));
     } else {
       verify(validatorApiChannel, never()).prepareBeaconProposer(any());
     }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.mockito.ArgumentCaptor;
+import tech.pegasys.teku.core.signatures.Signer;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
+import tech.pegasys.teku.validator.api.BeaconPreparableProposer;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.loader.OwnedValidators;
+
+@TestSpecContext(allMilestones = true)
+public class BeaconProposerPreparerTest {
+  private final int validator1Index = 19;
+  private final int validator2Index = 23;
+  private final ValidatorIndexProvider validatorIndexProvider = mock(ValidatorIndexProvider.class);
+  private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
+  private BeaconProposerPreparer beaconProposerPreparer;
+
+  private long slotsPerEpoch;
+
+  @BeforeEach
+  void setUp(SpecContext specContext) {
+    Validator validator1 =
+        new Validator(
+            specContext.getDataStructureUtil().randomPublicKey(),
+            mock(Signer.class),
+            Optional::empty);
+    Validator validator2 =
+        new Validator(
+            specContext.getDataStructureUtil().randomPublicKey(),
+            mock(Signer.class),
+            Optional::empty);
+
+    Set<Integer> validatorIndices = Set.of(validator1Index, validator2Index);
+    OwnedValidators validators =
+        new OwnedValidators(
+            Map.of(validator1.getPublicKey(), validator1, validator2.getPublicKey(), validator2));
+
+    beaconProposerPreparer =
+        new BeaconProposerPreparer(
+            validatorApiChannel, validatorIndexProvider, validators, specContext.getSpec());
+
+    slotsPerEpoch = specContext.getSpec().getSlotsPerEpoch(UInt64.ZERO);
+
+    when(validatorIndexProvider.getValidatorIndices(validators.getPublicKeys()))
+        .thenReturn(SafeFuture.completedFuture(validatorIndices));
+  }
+
+  @TestTemplate
+  void should_callPrepareBeaconProposerAtBeginningOfEpoch(SpecContext specContext) {
+    beaconProposerPreparer.onSlot(UInt64.valueOf(slotsPerEpoch * 2));
+
+    if (specContext.getSpecMilestone().isGreaterThanOrEqualTo(SpecMilestone.MERGE)) {
+      @SuppressWarnings("unchecked")
+      final ArgumentCaptor<Collection<BeaconPreparableProposer>> captor =
+          ArgumentCaptor.forClass(Collection.class);
+      verify(validatorApiChannel).prepareBeaconProposer(captor.capture());
+
+      assertThat(captor.getValue())
+          .containsExactlyInAnyOrder(
+              new BeaconPreparableProposer(UInt64.valueOf(validator1Index), null),
+              new BeaconPreparableProposer(UInt64.valueOf(validator2Index), null));
+    } else {
+      verify(validatorApiChannel, never()).prepareBeaconProposer(any());
+    }
+  }
+
+  @TestTemplate
+  void should_notCallPrepareBeaconProposerAfterFirstSlotOfEpoch() {
+    beaconProposerPreparer.onSlot(UInt64.ONE);
+    verify(validatorApiChannel, never()).prepareBeaconProposer(any());
+  }
+}


### PR DESCRIPTION
## PR Description
call prepareBeaconProposer on every new epoch, let beacon node know which are the potential proposers that might need to produce a block with `ExecutionPayload`

moves `--Xee-fee-recipient-address` under validator config `--Xvalidators-fee-recipient-address`

## Fixed Issue(s)
fixes #4659

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
