### PR TITLE
Use cached BLSPublicKey for sync committee participants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,6 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ## Unreleased Changes
 ### Additions and Improvements
+* Optimised sync committee processing to avoid duplicate group checks for public keys.
 
 ### Bug Fixes

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -577,8 +577,8 @@ public class Spec {
   }
 
   public Optional<BLSPublicKey> getValidatorPubKey(
-      final BeaconState state, final UInt64 proposerIndex) {
-    return atState(state).beaconStateAccessors().getValidatorPubKey(state, proposerIndex);
+      final BeaconState state, final UInt64 validatorIndex) {
+    return atState(state).beaconStateAccessors().getValidatorPubKey(state, validatorIndex);
   }
 
   // Validator Utils

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -151,6 +151,27 @@ public class SyncCommitteeUtil {
         .getOrDefault(validatorIndex, SyncSubcommitteeAssignments.NONE);
   }
 
+  public BLSPublicKey getCurrentSyncCommitteeParticipantPubKey(
+      final BeaconStateAltair state, final int committeeIndex) {
+    final SyncCommittee syncCommittee = state.getCurrentSyncCommittee();
+    return getSyncCommitteeParticipantPubKey(state, syncCommittee, committeeIndex);
+  }
+
+  public BLSPublicKey getSyncCommitteeParticipantPubKey(
+      final BeaconStateAltair state, final SyncCommittee syncCommittee, final int committeeIndex) {
+    final BLSPublicKey uncachedPublicKey =
+        syncCommittee.getPubkeys().get(committeeIndex).getBLSPublicKey();
+    final int validatorIndex =
+        validatorsUtil
+            .getValidatorIndex(state, uncachedPublicKey)
+            .orElseThrow(
+                () -> new IllegalStateException("Unknown validator found in sync committee"));
+    return beaconStateAccessors
+        .getValidatorPubKey(state, UInt64.valueOf(validatorIndex))
+        .orElseThrow(
+            () -> new IllegalStateException("Validator in sync committee has no public key"));
+  }
+
   public int getSubcommitteeSize() {
     return specConfig.getSyncCommitteeSize() / SYNC_COMMITTEE_SUBNET_COUNT;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -126,11 +126,15 @@ public class SpecLogicAltair extends AbstractSpecLogic {
             validatorsUtil,
             beaconStateUtil,
             validatorStatusFactory);
+    final SyncCommitteeUtil syncCommitteeUtil =
+        new SyncCommitteeUtil(
+            beaconStateAccessors, validatorsUtil, config, miscHelpers, schemaDefinitions);
     final BlockProcessorAltair blockProcessor =
         new BlockProcessorAltair(
             config,
             predicates,
             miscHelpers,
+            syncCommitteeUtil,
             beaconStateAccessors,
             beaconStateMutators,
             operationSignatureVerifier,
@@ -142,9 +146,6 @@ public class SpecLogicAltair extends AbstractSpecLogic {
         new ForkChoiceUtil(config, beaconStateAccessors, attestationUtil, miscHelpers);
     final BlockProposalUtil blockProposalUtil =
         new BlockProposalUtil(schemaDefinitions, blockProcessor);
-    final SyncCommitteeUtil syncCommitteeUtil =
-        new SyncCommitteeUtil(
-            beaconStateAccessors, validatorsUtil, config, miscHelpers, schemaDefinitions);
 
     // State upgrade
     final AltairStateUpgrade stateUpgrade =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/SpecLogicMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/SpecLogicMerge.java
@@ -132,11 +132,15 @@ public class SpecLogicMerge extends AbstractSpecLogic {
             validatorsUtil,
             beaconStateUtil,
             validatorStatusFactory);
+    final SyncCommitteeUtil syncCommitteeUtil =
+        new SyncCommitteeUtil(
+            beaconStateAccessors, validatorsUtil, config, miscHelpers, schemaDefinitions);
     final BlockProcessorMerge blockProcessor =
         new BlockProcessorMerge(
             config,
             predicates,
             miscHelpers,
+            syncCommitteeUtil,
             beaconStateAccessors,
             beaconStateMutators,
             operationSignatureVerifier,
@@ -149,9 +153,6 @@ public class SpecLogicMerge extends AbstractSpecLogic {
         new ForkChoiceUtil(config, beaconStateAccessors, attestationUtil, miscHelpers);
     final BlockProposalUtil blockProposalUtil =
         new BlockProposalUtil(schemaDefinitions, blockProcessor);
-    final SyncCommitteeUtil syncCommitteeUtil =
-        new SyncCommitteeUtil(
-            beaconStateAccessors, validatorsUtil, config, miscHelpers, schemaDefinitions);
 
     // State upgrade
     final MergeStateUpgrade stateUpgrade =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/block/BlockProcessorMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/block/BlockProcessorMerge.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValida
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
+import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair;
 import tech.pegasys.teku.spec.logic.versions.merge.helpers.BeaconStateAccessorsMerge;
@@ -44,6 +45,7 @@ public class BlockProcessorMerge extends BlockProcessorAltair {
       final SpecConfigMerge specConfig,
       final Predicates predicates,
       final MiscHelpersMerge miscHelpers,
+      final SyncCommitteeUtil syncCommitteeUtil,
       final BeaconStateAccessorsMerge beaconStateAccessors,
       final BeaconStateMutators beaconStateMutators,
       final OperationSignatureVerifier operationSignatureVerifier,
@@ -56,6 +58,7 @@ public class BlockProcessorMerge extends BlockProcessorAltair {
         specConfig,
         predicates,
         miscHelpers,
+        syncCommitteeUtil,
         beaconStateAccessors,
         beaconStateMutators,
         operationSignatureVerifier,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
@@ -215,7 +215,7 @@ public class SignedContributionAndProofValidator {
 
     final SpecConfigAltair config =
         SpecConfigAltair.required(spec.getSpecConfig(contributionEpoch));
-    final SyncCommittee currentSyncCommittee =
+    final SyncCommittee syncCommittee =
         syncCommitteeUtil.getSyncCommittee(state, contributionEpoch);
     final int subcommitteeSize = config.getSyncCommitteeSize() / SYNC_COMMITTEE_SUBNET_COUNT;
 
@@ -229,7 +229,7 @@ public class SignedContributionAndProofValidator {
             .mapToObj(
                 participantIndex ->
                     getParticipantPublicKey(
-                        currentSyncCommittee, contribution, subcommitteeSize, participantIndex))
+                        state, syncCommittee, contribution, subcommitteeSize, participantIndex))
             .collect(Collectors.toList());
 
     if (!signatureVerifier.verify(
@@ -261,14 +261,15 @@ public class SignedContributionAndProofValidator {
   }
 
   private BLSPublicKey getParticipantPublicKey(
-      final SyncCommittee currentSyncCommittee,
+      final BeaconStateAltair state,
+      final SyncCommittee syncCommittee,
       final SyncCommitteeContribution contribution,
       final int subcommitteeSize,
       final int participantIndex) {
-    return currentSyncCommittee
-        .getPubkeys()
-        .get(contribution.getSubcommitteeIndex().intValue() * subcommitteeSize + participantIndex)
-        .getBLSPublicKey();
+    final int committeeIndex =
+        contribution.getSubcommitteeIndex().intValue() * subcommitteeSize + participantIndex;
+    return spec.getSyncCommitteeUtilRequired(state.getSlot())
+        .getSyncCommitteeParticipantPubKey(state, syncCommittee, committeeIndex);
   }
 
   private boolean isInSyncSubcommittee(

--- a/infrastructure/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstPublicKey.java
+++ b/infrastructure/bls/src/main/java/tech/pegasys/teku/bls/impl/blst/BlstPublicKey.java
@@ -15,11 +15,11 @@ package tech.pegasys.teku.bls.impl.blst;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes48;
 import supranational.blst.P1;
 import supranational.blst.P1_Affine;
@@ -75,8 +75,8 @@ class BlstPublicKey implements PublicKey {
   }
 
   final P1_Affine ecPoint;
-  private final Supplier<Boolean> isInfinity = Suppliers.memoize(() -> checkForInfinity());
-  private final Supplier<Boolean> isInGroup = Suppliers.memoize(() -> checkGroupMembership());
+  private final Supplier<Boolean> isInfinity = Suppliers.memoize(this::checkForInfinity);
+  private final Supplier<Boolean> isInGroup = Suppliers.memoize(this::checkGroupMembership);
 
   public BlstPublicKey(P1_Affine ecPoint) {
     this.ecPoint = ecPoint;


### PR DESCRIPTION
## PR Description
Avoid performing duplicate group checks on public keys by using the cached public key rather than directly using the public key from the state's sync committee.

Note that we still wind up creating new public key instances when deserialising SSZ but we swap them for the cached version before doing any signature verification. It may be worth investigating changing our `SSZPublicKey` to only return the compressed bytes rather than creating an actual `BLSPublicKey` so it's not possible to use it directly and thus strongly encourage people to get the public key from the cache and avoid generating the extra garbage, but that's a pretty major change and I'm not sure it's worth it.

## Fixed Issue(s)
fixes #4776 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
