### PR TITLE
Restore ability to create attestations to finalized data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,5 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
 * Rest api endpoints accepting validator IDs will no longer reject valid bytes48 hex strings that are not on the g2 curve.
-* Upgraded discovery to fix `ConcurrentModificationException`
+* Upgraded discovery to fix `ConcurrentModificationException`.
+* Fixed 503 response from REST APIs when creating an attestation or block based on finalized data.

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -293,7 +293,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     }
     final BeaconState blockSlotState = maybeBlockSlotState.get();
     final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, slot.minus(1));
-    if (!combinedChainDataClient.isFullyValidatedHotBlock(parentRoot)) {
+    if (combinedChainDataClient.isOptimisticBlock(parentRoot)) {
       LOG.warn(
           "Unable to produce block at slot {} because parent has optimistically validated payload",
           slot);
@@ -342,7 +342,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                           final BeaconBlock block = blockAndState.getBlock().getMessage();
 
                           // The head block must not be optimistically synced.
-                          if (!combinedChainDataClient.isFullyValidatedHotBlock(block.getRoot())) {
+                          if (combinedChainDataClient.isOptimisticBlock(block.getRoot())) {
                             return NodeSyncingException.failedFuture();
                           }
                           if (blockAndState.getSlot().compareTo(minQuerySlot) < 0) {

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -153,7 +153,7 @@ class ValidatorApiHandlerTest {
   public void setUp() {
     when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
     when(forkChoiceTrigger.prepareForBlockProduction(any())).thenReturn(SafeFuture.COMPLETE);
-    when(chainDataClient.isFullyValidatedHotBlock(any())).thenReturn(true);
+    when(chainDataClient.isOptimisticBlock(any())).thenReturn(false);
   }
 
   @Test
@@ -429,7 +429,7 @@ class ValidatorApiHandlerTest {
     when(chainDataClient.getStateAtSlotExact(newSlot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockSlotState)));
     final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, newSlot.minus(1));
-    when(chainDataClient.isFullyValidatedHotBlock(parentRoot)).thenReturn(false);
+    when(chainDataClient.isOptimisticBlock(parentRoot)).thenReturn(true);
 
     final SafeFuture<Optional<BeaconBlock>> result =
         validatorApiHandler.createUnsignedBlock(
@@ -486,7 +486,7 @@ class ValidatorApiHandlerTest {
         .thenReturn(blockAndStateResult);
     when(forkChoiceTrigger.prepareForAttestationProduction(slot)).thenReturn(SafeFuture.COMPLETE);
 
-    when(chainDataClient.isFullyValidatedHotBlock(blockAndState.getRoot())).thenReturn(false);
+    when(chainDataClient.isOptimisticBlock(blockAndState.getRoot())).thenReturn(true);
 
     final int committeeIndex = 0;
     final SafeFuture<Optional<AttestationData>> result =

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ForkChoiceStrategy.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ForkChoiceStrategy.java
@@ -283,6 +283,15 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     }
   }
 
+  public boolean isOptimistic(final Bytes32 blockRoot) {
+    protoArrayLock.readLock().lock();
+    try {
+      return getProtoNode(blockRoot).map(ProtoNode::isOptimistic).orElse(false);
+    } finally {
+      protoArrayLock.readLock().unlock();
+    }
+  }
+
   @Override
   public Optional<Bytes32> getAncestor(final Bytes32 blockRoot, final UInt64 slot) {
     protoArrayLock.readLock().lock();

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -515,10 +515,10 @@ public class CombinedChainDataClient {
     return signedBeaconBlocks;
   }
 
-  public boolean isFullyValidatedHotBlock(final Bytes32 blockRoot) {
+  public boolean isOptimisticBlock(final Bytes32 blockRoot) {
     return recentChainData
         .getForkChoiceStrategy()
-        .map(forkChoice -> forkChoice.isFullyValidated(blockRoot))
+        .map(forkChoice -> forkChoice.isOptimistic(blockRoot))
         .orElse(false);
   }
 }


### PR DESCRIPTION
## PR Description
While it's not something a validator would normally do, previously we supported creating attestations and blocks based off of finalized data. When introducing the check for optimistic blocks this was unnecessarily restricted to only non-finalized blocks.

This PR restores the ability to create attestations and blocks on finalised data by only rejecting blocks known to be optimistic instead of rejecting blocks the fork choice records as valid (which would exclude finalised blocks).

## Fixed Issue(s)
fixes #4870 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
