### PR TITLE
Fix flaky tests with `InteropConfig.interopGenesisTime` current time default

### DIFF
--- a/teku/src/test/java/tech/pegasys/teku/cli/options/InteropOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/InteropOptionsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.options;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
+import tech.pegasys.teku.config.TekuConfiguration;
+
+public class InteropOptionsTest extends AbstractBeaconNodeCommandTest {
+
+  @Test
+  void interopEnabled_shouldDefaultGenesisTime() {
+    TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments("--Xinterop-enabled");
+
+    assertThat(tekuConfiguration.validatorClient().getInteropConfig().isInteropEnabled()).isTrue();
+
+    int interopGenesisTime =
+        tekuConfiguration.validatorClient().getInteropConfig().getInteropGenesisTime();
+    assertThat(interopGenesisTime)
+        .isGreaterThanOrEqualTo((int) (System.currentTimeMillis() / 1000));
+
+    assertThat(
+            createConfigBuilder()
+                .interop(b -> b.interopEnabled(true))
+                .build()
+                .validatorClient()
+                .getInteropConfig()
+                .getInteropGenesisTime())
+        .isGreaterThanOrEqualTo((int) (System.currentTimeMillis() / 1000));
+
+    assertThat(
+            createConfigBuilder()
+                .interop(b -> b.interopEnabled(true).interopGenesisTime(interopGenesisTime))
+                .build())
+        .usingRecursiveComparison()
+        .isEqualTo(tekuConfiguration);
+  }
+}

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/InteropConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/InteropConfig.java
@@ -48,11 +48,7 @@ public class InteropConfig {
   }
 
   public Integer getInteropGenesisTime() {
-    if (interopGenesisTime == 0) {
-      return Math.toIntExact((System.currentTimeMillis() / 1000) + 5);
-    } else {
-      return interopGenesisTime;
-    }
+    return interopGenesisTime;
   }
 
   public int getInteropOwnedValidatorStartIndex() {
@@ -114,6 +110,7 @@ public class InteropConfig {
     }
 
     public InteropConfig build() {
+      initMissingDefaults();
       validate();
       return new InteropConfig(
           interopGenesisTime,
@@ -121,6 +118,12 @@ public class InteropConfig {
           interopOwnedValidatorCount,
           interopNumberOfValidators,
           interopEnabled);
+    }
+
+    private void initMissingDefaults() {
+      if (interopEnabled && interopGenesisTime == 0) {
+        interopGenesisTime = Math.toIntExact((System.currentTimeMillis() / 1000) + 5);
+      }
     }
 
     private void validate() throws IllegalArgumentException {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Move default `InteropConfig.interopGenesisTime` value calculation to the config builder. 
- Set up current time only if interop is enabled
- Add a test for `--Xinterop-enabled` option

## Fixed Issue(s)

Fix flaky options tests like `BeaconRestApiOptionsTest.maxUrlLength_shouldAcceptLowerBound()`:
```
java.lang.AssertionError: 
Expecting:
  <tech.pegasys.teku.config.TekuConfiguration@6501b105>
to be equal to:
  <tech.pegasys.teku.config.TekuConfiguration@66ab924>
when recursively comparing field by field, but found the following difference:

field/property 'validatorClientConfig.interopConfig.interopGenesisTime' differ:
- actual value   : 1638525124
- expected value : 1638525125
```

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
