### PR TITLE
Don't require the --ee-endpoint option for the validator client

### DIFF
--- a/services/executionengine/src/main/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfiguration.java
+++ b/services/executionengine/src/main/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfiguration.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.services.executionengine;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.spec.Spec;
@@ -35,7 +33,7 @@ public class ExecutionEngineConfiguration {
   }
 
   public boolean isEnabled() {
-    return endpoint.isPresent();
+    return spec.isMilestoneSupported(SpecMilestone.MERGE);
   }
 
   public Spec getSpec() {
@@ -43,7 +41,10 @@ public class ExecutionEngineConfiguration {
   }
 
   public String getEndpoint() {
-    return endpoint.orElseThrow();
+    return endpoint.orElseThrow(
+        () ->
+            new InvalidConfigurationException(
+                "Invalid configuration. --ee-endpoint parameter is mandatory when Merge milestone is enabled"));
   }
 
   public static class Builder {
@@ -53,16 +54,7 @@ public class ExecutionEngineConfiguration {
     private Builder() {}
 
     public ExecutionEngineConfiguration build() {
-      validate();
       return new ExecutionEngineConfiguration(spec, endpoint);
-    }
-
-    private void validate() {
-      checkNotNull(spec, "Must specify a spec");
-      if (spec.isMilestoneSupported(SpecMilestone.MERGE) && endpoint.isEmpty()) {
-        throw new InvalidConfigurationException(
-            "Invalid configuration. --ee-endpoint parameter is mandatory when Merge milestone is enabled");
-      }
     }
 
     public Builder endpoint(final String endpoint) {

--- a/services/executionengine/src/test/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfigurationTest.java
+++ b/services/executionengine/src/test/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfigurationTest.java
@@ -22,31 +22,23 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 public class ExecutionEngineConfigurationTest {
   private final ExecutionEngineConfiguration.Builder configBuilder =
       ExecutionEngineConfiguration.builder();
-  private final Spec altairSpec = TestSpecFactory.createMinimalAltair();
   private final Spec mergeSpec = TestSpecFactory.createMinimalMerge();
 
   @Test
-  public void altair_noExceptionThrownIfNoEeEndpointSpecified() {
-    final ExecutionEngineConfiguration.Builder builder = configBuilder.specProvider(altairSpec);
-
-    Assertions.assertThatCode(builder::build).doesNotThrowAnyException();
-  }
-
-  @Test
-  public void merge_shouldThrowExceptionIfNoEeEndpointSpecified() {
-    final ExecutionEngineConfiguration.Builder builder = configBuilder.specProvider(mergeSpec);
+  public void shouldThrowExceptionIfNoEeEndpointSpecified() {
+    final ExecutionEngineConfiguration config = configBuilder.specProvider(mergeSpec).build();
 
     Assertions.assertThatExceptionOfType(InvalidConfigurationException.class)
-        .isThrownBy(builder::build)
+        .isThrownBy(config::getEndpoint)
         .withMessageContaining(
             "Invalid configuration. --ee-endpoint parameter is mandatory when Merge milestone is enabled");
   }
 
   @Test
-  public void merge_noExceptionThrownIfEeEndpointSpecified() {
-    final ExecutionEngineConfiguration.Builder builder =
-        configBuilder.specProvider(mergeSpec).endpoint("someEndpoint");
+  public void noExceptionThrownIfEeEndpointSpecified() {
+    final ExecutionEngineConfiguration config =
+        configBuilder.specProvider(mergeSpec).endpoint("someEndpoint").build();
 
-    Assertions.assertThatCode(builder::build).doesNotThrowAnyException();
+    Assertions.assertThatCode(config::getEndpoint).doesNotThrowAnyException();
   }
 }


### PR DESCRIPTION
## PR Description
The validator client doesn't support the `--ee-endpoint` but was previously requiring it. It should only be required for the beacon node.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
