### PR TITLE
Unmatched CLI options not confused as parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Breaking Changes
 
 ### Additions and Improvements
+* Updated CLI options ensuring unmatched options aren't confused as parameters.
 
 ### Bug Fixes
 * Updated to latest log4j and disabled JNDI lookup support.

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -204,18 +204,19 @@ public class BeaconNodeCommand implements Callable<Integer> {
     metricCategoryConverter.addCategories(StandardMetricCategory.class);
   }
 
-  private CommandLine registerConverters(final CommandLine commandLine) {
+  private CommandLine configureCommandLine(final CommandLine commandLine) {
     return commandLine
         .registerConverter(MetricCategory.class, metricCategoryConverter)
-        .registerConverter(UInt64.class, UInt64::valueOf);
+        .registerConverter(UInt64.class, UInt64::valueOf)
+        .setUnmatchedOptionsAllowedAsOptionParameters(false);
   }
 
   private CommandLine getConfigFileCommandLine(final ConfigFileCommand configFileCommand) {
-    return registerConverters(new CommandLine(configFileCommand));
+    return configureCommandLine(new CommandLine(configFileCommand));
   }
 
   private CommandLine getCommandLine() {
-    return registerConverters(new CommandLine(this));
+    return configureCommandLine(new CommandLine(this));
   }
 
   public int parse(final String[] args) {

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -83,6 +83,18 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  public void unmatchedOptionsNotAllowedAsOptionParameters() {
+    final String[] args = {"--eth1-endpoints http://localhost:8545 --foo"};
+
+    beaconNodeCommand.parse(args);
+    String str = getCommandLineOutput();
+    assertThat(str).contains("Unknown option");
+    assertThat(str).contains("To display full help:");
+    assertThat(str).contains("--help");
+    assertThat(str).doesNotContain("Default");
+  }
+
+  @Test
   public void invalidValueShouldDisplayShortHelpMessage() {
     final String[] args = {"--metrics-enabled=bob"};
 


### PR DESCRIPTION
## PR Description
Values that start with `--` should always be considered as a new CLI option rather than another value. This means that it will fail correctly when there are mistyped CLI options. Previously, CLI options that accept multiple values would treat any unknown value that follows as just another value. Now unmatched options are not allowed to be confused as parameters.

## Fixed Issue(s)
fixes #4765 
