### PR TITLE
Fix jmh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ eth-reference-tests/src/test/
 eth-reference-tests/src/referenceTest/generated/
 eth-reference-tests/src/referenceTest/generated_tests/
 eth-reference-tests/src/referenceTest/resources/eth2.0-spec-tests/
-
+/eth-benchmark-tests/src/jmh/generated_tests/
 
 /teku.db
 node_modules

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ plugins {
   id 'com.github.jk1.dependency-license-report' version '1.16'
   id 'io.spring.dependency-management' version '1.0.9.RELEASE'
   id 'net.ltgt.errorprone' version '2.0.2' apply false
-  id 'me.champeau.gradle.jmh' version '0.5.3' apply false
   id 'de.undercouch.download' version '4.1.2'
   id 'org.ajoberstar.grgit' version '4.1.0'
 }
@@ -551,6 +550,40 @@ subprojects {
       }
     }
   }
+
+  if (project.file('src/jmh/java').exists()) {
+    println "JMH in: ${project.name}"
+    sourceSets {
+      jmh {
+        java.srcDirs = ['src/jmh/java']
+        resources.srcDirs = ['src/jmh/resources']
+        compileClasspath += sourceSets.main.runtimeClasspath
+      }
+    }
+
+    tasks.getByName("compileJmhJava") {
+
+      options.compilerArgs = []
+
+      options.errorprone {
+        enabled = false
+      }
+    }
+
+    dependencies {
+      jmhImplementation 'org.openjdk.jmh:jmh-core'
+      jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
+    }
+
+    classes.finalizedBy(jmhClasses)
+
+    task jmh(type: JavaExec, dependsOn: jmhClasses) {
+      mainClass = 'org.openjdk.jmh.Main'
+      classpath = sourceSets.jmh.compileClasspath + sourceSets.jmh.runtimeClasspath
+      systemProperty("jmh.blackhole.mode", "COMPILER")
+    }
+  }
+
 
   configurations {
     integrationTestImplementation.extendsFrom testImplementation

--- a/eth-benchmark-tests/build.gradle
+++ b/eth-benchmark-tests/build.gradle
@@ -1,10 +1,6 @@
-plugins {
-  id 'me.champeau.gradle.jmh'
-}
-
 idea {
   module {
-    testSourceDirs += sourceSets.main.java.srcDirs
+    testSourceDirs += sourceSets.jmh.java.srcDirs
   }
 }
 
@@ -23,24 +19,8 @@ dependencies {
 
   implementation 'org.apache.tuweni:tuweni-bytes'
 
-  jmh project(':infrastructure:crypto')
-  jmh 'org.openjdk.jmh:jmh-core'
-  jmh 'org.openjdk.jmh:jmh-generator-annprocess'
-  jmh 'org.apache.tuweni:tuweni-ssz'
-  jmh project(':infrastructure:bls')
-  jmh testFixtures(project(':ethereum:weaksubjectivity'))
-  jmh testFixtures(project(':infrastructure:async'))
-}
-
-jmh {
-  resultFormat = 'CSV'
-  duplicateClassesStrategy = 'warn'
-}
-
-jmhJar {
-  manifest {
-    attributes(
-        'Multi-Release': 'true'
-    )
-  }
+  jmhImplementation project(':infrastructure:crypto')
+  jmhImplementation 'org.apache.tuweni:tuweni-ssz'
+  jmhImplementation testFixtures(project(':ethereum:weaksubjectivity'))
+  jmhImplementation testFixtures(project(':infrastructure:async'))
 }

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/BeaconBlockBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/BeaconBlockBenchmark.java
@@ -24,9 +24,10 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSTestUtil;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.util.config.Constants;
 
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
@@ -34,17 +35,14 @@ import tech.pegasys.teku.util.config.Constants;
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class BeaconBlockBenchmark {
 
+  private static final Spec spec = TestSpecFactory.createMainnetPhase0();
   private static final BLSPublicKey pubkey = BLSTestUtil.randomPublicKey(0);
   private static final DataStructureUtil dataStructureUtil =
-      new DataStructureUtil(0).withPubKeyGenerator(() -> pubkey);
+      new DataStructureUtil(0, spec).withPubKeyGenerator(() -> pubkey);
   private static final BeaconBlock fullBeaconBlock =
       dataStructureUtil.randomBeaconBlock(100, Bytes32.random(), true);
   private static final BeaconBlock sparseBeaconBlock =
       dataStructureUtil.randomBeaconBlock(100, Bytes32.random(), false);
-
-  public BeaconBlockBenchmark() {
-    Constants.setConstants("mainnet");
-  }
 
   @Benchmark
   public void hashFullBlocks(Blackhole bh) {

--- a/infrastructure/ssz/build.gradle
+++ b/infrastructure/ssz/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-  id 'me.champeau.gradle.jmh'
-}
-
 dependencies {
   implementation project(':infrastructure:crypto')
   implementation 'org.apache.commons:commons-lang3'
@@ -12,13 +8,4 @@ dependencies {
   testFixturesApi 'org.apache.tuweni:tuweni-bytes'
   testFixturesApi 'org.apache.tuweni:tuweni-units'
   testFixturesApi project(':infrastructure:unsigned')
-
-  jmh 'org.openjdk.jmh:jmh-generator-annprocess'
-  jmh 'org.apache.tuweni:tuweni-ssz'
-}
-
-jmh {
-  include = '.*'
-  resultFormat = 'CSV'
-  duplicateClassesStrategy = 'warn'
 }


### PR DESCRIPTION
## PR Description
Removes the JMH plugin which regularly breaks with gradle upgrades and manually applies a simple config for jmh.  Benchmarks can be run with either `gradle jmh` or in IntelliJ with the JMH plugin.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
