### PR TITLE
[Merge] align error messages to actual CLI params `--Xee-endpoint` and `--Xvalidators-suggested-fee-recipient-address`

### DIFF
--- a/services/executionengine/src/main/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfiguration.java
+++ b/services/executionengine/src/main/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfiguration.java
@@ -44,7 +44,7 @@ public class ExecutionEngineConfiguration {
     return endpoint.orElseThrow(
         () ->
             new InvalidConfigurationException(
-                "Invalid configuration. --ee-endpoint parameter is mandatory when Merge milestone is enabled"));
+                "Invalid configuration. --Xee-endpoint parameter is mandatory when Merge milestone is enabled"));
   }
 
   public static class Builder {

--- a/services/executionengine/src/test/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfigurationTest.java
+++ b/services/executionengine/src/test/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfigurationTest.java
@@ -31,7 +31,7 @@ public class ExecutionEngineConfigurationTest {
     Assertions.assertThatExceptionOfType(InvalidConfigurationException.class)
         .isThrownBy(config::getEndpoint)
         .withMessageContaining(
-            "Invalid configuration. --ee-endpoint parameter is mandatory when Merge milestone is enabled");
+            "Invalid configuration. --Xee-endpoint parameter is mandatory when Merge milestone is enabled");
   }
 
   @Test

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -183,7 +183,7 @@ public class ValidatorConfig {
     if (suggestedFeeRecipient.isEmpty()
         && !(validatorKeys.isEmpty() && validatorExternalSignerPublicKeySources.isEmpty())) {
       throw new InvalidConfigurationException(
-          "Invalid configuration. --validators-fee-recipient-address must be specified when Merge milestone is active");
+          "Invalid configuration. --Xvalidators-suggested-fee-recipient-address must be specified when Merge milestone is active");
     }
   }
 

--- a/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
+++ b/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
@@ -132,7 +132,7 @@ class ValidatorConfigTest {
     Assertions.assertThatExceptionOfType(InvalidConfigurationException.class)
         .isThrownBy(config::getSuggestedFeeRecipient)
         .withMessageContaining(
-            "Invalid configuration. --validators-fee-recipient-address must be specified when Merge milestone is active");
+            "Invalid configuration. --Xvalidators-suggested-fee-recipient-address must be specified when Merge milestone is active");
   }
 
   @Test
@@ -142,7 +142,7 @@ class ValidatorConfigTest {
     Assertions.assertThatExceptionOfType(InvalidConfigurationException.class)
         .isThrownBy(config::getSuggestedFeeRecipient)
         .withMessageContaining(
-            "Invalid configuration. --validators-fee-recipient-address must be specified when Merge milestone is active");
+            "Invalid configuration. --Xvalidators-suggested-fee-recipient-address must be specified when Merge milestone is active");
   }
 
   @Test

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -71,7 +71,7 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
     return feeRecipient.orElseThrow(
         () ->
             new InvalidConfigurationException(
-                "Invalid configuration. --validators-fee-recipient-address must be specified when Merge milestone is active"));
+                "Invalid configuration. --Xvalidators-suggested-fee-recipient-address must be specified when Merge milestone is active"));
   }
 
   @Override


### PR DESCRIPTION
## PR Description

Incorrect error message is printed when yet hidden params are required in Merge testnets.
Affected params: `--Xee-endpoint` and `--Xvalidators-suggested-fee-recipient-address`

## Fixed Issue(s)
fixes #4800

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
