### PR TITLE
When logging to console only, include date in the output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,5 +27,6 @@ For information on changes in released versions of Teku, see the [releases page]
     Existing databases and nodes using the default PRUNE storage mode are unchanged. Archive nodes wishing to take advantage of this will need to perform a full resync.
 - Docker images are now published with multi-arch support including Linux/amd64 and Linux/arm64 
 - The default docker image now uses JDK 17 instead of 16. The JDK 16 image is still available with the version suffix `-jdk16`
+- Include the date in output to console, when log files are not being written.
 
 ### Bug Fixes

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ConsolePatternSelector.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ConsolePatternSelector.java
@@ -21,6 +21,9 @@ import org.apache.logging.log4j.core.pattern.PatternFormatter;
 import org.apache.logging.log4j.core.pattern.PatternParser;
 
 public class ConsolePatternSelector implements PatternSelector {
+  private static final String DATE_CONSOLE_FORMAT = "%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level - %msg%n";
+  private static final String DATE_CONSOLE_EXCEPTION_FORMAT =
+      "%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level - %msg %throwable{1} (See log file for full stack trace)%n";
   private static final String CONSOLE_FORMAT = "%d{HH:mm:ss.SSS} %-5level - %msg%n";
   private static final String CONSOLE_EXCEPTION_FORMAT =
       "%d{HH:mm:ss.SSS} %-5level - %msg %throwable{1} (See log file for full stack trace)%n";
@@ -30,14 +33,23 @@ public class ConsolePatternSelector implements PatternSelector {
   private final PatternFormatter[] defaultFormat;
 
   public ConsolePatternSelector(
-      final AbstractConfiguration configuration, final boolean omitStackTraces) {
+      final AbstractConfiguration configuration,
+      final boolean omitStackTraces,
+      final boolean prependDateFormat) {
     this.omitStackTraces = omitStackTraces;
 
     final PatternParser patternParser = PatternLayout.createPatternParser(configuration);
     omitStackTraceFormat =
-        patternParser.parse(CONSOLE_EXCEPTION_FORMAT, false, true).toArray(PatternFormatter[]::new);
+        patternParser
+            .parse(
+                prependDateFormat ? DATE_CONSOLE_EXCEPTION_FORMAT : CONSOLE_EXCEPTION_FORMAT,
+                false,
+                true)
+            .toArray(PatternFormatter[]::new);
     defaultFormat =
-        patternParser.parse(CONSOLE_FORMAT, true, true).toArray(PatternFormatter[]::new);
+        patternParser
+            .parse(prependDateFormat ? DATE_CONSOLE_FORMAT : CONSOLE_FORMAT, true, true)
+            .toArray(PatternFormatter[]::new);
   }
 
   @Override

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
@@ -35,8 +35,8 @@ import org.apache.logging.log4j.status.StatusLogger;
 
 public class LoggingConfigurator {
 
-  static final String COLOR_LOG_REGEX = "([\\p{Cntrl}&&[^\r\n\u001b]])";
-  static final String NO_COLOR_LOG_REGEX = "([\\p{Cntrl}&&[^\r\n]])";
+  static final String COLOR_LOG_REGEX = "[\\p{Cntrl}&&[^\r\n\u001b]]";
+  static final String NO_COLOR_LOG_REGEX = "[\\p{Cntrl}&&[^\r\n]]";
 
   static final String EVENT_LOGGER_NAME = "teku-event-log";
   static final String STATUS_LOGGER_NAME = "teku-status-log";

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
@@ -13,8 +13,10 @@
 
 package tech.pegasys.teku.infrastructure.logging;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
@@ -28,9 +30,13 @@ import org.apache.logging.log4j.core.config.AbstractConfiguration;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.apache.logging.log4j.core.pattern.RegexReplacement;
 import org.apache.logging.log4j.status.StatusLogger;
 
 public class LoggingConfigurator {
+
+  static final String COLOR_LOG_REGEX = "([\\p{Cntrl}&&[^\r\n\u001b]])";
+  static final String NO_COLOR_LOG_REGEX = "([\\p{Cntrl}&&[^\r\n]])";
 
   static final String EVENT_LOGGER_NAME = "teku-event-log";
   static final String STATUS_LOGGER_NAME = "teku-status-log";
@@ -210,6 +216,14 @@ public class LoggingConfigurator {
     return DESTINATION == null;
   }
 
+  @VisibleForTesting
+  // returns the original destination
+  static LoggingDestination setDestination(final LoggingDestination destination) {
+    final LoggingDestination original = DESTINATION;
+    DESTINATION = destination;
+    return original;
+  }
+
   private static boolean isProgrammaticLoggingDisabled() {
     return DESTINATION == LoggingDestination.CUSTOM;
   }
@@ -260,17 +274,28 @@ public class LoggingConfigurator {
     return logger;
   }
 
+  @VisibleForTesting
+  static PatternLayout consoleAppenderLayout(
+      AbstractConfiguration configuration, final boolean omitStackTraces) {
+    final Pattern logReplacement =
+        Pattern.compile(isColorEnabled() ? COLOR_LOG_REGEX : NO_COLOR_LOG_REGEX);
+    return PatternLayout.newBuilder()
+        .withRegexReplacement(RegexReplacement.createRegexReplacement(logReplacement, ""))
+        .withAlwaysWriteExceptions(!omitStackTraces)
+        .withNoConsoleNoAnsi(true)
+        .withConfiguration(configuration)
+        .withPatternSelector(
+            new ConsolePatternSelector(
+                configuration, omitStackTraces, LoggingDestination.CONSOLE.equals(DESTINATION)))
+        .build();
+  }
+
   private static Appender consoleAppender(
       final AbstractConfiguration configuration, final boolean omitStackTraces) {
     configuration.removeAppender(CONSOLE_APPENDER_NAME);
 
-    final Layout<?> layout =
-        PatternLayout.newBuilder()
-            .withAlwaysWriteExceptions(!omitStackTraces)
-            .withNoConsoleNoAnsi(true)
-            .withConfiguration(configuration)
-            .withPatternSelector(new ConsolePatternSelector(configuration, omitStackTraces))
-            .build();
+    final Layout<?> layout = consoleAppenderLayout(configuration, omitStackTraces);
+
     final Appender consoleAppender =
         ConsoleAppender.newBuilder().setName(CONSOLE_APPENDER_NAME).setLayout(layout).build();
     consoleAppender.start();
@@ -278,14 +303,20 @@ public class LoggingConfigurator {
     return consoleAppender;
   }
 
+  @VisibleForTesting
+  static PatternLayout fileAppenderLayout(AbstractConfiguration configuration) {
+    final Pattern logReplacement =
+        Pattern.compile(isColorEnabled() ? COLOR_LOG_REGEX : NO_COLOR_LOG_REGEX);
+    return PatternLayout.newBuilder()
+        .withRegexReplacement(RegexReplacement.createRegexReplacement(logReplacement, ""))
+        .withPattern(FILE_MESSAGE_FORMAT)
+        .withConfiguration(configuration)
+        .build();
+  }
+
   private static Appender fileAppender(final AbstractConfiguration configuration) {
     configuration.removeAppender(FILE_APPENDER_NAME);
-
-    final Layout<?> layout =
-        PatternLayout.newBuilder()
-            .withConfiguration(configuration)
-            .withPattern(FILE_MESSAGE_FORMAT)
-            .build();
+    final Layout<?> layout = fileAppenderLayout(configuration);
 
     final Appender fileAppender =
         RollingFileAppender.newBuilder()

--- a/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/LoggingConfiguratorTest.java
+++ b/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/LoggingConfiguratorTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 public class LoggingConfiguratorTest {
   public static final String COLOR_STRING = "a\u001b[30mb\u001b[31mc\u001b[37md";
+  public static final String ENDL = System.lineSeparator();
 
   public static final String CTRL_STRING = "a\u0001b\u001fc\u007fd";
   public static final String STRIPPED_COLOR_STRING = "a[30mb[31mc[37md\n";
@@ -37,7 +38,7 @@ public class LoggingConfiguratorTest {
     try {
       LoggingConfigurator.setColorEnabled(true);
       fileAppenderLog(COLOR_STRING);
-      assertThat(outContent.toString()).endsWith(COLOR_STRING + "\n");
+      assertThat(outContent.toString()).endsWith(COLOR_STRING + ENDL);
     } finally {
       LoggingConfigurator.setColorEnabled(color);
     }
@@ -46,13 +47,13 @@ public class LoggingConfiguratorTest {
   @Test
   void toFile_shouldIgnoreNonPrintables() {
     fileAppenderLog(CTRL_STRING);
-    assertThat(outContent.toString()).endsWith("abcd\n");
+    assertThat(outContent.toString()).endsWith("abcd" + ENDL);
   }
 
   @Test
   void toConsole_shouldIgnoreNonPrintables() {
     consoleAppenderLog(CTRL_STRING);
-    assertThat(outContent.toString()).endsWith("abcd\n");
+    assertThat(outContent.toString()).endsWith("abcd" + ENDL);
   }
 
   @Test
@@ -61,7 +62,7 @@ public class LoggingConfiguratorTest {
     try {
       LoggingConfigurator.setColorEnabled(true);
       consoleAppenderLog(COLOR_STRING);
-      assertThat(outContent.toString()).endsWith(COLOR_STRING + "\n");
+      assertThat(outContent.toString()).endsWith(COLOR_STRING + ENDL);
     } finally {
       LoggingConfigurator.setColorEnabled(color);
     }
@@ -96,25 +97,25 @@ public class LoggingConfiguratorTest {
   @Test
   void toFile_shouldNotStripEndLine() {
     fileAppenderLog("a\r\nb");
-    assertThat(outContent.toString()).endsWith("a\r\nb\n");
+    assertThat(outContent.toString()).endsWith("a\r\nb" + ENDL);
   }
 
   @Test
   void toConsole_shouldNotStripEndLine() {
     consoleAppenderLog("a\r\nb");
-    assertThat(outContent.toString()).endsWith("a\r\nb\n");
+    assertThat(outContent.toString()).endsWith("a\r\nb" + ENDL);
   }
 
   @Test
   void toFile_MessageShouldHaveEndLine() {
     fileAppenderLog("ab");
-    assertThat(outContent.toString()).endsWith("ab\n");
+    assertThat(outContent.toString()).endsWith("ab" + ENDL);
   }
 
   @Test
   void toConsole_MessageShouldHaveEndLine() {
     consoleAppenderLog("ab");
-    assertThat(outContent.toString()).endsWith("ab\n");
+    assertThat(outContent.toString()).endsWith("ab" + ENDL);
   }
 
   @Test

--- a/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/LoggingConfiguratorTest.java
+++ b/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/LoggingConfiguratorTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.logging;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.io.CharArrayWriter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.WriterAppender;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.junit.jupiter.api.Test;
+
+public class LoggingConfiguratorTest {
+  public static final String COLOR_STRING = "a\u001b[30mb\u001b[31mc\u001b[37md";
+
+  public static final String CTRL_STRING = "a\u0001b\u001fc\u007fd";
+  public static final String STRIPPED_COLOR_STRING = "a[30mb[31mc[37md\n";
+  private WriterAppender appender;
+  private final CharArrayWriter outContent = new CharArrayWriter();
+
+  @Test
+  void toFile_shouldPrintColorIfEnabled() {
+    final boolean color = LoggingConfigurator.isColorEnabled();
+    try {
+      LoggingConfigurator.setColorEnabled(true);
+      fileAppenderLog(COLOR_STRING);
+      assertThat(outContent.toString()).endsWith(COLOR_STRING + "\n");
+    } finally {
+      LoggingConfigurator.setColorEnabled(color);
+    }
+  }
+
+  @Test
+  void toFile_shouldIgnoreNonPrintables() {
+    fileAppenderLog(CTRL_STRING);
+    assertThat(outContent.toString()).endsWith("abcd\n");
+  }
+
+  @Test
+  void toConsole_shouldIgnoreNonPrintables() {
+    consoleAppenderLog(CTRL_STRING);
+    assertThat(outContent.toString()).endsWith("abcd\n");
+  }
+
+  @Test
+  void toConsole_shouldPrintColorIfEnabled() {
+    final boolean color = LoggingConfigurator.isColorEnabled();
+    try {
+      LoggingConfigurator.setColorEnabled(true);
+      consoleAppenderLog(COLOR_STRING);
+      assertThat(outContent.toString()).endsWith(COLOR_STRING + "\n");
+    } finally {
+      LoggingConfigurator.setColorEnabled(color);
+    }
+  }
+
+  @Test
+  void toFile_shouldStripColorIfNotEnabled() {
+    final boolean color = LoggingConfigurator.isColorEnabled();
+    try {
+      LoggingConfigurator.setColorEnabled(false);
+      fileAppenderLog(COLOR_STRING);
+      // normally color codes won't get this far, but if they do the control character is removed
+      assertThat(outContent.toString()).endsWith(STRIPPED_COLOR_STRING);
+    } finally {
+      LoggingConfigurator.setColorEnabled(color);
+    }
+  }
+
+  @Test
+  void toConsole_shouldStripColorIfNotEnabled() {
+    final boolean color = LoggingConfigurator.isColorEnabled();
+    try {
+      LoggingConfigurator.setColorEnabled(false);
+      consoleAppenderLog(COLOR_STRING);
+      // normally color codes won't get this far, but if they do the control character is removed
+      assertThat(outContent.toString()).endsWith(STRIPPED_COLOR_STRING);
+    } finally {
+      LoggingConfigurator.setColorEnabled(color);
+    }
+  }
+
+  @Test
+  void toFile_shouldNotStripEndLine() {
+    fileAppenderLog("a\r\nb");
+    assertThat(outContent.toString()).endsWith("a\r\nb\n");
+  }
+
+  @Test
+  void toConsole_shouldNotStripEndLine() {
+    consoleAppenderLog("a\r\nb");
+    assertThat(outContent.toString()).endsWith("a\r\nb\n");
+  }
+
+  @Test
+  void toFile_MessageShouldHaveEndLine() {
+    fileAppenderLog("ab");
+    assertThat(outContent.toString()).endsWith("ab\n");
+  }
+
+  @Test
+  void toConsole_MessageShouldHaveEndLine() {
+    consoleAppenderLog("ab");
+    assertThat(outContent.toString()).endsWith("ab\n");
+  }
+
+  @Test
+  void toConsole_shouldPrependDateFormat() {
+    final LoggingDestination initialDestination =
+        LoggingConfigurator.setDestination(LoggingDestination.CONSOLE);
+    try {
+      consoleAppenderLog("ab");
+      assertThat(outContent.toString().indexOf("-")).isEqualTo(4);
+    } finally {
+      LoggingConfigurator.setDestination(initialDestination);
+    }
+  }
+
+  @Test
+  void toConsole_shouldNotPrependDateFormatIfDestinationIsBoth() {
+    final LoggingDestination initialDestination =
+        LoggingConfigurator.setDestination(LoggingDestination.BOTH);
+    try {
+      consoleAppenderLog("ab");
+      // if not in console logging mode, position of '-' is directly before message in this format
+      assertThat(outContent.toString().indexOf("-")).isEqualTo(19);
+    } finally {
+      LoggingConfigurator.setDestination(initialDestination);
+    }
+  }
+
+  private void fileAppenderLog(final String message) {
+    log(message, LoggingConfigurator.fileAppenderLayout(null));
+  }
+
+  private void consoleAppenderLog(final String message) {
+    log(message, LoggingConfigurator.consoleAppenderLayout(null, true));
+  }
+
+  private void log(final String message, final PatternLayout layout) {
+    try {
+      appender =
+          WriterAppender.newBuilder()
+              .setTarget(outContent)
+              .setLayout(layout)
+              .setName("TestLogger")
+              .build();
+      appender.start();
+      final LogEvent event =
+          Log4jLogEvent.newBuilder()
+              .setLoggerName("TestLogger")
+              .setLoggerFqcn(LoggingConfiguratorTest.class.getName())
+              .setMessage(new SimpleMessage(message))
+              .build();
+      appender.append(event);
+    } finally {
+      appender.stop();
+    }
+  }
+}

--- a/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/LoggingConfiguratorTest.java
+++ b/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/LoggingConfiguratorTest.java
@@ -28,7 +28,7 @@ public class LoggingConfiguratorTest {
   public static final String ENDL = System.lineSeparator();
 
   public static final String CTRL_STRING = "a\u0001b\u001fc\u007fd";
-  public static final String STRIPPED_COLOR_STRING = "a[30mb[31mc[37md\n";
+  public static final String STRIPPED_COLOR_STRING = "a[30mb[31mc[37md" + ENDL;
   private WriterAppender appender;
   private final CharArrayWriter outContent = new CharArrayWriter();
 


### PR DESCRIPTION
Added tests to show the behaviour of the layouts with different inputs.

If color is somehow mis-configured and gets included in log messages, only the code section (eg. `[31m`) will remain in the text, and color will remain off.

addresses #4638

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
