### PR TITLE
Consider gossip topics for all future forks relevant

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2GossipTopicFilter.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2GossipTopicFilter.java
@@ -53,15 +53,15 @@ public class Eth2GossipTopicFilter implements GossipTopicFilter {
     final ForkInfo forkInfo = recentChainData.getCurrentForkInfo().orElseThrow();
     final Bytes4 forkDigest = forkInfo.getForkDigest(spec);
     final Set<String> topics = getAllTopics(gossipEncoding, forkDigest);
-    recentChainData
-        .getNextFork(forkInfo.getFork())
+    spec.getForkSchedule().getForks().stream()
+        .filter(fork -> fork.getEpoch().isGreaterThanOrEqualTo(forkInfo.getFork().getEpoch()))
         .map(
-            nextFork ->
-                spec.atEpoch(nextFork.getEpoch())
+            futureFork ->
+                spec.atEpoch(futureFork.getEpoch())
                     .miscHelpers()
                     .computeForkDigest(
-                        nextFork.getCurrent_version(), forkInfo.getGenesisValidatorsRoot()))
-        .ifPresent(nextForkDigest -> topics.addAll(getAllTopics(gossipEncoding, nextForkDigest)));
+                        futureFork.getCurrent_version(), forkInfo.getGenesisValidatorsRoot()))
+        .forEach(futureForkDigest -> topics.addAll(getAllTopics(gossipEncoding, futureForkDigest)));
     return topics;
   }
 }


### PR DESCRIPTION
## PR Description
Add topics from all future forks to the list of relevant topics in the topic filter.  Otherwise Teku doesn't allow subscriptions to merge topics if it transitions from phase0 to altair to merge without restarting.

Cherry-picked from #4457

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
