### PR TITLE
Don't add shutdown hook when Node is not created

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/TekuFacade.java
+++ b/teku/src/main/java/tech/pegasys/teku/TekuFacade.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku;
 
+import java.util.Optional;
 import tech.pegasys.teku.config.TekuConfiguration;
 
 /**
@@ -23,7 +24,14 @@ import tech.pegasys.teku.config.TekuConfiguration;
  */
 public interface TekuFacade {
 
-  static NodeFacade startFromCLIArgs(String[] cliArgs) {
+  /**
+   * Starts Teku node from CLI args
+   *
+   * @return Either {@link NodeFacade} or {@link Optional#empty()} if arguments are not supposed to
+   *     start a Node (e.g. <code>--help</code> command)
+   * @throws RuntimeException if invalid args supplied or an internal error while starting a Node
+   */
+  static Optional<? extends NodeFacade> startFromCLIArgs(String[] cliArgs) {
     return Teku.startFromCLIArgs(cliArgs);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Fixes regression from #4601: when running `teku --help` we are printing `Teku is shutting down`

`Teku.startFromCLIArgs` may no create a `Node`, so make return value `Optional`.
Don't add shutdown hook when `Node` is not created

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
