### PR TITLE
[Merge] introduce `engine_getPayload` call when producing blocks

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -28,11 +28,12 @@ import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsMerge;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.ssz.SszList;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationForkChecker;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 
 public class BlockOperationSelectorFactory {
@@ -46,6 +47,8 @@ public class BlockOperationSelectorFactory {
   private final DepositProvider depositProvider;
   private final Eth1DataCache eth1DataCache;
   private final Bytes32 graffiti;
+  private final ForkChoiceNotifier forkChoiceNotifier;
+  private final ExecutionEngineChannel executionEngineChannel;
 
   public BlockOperationSelectorFactory(
       final Spec spec,
@@ -56,7 +59,9 @@ public class BlockOperationSelectorFactory {
       final SyncCommitteeContributionPool contributionPool,
       final DepositProvider depositProvider,
       final Eth1DataCache eth1DataCache,
-      final Bytes32 graffiti) {
+      final Bytes32 graffiti,
+      ForkChoiceNotifier forkChoiceNotifier,
+      ExecutionEngineChannel executionEngineChannel) {
     this.spec = spec;
     this.attestationPool = attestationPool;
     this.attesterSlashingPool = attesterSlashingPool;
@@ -66,6 +71,8 @@ public class BlockOperationSelectorFactory {
     this.depositProvider = depositProvider;
     this.eth1DataCache = eth1DataCache;
     this.graffiti = graffiti;
+    this.forkChoiceNotifier = forkChoiceNotifier;
+    this.executionEngineChannel = executionEngineChannel;
   }
 
   public Consumer<BeaconBlockBodyBuilder> createSelector(
@@ -120,11 +127,21 @@ public class BlockOperationSelectorFactory {
                   contributionPool.createSyncAggregateForBlock(
                       blockSlotState.getSlot(), parentRoot))
           .executionPayload(
-              () ->
-                  SchemaDefinitionsMerge.required(
-                          spec.atSlot(blockSlotState.getSlot()).getSchemaDefinitions())
-                      .getExecutionPayloadSchema()
-                      .getDefault());
+              () -> {
+                UInt64 currentSlot = blockSlotState.getSlot();
+                return forkChoiceNotifier
+                    .getPayloadId(parentRoot, currentSlot)
+                    .thenApply(
+                        maybePayloadId ->
+                            maybePayloadId.orElseThrow(
+                                () ->
+                                    new IllegalStateException(
+                                        "A payloadId was expected. Cannot build block.")))
+                    .thenApply(
+                        payloadId ->
+                            executionEngineChannel.getPayload(payloadId, currentSlot).join())
+                    .join();
+              });
     };
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -128,26 +128,24 @@ public class BlockOperationSelectorFactory {
                   contributionPool.createSyncAggregateForBlock(
                       blockSlotState.getSlot(), parentRoot))
           .executionPayload(
-              () -> {
-                UInt64 currentSlot = blockSlotState.getSlot();
-                return forkChoiceNotifier
-                    .getPayloadId(parentRoot, currentSlot)
-                    .thenApply(
-                        maybePayloadId -> {
-                          if (maybePayloadId.isEmpty()) {
-                            // TTD not reached
-                            return SchemaDefinitionsMerge.required(
-                                    spec.atSlot(blockSlotState.getSlot()).getSchemaDefinitions())
-                                .getExecutionPayloadSchema()
-                                .getDefault();
-                          } else {
-                            return executionEngineChannel
-                                .getPayload(maybePayloadId.get(), currentSlot)
-                                .join();
-                          }
-                        })
-                    .join();
-              });
+              () ->
+                  forkChoiceNotifier
+                      .getPayloadId(parentRoot)
+                      .thenApply(
+                          maybePayloadId -> {
+                            if (maybePayloadId.isEmpty()) {
+                              // TTD not reached
+                              return SchemaDefinitionsMerge.required(
+                                      spec.atSlot(blockSlotState.getSlot()).getSchemaDefinitions())
+                                  .getExecutionPayloadSchema()
+                                  .getDefault();
+                            } else {
+                              return executionEngineChannel
+                                  .getPayload(maybePayloadId.get(), blockSlotState.getSlot())
+                                  .join();
+                            }
+                          })
+                      .join());
     };
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
@@ -161,7 +161,7 @@ class BlockFactoryTest {
     when(proposerSlashingPool.getItemsForBlock(any(), any(), any())).thenReturn(proposerSlashings);
     when(voluntaryExitPool.getItemsForBlock(any(), any(), any())).thenReturn(voluntaryExits);
     when(eth1DataCache.getEth1Vote(any())).thenReturn(ETH1_DATA);
-    when(forkChoiceNotifier.getPayloadId(any(), any()))
+    when(forkChoiceNotifier.getPayloadId(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(Bytes8.fromHexStringLenient("0x0"))));
     when(executionEngine.getPayload(any(), any()))
         .thenReturn(SafeFuture.completedFuture(executionPayload));

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
@@ -24,8 +24,10 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
@@ -34,6 +36,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.merge.BeaconBlockBodyMerge;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
@@ -41,14 +45,18 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.BeaconBlockBodyLists;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsMerge;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.ssz.SszList;
+import tech.pegasys.teku.ssz.type.Bytes8;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -61,10 +69,13 @@ class BlockFactoryTest {
   final OperationPool<AttesterSlashing> attesterSlashingPool = mock(OperationPool.class);
   final OperationPool<ProposerSlashing> proposerSlashingPool = mock(OperationPool.class);
   final OperationPool<SignedVoluntaryExit> voluntaryExitPool = mock(OperationPool.class);
+  final ForkChoiceNotifier forkChoiceNotifier = mock(ForkChoiceNotifier.class);
+  final ExecutionEngineChannel executionEngine = mock(ExecutionEngineChannel.class);
   final SyncCommitteeContributionPool syncCommitteeContributionPool =
       mock(SyncCommitteeContributionPool.class);
   final DepositProvider depositProvider = mock(DepositProvider.class);
   final Eth1DataCache eth1DataCache = mock(Eth1DataCache.class);
+  ExecutionPayload executionPayload;
 
   @Test
   public void shouldCreateBlockAfterNormalSlot() throws Exception {
@@ -90,8 +101,19 @@ class BlockFactoryTest {
         .createSyncAggregateForBlock(UInt64.ONE, block.getParentRoot());
   }
 
+  @Test
+  void shouldIncludeExecutionPayloadWhenMergeIsActive() throws Exception {
+    final BeaconBlock block = assertBlockCreated(1, TestSpecFactory.createMinimalMerge());
+    final ExecutionPayload result = getExecutionPayload(block);
+    assertThat(result).isEqualTo(executionPayload);
+  }
+
   private SyncAggregate getSyncAggregate(final BeaconBlock block) {
     return BeaconBlockBodyAltair.required(block.getBody()).getSyncAggregate();
+  }
+
+  private ExecutionPayload getExecutionPayload(final BeaconBlock block) {
+    return BeaconBlockBodyMerge.required(block.getBody()).getExecutionPayload();
   }
 
   private BeaconBlock assertBlockCreated(final int blockSlot, final Spec spec)
@@ -107,6 +129,15 @@ class BlockFactoryTest {
     final SszList<ProposerSlashing> proposerSlashings = blockBodyLists.createProposerSlashings();
     final SszList<SignedVoluntaryExit> voluntaryExits = blockBodyLists.createVoluntaryExits();
 
+    if (spec.getGenesisSpec().getMilestone().isGreaterThanOrEqualTo(SpecMilestone.MERGE)) {
+      executionPayload =
+          SchemaDefinitionsMerge.required(spec.getGenesisSpec().getSchemaDefinitions())
+              .getExecutionPayloadSchema()
+              .getDefault();
+    } else {
+      executionPayload = null;
+    }
+
     final Bytes32 graffiti = dataStructureUtil.randomBytes32();
     final BlockFactory blockFactory =
         new BlockFactory(
@@ -120,7 +151,9 @@ class BlockFactoryTest {
                 syncCommitteeContributionPool,
                 depositProvider,
                 eth1DataCache,
-                graffiti));
+                graffiti,
+                forkChoiceNotifier,
+                executionEngine));
 
     when(depositProvider.getDeposits(any(), any())).thenReturn(deposits);
     when(attestationsPool.getAttestationsForBlock(any(), any(), any())).thenReturn(attestations);
@@ -128,6 +161,10 @@ class BlockFactoryTest {
     when(proposerSlashingPool.getItemsForBlock(any(), any(), any())).thenReturn(proposerSlashings);
     when(voluntaryExitPool.getItemsForBlock(any(), any(), any())).thenReturn(voluntaryExits);
     when(eth1DataCache.getEth1Vote(any())).thenReturn(ETH1_DATA);
+    when(forkChoiceNotifier.getPayloadId(any(), any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(Bytes8.fromHexStringLenient("0x0"))));
+    when(executionEngine.getPayload(any(), any()))
+        .thenReturn(SafeFuture.completedFuture(executionPayload));
     beaconChainUtil.initializeStorage();
 
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -149,7 +149,7 @@ class BlockOperationSelectorFactoryTest {
     when(attesterSlashingValidator.validateFully(any())).thenReturn(ACCEPT);
     when(proposerSlashingValidator.validateFully(any())).thenReturn(ACCEPT);
     when(voluntaryExitValidator.validateFully(any())).thenReturn(ACCEPT);
-    when(forkChoiceNotifier.getPayloadId(any(), any()))
+    when(forkChoiceNotifier.getPayloadId(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
   }
 
@@ -279,7 +279,7 @@ class BlockOperationSelectorFactoryTest {
     final Bytes8 payloadId = dataStructureUtil.randomBytes8();
     final ExecutionPayload randomExecutionPayload = dataStructureUtil.randomExecutionPayload();
 
-    when(forkChoiceNotifier.getPayloadId(any(), any()))
+    when(forkChoiceNotifier.getPayloadId(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(payloadId)));
     when(executionEngine.getPayload(payloadId, slot))
         .thenReturn(SafeFuture.completedFuture(randomExecutionPayload));

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
@@ -71,7 +71,8 @@ public class BlockProposalTestUtil {
       final SszList<ProposerSlashing> slashings,
       final SszList<Deposit> deposits,
       final SszList<SignedVoluntaryExit> exits,
-      final Optional<List<Bytes>> transactions)
+      final Optional<List<Bytes>> transactions,
+      final Optional<Bytes32> terminalBlock)
       throws StateTransitionException, EpochProcessingException, SlotProcessingException {
 
     final UInt64 newEpoch = spec.computeEpochAtSlot(newSlot);
@@ -98,7 +99,9 @@ public class BlockProposalTestUtil {
                     .syncAggregate(
                         () -> dataStructureUtil.emptySyncAggregateIfRequiredByState(blockSlotState))
                     .executionPayload(
-                        () -> createExecutionPayload(newSlot, state, newEpoch, transactions)));
+                        () ->
+                            createExecutionPayload(
+                                newSlot, state, newEpoch, transactions, terminalBlock)));
 
     // Sign block and set block signature
     final BeaconBlock block = newBlockAndState.getBlock();
@@ -112,7 +115,8 @@ public class BlockProposalTestUtil {
       final UInt64 newSlot,
       final BeaconState state,
       final UInt64 newEpoch,
-      final Optional<List<Bytes>> transactions) {
+      final Optional<List<Bytes>> transactions,
+      final Optional<Bytes32> terminalBlock) {
     final SpecVersion specVersion = spec.atSlot(newSlot);
     final ExecutionPayloadSchema schema =
         SchemaDefinitionsMerge.required(specVersion.getSchemaDefinitions())
@@ -120,8 +124,16 @@ public class BlockProposalTestUtil {
     if (transactions.isEmpty() && !isMergeComplete(state)) {
       return schema.getDefault();
     }
+
+    Bytes32 currentExecutionPayloadBlockHash =
+        BeaconStateMerge.required(state).getLatestExecutionPayloadHeader().getBlockHash();
+    if (!currentExecutionPayloadBlockHash.isZero() && terminalBlock.isPresent()) {
+      throw new IllegalArgumentException("Merge already happened, cannot set terminal block hash");
+    }
+    Bytes32 parentHash = terminalBlock.orElse(currentExecutionPayloadBlockHash);
+
     return schema.create(
-        BeaconStateMerge.required(state).getLatestExecutionPayloadHeader().getBlockHash(),
+        parentHash,
         Bytes20.ZERO,
         dataStructureUtil.randomBytes32(),
         dataStructureUtil.randomBytes32(),
@@ -150,7 +162,8 @@ public class BlockProposalTestUtil {
       final Optional<SszList<Deposit>> deposits,
       final Optional<SszList<SignedVoluntaryExit>> exits,
       final Optional<Eth1Data> eth1Data,
-      final Optional<List<Bytes>> transactions)
+      final Optional<List<Bytes>> transactions,
+      final Optional<Bytes32> terminalBlock)
       throws StateTransitionException, EpochProcessingException, SlotProcessingException {
     final UInt64 newEpoch = spec.computeEpochAtSlot(newSlot);
     return createNewBlock(
@@ -163,7 +176,8 @@ public class BlockProposalTestUtil {
         blockBodyLists.createProposerSlashings(),
         deposits.orElse(blockBodyLists.createDeposits()),
         exits.orElse(blockBodyLists.createVoluntaryExits()),
-        transactions);
+        transactions,
+        terminalBlock);
   }
 
   private Eth1Data get_eth1_data_stub(BeaconState state, UInt64 current_epoch) {

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -409,7 +409,8 @@ public class ChainBuilder {
               Optional.empty(),
               Optional.empty(),
               options.getEth1Data(),
-              options.getTransactions());
+              options.getTransactions(),
+              options.getTerminalBlockHash());
       trackBlock(nextBlockAndState);
       return nextBlockAndState;
     } catch (StateTransitionException | EpochProcessingException | SlotProcessingException e) {
@@ -519,6 +520,7 @@ public class ChainBuilder {
     private final List<Attestation> attestations = new ArrayList<>();
     private Optional<Eth1Data> eth1Data = Optional.empty();
     private Optional<List<Bytes>> transactions = Optional.empty();
+    private Optional<Bytes32> terminalBlockHash = Optional.empty();
 
     private BlockOptions() {}
 
@@ -541,6 +543,11 @@ public class ChainBuilder {
       return this;
     }
 
+    public BlockOptions setTerminalBlockHash(Bytes32 blockHash) {
+      this.terminalBlockHash = Optional.of(blockHash);
+      return this;
+    }
+
     private List<Attestation> getAttestations() {
       return attestations;
     }
@@ -551,6 +558,10 @@ public class ChainBuilder {
 
     public Optional<List<Bytes>> getTransactions() {
       return transactions;
+    }
+
+    public Optional<Bytes32> getTerminalBlockHash() {
+      return terminalBlockHash;
     }
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
@@ -56,6 +56,8 @@ public class ForkChoiceNotifier {
   private Optional<ForkChoiceState> lastSentForkChoiceState = Optional.empty();
   private Optional<PayloadAttributes> lastSentPayloadAttributes = Optional.empty();
   private Optional<Bytes8> lastPayloadId = Optional.empty();
+  private Optional<Bytes32> lastPayloadIdBeaconBlockRoot = Optional.empty();
+  private Optional<UInt64> lastPayloadIdSlot = Optional.empty();
 
   ForkChoiceNotifier(
       final EventThread eventThread,
@@ -75,6 +77,7 @@ public class ForkChoiceNotifier {
       final RecentChainData recentChainData) {
     final AsyncRunnerEventThread eventThread =
         new AsyncRunnerEventThread("forkChoiceNotifier", asyncRunnerFactory);
+    eventThread.start();
     return new ForkChoiceNotifier(eventThread, spec, executionEngineChannel, recentChainData);
   }
 
@@ -90,8 +93,31 @@ public class ForkChoiceNotifier {
     eventThread.execute(() -> internalAttestationsDue(slot));
   }
 
-  public SafeFuture<Optional<Bytes8>> getPayloadId() {
-    return eventThread.execute(() -> lastPayloadId);
+  public SafeFuture<Optional<Bytes8>> getPayloadId(Bytes32 beaconBlockRoot, UInt64 slot) {
+    return eventThread.execute(
+        () -> {
+          if (lastPayloadId.isPresent()) {
+            if (lastPayloadIdBeaconBlockRoot
+                    .map(fcsBeaconRoot -> fcsBeaconRoot.equals(beaconBlockRoot))
+                    .orElse(false)
+                && lastPayloadIdSlot.map(fcsSlot -> fcsSlot.compareTo(slot) == 0).orElse(false)) {
+              return lastPayloadId;
+            } else {
+              LOG.error(
+                  "Cannot provide payloadId {}. It doesn't belong to requested Beacon Block Root {} and Slot {}",
+                  lastPayloadId.get(),
+                  beaconBlockRoot,
+                  slot);
+              return Optional.empty();
+            }
+          } else {
+            LOG.error(
+                "PayloadId not available for requested Beacon Block Root {} and Slot {}",
+                beaconBlockRoot,
+                slot);
+            return Optional.empty();
+          }
+        });
   }
 
   private void internalUpdatePreparableProposers(
@@ -188,6 +214,8 @@ public class ForkChoiceNotifier {
           currentSlot);
       return;
     }
+    this.lastPayloadIdBeaconBlockRoot = recentChainData.getBestBlockRoot();
+    this.lastPayloadIdSlot = Optional.of(blockSlot);
     payloadAttributes = newPayloadAttributes;
     sendForkChoiceUpdated();
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
@@ -57,7 +57,6 @@ public class ForkChoiceNotifier {
   private Optional<ForkChoiceState> lastSentForkChoiceState = Optional.empty();
   private Optional<PayloadAttributes> lastSentPayloadAttributes = Optional.empty();
   private Optional<Bytes8> lastPayloadId = Optional.empty();
-  private Optional<UInt64> lastPayloadIdSlot = Optional.empty();
 
   private Optional<Bytes32> executionPayloadTerminalBlockHash = Optional.empty();
 
@@ -107,6 +106,10 @@ public class ForkChoiceNotifier {
     eventThread.checkOnEventThread();
     executionPayloadTerminalBlockHash = Optional.of(executionBlockHash);
 
+    // since forkChoice will never call onForkChoiceUpdated on pre-merge blocks
+    // this forkChoiceSate will remain available until merge happens.
+    // So, if we are proposer of the merge block, the corresponding payloadId should remain
+    // available
     internalForkChoiceUpdated(
         new ForkChoiceState(executionBlockHash, executionBlockHash, Bytes32.ZERO));
   }
@@ -308,7 +311,6 @@ public class ForkChoiceNotifier {
           currentSlot);
       return;
     }
-    this.lastPayloadIdSlot = Optional.of(blockSlot);
     payloadAttributes = newPayloadAttributes;
     sendForkChoiceUpdated();
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -153,23 +153,30 @@ class ForkChoiceNotifierTest {
   }
 
   @Test
-  void onAttestationsDue_shouldSendUpdateIfWeAreDueToProposeNext() {
+  void onAttestationsDue_shouldSendUpdateEvenWithAMissedBlockIfWeAreDueToProposeNextTwo() {
     final BeaconState headState = recentChainData.getBestState().orElseThrow();
-    final UInt64 blockSlot = headState.getSlot().plus(2);
-    final PayloadAttributes payloadAttributes = withProposerForSlot(headState, blockSlot);
+    final UInt64 blockSlot1 = headState.getSlot().plus(2);
+    final UInt64 blockSlot2 = headState.getSlot().plus(3);
+    final List<PayloadAttributes> payloadAttributes =
+        withProposerForTwoSlots(headState, blockSlot1, blockSlot2);
 
     final ForkChoiceState forkChoiceState = getCurrentForkChoiceState();
     notifier.onForkChoiceUpdated(forkChoiceState);
-    // Not proposing block 1 so no payload attributes
+    // Not proposing block +1 so no payload attributes
     verify(executionEngineChannel).forkChoiceUpdated(forkChoiceState, Optional.empty());
 
     notifier.onAttestationsDue(headState.getSlot());
     verifyNoMoreInteractions(executionEngineChannel);
 
-    // Slot 1 is now assumed empty so prepare to propose in slot 2
+    // Slot +1 is now assumed empty so prepare to propose in slot +2
     notifier.onAttestationsDue(headState.getSlot().plus(1));
     verify(executionEngineChannel)
-        .forkChoiceUpdated(forkChoiceState, Optional.of(payloadAttributes));
+        .forkChoiceUpdated(forkChoiceState, Optional.of(payloadAttributes.get(0)));
+
+    // Slot +2 is now assumed empty so prepare to propose in slot +3
+    notifier.onAttestationsDue(headState.getSlot().plus(2));
+    verify(executionEngineChannel)
+        .forkChoiceUpdated(forkChoiceState, Optional.of(payloadAttributes.get(1)));
   }
 
   @Test
@@ -349,6 +356,32 @@ class ForkChoiceNotifierTest {
             new BeaconPreparableProposer(
                 UInt64.valueOf(block2Proposer), payloadAttributes.getFeeRecipient())));
     return payloadAttributes;
+  }
+
+  private List<PayloadAttributes> withProposerForTwoSlots(
+      final BeaconState headState, final UInt64 blockSlot1, UInt64 blockSlot2) {
+    final int block2Proposer1 = spec.getBeaconProposerIndex(headState, blockSlot1);
+    final int block2Proposer2 = spec.getBeaconProposerIndex(headState, blockSlot2);
+    final PayloadAttributes payloadAttributes1 =
+        getExpectedPayloadAttributes(headState, blockSlot1);
+    final PayloadAttributes payloadAttributes2 =
+        getExpectedPayloadAttributes(headState, blockSlot2);
+
+    if (block2Proposer1 != block2Proposer2) {
+      notifier.onUpdatePreparableProposers(
+          List.of(
+              new BeaconPreparableProposer(
+                  UInt64.valueOf(block2Proposer1), payloadAttributes1.getFeeRecipient()),
+              new BeaconPreparableProposer(
+                  UInt64.valueOf(block2Proposer2), payloadAttributes2.getFeeRecipient())));
+      return List.of(payloadAttributes1, payloadAttributes2);
+    } else {
+      notifier.onUpdatePreparableProposers(
+          List.of(
+              new BeaconPreparableProposer(
+                  UInt64.valueOf(block2Proposer1), payloadAttributes1.getFeeRecipient())));
+      return List.of(payloadAttributes1, payloadAttributes1);
+    }
   }
 
   private PayloadAttributes getExpectedPayloadAttributes(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.core.ChainBuilder;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -325,19 +324,5 @@ class ForkChoiceNotifierTest {
         forkChoiceStrategy.executionBlockHash(finalizedRoot).orElseThrow();
 
     return new ForkChoiceState(headExecutionHash, headExecutionHash, finalizedExecutionHash);
-  }
-
-  private void doMerge(Bytes32 terminalBlockHash) {
-    SignedBlockAndState newBlockWithExecutionPayloadAtopTerminalBlock =
-        storageSystem
-            .chainUpdater()
-            .chainBuilder
-            .generateBlockAtSlot(
-                recentChainData.getHeadSlot().plus(1),
-                ChainBuilder.BlockOptions.create()
-                    .setTransactions(dataStructureUtil.randomBytes(40))
-                    .setTerminalBlockHash(terminalBlockHash));
-
-    storageSystem.chainUpdater().updateBestBlock(newBlockWithExecutionPayloadAtopTerminalBlock);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -229,7 +229,7 @@ class ForkChoiceNotifierTest {
   }
 
   @Test
-  void getPayloadId_shouldNotReturnLatestPayloadIdOnWrongRootOrSlot() {
+  void getPayloadId_shouldReturnExceptionallyLatestPayloadIdOnWrongRootOrSlot() {
     final Bytes8 payloadId = dataStructureUtil.randomBytes8();
     final ForkChoiceState forkChoiceState = getCurrentForkChoiceState();
     final BeaconState headState = recentChainData.getBestState().orElseThrow();
@@ -251,9 +251,28 @@ class ForkChoiceNotifierTest {
         new ForkChoiceUpdatedResult(ForkChoiceUpdatedStatus.SUCCESS, Optional.of(payloadId)));
 
     assertThatSafeFuture(notifier.getPayloadId(wrongBlockRoot, blockSlot))
-        .isCompletedWithEmptyOptional();
+        .isCompletedExceptionally();
     assertThatSafeFuture(notifier.getPayloadId(blockRoot, wrongBlockSlot))
+        .isCompletedExceptionally();
+  }
+
+  @Test
+  void getPayloadId_shouldReturnEmptyWithNoForkChoiceAndNoTTDReached() {
+    final Bytes32 blockRoot = recentChainData.getBestBlockRoot().orElseThrow();
+    final UInt64 blockSlot = UInt64.ONE;
+
+    assertThatSafeFuture(notifier.getPayloadId(blockRoot, blockSlot))
         .isCompletedWithEmptyOptional();
+  }
+
+  @Test
+  void getPayloadId_shouldReturnExceptionallyWithNoForkChoiceAndTTDReached() {
+    final Bytes32 blockRoot = recentChainData.getBestBlockRoot().orElseThrow();
+    final UInt64 blockSlot = UInt64.ONE;
+
+    notifier.onTTDReached(dataStructureUtil.randomBytes32());
+
+    assertThatSafeFuture(notifier.getPayloadId(blockRoot, blockSlot)).isCompletedExceptionally();
   }
 
   private PayloadAttributes withProposerForSlot(final UInt64 blockSlot) {

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -311,6 +311,7 @@ public class BeaconChainUtil {
         deposits,
         exits,
         eth1Data,
+        Optional.empty(),
         Optional.empty());
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -497,7 +497,9 @@ public class BeaconChainController extends Service implements TimeTickChannel {
                 syncCommitteeContributionPool,
                 depositProvider,
                 eth1DataCache,
-                VersionProvider.getDefaultGraffiti()));
+                VersionProvider.getDefaultGraffiti(),
+                forkChoiceNotifier,
+                executionEngine));
     syncCommitteeSubscriptionManager =
         beaconConfig.p2pConfig().isSubscribeAllSubnetsEnabled()
             ? new AllSyncCommitteeSubscriptions(p2pNetwork, spec)

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -459,6 +459,10 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     return getForkChoiceStrategy().flatMap(forkChoice -> forkChoice.blockSlot(root));
   }
 
+  public Optional<Bytes32> getExecutionBlockHashForBlockRoot(final Bytes32 root) {
+    return getForkChoiceStrategy().flatMap(forkChoice -> forkChoice.executionBlockHash(root));
+  }
+
   public SafeFuture<Optional<BeaconBlock>> retrieveBlockByRoot(final Bytes32 root) {
     if (store == null) {
       return EmptyStoreResults.EMPTY_BLOCK_FUTURE;


### PR DESCRIPTION
## PR Description
implements `engine_getPayload` to build blocks including `ExecutionPayload` obtained by the EL.

- requests `payloadId` from `ForckChoiceNotifier`
- adds consistency checks in `ForckChoiceNotifier::getPayloadId` by verifying BeaconBlockRoot and Slot
- calls ExecutionEngine with obtained `payloadId`
- requires an external monitor that follows the EL to detect TTD block

## Fixed Issue(s)
#4668

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
