### PR TITLE
Update to log4j 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,5 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Additions and Improvements
 
 ### Bug Fixes
-* Updated to latest log4j and disabled JNDI lookup support.
+* Updated to log4j 2.16.0.
 * Fix multiarch JDK17 variant docker image to bundle Java 17 instead of Java 16

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -96,7 +96,7 @@ dependencyManagement {
     dependency 'commons-io:commons-io:2.11.0'
     dependency 'org.apache.commons:commons-compress:1.21'
 
-    dependencySet(group: 'org.apache.logging.log4j', version: '2.15.0') {
+    dependencySet(group: 'org.apache.logging.log4j', version: '2.16.0') {
       entry 'log4j-api'
       entry 'log4j-core'
       entry 'log4j-slf4j-impl'


### PR DESCRIPTION
## PR Description
Updates to log4j 2.16.0 which includes a fix for CVE-2021-45046 where JNDI attacks may be possible via `ThreadContext`.  Teku does not use `ThreadContext` and none of the log patterns Teku sets use data from `ThreadContext` so isn't vulnerable to this issue.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
