### PR TITLE
Fix dockerUpload task by copying correct Dockerfile for buildx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
 * Updated to latest log4j and disabled JNDI lookup support.
+* Fix multiarch JDK17 variant docker image to bundle Java 17 instead of Java 16

--- a/build.gradle
+++ b/build.gradle
@@ -762,6 +762,11 @@ task dockerUpload {
         versionPrefixes.forEach { prefix -> tags += "-t ${dockerImageName}:${prefix.trim()} "}
       }
 
+      copy {
+        from file("${projectDir}/docker/${variant}/Dockerfile")
+        into(dockerBuildDir)
+      }
+      
       exec {
         workingDir dockerBuildDir
         executable "sh"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fix dockerUpload task by copying correct Dockerfile for buildx. This should fix Java16 being bundled in Java17 docker image.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
