### PR TITLE
Change to use less-swift for sync committee gossip AT.

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SyncCommitteeGossipAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SyncCommitteeGossipAcceptanceTest.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.test.acceptance.dsl.TekuValidatorNode;
 public class SyncCommitteeGossipAcceptanceTest extends AcceptanceTestBase {
   private static final int NODE_VALIDATORS = 8;
   private static final int TOTAL_VALIDATORS = NODE_VALIDATORS * 2;
+  private final String network = "less-swift";
 
   private final SystemTimeProvider timeProvider = new SystemTimeProvider();
   private TekuNode primaryNode;
@@ -36,7 +37,7 @@ public class SyncCommitteeGossipAcceptanceTest extends AcceptanceTestBase {
 
   @BeforeEach
   public void setup() {
-    final int genesisTime = timeProvider.getTimeInSeconds().plus(5).intValue();
+    final int genesisTime = timeProvider.getTimeInSeconds().plus(15).intValue();
     primaryNode =
         createTekuNode(
             config -> configureNode(config, genesisTime).withInteropValidators(0, NODE_VALIDATORS));
@@ -51,8 +52,7 @@ public class SyncCommitteeGossipAcceptanceTest extends AcceptanceTestBase {
         createValidatorNode(
             config ->
                 config
-                    .withNetwork("minimal")
-                    .withAltairEpoch(UInt64.ZERO)
+                    .withNetwork(network)
                     .withInteropValidators(NODE_VALIDATORS, NODE_VALIDATORS)
                     .withBeaconNode(secondaryNode));
   }
@@ -65,6 +65,8 @@ public class SyncCommitteeGossipAcceptanceTest extends AcceptanceTestBase {
     secondaryNode.start();
     secondaryNode.startEventListener(List.of(EventType.contribution_and_proof));
     validatorClient.start();
+
+    primaryNode.waitForEpoch(1);
 
     secondaryNode.waitForFullSyncCommitteeAggregate();
     validatorClient.stop();
@@ -86,7 +88,7 @@ public class SyncCommitteeGossipAcceptanceTest extends AcceptanceTestBase {
   }
 
   private TekuNode.Config configureNode(final TekuNode.Config node, final int genesisTime) {
-    return node.withNetwork("minimal")
+    return node.withNetwork(network)
         .withAltairEpoch(UInt64.ZERO)
         .withGenesisTime(genesisTime)
         .withInteropNumberOfValidators(TOTAL_VALIDATORS)

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SyncCommitteeGossipAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SyncCommitteeGossipAcceptanceTest.java
@@ -37,7 +37,7 @@ public class SyncCommitteeGossipAcceptanceTest extends AcceptanceTestBase {
 
   @BeforeEach
   public void setup() {
-    final int genesisTime = timeProvider.getTimeInSeconds().plus(15).intValue();
+    final int genesisTime = timeProvider.getTimeInSeconds().plus(10).intValue();
     primaryNode =
         createTekuNode(
             config -> configureNode(config, genesisTime).withInteropValidators(0, NODE_VALIDATORS));

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SyncCommitteeGossipAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SyncCommitteeGossipAcceptanceTest.java
@@ -37,7 +37,7 @@ public class SyncCommitteeGossipAcceptanceTest extends AcceptanceTestBase {
 
   @BeforeEach
   public void setup() {
-    final int genesisTime = timeProvider.getTimeInSeconds().plus(10).intValue();
+    final int genesisTime = timeProvider.getTimeInSeconds().plus(15).intValue();
     primaryNode =
         createTekuNode(
             config -> configureNode(config, genesisTime).withInteropValidators(0, NODE_VALIDATORS));

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -300,7 +300,7 @@ public class TekuNode extends Node {
           }
           assertThat(percentageOfBitsSet >= 1.0).isTrue();
         },
-        5,
+        2,
         MINUTES);
   }
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -300,7 +300,7 @@ public class TekuNode extends Node {
           }
           assertThat(percentageOfBitsSet >= 1.0).isTrue();
         },
-        2,
+        5,
         MINUTES);
   }
 


### PR DESCRIPTION
Also waited for first epoch before attempting to start looking for sync committees, this should give time for validators to be active before we're testing the intent of the AT.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
