### PR TITLE
Fail build when buildx plugin fails to download

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ commands:
           name: "Install Docker buildx plugin"
           command: |
             mkdir -vp ~/.docker/cli-plugins/
-            curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
+            curl --fail -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
             chmod a+x ~/.docker/cli-plugins/docker-buildx
 
   notify:


### PR DESCRIPTION
## PR Description
Fail the build when the buildx plugin fails to download (with more useful error message than we get when it later fails because the plugin isn't present).

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
