### PR TITLE
Validator id parameters should not be rejected for bytes48 not on g2 curve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ For information on changes in released versions of Teku, see the [releases page]
 * Updated Javalin to version 4.2.0.
 
 ### Bug Fixes
+* Rest api endpoints accepting validator IDs will no longer reject valid bytes48 hex strings that are not on the g2 curve.

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -33,6 +33,7 @@ import java.util.stream.IntStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.Bytes48;
 import tech.pegasys.teku.api.blockselector.BlockSelectorFactory;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.response.SszResponse;
@@ -46,14 +47,13 @@ import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.api.response.v1.debug.ChainHead;
 import tech.pegasys.teku.api.schema.Attestation;
-import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.api.schema.BeaconState;
 import tech.pegasys.teku.api.schema.Fork;
-import tech.pegasys.teku.api.schema.PublicKeyException;
 import tech.pegasys.teku.api.schema.Root;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.Version;
 import tech.pegasys.teku.api.stateselector.StateSelectorFactory;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.Merkleizable;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -232,14 +232,6 @@ public class ChainDataProvider {
                             spec.atSlot(state.getSlot()).getMilestone())));
   }
 
-  public boolean isFinalized(final SignedBeaconBlock signedBeaconBlock) {
-    return combinedChainDataClient.isFinalized(signedBeaconBlock.getMessage().slot);
-  }
-
-  public boolean isFinalized(final UInt64 slot) {
-    return combinedChainDataClient.isFinalized(slot);
-  }
-
   /**
    * Convert a {validator_id} from a URL to a validator index
    *
@@ -254,8 +246,7 @@ public class ChainDataProvider {
     }
     return recentChainData
         .getBestState()
-        .map(state -> validatorParameterToIndex(state, validatorParameter))
-        .orElse(Optional.empty());
+        .flatMap(state -> validatorParameterToIndex(state, validatorParameter));
   }
 
   private Optional<Integer> validatorParameterToIndex(
@@ -266,11 +257,13 @@ public class ChainDataProvider {
     }
 
     if (validatorParameter.toLowerCase().startsWith("0x")) {
+      final Bytes48 keyBytes = getBytes48FromParameter(validatorParameter);
       try {
-        BLSPubKey publicKey = BLSPubKey.fromHexString(validatorParameter);
-        return spec.getValidatorIndex(state, publicKey.asBLSPublicKey());
-      } catch (PublicKeyException ex) {
-        throw new BadRequestException(String.format("Invalid public key: %s", validatorParameter));
+        // validate key against g2 curve
+        return spec.getValidatorIndex(state, BLSPublicKey.fromBytesCompressedValidate(keyBytes));
+      } catch (IllegalArgumentException ex) {
+        // failure to validate on the curve guarantees it is not in the validator list
+        return Optional.empty();
       }
     }
     try {
@@ -287,6 +280,21 @@ public class ChainDataProvider {
       return Optional.of(validatorIndex);
     } catch (NumberFormatException ex) {
       throw new BadRequestException(String.format("Invalid validator: %s", validatorParameter));
+    }
+  }
+
+  private Bytes48 getBytes48FromParameter(final String validatorParameter) {
+    try {
+      if (validatorParameter.length() != 98) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Expected a length of 98 for a hex encoded bytes48 with 0x prefix, but got length %s",
+                validatorParameter.length()));
+      }
+      return Bytes48.fromHexString(validatorParameter);
+    } catch (IllegalArgumentException ex) {
+      throw new BadRequestException(
+          String.format("Invalid public key: %s; %s", validatorParameter, ex.getMessage()));
     }
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -259,10 +259,8 @@ public class ChainDataProvider {
     if (validatorParameter.toLowerCase().startsWith("0x")) {
       final Bytes48 keyBytes = getBytes48FromParameter(validatorParameter);
       try {
-        // validate key against g2 curve
-        return spec.getValidatorIndex(state, BLSPublicKey.fromBytesCompressedValidate(keyBytes));
+        return spec.getValidatorIndex(state, BLSPublicKey.fromBytesCompressed(keyBytes));
       } catch (IllegalArgumentException ex) {
-        // failure to validate on the curve guarantees it is not in the validator list
         return Optional.empty();
       }
     }


### PR DESCRIPTION
If a bytes48 key is provided that can't be validated on the curve, treat it as a missed key, not an invalid request. In a large list of bytes48 a single key will otherwise reject the entire request, where we could instead just process the rest of the request.

Internally we still need to map keys to the curve to be able to search for the key, so for any valid bytes48 we will still end up having to map to the curve to find the key.

0x hex with invalid length will still be rejected as a bad request.

fixes #4787

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
