### PR TITLE
Fix Windows build

### DIFF
--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
@@ -91,7 +91,7 @@ public class SpecConfigLoaderTest {
       writeStreamToFile(inputStream, file);
       assertThatThrownBy(() -> SpecConfigLoader.loadConfig(file.toAbsolutePath().toString()))
           .isInstanceOf(IllegalArgumentException.class)
-          .hasMessageMatching(
+          .hasMessage(
               "Unable to load configuration for network \""
                   + file.toAbsolutePath()
                   + "\": Could not load spec config preset '300' specified in config '"
@@ -107,7 +107,7 @@ public class SpecConfigLoaderTest {
       writeStreamToFile(inputStream, file);
       assertThatThrownBy(() -> SpecConfigLoader.loadConfig(file.toAbsolutePath().toString()))
           .isInstanceOf(IllegalArgumentException.class)
-          .hasMessageMatching(
+          .hasMessage(
               "Unable to load configuration for network \""
                   + file.toAbsolutePath()
                   + "\": Could not load spec config preset 'foo' specified in config '"


### PR DESCRIPTION
## PR Description
New tests were failing because the `\` in windows paths was being interpreted as an escape sequence.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
