### PR TITLE
[SPIKE] Spike simplify fork choice notifier

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -130,7 +130,7 @@ public class BlockOperationSelectorFactory {
           .executionPayload(
               () ->
                   forkChoiceNotifier
-                      .getPayloadId(parentRoot)
+                      .getPayloadId(parentRoot, blockSlotState.getSlot())
                       .thenApply(
                           maybePayloadId -> {
                             if (maybePayloadId.isEmpty()) {

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
@@ -161,7 +161,7 @@ class BlockFactoryTest {
     when(proposerSlashingPool.getItemsForBlock(any(), any(), any())).thenReturn(proposerSlashings);
     when(voluntaryExitPool.getItemsForBlock(any(), any(), any())).thenReturn(voluntaryExits);
     when(eth1DataCache.getEth1Vote(any())).thenReturn(ETH1_DATA);
-    when(forkChoiceNotifier.getPayloadId(any()))
+    when(forkChoiceNotifier.getPayloadId(any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(Bytes8.fromHexStringLenient("0x0"))));
     when(executionEngine.getPayload(any(), any()))
         .thenReturn(SafeFuture.completedFuture(executionPayload));

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -149,7 +149,7 @@ class BlockOperationSelectorFactoryTest {
     when(attesterSlashingValidator.validateFully(any())).thenReturn(ACCEPT);
     when(proposerSlashingValidator.validateFully(any())).thenReturn(ACCEPT);
     when(voluntaryExitValidator.validateFully(any())).thenReturn(ACCEPT);
-    when(forkChoiceNotifier.getPayloadId(any()))
+    when(forkChoiceNotifier.getPayloadId(any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
   }
 
@@ -279,7 +279,7 @@ class BlockOperationSelectorFactoryTest {
     final Bytes8 payloadId = dataStructureUtil.randomBytes8();
     final ExecutionPayload randomExecutionPayload = dataStructureUtil.randomExecutionPayload();
 
-    when(forkChoiceNotifier.getPayloadId(any()))
+    when(forkChoiceNotifier.getPayloadId(any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(payloadId)));
     when(executionEngine.getPayload(payloadId, slot))
         .thenReturn(SafeFuture.completedFuture(randomExecutionPayload));

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
@@ -155,10 +155,11 @@ public class ForkChoiceNotifier {
               newPayloadAttributes -> {
                 // update attributes and, since this has been executed async recheck suitability of
                 // Data since forkChoiceUpdateData could have been modified in the meantime
-                // TODO: is it possible that a on(Event) has been executed inbetween and changed
-                //  forkChoiceState contained in forkChoiceUpdateData? if yes, re-running
-                //  isPayloadIdSuitable is not enough, we need to ensure congruence with
-                //  parentBeaconBlockRoot
+                //
+                // if an on(Event) has been executed inbetween and changed
+                //  forkChoiceState contained in forkChoiceUpdateData, re-running
+                //  isPayloadIdSuitable should be fine: as long as has a correct
+                //  timestamp and builds atop the right block it is a usable payload
                 if (updatePayloadAttributes(blockSlot, newPayloadAttributes)
                     && forkChoiceUpdateData.isPayloadIdSuitable(parentExecutionHash, timestamp)) {
                   return forkChoiceUpdateData.getPayloadId();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.type.Bytes8;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.ForkChoiceState;
+import tech.pegasys.teku.spec.executionengine.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.spec.executionengine.PayloadAttributes;
+
+public class ForkChoiceUpdateData {
+
+  private final ForkChoiceState forkChoiceState;
+  private final Optional<PayloadAttributes> payloadAttributes;
+  private final Optional<Bytes32> terminalBlockHash;
+  private final SafeFuture<Optional<Bytes8>> payloadId = new SafeFuture<>();
+  private boolean sent = false;
+
+  public ForkChoiceUpdateData() {
+    this.forkChoiceState = new ForkChoiceState(Bytes32.ZERO, Bytes32.ZERO, Bytes32.ZERO);
+    this.payloadAttributes = Optional.empty();
+    this.terminalBlockHash = Optional.empty();
+  }
+
+  public ForkChoiceUpdateData(
+      final ForkChoiceState forkChoiceState,
+      final Optional<PayloadAttributes> payloadAttributes,
+      final Optional<Bytes32> terminalBlockHash) {
+    // TODO: Use terminalBlockHash as forkChoiceState head root if it was zero
+    this.forkChoiceState = forkChoiceState;
+    this.payloadAttributes = payloadAttributes;
+    this.terminalBlockHash = terminalBlockHash;
+  }
+
+  public ForkChoiceUpdateData withForkChoiceState(final ForkChoiceState forkChoiceState) {
+    if (this.forkChoiceState.equals(forkChoiceState)) {
+      return this;
+    }
+    return new ForkChoiceUpdateData(forkChoiceState, payloadAttributes, terminalBlockHash);
+  }
+
+  public ForkChoiceUpdateData withPayloadAttributes(
+      final Optional<PayloadAttributes> payloadAttributes) {
+    if (this.payloadAttributes.equals(payloadAttributes)) {
+      return this;
+    }
+    return new ForkChoiceUpdateData(forkChoiceState, payloadAttributes, terminalBlockHash);
+  }
+
+  public ForkChoiceUpdateData withPayloadAttributes(final PayloadAttributes payloadAttributes) {
+    if (this.payloadAttributes.isPresent()
+        && this.payloadAttributes.get().equals(payloadAttributes)) {
+      return this;
+    }
+    return new ForkChoiceUpdateData(
+        forkChoiceState, Optional.of(payloadAttributes), terminalBlockHash);
+  }
+
+  public ForkChoiceUpdateData withoutPayloadAttributes() {
+    if (this.payloadAttributes.isEmpty()) {
+      return this;
+    }
+    return new ForkChoiceUpdateData(forkChoiceState, Optional.empty(), terminalBlockHash);
+  }
+
+  public ForkChoiceUpdateData withTerminalBlockHash(final Bytes32 terminalBlockHash) {
+    if (this.terminalBlockHash.isPresent()
+        && this.terminalBlockHash.get().equals(terminalBlockHash)) {
+      return this;
+    }
+    return new ForkChoiceUpdateData(
+        forkChoiceState, payloadAttributes, Optional.of(terminalBlockHash));
+  }
+
+  public boolean isPayloadIdSuitable(final Bytes32 parentExecutionHash, final UInt64 timestamp) {
+    if (payloadAttributes.isEmpty()) {
+      return false;
+    }
+    final PayloadAttributes attributes = this.payloadAttributes.get();
+    if (!attributes.getTimestamp().equals(timestamp)) {
+      return false;
+    }
+    if (parentExecutionHash.isZero() && terminalBlockHash.isEmpty()) {
+      return false;
+    }
+    // TODO: This is wrong. :)
+    final Bytes32 requiredExecutionBlockHash =
+        parentExecutionHash.isZero() ? terminalBlockHash.get() : parentExecutionHash;
+    return forkChoiceState.getHeadBlockHash().equals(parentExecutionHash)
+        || (parentExecutionHash.isZero() && terminalBlockHash.isPresent());
+  }
+
+  public SafeFuture<Optional<Bytes8>> getPayloadId() {
+    return payloadId;
+  }
+
+  public void send(final ExecutionEngineChannel executionEngine) {
+    if (sent) {
+      return;
+    }
+    sent = true;
+    if (forkChoiceState.getHeadBlockHash().isZero()) {
+      payloadId.complete(Optional.empty());
+      return;
+    }
+    // TODO: Handle errors here instead of propagating to result?
+    executionEngine
+        .forkChoiceUpdated(forkChoiceState, payloadAttributes)
+        .thenApply(ForkChoiceUpdatedResult::getPayloadId)
+        .propagateTo(payloadId);
+  }
+
+  public boolean hasHeadBlockHash() {
+    return !forkChoiceState.getHeadBlockHash().isZero();
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
@@ -13,7 +13,10 @@
 
 package tech.pegasys.teku.statetransition.forkchoice;
 
+import com.google.common.base.MoreObjects;
 import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.type.Bytes8;
@@ -24,6 +27,7 @@ import tech.pegasys.teku.spec.executionengine.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.spec.executionengine.PayloadAttributes;
 
 public class ForkChoiceUpdateData {
+  private static final Logger LOG = LogManager.getLogger();
 
   private final ForkChoiceState forkChoiceState;
   private final Optional<PayloadAttributes> payloadAttributes;
@@ -41,8 +45,12 @@ public class ForkChoiceUpdateData {
       final ForkChoiceState forkChoiceState,
       final Optional<PayloadAttributes> payloadAttributes,
       final Optional<Bytes32> terminalBlockHash) {
-    // TODO: Use terminalBlockHash as forkChoiceState head root if it was zero
-    this.forkChoiceState = forkChoiceState;
+    if (terminalBlockHash.isPresent() && forkChoiceState.getHeadBlockHash().isZero()) {
+      this.forkChoiceState =
+          new ForkChoiceState(terminalBlockHash.get(), terminalBlockHash.get(), Bytes32.ZERO);
+    } else {
+      this.forkChoiceState = forkChoiceState;
+    }
     this.payloadAttributes = payloadAttributes;
     this.terminalBlockHash = terminalBlockHash;
   }
@@ -88,21 +96,38 @@ public class ForkChoiceUpdateData {
   }
 
   public boolean isPayloadIdSuitable(final Bytes32 parentExecutionHash, final UInt64 timestamp) {
+    LOG.debug(
+        "isPayloadIdSuitable - parentExecutionHash: {} timestamp: {}",
+        parentExecutionHash,
+        timestamp);
+
     if (payloadAttributes.isEmpty()) {
+      LOG.debug("isPayloadIdSuitable - payloadAttributes.isEmpty returning false");
+      // not producing a block
       return false;
     }
+
     final PayloadAttributes attributes = this.payloadAttributes.get();
     if (!attributes.getTimestamp().equals(timestamp)) {
+      LOG.debug("isPayloadIdSuitable - wrong timestamp");
+      // wrong timestamp
       return false;
     }
-    if (parentExecutionHash.isZero() && terminalBlockHash.isEmpty()) {
-      return false;
+
+    // payloadId is suitable if builds on top of the correct parent hash
+    if (parentExecutionHash.isZero()) {
+      // pre-merge, must build on top of a detected terminal block
+      boolean isSuitable =
+          terminalBlockHash.isPresent()
+              && forkChoiceState.getHeadBlockHash().equals(terminalBlockHash.get());
+      LOG.debug("isPayloadIdSuitable - pre-merge: returning {}", isSuitable);
+      return isSuitable;
+    } else {
+      // post-merge, must build on top of the existing parent
+      boolean isSuitable = forkChoiceState.getHeadBlockHash().equals(parentExecutionHash);
+      LOG.debug("isPayloadIdSuitable - post-merge: returning {}", isSuitable);
+      return isSuitable;
     }
-    // TODO: This is wrong. :)
-    final Bytes32 requiredExecutionBlockHash =
-        parentExecutionHash.isZero() ? terminalBlockHash.get() : parentExecutionHash;
-    return forkChoiceState.getHeadBlockHash().equals(parentExecutionHash)
-        || (parentExecutionHash.isZero() && terminalBlockHash.isPresent());
   }
 
   public SafeFuture<Optional<Bytes8>> getPayloadId() {
@@ -111,21 +136,47 @@ public class ForkChoiceUpdateData {
 
   public void send(final ExecutionEngineChannel executionEngine) {
     if (sent) {
+      LOG.debug("send - already sent");
       return;
     }
     sent = true;
     if (forkChoiceState.getHeadBlockHash().isZero()) {
+      LOG.debug("send - getHeadBlockHash is zero - returning empty");
       payloadId.complete(Optional.empty());
       return;
     }
+
+    LOG.debug("send - calling forkChoiceUpdated({}, {})", forkChoiceState, payloadAttributes);
     // TODO: Handle errors here instead of propagating to result?
     executionEngine
         .forkChoiceUpdated(forkChoiceState, payloadAttributes)
         .thenApply(ForkChoiceUpdatedResult::getPayloadId)
+        .thenPeek(
+            payloadId ->
+                LOG.debug(
+                    "send - forkChoiceUpdated returned payload id {} for {}, {}",
+                    payloadId,
+                    forkChoiceState,
+                    payloadAttributes))
         .propagateTo(payloadId);
   }
 
   public boolean hasHeadBlockHash() {
     return !forkChoiceState.getHeadBlockHash().isZero();
+  }
+
+  public boolean hasTerminalBlockHash() {
+    return terminalBlockHash.isPresent();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("forkChoiceState", forkChoiceState)
+        .add("payloadAttributes", payloadAttributes)
+        .add("terminalBlockHash", terminalBlockHash)
+        .add("payloadId", payloadId)
+        .add("sent", sent)
+        .toString();
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
@@ -20,24 +20,23 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
-import tech.pegasys.teku.infrastructure.ssz.type.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.operations.versions.merge.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.executionengine.ForkChoiceState;
 import tech.pegasys.teku.spec.executionengine.PayloadAttributes;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class PayloadAttributesCalculator {
+
   private static final long MAX_PROPOSER_SEEN_EPOCHS = 2;
 
   private final Spec spec;
   private final EventThread eventThread;
   private final RecentChainData recentChainData;
-
   private final Map<UInt64, ProposerInfo> proposerInfoByValidatorIndex = new HashMap<>();
 
   public PayloadAttributesCalculator(
@@ -47,8 +46,10 @@ public class PayloadAttributesCalculator {
     this.recentChainData = recentChainData;
   }
 
-  public void updateProposers(
-      final Collection<BeaconPreparableProposer> proposers, final UInt64 currentSlot) {
+  public void updateProposers(final Collection<BeaconPreparableProposer> proposers) {
+    // Default to the genesis slot if we're pre-genesis.
+    final UInt64 currentSlot = recentChainData.getCurrentSlot().orElse(SpecConfig.GENESIS_SLOT);
+
     // Remove expired validators
     proposerInfoByValidatorIndex.values().removeIf(info -> info.hasExpired(currentSlot));
 
@@ -64,13 +65,13 @@ public class PayloadAttributesCalculator {
   public SafeFuture<Optional<PayloadAttributes>> calculatePayloadAttributes(
       final UInt64 blockSlot,
       final boolean inSync,
-      final Optional<ForkChoiceState> forkChoiceState) {
+      final ForkChoiceUpdateData forkChoiceUpdateData) {
     eventThread.checkOnEventThread();
     if (!inSync) {
       // We don't produce blocks while syncing so don't bother preparing the payload
       return SafeFuture.completedFuture(Optional.empty());
     }
-    if (forkChoiceState.isEmpty() || forkChoiceState.get().getHeadBlockHash().isZero()) {
+    if (!forkChoiceUpdateData.hasHeadBlockHash()) {
       // No forkChoiceUpdated message will be sent so no point calculating payload attributes
       return SafeFuture.completedFuture(Optional.empty());
     }
@@ -114,20 +115,6 @@ public class PayloadAttributesCalculator {
     } else {
       return recentChainData.retrieveStateAtSlot(
           new SlotAndBlockRoot(spec.computeStartSlotAtEpoch(requiredEpoch), head.getRoot()));
-    }
-  }
-
-  private static class ProposerInfo {
-    UInt64 expirySlot;
-    Bytes20 feeRecipient;
-
-    public ProposerInfo(UInt64 expirySlot, Bytes20 feeRecipient) {
-      this.expirySlot = expirySlot;
-      this.feeRecipient = feeRecipient;
-    }
-
-    public boolean hasExpired(final UInt64 currentSlot) {
-      return currentSlot.isGreaterThanOrEqualTo(expirySlot);
     }
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
@@ -22,7 +22,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.operations.versions.merge.BeaconPreparableProposer;
@@ -46,10 +45,8 @@ public class PayloadAttributesCalculator {
     this.recentChainData = recentChainData;
   }
 
-  public void updateProposers(final Collection<BeaconPreparableProposer> proposers) {
-    // Default to the genesis slot if we're pre-genesis.
-    final UInt64 currentSlot = recentChainData.getCurrentSlot().orElse(SpecConfig.GENESIS_SLOT);
-
+  public void updateProposers(
+      final Collection<BeaconPreparableProposer> proposers, final UInt64 currentSlot) {
     // Remove expired validators
     proposerInfoByValidatorIndex.values().removeIf(info -> info.hasExpired(currentSlot));
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposerInfo.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposerInfo.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import tech.pegasys.teku.infrastructure.ssz.type.Bytes20;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+class ProposerInfo {
+
+  UInt64 expirySlot;
+  Bytes20 feeRecipient;
+
+  public ProposerInfo(UInt64 expirySlot, Bytes20 feeRecipient) {
+    this.expirySlot = expirySlot;
+    this.feeRecipient = feeRecipient;
+  }
+
+  public boolean hasExpired(final UInt64 currentSlot) {
+    return currentSlot.isGreaterThanOrEqualTo(expirySlot);
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -87,6 +87,7 @@ class ForkChoiceNotifierTest {
     notifier =
         new ForkChoiceNotifier(
             eventThread,
+            spec,
             executionEngineChannel,
             recentChainData,
             new PayloadAttributesCalculator(spec, eventThread, recentChainData));
@@ -112,6 +113,7 @@ class ForkChoiceNotifierTest {
     notifier =
         new ForkChoiceNotifier(
             eventThread,
+            spec,
             executionEngineChannel,
             recentChainData,
             new PayloadAttributesCalculator(spec, eventThread, recentChainData));
@@ -385,6 +387,9 @@ class ForkChoiceNotifierTest {
     validateGetPayloadIOnTheFlyRetrieval(
         blockRoot, finalizedForkChoiceState, payloadId, payloadAttributes);
   }
+
+  @Test
+  void getPayloadId_shouldHavePayloadWhenProposingAfterEmptySlot() {}
 
   private void validateGetPayloadIOnTheFlyRetrieval(
       final Bytes32 blockRoot,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -34,7 +34,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.ssz.type.Bytes20;
 import tech.pegasys.teku.infrastructure.ssz.type.Bytes8;
-import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
 import tech.pegasys.teku.spec.Spec;
@@ -60,7 +59,6 @@ class ForkChoiceNotifierTest {
 
   private final InlineEventThread eventThread = new InlineEventThread();
   private final Spec spec = TestSpecFactory.createMinimalMerge();
-  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   private StorageSystem storageSystem;
@@ -90,7 +88,6 @@ class ForkChoiceNotifierTest {
         new ForkChoiceNotifier(
             eventThread,
             spec,
-            timeProvider,
             executionEngineChannel,
             recentChainData,
             new PayloadAttributesCalculator(spec, eventThread, recentChainData));
@@ -117,7 +114,6 @@ class ForkChoiceNotifierTest {
         new ForkChoiceNotifier(
             eventThread,
             spec,
-            timeProvider,
             executionEngineChannel,
             recentChainData,
             new PayloadAttributesCalculator(spec, eventThread, recentChainData));

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -889,7 +889,8 @@ public class BeaconChainController extends Service
   protected void initForkChoiceNotifier() {
     LOG.debug("BeaconChainController.initForkChoiceNotifier()");
     forkChoiceNotifier =
-        ForkChoiceNotifier.create(asyncRunnerFactory, spec, executionEngine, recentChainData);
+        ForkChoiceNotifier.create(
+            asyncRunnerFactory, spec, timeProvider, executionEngine, recentChainData);
   }
 
   protected void setupInitialState(final RecentChainData client) {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -889,8 +889,7 @@ public class BeaconChainController extends Service
   protected void initForkChoiceNotifier() {
     LOG.debug("BeaconChainController.initForkChoiceNotifier()");
     forkChoiceNotifier =
-        ForkChoiceNotifier.create(
-            asyncRunnerFactory, spec, timeProvider, executionEngine, recentChainData);
+        ForkChoiceNotifier.create(asyncRunnerFactory, spec, executionEngine, recentChainData);
   }
 
   protected void setupInitialState(final RecentChainData client) {


### PR DESCRIPTION
## PR Description
Draft PR to show some ideas around simplifying `ForkChoiceNotifier` and splitting out responsibilities better.  Likely breaks some stuff so will need to be done more carefully but gives a rough idea.

Main thing is to introduce `ForkChoiceUpdateData` that holds the various bits of state to track what `forkChoiceUpdated` message have been sent and should be sent.  It can then encapsulate all the reasoning about whether the current payloadId is suitable for use.

`PayloadAttributesCalculator` has also been extracted (as already merged to master) to be responsible for calculating the payload attributes to send.  `getPayloadId` can then use that when it needs to calculate a new payloadId.

## Documentation

- [ ] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
