### PR TITLE
Include block root when querying all blocks at a slot.

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetAllBlocksAtSlotResponse.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetAllBlocksAtSlotResponse.json
@@ -9,7 +9,7 @@
       "uniqueItems" : true,
       "type" : "array",
       "items" : {
-        "$ref" : "#/components/schemas/SignedBeaconBlock"
+        "$ref" : "#/components/schemas/SignedBeaconBlockWithRoot"
       }
     }
   }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBeaconBlockWithRoot.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBeaconBlockWithRoot.json
@@ -1,0 +1,18 @@
+{
+  "type" : "object",
+  "properties" : {
+    "message" : {
+      "$ref" : "#/components/schemas/BeaconBlock"
+    },
+    "signature" : {
+      "type" : "string",
+      "description" : "Bytes96 hexadecimal",
+      "format" : "byte"
+    },
+    "root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "format" : "byte"
+    }
+  }
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.api.response.v1.beacon.ValidatorBalanceResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.api.response.v1.debug.ChainHead;
+import tech.pegasys.teku.api.response.v1.teku.GetAllBlocksAtSlotResponse;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.api.schema.BeaconState;
@@ -52,6 +53,7 @@ import tech.pegasys.teku.api.schema.Fork;
 import tech.pegasys.teku.api.schema.PublicKeyException;
 import tech.pegasys.teku.api.schema.Root;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
+import tech.pegasys.teku.api.schema.SignedBeaconBlockWithRoot;
 import tech.pegasys.teku.api.schema.Version;
 import tech.pegasys.teku.api.stateselector.StateSelectorFactory;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -201,7 +203,7 @@ public class ChainDataProvider {
                             spec.atSlot(state.getSlot()).getMilestone())));
   }
 
-  public SafeFuture<Set<SignedBeaconBlock>> getAllBlocksAtSlot(final String slot) {
+  public SafeFuture<GetAllBlocksAtSlotResponse> getAllBlocksAtSlot(final String slot) {
     if (slot.startsWith("0x")) {
       throw new BadRequestException(
           String.format("block roots are not currently supported: %s", slot));
@@ -210,10 +212,15 @@ public class ChainDataProvider {
           .nonCanonicalBlocksSelector(UInt64.valueOf(slot))
           .getBlock()
           .thenApply(
-              blockList ->
-                  blockList.stream()
-                      .map(schemaObjectProvider::getSignedBeaconBlock)
-                      .collect(Collectors.toSet()));
+              blockList -> {
+                final Set<SignedBeaconBlockWithRoot> blocks =
+                    blockList.stream()
+                        .map(SignedBeaconBlockWithRoot::new)
+                        .collect(Collectors.toSet());
+
+                return new GetAllBlocksAtSlotResponse(
+                    getVersionAtSlot(UInt64.valueOf(slot)), blocks);
+              });
     }
   }
 

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetAllBlocksAtSlotResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetAllBlocksAtSlotResponse.java
@@ -16,15 +16,15 @@ package tech.pegasys.teku.api.response.v1.teku;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Set;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock;
+import tech.pegasys.teku.api.schema.SignedBeaconBlockWithRoot;
 import tech.pegasys.teku.api.schema.Version;
 
 public class GetAllBlocksAtSlotResponse {
   private final Version version;
 
-  private final Set<SignedBeaconBlock> data;
+  private final Set<SignedBeaconBlockWithRoot> data;
 
-  public Set<SignedBeaconBlock> getData() {
+  public Set<SignedBeaconBlockWithRoot> getData() {
     return data;
   }
 
@@ -35,7 +35,7 @@ public class GetAllBlocksAtSlotResponse {
   @JsonCreator
   public GetAllBlocksAtSlotResponse(
       @JsonProperty("version") final Version version,
-      @JsonProperty("data") final Set<SignedBeaconBlock> data) {
+      @JsonProperty("data") final Set<SignedBeaconBlockWithRoot> data) {
     this.version = version;
     this.data = data;
   }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SignedBeaconBlockWithRoot.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SignedBeaconBlockWithRoot.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.schema;
+
+import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES32;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.apache.tuweni.bytes.Bytes32;
+
+public class SignedBeaconBlockWithRoot extends SignedBeaconBlock {
+
+  @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES32)
+  private final Bytes32 root;
+
+  public SignedBeaconBlockWithRoot(
+      final tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock) {
+    super(internalBlock);
+    root = internalBlock.getRoot();
+  }
+
+  public Bytes32 getRoot() {
+    return root;
+  }
+}


### PR DESCRIPTION
This is helpful when debugging issues, and the teku endpoint is specific to teku, and also the only one that includes non-canonical blocks.

This change is additive, so it should be compatible with anyone using the existing interface, unless they require the exact object structure returned.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
