### PR TITLE
[Merge] Periodically retry execution of optimistic chain heads

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -32,5 +32,7 @@ public interface ReadOnlyForkChoiceStrategy {
   /** @return A map from blockRoot to blockSlot for current chain heads */
   Map<Bytes32, UInt64> getChainHeads();
 
+  Map<Bytes32, UInt64> getOptimisticChainHeads();
+
   boolean contains(Bytes32 blockRoot);
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
@@ -79,6 +79,11 @@ public class RandomChainBuilderForkChoiceStrategy implements ReadOnlyForkChoiceS
   }
 
   @Override
+  public Map<Bytes32, UInt64> getOptimisticChainHeads() {
+    return Collections.emptyMap();
+  }
+
+  @Override
   public boolean contains(final Bytes32 blockRoot) {
     return getBlock(blockRoot).isPresent();
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/OptimisticHeadValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/OptimisticHeadValidator.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import java.time.Duration;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.Cancellable;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.service.serviceutils.Service;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+/**
+ * Periodically retries execution any chain heads that are only optimistically validated.
+ *
+ * <p>This ensures that any forks which are unable to be verified because the EL is syncing are
+ * retried. It also handles the case at startup where all non-finalized nodes are considered
+ * optimistically sync'd.
+ *
+ * <p>We only need to verify the chain head since a VALID response for a block also indicates all
+ * ancestors are valid.
+ */
+public class OptimisticHeadValidator extends Service {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  static final Duration RECHECK_INTERVAL = Duration.ofMinutes(1);
+  private final AsyncRunner asyncRunner;
+  private final RecentChainData recentChainData;
+  private final ExecutionEngineChannel executionEngine;
+  private Optional<Cancellable> cancellable = Optional.empty();
+
+  public OptimisticHeadValidator(
+      final AsyncRunner asyncRunner,
+      final RecentChainData recentChainData,
+      final ExecutionEngineChannel executionEngine) {
+    this.asyncRunner = asyncRunner;
+    this.recentChainData = recentChainData;
+    this.executionEngine = executionEngine;
+  }
+
+  @Override
+  protected synchronized SafeFuture<?> doStart() {
+    cancellable =
+        Optional.of(
+            asyncRunner.runWithFixedDelay(
+                this::verifyOptimisticHeads,
+                RECHECK_INTERVAL,
+                error -> LOG.error("Failed to validate optimistic chain heads", error)));
+    // Run immediately on start
+    verifyOptimisticHeads();
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
+  protected synchronized SafeFuture<?> doStop() {
+    cancellable.ifPresent(Cancellable::cancel);
+    cancellable = Optional.empty();
+    return SafeFuture.COMPLETE;
+  }
+
+  private void verifyOptimisticHeads() {
+    SafeFuture.allOf(
+            recentChainData.getOptimisticChainHeads().keySet().stream()
+                .map(this::reexecuteBlockPayload)
+                .toArray(SafeFuture[]::new))
+        .reportExceptions();
+  }
+
+  private SafeFuture<Void> reexecuteBlockPayload(final Bytes32 blockRoot) {
+    return recentChainData
+        .retrieveBlockByRoot(blockRoot)
+        .thenCompose(
+            maybeBlock ->
+                maybeBlock
+                    .flatMap(block -> block.getBody().getOptionalExecutionPayload())
+                    .map(executionPayload -> reexecutePayload(blockRoot, executionPayload))
+                    .orElse(SafeFuture.COMPLETE))
+        .exceptionally(
+            error -> {
+              LOG.warn("Failed to verify execution payload for block {}", blockRoot, error);
+              return null;
+            });
+  }
+
+  private SafeFuture<Void> reexecutePayload(
+      final Bytes32 blockRoot, final ExecutionPayload executionPayload) {
+    if (executionPayload.isDefault()) {
+      return SafeFuture.COMPLETE;
+    }
+    return executionEngine
+        .executePayload(executionPayload)
+        .thenAccept(
+            result ->
+                recentChainData
+                    .getForkChoiceStrategy()
+                    .orElseThrow()
+                    .onExecutionPayloadResult(blockRoot, result.getStatus()));
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/OptimisticHeadValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/OptimisticHeadValidatorTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.spec.executionengine.ExecutionPayloadStatus.VALID;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.executionengine.ExecutePayloadResult;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+class OptimisticHeadValidatorTest {
+  private final Spec spec = TestSpecFactory.createMinimalMerge();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
+  private final ExecutionEngineChannel executionEngine = mock(ExecutionEngineChannel.class);
+  private final ForkChoiceStrategy forkChoiceStrategy = mock(ForkChoiceStrategy.class);
+  private final RecentChainData recentChainData = mock(RecentChainData.class);
+
+  private final OptimisticHeadValidator validator =
+      new OptimisticHeadValidator(asyncRunner, recentChainData, executionEngine);
+
+  @BeforeEach
+  void setUp() {
+    when(recentChainData.getForkChoiceStrategy()).thenReturn(Optional.of(forkChoiceStrategy));
+    assertThat(validator.start()).isCompleted();
+  }
+
+  @Test
+  void shouldExecutePayloadsFromOptimisticChainHeads() {
+    final ExecutionPayload payload1 = dataStructureUtil.randomExecutionPayload();
+    final BeaconBlock block1 = dataStructureUtil.blockBuilder(1).executionPayload(payload1).build();
+    final BeaconBlock block2 = dataStructureUtil.blockBuilder(2).build();
+
+    when(recentChainData.getOptimisticChainHeads())
+        .thenReturn(Map.of(block1.getRoot(), block1.getSlot(), block2.getRoot(), block2.getSlot()));
+
+    when(recentChainData.retrieveBlockByRoot(block1.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block1)));
+    when(recentChainData.retrieveBlockByRoot(block2.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block2)));
+
+    when(executionEngine.executePayload(
+            block1.getBody().getOptionalExecutionPayload().orElseThrow()))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                new ExecutePayloadResult(VALID, Optional.empty(), Optional.empty())));
+
+    asyncRunner.executeQueuedActions();
+
+    verify(forkChoiceStrategy).onExecutionPayloadResult(block1.getRoot(), VALID);
+    verify(forkChoiceStrategy, never()).onExecutionPayloadResult(eq(block2.getRoot()), any());
+
+    // Should not execute default payloads
+    verify(executionEngine, never())
+        .executePayload(block2.getBody().getOptionalExecutionPayload().orElseThrow());
+  }
+
+  @Test
+  void shouldPeriodicallyReverify() {
+    when(recentChainData.getOptimisticChainHeads()).thenReturn(emptyMap());
+
+    // Should run immediately at startup
+    asyncRunner.executeDueActions();
+    verify(recentChainData).getOptimisticChainHeads();
+
+    // Too soon to retry
+    timeProvider.advanceTimeBy(OptimisticHeadValidator.RECHECK_INTERVAL.minusSeconds(1));
+    asyncRunner.executeDueActions();
+    verify(recentChainData, times(1)).getOptimisticChainHeads();
+
+    // And then retry when interval is reached
+    timeProvider.advanceTimeBySeconds(1);
+    asyncRunner.executeQueuedActions();
+    verify(recentChainData, times(2)).getOptimisticChainHeads();
+  }
+}

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoNode.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoNode.java
@@ -165,6 +165,10 @@ public class ProtoNode {
     return validationStatus == ProtoNodeValidationStatus.INVALID;
   }
 
+  public boolean isOptimistic() {
+    return validationStatus == ProtoNodeValidationStatus.OPTIMISTIC;
+  }
+
   public void setValidationStatus(final ProtoNodeValidationStatus validationStatus) {
     checkState(
         this.validationStatus == ProtoNodeValidationStatus.OPTIMISTIC

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/AbstractBlockMetadataStoreTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/AbstractBlockMetadataStoreTest.java
@@ -39,7 +39,7 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
 abstract class AbstractBlockMetadataStoreTest {
 
-  protected final Spec spec = TestSpecFactory.createDefault();
+  protected final Spec spec = TestSpecFactory.createMinimalMerge();
   private final ChainBuilder chainBuilder = ChainBuilder.create(spec);
   private final SignedBlockAndState genesis = chainBuilder.generateGenesis();
   private final Checkpoint genesisCheckpoint =

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -16,10 +16,8 @@ package tech.pegasys.teku.services.beaconchain;
 import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
 import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
-import static tech.pegasys.teku.util.config.Constants.SECONDS_PER_SLOT;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
 import com.google.common.base.Throwables;
 import java.net.BindException;
 import java.nio.file.Path;
@@ -27,6 +25,7 @@ import java.time.Duration;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.Random;
+import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -86,6 +85,7 @@ import tech.pegasys.teku.statetransition.block.BlockManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
+import tech.pegasys.teku.statetransition.forkchoice.OptimisticHeadValidator;
 import tech.pegasys.teku.statetransition.forkchoice.TerminalPowBlockMonitor;
 import tech.pegasys.teku.statetransition.genesis.GenesisHandler;
 import tech.pegasys.teku.statetransition.synccommittee.SignedContributionAndProofValidator;
@@ -176,17 +176,16 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   private volatile OperationPool<SignedVoluntaryExit> voluntaryExitPool;
   private volatile SyncCommitteeContributionPool syncCommitteeContributionPool;
   private volatile SyncCommitteeMessagePool syncCommitteeMessagePool;
-  private volatile OperationsReOrgManager operationsReOrgManager;
   private volatile WeakSubjectivityValidator weakSubjectivityValidator;
   private volatile PerformanceTracker performanceTracker;
   private volatile PendingPool<SignedBeaconBlock> pendingBlocks;
   private volatile CoalescingChainHeadChannel coalescingChainHeadChannel;
   private volatile ActiveValidatorTracker activeValidatorTracker;
   private volatile AttestationTopicSubscriber attestationTopicSubscriber;
-  private volatile SyncCommitteeSubscriptionManager syncCommitteeSubscriptionManager;
   private volatile ForkChoiceNotifier forkChoiceNotifier;
   private volatile ExecutionEngineChannel executionEngine;
   private volatile Optional<TerminalPowBlockMonitor> terminalPowBlockMonitor = Optional.empty();
+  private volatile Optional<OptimisticHeadValidator> optimisticHeadValidator = Optional.empty();
 
   private UInt64 genesisTimeTracker = ZERO;
   private BlockManager blockManager;
@@ -261,7 +260,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             attestationManager.stop(),
             p2pNetwork.stop(),
             SafeFuture.fromRunnable(
-                () -> terminalPowBlockMonitor.ifPresent(TerminalPowBlockMonitor::stop)))
+                () -> terminalPowBlockMonitor.ifPresent(TerminalPowBlockMonitor::stop)),
+            SafeFuture.fromRunnable(() -> optimisticHeadValidator.ifPresent(Service::stop)))
         .thenRun(forkChoiceExecutor::stop);
   }
 
@@ -315,6 +315,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     initExecutionEngine();
     initForkChoiceNotifier();
     initTerminalPowBlockMonitor();
+    initOptimisticHeadValidator();
     initForkChoice();
     initBlockImporter();
     initCombinedChainDataClient();
@@ -352,6 +353,14 @@ public class BeaconChainController extends Service implements TimeTickChannel {
           Optional.of(
               new TerminalPowBlockMonitor(
                   executionEngine, spec, recentChainData, forkChoiceNotifier, beaconAsyncRunner));
+    }
+  }
+
+  private void initOptimisticHeadValidator() {
+    if (spec.isMilestoneSupported(SpecMilestone.MERGE)) {
+      optimisticHeadValidator =
+          Optional.of(
+              new OptimisticHeadValidator(beaconAsyncRunner, recentChainData, executionEngine));
     }
   }
 
@@ -435,9 +444,8 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     return wsInitializer
         .finalizeAndStoreConfig(beaconConfig.weakSubjectivity(), queryChannel, updateChannel)
         .thenAccept(
-            finalConfig -> {
-              this.weakSubjectivityValidator = WeakSubjectivityValidator.moderate(finalConfig);
-            });
+            finalConfig ->
+                this.weakSubjectivityValidator = WeakSubjectivityValidator.moderate(finalConfig));
   }
 
   private void initForkChoice() {
@@ -517,7 +525,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
                 VersionProvider.getDefaultGraffiti(),
                 forkChoiceNotifier,
                 executionEngine));
-    syncCommitteeSubscriptionManager =
+    SyncCommitteeSubscriptionManager syncCommitteeSubscriptionManager =
         beaconConfig.p2pConfig().isSubscribeAllSubnetsEnabled()
             ? new AllSyncCommitteeSubscriptions(p2pNetwork, spec)
             : new SyncCommitteeSubscriptionManager(p2pNetwork);
@@ -845,7 +853,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
 
   private void initOperationsReOrgManager() {
     LOG.debug("BeaconChainController.initOperationsReOrgManager()");
-    operationsReOrgManager =
+    OperationsReOrgManager operationsReOrgManager =
         new OperationsReOrgManager(
             proposerSlashingPool,
             attesterSlashingPool,
@@ -920,6 +928,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
     }
     slotProcessor.setCurrentSlot(currentSlot);
     performanceTracker.start(currentSlot);
+    optimisticHeadValidator.ifPresent(validator -> validator.start().reportExceptions());
   }
 
   private UInt64 getCurrentSlot(final UInt64 genesisTime) {
@@ -927,14 +936,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
   }
 
   private UInt64 getCurrentSlot(final UInt64 genesisTime, final UInt64 currentTime) {
-    final UInt64 currentSlot;
-    if (currentTime.compareTo(genesisTime) >= 0) {
-      UInt64 deltaTime = currentTime.minus(genesisTime);
-      currentSlot = deltaTime.dividedBy(SECONDS_PER_SLOT);
-    } else {
-      currentSlot = ZERO;
-    }
-    return currentSlot;
+    return spec.getCurrentSlot(currentTime, genesisTime);
   }
 
   private void validateChain(final UInt64 currentSlot) {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -261,7 +261,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             p2pNetwork.stop(),
             SafeFuture.fromRunnable(
                 () -> terminalPowBlockMonitor.ifPresent(TerminalPowBlockMonitor::stop)),
-            SafeFuture.fromRunnable(() -> optimisticHeadValidator.ifPresent(Service::stop)))
+            optimisticHeadValidator.map(Service::stop).orElse(SafeFuture.completedFuture(null)))
         .thenRun(forkChoiceExecutor::stop);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -545,6 +545,12 @@ public abstract class RecentChainData implements StoreUpdateHandler {
         .orElse(Collections.emptyMap());
   }
 
+  public Map<Bytes32, UInt64> getOptimisticChainHeads() {
+    return getForkChoiceStrategy()
+        .map(ReadOnlyForkChoiceStrategy::getOptimisticChainHeads)
+        .orElse(Collections.emptyMap());
+  }
+
   public Set<Bytes32> getAllBlockRootsAtSlot(final UInt64 slot) {
     return getForkChoiceStrategy()
         .map(forkChoiceStrategy -> forkChoiceStrategy.getBlockRootsAtSlot(slot))

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -181,6 +181,16 @@ public class ChainUpdater {
     saveBlockTime(block);
   }
 
+  public void saveOptimisticBlock(final SignedBlockAndState block) {
+    assertThat(spec.isBlockProcessorOptimistic(block.getSlot()))
+        .withFailMessage("can't save optimistic block if block processor is not optimistic")
+        .isTrue();
+    final StoreTransaction tx = recentChainData.startStoreTransaction();
+    tx.putBlockAndState(block.getBlock(), block.getState());
+    assertThat(tx.commit()).isCompleted();
+    saveBlockTime(block);
+  }
+
   public void saveBlockTime(final SignedBlockAndState block) {
     // Make sure time is consistent with block
     final UInt64 blockTime = getSlotTime(block.getSlot());


### PR DESCRIPTION
## PR Description
If the EL is offline or syncing we may not be able to verify execution payloads and need to retry them later. To ensure this happens, periodically execute each chain head that is only optimistically verified.  If the chain head is valid, all ancestors are also valid.

## Fixed Issue(s)
fixes #4647 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
