### PR TITLE
Add the mutable local validator source.

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSource.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSource.java
@@ -20,6 +20,7 @@ import java.net.http.HttpClient;
 import java.util.List;
 import java.util.function.Supplier;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.core.signatures.Signer;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -85,6 +86,17 @@ public class ExternalValidatorSource implements ValidatorSource {
     return publicKeys.stream()
         .map(key -> new ExternalValidatorProvider(spec, key))
         .collect(toList());
+  }
+
+  @Override
+  public boolean canAddValidator() {
+    return false;
+  }
+
+  @Override
+  public MutableValidatorAddResult addValidator(
+      final KeyStoreData keyStoreData, final String password) {
+    throw new UnsupportedOperationException();
   }
 
   private static void setupExternalSignerStatusLogging(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/LocalValidatorSource.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/LocalValidatorSource.java
@@ -72,6 +72,17 @@ public class LocalValidatorSource implements ValidatorSource {
     return filePairs.stream().map(this::createValidatorProvider).collect(toList());
   }
 
+  @Override
+  public boolean canAddValidator() {
+    return false;
+  }
+
+  @Override
+  public MutableValidatorAddResult addValidator(
+      final KeyStoreData keyStoreData, final String password) {
+    throw new UnsupportedOperationException();
+  }
+
   private ValidatorProvider createValidatorProvider(
       final Pair<Path, Path> keystorePasswordFilePair) {
     final Path keystorePath = keystorePasswordFilePair.getLeft();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/MockStartValidatorSource.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/MockStartValidatorSource.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.core.signatures.LocalSigner;
@@ -50,6 +51,17 @@ public class MockStartValidatorSource implements ValidatorSource {
         .generateKeyPairs(startIndex, endIndex).stream()
             .map(MockStartValidatorProvider::new)
             .collect(toList());
+  }
+
+  @Override
+  public boolean canAddValidator() {
+    return false;
+  }
+
+  @Override
+  public MutableValidatorAddResult addValidator(
+      final KeyStoreData keyStoreData, final String password) {
+    throw new UnsupportedOperationException();
   }
 
   private class MockStartValidatorProvider implements ValidatorProvider {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/MutableLocalValidatorSource.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/MutableLocalValidatorSource.java
@@ -25,8 +25,8 @@ import tech.pegasys.teku.core.signatures.SlashingProtector;
 
 public class MutableLocalValidatorSource extends SlashingProtectedValidatorSource {
 
-  public MutableLocalValidatorSource(
-      final ValidatorSource delegate, final SlashingProtector slashingProtector) {
+  MutableLocalValidatorSource(
+      final LocalValidatorSource delegate, final SlashingProtector slashingProtector) {
     super(delegate, slashingProtector);
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/MutableValidatorAddResult.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/MutableValidatorAddResult.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.loader;
+
+import java.util.Objects;
+import java.util.Optional;
+import tech.pegasys.teku.core.signatures.Signer;
+import tech.pegasys.teku.validator.client.restapi.apis.schema.PostKeyResult;
+
+public class MutableValidatorAddResult {
+  private final PostKeyResult result;
+  private final Optional<Signer> signer;
+
+  public MutableValidatorAddResult(final PostKeyResult result, final Optional<Signer> signer) {
+    this.result = result;
+    this.signer = signer;
+  }
+
+  public PostKeyResult getResult() {
+    return result;
+  }
+
+  public Optional<Signer> getSigner() {
+    return signer;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final MutableValidatorAddResult that = (MutableValidatorAddResult) o;
+    return Objects.equals(result, that.result) && Objects.equals(signer, that.signer);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(result, signer);
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorLoader.java
@@ -15,17 +15,14 @@ package tech.pegasys.teku.validator.client.loader;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
-import java.io.File;
 import java.net.http.HttpClient;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.core.signatures.SlashingProtector;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -33,20 +30,23 @@ import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.validator.api.GraffitiProvider;
 import tech.pegasys.teku.validator.api.InteropConfig;
-import tech.pegasys.teku.validator.api.KeyStoreFilesLocator;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
-import tech.pegasys.teku.validator.client.ValidatorClientService;
 import tech.pegasys.teku.validator.client.loader.ValidatorSource.ValidatorProvider;
+import tech.pegasys.teku.validator.client.restapi.apis.schema.PostKeyResult;
 
 public class ValidatorLoader {
 
   private final List<ValidatorSource> validatorSources;
+  private final Optional<ValidatorSource> mutableValidatorSource;
   private final OwnedValidators ownedValidators = new OwnedValidators();
   private final GraffitiProvider graffitiProvider;
 
   private ValidatorLoader(
-      final List<ValidatorSource> validatorSources, final GraffitiProvider graffitiProvider) {
+      final List<ValidatorSource> validatorSources,
+      final Optional<ValidatorSource> mutableValidatorSource,
+      final GraffitiProvider graffitiProvider) {
     this.validatorSources = validatorSources;
+    this.mutableValidatorSource = mutableValidatorSource;
     this.graffitiProvider = graffitiProvider;
   }
 
@@ -58,7 +58,7 @@ public class ValidatorLoader {
       final PublicKeyLoader publicKeyLoader,
       final AsyncRunner asyncRunner,
       final MetricsSystem metricsSystem,
-      final Optional<DataDirLayout> maybeDataDir) {
+      final Optional<DataDirLayout> maybeMutableDir) {
     final Supplier<HttpClient> externalSignerHttpClientFactory =
         Suppliers.memoize(new HttpClientExternalSignerFactory(config)::get);
     return create(
@@ -70,7 +70,28 @@ public class ValidatorLoader {
         publicKeyLoader,
         asyncRunner,
         metricsSystem,
-        maybeDataDir);
+        maybeMutableDir);
+  }
+
+  // synchronized to ensure that only one load is active at a time
+  public synchronized void loadValidators() {
+    final Map<BLSPublicKey, ValidatorProvider> validatorProviders = new HashMap<>();
+    validatorSources.forEach(source -> addValidatorsFromSource(validatorProviders, source));
+    MultithreadedValidatorLoader.loadValidators(
+        ownedValidators, validatorProviders, graffitiProvider);
+  }
+
+  public synchronized MutableValidatorAddResult loadMutableValidator(
+      final KeyStoreData keyStoreData, final String password) {
+    if (mutableValidatorSource.isPresent() && mutableValidatorSource.get().canAddValidator()) {
+      return mutableValidatorSource.get().addValidator(keyStoreData, password);
+    }
+    return new MutableValidatorAddResult(
+        PostKeyResult.error("Not able to add validator"), Optional.empty());
+  }
+
+  public OwnedValidators getOwnedValidators() {
+    return ownedValidators;
   }
 
   @VisibleForTesting
@@ -83,117 +104,24 @@ public class ValidatorLoader {
       final PublicKeyLoader publicKeyLoader,
       final AsyncRunner asyncRunner,
       final MetricsSystem metricsSystem,
-      final Optional<DataDirLayout> maybeDataDir) {
-    final List<ValidatorSource> validatorSources = new ArrayList<>();
-    if (interopConfig.isInteropEnabled()) {
-      validatorSources.add(
-          slashingProtected(
-              new MockStartValidatorSource(spec, interopConfig, asyncRunner), slashingProtector));
-    } else {
-      addExternalValidatorSource(
-          spec,
-          config,
-          externalSignerHttpClientFactory,
-          slashingProtector,
-          publicKeyLoader,
-          asyncRunner,
-          metricsSystem,
-          validatorSources);
-      addLocalValidatorSource(spec, config, slashingProtector, asyncRunner, validatorSources);
-      if (maybeDataDir.isPresent()) {
-        addMutableValidatorSource(
-            spec, config, slashingProtector, asyncRunner, validatorSources, maybeDataDir.get());
-      }
-    }
+      final Optional<DataDirLayout> maybeMutableDir) {
+    final ValidatorSourceFactory validatorSources =
+        new ValidatorSourceFactory(
+            spec,
+            config,
+            interopConfig,
+            externalSignerHttpClientFactory,
+            slashingProtector,
+            publicKeyLoader,
+            asyncRunner,
+            metricsSystem,
+            maybeMutableDir);
 
-    return new ValidatorLoader(validatorSources, config.getGraffitiProvider());
-  }
-
-  private static void addMutableValidatorSource(
-      final Spec spec,
-      final ValidatorConfig config,
-      final SlashingProtector slashingProtector,
-      final AsyncRunner asyncRunner,
-      final List<ValidatorSource> validatorSources,
-      final DataDirLayout dataDirLayout) {
-    final Path keystorePath = ValidatorClientService.getAlterableKeystorePath(dataDirLayout);
-    final Path keystorePasswordPath =
-        ValidatorClientService.getAlterableKeystorePasswordPath(dataDirLayout);
-    if (Files.exists(keystorePath) && Files.exists(keystorePasswordPath)) {
-      final KeyStoreFilesLocator keyStoreFilesLocator =
-          new KeyStoreFilesLocator(
-              List.of(keystorePath + File.pathSeparator + keystorePasswordPath),
-              File.pathSeparator);
-      validatorSources.add(
-          slashingProtected(
-              new LocalValidatorSource(
-                  spec,
-                  config.isValidatorKeystoreLockingEnabled(),
-                  new KeystoreLocker(),
-                  keyStoreFilesLocator,
-                  asyncRunner,
-                  false),
-              slashingProtector));
-    }
-  }
-
-  private static void addLocalValidatorSource(
-      final Spec spec,
-      final ValidatorConfig config,
-      final SlashingProtector slashingProtector,
-      final AsyncRunner asyncRunner,
-      final List<ValidatorSource> validatorSources) {
-    if (config.getValidatorKeys() != null) {
-      KeyStoreFilesLocator keyStoreFilesLocator =
-          new KeyStoreFilesLocator(config.getValidatorKeys(), File.pathSeparator);
-      validatorSources.add(
-          slashingProtected(
-              new LocalValidatorSource(
-                  spec,
-                  config.isValidatorKeystoreLockingEnabled(),
-                  new KeystoreLocker(),
-                  keyStoreFilesLocator,
-                  asyncRunner,
-                  true),
-              slashingProtector));
-    }
-  }
-
-  private static void addExternalValidatorSource(
-      final Spec spec,
-      final ValidatorConfig config,
-      final Supplier<HttpClient> externalSignerHttpClientFactory,
-      final SlashingProtector slashingProtector,
-      final PublicKeyLoader publicKeyLoader,
-      final AsyncRunner asyncRunner,
-      final MetricsSystem metricsSystem,
-      final List<ValidatorSource> validatorSources) {
-    if (!config.getValidatorExternalSignerPublicKeySources().isEmpty()) {
-      final ValidatorSource externalValidatorSource =
-          ExternalValidatorSource.create(
-              spec,
-              metricsSystem,
-              config,
-              externalSignerHttpClientFactory,
-              publicKeyLoader,
-              asyncRunner);
-      validatorSources.add(
-          config.isValidatorExternalSignerSlashingProtectionEnabled()
-              ? slashingProtected(externalValidatorSource, slashingProtector)
-              : externalValidatorSource);
-    }
-  }
-
-  // synchronized to ensure that only one load is active at a time
-  public synchronized void loadValidators() {
-    final Map<BLSPublicKey, ValidatorProvider> validatorProviders = new HashMap<>();
-    validatorSources.forEach(source -> addValidatorsFromSource(validatorProviders, source));
-    MultithreadedValidatorLoader.loadValidators(
-        ownedValidators, validatorProviders, graffitiProvider);
-  }
-
-  public OwnedValidators getOwnedValidators() {
-    return ownedValidators;
+    final List<ValidatorSource> validatorSourceList = validatorSources.createValidatorSources();
+    return new ValidatorLoader(
+        validatorSourceList,
+        validatorSources.getMutableValidatorSource(),
+        config.getGraffitiProvider());
   }
 
   private void addValidatorsFromSource(
@@ -203,10 +131,5 @@ public class ValidatorLoader {
         .forEach(
             validatorProvider ->
                 validators.putIfAbsent(validatorProvider.getPublicKey(), validatorProvider));
-  }
-
-  private static ValidatorSource slashingProtected(
-      final ValidatorSource validatorSource, final SlashingProtector slashingProtector) {
-    return new SlashingProtectedValidatorSource(validatorSource, slashingProtector);
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorLoader.java
@@ -120,7 +120,7 @@ public class ValidatorLoader {
     final List<ValidatorSource> validatorSourceList = validatorSources.createValidatorSources();
     return new ValidatorLoader(
         validatorSourceList,
-        validatorSources.getMutableValidatorSource(),
+        validatorSources.getMutableLocalValidatorSource(),
         config.getGraffitiProvider());
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorSource.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorSource.java
@@ -14,11 +14,16 @@
 package tech.pegasys.teku.validator.client.loader;
 
 import java.util.List;
+import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.core.signatures.Signer;
 
 public interface ValidatorSource {
   List<ValidatorProvider> getAvailableValidators();
+
+  boolean canAddValidator();
+
+  MutableValidatorAddResult addValidator(KeyStoreData keyStoreData, String password);
 
   interface ValidatorProvider {
     BLSPublicKey getPublicKey();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorSourceFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorSourceFactory.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.loader;
+
+import java.io.File;
+import java.net.http.HttpClient;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.core.signatures.SlashingProtector;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.validator.api.InteropConfig;
+import tech.pegasys.teku.validator.api.KeyStoreFilesLocator;
+import tech.pegasys.teku.validator.api.ValidatorConfig;
+import tech.pegasys.teku.validator.client.ValidatorClientService;
+
+public class ValidatorSourceFactory {
+  private final Spec spec;
+  private final ValidatorConfig config;
+  private final InteropConfig interopConfig;
+  private final Supplier<HttpClient> externalSignerHttpClientFactory;
+  private final SlashingProtector slashingProtector;
+  private final PublicKeyLoader publicKeyLoader;
+  private final AsyncRunner asyncRunner;
+  private final MetricsSystem metricsSystem;
+  private final Optional<DataDirLayout> maybeDataDir;
+  private Optional<ValidatorSource> mutableValidatorSource = Optional.empty();
+
+  public ValidatorSourceFactory(
+      final Spec spec,
+      final ValidatorConfig config,
+      final InteropConfig interopConfig,
+      final Supplier<HttpClient> externalSignerHttpClientFactory,
+      final SlashingProtector slashingProtector,
+      final PublicKeyLoader publicKeyLoader,
+      final AsyncRunner asyncRunner,
+      final MetricsSystem metricsSystem,
+      final Optional<DataDirLayout> maybeDataDir) {
+    this.spec = spec;
+    this.config = config;
+    this.interopConfig = interopConfig;
+    this.externalSignerHttpClientFactory = externalSignerHttpClientFactory;
+    this.slashingProtector = slashingProtector;
+    this.publicKeyLoader = publicKeyLoader;
+    this.asyncRunner = asyncRunner;
+    this.metricsSystem = metricsSystem;
+    this.maybeDataDir = maybeDataDir;
+  }
+
+  public List<ValidatorSource> createValidatorSources() {
+    final List<ValidatorSource> validatorSources = new ArrayList<>();
+    if (interopConfig.isInteropEnabled()) {
+      validatorSources.add(
+          slashingProtected(new MockStartValidatorSource(spec, interopConfig, asyncRunner)));
+    } else {
+      addExternalValidatorSource().ifPresent(validatorSources::add);
+      addLocalValidatorSource().ifPresent(validatorSources::add);
+      addMutableValidatorSource().ifPresent(validatorSources::add);
+    }
+    return validatorSources;
+  }
+
+  public Optional<ValidatorSource> getMutableValidatorSource() {
+    return mutableValidatorSource;
+  }
+
+  private Optional<ValidatorSource> addMutableValidatorSource() {
+    if (maybeDataDir.isEmpty()) {
+      return Optional.empty();
+    }
+    final DataDirLayout dataDirLayout = maybeDataDir.get();
+    final Path keystorePath = ValidatorClientService.getAlterableKeystorePath(dataDirLayout);
+    final Path keystorePasswordPath =
+        ValidatorClientService.getAlterableKeystorePasswordPath(dataDirLayout);
+    if (!(Files.exists(keystorePath) && Files.exists(keystorePasswordPath))) {
+      return Optional.empty();
+    }
+
+    final KeyStoreFilesLocator keyStoreFilesLocator =
+        new KeyStoreFilesLocator(
+            List.of(keystorePath + File.pathSeparator + keystorePasswordPath), File.pathSeparator);
+
+    mutableValidatorSource =
+        Optional.of(
+            mutableSlashingProtected(
+                new LocalValidatorSource(
+                    spec,
+                    config.isValidatorKeystoreLockingEnabled(),
+                    new KeystoreLocker(),
+                    keyStoreFilesLocator,
+                    asyncRunner,
+                    false)));
+    return mutableValidatorSource;
+  }
+
+  private Optional<ValidatorSource> addLocalValidatorSource() {
+    if (config.getValidatorKeys() == null) {
+      return Optional.empty();
+    }
+    KeyStoreFilesLocator keyStoreFilesLocator =
+        new KeyStoreFilesLocator(config.getValidatorKeys(), File.pathSeparator);
+    return Optional.of(
+        slashingProtected(
+            new LocalValidatorSource(
+                spec,
+                config.isValidatorKeystoreLockingEnabled(),
+                new KeystoreLocker(),
+                keyStoreFilesLocator,
+                asyncRunner,
+                true)));
+  }
+
+  private Optional<ValidatorSource> addExternalValidatorSource() {
+    if (config.getValidatorExternalSignerPublicKeySources().isEmpty()) {
+      return Optional.empty();
+    }
+    final ValidatorSource externalValidatorSource =
+        ExternalValidatorSource.create(
+            spec,
+            metricsSystem,
+            config,
+            externalSignerHttpClientFactory,
+            publicKeyLoader,
+            asyncRunner);
+    return Optional.of(
+        config.isValidatorExternalSignerSlashingProtectionEnabled()
+            ? slashingProtected(externalValidatorSource)
+            : externalValidatorSource);
+  }
+
+  private ValidatorSource slashingProtected(final ValidatorSource validatorSource) {
+    return new SlashingProtectedValidatorSource(validatorSource, slashingProtector);
+  }
+
+  private ValidatorSource mutableSlashingProtected(final ValidatorSource validatorSource) {
+    return new MutableLocalValidatorSource(validatorSource, slashingProtector);
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/PostKeyResult.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/PostKeyResult.java
@@ -43,7 +43,7 @@ public class PostKeyResult {
   }
 
   public static PostKeyResult error(final String message) {
-    return new PostKeyResult(ImportStatus.IMPORTED, Optional.of(message));
+    return new PostKeyResult(ImportStatus.ERROR, Optional.of(message));
   }
 
   @Override

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSourceTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSourceTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.loader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.validator.api.ValidatorConfig;
+
+public class ExternalValidatorSourceTest {
+  private final Spec spec = TestSpecFactory.createMinimalAltair();
+  private final PublicKeyLoader publicKeyLoader = mock(PublicKeyLoader.class);
+  private final HttpClient httpClient = mock(HttpClient.class);
+  private final MetricsSystem metricsSystem = new StubMetricsSystem();
+  private final AsyncRunner asyncRunner = new StubAsyncRunner();
+
+  @SuppressWarnings("unchecked")
+  private final HttpResponse<Void> httpResponse = mock(HttpResponse.class);
+
+  private ValidatorConfig config;
+  private ValidatorSource validatorSource;
+
+  public ExternalValidatorSourceTest() {}
+
+  @BeforeEach
+  void setup() throws IOException, InterruptedException {
+    config =
+        ValidatorConfig.builder()
+            .validatorExternalSignerUrl(new URL("http://localhost:9000"))
+            .build();
+    when(httpResponse.statusCode()).thenReturn(SC_OK);
+    when(httpClient.send(any(), ArgumentMatchers.<HttpResponse.BodyHandler<Void>>any()))
+        .thenReturn(httpResponse);
+    validatorSource =
+        ExternalValidatorSource.create(
+            spec, metricsSystem, config, () -> httpClient, publicKeyLoader, asyncRunner);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenAddValidator() {
+    assertThatThrownBy(() -> validatorSource.addValidator(null, "pass"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void shouldSayFalseToAddValidators() {
+    assertThat(validatorSource.canAddValidator()).isFalse();
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/LocalValidatorSourceTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/LocalValidatorSourceTest.java
@@ -179,4 +179,15 @@ class LocalValidatorSourceTest {
     final BLSSignature signature = signingFuture.getNow(null);
     assertThat(BLS.verify(expectedKeyPair.getPublicKey(), signingRoot, signature)).isTrue();
   }
+
+  @Test
+  void shouldThrowExceptionWhenAddValidator() {
+    assertThatThrownBy(() -> validatorSource.addValidator(null, "pass"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void shouldSayFalseToAddValidators() {
+    assertThat(validatorSource.canAddValidator()).isFalse();
+  }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/MutableLocalValidatorSourceTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/MutableLocalValidatorSourceTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.loader;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.commons.lang3.NotImplementedException;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.core.signatures.SlashingProtector;
+
+class MutableLocalValidatorSourceTest {
+  private final ValidatorSource delegate = mock(ValidatorSource.class);
+  private final SlashingProtector slashingProtector = mock(SlashingProtector.class);
+  final MutableLocalValidatorSource validatorSource =
+      new MutableLocalValidatorSource(delegate, slashingProtector);
+
+  @Test
+  void shouldCreateMutableValidatorSource() {
+    assertThatThrownBy(() -> validatorSource.addValidator(null, "pass"))
+        .isInstanceOf(NotImplementedException.class);
+  }
+
+  @Test
+  void canAddValidator_shouldBeTrue() {
+    assertThat(validatorSource.canAddValidator()).isTrue();
+  }
+
+  @Test
+  void availableValidators_shouldNotBeReadOnly() {
+    when(delegate.getAvailableValidators())
+        .thenReturn(List.of(mock(ValidatorSource.ValidatorProvider.class)));
+    assertThat(validatorSource.getAvailableValidators().get(0).isReadOnly()).isFalse();
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/MutableLocalValidatorSourceTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/MutableLocalValidatorSourceTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.core.signatures.SlashingProtector;
 
 class MutableLocalValidatorSourceTest {
-  private final ValidatorSource delegate = mock(ValidatorSource.class);
+  private final LocalValidatorSource delegate = mock(LocalValidatorSource.class);
   private final SlashingProtector slashingProtector = mock(SlashingProtector.class);
   final MutableLocalValidatorSource validatorSource =
       new MutableLocalValidatorSource(delegate, slashingProtector);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/SlashingProtectedValidatorSourceTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/SlashingProtectedValidatorSourceTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.loader;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.core.signatures.SlashingProtector;
+
+public class SlashingProtectedValidatorSourceTest {
+  private final ValidatorSource delegate = mock(ValidatorSource.class);
+  private final SlashingProtector slashingProtector = mock(SlashingProtector.class);
+  private final ValidatorSource validatorSource =
+      new SlashingProtectedValidatorSource(delegate, slashingProtector);
+
+  @Test
+  void shouldDelegateAddValidator() {
+    validatorSource.addValidator(null, "pass");
+    verify(delegate).addValidator(null, "pass");
+  }
+
+  @Test
+  void shouldDelegateCanAddValidator() {
+    validatorSource.canAddValidator();
+    verify(delegate).canAddValidator();
+  }
+
+  @Test
+  void availableValidators_shouldBeReadOnly() {
+    final ValidatorSource.ValidatorProvider provider =
+        mock(ValidatorSource.ValidatorProvider.class);
+    when(provider.isReadOnly()).thenReturn(true);
+    when(delegate.getAvailableValidators()).thenReturn(List.of(provider));
+    assertThat(validatorSource.getAvailableValidators().get(0).isReadOnly()).isTrue();
+  }
+}


### PR DESCRIPTION
 - the result of adding a validator is a little more complex so a POJO has been added
 - split out the static implementations in ValidatorLoader to a ValidatorSourceFactory.
 - stubbed the implementation of `loadMutableValidator` to load an individual local keystore to the mutable validator source

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
