### PR TITLE
Ensure status is set to valid if no payload needed to be executed

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutor.java
@@ -60,6 +60,8 @@ class ForkChoicePayloadExecutor implements OptimisticExecutionPayloadExecutor {
     }
     if (result.isEmpty()) {
       // No execution was started so can return result unchanged
+      getForkChoiceStrategy()
+          .onExecutionPayloadResult(block.getRoot(), ExecutionPayloadStatus.VALID);
       updateForkChoiceForImportedBlock(block, blockImportResult, getForkChoiceStrategy());
       return SafeFuture.completedFuture(blockImportResult);
     }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.executionengine.ExecutionPayloadStatus;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
 public class ChainUpdater {
@@ -139,6 +140,10 @@ public class ChainUpdater {
     final StoreTransaction tx = recentChainData.startStoreTransaction();
     tx.putBlockAndState(block.getBlock(), block.getState());
     assertThat(tx.commit()).isCompleted();
+    recentChainData
+        .getForkChoiceStrategy()
+        .orElseThrow()
+        .onExecutionPayloadResult(block.getRoot(), ExecutionPayloadStatus.VALID);
     saveBlockTime(block);
   }
 


### PR DESCRIPTION
## PR Description
Fix fork choice so that when blocks post-merge but before TTD are imported they are marked as valid.  Previously they stayed optimistic because there was no request to executePayload and so no valid response was received.

Also updates `ChainUpdater` to mark the blocks as valid when it's inserting them into storage manually.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
