### PR TITLE
Remove requirement for ValidatorConfig to access the Spec to verify the fee address is specified

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/eth1/Eth1Address.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/eth1/Eth1Address.java
@@ -13,67 +13,17 @@
 
 package tech.pegasys.teku.spec.datastructures.eth1;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
-import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.ssz.type.Bytes20;
 
-public class Eth1Address {
-  /** The number of bytes in this value - i.e. 20 */
-  private static final int SIZE = 20;
+public class Eth1Address extends Bytes20 {
+  public static final Eth1Address ZERO = new Eth1Address(Bytes.wrap(new byte[SIZE]));
 
-  private final Bytes bytes;
-
-  public static Eth1Address ZERO =
-      Eth1Address.fromHexString("0x0000000000000000000000000000000000000000");
-
-  public Eth1Address(Bytes bytes) {
-    checkArgument(
-        bytes.size() == SIZE,
-        "Bytes%s should be %s bytes, but was %s bytes.",
-        SIZE,
-        SIZE,
-        bytes.size());
-    this.bytes = bytes;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final Eth1Address address = (Eth1Address) o;
-    return bytes.equals(address.bytes);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(bytes);
-  }
-
-  @Override
-  public String toString() {
-    return bytes.toString();
+  public Eth1Address(final Bytes bytes) {
+    super(bytes);
   }
 
   public static Eth1Address fromHexString(String value) {
-    Bytes bytes = Bytes.fromHexString(value);
-    return new Eth1Address(bytes);
-  }
-
-  public String toHexString() {
-    return bytes.toHexString();
-  }
-
-  public Bytes toBytes() {
-    return bytes;
-  }
-
-  public Bytes20 toBytes20() {
-    return new Bytes20(bytes);
+    return new Eth1Address(Bytes.fromHexString(value));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -216,7 +216,6 @@ public class TekuConfiguration {
       p2pConfigBuilder.specProvider(spec);
       powchainConfigBuilder.specProvider(spec);
       executionEngineConfigBuilder.specProvider(spec);
-      validatorConfigBuilder.specProvider(spec);
 
       Eth1Address depositContractAddress = eth2NetworkConfiguration.getEth1DepositContractAddress();
       Optional<UInt64> depositContractDeployBlock =

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -148,13 +148,13 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void ShouldReportEmptyIfFeeRecipientNotSpecified() {
+  public void shouldReportEmptyIfFeeRecipientNotSpecified() {
     final TekuConfiguration config = getTekuConfigurationFromArguments();
     assertThat(config.validatorClient().getValidatorConfig().getSuggestedFeeRecipient()).isEmpty();
   }
 
   @Test
-  public void ShouldReportAddressIfFeeRecipientSpecified() {
+  public void shouldReportAddressIfFeeRecipientSpecified() {
     final String[] args = {
       "--Xvalidators-suggested-fee-recipient-address", "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73"
     };

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.validator.api;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
@@ -179,15 +181,10 @@ public class ValidatorConfig {
 
   private void validateFeeRecipient() {
     if (suggestedFeeRecipient.isEmpty()
-        && !(validatorKeys.isEmpty() && externalPublicKeysNotDefined())) {
+        && !(validatorKeys.isEmpty() && validatorExternalSignerPublicKeySources.isEmpty())) {
       throw new InvalidConfigurationException(
           "Invalid configuration. --validators-fee-recipient-address must be specified when Merge milestone is active");
     }
-  }
-
-  private boolean externalPublicKeysNotDefined() {
-    return validatorExternalSignerPublicKeySources == null
-        || validatorExternalSignerPublicKeySources.isEmpty();
   }
 
   public static final class Builder {
@@ -223,8 +220,9 @@ public class ValidatorConfig {
     }
 
     public Builder validatorExternalSignerPublicKeySources(
-        List<String> validatorExternalSignerPublicKeys) {
-      this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeys;
+        List<String> validatorExternalSignerPublicKeySources) {
+      checkNotNull(validatorExternalSignerPublicKeySources);
+      this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
       return this;
     }
 
@@ -359,7 +357,7 @@ public class ValidatorConfig {
     }
 
     private void validateExternalSignerUrlAndPublicKeys() {
-      if (externalPublicKeysNotDefined()) {
+      if (validatorExternalSignerPublicKeySources.isEmpty()) {
         return;
       }
 
@@ -389,7 +387,7 @@ public class ValidatorConfig {
     }
 
     private void validateExternalSignerURLScheme() {
-      if (externalPublicKeysNotDefined() || validatorExternalSignerUrl == null) {
+      if (validatorExternalSignerPublicKeySources.isEmpty() || validatorExternalSignerUrl == null) {
         return;
       }
 
@@ -402,11 +400,6 @@ public class ValidatorConfig {
           throw new InvalidConfigurationException(errorMessage);
         }
       }
-    }
-
-    private boolean externalPublicKeysNotDefined() {
-      return validatorExternalSignerPublicKeySources == null
-          || validatorExternalSignerPublicKeySources.isEmpty();
     }
 
     private static boolean isURLSchemeHttps(final URL url) {

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerAltairIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerAltairIntegrationTest.java
@@ -93,7 +93,6 @@ public class ExternalSignerAltairIntegrationTest {
     this.client = client;
     final ValidatorConfig config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorExternalSignerPublicKeySources(List.of(KEYPAIR.getPublicKey().toString()))
             .validatorExternalSignerUrl(new URL("http://127.0.0.1:" + client.getLocalPort()))
             .validatorExternalSignerTimeout(TIMEOUT)

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerIntegrationTest.java
@@ -79,7 +79,6 @@ public class ExternalSignerIntegrationTest {
     this.client = client;
     final ValidatorConfig config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorExternalSignerPublicKeySources(List.of(KEYPAIR.getPublicKey().toString()))
             .validatorExternalSignerUrl(new URL("http://127.0.0.1:" + client.getLocalPort()))
             .validatorExternalSignerTimeout(TIMEOUT)

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerUpcheckTLSIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerUpcheckTLSIntegrationTest.java
@@ -84,7 +84,6 @@ public class ExternalSignerUpcheckTLSIntegrationTest {
   private static ExternalSignerUpcheck buildExternalSignerUpcheck(final URL serverUrl) {
     final ValidatorConfig config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorExternalSignerPublicKeySources(List.of(KEYPAIR.getPublicKey().toString()))
             .validatorExternalSignerUrl(serverUrl)
             .validatorExternalSignerTimeout(TIMEOUT)

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerUpcheckTLSIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerUpcheckTLSIntegrationTest.java
@@ -34,14 +34,11 @@ import org.mockserver.junit.jupiter.MockServerExtension;
 import org.mockserver.model.HttpResponse;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSTestUtil;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
 import tech.pegasys.teku.validator.client.loader.HttpClientExternalSignerFactory;
 
 @ExtendWith(MockServerExtension.class)
 public class ExternalSignerUpcheckTLSIntegrationTest {
-  private static final Spec spec = TestSpecFactory.createMinimalPhase0();
   private static final BLSKeyPair KEYPAIR = BLSTestUtil.randomKeyPair(1234);
   private static final Duration TIMEOUT = Duration.ofMillis(500);
   private static final Path TEKU_KEYSTORE;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -35,7 +35,6 @@ import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.beaconnode.BeaconNodeApi;
@@ -228,7 +227,7 @@ public class ValidatorClientService extends Service {
           new BeaconProposerPreparer(
               validatorApiChannel,
               validatorIndexProvider,
-              config.getValidatorConfig().getSuggestedFeeRecipient().map(Eth1Address::toBytes20),
+              config.getValidatorConfig().getSuggestedFeeRecipient(),
               validators,
               spec));
     }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
@@ -31,11 +31,11 @@ import org.junit.jupiter.api.TestTemplate;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.core.signatures.Signer;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.ssz.type.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.operations.versions.merge.BeaconPreparableProposer;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
@@ -47,7 +47,7 @@ public class BeaconProposerPreparerTest {
   private final ValidatorIndexProvider validatorIndexProvider = mock(ValidatorIndexProvider.class);
   private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
   private BeaconProposerPreparer beaconProposerPreparer;
-  private Bytes20 feeRecipient;
+  private Eth1Address feeRecipient;
 
   private long slotsPerEpoch;
 
@@ -69,7 +69,7 @@ public class BeaconProposerPreparerTest {
         new OwnedValidators(
             Map.of(validator1.getPublicKey(), validator1, validator2.getPublicKey(), validator2));
 
-    feeRecipient = specContext.getDataStructureUtil().randomBytes20();
+    feeRecipient = specContext.getDataStructureUtil().randomEth1Address();
 
     beaconProposerPreparer =
         new BeaconProposerPreparer(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSourceTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSourceTest.java
@@ -55,7 +55,6 @@ public class ExternalValidatorSourceTest {
   void setup() throws IOException, InterruptedException {
     config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorExternalSignerUrl(new URL("http://localhost:9000"))
             .build();
     when(httpResponse.statusCode()).thenReturn(SC_OK);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -114,7 +114,6 @@ class ValidatorLoaderTest {
 
     final ValidatorConfig config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorExternalSignerUrl(SIGNER_URL)
             .validatorExternalSignerPublicKeySources(Collections.singletonList(publicKeysUrl))
             .validatorExternalSignerSlashingProtectionEnabled(true)
@@ -152,7 +151,6 @@ class ValidatorLoaderTest {
   void initializeValidatorsWithExternalSignerAndSlashingProtection() {
     final ValidatorConfig config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorExternalSignerUrl(SIGNER_URL)
             .validatorExternalSignerPublicKeySources(
                 Collections.singletonList(PUBLIC_KEY1.toString()))
@@ -195,7 +193,6 @@ class ValidatorLoaderTest {
   void initializeValidatorsWithExternalSignerAndNoSlashingProtection() {
     final ValidatorConfig config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorExternalSignerUrl(SIGNER_URL)
             .validatorExternalSignerPublicKeySources(
                 Collections.singletonList(PUBLIC_KEY1.toString()))
@@ -240,7 +237,6 @@ class ValidatorLoaderTest {
     writeKeystore(tempDir);
     final ValidatorConfig config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorExternalSignerUrl(SIGNER_URL)
             .validatorExternalSignerPublicKeySources(
                 Collections.singletonList(PUBLIC_KEY2.toString()))
@@ -289,7 +285,6 @@ class ValidatorLoaderTest {
     writeMutableKeystore(dataDirLayout);
     final ValidatorConfig config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorKeys(
                 List.of(tempDir.toAbsolutePath() + File.pathSeparator + tempDir.toAbsolutePath()))
             .build();
@@ -330,7 +325,6 @@ class ValidatorLoaderTest {
     writeMutableKeystore(dataDirLayout);
     final ValidatorConfig config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorKeys(
                 List.of(tempDir.toAbsolutePath() + File.pathSeparator + tempDir.toAbsolutePath()))
             .build();
@@ -366,7 +360,6 @@ class ValidatorLoaderTest {
 
     final ValidatorConfig config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorKeys(
                 List.of(tempDir.toAbsolutePath() + File.pathSeparator + tempDir.toAbsolutePath()))
             .build();
@@ -399,7 +392,6 @@ class ValidatorLoaderTest {
     writeKeystore(tempDir);
     final ValidatorConfig config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorExternalSignerUrl(SIGNER_URL)
             .validatorExternalSignerPublicKeySources(
                 Collections.singletonList(PUBLIC_KEY1.toString()))
@@ -437,7 +429,6 @@ class ValidatorLoaderTest {
 
     final ValidatorConfig config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorKeys(
                 List.of(tempDir.toAbsolutePath() + File.pathSeparator + tempDir.toAbsolutePath()))
             .build();
@@ -477,7 +468,6 @@ class ValidatorLoaderTest {
 
     final ValidatorConfig config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorExternalSignerUrl(SIGNER_URL)
             .validatorExternalSignerPublicKeySources(Collections.singletonList(publicKeysUrl))
             .validatorExternalSignerSlashingProtectionEnabled(true)
@@ -514,7 +504,6 @@ class ValidatorLoaderTest {
 
     final ValidatorConfig config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorExternalSignerUrl(SIGNER_URL)
             .validatorExternalSignerPublicKeySources(Collections.singletonList(publicKeysUrl))
             .validatorExternalSignerSlashingProtectionEnabled(true)
@@ -546,7 +535,6 @@ class ValidatorLoaderTest {
   void shouldLoadAdditionalLocalValidatorsOnReload(final @TempDir Path tempDir) throws Exception {
     final ValidatorConfig config =
         ValidatorConfig.builder()
-            .specProvider(spec)
             .validatorKeys(
                 List.of(tempDir.toAbsolutePath() + File.pathSeparator + tempDir.toAbsolutePath()))
             .build();
@@ -584,7 +572,7 @@ class ValidatorLoaderTest {
             .interopEnabled(true)
             .interopOwnedValidatorCount(ownedValidatorCount)
             .build();
-    final ValidatorConfig config = ValidatorConfig.builder().specProvider(spec).build();
+    final ValidatorConfig config = ValidatorConfig.builder().build();
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
             spec,
@@ -604,7 +592,7 @@ class ValidatorLoaderTest {
 
   @Test
   void shouldNotLoadMutableValidatorIfNotEnabled() {
-    final ValidatorConfig config = ValidatorConfig.builder().specProvider(spec).build();
+    final ValidatorConfig config = ValidatorConfig.builder().build();
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
             spec,
@@ -623,7 +611,7 @@ class ValidatorLoaderTest {
 
   @Test
   void shouldLoadMutableValidatorIfEnabled(@TempDir final Path tempDir) throws Exception {
-    final ValidatorConfig config = ValidatorConfig.builder().specProvider(spec).build();
+    final ValidatorConfig config = ValidatorConfig.builder().build();
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
             spec,
@@ -659,7 +647,7 @@ class ValidatorLoaderTest {
             .interopEnabled(false)
             .interopOwnedValidatorCount(ownedValidatorCount)
             .build();
-    final ValidatorConfig config = ValidatorConfig.builder().specProvider(spec).build();
+    final ValidatorConfig config = ValidatorConfig.builder().build();
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
             spec,


### PR DESCRIPTION
## PR Description
Remove requirement for ValidatorConfig to access the Spec to verify the fee address is specified because it made tests harder in some cases.
Better handle the case where fee recipient isn't specified because there are no validators at startup but then is required because they're added at runtime.

Change Eth1Address to extend Bytes20 instead of wrapping it for simplicity.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
