### PR TITLE
Retry loading validator indices on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ For information on changes in released versions of Teku, see the [releases page]
 * Made BadRequests compliant with the api, returning 'code' rather than 'status'.
 * Fixed: Invalid sync contributions were created if a validator was present multiple times in the same sync sub-committee.
 * Reduced error to warning when sync contribution cannot be created because the beacon node has no matching sync messages.
+* Fixed issue where validator duties were not performed during the first epoch after startup.

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyLoader.java
@@ -36,12 +36,13 @@ public abstract class AbstractDutyLoader<D, S extends ScheduledDuties> implement
 
   @Override
   public SafeFuture<Optional<S>> loadDutiesForEpoch(final UInt64 epoch) {
-    LOG.trace("Requesting attestation duties for epoch {}", epoch);
+    LOG.trace("Requesting duties for epoch {}", epoch);
     return validatorIndexProvider
         .getValidatorIndices(validators.getPublicKeys())
         .thenCompose(
             validatorIndices -> {
               if (validatorIndices.isEmpty()) {
+                LOG.trace("No duties because no validator indices are known");
                 return SafeFuture.completedFuture(Optional.empty());
               }
               return requestDuties(epoch, validatorIndices)

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -167,7 +167,8 @@ public class ValidatorClientService extends Service {
       AsyncRunner asyncRunner) {
     validatorLoader.loadValidators();
     final OwnedValidators validators = validatorLoader.getOwnedValidators();
-    this.validatorIndexProvider = new ValidatorIndexProvider(validators, validatorApiChannel);
+    this.validatorIndexProvider =
+        new ValidatorIndexProvider(validators, validatorApiChannel, asyncRunner);
     final BlockDutyFactory blockDutyFactory =
         new BlockDutyFactory(forkProvider, validatorApiChannel, spec);
     final AttestationDutyFactory attestationDutyFactory =


### PR DESCRIPTION
## PR Description
Retry loading validator indices if they fail.  Previously this would only retry at the start of the next epoch which could lead to a delay in beginning validator duties if the beacon node hadn't loaded data from disk before the first attempt to load indices was received.

## Fixed Issue(s)
fixes #4808 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
