### PR TITLE
Only require block slot state to create blocks

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -61,8 +61,6 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.merge.BeaconPre
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
-import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
-import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
@@ -289,7 +287,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
       final Optional<BeaconState> blockSlotState)
-      throws EpochProcessingException, SlotProcessingException, StateTransitionException {
+      throws StateTransitionException {
     if (blockSlotState.isEmpty()) {
       return Optional.empty();
     }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -433,16 +433,14 @@ class ValidatorApiHandlerTest {
     when(chainDataClient.getHeadSlot()).thenReturn(UInt64.valueOf(24));
     when(chainDataClient.getStateAtSlotExact(newSlot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockSlotState)));
-    when(blockFactory.createUnsignedBlock(
-            blockSlotState, newSlot, randaoReveal, Optional.empty()))
+    when(blockFactory.createUnsignedBlock(blockSlotState, newSlot, randaoReveal, Optional.empty()))
         .thenReturn(createdBlock);
 
     final SafeFuture<Optional<BeaconBlock>> result =
         validatorApiHandler.createUnsignedBlock(newSlot, randaoReveal, Optional.empty());
 
     verify(blockFactory)
-        .createUnsignedBlock(
-            blockSlotState, newSlot, randaoReveal, Optional.empty());
+        .createUnsignedBlock(blockSlotState, newSlot, randaoReveal, Optional.empty());
     assertThat(result).isCompletedWithValue(Optional.of(createdBlock));
   }
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -425,19 +425,16 @@ class ValidatorApiHandlerTest {
   public void createUnsignedBlock_shouldCreateBlock() throws Exception {
     final UInt64 newSlot = UInt64.valueOf(25);
     final Bytes32 blockRoot = dataStructureUtil.randomBytes32();
-    final BeaconState previousState = dataStructureUtil.randomBeaconState(newSlot.minus(1));
     final BeaconState blockSlotState = dataStructureUtil.randomBeaconState(newSlot);
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
     final BeaconBlock createdBlock = dataStructureUtil.randomBeaconBlock(newSlot.longValue());
 
     when(chainDataClient.getBestBlockRoot()).thenReturn(Optional.of(blockRoot));
     when(chainDataClient.getHeadSlot()).thenReturn(UInt64.valueOf(24));
-    when(chainDataClient.getStateAtSlotExact(newSlot.minus(ONE)))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(previousState)));
     when(chainDataClient.getStateAtSlotExact(newSlot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockSlotState)));
     when(blockFactory.createUnsignedBlock(
-            previousState, Optional.of(blockSlotState), newSlot, randaoReveal, Optional.empty()))
+            blockSlotState, newSlot, randaoReveal, Optional.empty()))
         .thenReturn(createdBlock);
 
     final SafeFuture<Optional<BeaconBlock>> result =
@@ -445,7 +442,7 @@ class ValidatorApiHandlerTest {
 
     verify(blockFactory)
         .createUnsignedBlock(
-            previousState, Optional.of(blockSlotState), newSlot, randaoReveal, Optional.empty());
+            blockSlotState, newSlot, randaoReveal, Optional.empty());
     assertThat(result).isCompletedWithValue(Optional.of(createdBlock));
   }
 


### PR DESCRIPTION
## PR Description
Simplify block creation - only the block slot state is now required. Previously the state from the previous block was required, with the block slot state optional to avoid reprocessing slots.  This caused the production code to potentially generate two states when only one is needed.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
