### PR TITLE
[Merge] Don't send fork choice updated notifications when the head block hash is zero

### DIFF
--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -86,9 +86,9 @@ public class ChainDataProviderTest {
 
   @BeforeEach
   public void setup() {
-    slot = UInt64.valueOf(specConfig.getSlotsPerEpoch() * 3);
+    slot = UInt64.valueOf(specConfig.getSlotsPerEpoch() * 3L);
     actualBalance = specConfig.getMaxEffectiveBalance().plus(100000);
-    storageSystem.chainUpdater().initializeGenesis(true, actualBalance);
+    storageSystem.chainUpdater().initializeGenesis(true, actualBalance, Optional.empty());
     bestBlock = storageSystem.chainUpdater().advanceChain(slot);
     storageSystem.chainUpdater().updateBestBlock(bestBlock);
 

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.core;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
@@ -116,7 +117,7 @@ public class BlockProposalTestUtil {
     final ExecutionPayloadSchema schema =
         SchemaDefinitionsMerge.required(specVersion.getSchemaDefinitions())
             .getExecutionPayloadSchema();
-    if (transactions.isEmpty()) {
+    if (transactions.isEmpty() && isMergePending(state)) {
       return schema.getDefault();
     }
     return schema.create(
@@ -133,7 +134,14 @@ public class BlockProposalTestUtil {
         dataStructureUtil.randomBytes32(),
         UInt256.ONE,
         dataStructureUtil.randomBytes32(),
-        transactions.get());
+        transactions.orElse(Collections.emptyList()));
+  }
+
+  private Boolean isMergePending(final BeaconState state) {
+    return state
+        .toVersionMerge()
+        .map(s -> s.getLatestExecutionPayloadHeader().isDefault())
+        .orElse(false);
   }
 
   public SignedBlockAndState createBlock(

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
@@ -117,7 +117,7 @@ public class BlockProposalTestUtil {
     final ExecutionPayloadSchema schema =
         SchemaDefinitionsMerge.required(specVersion.getSchemaDefinitions())
             .getExecutionPayloadSchema();
-    if (transactions.isEmpty() && isMergePending(state)) {
+    if (transactions.isEmpty() && !isMergeComplete(state)) {
       return schema.getDefault();
     }
     return schema.create(
@@ -137,11 +137,8 @@ public class BlockProposalTestUtil {
         transactions.orElse(Collections.emptyList()));
   }
 
-  private Boolean isMergePending(final BeaconState state) {
-    return state
-        .toVersionMerge()
-        .map(s -> s.getLatestExecutionPayloadHeader().isDefault())
-        .orElse(false);
+  private Boolean isMergeComplete(final BeaconState state) {
+    return spec.atSlot(state.getSlot()).miscHelpers().isMergeComplete(state);
   }
 
   public SignedBlockAndState createBlock(

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.interop.MockStartBeaconStateGenerator;
 import tech.pegasys.teku.spec.datastructures.interop.MockStartDepositGenerator;
 import tech.pegasys.teku.spec.datastructures.interop.MockStartValidatorKeyPairFactory;
@@ -233,11 +234,17 @@ public class ChainBuilder {
 
   public SignedBlockAndState generateGenesis(final UInt64 genesisTime, final boolean signDeposits) {
     return generateGenesis(
-        genesisTime, signDeposits, spec.getGenesisSpecConfig().getMaxEffectiveBalance());
+        genesisTime,
+        signDeposits,
+        spec.getGenesisSpecConfig().getMaxEffectiveBalance(),
+        Optional.empty());
   }
 
   public SignedBlockAndState generateGenesis(
-      final UInt64 genesisTime, final boolean signDeposits, final UInt64 depositAmount) {
+      final UInt64 genesisTime,
+      final boolean signDeposits,
+      final UInt64 depositAmount,
+      final Optional<ExecutionPayloadHeader> payloadHeader) {
     checkState(blocks.isEmpty(), "Genesis already created");
 
     // Generate genesis state
@@ -246,7 +253,7 @@ public class ChainBuilder {
             .createDeposits(validatorKeys, depositAmount);
     BeaconState genesisState =
         new MockStartBeaconStateGenerator(spec)
-            .createInitialBeaconState(genesisTime, initialDepositData);
+            .createInitialBeaconState(genesisTime, initialDepositData, payloadHeader);
 
     // Generate genesis block
     BeaconBlock genesisBlock = BeaconBlock.fromGenesisState(spec, genesisState);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/InteropStartupUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/InteropStartupUtil.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.interop;
 
 import java.util.List;
+import java.util.Optional;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -44,6 +45,7 @@ public final class InteropStartupUtil {
         new MockStartDepositGenerator(new DepositGenerator(spec, signDeposits))
             .createDeposits(validatorKeys);
     return new MockStartBeaconStateGenerator(spec)
-        .createInitialBeaconState(UInt64.valueOf(genesisTime), initialDepositData);
+        .createInitialBeaconState(
+            UInt64.valueOf(genesisTime), initialDepositData, Optional.empty());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/MockStartBeaconStateGenerator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/MockStartBeaconStateGenerator.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.operations.DepositWithIndex;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -40,7 +41,9 @@ public class MockStartBeaconStateGenerator {
   }
 
   public BeaconState createInitialBeaconState(
-      final UInt64 genesisTime, final List<DepositData> initialDepositData) {
+      final UInt64 genesisTime,
+      final List<DepositData> initialDepositData,
+      final Optional<ExecutionPayloadHeader> payloadHeader) {
     final List<DepositWithIndex> deposits = new ArrayList<>();
     for (int index = 0; index < initialDepositData.size(); index++) {
       final DepositData data = initialDepositData.get(index);
@@ -48,7 +51,7 @@ public class MockStartBeaconStateGenerator {
       deposits.add(deposit);
     }
     final BeaconState initialState =
-        spec.initializeBeaconStateFromEth1(BLOCK_HASH, genesisTime, deposits, Optional.empty());
+        spec.initializeBeaconStateFromEth1(BLOCK_HASH, genesisTime, deposits, payloadHeader);
     return initialState.updated(state -> state.setGenesis_time(genesisTime));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -240,4 +240,8 @@ public class MiscHelpers {
   private Bytes32 computeForkDataRoot(Bytes4 currentVersion, Bytes32 genesisValidatorsRoot) {
     return new ForkData(currentVersion, genesisValidatorsRoot).hashTreeRoot();
   }
+
+  public boolean isMergeComplete(final BeaconState state) {
+    return false;
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/helpers/MiscHelpersMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/helpers/MiscHelpersMerge.java
@@ -27,6 +27,7 @@ public class MiscHelpersMerge extends MiscHelpersAltair {
     super(specConfig);
   }
 
+  @Override
   public boolean isMergeComplete(final BeaconState genericState) {
     final BeaconStateMerge state = BeaconStateMerge.required(genericState);
     return !state.getLatestExecutionPayloadHeader().isDefault();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/util/MockStartBeaconStateGeneratorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/util/MockStartBeaconStateGeneratorTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.datastructures.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSKeyPair;
@@ -45,7 +46,8 @@ class MockStartBeaconStateGeneratorTest {
         new MockStartDepositGenerator(spec).createDeposits(validatorKeyPairs);
 
     final BeaconState initialBeaconState =
-        new MockStartBeaconStateGenerator(spec).createInitialBeaconState(genesisTime, deposits);
+        new MockStartBeaconStateGenerator(spec)
+            .createInitialBeaconState(genesisTime, deposits, Optional.empty());
 
     assertEquals(validatorCount, initialBeaconState.getValidators().size());
     assertEquals(validatorCount, initialBeaconState.getEth1_data().getDeposit_count().longValue());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
@@ -144,6 +144,9 @@ public class ForkChoiceNotifier {
     }
     forkChoiceState.ifPresentOrElse(
         forkChoiceState -> {
+          if (forkChoiceState.getHeadBlockHash().isZero()) {
+            return;
+          }
           lastSentForkChoiceState = this.forkChoiceState;
           lastSentPayloadAttributes = payloadAttributes;
           // Previous payload is no longer useful as we've moved on to prepping the next block

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
@@ -80,7 +81,7 @@ class ForkChoiceNotifierTest {
 
   @BeforeEach
   void setUp() {
-    storageSystem.chainUpdater().initializeGenesis(false);
+    storageSystem.chainUpdater().initializeGenesisWithPayload(false);
     forkChoiceStrategy = recentChainData.getForkChoiceStrategy().orElseThrow();
     when(executionEngineChannel.executePayload(any()))
         .thenReturn(
@@ -125,6 +126,13 @@ class ForkChoiceNotifierTest {
 
     notifier.onForkChoiceUpdated(forkChoiceState);
     verify(executionEngineChannel).forkChoiceUpdated(forkChoiceState, Optional.empty());
+  }
+
+  @Test
+  void onForkChoiceUpdated_shouldNotSendNotificationWhenHeadBlockHashIsZero() {
+    notifier.onForkChoiceUpdated(new ForkChoiceState(Bytes32.ZERO, Bytes32.ZERO, Bytes32.ZERO));
+
+    verifyNoInteractions(executionEngineChannel);
   }
 
   @Test


### PR DESCRIPTION
## PR Description
The CL shouldn't start sending forkChoiceUpdated notifications to the EL until the first execution payload is included in a block so we can skip sending any updates with a head block hash of zero.

Also update storage system/chain builder to support creating chains that include execution payloads to enable testing these kinds of things.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
