### PR TITLE
Reject create block and attestation requests when chain head is optimistic

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -341,13 +341,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                           final SignedBlockAndState blockAndState = maybeBlockAndState.get();
                           final BeaconBlock block = blockAndState.getBlock().getMessage();
 
-                          // The head block and justified checkpoint must be fully validated
-                          if (!combinedChainDataClient.isFullyValidatedHotBlock(block.getRoot())
-                              || !combinedChainDataClient.isFullyValidatedHotBlock(
-                                  blockAndState
-                                      .getState()
-                                      .getCurrent_justified_checkpoint()
-                                      .getRoot())) {
+                          // The head block must not be optimistically synced.
+                          if (!combinedChainDataClient.isFullyValidatedHotBlock(block.getRoot())) {
                             return NodeSyncingException.failedFuture();
                           }
                           if (blockAndState.getSlot().compareTo(minQuerySlot) < 0) {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -286,13 +286,21 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
-      final Optional<BeaconState> blockSlotState)
+      final Optional<BeaconState> maybeBlockSlotState)
       throws StateTransitionException {
-    if (blockSlotState.isEmpty()) {
+    if (maybeBlockSlotState.isEmpty()) {
       return Optional.empty();
     }
+    final BeaconState blockSlotState = maybeBlockSlotState.get();
+    final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, slot.minus(1));
+    if (!combinedChainDataClient.isFullyValidatedHotBlock(parentRoot)) {
+      LOG.warn(
+          "Unable to produce block at slot {} because parent has optimistically validated payload",
+          slot);
+      throw new NodeSyncingException();
+    }
     return Optional.of(
-        blockFactory.createUnsignedBlock(blockSlotState.get(), slot, randaoReveal, graffiti));
+        blockFactory.createUnsignedBlock(blockSlotState, slot, randaoReveal, graffiti));
   }
 
   @Override
@@ -332,6 +340,16 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                           }
                           final SignedBlockAndState blockAndState = maybeBlockAndState.get();
                           final BeaconBlock block = blockAndState.getBlock().getMessage();
+
+                          // The head block and justified checkpoint must be fully validated
+                          if (!combinedChainDataClient.isFullyValidatedHotBlock(block.getRoot())
+                              || !combinedChainDataClient.isFullyValidatedHotBlock(
+                                  blockAndState
+                                      .getState()
+                                      .getCurrent_justified_checkpoint()
+                                      .getRoot())) {
+                            return NodeSyncingException.failedFuture();
+                          }
                           if (blockAndState.getSlot().compareTo(minQuerySlot) < 0) {
                             // The current effective block is too far in the past - so roll the
                             // state forward to the current epoch. Ensures we have the latest

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -511,9 +511,14 @@ public class CombinedChainDataClient {
       final Set<SignedBeaconBlock> signedBeaconBlocks,
       final Optional<SignedBeaconBlock> canonicalBlock) {
     verifyNotNull(signedBeaconBlocks, "Expected empty set but got null");
-    if (canonicalBlock.isPresent()) {
-      signedBeaconBlocks.add(canonicalBlock.get());
-    }
+    canonicalBlock.ifPresent(signedBeaconBlocks::add);
     return signedBeaconBlocks;
+  }
+
+  public boolean isFullyValidatedHotBlock(final Bytes32 blockRoot) {
+    return recentChainData
+        .getForkChoiceStrategy()
+        .map(forkChoice -> forkChoice.isFullyValidated(blockRoot))
+        .orElse(false);
   }
 }


### PR DESCRIPTION
## PR Description
It is not safe for validators to produce blocks on top of or attest to blocks that have only been optimistically synced. So if the referenced block is not fully validated, return a node syncing response rather than creating the block/attestation. Node syncing is used because the execution engine is still syncing and unable to verify the payload.

Since blocks and attestations use the chain head which is normally not optimistic block production and attestation creation can continue while there are some optimistically sync'd blocks, as long as we still have a fully validated block close enough to use as our chain head and build on. If we've optimistically finalized, we will cease block and attestation production.

We don't prevent creating aggregates because the validator client will only create aggregates for attestations they produced, so if they managed to produce the attestation it must have been validated (though potentially by a different beacon node).

## Fixed Issue(s)
#4650 - need to handle sync committee messages separately as they don't have a create call.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
