### PR TITLE
Add ability to switch between optimised and portable BLST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,5 +32,9 @@ For information on changes in released versions of Teku, see the [releases page]
 - Added new metrics `executor_signature_verifications_queue_size`, `executor_signature_verifications_task_count`, 
     `executor_signature_verifications_batch_count` and `executor_signature_verifications_batch_size` to give visibility 
     into the remaining capacity of the signature verification process.
+- Added support for using the optimized BLST which is more efficient but does not support some older CPUs. 
+    On Linux and Mac Teku will attempt to detect if the CPU is compatible and automatically use the optimized version.
+    On Windows or if auto-detection fails the portable version continues to be used.
+    The version of BLST to use can be explicitly set by setting the `teku.portableBlst` system property. e.g `JAVA_OPTS="-Dteku.portableBlst=true" teku`
 
 ### Bug Fixes

--- a/bls/build.gradle
+++ b/bls/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-ssz'
+  implementation 'commons-io:commons-io'
   implementation 'tech.pegasys:jblst'
   implementation project(':infrastructure:crypto')
   implementation project(':infrastructure:logging')

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/LinuxCpuInfo.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/LinuxCpuInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.bls.impl.blst;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.io.IOUtils;
+
+public class LinuxCpuInfo {
+
+  public static boolean supportsOptimisedBlst() throws IOException {
+    return allCpusHaveFeatures("bmi2", "adx");
+  }
+
+  public static boolean allCpusHaveFeatures(final String... requiredFeatures) throws IOException {
+    return allCpusHaveFeatures(Path.of("/proc/cpuinfo"), requiredFeatures);
+  }
+
+  static boolean allCpusHaveFeatures(final Path cpuInfoPath, final String... requiredFeatures)
+      throws IOException {
+    return allCpusHaveFeatures(Files.newBufferedReader(cpuInfoPath), requiredFeatures);
+  }
+
+  static boolean allCpusHaveFeatures(final Reader in, final String... requiredFeatures)
+      throws IOException {
+    checkArgument(requiredFeatures.length > 0, "Must require some features");
+    final List<String> lines = IOUtils.readLines(in);
+    // All CPUs must support the required instruction sets.
+    return lines.stream()
+        .filter(LinuxCpuInfo::isFlagsLine)
+        .map(flagLine -> hasAllRequiredFeatures(flagLine, requiredFeatures))
+        .reduce(Boolean::logicalAnd)
+        .orElse(false);
+  }
+
+  private static boolean isFlagsLine(final String line) {
+    return line.matches("^flags\\s*:.*");
+  }
+
+  private static boolean hasAllRequiredFeatures(
+      final String flagLine, final String... requiredFeatures) {
+    final Set<String> flags = Set.of(flagLine.substring(flagLine.indexOf(':') + 1).split("\\s"));
+    for (String requiredFeature : requiredFeatures) {
+      if (!flags.contains(requiredFeature)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/MacCpuInfo.java
+++ b/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/MacCpuInfo.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.bls.impl.blst;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import org.apache.commons.io.IOUtils;
+
+public class MacCpuInfo {
+
+  public static boolean supportsOptimisedBlst() throws IOException {
+    return macHasCpuFeature("arm64") || (macHasCpuFeature("bmi2") && macHasCpuFeature("adx"));
+  }
+
+  private static boolean macHasCpuFeature(final String cpuFeature) throws IOException {
+    final Process process =
+        new ProcessBuilder("/usr/sbin/sysctl", "-n", "hw.optional." + cpuFeature)
+            .redirectErrorStream(true)
+            .start();
+    final String output = IOUtils.toString(process.getInputStream(), Charset.defaultCharset());
+    return process.exitValue() == 0 && output != null && output.trim().equals("1");
+  }
+}

--- a/bls/src/test/java/tech/pegasys/teku/bls/impl/blst/BlstLoaderTest.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/impl/blst/BlstLoaderTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.bls.impl.blst;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class BlstLoaderTest {
+  @Test
+  void shouldLoad() {
+    assertThat(BlstLoader.INSTANCE).isPresent();
+  }
+}

--- a/bls/src/test/java/tech/pegasys/teku/bls/impl/blst/LinuxCpuInfoTest.java
+++ b/bls/src/test/java/tech/pegasys/teku/bls/impl/blst/LinuxCpuInfoTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.bls.impl.blst;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.io.Resources;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LinuxCpuInfoTest {
+  @Test
+  void shouldReturnTrueWhenAllRequiredFeaturesArePresent() throws Exception {
+    assertThat(allCpusHaveFeatures("allCpusHaveFeatures.txt", "bmi2", "adx")).isTrue();
+  }
+
+  @Test
+  void shouldReturnFalseWhenRequiredFeaturesAreNotPresent() throws Exception {
+    assertThat(allCpusHaveFeatures("allCpusHaveFeatures.txt", "adx", "nope")).isFalse();
+  }
+
+  @Test
+  void shouldReturnFalseWhenSomeButNotAllCpusHaveFeatures() throws Exception {
+    assertThat(allCpusHaveFeatures("cpusHaveDifferentFeatures.txt", "adx", "bmi2")).isFalse();
+  }
+
+  @Test
+  void shouldReturnTrueWhenCpusHaveDifferentFeaturesButAllHaveRequiredFeature() throws Exception {
+    assertThat(allCpusHaveFeatures("cpusHaveDifferentFeatures.txt", "fpu")).isTrue();
+  }
+
+  @Test
+  void shouldReturnFalseWhenThereAreNoCpus() throws Exception {
+    assertThat(LinuxCpuInfo.allCpusHaveFeatures(new StringReader(""), "fpu")).isFalse();
+  }
+
+  @Test
+  void shouldThrowExceptionWhenFileDoesNotExist(@TempDir Path tempDir) {
+    assertThatThrownBy(() -> LinuxCpuInfo.allCpusHaveFeatures(tempDir.resolve("nofile")))
+        .isInstanceOf(IOException.class);
+  }
+
+  @Test
+  void shouldReturnFalseWhenFlagsLineIsNotPresent() throws Exception {
+    assertThat(allCpusHaveFeatures("missingFlagsLine.txt", "bmi2")).isFalse();
+  }
+
+  private boolean allCpusHaveFeatures(final String testFileName, final String... requiredFeatures)
+      throws Exception {
+    try (final Reader reader = loadCpuInfoFile(testFileName)) {
+      return LinuxCpuInfo.allCpusHaveFeatures(reader, requiredFeatures);
+    }
+  }
+
+  private Reader loadCpuInfoFile(final String filename) throws Exception {
+    final URL resource = Resources.getResource(LinuxCpuInfoTest.class, "/cpuinfo/" + filename);
+    return new BufferedReader(
+        new InputStreamReader(resource.openStream(), StandardCharsets.US_ASCII));
+  }
+}

--- a/bls/src/test/resources/cpuinfo/allCpusHaveFeatures.txt
+++ b/bls/src/test/resources/cpuinfo/allCpusHaveFeatures.txt
@@ -1,0 +1,107 @@
+processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 85
+model name	: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
+stepping	: 7
+microcode	: 0x5003005
+cpu MHz		: 3157.837
+cache size	: 36608 KB
+physical id	: 0
+siblings	: 4
+core id		: 0
+cpu cores	: 2
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch invpcid_single pti fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx avx512f avx512dq rdseed adx smap clflushopt clwb avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves ida arat pku ospke
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit
+bogomips	: 4999.99
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 85
+model name	: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
+stepping	: 7
+microcode	: 0x5003005
+cpu MHz		: 3104.154
+cache size	: 36608 KB
+physical id	: 0
+siblings	: 4
+core id		: 1
+cpu cores	: 2
+apicid		: 2
+initial apicid	: 2
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch invpcid_single pti fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx avx512f avx512dq rdseed adx smap clflushopt clwb avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves ida arat pku ospke
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit
+bogomips	: 4999.99
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 2
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 85
+model name	: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
+stepping	: 7
+microcode	: 0x5003005
+cpu MHz		: 3097.546
+cache size	: 36608 KB
+physical id	: 0
+siblings	: 4
+core id		: 0
+cpu cores	: 2
+apicid		: 1
+initial apicid	: 1
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch invpcid_single pti fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx avx512f avx512dq rdseed adx smap clflushopt clwb avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves ida arat pku ospke
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit
+bogomips	: 4999.99
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 3
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 85
+model name	: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
+stepping	: 7
+microcode	: 0x5003005
+cpu MHz		: 3032.943
+cache size	: 36608 KB
+physical id	: 0
+siblings	: 4
+core id		: 1
+cpu cores	: 2
+apicid		: 3
+initial apicid	: 3
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch invpcid_single pti fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx avx512f avx512dq rdseed adx smap clflushopt clwb avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves ida arat pku ospke
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit
+bogomips	: 4999.99
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:

--- a/bls/src/test/resources/cpuinfo/cpusHaveDifferentFeatures.txt
+++ b/bls/src/test/resources/cpuinfo/cpusHaveDifferentFeatures.txt
@@ -1,0 +1,107 @@
+processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 85
+model name	: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
+stepping	: 7
+microcode	: 0x5003005
+cpu MHz		: 3157.837
+cache size	: 36608 KB
+physical id	: 0
+siblings	: 4
+core id		: 0
+cpu cores	: 2
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch invpcid_single pti fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx avx512f avx512dq rdseed adx smap clflushopt clwb avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves ida arat pku ospke
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit
+bogomips	: 4999.99
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 85
+model name	: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
+stepping	: 7
+microcode	: 0x5003005
+cpu MHz		: 3104.154
+cache size	: 36608 KB
+physical id	: 0
+siblings	: 4
+core id		: 1
+cpu cores	: 2
+apicid		: 2
+initial apicid	: 2
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch invpcid_single pti fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx avx512f avx512dq rdseed adx smap clflushopt clwb avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves ida arat pku ospke
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit
+bogomips	: 4999.99
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 2
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 85
+model name	: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
+stepping	: 7
+microcode	: 0x5003005
+cpu MHz		: 3097.546
+cache size	: 36608 KB
+physical id	: 0
+siblings	: 4
+core id		: 0
+cpu cores	: 2
+apicid		: 1
+initial apicid	: 1
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit
+bogomips	: 4999.99
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 3
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 85
+model name	: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
+stepping	: 7
+microcode	: 0x5003005
+cpu MHz		: 3032.943
+cache size	: 36608 KB
+physical id	: 0
+siblings	: 4
+core id		: 1
+cpu cores	: 2
+apicid		: 3
+initial apicid	: 3
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch invpcid_single pti fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx avx512f avx512dq rdseed adx smap clflushopt clwb avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves ida arat pku ospke
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit
+bogomips	: 4999.99
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:

--- a/bls/src/test/resources/cpuinfo/missingFlagsLine.txt
+++ b/bls/src/test/resources/cpuinfo/missingFlagsLine.txt
@@ -1,0 +1,51 @@
+processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 85
+model name	: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
+stepping	: 7
+microcode	: 0x5003005
+cpu MHz		: 3157.837
+cache size	: 36608 KB
+physical id	: 0
+siblings	: 4
+core id		: 0
+cpu cores	: 2
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit
+bogomips	: 4999.99
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 85
+model name	: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
+stepping	: 7
+microcode	: 0x5003005
+cpu MHz		: 3104.154
+cache size	: 36608 KB
+physical id	: 0
+siblings	: 4
+core id		: 1
+cpu cores	: 2
+apicid		: 2
+initial apicid	: 2
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit
+bogomips	: 4999.99
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -42,7 +42,7 @@ dependencyManagement {
     dependency 'io.protostuff:protostuff-runtime:1.6.2'
 
     dependency 'io.libp2p:jvm-libp2p-minimal:0.8.3-RELEASE'
-    dependency 'tech.pegasys:jblst:0.3.6-3'
+    dependency 'tech.pegasys:jblst:0.3.6-4'
 
     dependency 'org.hdrhistogram:HdrHistogram:2.1.12'
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -49,6 +49,14 @@ public class StatusLogger {
             + "You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0");
   }
 
+  public void reportOptimisedBlst() {
+    log.info("Using optimized BLST library");
+  }
+
+  public void warnPortableBlst() {
+    log.info(print("Using portable BLST library.", Color.YELLOW));
+  }
+
   public void warnForkEpochChanged(final String milestoneName, final UInt64 newEpoch) {
     log.warn(
         print(


### PR DESCRIPTION
## PR Description
CPU auto-detection is implemented for Linux and Mac. If auto-detection fails or is unavailable the portable version is used by default.
Users can override auto-detection by setting the teku.portableBlst system property to true or false.


Will require a jblst release that includes https://github.com/supranational/blst/pull/91 before it can actually change the BLST version used.

## Fixed Issue(s)
fixes #3646 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
