### PR TITLE
Update to log4j 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ For information on changes in released versions of Teku, see the [releases page]
 * Added `kintsugi` network definition. 
 
 ### Bug Fixes
+* Updated to log4j 2.17.0.

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -96,7 +96,7 @@ dependencyManagement {
     dependency 'commons-io:commons-io:2.11.0'
     dependency 'org.apache.commons:commons-compress:1.21'
 
-    dependencySet(group: 'org.apache.logging.log4j', version: '2.16.0') {
+    dependencySet(group: 'org.apache.logging.log4j', version: '2.17.0') {
       entry 'log4j-api'
       entry 'log4j-core'
       entry 'log4j-slf4j-impl'


### PR DESCRIPTION
## PR Description
Update log4j again.  Latest variant of the attack requires usage of `ThreadContext` which Teku does not use so we aren't vulnerable but worth staying up to date anyway.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
