### PR TITLE
[Merge] Implements payloadId on-the-fly retrieval for post-merge blocks

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.AsyncRunnerEventThread;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -145,10 +146,14 @@ public class ForkChoiceNotifier {
             .map(ForkChoiceState::getHeadBlockHash)
             .map(
                 fcsHead -> {
-                  if (fcsHead.equals(parentExecutionHash)) {
+                  // post-merge block
+                  if (!parentExecutionHash.isZero() && fcsHead.equals(parentExecutionHash)) {
                     return true;
                   }
-                  return executionPayloadTerminalBlockHash.isPresent()
+
+                  // merge block
+                  return parentExecutionHash.isZero()
+                      && executionPayloadTerminalBlockHash.isPresent()
                       && fcsHead.equals(executionPayloadTerminalBlockHash.get());
                 })
             .orElse(false);
@@ -159,8 +164,8 @@ public class ForkChoiceNotifier {
       return lastFuturePayloadId.thenApply(
           payloadId -> {
 
-            // Only accept empty payload pre-merge
-            if (payloadId.isPresent() || parentExecutionHash.isZero()) {
+            // at this stage we expect payloadId to be present
+            if (payloadId.isPresent()) {
               return payloadId;
             }
 
@@ -184,22 +189,57 @@ public class ForkChoiceNotifier {
         // we are in pre-merge and terminal block is reached
         // try to obtain a payloadId now
         final Bytes32 terminalBlockHash = executionPayloadTerminalBlockHash.get();
-        final ForkChoiceState terminalForkChoiceState =
-            new ForkChoiceState(terminalBlockHash, terminalBlockHash, Bytes32.ZERO);
-        internalForkChoiceUpdated(terminalForkChoiceState);
-        checkState(
-            lastSentForkChoiceState.isPresent()
-                && lastSentForkChoiceState.get().equals(terminalForkChoiceState),
-            "Required fork choice state was not sent");
-        return internalGetPayloadId(parentBeaconBlockRoot, false);
+        return requestPayloadId(terminalBlockHash, Bytes32.ZERO, parentBeaconBlockRoot);
       }
     }
 
-    // Merge is complete so we must have a real payload, but we don't have one that matches
-    // TODO: try to obtain a payloadId on the fly?
+    // Merge is complete, so we must have a real payload, but we don't have one that matches
+
+    if (allowPayloadIdOnTheFlyRetrieval) {
+      // try to obtain a payloadId now
+      Bytes32 finalizedExecutionBlockHash;
+      try {
+        finalizedExecutionBlockHash =
+            lastSentForkChoiceState
+                .map(ForkChoiceState::getFinalizedBlockHash)
+                .orElseGet(this::retrieveFinalizedExecutionBlockHash);
+      } catch (Exception e) {
+        throw new IllegalStateException(
+            String.format(
+                "Error while trying to retrieve current finalized Execution Block Hash for Beacon Block Root %s",
+                parentBeaconBlockRoot),
+            e);
+      }
+      return requestPayloadId(
+          parentExecutionHash, finalizedExecutionBlockHash, parentBeaconBlockRoot);
+    }
 
     throw new IllegalStateException(
         String.format("PayloadId not available for Beacon Block Root %s", parentBeaconBlockRoot));
+  }
+
+  private SafeFuture<Optional<Bytes8>> requestPayloadId(
+      Bytes32 parentExecutionBlockHash,
+      Bytes32 finalizedExecutionBlockHash,
+      Bytes32 parentBeaconBlockRoot) {
+
+    final ForkChoiceState newForkChoiceState =
+        new ForkChoiceState(
+            parentExecutionBlockHash, parentExecutionBlockHash, finalizedExecutionBlockHash);
+
+    internalForkChoiceUpdated(newForkChoiceState);
+    checkState(
+        lastSentForkChoiceState
+            .map(lsfcState -> lsfcState.equals(newForkChoiceState))
+            .orElse(false),
+        "Required fork choice state was not sent");
+    return internalGetPayloadId(parentBeaconBlockRoot, false);
+  }
+
+  private Bytes32 retrieveFinalizedExecutionBlockHash() {
+    ForkChoiceStrategy forkChoiceStrategy = recentChainData.getForkChoiceStrategy().orElseThrow();
+    final Bytes32 finalizedRoot = recentChainData.getFinalizedCheckpoint().orElseThrow().getRoot();
+    return forkChoiceStrategy.executionBlockHash(finalizedRoot).orElseThrow();
   }
 
   private void internalUpdatePreparableProposers(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -118,9 +118,7 @@ class ForkChoiceNotifierTest {
             .chainBuilder
             .generateBlockAtSlot(
                 recentChainData.getHeadSlot().plus(1),
-                ChainBuilder.BlockOptions.create()
-                    .setTransactions(dataStructureUtil.randomBytes(40))
-                    .setTerminalBlockHash(terminalBlockHash));
+                ChainBuilder.BlockOptions.create().setTerminalBlockHash(terminalBlockHash));
 
     storageSystem.chainUpdater().updateBestBlock(newBlockWithExecutionPayloadAtopTerminalBlock);
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.core.ChainBuilder;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -108,6 +109,20 @@ class ForkChoiceNotifierTest {
     storageSystem.chainUpdater().initializeGenesis(false);
     storageSystem.chainUpdater().updateBestBlock(storageSystem.chainUpdater().advanceChain());
     forkChoiceStrategy = recentChainData.getForkChoiceStrategy().orElseThrow();
+  }
+
+  private void doMerge(Bytes32 terminalBlockHash) {
+    SignedBlockAndState newBlockWithExecutionPayloadAtopTerminalBlock =
+        storageSystem
+            .chainUpdater()
+            .chainBuilder
+            .generateBlockAtSlot(
+                recentChainData.getHeadSlot().plus(1),
+                ChainBuilder.BlockOptions.create()
+                    .setTransactions(dataStructureUtil.randomBytes(40))
+                    .setTerminalBlockHash(terminalBlockHash));
+
+    storageSystem.chainUpdater().updateBestBlock(newBlockWithExecutionPayloadAtopTerminalBlock);
   }
 
   @Test
@@ -324,6 +339,50 @@ class ForkChoiceNotifierTest {
 
     notifier.onTerminalBlockReached(terminalBlockHash);
 
+    validateGetPayloadIOnTheFlyRetrieval(blockRoot, forkChoiceState, payloadId, payloadAttributes);
+  }
+
+  @Test
+  void getPayloadId_shouldObtainAPayloadIdOnPostMergeBlockNonFinalized() {
+    reInitializePreMerge();
+    Bytes32 terminalBlockHash = dataStructureUtil.randomBytes32();
+    doMerge(terminalBlockHash);
+
+    ForkChoiceState nonFinalizedForkChoiceState = getCurrentForkChoiceState();
+    assertThat(nonFinalizedForkChoiceState.getFinalizedBlockHash()).isEqualTo(Bytes32.ZERO);
+
+    final Bytes8 payloadId = dataStructureUtil.randomBytes8();
+
+    final BeaconState headState = recentChainData.getBestState().orElseThrow();
+    final UInt64 blockSlot = headState.getSlot().plus(1);
+    final Bytes32 blockRoot = recentChainData.getBestBlockRoot().orElseThrow();
+    final PayloadAttributes payloadAttributes = withProposerForSlot(headState, blockSlot);
+
+    validateGetPayloadIOnTheFlyRetrieval(
+        blockRoot, nonFinalizedForkChoiceState, payloadId, payloadAttributes);
+  }
+
+  @Test
+  void getPayloadId_shouldObtainAPayloadIdOnPostMergeBlockFinalized() {
+    final Bytes8 payloadId = dataStructureUtil.randomBytes8();
+
+    ForkChoiceState finalizedForkChoiceState = getCurrentForkChoiceState();
+    assertThat(finalizedForkChoiceState.getFinalizedBlockHash()).isNotEqualTo(Bytes32.ZERO);
+
+    final BeaconState headState = recentChainData.getBestState().orElseThrow();
+    final UInt64 blockSlot = headState.getSlot().plus(1);
+    final Bytes32 blockRoot = recentChainData.getBestBlockRoot().orElseThrow();
+    final PayloadAttributes payloadAttributes = withProposerForSlot(headState, blockSlot);
+
+    validateGetPayloadIOnTheFlyRetrieval(
+        blockRoot, finalizedForkChoiceState, payloadId, payloadAttributes);
+  }
+
+  private void validateGetPayloadIOnTheFlyRetrieval(
+      final Bytes32 blockRoot,
+      final ForkChoiceState forkChoiceState,
+      final Bytes8 payloadId,
+      final PayloadAttributes payloadAttributes) {
     final SafeFuture<ForkChoiceUpdatedResult> responseFuture = new SafeFuture<>();
     when(executionEngineChannel.forkChoiceUpdated(forkChoiceState, Optional.of(payloadAttributes)))
         .thenReturn(responseFuture);


### PR DESCRIPTION
## PR Description

- implements payloadId on-the-fly retrieval for post-merge blocks

- more precisely set lastForkChoiceStateCorrectlyBuildsOnTop, so we will resolve payloadIdFuture only when we expect non-empty payloadId.

## Fixed Issue(s)
fixes #4668

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
