### PR TITLE
Rename bad request code to comply to api.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ## Unreleased Changes
 ### Breaking Changes
+* API users should switch to using response 'code' from BadRequests, rather than 'status' field, in line with the standard API.
 
 ### Additions and Improvements
 * Added `kintsugi` network definition. 
 
 ### Bug Fixes
 * Updated to log4j 2.17.0.
+* Made BadRequests compliant with the api, returning 'code' rather than 'status'.

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetStateCommitteesTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetStateCommitteesTest.java
@@ -96,7 +96,7 @@ public class GetStateCommitteesTest extends AbstractDataBackedRestAPIIntegration
     final Response response = get("head", Map.of("slot", "1", "epoch", "1"));
     assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
     final BadRequest body = jsonProvider.jsonToObject(response.body().string(), BadRequest.class);
-    assertThat(body.getStatus()).isEqualTo(SC_BAD_REQUEST);
+    assertThat(body.getCode()).isEqualTo(SC_BAD_REQUEST);
     assertThat(body.getMessage()).isEqualToIgnoringCase("Slot 1 is not in epoch 1");
   }
 
@@ -105,7 +105,7 @@ public class GetStateCommitteesTest extends AbstractDataBackedRestAPIIntegration
     final Response response = get("head", Map.of("epoch", "1024000"));
     assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
     final BadRequest body = jsonProvider.jsonToObject(response.body().string(), BadRequest.class);
-    assertThat(body.getStatus()).isEqualTo(SC_BAD_REQUEST);
+    assertThat(body.getCode()).isEqualTo(SC_BAD_REQUEST);
     assertThat(body.getMessage()).startsWith("Epoch 1024000 is too far ahead ");
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/schema/BadRequest.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/schema/BadRequest.java
@@ -27,24 +27,23 @@ import tech.pegasys.teku.provider.JsonProvider;
 
 public class BadRequest {
   private static final Logger LOG = LogManager.getLogger();
-  private final Integer status;
+  private final Integer code;
   private final String message;
 
   public BadRequest(String message) {
     this.message = message;
-    this.status = SC_BAD_REQUEST;
+    this.code = SC_BAD_REQUEST;
   }
 
   @JsonCreator
-  public BadRequest(
-      @JsonProperty("status") Integer status, @JsonProperty("message") String message) {
-    this.status = status;
+  public BadRequest(@JsonProperty("code") Integer code, @JsonProperty("message") String message) {
+    this.code = code;
     this.message = message;
   }
 
-  @JsonProperty("status")
-  public final Integer getStatus() {
-    return status;
+  @JsonProperty("code")
+  public final Integer getCode() {
+    return code;
   }
 
   @JsonProperty("message")

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/schema/BadRequestTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/schema/BadRequestTest.java
@@ -29,7 +29,7 @@ public class BadRequestTest {
   @Test
   void shouldSerializeFromCodeAndMessage() {
     final String string = BadRequest.serialize(jsonProvider, 1, "1");
-    assertThat(string).isEqualTo("{\"status\":1,\"message\":\"1\"}");
+    assertThat(string).isEqualTo("{\"code\":1,\"message\":\"1\"}");
   }
 
   @Test


### PR DESCRIPTION
It seems that we've had status forever, but the response code should be in the 'code' field, so making this compliant to standard.

Technically this is not backwards compatible, so I'll put a note in, but since it's just error conditions it shouldn't be a huge issue.

partially addresses #4787

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
