### PR TITLE
Change ProtoArray to have no strict head if the justified block is optimistic

### DIFF
--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
@@ -194,6 +194,10 @@ public class ProtoArray {
     ProtoNode justifiedNode =
         checkNotNull(nodes.get(justifiedIndex), "ProtoArray: Unknown justified index");
 
+    if (!hasSuitableValidationState.test(justifiedNode)) {
+      return Optional.empty();
+    }
+
     int bestDescendantIndex = justifiedNode.getBestDescendantIndex().orElse(justifiedIndex);
     ProtoNode bestNode =
         checkNotNull(nodes.get(bestDescendantIndex), "ProtoArray: Unknown best descendant index");


### PR DESCRIPTION
## PR Description
Return empty from `findHead` if the justified checkpoint is optimistic.

The chain head must always be a descendant of the justified checkpoint based on fork choice rules. So if justified is optimistic we must have no strict chain head.

This avoids the "Best node is not viable for head" error if finalized is fully validated but justified is not.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
