### PR TITLE
[Java API] Customize Network building 

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -118,11 +117,6 @@ public class Eth2P2PNetworkBuilder {
   protected OperationProcessor<ValidateableSyncCommitteeMessage>
       gossipedSyncCommitteeMessageProcessor;
   protected GossipPublisher<ValidateableSyncCommitteeMessage> syncCommitteeMessageGossipPublisher;
-
-  protected Supplier<DiscoveryNetworkBuilder> discoveryNetworkBuilderSupplier =
-      DiscoveryNetworkBuilder::create;
-  protected Supplier<LibP2PNetworkBuilder> libP2PNetworkBuilderSupplier =
-      LibP2PNetworkBuilder::create;
 
   protected Eth2P2PNetworkBuilder() {}
 
@@ -281,8 +275,7 @@ public class Eth2P2PNetworkBuilder {
     final DiscoveryConfig discoConfig = config.getDiscoveryConfig();
 
     final P2PNetwork<Peer> p2pNetwork =
-        libP2PNetworkBuilderSupplier
-            .get()
+        createLibP2PNetworkBuilder()
             .asyncRunner(asyncRunner)
             .metricsSystem(metricsSystem)
             .config(networkConfig)
@@ -307,8 +300,7 @@ public class Eth2P2PNetworkBuilder {
             discoConfig.getMinRandomlySelectedPeers());
     final SchemaDefinitionsSupplier currentSchemaDefinitions =
         () -> recentChainData.getCurrentSpec().getSchemaDefinitions();
-    return discoveryNetworkBuilderSupplier
-        .get()
+    return createDiscoveryNetworkBuilder()
         .metricsSystem(metricsSystem)
         .asyncRunner(asyncRunner)
         .kvStore(keyValueStore)
@@ -331,6 +323,14 @@ public class Eth2P2PNetworkBuilder {
         .spec(config.getSpec())
         .currentSchemaDefinitionsSupplier(currentSchemaDefinitions)
         .build();
+  }
+
+  protected DiscoveryNetworkBuilder createDiscoveryNetworkBuilder() {
+    return DiscoveryNetworkBuilder.create();
+  }
+
+  protected LibP2PNetworkBuilder createLibP2PNetworkBuilder() {
+    return LibP2PNetworkBuilder.create();
   }
 
   private void validate() {
@@ -540,19 +540,6 @@ public class Eth2P2PNetworkBuilder {
   public Eth2P2PNetworkBuilder specProvider(final Spec spec) {
     checkNotNull(spec);
     this.spec = spec;
-    return this;
-  }
-
-  public Eth2P2PNetworkBuilder discoveryNetworkBuilderSupplier(
-      Supplier<DiscoveryNetworkBuilder> discoveryNetworkBuilderSupplier) {
-    checkNotNull(discoveryNetworkBuilderSupplier);
-    this.discoveryNetworkBuilderSupplier = discoveryNetworkBuilderSupplier;
-    return this;
-  }
-
-  public Eth2P2PNetworkBuilder libP2PNetworkBuilderSupplier(
-      Supplier<LibP2PNetworkBuilder> libP2PNetworkBuilderSupplier) {
-    this.libP2PNetworkBuilderSupplier = libP2PNetworkBuilderSupplier;
     return this;
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -276,18 +276,20 @@ public class Eth2P2PNetworkBuilder {
     final NetworkConfig networkConfig = config.getNetworkConfig();
     final DiscoveryConfig discoConfig = config.getDiscoveryConfig();
 
-    final P2PNetwork<Peer> p2pNetwork = libP2PNetworkBuilderSupplier.get()
-        .asyncRunner(asyncRunner)
-        .metricsSystem(metricsSystem)
-        .config(networkConfig)
-        .privateKeyProvider(
-            new LibP2PPrivateKeyLoader(keyValueStore, networkConfig.getPrivateKeyFile()))
-        .reputationManager(reputationManager)
-        .rpcMethods(rpcMethods)
-        .peerHandlers(peerHandlers)
-        .preparedGossipMessageFactory(defaultMessageFactory)
-        .gossipTopicFilter(gossipTopicsFilter)
-        .build();
+    final P2PNetwork<Peer> p2pNetwork =
+        libP2PNetworkBuilderSupplier
+            .get()
+            .asyncRunner(asyncRunner)
+            .metricsSystem(metricsSystem)
+            .config(networkConfig)
+            .privateKeyProvider(
+                new LibP2PPrivateKeyLoader(keyValueStore, networkConfig.getPrivateKeyFile()))
+            .reputationManager(reputationManager)
+            .rpcMethods(rpcMethods)
+            .peerHandlers(peerHandlers)
+            .preparedGossipMessageFactory(defaultMessageFactory)
+            .gossipTopicFilter(gossipTopicsFilter)
+            .build();
 
     final AttestationSubnetTopicProvider attestationSubnetTopicProvider =
         new AttestationSubnetTopicProvider(recentChainData, gossipEncoding);
@@ -301,7 +303,8 @@ public class Eth2P2PNetworkBuilder {
             discoConfig.getMinRandomlySelectedPeers());
     final SchemaDefinitionsSupplier currentSchemaDefinitions =
         () -> recentChainData.getCurrentSpec().getSchemaDefinitions();
-    return discoveryNetworkBuilderSupplier.get()
+    return discoveryNetworkBuilderSupplier
+        .get()
         .metricsSystem(metricsSystem)
         .asyncRunner(asyncRunner)
         .kvStore(keyValueStore)

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -78,6 +78,10 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.store.KeyValueStore;
 import tech.pegasys.teku.util.config.Constants;
 
+/**
+ * CAUTION: this API is unstable and primarily intended for debugging and testing purposes this API
+ * might be changed in any version in backward incompatible way
+ */
 public class Eth2P2PNetworkBuilder {
   public static final Duration DEFAULT_ETH2_RPC_PING_INTERVAL = Duration.ofSeconds(10);
   public static final int DEFAULT_ETH2_RPC_OUTSTANDING_PING_THRESHOLD = 2;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -79,39 +79,39 @@ public class Eth2P2PNetworkBuilder {
   public static final int DEFAULT_ETH2_RPC_OUTSTANDING_PING_THRESHOLD = 2;
   public static final Duration DEFAULT_ETH2_STATUS_UPDATE_INTERVAL = Duration.ofMinutes(5);
 
-  private P2PConfig config;
-  private EventChannels eventChannels;
-  private RecentChainData recentChainData;
-  private OperationProcessor<SignedBeaconBlock> gossipedBlockProcessor;
-  private OperationProcessor<ValidateableAttestation> gossipedAttestationConsumer;
-  private OperationProcessor<ValidateableAttestation> gossipedAggregateProcessor;
-  private OperationProcessor<AttesterSlashing> gossipedAttesterSlashingConsumer;
-  private GossipPublisher<AttesterSlashing> attesterSlashingGossipPublisher;
-  private OperationProcessor<ProposerSlashing> gossipedProposerSlashingConsumer;
-  private GossipPublisher<ProposerSlashing> proposerSlashingGossipPublisher;
-  private OperationProcessor<SignedVoluntaryExit> gossipedVoluntaryExitConsumer;
-  private GossipPublisher<SignedVoluntaryExit> voluntaryExitGossipPublisher;
-  private ProcessedAttestationSubscriptionProvider processedAttestationSubscriptionProvider;
-  private StorageQueryChannel historicalChainData;
-  private MetricsSystem metricsSystem;
-  private final List<RpcMethod<?, ?, ?>> rpcMethods = new ArrayList<>();
-  private final List<PeerHandler> peerHandlers = new ArrayList<>();
-  private TimeProvider timeProvider;
-  private AsyncRunner asyncRunner;
-  private KeyValueStore<String, Bytes> keyValueStore;
-  private Duration eth2RpcPingInterval = DEFAULT_ETH2_RPC_PING_INTERVAL;
-  private int eth2RpcOutstandingPingThreshold = DEFAULT_ETH2_RPC_OUTSTANDING_PING_THRESHOLD;
-  private final Duration eth2StatusUpdateInterval = DEFAULT_ETH2_STATUS_UPDATE_INTERVAL;
-  private Optional<Checkpoint> requiredCheckpoint = Optional.empty();
-  private Spec spec;
-  private OperationProcessor<SignedContributionAndProof>
+  protected P2PConfig config;
+  protected EventChannels eventChannels;
+  protected RecentChainData recentChainData;
+  protected OperationProcessor<SignedBeaconBlock> gossipedBlockProcessor;
+  protected OperationProcessor<ValidateableAttestation> gossipedAttestationConsumer;
+  protected OperationProcessor<ValidateableAttestation> gossipedAggregateProcessor;
+  protected OperationProcessor<AttesterSlashing> gossipedAttesterSlashingConsumer;
+  protected GossipPublisher<AttesterSlashing> attesterSlashingGossipPublisher;
+  protected OperationProcessor<ProposerSlashing> gossipedProposerSlashingConsumer;
+  protected GossipPublisher<ProposerSlashing> proposerSlashingGossipPublisher;
+  protected OperationProcessor<SignedVoluntaryExit> gossipedVoluntaryExitConsumer;
+  protected GossipPublisher<SignedVoluntaryExit> voluntaryExitGossipPublisher;
+  protected ProcessedAttestationSubscriptionProvider processedAttestationSubscriptionProvider;
+  protected StorageQueryChannel historicalChainData;
+  protected MetricsSystem metricsSystem;
+  protected final List<RpcMethod<?, ?, ?>> rpcMethods = new ArrayList<>();
+  protected final List<PeerHandler> peerHandlers = new ArrayList<>();
+  protected TimeProvider timeProvider;
+  protected AsyncRunner asyncRunner;
+  protected KeyValueStore<String, Bytes> keyValueStore;
+  protected Duration eth2RpcPingInterval = DEFAULT_ETH2_RPC_PING_INTERVAL;
+  protected int eth2RpcOutstandingPingThreshold = DEFAULT_ETH2_RPC_OUTSTANDING_PING_THRESHOLD;
+  protected final Duration eth2StatusUpdateInterval = DEFAULT_ETH2_STATUS_UPDATE_INTERVAL;
+  protected Optional<Checkpoint> requiredCheckpoint = Optional.empty();
+  protected Spec spec;
+  protected OperationProcessor<SignedContributionAndProof>
       gossipedSignedContributionAndProofProcessor;
-  private GossipPublisher<SignedContributionAndProof> signedContributionAndProofGossipPublisher;
-  private OperationProcessor<ValidateableSyncCommitteeMessage>
+  protected GossipPublisher<SignedContributionAndProof> signedContributionAndProofGossipPublisher;
+  protected OperationProcessor<ValidateableSyncCommitteeMessage>
       gossipedSyncCommitteeMessageProcessor;
-  private GossipPublisher<ValidateableSyncCommitteeMessage> syncCommitteeMessageGossipPublisher;
+  protected GossipPublisher<ValidateableSyncCommitteeMessage> syncCommitteeMessageGossipPublisher;
 
-  private Eth2P2PNetworkBuilder() {}
+  protected Eth2P2PNetworkBuilder() {}
 
   public static Eth2P2PNetworkBuilder create() {
     return new Eth2P2PNetworkBuilder();

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -63,7 +63,6 @@ import tech.pegasys.teku.networking.p2p.connection.TargetPeerRange;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetwork;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetworkBuilder;
-import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork;
 import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetworkBuilder;
 import tech.pegasys.teku.networking.p2p.libp2p.gossip.GossipTopicFilter;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
@@ -230,30 +229,33 @@ public class Eth2P2PNetworkFactory {
                 .metricsSystem(metricsSystem)
                 .asyncRunner(asyncRunner)
                 .kvStore(keyValueStore)
-                .p2pNetwork(LibP2PNetworkBuilder.create()
-                    .asyncRunner(DelayedExecutorAsyncRunner.create())
-                    .config(config.getNetworkConfig())
-                    .privateKeyProvider(PrivateKeyGenerator::generate)
-                    .reputationManager(reputationManager)
-                    .metricsSystem(METRICS_SYSTEM)
-                    .rpcMethods(new ArrayList<>(rpcMethods))
-                    .peerHandlers(peerHandlers)
-                    .preparedGossipMessageFactory(gossipEncoding.createPreparedGossipMessageFactory(
-                        recentChainData::getMilestoneByForkDigest))
-                    .gossipTopicFilter(gossipTopicsFilter)
-                    .build())
-                .peerSelectionStrategy(new Eth2PeerSelectionStrategy(
-                    targetPeerRange,
-                    gossipNetwork ->
-                        PeerSubnetSubscriptions.create(
-                            currentSchemaDefinitions,
-                            gossipNetwork,
-                            attestationSubnetTopicProvider,
-                            syncCommitteeTopicProvider,
-                            syncCommitteeSubnetService,
-                            config.getTargetSubnetSubscriberCount()),
-                    reputationManager,
-                    Collections::shuffle))
+                .p2pNetwork(
+                    LibP2PNetworkBuilder.create()
+                        .asyncRunner(DelayedExecutorAsyncRunner.create())
+                        .config(config.getNetworkConfig())
+                        .privateKeyProvider(PrivateKeyGenerator::generate)
+                        .reputationManager(reputationManager)
+                        .metricsSystem(METRICS_SYSTEM)
+                        .rpcMethods(new ArrayList<>(rpcMethods))
+                        .peerHandlers(peerHandlers)
+                        .preparedGossipMessageFactory(
+                            gossipEncoding.createPreparedGossipMessageFactory(
+                                recentChainData::getMilestoneByForkDigest))
+                        .gossipTopicFilter(gossipTopicsFilter)
+                        .build())
+                .peerSelectionStrategy(
+                    new Eth2PeerSelectionStrategy(
+                        targetPeerRange,
+                        gossipNetwork ->
+                            PeerSubnetSubscriptions.create(
+                                currentSchemaDefinitions,
+                                gossipNetwork,
+                                attestationSubnetTopicProvider,
+                                syncCommitteeTopicProvider,
+                                syncCommitteeSubnetService,
+                                config.getTargetSubnetSubscriberCount()),
+                        reputationManager,
+                        Collections::shuffle))
                 .discoveryConfig(config.getDiscoveryConfig())
                 .p2pConfig(config.getNetworkConfig())
                 .spec(config.getSpec())

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -62,7 +62,9 @@ import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.networking.p2p.connection.TargetPeerRange;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetwork;
+import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetworkBuilder;
 import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork;
+import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetworkBuilder;
 import tech.pegasys.teku.networking.p2p.libp2p.gossip.GossipTopicFilter;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.networking.p2p.network.PeerHandler;
@@ -224,22 +226,23 @@ public class Eth2P2PNetworkFactory {
         final SchemaDefinitionsSupplier currentSchemaDefinitions =
             () -> config.getSpec().getGenesisSchemaDefinitions();
         final DiscoveryNetwork<?> network =
-            DiscoveryNetwork.create(
-                metricsSystem,
-                asyncRunner,
-                keyValueStore,
-                new LibP2PNetwork(
-                    asyncRunner,
-                    config.getNetworkConfig(),
-                    PrivateKeyGenerator::generate,
-                    reputationManager,
-                    METRICS_SYSTEM,
-                    new ArrayList<>(rpcMethods),
-                    peerHandlers,
-                    gossipEncoding.createPreparedGossipMessageFactory(
-                        recentChainData::getMilestoneByForkDigest),
-                    gossipTopicsFilter),
-                new Eth2PeerSelectionStrategy(
+            DiscoveryNetworkBuilder.create()
+                .metricsSystem(metricsSystem)
+                .asyncRunner(asyncRunner)
+                .kvStore(keyValueStore)
+                .p2pNetwork(LibP2PNetworkBuilder.create()
+                    .asyncRunner(DelayedExecutorAsyncRunner.create())
+                    .config(config.getNetworkConfig())
+                    .privateKeyProvider(PrivateKeyGenerator::generate)
+                    .reputationManager(reputationManager)
+                    .metricsSystem(METRICS_SYSTEM)
+                    .rpcMethods(new ArrayList<>(rpcMethods))
+                    .peerHandlers(peerHandlers)
+                    .preparedGossipMessageFactory(gossipEncoding.createPreparedGossipMessageFactory(
+                        recentChainData::getMilestoneByForkDigest))
+                    .gossipTopicFilter(gossipTopicsFilter)
+                    .build())
+                .peerSelectionStrategy(new Eth2PeerSelectionStrategy(
                     targetPeerRange,
                     gossipNetwork ->
                         PeerSubnetSubscriptions.create(
@@ -250,11 +253,12 @@ public class Eth2P2PNetworkFactory {
                             syncCommitteeSubnetService,
                             config.getTargetSubnetSubscriberCount()),
                     reputationManager,
-                    Collections::shuffle),
-                config.getDiscoveryConfig(),
-                config.getNetworkConfig(),
-                config.getSpec(),
-                currentSchemaDefinitions);
+                    Collections::shuffle))
+                .discoveryConfig(config.getDiscoveryConfig())
+                .p2pConfig(config.getNetworkConfig())
+                .spec(config.getSpec())
+                .currentSchemaDefinitionsSupplier(currentSchemaDefinitions)
+                .build();
 
         final GossipForkManager.Builder gossipForkManagerBuilder =
             GossipForkManager.builder().spec(spec).recentChainData(recentChainData);

--- a/networking/p2p/src/integration-test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkIntegrationTest.java
@@ -37,16 +37,16 @@ public class DiscoveryNetworkIntegrationTest {
 
   @Test
   public void shouldConnectToStaticPeers() throws Exception {
-    final DiscoveryNetwork<Peer> network1 = discoveryNetworkFactory.builder().buildAndStart();
-    final DiscoveryNetwork<Peer> network2 =
+    final DiscoveryNetwork<?> network1 = discoveryNetworkFactory.builder().buildAndStart();
+    final DiscoveryNetwork<?> network2 =
         discoveryNetworkFactory.builder().staticPeer(network1.getNodeAddress()).buildAndStart();
     assertConnected(network1, network2);
   }
 
   @Test
   public void shouldReconnectToStaticPeersAfterDisconnection() throws Exception {
-    final DiscoveryNetwork<Peer> network1 = discoveryNetworkFactory.builder().buildAndStart();
-    final DiscoveryNetwork<Peer> network2 =
+    final DiscoveryNetwork<?> network1 = discoveryNetworkFactory.builder().buildAndStart();
+    final DiscoveryNetwork<?> network2 =
         discoveryNetworkFactory.builder().staticPeer(network1.getNodeAddress()).buildAndStart();
     assertConnected(network1, network2);
 
@@ -62,8 +62,8 @@ public class DiscoveryNetworkIntegrationTest {
 
   @Test
   public void shouldReconnectToStaticPeersWhenAlreadyConnected() throws Exception {
-    final DiscoveryNetwork<Peer> network1 = discoveryNetworkFactory.builder().buildAndStart();
-    final DiscoveryNetwork<Peer> network2 =
+    final DiscoveryNetwork<?> network1 = discoveryNetworkFactory.builder().buildAndStart();
+    final DiscoveryNetwork<?> network2 =
         discoveryNetworkFactory.builder().staticPeer(network1.getNodeAddress()).buildAndStart();
     assertConnected(network1, network2);
 
@@ -83,8 +83,8 @@ public class DiscoveryNetworkIntegrationTest {
 
   @Test
   public void shouldConnectToBootnodes() throws Exception {
-    final DiscoveryNetwork<Peer> network1 = discoveryNetworkFactory.builder().buildAndStart();
-    final DiscoveryNetwork<Peer> network2 =
+    final DiscoveryNetwork<?> network1 = discoveryNetworkFactory.builder().buildAndStart();
+    final DiscoveryNetwork<?> network2 =
         discoveryNetworkFactory.builder().bootnode(network1.getEnr().orElseThrow()).buildAndStart();
     assertConnected(network1, network2);
   }
@@ -92,20 +92,20 @@ public class DiscoveryNetworkIntegrationTest {
   @Test
   @Disabled("Discovery library still buggy")
   public void shouldDiscoverPeers() throws Exception {
-    final DiscoveryNetwork<Peer> network1 = discoveryNetworkFactory.builder().buildAndStart();
-    final DiscoveryNetwork<Peer> network2 =
+    final DiscoveryNetwork<?> network1 = discoveryNetworkFactory.builder().buildAndStart();
+    final DiscoveryNetwork<?> network2 =
         discoveryNetworkFactory.builder().bootnode(network1.getEnr().orElseThrow()).buildAndStart();
     assertConnected(network1, network2);
 
     // Only knows about network1, but should discovery network2
-    final DiscoveryNetwork<Peer> network3 =
+    final DiscoveryNetwork<?> network3 =
         discoveryNetworkFactory.builder().bootnode(network1.getEnr().orElseThrow()).buildAndStart();
     assertConnected(network1, network3);
     assertConnected(network2, network3);
   }
 
   private void assertConnected(
-      final DiscoveryNetwork<Peer> network1, final DiscoveryNetwork<Peer> network2) {
+      final DiscoveryNetwork<?> network1, final DiscoveryNetwork<?> network2) {
     Waiter.waitFor(
         () -> {
           assertThat(network1.getPeer(network2.getNodeId())).isPresent();

--- a/networking/p2p/src/integration-test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkIntegrationTest.java
+++ b/networking/p2p/src/integration-test/java/tech/pegasys/teku/networking/p2p/DiscoveryNetworkIntegrationTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.network.p2p.DiscoveryNetworkFactory;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetwork;
-import tech.pegasys.teku.networking.p2p.peer.Peer;
 
 public class DiscoveryNetworkIntegrationTest {
   private final DiscoveryNetworkFactory discoveryNetworkFactory = new DiscoveryNetworkFactory();

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
@@ -13,27 +13,19 @@
 
 package tech.pegasys.teku.networking.p2p.discovery;
 
-import static java.util.stream.Collectors.toList;
-
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 import tech.pegasys.teku.infrastructure.ssz.type.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.p2p.connection.ConnectionManager;
-import tech.pegasys.teku.networking.p2p.connection.PeerSelectionStrategy;
-import tech.pegasys.teku.networking.p2p.discovery.discv5.DiscV5Service;
-import tech.pegasys.teku.networking.p2p.discovery.noop.NoOpDiscoveryService;
 import tech.pegasys.teku.networking.p2p.network.DelegatingP2PNetwork;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
-import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
@@ -44,7 +36,6 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.EnrForkId;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsSupplier;
-import tech.pegasys.teku.storage.store.KeyValueStore;
 
 public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
   private static final Logger LOG = LogManager.getLogger();

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetwork.java
@@ -61,7 +61,7 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
 
   private volatile Optional<EnrForkId> enrForkId = Optional.empty();
 
-  DiscoveryNetwork(
+  protected DiscoveryNetwork(
       final P2PNetwork<P> p2pNetwork,
       final DiscoveryService discoveryService,
       final ConnectionManager connectionManager,
@@ -83,64 +83,6 @@ public class DiscoveryNetwork<P extends Peer> extends DelegatingP2PNetwork<P> {
     // Set connection manager peer predicate so that we don't attempt to connect peers with
     // different fork digests
     connectionManager.addPeerPredicate(this::dontConnectPeersWithDifferentForkDigests);
-  }
-
-  public static <P extends Peer> DiscoveryNetwork<P> create(
-      final MetricsSystem metricsSystem,
-      final AsyncRunner asyncRunner,
-      final KeyValueStore<String, Bytes> kvStore,
-      final P2PNetwork<P> p2pNetwork,
-      final PeerSelectionStrategy peerSelectionStrategy,
-      final DiscoveryConfig discoveryConfig,
-      final NetworkConfig p2pConfig,
-      final Spec spec,
-      final SchemaDefinitionsSupplier currentSchemaDefinitionsSupplier) {
-    final DiscoveryService discoveryService =
-        createDiscoveryService(
-            metricsSystem,
-            asyncRunner,
-            discoveryConfig,
-            p2pConfig,
-            kvStore,
-            p2pNetwork.getPrivateKey(),
-            currentSchemaDefinitionsSupplier);
-    final ConnectionManager connectionManager =
-        new ConnectionManager(
-            metricsSystem,
-            discoveryService,
-            asyncRunner,
-            p2pNetwork,
-            peerSelectionStrategy,
-            discoveryConfig.getStaticPeers().stream()
-                .map(p2pNetwork::createPeerAddress)
-                .collect(toList()));
-    return new DiscoveryNetwork<>(
-        p2pNetwork, discoveryService, connectionManager, spec, currentSchemaDefinitionsSupplier);
-  }
-
-  private static DiscoveryService createDiscoveryService(
-      final MetricsSystem metricsSystem,
-      final AsyncRunner asyncRunner,
-      final DiscoveryConfig discoConfig,
-      final NetworkConfig p2pConfig,
-      final KeyValueStore<String, Bytes> kvStore,
-      final Bytes privateKey,
-      final SchemaDefinitionsSupplier currentSchemaDefinitionsSupplier) {
-    final DiscoveryService discoveryService;
-    if (discoConfig.isDiscoveryEnabled()) {
-      discoveryService =
-          new DiscV5Service(
-              metricsSystem,
-              asyncRunner,
-              discoConfig,
-              p2pConfig,
-              kvStore,
-              privateKey,
-              currentSchemaDefinitionsSupplier);
-    } else {
-      discoveryService = new NoOpDiscoveryService();
-    }
-    return discoveryService;
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkBuilder.java
@@ -1,0 +1,162 @@
+package tech.pegasys.teku.networking.p2p.discovery;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.stream.Collectors.toList;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.networking.p2p.connection.ConnectionManager;
+import tech.pegasys.teku.networking.p2p.connection.PeerSelectionStrategy;
+import tech.pegasys.teku.networking.p2p.discovery.discv5.DiscV5Service;
+import tech.pegasys.teku.networking.p2p.discovery.noop.NoOpDiscoveryService;
+import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
+import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsSupplier;
+import tech.pegasys.teku.storage.store.KeyValueStore;
+
+public class DiscoveryNetworkBuilder {
+
+  public static DiscoveryNetworkBuilder create() {
+    return new DiscoveryNetworkBuilder();
+  }
+
+  protected MetricsSystem metricsSystem;
+  protected AsyncRunner asyncRunner;
+  protected KeyValueStore<String, Bytes> kvStore;
+  protected P2PNetwork<?> p2pNetwork;
+  protected PeerSelectionStrategy peerSelectionStrategy;
+  protected DiscoveryConfig discoveryConfig;
+  protected NetworkConfig p2pConfig;
+  protected Spec spec;
+  protected SchemaDefinitionsSupplier currentSchemaDefinitionsSupplier;
+
+  protected DiscoveryService discoveryService;
+  protected ConnectionManager connectionManager;
+
+  protected DiscoveryNetworkBuilder() {
+  }
+
+  protected void initMissingDefaults() {
+    if (discoveryService == null) {
+      discoveryService = createDiscoveryService();
+    }
+
+    if (connectionManager == null) {
+      connectionManager = createConnectionManager();
+    }
+  }
+
+  public DiscoveryNetwork<?> build() {
+    initMissingDefaults();
+    return new DiscoveryNetwork<>(p2pNetwork, discoveryService, connectionManager, spec,
+        currentSchemaDefinitionsSupplier);
+  }
+
+  protected ConnectionManager createConnectionManager() {
+    checkNotNull(metricsSystem);
+    checkNotNull(discoveryService);
+    checkNotNull(asyncRunner);
+    checkNotNull(p2pNetwork);
+    checkNotNull(peerSelectionStrategy);
+    checkNotNull(discoveryConfig);
+
+    return new ConnectionManager(
+            metricsSystem,
+            discoveryService,
+            asyncRunner,
+            p2pNetwork,
+            peerSelectionStrategy,
+            discoveryConfig.getStaticPeers().stream()
+                .map(p2pNetwork::createPeerAddress)
+                .collect(toList()));
+  }
+
+  protected DiscoveryService createDiscoveryService() {
+    final DiscoveryService discoveryService;
+    if (discoveryConfig.isDiscoveryEnabled()) {
+      checkNotNull(metricsSystem);
+      checkNotNull(asyncRunner);
+      checkNotNull(discoveryConfig);
+      checkNotNull(p2pConfig);
+      checkNotNull(kvStore);
+      checkNotNull(p2pNetwork);
+      checkNotNull(currentSchemaDefinitionsSupplier);
+
+      discoveryService =
+          new DiscV5Service(
+              metricsSystem,
+              asyncRunner,
+              discoveryConfig,
+              p2pConfig,
+              kvStore,
+              p2pNetwork.getPrivateKey(),
+              currentSchemaDefinitionsSupplier);
+    } else {
+      discoveryService = new NoOpDiscoveryService();
+    }
+    return discoveryService;
+  }
+
+  public DiscoveryNetworkBuilder metricsSystem(MetricsSystem metricsSystem) {
+    this.metricsSystem = metricsSystem;
+    return this;
+  }
+
+  public DiscoveryNetworkBuilder asyncRunner(AsyncRunner asyncRunner) {
+    this.asyncRunner = asyncRunner;
+    return this;
+  }
+
+  public DiscoveryNetworkBuilder kvStore(
+      KeyValueStore<String, Bytes> kvStore) {
+    this.kvStore = kvStore;
+    return this;
+  }
+
+  public DiscoveryNetworkBuilder p2pNetwork(P2PNetwork<?> p2pNetwork) {
+    this.p2pNetwork = p2pNetwork;
+    return this;
+  }
+
+  public DiscoveryNetworkBuilder peerSelectionStrategy(
+      PeerSelectionStrategy peerSelectionStrategy) {
+    this.peerSelectionStrategy = peerSelectionStrategy;
+    return this;
+  }
+
+  public DiscoveryNetworkBuilder discoveryConfig(
+      DiscoveryConfig discoveryConfig) {
+    this.discoveryConfig = discoveryConfig;
+    return this;
+  }
+
+  public DiscoveryNetworkBuilder p2pConfig(NetworkConfig p2pConfig) {
+    this.p2pConfig = p2pConfig;
+    return this;
+  }
+
+  public DiscoveryNetworkBuilder spec(Spec spec) {
+    this.spec = spec;
+    return this;
+  }
+
+  public DiscoveryNetworkBuilder currentSchemaDefinitionsSupplier(
+      SchemaDefinitionsSupplier currentSchemaDefinitionsSupplier) {
+    this.currentSchemaDefinitionsSupplier = currentSchemaDefinitionsSupplier;
+    return this;
+  }
+
+  public DiscoveryNetworkBuilder discoveryService(
+      DiscoveryService discoveryService) {
+    this.discoveryService = discoveryService;
+    return this;
+  }
+
+  public DiscoveryNetworkBuilder connectionManager(
+      ConnectionManager connectionManager) {
+    this.connectionManager = connectionManager;
+    return this;
+  }
+}

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkBuilder.java
@@ -29,6 +29,10 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsSupplier;
 import tech.pegasys.teku.storage.store.KeyValueStore;
 
+/**
+ * CAUTION: this API is unstable and primarily intended for debugging and testing purposes this API
+ * might be changed in any version in backward incompatible way
+ */
 public class DiscoveryNetworkBuilder {
 
   public static DiscoveryNetworkBuilder create() {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkBuilder.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.networking.p2p.discovery;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -35,8 +48,7 @@ public class DiscoveryNetworkBuilder {
   protected DiscoveryService discoveryService;
   protected ConnectionManager connectionManager;
 
-  protected DiscoveryNetworkBuilder() {
-  }
+  protected DiscoveryNetworkBuilder() {}
 
   protected void initMissingDefaults() {
     if (discoveryService == null) {
@@ -50,8 +62,8 @@ public class DiscoveryNetworkBuilder {
 
   public DiscoveryNetwork<?> build() {
     initMissingDefaults();
-    return new DiscoveryNetwork<>(p2pNetwork, discoveryService, connectionManager, spec,
-        currentSchemaDefinitionsSupplier);
+    return new DiscoveryNetwork<>(
+        p2pNetwork, discoveryService, connectionManager, spec, currentSchemaDefinitionsSupplier);
   }
 
   protected ConnectionManager createConnectionManager() {
@@ -63,14 +75,14 @@ public class DiscoveryNetworkBuilder {
     checkNotNull(discoveryConfig);
 
     return new ConnectionManager(
-            metricsSystem,
-            discoveryService,
-            asyncRunner,
-            p2pNetwork,
-            peerSelectionStrategy,
-            discoveryConfig.getStaticPeers().stream()
-                .map(p2pNetwork::createPeerAddress)
-                .collect(toList()));
+        metricsSystem,
+        discoveryService,
+        asyncRunner,
+        p2pNetwork,
+        peerSelectionStrategy,
+        discoveryConfig.getStaticPeers().stream()
+            .map(p2pNetwork::createPeerAddress)
+            .collect(toList()));
   }
 
   protected DiscoveryService createDiscoveryService() {
@@ -109,8 +121,7 @@ public class DiscoveryNetworkBuilder {
     return this;
   }
 
-  public DiscoveryNetworkBuilder kvStore(
-      KeyValueStore<String, Bytes> kvStore) {
+  public DiscoveryNetworkBuilder kvStore(KeyValueStore<String, Bytes> kvStore) {
     this.kvStore = kvStore;
     return this;
   }
@@ -126,8 +137,7 @@ public class DiscoveryNetworkBuilder {
     return this;
   }
 
-  public DiscoveryNetworkBuilder discoveryConfig(
-      DiscoveryConfig discoveryConfig) {
+  public DiscoveryNetworkBuilder discoveryConfig(DiscoveryConfig discoveryConfig) {
     this.discoveryConfig = discoveryConfig;
     return this;
   }
@@ -148,14 +158,12 @@ public class DiscoveryNetworkBuilder {
     return this;
   }
 
-  public DiscoveryNetworkBuilder discoveryService(
-      DiscoveryService discoveryService) {
+  public DiscoveryNetworkBuilder discoveryService(DiscoveryService discoveryService) {
     this.discoveryService = discoveryService;
     return this;
   }
 
-  public DiscoveryNetworkBuilder connectionManager(
-      ConnectionManager connectionManager) {
+  public DiscoveryNetworkBuilder connectionManager(ConnectionManager connectionManager) {
     this.connectionManager = connectionManager;
     return this;
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -16,54 +16,29 @@ package tech.pegasys.teku.networking.p2p.libp2p;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
 import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 
-import identify.pb.IdentifyOuterClass;
 import io.libp2p.core.Host;
 import io.libp2p.core.PeerId;
 import io.libp2p.core.crypto.PrivKey;
-import io.libp2p.core.dsl.Builder.Defaults;
-import io.libp2p.core.dsl.BuilderJKt;
 import io.libp2p.core.multiformats.Multiaddr;
-import io.libp2p.core.multistream.ProtocolBinding;
-import io.libp2p.core.mux.StreamMuxerProtocol;
-import io.libp2p.etc.types.ByteArrayExtKt;
-import io.libp2p.protocol.Identify;
-import io.libp2p.protocol.Ping;
-import io.libp2p.security.noise.NoiseXXSecureChannel;
-import io.libp2p.transport.tcp.TcpTransport;
-import io.netty.handler.logging.LogLevel;
-import java.net.InetSocketAddress;
-import java.time.Duration;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.version.VersionProvider;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
-import tech.pegasys.teku.networking.p2p.gossip.PreparedGossipMessageFactory;
 import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
 import tech.pegasys.teku.networking.p2p.gossip.TopicHandler;
 import tech.pegasys.teku.networking.p2p.gossip.config.GossipTopicsScoringConfig;
-import tech.pegasys.teku.networking.p2p.libp2p.gossip.GossipTopicFilter;
 import tech.pegasys.teku.networking.p2p.libp2p.gossip.LibP2PGossipNetwork;
-import tech.pegasys.teku.networking.p2p.libp2p.rpc.RpcHandler;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.networking.p2p.network.PeerAddress;
-import tech.pegasys.teku.networking.p2p.network.PeerHandler;
-import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
-import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
-import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 
 public class LibP2PNetwork implements P2PNetwork<Peer> {
 
@@ -82,9 +57,14 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
   private final AtomicReference<State> state = new AtomicReference<>(State.IDLE);
   private final int listenPort;
 
-  protected LibP2PNetwork(PrivKey privKey, NodeId nodeId, Host host,
-      PeerManager peerManager, Multiaddr advertisedAddr,
-      LibP2PGossipNetwork gossipNetwork, int listenPort) {
+  protected LibP2PNetwork(
+      PrivKey privKey,
+      NodeId nodeId,
+      Host host,
+      PeerManager peerManager,
+      Multiaddr advertisedAddr,
+      LibP2PGossipNetwork gossipNetwork,
+      int listenPort) {
     this.privKey = privKey;
     this.nodeId = nodeId;
     this.host = host;

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -68,8 +68,8 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 public class LibP2PNetwork implements P2PNetwork<Peer> {
 
   private static final Logger LOG = LogManager.getLogger();
-  private static final int REMOTE_OPEN_STREAMS_RATE_LIMIT = 256;
-  private static final int REMOTE_PARALLEL_OPEN_STREAMS_COUNT_LIMIT = 256;
+  static final int REMOTE_OPEN_STREAMS_RATE_LIMIT = 256;
+  static final int REMOTE_PARALLEL_OPEN_STREAMS_COUNT_LIMIT = 256;
 
   private final PrivKey privKey;
   private final NodeId nodeId;
@@ -81,6 +81,18 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
 
   private final AtomicReference<State> state = new AtomicReference<>(State.IDLE);
   private final int listenPort;
+
+  public LibP2PNetwork(PrivKey privKey, NodeId nodeId, Host host,
+      PeerManager peerManager, Multiaddr advertisedAddr,
+      LibP2PGossipNetwork gossipNetwork, int listenPort) {
+    this.privKey = privKey;
+    this.nodeId = nodeId;
+    this.host = host;
+    this.peerManager = peerManager;
+    this.advertisedAddr = advertisedAddr;
+    this.gossipNetwork = gossipNetwork;
+    this.listenPort = listenPort;
+  }
 
   public LibP2PNetwork(
       final AsyncRunner asyncRunner,

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -1,0 +1,232 @@
+package tech.pegasys.teku.networking.p2p.libp2p;
+
+import static tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork.REMOTE_OPEN_STREAMS_RATE_LIMIT;
+import static tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork.REMOTE_PARALLEL_OPEN_STREAMS_COUNT_LIMIT;
+
+import identify.pb.IdentifyOuterClass;
+import io.libp2p.core.Host;
+import io.libp2p.core.PeerId;
+import io.libp2p.core.crypto.PrivKey;
+import io.libp2p.core.crypto.PubKey;
+import io.libp2p.core.dsl.Builder.Defaults;
+import io.libp2p.core.dsl.BuilderJKt;
+import io.libp2p.core.multiformats.Multiaddr;
+import io.libp2p.core.multistream.ProtocolBinding;
+import io.libp2p.core.mux.StreamMuxerProtocol;
+import io.libp2p.etc.types.ByteArrayExtKt;
+import io.libp2p.protocol.Identify;
+import io.libp2p.protocol.Ping;
+import io.libp2p.security.noise.NoiseXXSecureChannel;
+import io.libp2p.transport.tcp.TcpTransport;
+import io.netty.handler.logging.LogLevel;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.version.VersionProvider;
+import tech.pegasys.teku.networking.p2p.gossip.PreparedGossipMessageFactory;
+import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork.PrivateKeyProvider;
+import tech.pegasys.teku.networking.p2p.libp2p.gossip.GossipTopicFilter;
+import tech.pegasys.teku.networking.p2p.libp2p.gossip.LibP2PGossipNetwork;
+import tech.pegasys.teku.networking.p2p.libp2p.rpc.RpcHandler;
+import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
+import tech.pegasys.teku.networking.p2p.network.PeerHandler;
+import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
+import tech.pegasys.teku.networking.p2p.peer.NodeId;
+import tech.pegasys.teku.networking.p2p.peer.Peer;
+import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
+import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
+
+public class LibP2PNetworkBuilder {
+
+  public static LibP2PNetworkBuilder create() {
+    return new LibP2PNetworkBuilder();
+  }
+
+  protected AsyncRunner asyncRunner;
+  protected NetworkConfig config;
+  protected PrivateKeyProvider privateKeyProvider;
+  protected ReputationManager reputationManager;
+  protected MetricsSystem metricsSystem;
+  protected List<RpcMethod<?, ?, ?>> rpcMethods;
+  protected List<PeerHandler> peerHandlers;
+  protected PreparedGossipMessageFactory preparedGossipMessageFactory;
+  protected GossipTopicFilter gossipTopicFilter;
+
+  protected LibP2PGossipNetwork gossipNetwork;
+  protected PeerManager peerManager;
+
+  protected Defaults hostBuilderDefaults = Defaults.None;
+  protected Host host;
+
+  protected LibP2PNetworkBuilder() {
+  }
+
+  public P2PNetwork<Peer> build() {
+    if (gossipNetwork == null) {
+      // Setup gossip
+      gossipNetwork =
+          LibP2PGossipNetwork.create(
+              metricsSystem,
+              config.getGossipConfig(),
+              preparedGossipMessageFactory,
+              gossipTopicFilter,
+              config.getWireLogsConfig().isLogWireGossip());
+    }
+
+    // Setup rpc methods
+    final List<RpcHandler<?, ?, ?>> rpcHandlers =
+        rpcMethods.stream().map(m -> new RpcHandler<>(asyncRunner, m)).collect(Collectors.toList());
+
+    if (peerManager == null) {
+      // Setup peers
+      peerManager =
+          new PeerManager(
+              metricsSystem,
+              reputationManager,
+              peerHandlers,
+              rpcHandlers,
+              (peerId) -> gossipNetwork.getGossip().getGossipScore(peerId));
+    }
+
+    PrivKey privKey = privateKeyProvider.get();
+    NodeId nodeId = new LibP2PNodeId(PeerId.fromPubKey(privKey.publicKey()));
+
+    Multiaddr advertisedAddr =
+        MultiaddrUtil.fromInetSocketAddress(
+            new InetSocketAddress(config.getAdvertisedIp(), config.getAdvertisedPort()), nodeId);
+    final Multiaddr listenAddr =
+        MultiaddrUtil.fromInetSocketAddress(
+            new InetSocketAddress(config.getNetworkInterface(), config.getListenPort()));
+
+    if (host == null) {
+      host =
+          BuilderJKt.hostJ(
+              hostBuilderDefaults,
+              b -> {
+                b.getIdentity().setFactory(() -> privKey);
+                b.getTransports().add(TcpTransport::new);
+                b.getSecureChannels().add(NoiseXXSecureChannel::new);
+                b.getMuxers().add(StreamMuxerProtocol.getMplex());
+
+                b.getNetwork().listen(listenAddr.toString());
+
+                b.getProtocols().addAll(getDefaultProtocols(privKey.publicKey(), advertisedAddr));
+                b.getProtocols().addAll(rpcHandlers);
+
+                if (config.getWireLogsConfig().isLogWireCipher()) {
+                  b.getDebug().getBeforeSecureHandler().addLogger(LogLevel.DEBUG, "wire.ciphered");
+                }
+                Firewall firewall = new Firewall(Duration.ofSeconds(30));
+                b.getDebug().getBeforeSecureHandler().addNettyHandler(firewall);
+
+                if (config.getWireLogsConfig().isLogWirePlain()) {
+                  b.getDebug().getAfterSecureHandler().addLogger(LogLevel.DEBUG, "wire.plain");
+                }
+                if (config.getWireLogsConfig().isLogWireMuxFrames()) {
+                  b.getDebug().getMuxFramesHandler().addLogger(LogLevel.DEBUG, "wire.mux");
+                }
+
+                b.getConnectionHandlers().add(peerManager);
+
+                MplexFirewall mplexFirewall =
+                    new MplexFirewall(
+                        REMOTE_OPEN_STREAMS_RATE_LIMIT, REMOTE_PARALLEL_OPEN_STREAMS_COUNT_LIMIT);
+                b.getDebug().getMuxFramesHandler().addHandler(mplexFirewall);
+              });
+    }
+
+    return new LibP2PNetwork(privKey, nodeId, host, peerManager, advertisedAddr, gossipNetwork,
+        config.getListenPort());
+  }
+
+  protected List<ProtocolBinding<?>> getDefaultProtocols(PubKey nodePubKey, Multiaddr advertisedAddr) {
+    final Ping ping = new Ping();
+    IdentifyOuterClass.Identify identifyMsg =
+        IdentifyOuterClass.Identify.newBuilder()
+            .setProtocolVersion("ipfs/0.1.0")
+            .setAgentVersion(VersionProvider.CLIENT_IDENTITY + "/" + VersionProvider.VERSION)
+            .setPublicKey(ByteArrayExtKt.toProtobuf(nodePubKey.bytes()))
+            .addListenAddrs(ByteArrayExtKt.toProtobuf(advertisedAddr.getBytes()))
+            .setObservedAddr(ByteArrayExtKt.toProtobuf(advertisedAddr.getBytes()))
+            .addAllProtocols(ping.getProtocolDescriptor().getAnnounceProtocols())
+            .addAllProtocols(
+                gossipNetwork.getGossip().getProtocolDescriptor().getAnnounceProtocols())
+            .build();
+    return List.of(ping, new Identify(identifyMsg), gossipNetwork.getGossip());
+  }
+
+  public LibP2PNetworkBuilder asyncRunner(AsyncRunner asyncRunner) {
+    this.asyncRunner = asyncRunner;
+    return this;
+  }
+
+  public LibP2PNetworkBuilder config(NetworkConfig config) {
+    this.config = config;
+    return this;
+  }
+
+  public LibP2PNetworkBuilder privateKeyProvider(
+      PrivateKeyProvider privateKeyProvider) {
+    this.privateKeyProvider = privateKeyProvider;
+    return this;
+  }
+
+  public LibP2PNetworkBuilder reputationManager(
+      ReputationManager reputationManager) {
+    this.reputationManager = reputationManager;
+    return this;
+  }
+
+  public LibP2PNetworkBuilder metricsSystem(MetricsSystem metricsSystem) {
+    this.metricsSystem = metricsSystem;
+    return this;
+  }
+
+  public LibP2PNetworkBuilder rpcMethods(
+      List<RpcMethod<?, ?, ?>> rpcMethods) {
+    this.rpcMethods = rpcMethods;
+    return this;
+  }
+
+  public LibP2PNetworkBuilder peerHandlers(
+      List<PeerHandler> peerHandlers) {
+    this.peerHandlers = peerHandlers;
+    return this;
+  }
+
+  public LibP2PNetworkBuilder preparedGossipMessageFactory(
+      PreparedGossipMessageFactory preparedGossipMessageFactory) {
+    this.preparedGossipMessageFactory = preparedGossipMessageFactory;
+    return this;
+  }
+
+  public LibP2PNetworkBuilder gossipTopicFilter(
+      GossipTopicFilter gossipTopicFilter) {
+    this.gossipTopicFilter = gossipTopicFilter;
+    return this;
+  }
+
+  public LibP2PNetworkBuilder gossipNetwork(
+      LibP2PGossipNetwork gossipNetwork) {
+    this.gossipNetwork = gossipNetwork;
+    return this;
+  }
+
+  public LibP2PNetworkBuilder peerManager(PeerManager peerManager) {
+    this.peerManager = peerManager;
+    return this;
+  }
+
+  public LibP2PNetworkBuilder hostBuilderDefaults(Defaults hostBuilderDefaults) {
+    this.hostBuilderDefaults = hostBuilderDefaults;
+    return this;
+  }
+
+  public LibP2PNetworkBuilder host(Host host) {
+    this.host = host;
+    return this;
+  }
+}

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.networking.p2p.libp2p;
 
 import static tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork.REMOTE_OPEN_STREAMS_RATE_LIMIT;
@@ -61,8 +74,7 @@ public class LibP2PNetworkBuilder {
   protected Defaults hostBuilderDefaults = Defaults.None;
   protected Host host;
 
-  protected LibP2PNetworkBuilder() {
-  }
+  protected LibP2PNetworkBuilder() {}
 
   public P2PNetwork<Peer> build() {
     if (gossipNetwork == null) {
@@ -138,11 +150,12 @@ public class LibP2PNetworkBuilder {
               });
     }
 
-    return new LibP2PNetwork(privKey, nodeId, host, peerManager, advertisedAddr, gossipNetwork,
-        config.getListenPort());
+    return new LibP2PNetwork(
+        privKey, nodeId, host, peerManager, advertisedAddr, gossipNetwork, config.getListenPort());
   }
 
-  protected List<ProtocolBinding<?>> getDefaultProtocols(PubKey nodePubKey, Multiaddr advertisedAddr) {
+  protected List<ProtocolBinding<?>> getDefaultProtocols(
+      PubKey nodePubKey, Multiaddr advertisedAddr) {
     final Ping ping = new Ping();
     IdentifyOuterClass.Identify identifyMsg =
         IdentifyOuterClass.Identify.newBuilder()
@@ -168,14 +181,12 @@ public class LibP2PNetworkBuilder {
     return this;
   }
 
-  public LibP2PNetworkBuilder privateKeyProvider(
-      PrivateKeyProvider privateKeyProvider) {
+  public LibP2PNetworkBuilder privateKeyProvider(PrivateKeyProvider privateKeyProvider) {
     this.privateKeyProvider = privateKeyProvider;
     return this;
   }
 
-  public LibP2PNetworkBuilder reputationManager(
-      ReputationManager reputationManager) {
+  public LibP2PNetworkBuilder reputationManager(ReputationManager reputationManager) {
     this.reputationManager = reputationManager;
     return this;
   }
@@ -185,14 +196,12 @@ public class LibP2PNetworkBuilder {
     return this;
   }
 
-  public LibP2PNetworkBuilder rpcMethods(
-      List<RpcMethod<?, ?, ?>> rpcMethods) {
+  public LibP2PNetworkBuilder rpcMethods(List<RpcMethod<?, ?, ?>> rpcMethods) {
     this.rpcMethods = rpcMethods;
     return this;
   }
 
-  public LibP2PNetworkBuilder peerHandlers(
-      List<PeerHandler> peerHandlers) {
+  public LibP2PNetworkBuilder peerHandlers(List<PeerHandler> peerHandlers) {
     this.peerHandlers = peerHandlers;
     return this;
   }
@@ -203,14 +212,12 @@ public class LibP2PNetworkBuilder {
     return this;
   }
 
-  public LibP2PNetworkBuilder gossipTopicFilter(
-      GossipTopicFilter gossipTopicFilter) {
+  public LibP2PNetworkBuilder gossipTopicFilter(GossipTopicFilter gossipTopicFilter) {
     this.gossipTopicFilter = gossipTopicFilter;
     return this;
   }
 
-  public LibP2PNetworkBuilder gossipNetwork(
-      LibP2PGossipNetwork gossipNetwork) {
+  public LibP2PNetworkBuilder gossipNetwork(LibP2PGossipNetwork gossipNetwork) {
     this.gossipNetwork = gossipNetwork;
     return this;
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -52,6 +52,10 @@ import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 
+/**
+ * CAUTION: this API is unstable and primarily intended for debugging and testing purposes this API
+ * might be changed in any version in backward incompatible way
+ */
 public class LibP2PNetworkBuilder {
 
   public static LibP2PNetworkBuilder create() {

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkTest.java
@@ -158,17 +158,18 @@ class DiscoveryNetworkTest {
     final NetworkConfig networkConfig = NetworkConfig.builder().build();
     final PeerSelectionStrategy peerSelectionStrategy =
         new SimplePeerSelectionStrategy(new TargetPeerRange(20, 30, 0));
-    final DiscoveryNetwork<Peer> network =
-        DiscoveryNetwork.create(
-            new NoOpMetricsSystem(),
-            DelayedExecutorAsyncRunner.create(),
-            new MemKeyValueStore<>(),
-            p2pNetwork,
-            peerSelectionStrategy,
-            discoveryConfig,
-            networkConfig,
-            spec,
-            spec::getGenesisSchemaDefinitions);
+    final DiscoveryNetwork<?> network =
+        DiscoveryNetworkBuilder.create()
+            .metricsSystem(new NoOpMetricsSystem())
+            .asyncRunner(DelayedExecutorAsyncRunner.create())
+            .kvStore(new MemKeyValueStore<>())
+            .p2pNetwork(p2pNetwork)
+            .peerSelectionStrategy(peerSelectionStrategy)
+            .discoveryConfig(discoveryConfig)
+            .p2pConfig(networkConfig)
+            .spec(spec)
+            .currentSchemaDefinitionsSupplier(spec::getGenesisSchemaDefinitions)
+            .build();
     assertThat(network.getEnr()).isEmpty();
   }
 

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
@@ -37,7 +37,6 @@ import tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetwork;
 import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetworkBuilder;
 import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
-import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -68,8 +67,7 @@ public class DiscoveryNetworkFactory {
     private final List<String> bootnodes = new ArrayList<>();
     private Spec spec = TestSpecFactory.createMinimalPhase0();
 
-    private DiscoveryNetworkBuilder() {
-    }
+    private DiscoveryNetworkBuilder() {}
 
     public DiscoveryNetworkBuilder staticPeer(final String staticPeer) {
       this.staticPeers.add(staticPeer);
@@ -112,7 +110,8 @@ public class DiscoveryNetworkFactory {
                 .metricsSystem(metricsSystem)
                 .asyncRunner(DelayedExecutorAsyncRunner.create())
                 .kvStore(new MemKeyValueStore<>())
-                .p2pNetwork(LibP2PNetworkBuilder.create()
+                .p2pNetwork(
+                    LibP2PNetworkBuilder.create()
                         .asyncRunner(DelayedExecutorAsyncRunner.create())
                         .config(config)
                         .privateKeyProvider(PrivateKeyGenerator::generate)
@@ -120,11 +119,12 @@ public class DiscoveryNetworkFactory {
                         .metricsSystem(METRICS_SYSTEM)
                         .rpcMethods(Collections.emptyList())
                         .peerHandlers(Collections.emptyList())
-                        .preparedGossipMessageFactory((__1, __2) -> {
-                          throw new UnsupportedOperationException();
-                        }).gossipTopicFilter(topic -> true)
-                        .build()
-                    )
+                        .preparedGossipMessageFactory(
+                            (__1, __2) -> {
+                              throw new UnsupportedOperationException();
+                            })
+                        .gossipTopicFilter(topic -> true)
+                        .build())
                 .peerSelectionStrategy(peerSelectionStrategy)
                 .discoveryConfig(discoveryConfig)
                 .p2pConfig(config)

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.networking.p2p.connection.PeerSelectionStrategy;
 import tech.pegasys.teku.networking.p2p.connection.TargetPeerRange;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetwork;
+import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetworkBuilder;
 import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetworkBuilder;
 import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
@@ -52,8 +53,8 @@ public class DiscoveryNetworkFactory {
 
   private final List<DiscoveryNetwork<?>> networks = new ArrayList<>();
 
-  public DiscoveryNetworkBuilder builder() {
-    return new DiscoveryNetworkBuilder();
+  public DiscoveryTestNetworkBuilder builder() {
+    return new DiscoveryTestNetworkBuilder();
   }
 
   public void stopAll() throws InterruptedException, ExecutionException, TimeoutException {
@@ -61,20 +62,20 @@ public class DiscoveryNetworkFactory {
         SafeFuture.allOf(networks.stream().map(DiscoveryNetwork::stop).toArray(SafeFuture[]::new)));
   }
 
-  public class DiscoveryNetworkBuilder {
+  public class DiscoveryTestNetworkBuilder {
 
     private final List<String> staticPeers = new ArrayList<>();
     private final List<String> bootnodes = new ArrayList<>();
     private Spec spec = TestSpecFactory.createMinimalPhase0();
 
-    private DiscoveryNetworkBuilder() {}
+    private DiscoveryTestNetworkBuilder() {}
 
-    public DiscoveryNetworkBuilder staticPeer(final String staticPeer) {
+    public DiscoveryTestNetworkBuilder staticPeer(final String staticPeer) {
       this.staticPeers.add(staticPeer);
       return this;
     }
 
-    public DiscoveryNetworkBuilder bootnode(final String bootnode) {
+    public DiscoveryTestNetworkBuilder bootnode(final String bootnode) {
       this.bootnodes.add(bootnode);
       return this;
     }
@@ -106,7 +107,7 @@ public class DiscoveryNetworkFactory {
         final PeerSelectionStrategy peerSelectionStrategy =
             new SimplePeerSelectionStrategy(new TargetPeerRange(20, 30, 0));
         final DiscoveryNetwork<?> network =
-            tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetworkBuilder.create()
+            DiscoveryNetworkBuilder.create()
                 .metricsSystem(metricsSystem)
                 .asyncRunner(DelayedExecutorAsyncRunner.create())
                 .kvStore(new MemKeyValueStore<>())

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.networking.p2p.connection.PeerSelectionStrategy;
 import tech.pegasys.teku.networking.p2p.connection.TargetPeerRange;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetwork;
-import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork;
+import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetworkBuilder;
 import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
@@ -51,7 +51,7 @@ public class DiscoveryNetworkFactory {
   private static final int MIN_PORT = 9000;
   private static final int MAX_PORT = 12000;
 
-  private final List<DiscoveryNetwork<Peer>> networks = new ArrayList<>();
+  private final List<DiscoveryNetwork<?>> networks = new ArrayList<>();
 
   public DiscoveryNetworkBuilder builder() {
     return new DiscoveryNetworkBuilder();
@@ -63,11 +63,13 @@ public class DiscoveryNetworkFactory {
   }
 
   public class DiscoveryNetworkBuilder {
+
     private final List<String> staticPeers = new ArrayList<>();
     private final List<String> bootnodes = new ArrayList<>();
     private Spec spec = TestSpecFactory.createMinimalPhase0();
 
-    private DiscoveryNetworkBuilder() {}
+    private DiscoveryNetworkBuilder() {
+    }
 
     public DiscoveryNetworkBuilder staticPeer(final String staticPeer) {
       this.staticPeers.add(staticPeer);
@@ -79,7 +81,7 @@ public class DiscoveryNetworkFactory {
       return this;
     }
 
-    public DiscoveryNetwork<Peer> buildAndStart() throws Exception {
+    public DiscoveryNetwork<?> buildAndStart() throws Exception {
       int attempt = 1;
       while (true) {
 
@@ -105,28 +107,30 @@ public class DiscoveryNetworkFactory {
                 Constants.REPUTATION_MANAGER_CAPACITY);
         final PeerSelectionStrategy peerSelectionStrategy =
             new SimplePeerSelectionStrategy(new TargetPeerRange(20, 30, 0));
-        final DiscoveryNetwork<Peer> network =
-            DiscoveryNetwork.create(
-                metricsSystem,
-                DelayedExecutorAsyncRunner.create(),
-                new MemKeyValueStore<>(),
-                new LibP2PNetwork(
-                    DelayedExecutorAsyncRunner.create(),
-                    config,
-                    PrivateKeyGenerator::generate,
-                    reputationManager,
-                    METRICS_SYSTEM,
-                    Collections.emptyList(),
-                    Collections.emptyList(),
-                    (__1, __2) -> {
-                      throw new UnsupportedOperationException();
-                    },
-                    topic -> true),
-                peerSelectionStrategy,
-                discoveryConfig,
-                config,
-                spec,
-                spec::getGenesisSchemaDefinitions);
+        final DiscoveryNetwork<?> network =
+            tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetworkBuilder.create()
+                .metricsSystem(metricsSystem)
+                .asyncRunner(DelayedExecutorAsyncRunner.create())
+                .kvStore(new MemKeyValueStore<>())
+                .p2pNetwork(LibP2PNetworkBuilder.create()
+                        .asyncRunner(DelayedExecutorAsyncRunner.create())
+                        .config(config)
+                        .privateKeyProvider(PrivateKeyGenerator::generate)
+                        .reputationManager(reputationManager)
+                        .metricsSystem(METRICS_SYSTEM)
+                        .rpcMethods(Collections.emptyList())
+                        .peerHandlers(Collections.emptyList())
+                        .preparedGossipMessageFactory((__1, __2) -> {
+                          throw new UnsupportedOperationException();
+                        }).gossipTopicFilter(topic -> true)
+                        .build()
+                    )
+                .peerSelectionStrategy(peerSelectionStrategy)
+                .discoveryConfig(discoveryConfig)
+                .p2pConfig(config)
+                .spec(spec)
+                .currentSchemaDefinitionsSupplier(spec::getGenesisSchemaDefinitions)
+                .build();
         try {
           network.start().get(30, TimeUnit.SECONDS);
           networks.add(network);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -722,7 +722,7 @@ public class BeaconChainController extends Service implements TimeTickChannel {
         new FileKeyValueStore(beaconDataDirectory.resolve(KEY_VALUE_STORE_SUBDIRECTORY));
 
     this.p2pNetwork =
-        Eth2P2PNetworkBuilder.create()
+        createEth2P2PNetworkBuilder()
             .config(beaconConfig.p2pConfig())
             .eventChannels(eventChannels)
             .recentChainData(recentChainData)
@@ -750,6 +750,10 @@ public class BeaconChainController extends Service implements TimeTickChannel {
             .requiredCheckpoint(weakSubjectivityValidator.getWSCheckpoint())
             .specProvider(spec)
             .build();
+  }
+
+  protected Eth2P2PNetworkBuilder createEth2P2PNetworkBuilder() {
+    return Eth2P2PNetworkBuilder.create();
   }
 
   protected void initSlotProcessor() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

This PR adds more customization to the `BeaconNode` creation process, in particular networking components 
- add a protected method `BeaconChainController.createEth2P2PNetworkBuilder()` which allows to override a network builder 
- make `Eth2P2PNetworkBuilder` fields protected to have access to them for a subclass 
- add `LibP2PNetworkBuilder` and `DiscoveryNetworkBuilder`
- add `Eth2P2PNetworkBuilder` `discoveryNetworkBuilderSupplier` and `libP2PNetworkBuilderSupplier` fields to alter corresponding building behavior 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Follow up to #4601 and #4735

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
