### PR TITLE
[Merge] Implements `TerminalPowBlockMonitor`

### DIFF
--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
@@ -121,7 +121,7 @@ public class BlockProposalTestUtil {
     final ExecutionPayloadSchema schema =
         SchemaDefinitionsMerge.required(specVersion.getSchemaDefinitions())
             .getExecutionPayloadSchema();
-    if (transactions.isEmpty() && !isMergeComplete(state)) {
+    if (terminalBlock.isEmpty() && !isMergeComplete(state)) {
       return schema.getDefault();
     }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitor.java
@@ -51,6 +51,8 @@ public class TerminalPowBlockMonitor {
   private Optional<Bytes32> maybeBlockHashTracking = Optional.empty();
   private Duration pollingPeriod;
 
+  private Optional<Bytes32> foundTerminalBlockHash = Optional.empty();
+
   public TerminalPowBlockMonitor(
       ExecutionEngineChannel executionEngine,
       Spec spec,
@@ -206,7 +208,10 @@ public class TerminalPowBlockMonitor {
   }
 
   private void onTerminalPowBlockFound(Bytes32 blockHash) {
-    forkChoiceNotifier.onTerminalBlockReached(blockHash);
-    EVENT_LOG.terminalPowBlockDetected(blockHash);
+    if (foundTerminalBlockHash.map(blockHash::equals).orElse(true)) {
+      foundTerminalBlockHash = Optional.of(blockHash);
+      forkChoiceNotifier.onTerminalBlockReached(blockHash);
+      EVENT_LOG.terminalPowBlockDetected(blockHash);
+    }
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitor.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.Cancellable;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.config.SpecConfigMerge;
+import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+public class TerminalPowBlockMonitor {
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final ExecutionEngineChannel executionEngine;
+  private final AsyncRunner asyncRunner;
+  private Optional<Cancellable> timer = Optional.empty();
+  private final Spec spec;
+  private final RecentChainData recentChainData;
+  private final ForkChoiceNotifier forkChoiceNotifier;
+
+  private final AtomicBoolean isMerge = new AtomicBoolean(false);
+
+  private MiscHelpers miscHelpers;
+  private SpecConfigMerge specConfigMerge;
+
+  private Optional<Bytes32> maybeBlockHashTracking = Optional.empty();
+  private Duration pollingPeriod;
+
+  public TerminalPowBlockMonitor(
+      ExecutionEngineChannel executionEngine,
+      Spec spec,
+      RecentChainData recentChainData,
+      ForkChoiceNotifier forkChoiceNotifier,
+      AsyncRunner asyncRunner) {
+    this.executionEngine = executionEngine;
+    this.asyncRunner = asyncRunner;
+    this.spec = spec;
+    this.recentChainData = recentChainData;
+    this.forkChoiceNotifier = forkChoiceNotifier;
+  }
+
+  public synchronized void start() {
+    if (timer.isPresent()) {
+      return;
+    }
+    pollingPeriod =
+        Duration.ofSeconds(spec.getGenesisSpec().getConfig().getSecondsPerEth1Block().longValue());
+    timer =
+        Optional.of(
+            asyncRunner.runWithFixedDelay(
+                this::monitor,
+                pollingPeriod,
+                (error) -> LOG.error("An error occurred while executing the monitor task", error)));
+    LOG.info("Monitor has started. Waiting MERGE fork activation. Polling every {}", pollingPeriod);
+  }
+
+  public synchronized void stop() {
+    if (timer.isEmpty()) {
+      return;
+    }
+    timer.get().cancel();
+    timer = Optional.empty();
+    LOG.info("Monitor has stopped");
+  }
+
+  public synchronized boolean isRunning() {
+    return timer.isPresent();
+  }
+
+  private synchronized void monitor() {
+    if (!isMerge.get()) {
+      initMergeState();
+      if (!isMerge.get()) {
+        LOG.trace("Monitor is sill inactive. MERGE fork not yet activated.");
+        return;
+      }
+    }
+
+    // beaconState must be available at this stage
+    BeaconState beaconState = recentChainData.getBestState().orElseThrow();
+
+    if (miscHelpers.isMergeComplete(beaconState)) {
+      LOG.info("MERGE is completed. Stopping.");
+      stop();
+      return;
+    }
+
+    maybeBlockHashTracking.ifPresentOrElse(
+        this::checkTerminalBlockByBlockHash, this::checkTerminalBlockByTTD);
+  }
+
+  private void initMergeState() {
+    Optional<UInt64> maybeSlot = recentChainData.getCurrentSlot();
+    if (maybeSlot.isEmpty()) {
+      return;
+    }
+
+    UInt64 epoch = spec.computeEpochAtSlot(maybeSlot.get());
+    Optional<SpecConfigMerge> maybeMergeSpecConfig = spec.getSpecConfig(epoch).toVersionMerge();
+    if (maybeMergeSpecConfig.isEmpty()
+        || maybeMergeSpecConfig.get().getMergeForkEpoch().isGreaterThan(epoch)) {
+      return;
+    }
+
+    specConfigMerge = maybeMergeSpecConfig.get();
+    miscHelpers = spec.atSlot(maybeSlot.get()).miscHelpers();
+
+    Optional<BeaconState> beaconState = recentChainData.getBestState();
+    if (beaconState.isEmpty()) {
+      LOG.trace("beaconState not yet available");
+      return;
+    }
+
+    if (miscHelpers.isMergeComplete(beaconState.get())) {
+      LOG.info("MERGE is completed. Stopping.");
+      stop();
+      return;
+    }
+
+    if (specConfigMerge.getTerminalBlockHash().isZero()) {
+      maybeBlockHashTracking = Optional.empty();
+      LOG.info(
+          "Enabling tracking by Block Total Difficulty {}",
+          specConfigMerge.getTerminalTotalDifficulty());
+    } else {
+      maybeBlockHashTracking = Optional.of(specConfigMerge.getTerminalBlockHash());
+      LOG.info(
+          "Enabling tracking by Block Hash {} and Activation Epoch {}",
+          specConfigMerge.getTerminalBlockHash(),
+          specConfigMerge.getTerminalBlockHashActivationEpoch());
+    }
+
+    isMerge.set(true);
+    LOG.info("Monitor is now active");
+  }
+
+  private void checkTerminalBlockByBlockHash(Bytes32 blockHashTracking) {
+    UInt64 slot = recentChainData.getCurrentSlot().orElseThrow();
+
+    final boolean isActivationEpochReached =
+        miscHelpers
+            .computeEpochAtSlot(slot)
+            .isGreaterThanOrEqualTo(specConfigMerge.getTerminalBlockHashActivationEpoch());
+
+    if (isActivationEpochReached) {
+      executionEngine
+          .getPowBlock(blockHashTracking)
+          .thenAccept(
+              maybePowBlock ->
+                  maybePowBlock
+                      .map(PowBlock::getBlockHash)
+                      .map(blockHashTracking::equals)
+                      .ifPresent(
+                          found -> {
+                            if (found) {
+                              LOG.trace("checkTerminalBlockByBlockHash: Terminal Block found!");
+                              onTerminalPowBlockFound(blockHashTracking);
+                            } else {
+                              LOG.trace("checkTerminalBlockByBlockHash: Terminal Block not found.");
+                            }
+                          }))
+          .finish(
+              error -> LOG.error("Unexpected error while searching Terminal Block by Hash", error));
+    }
+  }
+
+  private void checkTerminalBlockByTTD() {
+    executionEngine
+        .getPowChainHead()
+        .thenAccept(
+            powBlock -> {
+              UInt256 difficulty = powBlock.getTotalDifficulty();
+              if (difficulty.compareTo(specConfigMerge.getTerminalTotalDifficulty()) >= 0) {
+                LOG.trace("checkTerminalBlockByTTD: Terminal Block found!");
+                onTerminalPowBlockFound(powBlock.getBlockHash());
+              } else {
+                LOG.trace("checkTerminalBlockByTTD: Terminal Block not found.");
+              }
+            })
+        .finish(error -> LOG.error("Unexpected error while checking TTD", error));
+  }
+
+  private void onTerminalPowBlockFound(Bytes32 blockHash) {
+    forkChoiceNotifier.onTerminalBlockReached(blockHash);
+    EVENT_LOG.terminalPowBlockDetected(blockHash);
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitorTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.core.ChainBuilder;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigLoader;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
+
+public class TerminalPowBlockMonitorTest {
+  private static final UInt64 MERGE_FORK_EPOCH = UInt64.ONE;
+  private static final UInt256 TTD = UInt256.valueOf(10_000_000);
+  private static final Bytes32 TERMINAL_BLOCK_HASH = Bytes32.random();
+  private static final UInt64 TERMINAL_BLOCK_EPOCH = UInt64.valueOf(2);
+
+  private final ExecutionEngineChannel executionEngine = mock(ExecutionEngineChannel.class);
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(10_000);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
+  private final ForkChoiceNotifier forkChoiceNotifier = mock(ForkChoiceNotifier.class);
+
+  private Spec spec;
+  private DataStructureUtil dataStructureUtil;
+  private StorageSystem storageSystem;
+  private RecentChainData recentChainData;
+  private TerminalPowBlockMonitor terminalPowBlockMonitor;
+
+  @BeforeAll
+  public static void initSession() {
+    AbstractBlockProcessor.BLS_VERIFY_DEPOSIT = false;
+  }
+
+  @AfterAll
+  public static void resetSession() {
+    AbstractBlockProcessor.BLS_VERIFY_DEPOSIT = true;
+  }
+
+  private void setUpTerminalBlockHashConfig() {
+    spec =
+        TestSpecFactory.createMerge(
+            SpecConfigLoader.loadConfig(
+                "minimal",
+                phase0Builder ->
+                    phase0Builder
+                        .altairBuilder(altairBuilder -> altairBuilder.altairForkEpoch(UInt64.ZERO))
+                        .mergeBuilder(
+                            mergeBuilder ->
+                                mergeBuilder
+                                    .mergeForkEpoch(MERGE_FORK_EPOCH)
+                                    .terminalBlockHash(TERMINAL_BLOCK_HASH)
+                                    .terminalBlockHashActivationEpoch(TERMINAL_BLOCK_EPOCH))));
+
+    setUpCommon();
+  }
+
+  private void setUpTTDConfig() {
+    spec =
+        TestSpecFactory.createMerge(
+            SpecConfigLoader.loadConfig(
+                "minimal",
+                phase0Builder ->
+                    phase0Builder
+                        .altairBuilder(altairBuilder -> altairBuilder.altairForkEpoch(UInt64.ZERO))
+                        .mergeBuilder(
+                            mergeBuilder ->
+                                mergeBuilder
+                                    .mergeForkEpoch(MERGE_FORK_EPOCH)
+                                    .terminalTotalDifficulty(TTD))));
+
+    setUpCommon();
+  }
+
+  private void setUpCommon() {
+    dataStructureUtil = new DataStructureUtil(spec);
+    storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
+    storageSystem.chainUpdater().initializeGenesis(false);
+    recentChainData = storageSystem.recentChainData();
+
+    terminalPowBlockMonitor =
+        new TerminalPowBlockMonitor(
+            executionEngine, spec, recentChainData, forkChoiceNotifier, asyncRunner);
+  }
+
+  private void goToSlot(UInt64 slot) {
+    storageSystem
+        .chainUpdater()
+        .updateBestBlock(storageSystem.chainUpdater().advanceChainUntil(slot));
+  }
+
+  private void doMerge(Bytes32 terminalBlockHash) {
+    SignedBlockAndState newBlockWithExecutionPayloadAtopTerminalBlock =
+        storageSystem
+            .chainUpdater()
+            .chainBuilder
+            .generateBlockAtSlot(
+                recentChainData.getHeadSlot().plus(1),
+                ChainBuilder.BlockOptions.create()
+                    .setTransactions(dataStructureUtil.randomBytes(40))
+                    .setTerminalBlockHash(terminalBlockHash));
+
+    storageSystem.chainUpdater().updateBestBlock(newBlockWithExecutionPayloadAtopTerminalBlock);
+  }
+
+  @Test
+  public void shouldPerformTerminalBlockDetectionByTTD() {
+    setUpTTDConfig();
+
+    terminalPowBlockMonitor.start();
+
+    // NOT YET MERGE FORK
+    goToSlot(UInt64.ONE);
+
+    assertThat(terminalPowBlockMonitor.isRunning()).isTrue();
+    assertThat(asyncRunner.hasDelayedActions()).isTrue();
+
+    asyncRunner.executeQueuedActions();
+
+    verify(executionEngine, times(0)).getPowChainHead();
+    verify(forkChoiceNotifier, times(0)).onTerminalBlockReached(any());
+
+    // AT MERGE FORK, TTD not reached
+    Bytes32 headBlockHash = dataStructureUtil.randomBytes32();
+
+    goToSlot(MERGE_FORK_EPOCH.times(spec.getGenesisSpecConfig().getSlotsPerEpoch()));
+
+    when(executionEngine.getPowChainHead())
+        .thenReturn(
+            completedFuture(
+                new PowBlock(headBlockHash, dataStructureUtil.randomBytes32(), TTD.subtract(10))));
+
+    asyncRunner.executeQueuedActions();
+
+    verify(executionEngine, times(1)).getPowChainHead();
+    verify(forkChoiceNotifier, times(0)).onTerminalBlockReached(any());
+
+    // AT MERGE FORK, TTD reached
+    headBlockHash = dataStructureUtil.randomBytes32();
+    when(executionEngine.getPowChainHead())
+        .thenReturn(
+            completedFuture(new PowBlock(headBlockHash, dataStructureUtil.randomBytes32(), TTD)));
+
+    asyncRunner.executeQueuedActions();
+
+    verify(executionEngine, times(2)).getPowChainHead();
+    verify(forkChoiceNotifier, times(1)).onTerminalBlockReached(headBlockHash);
+
+    // MERGE Completed
+    doMerge(headBlockHash);
+
+    asyncRunner.executeQueuedActions();
+
+    assertThat(terminalPowBlockMonitor.isRunning()).isFalse();
+
+    // final check
+    verify(executionEngine, times(0)).getPowBlock(any());
+  }
+
+  @Test
+  void shouldPerformTerminalBlockDetectionByTerminalBlockHash() {
+    setUpTerminalBlockHashConfig();
+
+    terminalPowBlockMonitor.start();
+
+    // NOT YET MERGE FORK
+    goToSlot(UInt64.ONE);
+
+    assertThat(terminalPowBlockMonitor.isRunning()).isTrue();
+    assertThat(asyncRunner.hasDelayedActions()).isTrue();
+
+    asyncRunner.executeQueuedActions();
+
+    verify(executionEngine, times(0)).getPowChainHead();
+    verify(forkChoiceNotifier, times(0)).onTerminalBlockReached(any());
+
+    // AT MERGE FORK, Terminal Bloch Epoch not reached
+    goToSlot(MERGE_FORK_EPOCH.times(spec.getGenesisSpecConfig().getSlotsPerEpoch()));
+
+    asyncRunner.executeQueuedActions();
+
+    verify(executionEngine, times(0)).getPowBlock(any());
+    verify(forkChoiceNotifier, times(0)).onTerminalBlockReached(any());
+
+    // AT Terminal Bloch Epoch, Terminal Block Hash not found
+    goToSlot(TERMINAL_BLOCK_EPOCH.times(spec.getGenesisSpecConfig().getSlotsPerEpoch()));
+    when(executionEngine.getPowBlock(TERMINAL_BLOCK_HASH))
+        .thenReturn(completedFuture(Optional.empty()));
+
+    asyncRunner.executeQueuedActions();
+
+    verify(executionEngine, times(1)).getPowBlock(TERMINAL_BLOCK_HASH);
+    verify(forkChoiceNotifier, times(0)).onTerminalBlockReached(any());
+
+    // AT Terminal Bloch Epoch, Terminal Block Hash found
+    when(executionEngine.getPowBlock(TERMINAL_BLOCK_HASH))
+        .thenReturn(
+            completedFuture(
+                Optional.of(
+                    new PowBlock(
+                        TERMINAL_BLOCK_HASH, dataStructureUtil.randomBytes32(), UInt256.ONE))));
+
+    asyncRunner.executeQueuedActions();
+
+    verify(executionEngine, times(2)).getPowBlock(TERMINAL_BLOCK_HASH);
+    verify(forkChoiceNotifier, times(1)).onTerminalBlockReached(TERMINAL_BLOCK_HASH);
+
+    // MERGE Completed
+    doMerge(TERMINAL_BLOCK_HASH);
+    asyncRunner.executeQueuedActions();
+    assertThat(terminalPowBlockMonitor.isRunning()).isFalse();
+
+    // final check
+    verify(executionEngine, times(0)).getPowChainHead();
+  }
+
+  @Test
+  void shouldImmediatelyStopWhenMergeCompleted() {
+    setUpTerminalBlockHashConfig();
+    goToSlot(MERGE_FORK_EPOCH.times(spec.getGenesisSpecConfig().getSlotsPerEpoch()));
+    doMerge(TERMINAL_BLOCK_HASH);
+
+    terminalPowBlockMonitor.start();
+
+    asyncRunner.executeQueuedActions();
+
+    assertThat(terminalPowBlockMonitor.isRunning()).isFalse();
+  }
+}

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -147,6 +147,10 @@ public class EventLogger {
         Color.GREEN);
   }
 
+  public void terminalPowBlockDetected(final Bytes32 terminalBlockHash) {
+    info(String.format("Merge   *** Terminal Block detected: %s", terminalBlockHash), Color.GREEN);
+  }
+
   private void info(final String message, final Color color) {
     log.info(print(message, color));
   }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -61,6 +61,7 @@ import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.services.timer.TimeTickChannel;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
@@ -85,6 +86,7 @@ import tech.pegasys.teku.statetransition.block.BlockManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
+import tech.pegasys.teku.statetransition.forkchoice.TerminalPowBlockMonitor;
 import tech.pegasys.teku.statetransition.genesis.GenesisHandler;
 import tech.pegasys.teku.statetransition.synccommittee.SignedContributionAndProofValidator;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
@@ -184,6 +186,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   private volatile SyncCommitteeSubscriptionManager syncCommitteeSubscriptionManager;
   private volatile ForkChoiceNotifier forkChoiceNotifier;
   private volatile ExecutionEngineChannel executionEngine;
+  private volatile Optional<TerminalPowBlockMonitor> terminalPowBlockMonitor = Optional.empty();
 
   private UInt64 genesisTimeTracker = ZERO;
   private BlockManager blockManager;
@@ -229,7 +232,9 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             attestationManager.start(),
             p2pNetwork.start(),
             blockManager.start(),
-            syncService.start())
+            syncService.start(),
+            SafeFuture.fromRunnable(
+                () -> terminalPowBlockMonitor.ifPresent(TerminalPowBlockMonitor::start)))
         .finish(
             error -> {
               Throwable rootCause = Throwables.getRootCause(error);
@@ -254,7 +259,9 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             syncService.stop(),
             blockManager.stop(),
             attestationManager.stop(),
-            p2pNetwork.stop())
+            p2pNetwork.stop(),
+            SafeFuture.fromRunnable(
+                () -> terminalPowBlockMonitor.ifPresent(TerminalPowBlockMonitor::stop)))
         .thenRun(forkChoiceExecutor::stop);
   }
 
@@ -307,6 +314,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   public void initAll() {
     initExecutionEngine();
     initForkChoiceNotifier();
+    initTerminalPowBlockMonitor();
     initForkChoice();
     initBlockImporter();
     initCombinedChainDataClient();
@@ -336,6 +344,15 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   private void initExecutionEngine() {
     executionEngine = eventChannels.getPublisher(ExecutionEngineChannel.class, beaconAsyncRunner);
+  }
+
+  private void initTerminalPowBlockMonitor() {
+    if (spec.isMilestoneSupported(SpecMilestone.MERGE)) {
+      terminalPowBlockMonitor =
+          Optional.of(
+              new TerminalPowBlockMonitor(
+                  executionEngine, spec, recentChainData, forkChoiceNotifier, beaconAsyncRunner));
+    }
   }
 
   private void initPendingBlocks() {


### PR DESCRIPTION
## PR Description

Implements `TerminalPowBlockMonitor` by monitoring the PoW chain by TTD or by TerminalBlockHash\ActivationEpoch

## Fixed Issue(s)
fixes: #4670

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
