### PR TITLE
call `engine_forkChoiceUpdated` with PayloadAttributes using default fee recipient if proposer is not prepared

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.statetransition.forkchoice;
 
+import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
+
 import java.util.Collection;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
@@ -178,6 +180,10 @@ public class ForkChoiceNotifier {
     eventThread.checkOnEventThread();
 
     LOG.debug("internalUpdatePreparableProposers proposers {}", proposers);
+
+    if (!payloadAttributesCalculator.isProposerDefaultFeeRecipientDefined()) {
+      STATUS_LOG.warnMissingProposerDefaultFeeRecipientWithPreparedBeaconProposerBeingCalled();
+    }
 
     // Default to the genesis slot if we're pre-genesis.
     final UInt64 currentSlot = recentChainData.getCurrentSlot().orElse(SpecConfig.GENESIS_SLOT);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
@@ -221,11 +221,9 @@ public class ForkChoiceNotifier {
 
     forkChoiceUpdateData
         .withPayloadAttributesAsync(
-            // PayloadAttributes supplier
             () ->
                 payloadAttributesCalculator.calculatePayloadAttributes(
                     blockSlot, inSync, forkChoiceUpdateData, false),
-            // Executor
             eventThread)
         .thenAccept(
             newForkChoiceUpdateData -> {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
@@ -14,7 +14,10 @@
 package tech.pegasys.teku.statetransition.forkchoice;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Supplier;
 import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -34,6 +37,9 @@ public class ForkChoiceUpdateData {
   private final Optional<Bytes32> terminalBlockHash;
   private final SafeFuture<Optional<Bytes8>> payloadId = new SafeFuture<>();
   private boolean sent = false;
+
+  private long payloadAttributesSequenceProducer = 0;
+  private long payloadAttributesSequenceConsumer = -1;
 
   public ForkChoiceUpdateData() {
     this.forkChoiceState =
@@ -85,6 +91,35 @@ public class ForkChoiceUpdateData {
     }
     return new ForkChoiceUpdateData(
         forkChoiceState, payloadAttributes, Optional.of(terminalBlockHash));
+  }
+
+  public void withPayloadAttributesAsync(
+      final Supplier<SafeFuture<Optional<PayloadAttributes>>> payloadAttributesCalculator,
+      final Consumer<ForkChoiceUpdateData> forkChoiceUpdateDataConsumer,
+      final Consumer<Throwable> errorConsumer,
+      final Executor executor) {
+    // we want to preserve ordering in payload calculation,
+    // so we first generate a sequence for each calculation request
+    final long sequenceNumber = payloadAttributesSequenceProducer++;
+
+    payloadAttributesCalculator
+        .get()
+        .thenAcceptAsync(
+            newPayloadAttributes -> {
+              // to preserve ordering we make sure we haven't already calculated a payload that has
+              // been
+              // requested later than the current one
+              if (sequenceNumber <= payloadAttributesSequenceConsumer) {
+                LOG.warn("Ignoring calculated payload attributes since it violates ordering");
+                return;
+              }
+
+              payloadAttributesSequenceConsumer = sequenceNumber;
+
+              forkChoiceUpdateDataConsumer.accept(this.withPayloadAttributes(newPayloadAttributes));
+            },
+            executor)
+        .finish(errorConsumer);
   }
 
   public boolean isPayloadIdSuitable(final Bytes32 parentExecutionHash, final UInt64 timestamp) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
@@ -162,4 +162,8 @@ public class PayloadAttributesCalculator {
                     .build())
         .collect(Collectors.toList());
   }
+
+  public boolean isProposerDefaultFeeRecipientDefined() {
+    return proposerDefaultFeeRecipient.isPresent();
+  }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
@@ -20,9 +20,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
+import tech.pegasys.teku.infrastructure.ssz.type.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -33,18 +36,24 @@ import tech.pegasys.teku.spec.executionengine.PayloadAttributes;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class PayloadAttributesCalculator {
+  private static final Logger LOG = LogManager.getLogger();
   private static final long MAX_PROPOSER_SEEN_EPOCHS = 2;
 
   private final Spec spec;
   private final EventThread eventThread;
   private final RecentChainData recentChainData;
   private final Map<UInt64, ProposerInfo> proposerInfoByValidatorIndex = new ConcurrentHashMap<>();
+  private final Optional<? extends Bytes20> proposerDefaultFeeRecipient;
 
   public PayloadAttributesCalculator(
-      final Spec spec, final EventThread eventThread, final RecentChainData recentChainData) {
+      final Spec spec,
+      final EventThread eventThread,
+      final RecentChainData recentChainData,
+      final Optional<? extends Bytes20> proposerDefaultFeeRecipient) {
     this.spec = spec;
     this.eventThread = eventThread;
     this.recentChainData = recentChainData;
+    this.proposerDefaultFeeRecipient = proposerDefaultFeeRecipient;
   }
 
   public void updateProposers(
@@ -64,7 +73,8 @@ public class PayloadAttributesCalculator {
   public SafeFuture<Optional<PayloadAttributes>> calculatePayloadAttributes(
       final UInt64 blockSlot,
       final boolean inSync,
-      final ForkChoiceUpdateData forkChoiceUpdateData) {
+      final ForkChoiceUpdateData forkChoiceUpdateData,
+      final boolean mandatoryPayloadAttributes) {
     eventThread.checkOnEventThread();
     if (!inSync) {
       // We don't produce blocks while syncing so don't bother preparing the payload
@@ -82,11 +92,17 @@ public class PayloadAttributesCalculator {
     final UInt64 epoch = spec.computeEpochAtSlot(blockSlot);
     return getStateInEpoch(epoch)
         .thenApplyAsync(
-            maybeState -> calculatePayloadAttributes(blockSlot, epoch, maybeState), eventThread);
+            maybeState ->
+                calculatePayloadAttributes(
+                    blockSlot, epoch, maybeState, mandatoryPayloadAttributes),
+            eventThread);
   }
 
   private Optional<PayloadAttributes> calculatePayloadAttributes(
-      final UInt64 blockSlot, final UInt64 epoch, final Optional<BeaconState> maybeState) {
+      final UInt64 blockSlot,
+      final UInt64 epoch,
+      final Optional<BeaconState> maybeState,
+      final boolean mandatoryPayloadAttributes) {
     eventThread.checkOnEventThread();
     if (maybeState.isEmpty()) {
       return Optional.empty();
@@ -94,13 +110,29 @@ public class PayloadAttributesCalculator {
     final BeaconState state = maybeState.get();
     final UInt64 proposerIndex = UInt64.valueOf(spec.getBeaconProposerIndex(state, blockSlot));
     final ProposerInfo proposerInfo = proposerInfoByValidatorIndex.get(proposerIndex);
-    if (proposerInfo == null) {
+    if (proposerInfo == null && !mandatoryPayloadAttributes) {
       // Proposer is not one of our validators. No need to propose a block.
       return Optional.empty();
     }
     final UInt64 timestamp = spec.computeTimeAtSlot(state, blockSlot);
     final Bytes32 random = spec.getRandaoMix(state, epoch);
-    return Optional.of(new PayloadAttributes(timestamp, random, proposerInfo.feeRecipient));
+    return Optional.of(new PayloadAttributes(timestamp, random, getFeeRecipient(proposerInfo)));
+  }
+
+  // this function MUST return a fee recipient.
+  private Bytes20 getFeeRecipient(final ProposerInfo proposerInfo) {
+    if (proposerInfo != null) {
+      return proposerInfo.feeRecipient;
+    }
+    if (proposerDefaultFeeRecipient.isPresent()) {
+      LOG.warn(
+          "Payload Attributes are required but current proposer hasn't prepared. Using Beacon Node's default values.");
+      return proposerDefaultFeeRecipient.get();
+    }
+    // TODO: rise a RED EVENT LOG?
+    LOG.error(
+        "Payload Attributes are required but current proposer hasn't prepared and there is no default fee recipient configured. FEES ARE GOING TO BE BURNED!");
+    return Bytes20.ZERO;
   }
 
   private SafeFuture<Optional<BeaconState>> getStateInEpoch(final UInt64 requiredEpoch) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionengine.ExecutePayloadResult;
@@ -69,6 +70,7 @@ class ForkChoiceNotifierTest {
   private RecentChainData recentChainData;
   private ForkChoiceStrategy forkChoiceStrategy;
   private PayloadAttributesCalculator payloadAttributesCalculator;
+  private Optional<Eth1Address> defaultFeeRecipient = Optional.of(Eth1Address.ZERO);
 
   private final ExecutionEngineChannel executionEngineChannel = mock(ExecutionEngineChannel.class);
 
@@ -90,7 +92,9 @@ class ForkChoiceNotifierTest {
     storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
     recentChainData = storageSystem.recentChainData();
     payloadAttributesCalculator =
-        spy(new PayloadAttributesCalculator(spec, eventThread, recentChainData));
+        spy(
+            new PayloadAttributesCalculator(
+                spec, eventThread, recentChainData, defaultFeeRecipient));
     notifier =
         new ForkChoiceNotifier(
             eventThread,
@@ -115,7 +119,9 @@ class ForkChoiceNotifierTest {
     storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
     recentChainData = storageSystem.recentChainData();
     payloadAttributesCalculator =
-        spy(new PayloadAttributesCalculator(spec, eventThread, recentChainData));
+        spy(
+            new PayloadAttributesCalculator(
+                spec, eventThread, recentChainData, defaultFeeRecipient));
     notifier =
         new ForkChoiceNotifier(
             eventThread,
@@ -210,7 +216,7 @@ class ForkChoiceNotifierTest {
               return deferredResponseA;
             })
         .when(payloadAttributesCalculator)
-        .calculatePayloadAttributes(any(), anyBoolean(), any());
+        .calculatePayloadAttributes(any(), anyBoolean(), any(), anyBoolean());
 
     notifier.onForkChoiceUpdated(forkChoiceState); // calculate attributes for slot 2
     // it is called once with no attributes. the one with attributes is pending
@@ -219,7 +225,7 @@ class ForkChoiceNotifierTest {
     // forward to real method call
     doAnswer(InvocationOnMock::callRealMethod)
         .when(payloadAttributesCalculator)
-        .calculatePayloadAttributes(any(), anyBoolean(), any());
+        .calculatePayloadAttributes(any(), anyBoolean(), any(), anyBoolean());
 
     storageSystem
         .chainUpdater()

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -71,6 +71,15 @@ public class StatusLogger {
             Color.YELLOW));
   }
 
+  public void warnMissingProposerDefaultFeeRecipientWithRestAPIEnabled() {
+    log.warn(
+        print(
+            "No default proposer fee recipient has been specified and rest API are enabled. "
+                + "If a Validator Client is going to use this node is strongly recommended to "
+                + "configure it to avoid possible loss of fees gained proposing a block",
+            Color.RED));
+  }
+
   public void fatalError(final String description, final Throwable cause) {
     log.fatal("Exiting due to fatal error in {}", description, cause);
   }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -80,6 +80,14 @@ public class StatusLogger {
             Color.RED));
   }
 
+  public void warnMissingProposerDefaultFeeRecipientWithPreparedBeaconProposerBeingCalled() {
+    log.warn(
+        print(
+            "Validator Client detected and NO DEFAULT PROPOSER FEE RECIPIENT!!! "
+                + "it is STRONGLY recommended to configure it to avoid possible LOSS OF FEES gained proposing a block",
+            Color.RED));
+  }
+
   public void fatalError(final String description, final Throwable cause) {
     log.fatal("Exiting due to fatal error in {}", description, cause);
   }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -74,17 +74,17 @@ public class StatusLogger {
   public void warnMissingProposerDefaultFeeRecipientWithRestAPIEnabled() {
     log.warn(
         print(
-            "No default proposer fee recipient has been specified and rest API are enabled. "
-                + "If a Validator Client is going to use this node is strongly recommended to "
-                + "configure it to avoid possible loss of fees gained proposing a block",
+            "No default proposer fee recipient has been specified and rest API is enabled. "
+                + "If a Validator Client is going to use this node it is strongly recommended to "
+                + "configure it to avoid possible block production failures",
             Color.RED));
   }
 
   public void warnMissingProposerDefaultFeeRecipientWithPreparedBeaconProposerBeingCalled() {
     log.warn(
         print(
-            "Validator Client detected and NO DEFAULT PROPOSER FEE RECIPIENT!!! "
-                + "it is STRONGLY recommended to configure it to avoid possible LOSS OF FEES gained proposing a block",
+            "Validator Client detected and no default proposer fee recipient configured! "
+                + "it is strongly recommended to configure it to avoid possible block production failures",
             Color.RED));
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -158,4 +158,14 @@ public class ValidatorLogger {
     final String errorString = String.format("%sFailed to send proposers to Beacon Node", PREFIX);
     log.error(ColorConsolePrinter.print(errorString, Color.RED), error);
   }
+
+  public void executionPayloadPreparedUsingBeaconDefaultFeeRecipient(final UInt64 slot) {
+    log.warn(
+        ColorConsolePrinter.print(
+            "Beacon Node has been requested to produce a block for slot "
+                + slot
+                + " but proposer hasn't been prepared by any Validator Client. "
+                + "Using Beacon Node's default fee recipient.",
+            Color.YELLOW));
+  }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -873,7 +873,12 @@ public class BeaconChainController extends Service
   protected void initForkChoiceNotifier() {
     LOG.debug("BeaconChainController.initForkChoiceNotifier()");
     forkChoiceNotifier =
-        ForkChoiceNotifier.create(asyncRunnerFactory, spec, executionEngine, recentChainData);
+        ForkChoiceNotifier.create(
+            asyncRunnerFactory,
+            spec,
+            executionEngine,
+            recentChainData,
+            beaconConfig.validatorConfig().getProposerDefaultFeeRecipient());
   }
 
   protected void setupInitialState(final RecentChainData client) {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.infrastructure.async.eventthread.AsyncRunnerEventThread
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.io.PortAvailability;
+import tech.pegasys.teku.infrastructure.ssz.type.Bytes20;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
@@ -878,7 +879,9 @@ public class BeaconChainController extends Service
             spec,
             executionEngine,
             recentChainData,
-            beaconConfig.validatorConfig().getProposerDefaultFeeRecipient());
+            spec.isMilestoneSupported(SpecMilestone.BELLATRIX)
+                ? beaconConfig.validatorConfig().getProposerDefaultFeeRecipient()
+                : Optional.of(Bytes20.ZERO));
   }
 
   protected void setupInitialState(final RecentChainData client) {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -879,9 +879,21 @@ public class BeaconChainController extends Service
             spec,
             executionEngine,
             recentChainData,
-            spec.isMilestoneSupported(SpecMilestone.BELLATRIX)
-                ? beaconConfig.validatorConfig().getProposerDefaultFeeRecipient()
-                : Optional.of(Bytes20.ZERO));
+            getProposerDefaultFeeRecipient());
+  }
+
+  private Optional<? extends Bytes20> getProposerDefaultFeeRecipient() {
+    if (!spec.isMilestoneSupported(SpecMilestone.BELLATRIX)) {
+      return Optional.of(Bytes20.ZERO);
+    }
+
+    Optional<? extends Bytes20> defaultFeeRecipient =
+        beaconConfig.validatorConfig().getProposerDefaultFeeRecipient();
+    if (defaultFeeRecipient.isEmpty() && beaconConfig.beaconRestApiConfig().isRestApiEnabled()) {
+      STATUS_LOG.warnMissingProposerDefaultFeeRecipientWithRestAPIEnabled();
+    }
+
+    return defaultFeeRecipient;
   }
 
   protected void setupInitialState(final RecentChainData client) {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -16,8 +16,8 @@ package tech.pegasys.teku.cli.options;
 import java.nio.file.Path;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
-import picocli.CommandLine;
 import picocli.CommandLine.Help.Visibility;
+import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import tech.pegasys.teku.cli.converter.GraffitiConverter;
 import tech.pegasys.teku.config.TekuConfiguration;
@@ -27,8 +27,11 @@ import tech.pegasys.teku.validator.api.ValidatorPerformanceTrackingMode;
 
 public class ValidatorOptions {
 
-  @CommandLine.Mixin(name = "Validator Keys")
+  @Mixin(name = "Validator Keys")
   private ValidatorKeysOptions validatorKeysOptions;
+
+  @Mixin(name = "Validator Proposer")
+  private ValidatorProposerOptions validatorProposerOptions;
 
   @Option(
       names = {"--validators-graffiti"},
@@ -106,15 +109,6 @@ public class ValidatorOptions {
       arity = "0..1")
   private boolean generateEarlyAttestations = ValidatorConfig.DEFAULT_GENERATE_EARLY_ATTESTATIONS;
 
-  @Option(
-      names = {"--Xvalidators-suggested-fee-recipient-address"},
-      paramLabel = "<ADDRESS>",
-      description =
-          "Suggested fee recipient sent to the execution engine, which could use it as fee recipient when producing a new execution block.",
-      arity = "0..1",
-      hidden = true)
-  private String suggestedFeeRecipient = null;
-
   public void configure(TekuConfiguration.Builder builder) {
     if (validatorPerformanceTrackingEnabled != null) {
       if (validatorPerformanceTrackingEnabled) {
@@ -135,8 +129,8 @@ public class ValidatorOptions {
                     new FileBackedGraffitiProvider(
                         Optional.ofNullable(graffiti), Optional.ofNullable(graffitiFile)))
                 .useDependentRoots(useDependentRoots)
-                .generateEarlyAttestations(generateEarlyAttestations)
-                .suggestedFeeRecipient(suggestedFeeRecipient));
+                .generateEarlyAttestations(generateEarlyAttestations));
+    validatorProposerOptions.configure(builder);
     validatorKeysOptions.configure(builder);
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.options;
+
+import picocli.CommandLine.Option;
+import tech.pegasys.teku.config.TekuConfiguration;
+
+public class ValidatorProposerOptions {
+  @Option(
+      names = {"--Xvalidators-proposer-default-fee-recipient"},
+      paramLabel = "<ADDRESS>",
+      description =
+          "Default fee recipient sent to the execution engine, which could use it as fee recipient when producing a new execution block.",
+      arity = "0..1",
+      hidden = true)
+  private String proposerDefaultFeeRecipient = null;
+
+  public void configure(TekuConfiguration.Builder builder) {
+    builder.validator(config -> config.proposerDefaultFeeRecipient(proposerDefaultFeeRecipient));
+  }
+}

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -102,16 +102,17 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
   @Test
   public void shouldReportEmptyIfFeeRecipientNotSpecified() {
     final TekuConfiguration config = getTekuConfigurationFromArguments();
-    assertThat(config.validatorClient().getValidatorConfig().getSuggestedFeeRecipient()).isEmpty();
+    assertThat(config.validatorClient().getValidatorConfig().getProposerDefaultFeeRecipient())
+        .isEmpty();
   }
 
   @Test
   public void shouldReportAddressIfFeeRecipientSpecified() {
     final String[] args = {
-      "--Xvalidators-suggested-fee-recipient-address", "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73"
+      "--Xvalidators-proposer-default-fee-recipient", "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73"
     };
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(config.validatorClient().getValidatorConfig().getSuggestedFeeRecipient())
+    assertThat(config.validatorClient().getValidatorConfig().getProposerDefaultFeeRecipient())
         .isEqualTo(
             Optional.of(Eth1Address.fromHexString("0xfe3b557e8fb62b89f4916b721be55ceb828dbd73")));
   }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -57,7 +57,7 @@ public class ValidatorConfig {
   private final int validatorExternalSignerConcurrentRequestLimit;
   private final boolean useDependentRoots;
   private final boolean generateEarlyAttestations;
-  private final Optional<Eth1Address> suggestedFeeRecipient;
+  private final Optional<Eth1Address> proposerDefaultFeeRecipient;
 
   private ValidatorConfig(
       final List<String> validatorKeys,
@@ -76,7 +76,7 @@ public class ValidatorConfig {
       final int validatorExternalSignerConcurrentRequestLimit,
       final boolean useDependentRoots,
       final boolean generateEarlyAttestations,
-      final Optional<Eth1Address> suggestedFeeRecipient) {
+      final Optional<Eth1Address> proposerDefaultFeeRecipient) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
     this.validatorExternalSignerUrl = validatorExternalSignerUrl;
@@ -96,7 +96,7 @@ public class ValidatorConfig {
         validatorExternalSignerConcurrentRequestLimit;
     this.useDependentRoots = useDependentRoots;
     this.generateEarlyAttestations = generateEarlyAttestations;
-    this.suggestedFeeRecipient = suggestedFeeRecipient;
+    this.proposerDefaultFeeRecipient = proposerDefaultFeeRecipient;
   }
 
   public static Builder builder() {
@@ -160,16 +160,16 @@ public class ValidatorConfig {
     return useDependentRoots;
   }
 
-  public Optional<Eth1Address> getSuggestedFeeRecipient() {
-    validateFeeRecipient();
-    return suggestedFeeRecipient;
+  public Optional<Eth1Address> getProposerDefaultFeeRecipient() {
+    validateProposerDefaultFeeRecipient();
+    return proposerDefaultFeeRecipient;
   }
 
-  private void validateFeeRecipient() {
-    if (suggestedFeeRecipient.isEmpty()
+  private void validateProposerDefaultFeeRecipient() {
+    if (proposerDefaultFeeRecipient.isEmpty()
         && !(validatorKeys.isEmpty() && validatorExternalSignerPublicKeySources.isEmpty())) {
       throw new InvalidConfigurationException(
-          "Invalid configuration. --Xvalidators-suggested-fee-recipient-address must be specified when Bellatrix milestone is active");
+          "Invalid configuration. --Xvalidators-proposer-default-fee-recipient must be specified when Bellatrix milestone is active");
     }
   }
 
@@ -194,7 +194,7 @@ public class ValidatorConfig {
         DEFAULT_VALIDATOR_EXTERNAL_SIGNER_SLASHING_PROTECTION_ENABLED;
     private boolean useDependentRoots = DEFAULT_USE_DEPENDENT_ROOTS;
     private boolean generateEarlyAttestations = DEFAULT_GENERATE_EARLY_ATTESTATIONS;
-    private Optional<Eth1Address> suggestedFeeRecipient = Optional.empty();
+    private Optional<Eth1Address> proposerDefaultFeeRecipient = Optional.empty();
 
     private Builder() {}
 
@@ -289,16 +289,17 @@ public class ValidatorConfig {
       return this;
     }
 
-    public Builder suggestedFeeRecipient(final Eth1Address suggestedFeeRecipient) {
-      this.suggestedFeeRecipient = Optional.ofNullable(suggestedFeeRecipient);
+    public Builder proposerDefaultFeeRecipient(final Eth1Address proposerDefaultFeeRecipient) {
+      this.proposerDefaultFeeRecipient = Optional.ofNullable(proposerDefaultFeeRecipient);
       return this;
     }
 
-    public Builder suggestedFeeRecipient(final String suggestedFeeRecipient) {
-      if (suggestedFeeRecipient == null) {
-        this.suggestedFeeRecipient = Optional.empty();
+    public Builder proposerDefaultFeeRecipient(final String proposerDefaultFeeRecipient) {
+      if (proposerDefaultFeeRecipient == null) {
+        this.proposerDefaultFeeRecipient = Optional.empty();
       } else {
-        this.suggestedFeeRecipient = Optional.of(Eth1Address.fromHexString(suggestedFeeRecipient));
+        this.proposerDefaultFeeRecipient =
+            Optional.of(Eth1Address.fromHexString(proposerDefaultFeeRecipient));
       }
       return this;
     }
@@ -325,7 +326,7 @@ public class ValidatorConfig {
           validatorExternalSignerConcurrentRequestLimit,
           useDependentRoots,
           generateEarlyAttestations,
-          suggestedFeeRecipient);
+          proposerDefaultFeeRecipient);
     }
 
     private void validateExternalSignerUrlAndPublicKeys() {

--- a/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
+++ b/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
@@ -130,9 +130,9 @@ class ValidatorConfigTest {
             .build();
 
     Assertions.assertThatExceptionOfType(InvalidConfigurationException.class)
-        .isThrownBy(config::getSuggestedFeeRecipient)
+        .isThrownBy(config::getProposerDefaultFeeRecipient)
         .withMessageContaining(
-            "Invalid configuration. --Xvalidators-suggested-fee-recipient-address must be specified when Bellatrix milestone is active");
+            "Invalid configuration. --Xvalidators-proposer-default-fee-recipient must be specified when Bellatrix milestone is active");
   }
 
   @Test
@@ -140,9 +140,9 @@ class ValidatorConfigTest {
     final ValidatorConfig config = configBuilder.validatorKeys(List.of("some string")).build();
 
     Assertions.assertThatExceptionOfType(InvalidConfigurationException.class)
-        .isThrownBy(config::getSuggestedFeeRecipient)
+        .isThrownBy(config::getProposerDefaultFeeRecipient)
         .withMessageContaining(
-            "Invalid configuration. --Xvalidators-suggested-fee-recipient-address must be specified when Bellatrix milestone is active");
+            "Invalid configuration. --Xvalidators-proposer-default-fee-recipient must be specified when Bellatrix milestone is active");
   }
 
   @Test
@@ -153,10 +153,10 @@ class ValidatorConfigTest {
             .validatorExternalSignerPublicKeySources(
                 List.of(BLSTestUtil.randomKeyPair(0).getPublicKey().toString()))
             .validatorExternalSignerUrl(URI.create("http://localhost:9000").toURL())
-            .suggestedFeeRecipient("0x0000000000000000000000000000000000000000")
+            .proposerDefaultFeeRecipient("0x0000000000000000000000000000000000000000")
             .build();
 
-    Assertions.assertThatCode(config::getSuggestedFeeRecipient).doesNotThrowAnyException();
+    Assertions.assertThatCode(config::getProposerDefaultFeeRecipient).doesNotThrowAnyException();
   }
 
   @Test
@@ -164,10 +164,10 @@ class ValidatorConfigTest {
     final ValidatorConfig config =
         configBuilder
             .validatorKeys(List.of("some string"))
-            .suggestedFeeRecipient(
+            .proposerDefaultFeeRecipient(
                 Eth1Address.fromHexString("0x0000000000000000000000000000000000000000"))
             .build();
 
-    Assertions.assertThatCode(config::getSuggestedFeeRecipient).doesNotThrowAnyException();
+    Assertions.assertThatCode(config::getProposerDefaultFeeRecipient).doesNotThrowAnyException();
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -19,9 +19,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.infrastructure.ssz.type.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
@@ -32,13 +32,13 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
   private final ValidatorIndexProvider validatorIndexProvider;
   private final OwnedValidators validators;
   private final Spec spec;
-  private final Optional<Eth1Address> feeRecipient;
+  private final Optional<? extends Bytes20> feeRecipient;
   private boolean firstCallDone = false;
 
   public BeaconProposerPreparer(
       ValidatorApiChannel validatorApiChannel,
       ValidatorIndexProvider validatorIndexProvider,
-      Optional<Eth1Address> feeRecipient,
+      Optional<? extends Bytes20> feeRecipient,
       OwnedValidators validators,
       Spec spec) {
     this.validatorApiChannel = validatorApiChannel;
@@ -67,11 +67,11 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
     }
   }
 
-  private Eth1Address getFeeRecipient() {
+  private Bytes20 getFeeRecipient() {
     return feeRecipient.orElseThrow(
         () ->
             new InvalidConfigurationException(
-                "Invalid configuration. --Xvalidators-suggested-fee-recipient-address must be specified when Bellatrix milestone is active"));
+                "Invalid configuration. --Xvalidators-proposer-default-fee-recipient must be specified when Bellatrix milestone is active"));
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -238,7 +238,7 @@ public class ValidatorClientService extends Service {
           new BeaconProposerPreparer(
               validatorApiChannel,
               validatorIndexProvider,
-              config.getValidatorConfig().getSuggestedFeeRecipient(),
+              config.getValidatorConfig().getProposerDefaultFeeRecipient(),
               validators,
               spec));
     }


### PR DESCRIPTION
## PR Description

- call `engine_forkChoiceUpdated` with PayloadAttributes using default fee recipient if proposer is not prepared
- rename `--Xvalidators-suggested-fee-recipient-address` to `--Xvalidators-proposer-default-fee-recipient` (first step toward a multi fee-recipient support #4850)
- better separation between ForkChoiceNotifier and ForkChoiceUpdateData
- if running a BN without validator keys but with enabled rest API, it logs a RED warning at startup suggesting to specify proposer default fee recipient if a VC is going to use the node
  - an actual call to `prepare_beacon_proposer` api will print another status log RED warning

## Fixed Issue(s)
fixes #4691

## Documentation

- [ ] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
