### PR TITLE
[Merge] implement independent JSON-RPC request id in engine APIs

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/ExecutionEngineClient.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/ExecutionEngineClient.java
@@ -26,6 +26,8 @@ import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.ssz.type.Bytes8;
 
 public interface ExecutionEngineClient {
+  long MESSAGE_ORDER_RESET_ID = 0;
+
   SafeFuture<Optional<PowBlock>> getPowBlock(Bytes32 blockHash);
 
   SafeFuture<PowBlock> getPowChainHead();

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClient.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClient.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.apache.logging.log4j.LogManager;
@@ -44,6 +45,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
   private final Web3j eth1Web3j;
   private final HttpService eeWeb3jService;
+  private final AtomicLong nextId = new AtomicLong(MESSAGE_ORDER_RESET_ID);
 
   public Web3JExecutionEngineClient(String eeEndpoint) {
     this.eeWeb3jService = new HttpService(eeEndpoint, createOkHttpClient());
@@ -122,6 +124,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
   private <T> SafeFuture<Response<T>> doRequest(
       Request<?, ? extends org.web3j.protocol.core.Response<T>> web3jRequest) {
+    web3jRequest.setId(nextId.getAndIncrement());
     CompletableFuture<Response<T>> responseFuture =
         web3jRequest
             .sendAsync()


### PR DESCRIPTION
## PR Description

no way to avoid double `AtomicLong` increment. In any case you have to use the constructor with params since `setWeb3jService` method is not present.

## Fixed Issue(s)
fixes #4716 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
