### PR TITLE
Fix flaky test on Win: node dir sometimes couldn't be deleted 

### DIFF
--- a/infrastructure/io/build.gradle
+++ b/infrastructure/io/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation 'org.apache.tuweni:tuweni-bytes'
-    implementation 'commons-io:commons-io'
     implementation project(':infrastructure:exceptions')
+
+    testFixtures 'commons-io:commons-io'
 }

--- a/infrastructure/io/build.gradle
+++ b/infrastructure/io/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
     implementation 'org.apache.tuweni:tuweni-bytes'
+    implementation 'commons-io:commons-io'
     implementation project(':infrastructure:exceptions')
 }

--- a/infrastructure/io/build.gradle
+++ b/infrastructure/io/build.gradle
@@ -2,5 +2,5 @@ dependencies {
     implementation 'org.apache.tuweni:tuweni-bytes'
     implementation project(':infrastructure:exceptions')
 
-    testFixtures 'commons-io:commons-io'
+    testFixturesImplementation 'commons-io:commons-io'
 }

--- a/infrastructure/io/src/testFixtures/java/tech/pegasys/teku/cli/TempDirUtils.java
+++ b/infrastructure/io/src/testFixtures/java/tech/pegasys/teku/cli/TempDirUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.commons.io.FileUtils;
+
+public class TempDirUtils {
+
+  public static Path createTempDir() {
+    try {
+      return Files.createTempDirectory("teku_unit_test_");
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static boolean deleteDirLenient(Path dir, int maxDeleteAttempts, boolean throwIfFailed) {
+    IOException lastException = null;
+    for (int i = 0; i < maxDeleteAttempts; i++) {
+      try {
+        System.out.println("Deleting");
+        FileUtils.deleteDirectory(dir.toFile());
+        return true;
+      } catch (IOException e) {
+        lastException = e;
+        try {
+          Thread.sleep(1000);
+        } catch (InterruptedException interruptedException) {
+          throw new RuntimeException(interruptedException);
+        }
+      }
+    }
+    if (throwIfFailed) {
+      throw new AssertionError(
+          "Directory " + dir + " couldn't be deleted after " + maxDeleteAttempts + " attempts",
+          lastException);
+    } else {
+      return false;
+    }
+  }
+}

--- a/teku/src/test/java/tech/pegasys/teku/config/TekuConfigurationTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/config/TekuConfigurationTest.java
@@ -17,10 +17,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import tech.pegasys.teku.BeaconNodeFacade;
 import tech.pegasys.teku.TekuFacade;
+import tech.pegasys.teku.cli.TempDirUtils;
 import tech.pegasys.teku.infrastructure.logging.LoggingDestination;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetworkBuilder;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetwork;
@@ -35,7 +36,12 @@ import tech.pegasys.teku.services.beaconchain.BeaconChainControllerFactory;
 
 public class TekuConfigurationTest {
 
-  @TempDir Path tempDir;
+  Path tempDir = TempDirUtils.createTempDir();
+
+  @AfterEach
+  void cleanup() {
+    TempDirUtils.deleteDirLenient(tempDir, 10, true);
+  }
 
   @Test
   void beaconChainControllerFactory_useCustomFactories() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Some DB files are periodically not released right after the DB close. On Windows it leads to temp dir couldn't be deleted. 
I hope this is a mere concurrency issue in levelDB so the fix is retrying to delete temp dir with 1 sec pauses. After 10 attempts it gives up. 

The example of test failing: https://app.circleci.com/pipelines/github/ConsenSys/teku/15422/workflows/8b275a8a-ddae-4e3f-adda-9ddf894f86db/jobs/102667/tests#failed-test-0

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
