### PR TITLE
Add REST API to get prepared beacon proposers

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_teku_v1_beacon_prepared_beacon_proposers.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_teku_v1_beacon_prepared_beacon_proposers.json
@@ -1,0 +1,26 @@
+{
+  "get" : {
+    "tags" : [ "Teku" ],
+    "summary" : "Get current prepared beacon proposers",
+    "description" : "Get the current proposers information held by beacon node as result of prepare_beacon_proposer validator API calls. This API is considered unstable and the returned data format may change in the future.",
+    "operationId" : "getTekuV1BeaconPrepared_beacon_proposers",
+    "responses" : {
+      "200" : {
+        "description" : "OK",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/GetPreparedBeaconProposersResponse"
+            }
+          }
+        }
+      },
+      "500" : {
+        "description" : "Server Error"
+      },
+      "503" : {
+        "description" : "Beacon node is currently syncing and not serving requests"
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_teku_v1_beacon_prepared_beacon_proposers.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_teku_v1_beacon_prepared_beacon_proposers.json
@@ -1,6 +1,6 @@
 {
   "get" : {
-    "tags" : [ "Teku" ],
+    "tags" : [ "Experimental" ],
     "summary" : "Get current prepared beacon proposers",
     "description" : "Get the current proposers information held by beacon node as result of prepare_beacon_proposer validator API calls. This API is considered unstable and the returned data format may change in the future.",
     "operationId" : "getTekuV1BeaconPrepared_beacon_proposers",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetPreparedBeaconProposersResponse.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetPreparedBeaconProposersResponse.json
@@ -1,0 +1,17 @@
+{
+  "type" : "object",
+  "properties" : {
+    "data" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "additionalProperties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetPreparedBeaconProposersResponse.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetPreparedBeaconProposersResponse.json
@@ -4,10 +4,7 @@
     "data" : {
       "type" : "array",
       "items" : {
-        "type" : "object",
-        "additionalProperties" : {
-          "type" : "object"
-        }
+        "$ref" : "#/components/schemas/ProposerInfoSchema"
       }
     }
   }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetPreparedBeaconProposersResponse.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetPreparedBeaconProposersResponse.json
@@ -6,10 +6,7 @@
       "items" : {
         "type" : "object",
         "additionalProperties" : {
-          "type" : "object",
-          "additionalProperties" : {
-            "type" : "object"
-          }
+          "type" : "object"
         }
       }
     }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ProposerInfoSchema.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ProposerInfoSchema.json
@@ -1,0 +1,19 @@
+{
+  "type" : "object",
+  "properties" : {
+    "proposer_index" : {
+      "type" : "string",
+      "format" : "uint64"
+    },
+    "fee_recipient" : {
+      "pattern" : "^0x[a-fA-F0-9]{40}$",
+      "type" : "string",
+      "description" : "Bytes20 hexadecimal",
+      "format" : "byte"
+    },
+    "expiry_slot" : {
+      "type" : "string",
+      "format" : "uint64"
+    }
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.Liveness;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.PutLogLevel;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.Readiness;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetAllBlocksAtSlot;
+import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetPreparedBeaconProposers;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetProtoArray;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetSszState;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon.GetStateByBlockRoot;
@@ -305,6 +306,8 @@ public class BeaconRestApi {
     app.get(GetAllBlocksAtSlot.ROUTE, new GetAllBlocksAtSlot(provider, jsonProvider));
     app.get(GetPeersScore.ROUTE, new GetPeersScore(provider, jsonProvider));
     app.get(GetProtoArray.ROUTE, new GetProtoArray(provider, jsonProvider));
+    app.get(
+        GetPreparedBeaconProposers.ROUTE, new GetPreparedBeaconProposers(provider, jsonProvider));
   }
 
   private void addNodeHandlers(final DataProvider provider) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetPreparedBeaconProposers.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetPreparedBeaconProposers.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon;
+
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.CACHE_NONE;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_INTERNAL_ERROR;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_OK;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_TEKU;
+
+import io.javalin.core.util.Header;
+import io.javalin.http.Context;
+import io.javalin.http.Handler;
+import io.javalin.plugin.openapi.annotations.HttpMethod;
+import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiContent;
+import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.NodeDataProvider;
+import tech.pegasys.teku.api.response.v1.teku.GetPreparedBeaconProposersResponse;
+import tech.pegasys.teku.provider.JsonProvider;
+
+public class GetPreparedBeaconProposers implements Handler {
+
+  public static final String ROUTE = "/teku/v1/beacon/prepared_beacon_proposers";
+
+  private final JsonProvider jsonProvider;
+  private final NodeDataProvider nodeDataProvider;
+
+  public GetPreparedBeaconProposers(final DataProvider provider, final JsonProvider jsonProvider) {
+    this(provider.getNodeDataProvider(), jsonProvider);
+  }
+
+  GetPreparedBeaconProposers(
+      final NodeDataProvider nodeDataProvider, final JsonProvider jsonProvider) {
+    this.jsonProvider = jsonProvider;
+    this.nodeDataProvider = nodeDataProvider;
+  }
+
+  @OpenApi(
+      path = ROUTE,
+      method = HttpMethod.GET,
+      summary = "Get current prepared beacon proposers",
+      tags = {TAG_TEKU},
+      description =
+          "Get the current proposers information held by beacon node as result of prepare_beacon_proposer validator API calls. This API is considered unstable and the returned data format may change in the future.",
+      responses = {
+        @OpenApiResponse(
+            status = RES_OK,
+            content = @OpenApiContent(from = GetPreparedBeaconProposersResponse.class)),
+        @OpenApiResponse(status = RES_INTERNAL_ERROR),
+        @OpenApiResponse(status = RES_SERVICE_UNAVAILABLE, description = SERVICE_UNAVAILABLE)
+      })
+  @Override
+  public void handle(final Context ctx) throws Exception {
+    ctx.header(Header.CACHE_CONTROL, CACHE_NONE);
+
+    final GetPreparedBeaconProposersResponse response =
+        new GetPreparedBeaconProposersResponse(nodeDataProvider.getPreparedBeaconProposers());
+    ctx.result(jsonProvider.objectToJSON(response));
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetPreparedBeaconProposers.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetPreparedBeaconProposers.java
@@ -18,7 +18,7 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_INTERNA
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SERVICE_UNAVAILABLE;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_TEKU;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_EXPERIMENTAL;
 
 import io.javalin.core.util.Header;
 import io.javalin.http.Context;
@@ -53,7 +53,7 @@ public class GetPreparedBeaconProposers implements Handler {
       path = ROUTE,
       method = HttpMethod.GET,
       summary = "Get current prepared beacon proposers",
-      tags = {TAG_TEKU},
+      tags = {TAG_EXPERIMENTAL},
       description =
           "Get the current proposers information held by beacon node as result of prepare_beacon_proposer validator API calls. This API is considered unstable and the returned data format may change in the future.",
       responses = {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockManager;
+import tech.pegasys.teku.statetransition.forkchoice.PayloadAttributesCalculator;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -97,6 +98,7 @@ public class DataProvider {
     private OperationPool<ProposerSlashing> proposerSlashingPool;
     private OperationPool<SignedVoluntaryExit> voluntaryExitPool;
     private SyncCommitteeContributionPool syncCommitteeContributionPool;
+    private PayloadAttributesCalculator payloadAttributesCalculator;
 
     private boolean isLivenessTrackingEnabled = true;
 
@@ -173,6 +175,12 @@ public class DataProvider {
       return this;
     }
 
+    public Builder payloadAttributesCalculator(
+        final PayloadAttributesCalculator payloadAttributesCalculator) {
+      this.payloadAttributesCalculator = payloadAttributesCalculator;
+      return this;
+    }
+
     public Builder spec(final Spec spec) {
       this.spec = spec;
       return this;
@@ -191,7 +199,8 @@ public class DataProvider {
               blockManager,
               attestationManager,
               isLivenessTrackingEnabled,
-              activeValidatorChannel);
+              activeValidatorChannel,
+              payloadAttributesCalculator);
       final ChainDataProvider chainDataProvider =
           new ChainDataProvider(spec, recentChainData, combinedChainDataClient);
       final SyncDataProvider syncDataProvider = new SyncDataProvider(syncService);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorCa
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
@@ -37,6 +38,7 @@ import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockManager;
+import tech.pegasys.teku.statetransition.forkchoice.PayloadAttributesCalculator;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
@@ -55,20 +57,22 @@ public class NodeDataProvider {
   private final AttestationManager attestationManager;
   private final ActiveValidatorChannel activeValidatorChannel;
   private final boolean isLivenessTrackingEnabled;
+  private final PayloadAttributesCalculator payloadAttributesCalculator;
 
   public NodeDataProvider(
-      AggregatingAttestationPool attestationPool,
-      OperationPool<tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing>
+      final AggregatingAttestationPool attestationPool,
+      final OperationPool<tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing>
           attesterSlashingsPool,
-      OperationPool<tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing>
+      final OperationPool<tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing>
           proposerSlashingPool,
-      OperationPool<tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit>
+      final OperationPool<tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit>
           voluntaryExitPool,
       final SyncCommitteeContributionPool syncCommitteeContributionPool,
-      BlockManager blockManager,
-      AttestationManager attestationManager,
+      final BlockManager blockManager,
+      final AttestationManager attestationManager,
       final boolean isLivenessTrackingEnabled,
-      final ActiveValidatorChannel activeValidatorChannel) {
+      final ActiveValidatorChannel activeValidatorChannel,
+      final PayloadAttributesCalculator payloadAttributesCalculator) {
     this.attestationPool = attestationPool;
     this.attesterSlashingPool = attesterSlashingsPool;
     this.proposerSlashingPool = proposerSlashingPool;
@@ -78,6 +82,7 @@ public class NodeDataProvider {
     this.attestationManager = attestationManager;
     this.activeValidatorChannel = activeValidatorChannel;
     this.isLivenessTrackingEnabled = isLivenessTrackingEnabled;
+    this.payloadAttributesCalculator = payloadAttributesCalculator;
   }
 
   public List<Attestation> getAttestations(
@@ -180,5 +185,9 @@ public class NodeDataProvider {
                           new ValidatorLivenessAtEpoch(validatorIndex, request.epoch, liveness)));
               return Optional.of(new PostValidatorLivenessResponse(livenessAtEpochs));
             });
+  }
+
+  public List<Map<Integer, Map<String, Object>>> getPreparedBeaconProposers() {
+    return payloadAttributesCalculator.getData();
   }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -187,7 +187,7 @@ public class NodeDataProvider {
             });
   }
 
-  public List<Map<Integer, Map<String, Object>>> getPreparedBeaconProposers() {
+  public List<Map<String, Object>> getPreparedBeaconProposers() {
     return payloadAttributesCalculator.getData();
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetPreparedBeaconProposersResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetPreparedBeaconProposersResponse.java
@@ -19,15 +19,15 @@ import java.util.List;
 import java.util.Map;
 
 public class GetPreparedBeaconProposersResponse {
-  private final List<Map<Integer, Map<String, Object>>> data;
+  private final List<Map<String, Object>> data;
 
   @JsonCreator
   public GetPreparedBeaconProposersResponse(
-      @JsonProperty("data") final List<Map<Integer, Map<String, Object>>> data) {
+      @JsonProperty("data") final List<Map<String, Object>> data) {
     this.data = data;
   }
 
-  public List<Map<Integer, Map<String, Object>>> getData() {
+  public List<Map<String, Object>> getData() {
     return data;
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetPreparedBeaconProposersResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetPreparedBeaconProposersResponse.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.response.v1.teku;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+public class GetPreparedBeaconProposersResponse {
+  private final List<Map<Integer, Map<String, Object>>> data;
+
+  @JsonCreator
+  public GetPreparedBeaconProposersResponse(
+      @JsonProperty("data") final List<Map<Integer, Map<String, Object>>> data) {
+    this.data = data;
+  }
+
+  public List<Map<Integer, Map<String, Object>>> getData() {
+    return data;
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/ProposerInfoSchema.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/ProposerInfoSchema.java
@@ -13,24 +13,29 @@
 
 package tech.pegasys.teku.api.response.v1.teku;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES20;
+import static tech.pegasys.teku.api.schema.SchemaConstants.PATTERN_BYTES20;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
-import java.util.Map;
+import tech.pegasys.teku.infrastructure.ssz.type.Bytes20;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class GetPreparedBeaconProposersResponse {
-  @ArraySchema(schema = @Schema(implementation = ProposerInfoSchema.class))
-  private final List<Map<String, Object>> data;
+public class ProposerInfoSchema {
 
-  @JsonCreator
-  public GetPreparedBeaconProposersResponse(
-      @JsonProperty("data") final List<Map<String, Object>> proposers_info) {
-    this.data = proposers_info;
-  }
+  @Schema(type = "string", format = "uint64")
+  @JsonProperty("proposer_index")
+  UInt64 proposer_index;
 
-  public List<Map<String, Object>> getData() {
-    return data;
-  }
+  @Schema(
+      type = "string",
+      format = "byte",
+      pattern = PATTERN_BYTES20,
+      description = DESCRIPTION_BYTES20)
+  @JsonProperty("fee_recipient")
+  Bytes20 fee_recipient;
+
+  @Schema(type = "string", format = "uint64")
+  @JsonProperty("expiry_slot")
+  UInt64 expiry_slot;
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
@@ -257,4 +257,8 @@ public class ForkChoiceNotifier {
     sendForkChoiceUpdated();
     return true;
   }
+
+  public PayloadAttributesCalculator getPayloadAttributesCalculator() {
+    return payloadAttributesCalculator;
+  }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
@@ -13,10 +13,13 @@
 
 package tech.pegasys.teku.statetransition.forkchoice;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
@@ -35,7 +38,7 @@ public class PayloadAttributesCalculator {
   private final Spec spec;
   private final EventThread eventThread;
   private final RecentChainData recentChainData;
-  private final Map<UInt64, ProposerInfo> proposerInfoByValidatorIndex = new HashMap<>();
+  private final Map<UInt64, ProposerInfo> proposerInfoByValidatorIndex = new ConcurrentHashMap<>();
 
   public PayloadAttributesCalculator(
       final Spec spec, final EventThread eventThread, final RecentChainData recentChainData) {
@@ -112,5 +115,15 @@ public class PayloadAttributesCalculator {
       return recentChainData.retrieveStateAtSlot(
           new SlotAndBlockRoot(spec.computeStartSlotAtEpoch(requiredEpoch), head.getRoot()));
     }
+  }
+
+  public List<Map<Integer, Map<String, Object>>> getData() {
+    return proposerInfoByValidatorIndex.entrySet().stream()
+        .map(
+            uInt64ProposerInfoEntry ->
+                ImmutableMap.of(
+                    uInt64ProposerInfoEntry.getKey().intValue(),
+                    uInt64ProposerInfoEntry.getValue().getData()))
+        .collect(Collectors.toList());
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
@@ -122,9 +122,11 @@ public class PayloadAttributesCalculator {
         .map(
             proposerInfoEntry ->
                 ImmutableMap.<String, Object>builder()
-                    .put("proposerIndex", proposerInfoEntry.getKey().intValue())
-                    .put("feeRecipient", proposerInfoEntry.getValue().feeRecipient.toHexString())
-                    .put("expirySlot", proposerInfoEntry.getValue().expirySlot.intValue())
+                    // changing the following attributes require a change to
+                    // tech.pegasys.teku.api.response.v1.teku.ProposerInfoSchema
+                    .put("proposer_index", proposerInfoEntry.getKey())
+                    .put("fee_recipient", proposerInfoEntry.getValue().feeRecipient)
+                    .put("expiry_slot", proposerInfoEntry.getValue().expirySlot)
                     .build())
         .collect(Collectors.toList());
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
@@ -117,13 +117,15 @@ public class PayloadAttributesCalculator {
     }
   }
 
-  public List<Map<Integer, Map<String, Object>>> getData() {
+  public List<Map<String, Object>> getData() {
     return proposerInfoByValidatorIndex.entrySet().stream()
         .map(
-            uInt64ProposerInfoEntry ->
-                ImmutableMap.of(
-                    uInt64ProposerInfoEntry.getKey().intValue(),
-                    uInt64ProposerInfoEntry.getValue().getData()))
+            proposerInfoEntry ->
+                ImmutableMap.<String, Object>builder()
+                    .put("proposerIndex", proposerInfoEntry.getKey().intValue())
+                    .put("feeRecipient", proposerInfoEntry.getValue().feeRecipient.toHexString())
+                    .put("expirySlot", proposerInfoEntry.getValue().expirySlot.intValue())
+                    .build())
         .collect(Collectors.toList());
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposerInfo.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposerInfo.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.statetransition.forkchoice;
 
-import com.google.common.collect.ImmutableMap;
-import java.util.Map;
 import tech.pegasys.teku.infrastructure.ssz.type.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
@@ -30,12 +28,5 @@ class ProposerInfo {
 
   public boolean hasExpired(final UInt64 currentSlot) {
     return currentSlot.isGreaterThanOrEqualTo(expirySlot);
-  }
-
-  public Map<String, Object> getData() {
-    return ImmutableMap.<String, Object>builder()
-        .put("expirySlot", expirySlot.intValue())
-        .put("feeRecipient", feeRecipient.toHexString())
-        .build();
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposerInfo.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposerInfo.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.statetransition.forkchoice;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import tech.pegasys.teku.infrastructure.ssz.type.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
@@ -28,5 +30,12 @@ class ProposerInfo {
 
   public boolean hasExpired(final UInt64 currentSlot) {
     return currentSlot.isGreaterThanOrEqualTo(expirySlot);
+  }
+
+  public Map<String, Object> getData() {
+    return ImmutableMap.<String, Object>builder()
+        .put("expirySlot", expirySlot.intValue())
+        .put("feeRecipient", feeRecipient.toHexString())
+        .build();
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -802,6 +802,7 @@ public class BeaconChainController extends Service
             .proposerSlashingPool(proposerSlashingPool)
             .voluntaryExitPool(voluntaryExitPool)
             .syncCommitteeContributionPool(syncCommitteeContributionPool)
+            .payloadAttributesCalculator(forkChoiceNotifier.getPayloadAttributesCalculator())
             .build();
 
     if (beaconConfig.beaconRestApiConfig().isRestApiEnabled()) {


### PR DESCRIPTION
## PR Description

Allows troubleshooting and monitoring current prepared proposers in beacon node sent by validator clients via `/eth/v1/validator/prepare_beacon_proposer`

![image](https://user-images.githubusercontent.com/15999009/149806089-f43edee2-b301-46af-8f3a-a0f286b784c6.png)


## Documentation

- [ ] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
