### PR TITLE
Implement ssz_generic tests.

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.reference.phase0.genesis.GenesisTests;
 import tech.pegasys.teku.reference.phase0.rewards.RewardsTestExecutorPhase0;
 import tech.pegasys.teku.reference.phase0.sanity.SanityTests;
 import tech.pegasys.teku.reference.phase0.shuffling.ShufflingTestExecutor;
+import tech.pegasys.teku.reference.phase0.ssz_generic.SszGenericTests;
 import tech.pegasys.teku.reference.phase0.ssz_static.SszTestExecutor;
 import tech.pegasys.teku.reference.phase0.ssz_static.SszTestExecutorDeprecated;
 import tech.pegasys.teku.util.config.Constants;
@@ -44,6 +45,7 @@ public abstract class Eth2ReferenceTestCase {
           .putAll(ShufflingTestExecutor.SHUFFLING_TEST_TYPES)
           .putAll(EpochProcessingTestExecutor.EPOCH_PROCESSING_TEST_TYPES)
           .putAll(SszTestExecutor.SSZ_TEST_TYPES)
+          .putAll(SszGenericTests.SSZ_GENERIC_TEST_TYPES)
           .putAll(OperationsTestExecutor.OPERATIONS_TEST_TYPES)
           .putAll(SanityTests.SANITY_TEST_TYPES)
           .putAll(SszTestExecutorDeprecated.SSZ_TEST_TYPES)

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -39,7 +39,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    * <p>e.g. set to "ssz_static" to run only ssz static tests or "ssz_static/Attestation" for only
    * attestation ssz tests.
    */
-  private static final String TEST_TYPE = "operations/execution_payload";
+  private static final String TEST_TYPE = "ssz_generic/basic_vector";
 
   /** Filter test to run to those from the specified spec. One of general, minimal or mainnet */
   private static final String SPEC = "";

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/AbstractSszGenericTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/AbstractSszGenericTestExecutor.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.assertj.core.api.Assertions;
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
+import tech.pegasys.teku.reference.TestDataUtils;
+import tech.pegasys.teku.reference.TestExecutor;
+
+public abstract class AbstractSszGenericTestExecutor implements TestExecutor {
+
+  @Override
+  public void runTest(final TestDefinition testDefinition) throws Throwable {
+    final Bytes inputData = TestDataUtils.readSszData(testDefinition, "serialized.ssz_snappy");
+    final Path path = testDefinition.getTestDirectory().resolve("value.yaml");
+    if (path.toFile().exists()) {
+      final SszSchema<?> schema = getSchema(testDefinition);
+      final Meta meta = TestDataUtils.loadYaml(testDefinition, "meta.yaml", Meta.class);
+      final SszData result = schema.sszDeserialize(inputData);
+      assertThat(result.hashTreeRoot()).isEqualTo(Bytes32.fromHexString(meta.root));
+      assertValueCorrect(testDefinition, result);
+    } else {
+      try {
+        final SszSchema<?> schema = getSchema(testDefinition);
+        assertThatThrownBy(() -> schema.sszDeserialize(inputData))
+            .isInstanceOf(IllegalArgumentException.class);
+      } catch (final IllegalArgumentException e) {
+        // The schema itself was invalid so this counts as success
+        // Can't just put getSchema in the assertThatThrownBy because we need to let
+        // TestAbortedException actually throw so that the test is ignored if we don't support the
+        // type
+      }
+    }
+  }
+
+  protected void assertValueCorrect(final TestDefinition testDefinition, final SszData result)
+      throws IOException {
+    final String stringValue = TestDataUtils.loadYaml(testDefinition, "value.yaml", String.class);
+    assertStringValueMatches(testDefinition, stringValue, result);
+  }
+
+  protected void assertStringValueMatches(
+      final TestDefinition testDefinition, final String stringValue, final SszData result) {
+    assertThat(result).isEqualTo(parseString(testDefinition, stringValue));
+  }
+
+  protected abstract SszSchema<?> getSchema(final TestDefinition testDefinition);
+
+  protected abstract Object parseString(final TestDefinition testDefinition, final String value);
+
+  protected static int getSize(final TestDefinition testDefinition) {
+    final String name = testDefinition.getTestName();
+    final String typePart = name.substring(name.indexOf('/') + 1);
+    final String withoutTypePrefix = typePart.substring(typePart.indexOf('_') + 1);
+    final String size =
+        withoutTypePrefix.contains("_")
+            ? withoutTypePrefix.substring(0, withoutTypePrefix.indexOf('_'))
+            : withoutTypePrefix;
+    try {
+      return Integer.parseInt(size);
+    } catch (final NumberFormatException e) {
+      if (name.startsWith("invalid/")) {
+        return Integer.MAX_VALUE;
+      }
+      Assertions.fail(
+          "Could not determine bitlist size for %s. %s failed to parse as a number", name, size);
+      return 0;
+    }
+  }
+
+  private static class Meta {
+    @JsonProperty(value = "root", required = true)
+    private String root;
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericBasicVectorTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericBasicVectorTestExecutor.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.reference.phase0.ssz_generic.containers.UInt16PrimitiveSchema.UINT16_SCHEMA;
+
+import java.io.IOException;
+import java.util.List;
+import org.opentest4j.TestAbortedException;
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.SszVector;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszVectorSchema;
+import tech.pegasys.teku.reference.TestDataUtils;
+
+public class SszGenericBasicVectorTestExecutor extends AbstractSszGenericTestExecutor {
+
+  @Override
+  protected void assertValueCorrect(final TestDefinition testDefinition, final SszData result)
+      throws IOException {
+    final List<String> expectedValue =
+        ((List<?>) TestDataUtils.loadYaml(testDefinition, "value.yaml", List.class))
+            .stream().map(value -> parseString(testDefinition, value.toString())).collect(toList());
+    final SszVector<?> vector = (SszVector<?>) result;
+    final List<?> actualList = vector.stream().map(Object::toString).collect(toList());
+    assertThat(actualList).isEqualTo(expectedValue);
+  }
+
+  @Override
+  protected SszSchema<?> getSchema(final TestDefinition testDefinition) {
+    final int vectorLength = getVectorLength(testDefinition);
+    final SszSchema<?> elementSchema = getElementSchema(testDefinition);
+    return SszVectorSchema.create(elementSchema, vectorLength);
+  }
+
+  @Override
+  protected String parseString(final TestDefinition testDefinition, final String value) {
+    switch (getElementType(testDefinition)) {
+      case "bool":
+        switch (value) {
+          case "false":
+            return "0";
+          case "true":
+            return "1";
+          default:
+            throw new IllegalArgumentException("Unexpected boolean value: " + value);
+        }
+      case "uint8":
+        // Java will treat the byte as a signed byte so unsigned value to signed byte
+        return Byte.toString((byte) Integer.parseUnsignedInt(value));
+      default:
+        return value;
+    }
+  }
+
+  // vec_{element type}_{length}
+  private SszSchema<?> getElementSchema(final TestDefinition testDefinition) {
+    final String elementType = getElementType(testDefinition);
+    switch (elementType) {
+        // bool is not a bit in this case, it's a full one byte boolean which we don't support
+      case "bool":
+      case "uint8":
+        return SszPrimitiveSchemas.BYTE_SCHEMA;
+      case "uint16":
+        return UINT16_SCHEMA;
+      case "uint64":
+        return SszPrimitiveSchemas.UINT64_SCHEMA;
+      case "uint256":
+        return SszPrimitiveSchemas.UINT256_SCHEMA;
+      case "uint32":
+      case "uint128":
+        throw new TestAbortedException(
+            "Element type not supported: "
+                + elementType
+                + " From: "
+                + testDefinition.getTestName());
+      default:
+        throw new UnsupportedOperationException(
+            "No schema for type: " + testDefinition.getTestName());
+    }
+  }
+
+  private String getElementType(final TestDefinition testDefinition) {
+    final String testName = testDefinition.getTestName();
+    final String typePart = testName.substring(testName.indexOf('/') + 1 + "vec_".length());
+    return typePart.substring(0, typePart.indexOf("_"));
+  }
+
+  private int getVectorLength(final TestDefinition testDefinition) {
+    final String testName = testDefinition.getTestName();
+    final String typePart = testName.substring(testName.indexOf('/') + 1 + "vec_".length());
+    final String lengthString = typePart.split("_", -1)[1];
+    return Integer.parseInt(lengthString);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericBitlistTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericBitlistTestExecutor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitlistSchema;
+
+public class SszGenericBitlistTestExecutor extends AbstractSszGenericTestExecutor {
+
+  @Override
+  protected void assertStringValueMatches(
+      final TestDefinition testDefinition, final String stringValue, final SszData result) {
+    assertThat(result.sszSerialize().toString()).isEqualTo(stringValue);
+  }
+
+  @Override
+  protected SszBitlistSchema<SszBitlist> getSchema(final TestDefinition testDefinition) {
+    return SszBitlistSchema.create(getSize(testDefinition));
+  }
+
+  @Override
+  protected Object parseString(final TestDefinition testDefinition, final String value) {
+    return value;
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericBitvectorTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericBitvectorTestExecutor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitvectorSchema;
+
+public class SszGenericBitvectorTestExecutor extends AbstractSszGenericTestExecutor {
+
+  @Override
+  protected void assertStringValueMatches(
+      final TestDefinition testDefinition, final String stringValue, final SszData result) {
+    assertThat(result.sszSerialize().toString()).isEqualTo(stringValue);
+  }
+
+  @Override
+  protected SszSchema<?> getSchema(final TestDefinition testDefinition) {
+    return SszBitvectorSchema.create(getSize(testDefinition));
+  }
+
+  @Override
+  protected Object parseString(final TestDefinition testDefinition, final String value) {
+    return value;
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericBooleanTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericBooleanTestExecutor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic;
+
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBit;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
+
+public class SszGenericBooleanTestExecutor extends AbstractSszGenericTestExecutor {
+
+  @Override
+  protected SszSchema<?> getSchema(final TestDefinition testDefinition) {
+    return SszPrimitiveSchemas.BIT_SCHEMA;
+  }
+
+  @Override
+  protected Object parseString(final TestDefinition testDefinition, final String value) {
+    return SszBit.of(Boolean.parseBoolean(value));
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericContainerTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericContainerTestExecutor.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.ssz.SszCollection;
+import tech.pegasys.teku.infrastructure.ssz.SszContainer;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes4;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
+import tech.pegasys.teku.reference.TestDataUtils;
+import tech.pegasys.teku.reference.phase0.ssz_generic.containers.BitsStructSchema;
+import tech.pegasys.teku.reference.phase0.ssz_generic.containers.ComplexTestStructSchema;
+import tech.pegasys.teku.reference.phase0.ssz_generic.containers.FixedTestStructSchema;
+import tech.pegasys.teku.reference.phase0.ssz_generic.containers.SingleFieldTestStructSchema;
+import tech.pegasys.teku.reference.phase0.ssz_generic.containers.SmallTestStructSchema;
+import tech.pegasys.teku.reference.phase0.ssz_generic.containers.VarTestStructSchema;
+
+public class SszGenericContainerTestExecutor extends AbstractSszGenericTestExecutor {
+
+  @Override
+  protected void assertValueCorrect(final TestDefinition testDefinition, final SszData result)
+      throws IOException {
+    final Map<String, String> expected = loadExpectedValues(testDefinition);
+    final SszContainer container = (SszContainer) result;
+    final Map<String, String> actual = formatSszContainer(container);
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, String> loadExpectedValues(final TestDefinition testDefinition)
+      throws IOException {
+    final Map<String, Object> objectMap =
+        TestDataUtils.loadYaml(testDefinition, "value.yaml", Map.class);
+    return objectMap.entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toString()));
+  }
+
+  @Override
+  protected SszSchema<?> getSchema(final TestDefinition testDefinition) {
+    final String testName = testDefinition.getTestName();
+    final String type = testName.substring(testName.indexOf('/') + 1, testName.indexOf('_'));
+    switch (type) {
+      case "SingleFieldTestStruct":
+        return new SingleFieldTestStructSchema();
+      case "BitsStruct":
+        return new BitsStructSchema();
+      case "SmallTestStruct":
+        return new SmallTestStructSchema();
+      case "VarTestStruct":
+        return new VarTestStructSchema();
+      case "FixedTestStruct":
+        return new FixedTestStructSchema();
+      case "ComplexTestStruct": // Not implemented yet
+        return new ComplexTestStructSchema();
+      default:
+        throw new UnsupportedOperationException("Unsupported container type: " + type);
+    }
+  }
+
+  @Override
+  protected Object parseString(final TestDefinition testDefinition, final String value) {
+    return null;
+  }
+
+  private Map<String, String> formatSszContainer(final SszContainer container) {
+    return container.getSchema().getFieldNames().stream()
+        .collect(
+            Collectors.toMap(
+                Function.identity(),
+                name -> format(container.get(container.getSchema().getFieldIndex(name)))));
+  }
+
+  private String format(final Object value) {
+    if (value instanceof SszByte) {
+      return Integer.toString(Byte.toUnsignedInt(((SszByte) value).get()));
+    } else if (value instanceof SszBytes4) {
+      return Long.toString(
+          ((SszBytes4) value).get().getWrappedBytes().toLong(ByteOrder.LITTLE_ENDIAN));
+    } else if (value instanceof SszBitlist) {
+      return ((SszBitlist) value).sszSerialize().toHexString();
+    } else if (value instanceof SszByteList) {
+      return ((SszByteList) value).sszSerialize().toHexString();
+    } else if (value instanceof SszBitvector) {
+      return ((SszBitvector) value).sszSerialize().toHexString();
+    } else if (value instanceof SszCollection<?>) {
+      final SszCollection<?> list = (SszCollection<?>) value;
+      return list.stream().map(this::format).collect(toList()).toString();
+    } else if (value instanceof SszContainer) {
+      return formatSszContainer((SszContainer) value).toString();
+    } else {
+      return value.toString();
+    }
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericTests.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericTests.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic;
+
+import com.google.common.collect.ImmutableMap;
+import tech.pegasys.teku.reference.TestExecutor;
+
+public class SszGenericTests {
+
+  public static ImmutableMap<String, TestExecutor> SSZ_GENERIC_TEST_TYPES =
+      ImmutableMap.<String, TestExecutor>builder()
+          // SSZ Generic
+          .put("ssz_generic/basic_vector", new SszGenericBasicVectorTestExecutor())
+          .put("ssz_generic/bitlist", new SszGenericBitlistTestExecutor())
+          .put("ssz_generic/bitvector", new SszGenericBitvectorTestExecutor())
+          .put("ssz_generic/boolean", new SszGenericBooleanTestExecutor())
+          .put("ssz_generic/containers", new SszGenericContainerTestExecutor())
+          .put("ssz_generic/uints", new SszGenericUIntTestExecutor())
+          .build();
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericUIntTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericUIntTestExecutor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic;
+
+import static tech.pegasys.teku.reference.phase0.ssz_generic.containers.UInt16PrimitiveSchema.UINT16_SCHEMA;
+
+import java.math.BigInteger;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.opentest4j.TestAbortedException;
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.reference.phase0.ssz_generic.containers.SszUInt16;
+
+public class SszGenericUIntTestExecutor extends AbstractSszGenericTestExecutor {
+
+  @Override
+  protected SszSchema<?> getSchema(final TestDefinition testDefinition) {
+    switch (getSize(testDefinition)) {
+      case 8:
+        return SszPrimitiveSchemas.BYTE_SCHEMA;
+      case 16:
+        return UINT16_SCHEMA;
+      case 64:
+        return SszPrimitiveSchemas.UINT64_SCHEMA;
+      case 256:
+        return SszPrimitiveSchemas.UINT256_SCHEMA;
+      case 32:
+      case 128:
+        throw new TestAbortedException("UInt type not supported: " + testDefinition.getTestName());
+      default:
+        throw new UnsupportedOperationException(
+            "No schema for type: " + testDefinition.getTestName());
+    }
+  }
+
+  @Override
+  protected Object parseString(final TestDefinition testDefinition, final String value) {
+    switch (getSize(testDefinition)) {
+      case 8:
+        return SszByte.of(Integer.parseInt(value));
+      case 16:
+        return SszUInt16.of(Integer.parseInt(value));
+      case 64:
+        return SszUInt64.of(UInt64.valueOf(value));
+      case 256:
+        return SszUInt256.of(UInt256.valueOf(new BigInteger(value)));
+      case 32:
+      case 128:
+        throw new TestAbortedException("UInt type not supported: " + testDefinition.getTestName());
+      default:
+        throw new UnsupportedOperationException(
+            "No parser for type: " + testDefinition.getTestName());
+    }
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/BitsStruct.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/BitsStruct.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container5;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema5;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class BitsStruct
+    extends Container5<
+        BitsStruct, SszBitlist, SszBitvector, SszBitvector, SszBitlist, SszBitvector> {
+
+  protected BitsStruct(
+      final ContainerSchema5<
+              BitsStruct, SszBitlist, SszBitvector, SszBitvector, SszBitlist, SszBitvector>
+          schema,
+      final TreeNode backingNode) {
+    super(schema, backingNode);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/BitsStructSchema.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/BitsStructSchema.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema5;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitlistSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitvectorSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class BitsStructSchema
+    extends ContainerSchema5<
+        BitsStruct, SszBitlist, SszBitvector, SszBitvector, SszBitlist, SszBitvector> {
+
+  public BitsStructSchema() {
+    super(
+        BitsStructSchema.class.getSimpleName(),
+        NamedSchema.of("A", SszBitlistSchema.create(5)),
+        NamedSchema.of("B", SszBitvectorSchema.create(2)),
+        NamedSchema.of("C", SszBitvectorSchema.create(1)),
+        NamedSchema.of("D", SszBitlistSchema.create(6)),
+        NamedSchema.of("E", SszBitvectorSchema.create(8)));
+  }
+
+  @Override
+  public BitsStruct createFromBackingNode(final TreeNode node) {
+    return new BitsStruct(this, node);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/ComplexTestStruct.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/ComplexTestStruct.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.SszVector;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container7;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema7;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class ComplexTestStruct
+    extends Container7<
+        ComplexTestStruct,
+        SszUInt16,
+        SszList<SszUInt16>,
+        SszByte,
+        SszByteList,
+        VarTestStruct,
+        SszVector<FixedTestStruct>,
+        SszVector<VarTestStruct>> {
+
+  protected ComplexTestStruct(
+      final ContainerSchema7<
+              ComplexTestStruct,
+              SszUInt16,
+              SszList<SszUInt16>,
+              SszByte,
+              SszByteList,
+              VarTestStruct,
+              SszVector<FixedTestStruct>,
+              SszVector<VarTestStruct>>
+          schema,
+      final TreeNode backingNode) {
+    super(schema, backingNode);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/ComplexTestStructSchema.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/ComplexTestStructSchema.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import static tech.pegasys.teku.reference.phase0.ssz_generic.containers.UInt16PrimitiveSchema.UINT16_SCHEMA;
+
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.SszVector;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema7;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszVectorSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class ComplexTestStructSchema
+    extends ContainerSchema7<
+        ComplexTestStruct,
+        SszUInt16,
+        SszList<SszUInt16>,
+        SszByte,
+        SszByteList,
+        VarTestStruct,
+        SszVector<FixedTestStruct>,
+        SszVector<VarTestStruct>> {
+
+  public ComplexTestStructSchema() {
+    super(
+        ComplexTestStruct.class.getSimpleName(),
+        NamedSchema.of("A", UINT16_SCHEMA),
+        NamedSchema.of("B", SszListSchema.create(UINT16_SCHEMA, 128)),
+        NamedSchema.of("C", SszPrimitiveSchemas.BYTE_SCHEMA),
+        NamedSchema.of("D", SszByteListSchema.create(256)),
+        NamedSchema.of("E", new VarTestStructSchema()),
+        NamedSchema.of("F", SszVectorSchema.create(new FixedTestStructSchema(), 4)),
+        NamedSchema.of("G", SszVectorSchema.create(new VarTestStructSchema(), 2)));
+  }
+
+  @Override
+  public ComplexTestStruct createFromBackingNode(final TreeNode node) {
+    return new ComplexTestStruct(this, node);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/FixedTestStruct.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/FixedTestStruct.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.Container3;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema3;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes4;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class FixedTestStruct extends Container3<FixedTestStruct, SszByte, SszUInt64, SszBytes4> {
+
+  protected FixedTestStruct(
+      final ContainerSchema3<FixedTestStruct, SszByte, SszUInt64, SszBytes4> schema,
+      final TreeNode backingNode) {
+    super(schema, backingNode);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/FixedTestStructSchema.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/FixedTestStructSchema.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema3;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes4;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class FixedTestStructSchema
+    extends ContainerSchema3<FixedTestStruct, SszByte, SszUInt64, SszBytes4> {
+
+  public FixedTestStructSchema() {
+    super(
+        FixedTestStruct.class.getSimpleName(),
+        NamedSchema.of("A", SszPrimitiveSchemas.BYTE_SCHEMA),
+        NamedSchema.of("B", SszPrimitiveSchemas.UINT64_SCHEMA),
+        NamedSchema.of("C", SszPrimitiveSchemas.BYTES4_SCHEMA));
+  }
+
+  @Override
+  public FixedTestStruct createFromBackingNode(final TreeNode node) {
+    return new FixedTestStruct(this, node);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/SingleFieldTestStruct.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/SingleFieldTestStruct.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.Container1;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema1;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class SingleFieldTestStruct extends Container1<SingleFieldTestStruct, SszByte> {
+
+  protected SingleFieldTestStruct(
+      final ContainerSchema1<SingleFieldTestStruct, SszByte> schema, final TreeNode backingNode) {
+    super(schema, backingNode);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/SingleFieldTestStructSchema.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/SingleFieldTestStructSchema.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema1;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class SingleFieldTestStructSchema extends ContainerSchema1<SingleFieldTestStruct, SszByte> {
+
+  public SingleFieldTestStructSchema() {
+    super(
+        SingleFieldTestStructSchema.class.getSimpleName(),
+        NamedSchema.of("A", SszPrimitiveSchemas.BYTE_SCHEMA));
+  }
+
+  @Override
+  public SingleFieldTestStruct createFromBackingNode(final TreeNode node) {
+    return new SingleFieldTestStruct(this, node);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/SmallTestStruct.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/SmallTestStruct.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class SmallTestStruct extends Container2<SmallTestStruct, SszUInt16, SszUInt16> {
+
+  protected SmallTestStruct(
+      final ContainerSchema2<SmallTestStruct, SszUInt16, SszUInt16> schema,
+      final TreeNode backingNode) {
+    super(schema, backingNode);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/SmallTestStructSchema.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/SmallTestStructSchema.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import static tech.pegasys.teku.reference.phase0.ssz_generic.containers.UInt16PrimitiveSchema.UINT16_SCHEMA;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class SmallTestStructSchema extends ContainerSchema2<SmallTestStruct, SszUInt16, SszUInt16> {
+
+  public SmallTestStructSchema() {
+    super(
+        SmallTestStruct.class.getSimpleName(),
+        NamedSchema.of("A", UINT16_SCHEMA),
+        NamedSchema.of("B", UINT16_SCHEMA));
+  }
+
+  @Override
+  public SmallTestStruct createFromBackingNode(final TreeNode node) {
+    return new SmallTestStruct(this, node);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/SszUInt16.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/SszUInt16.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import tech.pegasys.teku.infrastructure.ssz.impl.AbstractSszPrimitive;
+
+public class SszUInt16 extends AbstractSszPrimitive<Integer, SszUInt16> {
+
+  public static SszUInt16 of(Integer val) {
+    return new SszUInt16(val);
+  }
+
+  private SszUInt16(Integer val) {
+    super(val, UInt16PrimitiveSchema.UINT16_SCHEMA);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/UInt16PrimitiveSchema.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/UInt16PrimitiveSchema.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import java.nio.ByteOrder;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszPrimitiveSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.LeafDataNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.LeafNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class UInt16PrimitiveSchema extends AbstractSszPrimitiveSchema<Integer, SszUInt16> {
+
+  public static AbstractSszPrimitiveSchema<Integer, SszUInt16> UINT16_SCHEMA =
+      new UInt16PrimitiveSchema();
+
+  private UInt16PrimitiveSchema() {
+    super(16);
+  }
+
+  @Override
+  public SszUInt16 createFromLeafBackingNode(LeafDataNode node, int internalIndex) {
+    // reverse() is due to LE -> BE conversion
+    Bytes leafNodeBytes = node.getData();
+    Bytes elementBytes = leafNodeBytes.slice(internalIndex * 2, 2);
+    return SszUInt16.of(elementBytes.toInt(ByteOrder.LITTLE_ENDIAN));
+  }
+
+  @Override
+  public TreeNode updateBackingNode(TreeNode srcNode, int internalIndex, SszData newValue) {
+    final Integer intValue = ((SszUInt16) newValue).get();
+    return LeafNode.create(Bytes.ofUnsignedInt(intValue, ByteOrder.LITTLE_ENDIAN));
+  }
+
+  @Override
+  public SszUInt16 boxed(Integer rawValue) {
+    return SszUInt16.of(rawValue);
+  }
+
+  @Override
+  public TreeNode getDefaultTree() {
+    return LeafNode.ZERO_LEAVES[16];
+  }
+
+  @Override
+  public String toString() {
+    return "UInt16";
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/VarTestStruct.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/VarTestStruct.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container3;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema3;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class VarTestStruct
+    extends Container3<VarTestStruct, SszUInt16, SszList<SszUInt16>, SszByte> {
+
+  protected VarTestStruct(
+      final ContainerSchema3<VarTestStruct, SszUInt16, SszList<SszUInt16>, SszByte> schema,
+      final TreeNode backingNode) {
+    super(schema, backingNode);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/VarTestStructSchema.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/VarTestStructSchema.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import static tech.pegasys.teku.reference.phase0.ssz_generic.containers.UInt16PrimitiveSchema.UINT16_SCHEMA;
+
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema3;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class VarTestStructSchema
+    extends ContainerSchema3<VarTestStruct, SszUInt16, SszList<SszUInt16>, SszByte> {
+
+  public VarTestStructSchema() {
+    super(
+        VarTestStructSchema.class.getSimpleName(),
+        NamedSchema.of("A", UINT16_SCHEMA),
+        NamedSchema.of("B", SszListSchema.create(UINT16_SCHEMA, 1024)),
+        NamedSchema.of("C", SszPrimitiveSchemas.BYTE_SCHEMA));
+  }
+
+  @Override
+  public VarTestStruct createFromBackingNode(final TreeNode node) {
+    return new VarTestStruct(this, node);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
@@ -99,14 +99,6 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
               new SszTestExecutor<>(
                   schemas -> SchemaDefinitionsMerge.required(schemas).getExecutionPayloadSchema()))
           .put("ssz_static/PowBlock", IGNORE_TESTS)
-
-          // SSZ Generic
-          .put("ssz_generic/basic_vector", IGNORE_TESTS)
-          .put("ssz_generic/bitlist", IGNORE_TESTS)
-          .put("ssz_generic/bitvector", IGNORE_TESTS)
-          .put("ssz_generic/boolean", IGNORE_TESTS)
-          .put("ssz_generic/containers", IGNORE_TESTS)
-          .put("ssz_generic/uints", IGNORE_TESTS)
           .build();
 
   public SszTestExecutor(final SchemaProvider<T> sszType) {

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPrimitiveSchemas.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPrimitiveSchemas.java
@@ -230,7 +230,7 @@ public interface SszPrimitiveSchemas {
         @Override
         public SszUInt256 createFromLeafBackingNode(LeafDataNode node, int internalIndex) {
           // reverse() is due to LE -> BE conversion
-          return SszUInt256.of(UInt256.fromBytes(node.hashTreeRoot().reverse()));
+          return SszUInt256.of(UInt256.fromBytes(node.getData().reverse()));
         }
 
         @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszVectorSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszVectorSchema.java
@@ -43,7 +43,7 @@ public interface SszVectorSchema<
   @SuppressWarnings("unchecked")
   static <ElementDataT extends SszData> SszVectorSchema<ElementDataT, ?> create(
       SszSchema<ElementDataT> elementSchema, long length, SszSchemaHints hints) {
-    checkArgument(length >= 0 && length <= MAX_VECTOR_LENGTH);
+    checkArgument(length > 0 && length <= MAX_VECTOR_LENGTH);
     if (elementSchema instanceof SszPrimitiveSchema) {
       return (SszVectorSchema<ElementDataT, ?>)
           SszPrimitiveVectorSchema.create((SszPrimitiveSchema<?, ?>) elementSchema, length, hints);


### PR DESCRIPTION
## PR Description
Implement ssz_generic tests. There are a number still ignored because we don't support those types (e.g. uint128).

Most of the code is implementing the container types the tests need.

And there's a lot of ugliness involved in parsing test names to find the type definition as well as in converting types back to strings in the right form to compare to the expected value.

## Fixed Issue(s)
fixes #4771 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
