### PR TITLE
Make required fields defined by the api cause failure if missing

### DIFF
--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/exceptions/MissingRequiredFieldException.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/exceptions/MissingRequiredFieldException.java
@@ -11,22 +11,12 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.infrastructure.restapi.types;
+package tech.pegasys.teku.infrastructure.restapi.exceptions;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import java.io.IOException;
-import java.util.Collection;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
-public interface SerializableFieldDefinition<TObject> {
-  void writeField(final TObject source, JsonGenerator gen) throws IOException;
-
-  void writeOpenApiField(JsonGenerator gen) throws IOException;
-
-  Collection<OpenApiTypeDefinition> getReferencedTypeDefinitions();
-
-  String getName();
-
-  default boolean isRequired() {
-    return false;
+public class MissingRequiredFieldException extends JsonProcessingException {
+  public MissingRequiredFieldException(final String msg) {
+    super(msg);
   }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/DeserializableObjectTypeDefinitionBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/DeserializableObjectTypeDefinitionBuilder.java
@@ -49,6 +49,15 @@ public class DeserializableObjectTypeDefinitionBuilder<TObject> {
     return this;
   }
 
+  public <TField> DeserializableObjectTypeDefinitionBuilder<TObject> withOptionalField(
+      final String name,
+      final DeserializableTypeDefinition<TField> type,
+      final Function<TObject, Optional<TField>> getter,
+      final BiConsumer<TObject, Optional<TField>> setter) {
+    this.fields.put(name, new OptionalDeserializableFieldDefinition<>(name, getter, setter, type));
+    return this;
+  }
+
   public DeserializableTypeDefinition<TObject> build() {
     checkNotNull(initializer, "Must specify an initializer");
     return new DeserializableObjectTypeDefinition<>(name, initializer, fields);

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/OptionalDeserializableFieldDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/OptionalDeserializableFieldDefinition.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.types;
+
+import com.fasterxml.jackson.core.JsonParser;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+public class OptionalDeserializableFieldDefinition<TObject, TField>
+    extends OptionalSerializableFieldDefinition<TObject, TField>
+    implements DeserializableFieldDefinition<TObject> {
+  private final BiConsumer<TObject, Optional<TField>> setter;
+  private final DeserializableTypeDefinition<TField> deserializableType;
+
+  OptionalDeserializableFieldDefinition(
+      final String name,
+      final Function<TObject, Optional<TField>> getter,
+      final BiConsumer<TObject, Optional<TField>> setter,
+      final DeserializableTypeDefinition<TField> type) {
+    super(name, getter, type);
+    this.setter = setter;
+    this.deserializableType = type;
+  }
+
+  @Override
+  public void readField(final TObject target, final JsonParser parser) throws IOException {
+    final Optional<TField> value = Optional.ofNullable(deserializableType.deserialize(parser));
+    setter.accept(target, value);
+  }
+}

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/OptionalSerializableFieldDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/OptionalSerializableFieldDefinition.java
@@ -53,4 +53,9 @@ class OptionalSerializableFieldDefinition<TObject, TField>
   public Collection<OpenApiTypeDefinition> getReferencedTypeDefinitions() {
     return type.getSelfAndReferencedTypeDefinitions();
   }
+
+  @Override
+  public String getName() {
+    return name;
+  }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/RequiredSerializableFieldDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/RequiredSerializableFieldDefinition.java
@@ -49,4 +49,14 @@ class RequiredSerializableFieldDefinition<TObject, TField>
   public Collection<OpenApiTypeDefinition> getReferencedTypeDefinitions() {
     return type.getSelfAndReferencedTypeDefinitions();
   }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public boolean isRequired() {
+    return true;
+  }
 }

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/RequiredDeserializableFieldDefinitionTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/RequiredDeserializableFieldDefinitionTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.types;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.restapi.types.CoreTypes.STRING_TYPE;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.restapi.exceptions.MissingRequiredFieldException;
+import tech.pegasys.teku.infrastructure.restapi.json.JsonUtil;
+
+public class RequiredDeserializableFieldDefinitionTest {
+  private final DeserializableTypeDefinition<TestClass> definition =
+      DeserializableTypeDefinition.object(TestClass.class)
+          .name("TestClass")
+          .initializer(TestClass::new)
+          .withField("a", STRING_TYPE, TestClass::getFirst, TestClass::setFirst)
+          .withField("b", STRING_TYPE, TestClass::getSecond, TestClass::setSecond)
+          .withOptionalField("c", STRING_TYPE, TestClass::getThird, TestClass::setThird)
+          .build();
+
+  @Test
+  void shouldCauseExceptionIfRequiredFieldIsMissing() {
+    assertThatThrownBy(() -> JsonUtil.parse("{\"a\": \"zz\"}", definition))
+        .isInstanceOf(MissingRequiredFieldException.class)
+        .hasMessageContaining("fields: (b)");
+  }
+
+  @Test
+  void shouldCauseExceptionIfMultipleRequiredFieldIsMissing() {
+    assertThatThrownBy(() -> JsonUtil.parse("{}", definition))
+        .isInstanceOf(MissingRequiredFieldException.class)
+        .hasMessageContaining("fields: (a, b)");
+  }
+
+  @Test
+  void shouldParseIfAllRequiredFieldsPresent() throws JsonProcessingException {
+    final TestClass testClass = JsonUtil.parse("{\"a\": \"aa\", \"b\": \"bb\"}", definition);
+    assertThat(testClass).isNotNull();
+  }
+
+  @Test
+  void shouldParseIfAllFieldsPresent() throws JsonProcessingException {
+    final TestClass testClass =
+        JsonUtil.parse("{\"a\": \"aa\", \"b\": \"bb\", \"c\": \"cc\"}", definition);
+    assertThat(testClass).isNotNull();
+  }
+
+  private static class TestClass {
+    private String first;
+    private String second;
+    private Optional<String> third;
+
+    TestClass() {}
+
+    public String getFirst() {
+      return first;
+    }
+
+    public void setFirst(final String first) {
+      this.first = first;
+    }
+
+    public String getSecond() {
+      return second;
+    }
+
+    public void setSecond(final String second) {
+      this.second = second;
+    }
+
+    public Optional<String> getThird() {
+      return third;
+    }
+
+    public void setThird(final Optional<String> third) {
+      this.third = third;
+    }
+  }
+}


### PR DESCRIPTION
If we are defining a required field, and it is not present, it should fail when deserializing, otherwise we could end up with nulls being fed into the code base and that could cause issues.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
