### PR TITLE
Implement new proposer boost in fork choice

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -225,7 +225,7 @@ allprojects {
   }
 }
 
-def refTestVersion = 'v1.1.4' // Arbitrary change to refresh cache number: 1
+def refTestVersion = 'v1.1.6' // Arbitrary change to refresh cache number: 1
 def blsRefTestVersion = 'v0.1.0'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
 def blsRefTestBaseUrl = 'https://github.com/ethereum/bls12-381-tests/releases/download'

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -47,6 +47,9 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
   /** Filter test to run only those for a specific milestone. Use values from TestFork. */
   private static final String MILESTONE = null;
 
+  /** Filter tests to run only those where the display name contains this string. */
+  private static final String DISPLAY_NAME = "";
+
   @ParameterizedTest(name = "{0}")
   @MethodSource("loadReferenceTests")
   void shouldRunReferenceTest(final String name, final TestDefinition testDefinition)
@@ -63,6 +66,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
                 SPEC.isBlank() || testDefinition.getConfigName().equalsIgnoreCase(SPEC))
         .filter(testDefinition -> testDefinition.getTestType().startsWith(TEST_TYPE))
         .filter(ManualReferenceTestRunner::isSelectedMilestone)
+        .filter(test -> test.getDisplayName().contains(DISPLAY_NAME))
         .map(testDefinition -> Arguments.of(testDefinition.getDisplayName(), testDefinition));
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -564,6 +564,10 @@ public class Spec {
     return atState(state).beaconStateAccessors().getTotalActiveBalance(state);
   }
 
+  public UInt64 getProposerBoostAmount(BeaconState state) {
+    return atState(state).beaconStateAccessors().getProposerBoostAmount(state);
+  }
+
   public int getPreviousEpochAttestationCapacity(final BeaconState state) {
     return atState(state).beaconStateAccessors().getPreviousEpochAttestationCapacity(state);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
@@ -289,4 +289,9 @@ public class DelegatingSpecConfig implements SpecConfig {
   public Bytes getDepositContractAddress() {
     return specConfig.getDepositContractAddress();
   }
+
+  @Override
+  public int getProposerScoreBoost() {
+    return specConfig.getProposerScoreBoost();
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
@@ -129,6 +129,8 @@ public interface SpecConfig {
 
   int getSafeSlotsToUpdateJustified();
 
+  int getProposerScoreBoost();
+
   int getDepositChainId();
 
   int getDepositNetworkId();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
@@ -93,6 +93,8 @@ public class SpecConfigBuilder {
 
   // Fork Choice
   private Integer safeSlotsToUpdateJustified;
+  // Added after Phase0 was live, so default to 0 which disables proposer score boosting.
+  private int proposerScoreBoost = 0;
 
   // Deposit Contract
   private Integer depositChainId;
@@ -155,6 +157,7 @@ public class SpecConfigBuilder {
             maxVoluntaryExits,
             secondsPerEth1Block,
             safeSlotsToUpdateJustified,
+            proposerScoreBoost,
             depositChainId,
             depositNetworkId,
             depositContractAddress);
@@ -520,6 +523,12 @@ public class SpecConfigBuilder {
   public SpecConfigBuilder safeSlotsToUpdateJustified(final Integer safeSlotsToUpdateJustified) {
     checkNotNull(safeSlotsToUpdateJustified);
     this.safeSlotsToUpdateJustified = safeSlotsToUpdateJustified;
+    return this;
+  }
+
+  public SpecConfigBuilder proposerScoreBoost(final Integer proposerScoreBoost) {
+    checkNotNull(proposerScoreBoost);
+    this.proposerScoreBoost = proposerScoreBoost;
     return this;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
@@ -90,6 +90,7 @@ public class SpecConfigPhase0 implements SpecConfig {
 
   // Fork Choice
   private final int safeSlotsToUpdateJustified;
+  private final int proposerScoreBoost;
 
   // Deposit Contract
   private final int depositChainId;
@@ -143,6 +144,7 @@ public class SpecConfigPhase0 implements SpecConfig {
       final int maxVoluntaryExits,
       final UInt64 secondsPerEth1Block,
       final int safeSlotsToUpdateJustified,
+      final int proposerScoreBoost,
       final int depositChainId,
       final int depositNetworkId,
       final Bytes depositContractAddress) {
@@ -192,6 +194,7 @@ public class SpecConfigPhase0 implements SpecConfig {
     this.maxVoluntaryExits = maxVoluntaryExits;
     this.secondsPerEth1Block = secondsPerEth1Block;
     this.safeSlotsToUpdateJustified = safeSlotsToUpdateJustified;
+    this.proposerScoreBoost = proposerScoreBoost;
     this.depositChainId = depositChainId;
     this.depositNetworkId = depositNetworkId;
     this.depositContractAddress = depositContractAddress;
@@ -448,6 +451,11 @@ public class SpecConfigPhase0 implements SpecConfig {
   }
 
   @Override
+  public int getProposerScoreBoost() {
+    return proposerScoreBoost;
+  }
+
+  @Override
   public int getDepositChainId() {
     return depositChainId;
   }
@@ -498,6 +506,7 @@ public class SpecConfigPhase0 implements SpecConfig {
         && maxDeposits == that.maxDeposits
         && maxVoluntaryExits == that.maxVoluntaryExits
         && safeSlotsToUpdateJustified == that.safeSlotsToUpdateJustified
+        && proposerScoreBoost == that.proposerScoreBoost
         && depositChainId == that.depositChainId
         && depositNetworkId == that.depositNetworkId
         && Objects.equals(baseRewardsPerEpoch, that.baseRewardsPerEpoch)
@@ -573,6 +582,7 @@ public class SpecConfigPhase0 implements SpecConfig {
         maxVoluntaryExits,
         secondsPerEth1Block,
         safeSlotsToUpdateJustified,
+        proposerScoreBoost,
         depositChainId,
         depositNetworkId,
         depositContractAddress);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
@@ -20,4 +20,5 @@ public class NetworkConstants {
   public static final int SYNC_COMMITTEE_SUBNET_COUNT = 4;
   public static final Bytes BLS_WITHDRAWAL_PREFIX = Bytes.fromHexString("0x00");
   public static final int DEPOSIT_CONTRACT_TREE_DEPTH = 32;
+  public static final int INTERVALS_PER_SLOT = 3;
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -40,4 +40,8 @@ public interface MutableStore extends ReadOnlyStore {
   void setFinalizedCheckpoint(Checkpoint finalized_checkpoint);
 
   void setBestJustifiedCheckpoint(Checkpoint best_justified_checkpoint);
+
+  void setProposerBoostRoot(Bytes32 boostedBlockRoot);
+
+  void removeProposerBoostRoot();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -58,6 +58,8 @@ public interface ReadOnlyStore {
 
   Checkpoint getBestJustifiedCheckpoint();
 
+  Optional<Bytes32> getProposerBoostRoot();
+
   ReadOnlyForkChoiceStrategy getForkChoiceStrategy();
 
   boolean containsBlock(Bytes32 blockRoot);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/VoteUpdater.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/VoteUpdater.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.forkchoice;
 
 import java.util.List;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -29,7 +30,9 @@ public interface VoteUpdater {
   Bytes32 applyForkChoiceScoreChanges(
       Checkpoint finalizedCheckpoint,
       Checkpoint justifiedCheckpoint,
-      List<UInt64> justifiedCheckpointEffectiveBalances);
+      List<UInt64> justifiedCheckpointEffectiveBalances,
+      Optional<Bytes32> proposerBoostRoot,
+      UInt64 proposerScoreBoostAmount);
 
   void commit();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -143,6 +143,14 @@ public abstract class BeaconStateAccessors {
             epoch -> getTotalBalance(state, getActiveValidatorIndices(state, epoch)));
   }
 
+  public UInt64 getProposerBoostAmount(final BeaconState state) {
+    final int numValidators = getActiveValidatorIndices(state, getCurrentEpoch(state)).size();
+    final UInt64 avgBalance = getTotalActiveBalance(state).dividedBy(numValidators);
+    final long committeeSize = numValidators / config.getSlotsPerEpoch();
+    final UInt64 committeeWeight = avgBalance.times(committeeSize);
+    return committeeWeight.times(config.getProposerScoreBoost()).dividedBy(100);
+  }
+
   public Bytes32 getSeed(BeaconState state, UInt64 epoch, Bytes4 domain_type)
       throws IllegalArgumentException {
     UInt64 randaoIndex =

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/StubVoteUpdater.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/StubVoteUpdater.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.datastructures.forkchoice;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -45,7 +46,9 @@ public class StubVoteUpdater implements VoteUpdater {
   public Bytes32 applyForkChoiceScoreChanges(
       final Checkpoint finalizedCheckpoint,
       final Checkpoint justifiedCheckpoint,
-      final List<UInt64> justifiedCheckpointEffectiveBalances) {
+      final List<UInt64> justifiedCheckpointEffectiveBalances,
+      final Optional<Bytes32> proposerBoostRoot,
+      final UInt64 proposerScoreBoostAmount) {
     throw new UnsupportedOperationException("Not implemented");
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -43,6 +43,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   protected Map<Bytes32, BeaconState> block_states;
   protected Map<Checkpoint, BeaconState> checkpoint_states;
   protected Map<UInt64, VoteTracker> votes;
+  protected Optional<Bytes32> proposerBoostRoot = Optional.empty();
 
   TestStoreImpl(
       final Spec spec,
@@ -110,6 +111,11 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   @Override
   public Checkpoint getBestJustifiedCheckpoint() {
     return best_justified_checkpoint;
+  }
+
+  @Override
+  public Optional<Bytes32> getProposerBoostRoot() {
+    return proposerBoostRoot;
   }
 
   @Override
@@ -260,6 +266,16 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
+  public void setProposerBoostRoot(final Bytes32 boostedBlockRoot) {
+    proposerBoostRoot = Optional.of(boostedBlockRoot);
+  }
+
+  @Override
+  public void removeProposerBoostRoot() {
+    proposerBoostRoot = Optional.empty();
+  }
+
+  @Override
   public VoteTracker getVote(final UInt64 validatorIndex) {
     VoteTracker vote = votes.get(validatorIndex);
     return vote != null ? vote : VoteTracker.DEFAULT;
@@ -277,7 +293,9 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   public Bytes32 applyForkChoiceScoreChanges(
       final Checkpoint finalizedCheckpoint,
       final Checkpoint justifiedCheckpoint,
-      final List<UInt64> justifiedCheckpointEffectiveBalances) {
+      final List<UInt64> justifiedCheckpointEffectiveBalances,
+      final Optional<Bytes32> proposerBoostRoot,
+      final UInt64 proposerScoreBoostAmount) {
     throw new UnsupportedOperationException("Not implemented");
   }
 }

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayScoreCalculator.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArrayScoreCalculator.java
@@ -50,7 +50,11 @@ class ProtoArrayScoreCalculator {
       int protoArraySize,
       Function<Bytes32, Optional<Integer>> getIndexByRoot,
       List<UInt64> oldBalances,
-      List<UInt64> newBalances) {
+      List<UInt64> newBalances,
+      Optional<Bytes32> previousProposerBoostRoot,
+      Optional<Bytes32> newProposerBoostRoot,
+      UInt64 previousBoostAmount,
+      UInt64 newBoostAmount) {
     List<Long> deltas = new ArrayList<>(Collections.nCopies(protoArraySize, 0L));
 
     UInt64.rangeClosed(UInt64.ZERO, store.getHighestVotedValidatorIndex())
@@ -59,6 +63,10 @@ class ProtoArrayScoreCalculator {
                 computeDelta(
                     store, getIndexByRoot, oldBalances, newBalances, deltas, validatorIndex));
 
+    previousProposerBoostRoot.ifPresent(
+        root -> subtractBalance(getIndexByRoot, deltas, root, previousBoostAmount));
+    newProposerBoostRoot.ifPresent(
+        root -> addBalance(getIndexByRoot, deltas, root, newBoostAmount));
     return deltas;
   }
 

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/FFGUpdatesTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/FFGUpdatesTest.java
@@ -22,6 +22,7 @@ import static tech.pegasys.teku.protoarray.ProtoArrayTestUtil.getHash;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -307,6 +308,11 @@ public class FFGUpdatesTest {
       final Checkpoint justifiedCheckpoint,
       final List<UInt64> justifiedStateEffectiveBalances) {
     return forkChoice.applyPendingVotes(
-        store, finalizedCheckpoint, justifiedCheckpoint, justifiedStateEffectiveBalances);
+        store,
+        Optional.empty(),
+        finalizedCheckpoint,
+        justifiedCheckpoint,
+        justifiedStateEffectiveBalances,
+        ZERO);
   }
 }

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/ForkChoiceStrategyTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/ForkChoiceStrategyTest.java
@@ -112,7 +112,12 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             .getEffectiveBalances(anchor.getState());
     final Bytes32 head =
         forkChoiceStrategy.applyPendingVotes(
-            store, anchor.getCheckpoint(), anchor.getCheckpoint(), effectiveBalances);
+            store,
+            Optional.empty(),
+            anchor.getCheckpoint(),
+            anchor.getCheckpoint(),
+            effectiveBalances,
+            ZERO);
     assertThat(head).isEqualTo(anchor.getRoot());
   }
 
@@ -327,9 +332,11 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     final Bytes32 bestHead =
         strategy.applyPendingVotes(
             transaction,
+            Optional.empty(),
             storageSystem.recentChainData().getFinalizedCheckpoint().orElseThrow(),
             storageSystem.recentChainData().getStore().getBestJustifiedCheckpoint(),
-            effectiveBalances);
+            effectiveBalances,
+            ZERO);
     transaction.commit();
 
     assertThat(bestHead).isEqualTo(block4.getRoot());

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/NoVotesTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/NoVotesTest.java
@@ -23,6 +23,7 @@ import static tech.pegasys.teku.protoarray.ProtoArrayTestUtil.getHash;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -202,7 +203,12 @@ public class NoVotesTest {
       final Checkpoint justifiedCheckpoint,
       final List<UInt64> justifiedStateEffectiveBalances) {
     return forkChoice.applyPendingVotes(
-        store, finalizedCheckpoint, justifiedCheckpoint, justifiedStateEffectiveBalances);
+        store,
+        Optional.empty(),
+        finalizedCheckpoint,
+        justifiedCheckpoint,
+        justifiedStateEffectiveBalances,
+        ZERO);
   }
 
   private UInt64 unsigned(final int i) {

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayTest.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.protoarray.ProtoNodeValidationStatus.OPTIMISTIC;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -432,6 +433,10 @@ class ProtoArrayTest {
         protoArray.getTotalTrackedNodeCount(),
         protoArray::getIndexByRoot,
         balances,
-        balances);
+        balances,
+        Optional.empty(),
+        Optional.empty(),
+        UInt64.ZERO,
+        UInt64.ZERO);
   }
 }

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/VotesTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/VotesTest.java
@@ -24,6 +24,7 @@ import static tech.pegasys.teku.protoarray.ProtoArrayTestUtil.getHash;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -547,6 +548,11 @@ public class VotesTest {
       final Checkpoint justifiedCheckpoint,
       final List<UInt64> justifiedStateEffectiveBalances) {
     return forkChoice.applyPendingVotes(
-        store, finalizedCheckpoint, justifiedCheckpoint, justifiedStateEffectiveBalances);
+        store,
+        Optional.empty(),
+        finalizedCheckpoint,
+        justifiedCheckpoint,
+        justifiedStateEffectiveBalances,
+        ZERO);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -86,6 +86,7 @@ class Store implements UpdatableStore {
   AnchorPoint finalizedAnchor;
   Checkpoint justifiedCheckpoint;
   Checkpoint bestJustifiedCheckpoint;
+  Optional<Bytes32> proposerBoostRoot = Optional.empty();
   final CachingTaskQueue<Bytes32, StateAndBlockSummary> states;
   final Map<Bytes32, SignedBeaconBlock> blocks;
   final CachingTaskQueue<SlotAndBlockRoot, BeaconState> checkpointStates;
@@ -357,6 +358,16 @@ class Store implements UpdatableStore {
     readLock.lock();
     try {
       return bestJustifiedCheckpoint;
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  @Override
+  public Optional<Bytes32> getProposerBoostRoot() {
+    readLock.lock();
+    try {
+      return proposerBoostRoot;
     } finally {
       readLock.unlock();
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -56,6 +56,8 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   Optional<Checkpoint> justifiedCheckpoint = Optional.empty();
   Optional<Checkpoint> finalizedCheckpoint = Optional.empty();
   Optional<Checkpoint> bestJustifiedCheckpoint = Optional.empty();
+  Optional<Bytes32> proposerBoostRoot = Optional.empty();
+  boolean proposerBoostRootSet = false;
   Map<Bytes32, SlotAndBlockRoot> stateRoots = new HashMap<>();
   Map<Bytes32, SignedBlockAndState> blockAndStates = new HashMap<>();
   private final UpdatableStore.StoreUpdateHandler updateHandler;
@@ -120,6 +122,18 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   @Override
   public void setBestJustifiedCheckpoint(Checkpoint best_justified_checkpoint) {
     this.bestJustifiedCheckpoint = Optional.of(best_justified_checkpoint);
+  }
+
+  @Override
+  public void setProposerBoostRoot(final Bytes32 boostedBlockRoot) {
+    proposerBoostRoot = Optional.of(boostedBlockRoot);
+    proposerBoostRootSet = true;
+  }
+
+  @Override
+  public void removeProposerBoostRoot() {
+    proposerBoostRoot = Optional.empty();
+    proposerBoostRootSet = true;
   }
 
   @CheckReturnValue
@@ -224,6 +238,11 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   @Override
   public Checkpoint getBestJustifiedCheckpoint() {
     return bestJustifiedCheckpoint.orElseGet(store::getBestJustifiedCheckpoint);
+  }
+
+  @Override
+  public Optional<Bytes32> getProposerBoostRoot() {
+    return proposerBoostRootSet ? proposerBoostRoot : store.getProposerBoostRoot();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -98,6 +98,10 @@ class StoreTransactionUpdates {
               slotAndBlockRoot -> slotAndBlockRoot.getBlockRoot().equals(root));
         });
 
+    if (tx.proposerBoostRootSet) {
+      store.proposerBoostRoot = tx.proposerBoostRoot;
+    }
+
     store.forkChoiceStrategy.applyUpdate(
         hotBlocks.values(), prunedHotBlockRoots, store.getFinalizedCheckpoint());
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreVoteUpdater.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreVoteUpdater.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.locks.ReadWriteLock;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -66,7 +67,9 @@ public class StoreVoteUpdater implements VoteUpdater {
   public Bytes32 applyForkChoiceScoreChanges(
       final Checkpoint finalizedCheckpoint,
       final Checkpoint justifiedCheckpoint,
-      final List<UInt64> justifiedCheckpointEffectiveBalances) {
+      final List<UInt64> justifiedCheckpointEffectiveBalances,
+      final Optional<Bytes32> proposerBoostRoot,
+      final UInt64 proposerBoostAmount) {
 
     // Ensure the store lock is taken before entering forkChoiceStrategy. Otherwise it takes the
     // protoArray lock first, and may deadlock when it later needs to get votes which requires the
@@ -76,7 +79,12 @@ public class StoreVoteUpdater implements VoteUpdater {
       return store
           .getForkChoiceStrategy()
           .applyPendingVotes(
-              this, finalizedCheckpoint, justifiedCheckpoint, justifiedCheckpointEffectiveBalances);
+              this,
+              proposerBoostRoot,
+              finalizedCheckpoint,
+              justifiedCheckpoint,
+              justifiedCheckpointEffectiveBalances,
+              proposerBoostAmount);
     } finally {
       lock.writeLock().unlock();
     }

--- a/util/src/main/java/tech/pegasys/teku/util/config/ConstantsReader.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/ConstantsReader.java
@@ -89,7 +89,8 @@ class ConstantsReader {
           "MAX_VOLUNTARY_EXITS",
           "SAFE_SLOTS_TO_UPDATE_JUSTIFIED",
           "DEPOSIT_NETWORK_ID",
-          "DEPOSIT_CONTRACT_ADDRESS");
+          "DEPOSIT_CONTRACT_ADDRESS",
+          "PROPOSER_SCORE_BOOST");
 
   private static final ImmutableMap<Class<?>, Function<Object, ?>> PARSERS =
       ImmutableMap.<Class<?>, Function<Object, ?>>builder()

--- a/util/src/main/resources/tech/pegasys/teku/util/config/configs/less-swift.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/configs/less-swift.yaml
@@ -72,6 +72,12 @@ MIN_PER_EPOCH_CHURN_LIMIT: 4
 CHURN_LIMIT_QUOTIENT: 32
 
 
+# Fork choice
+# ---------------------------------------------------------------
+# 70%
+PROPOSER_SCORE_BOOST: 70
+
+
 # Deposit contract
 # ---------------------------------------------------------------
 # Ethereum Goerli testnet

--- a/util/src/main/resources/tech/pegasys/teku/util/config/configs/mainnet.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/configs/mainnet.yaml
@@ -72,6 +72,12 @@ MIN_PER_EPOCH_CHURN_LIMIT: 4
 CHURN_LIMIT_QUOTIENT: 65536
 
 
+# Fork choice
+# ---------------------------------------------------------------
+# 70%
+PROPOSER_SCORE_BOOST: 70
+
+
 # Deposit contract
 # ---------------------------------------------------------------
 # Ethereum PoW Mainnet

--- a/util/src/main/resources/tech/pegasys/teku/util/config/configs/minimal.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/configs/minimal.yaml
@@ -68,6 +68,12 @@ MIN_PER_EPOCH_CHURN_LIMIT: 4
 CHURN_LIMIT_QUOTIENT: 32
 
 
+# Fork choice
+# ---------------------------------------------------------------
+# 70%
+PROPOSER_SCORE_BOOST: 70
+
+
 # Deposit contract
 # ---------------------------------------------------------------
 # Ethereum Goerli testnet

--- a/util/src/main/resources/tech/pegasys/teku/util/config/configs/prater.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/configs/prater.yaml
@@ -71,6 +71,12 @@ MIN_PER_EPOCH_CHURN_LIMIT: 4
 CHURN_LIMIT_QUOTIENT: 65536
 
 
+# Fork choice
+# ---------------------------------------------------------------
+# 70%
+PROPOSER_SCORE_BOOST: 70
+
+
 # Deposit contract
 # ---------------------------------------------------------------
 # Ethereum Goerli testnet

--- a/util/src/main/resources/tech/pegasys/teku/util/config/configs/pyrmont.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/configs/pyrmont.yaml
@@ -72,6 +72,12 @@ MIN_PER_EPOCH_CHURN_LIMIT: 4
 CHURN_LIMIT_QUOTIENT: 65536
 
 
+# Fork choice
+# ---------------------------------------------------------------
+# 70%
+PROPOSER_SCORE_BOOST: 70
+
+
 # Deposit contract
 # ---------------------------------------------------------------
 # Ethereum PoW Mainnet

--- a/util/src/main/resources/tech/pegasys/teku/util/config/configs/swift.yaml
+++ b/util/src/main/resources/tech/pegasys/teku/util/config/configs/swift.yaml
@@ -73,6 +73,12 @@ MIN_PER_EPOCH_CHURN_LIMIT: 4
 CHURN_LIMIT_QUOTIENT: 65536
 
 
+# Fork choice
+# ---------------------------------------------------------------
+# 70%
+PROPOSER_SCORE_BOOST: 70
+
+
 # Deposit contract
 # ---------------------------------------------------------------
 # Ethereum Goerli testnet


### PR DESCRIPTION
## PR Description
Implements the new proposer boost process in fork choice, replacing the previous balance attack mitigation which hadn't been toggled one.  Proposer boost is still toggled off by default but required for reference tests. Needs to be tested in the real world and then enabled.

Updates reference tests to 1.1.6.

## Fixed Issue(s)
fixes #4732


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
