### PR TITLE
Fix web3j version

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -127,7 +127,7 @@ dependencyManagement {
     dependency 'org.fusesource.leveldbjni:leveldbjni-win32:1.8'
     dependency 'tech.pegasys:leveldb-native:0.2.0'
 
-    dependencySet(group: "org.web3j", version: "5.0.0") {
+    dependencySet(group: "org.web3j", version: "4.8.9") {
       entry 'core'
       entry 'abi'
       entry 'crypto'


### PR DESCRIPTION
## PR Description
web3j 5.0.0 is not actually the latest version - 4.8.9 is so switch to that.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
