### PR TITLE
Add hidden options to tune signature verification service

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/signatures/SignatureVerificationService.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/signatures/SignatureVerificationService.java
@@ -13,17 +13,11 @@
 
 package tech.pegasys.teku.statetransition.validation.signatures;
 
-import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 
 public abstract class SignatureVerificationService extends Service
     implements AsyncBLSSignatureVerifier {
-  public static SignatureVerificationService createAggregatingService(
-      final MetricsSystem metrics, final AsyncRunnerFactory asyncRunnerFactory) {
-    return new AggregatingSignatureVerificationService(metrics, asyncRunnerFactory);
-  }
 
   public static SignatureVerificationService createSimple() {
     return new SimpleSignatureVerificationService();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/signatures/AggregatingSignatureVerificationServiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/signatures/AggregatingSignatureVerificationServiceTest.java
@@ -47,6 +47,7 @@ public class AggregatingSignatureVerificationServiceTest {
   private final int batchSize = 25;
   private final int minBatchSizeToSplit = 5;
   private final int numThreads = 2;
+  private final boolean strictThreadLimitEnabled = true;
 
   private final StubAsyncRunnerFactory asyncRunnerFactory = new StubAsyncRunnerFactory();
   private AggregatingSignatureVerificationService service =
@@ -56,7 +57,8 @@ public class AggregatingSignatureVerificationServiceTest {
           numThreads,
           queueCapacity,
           batchSize,
-          minBatchSizeToSplit);
+          minBatchSizeToSplit,
+          strictThreadLimitEnabled);
 
   @Test
   public void start_shouldQueueTasks() {
@@ -238,7 +240,13 @@ public class AggregatingSignatureVerificationServiceTest {
         AsyncRunnerFactory.createDefault(new MetricTrackingExecutorFactory(metrics));
     service =
         new AggregatingSignatureVerificationService(
-            metrics, realRunnerFactory, 1, queueCapacity, batchSize, minBatchSizeToSplit);
+            metrics,
+            realRunnerFactory,
+            1,
+            queueCapacity,
+            batchSize,
+            minBatchSizeToSplit,
+            strictThreadLimitEnabled);
     startService();
 
     final Random random = new Random(1);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -32,6 +32,10 @@ public class P2PConfig {
   public static final boolean DEFAULT_SUBSCRIBE_ALL_SUBNETS_ENABLED = false;
   public static final boolean DEFAULT_GOSSIP_SCORING_ENABLED = false;
   public static final boolean DEFAULT_BATCH_VERIFY_ATTESTATION_SIGNATURES = true;
+  public static final int DEFAULT_BATCH_VERIFY_MAX_THREADS = 2;
+  public static final int DEFAULT_BATCH_VERIFY_QUEUE_CAPACITY = 15_000;
+  public static final int DEFAULT_BATCH_VERIFY_MAX_BATCH_SIZE = 250;
+  public static final boolean DEFAULT_BATCH_VERIFY_STRICT_THREAD_LIMIT_ENABLED = false;
 
   private final Spec spec;
   private final NetworkConfig networkConfig;
@@ -44,6 +48,10 @@ public class P2PConfig {
   private final int peerRateLimit;
   private final int peerRequestLimit;
   private final boolean batchVerifyAttestationSignatures;
+  private final int batchVerifyMaxThreads;
+  private final int batchVerifyQueueCapacity;
+  private final int batchVerifyMaxBatchSize;
+  private final boolean batchVerifyStrictThreadLimitEnabled;
 
   private P2PConfig(
       final Spec spec,
@@ -55,7 +63,11 @@ public class P2PConfig {
       final boolean subscribeAllSubnetsEnabled,
       final int peerRateLimit,
       final int peerRequestLimit,
-      final boolean batchVerifyAttestationSignatures) {
+      final boolean batchVerifyAttestationSignatures,
+      final int batchVerifyMaxThreads,
+      final int batchVerifyQueueCapacity,
+      final int batchVerifyMaxBatchSize,
+      final boolean batchVerifyStrictThreadLimitEnabled) {
     this.spec = spec;
     this.networkConfig = networkConfig;
     this.discoveryConfig = discoveryConfig;
@@ -66,6 +78,10 @@ public class P2PConfig {
     this.peerRateLimit = peerRateLimit;
     this.peerRequestLimit = peerRequestLimit;
     this.batchVerifyAttestationSignatures = batchVerifyAttestationSignatures;
+    this.batchVerifyMaxThreads = batchVerifyMaxThreads;
+    this.batchVerifyQueueCapacity = batchVerifyQueueCapacity;
+    this.batchVerifyMaxBatchSize = batchVerifyMaxBatchSize;
+    this.batchVerifyStrictThreadLimitEnabled = batchVerifyStrictThreadLimitEnabled;
   }
 
   public static Builder builder() {
@@ -112,6 +128,22 @@ public class P2PConfig {
     return batchVerifyAttestationSignatures;
   }
 
+  public int getBatchVerifyMaxThreads() {
+    return batchVerifyMaxThreads;
+  }
+
+  public int getBatchVerifyMaxBatchSize() {
+    return batchVerifyMaxBatchSize;
+  }
+
+  public int getBatchVerifyQueueCapacity() {
+    return batchVerifyQueueCapacity;
+  }
+
+  public boolean isBatchVerifyStrictThreadLimitEnabled() {
+    return batchVerifyStrictThreadLimitEnabled;
+  }
+
   public static class Builder {
     private final NetworkConfig.Builder networkConfig = NetworkConfig.builder();
     private final DiscoveryConfig.Builder discoveryConfig = DiscoveryConfig.builder();
@@ -124,6 +156,11 @@ public class P2PConfig {
     private Integer peerRateLimit = DEFAULT_PEER_RATE_LIMIT;
     private Integer peerRequestLimit = DEFAULT_PEER_REQUEST_LIMIT;
     private Boolean batchVerifyAttestationSignatures = DEFAULT_BATCH_VERIFY_ATTESTATION_SIGNATURES;
+    private int batchVerifyMaxThreads = DEFAULT_BATCH_VERIFY_MAX_THREADS;
+    private int batchVerifyQueueCapacity = DEFAULT_BATCH_VERIFY_QUEUE_CAPACITY;
+    private int batchVerifyMaxBatchSize = DEFAULT_BATCH_VERIFY_MAX_BATCH_SIZE;
+    private boolean batchVerifyStrictThreadLimitEnabled =
+        DEFAULT_BATCH_VERIFY_STRICT_THREAD_LIMIT_ENABLED;
 
     private Builder() {}
 
@@ -155,7 +192,11 @@ public class P2PConfig {
           subscribeAllSubnetsEnabled,
           peerRateLimit,
           peerRequestLimit,
-          batchVerifyAttestationSignatures);
+          batchVerifyAttestationSignatures,
+          batchVerifyMaxThreads,
+          batchVerifyQueueCapacity,
+          batchVerifyMaxBatchSize,
+          batchVerifyStrictThreadLimitEnabled);
     }
 
     private void validate() {
@@ -212,6 +253,27 @@ public class P2PConfig {
         final Boolean batchVerifyAttestationSignatures) {
       checkNotNull(batchVerifyAttestationSignatures);
       this.batchVerifyAttestationSignatures = batchVerifyAttestationSignatures;
+      return this;
+    }
+
+    public Builder batchVerifyMaxThreads(final int batchVerifyMaxThreads) {
+      this.batchVerifyMaxThreads = batchVerifyMaxThreads;
+      return this;
+    }
+
+    public Builder batchVerifyQueueCapacity(final int batchVerifyQueueCapacity) {
+      this.batchVerifyQueueCapacity = batchVerifyQueueCapacity;
+      return this;
+    }
+
+    public Builder batchVerifyMaxBatchSize(final int batchVerifyMaxBatchSize) {
+      this.batchVerifyMaxBatchSize = batchVerifyMaxBatchSize;
+      return this;
+    }
+
+    public Builder batchVerifyStrictThreadLimitEnabled(
+        final boolean batchVerifyStrictThreadLimitEnabled) {
+      this.batchVerifyStrictThreadLimitEnabled = batchVerifyStrictThreadLimitEnabled;
       return this;
     }
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -148,6 +148,7 @@ public class P2POptions {
   @Option(
       names = {"--Xp2p-multipeer-sync-enabled"},
       paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
       description = "Enables experimental multipeer sync",
       hidden = true,
       arity = "1")
@@ -165,6 +166,7 @@ public class P2POptions {
   @Option(
       names = {"--Xp2p-gossip-scoring-enabled"},
       paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
       description = "Enables experimental gossip scoring",
       hidden = true,
       arity = "0..1",
@@ -174,6 +176,7 @@ public class P2POptions {
   @Option(
       names = {"--Xp2p-batch-verify-attestation-signatures-enabled"},
       paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
       description = "If true, turn on batch verification for gossiped attestation signatures",
       hidden = true,
       arity = "0..1")
@@ -197,6 +200,42 @@ public class P2POptions {
       arity = "1",
       hidden = true)
   private Integer peerRequestLimit = P2PConfig.DEFAULT_PEER_REQUEST_LIMIT;
+
+  @Option(
+      names = {"--Xp2p-batch-verify-signatures-max-threads"},
+      paramLabel = "<NUMBER>",
+      description = "Maximum number of threads to use for aggregated signature verification",
+      arity = "1",
+      hidden = true)
+  private int batchVerifyMaxThreads = P2PConfig.DEFAULT_BATCH_VERIFY_MAX_THREADS;
+
+  @Option(
+      names = {"--Xp2p-batch-verify-signatures-queue-capacity"},
+      paramLabel = "<NUMBER>",
+      description = "Maximum queue size for pending aggregated signature verification",
+      arity = "1",
+      hidden = true)
+  private int batchVerifyQueueCapacity = P2PConfig.DEFAULT_BATCH_VERIFY_QUEUE_CAPACITY;
+
+  @Option(
+      names = {"--Xp2p-batch-verify-signatures-max-batch-size"},
+      paramLabel = "<NUMBER>",
+      description = "Maximum number of verification tasks to include in a single batch",
+      arity = "1",
+      hidden = true)
+  private int batchVerifyMaxBatchSize = P2PConfig.DEFAULT_BATCH_VERIFY_MAX_BATCH_SIZE;
+
+  @Option(
+      names = {"--Xp2p-batch-verify-signatures-strict-thread-limit-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description =
+          "When enabled, signature verification is entirely constrained to the max threads with no use of shared executor pools",
+      arity = "1",
+      hidden = true,
+      fallbackValue = "true")
+  private boolean batchVerifyStrictThreadLimitEnabled =
+      P2PConfig.DEFAULT_BATCH_VERIFY_STRICT_THREAD_LIMIT_ENABLED;
 
   private int getP2pLowerBound() {
     if (p2pLowerBound > p2pUpperBound) {
@@ -222,6 +261,10 @@ public class P2POptions {
             b ->
                 b.subscribeAllSubnetsEnabled(subscribeAllSubnetsEnabled)
                     .batchVerifyAttestationSignatures(batchVerifyAttestationSignatures)
+                    .batchVerifyMaxThreads(batchVerifyMaxThreads)
+                    .batchVerifyQueueCapacity(batchVerifyQueueCapacity)
+                    .batchVerifyMaxBatchSize(batchVerifyMaxBatchSize)
+                    .batchVerifyStrictThreadLimitEnabled(batchVerifyStrictThreadLimitEnabled)
                     .targetSubnetSubscriberCount(p2pTargetSubnetSubscriberCount)
                     .isGossipScoringEnabled(gossipScoringEnabled)
                     .peerRateLimit(peerRateLimit)


### PR DESCRIPTION
## PR Description
Adds `--X` options to support tuning the signature verification service. This will let us do some longer term tests to find the optimal values without having to include the changes in a release before we're confident.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
