### PR TITLE
Reimplement integerSquareRoot using primitive operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
 * Added `kintsugi` network definition. 
-* Optimsied discv5 by caching calculated node ID.
+* Optimised discv5 by caching calculated node ID.
+* Avoided object allocation when calculating integer square root values.
 
 ### Bug Fixes
 * Updated to log4j 2.17.0.

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MathHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MathHelpers.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.spec.logic.common.helpers;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import java.nio.ByteOrder;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -27,15 +25,17 @@ public class MathHelpers {
   }
 
   public static UInt64 integerSquareRoot(UInt64 n) {
-    checkArgument(
-        n.compareTo(UInt64.ZERO) >= 0, "checkArgument threw an exception in integerSquareRoot()");
-    UInt64 x = n;
-    UInt64 y = x.plus(UInt64.ONE).dividedBy(2);
-    while (y.compareTo(x) < 0) {
-      x = y;
-      y = x.plus(n.dividedBy(x)).dividedBy(2);
+    if (n.compareTo(UInt64.MAX_VALUE) >= 0) {
+      throw new ArithmeticException("uint64 overflow");
     }
-    return x;
+    long x = n.longValue();
+    long y = Long.divideUnsigned(x + 1, 2);
+    while (Long.compareUnsigned(y, x) < 0) {
+      x = y;
+      final long nDividedByX = Long.divideUnsigned(n.longValue(), x);
+      y = Long.divideUnsigned(x + nDividedByX, 2);
+    }
+    return UInt64.valueOf(x);
   }
 
   public static Bytes uintToBytes(long value, int numBytes) {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/MathHelpersTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/MathHelpersTest.java
@@ -13,8 +13,8 @@
 
 package tech.pegasys.teku.spec.logic.common.helpers;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -67,15 +67,36 @@ public class MathHelpersTest {
   }
 
   @Test
-  void sqrtOfANonSquareNumber() {
-    UInt64 actual = MathHelpers.integerSquareRoot(UInt64.valueOf(27L));
-    UInt64 expected = UInt64.valueOf(5L);
+  void sqrtOfMaxValue() {
+    assertThatThrownBy(() -> MathHelpers.integerSquareRoot(UInt64.MAX_VALUE))
+        .isInstanceOf(ArithmeticException.class);
+  }
+
+  @Test
+  void sqrtOfMaxValueMinusOne() {
+    UInt64 actual = MathHelpers.integerSquareRoot(UInt64.MAX_VALUE.minus(1));
+    UInt64 expected = UInt64.valueOf(4294967295L);
     assertEquals(expected, actual);
   }
 
   @Test
-  void sqrtOfANegativeNumber() {
-    assertThrows(
-        IllegalArgumentException.class, () -> MathHelpers.integerSquareRoot(UInt64.valueOf(-1L)));
+  void sqrtOfZero() {
+    UInt64 actual = MathHelpers.integerSquareRoot(UInt64.ZERO);
+    UInt64 expected = UInt64.ZERO;
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void sqrtOfOne() {
+    UInt64 actual = MathHelpers.integerSquareRoot(UInt64.ONE);
+    UInt64 expected = UInt64.ONE;
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void sqrtOfANonSquareNumber() {
+    UInt64 actual = MathHelpers.integerSquareRoot(UInt64.valueOf(27L));
+    UInt64 expected = UInt64.valueOf(5L);
+    assertEquals(expected, actual);
   }
 }


### PR DESCRIPTION
## PR Description
Use primitive operations to calculate integer square root. Significantly reduces the number of garbage objects created and eliminates a lot of unnecessary overflow checks.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
