### PR TITLE
Update storage routes for managed keys

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
@@ -130,7 +130,7 @@ public class TekuValidatorNode extends Node {
 
   public String getApiPassword() {
     return container.copyFileFromContainer(
-        VALIDATOR_PATH + "validator-api-bearer",
+        VALIDATOR_PATH + "key-manager/validator-api-bearer",
         in -> IOUtils.toString(in, StandardCharsets.UTF_8));
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -252,12 +252,20 @@ public class ValidatorClientService extends Service {
     return dataDirLayout.getValidatorDataDirectory().resolve("slashprotection");
   }
 
-  public static Path getAlterableKeystorePath(final DataDirLayout dataDirLayout) {
-    return dataDirLayout.getValidatorDataDirectory().resolve("alterable-keystores");
+  public static Path getManagedLocalKeystorePath(final DataDirLayout dataDirLayout) {
+    return getKeyManagerPath(dataDirLayout).resolve("local");
   }
 
-  public static Path getAlterableKeystorePasswordPath(final DataDirLayout dataDirLayout) {
-    return dataDirLayout.getValidatorDataDirectory().resolve("alterable-passwords");
+  public static Path getManagedLocalKeystorePasswordPath(final DataDirLayout dataDirLayout) {
+    return getKeyManagerPath(dataDirLayout).resolve("local-passwords");
+  }
+
+  public static Path getManagedRemoteKeyPath(final DataDirLayout dataDirLayout) {
+    return getKeyManagerPath(dataDirLayout).resolve("remote");
+  }
+
+  public static Path getKeyManagerPath(final DataDirLayout dataDirLayout) {
+    return dataDirLayout.getValidatorDataDirectory().resolve("key-manager");
   }
 
   private static void addValidatorCountMetric(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/LocalValidatorSource.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/LocalValidatorSource.java
@@ -123,8 +123,9 @@ public class LocalValidatorSource implements ValidatorSource {
     final Path passwordPath = getPasswordPath(publicKey);
     final Path keystorePath = getKeystorePath(publicKey);
     try {
-      ensureDirectoryExists(ValidatorClientService.getAlterableKeystorePasswordPath(dataDirLayout));
-      ensureDirectoryExists(ValidatorClientService.getAlterableKeystorePath(dataDirLayout));
+      ensureDirectoryExists(
+          ValidatorClientService.getManagedLocalKeystorePasswordPath(dataDirLayout));
+      ensureDirectoryExists(ValidatorClientService.getManagedLocalKeystorePath(dataDirLayout));
 
       if (passwordPath.toFile().exists() || keystorePath.toFile().exists()) {
         return new AddLocalValidatorResult(PostKeyResult.duplicate(), Optional.empty());
@@ -149,14 +150,14 @@ public class LocalValidatorSource implements ValidatorSource {
   private Path getKeystorePath(final BLSPublicKey publicKey) {
     final DataDirLayout dataDirLayout = maybeDataDirLayout.orElseThrow();
     final String fileName = publicKey.toBytesCompressed().toUnprefixedHexString();
-    return ValidatorClientService.getAlterableKeystorePath(dataDirLayout)
+    return ValidatorClientService.getManagedLocalKeystorePath(dataDirLayout)
         .resolve(fileName + ".json");
   }
 
   private Path getPasswordPath(final BLSPublicKey publicKey) {
     final DataDirLayout dataDirLayout = maybeDataDirLayout.orElseThrow();
     final String fileName = publicKey.toBytesCompressed().toUnprefixedHexString();
-    return ValidatorClientService.getAlterableKeystorePasswordPath(dataDirLayout)
+    return ValidatorClientService.getManagedLocalKeystorePasswordPath(dataDirLayout)
         .resolve(fileName + ".txt");
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorSourceFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorSourceFactory.java
@@ -88,9 +88,9 @@ public class ValidatorSourceFactory {
       return Optional.empty();
     }
     final DataDirLayout dataDirLayout = maybeDataDir.get();
-    final Path keystorePath = ValidatorClientService.getAlterableKeystorePath(dataDirLayout);
+    final Path keystorePath = ValidatorClientService.getManagedLocalKeystorePath(dataDirLayout);
     final Path keystorePasswordPath =
-        ValidatorClientService.getAlterableKeystorePasswordPath(dataDirLayout);
+        ValidatorClientService.getManagedLocalKeystorePasswordPath(dataDirLayout);
 
     if (!ensurePathExists(keystorePath) || !ensurePathExists(keystorePasswordPath)) {
       LOG.error("Could not initialise mutable paths, mutable storage will not be available");

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApi.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApi.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.infrastructure.restapi.RestApi;
 import tech.pegasys.teku.infrastructure.restapi.RestApiBuilder;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
 import tech.pegasys.teku.validator.client.KeyManager;
+import tech.pegasys.teku.validator.client.ValidatorClientService;
 import tech.pegasys.teku.validator.client.restapi.apis.DeleteKeys;
 import tech.pegasys.teku.validator.client.restapi.apis.GetKeys;
 import tech.pegasys.teku.validator.client.restapi.apis.PostKeys;
@@ -62,9 +63,7 @@ public class ValidatorRestApi {
         .endpoint(new PostKeys(keyManager))
         .sslCertificate(config.getRestApiKeystoreFile(), config.getRestApiKeystorePasswordFile())
         .passwordFilePath(
-            keyManager
-                .getDataDirLayout()
-                .getValidatorDataDirectory()
+            ValidatorClientService.getKeyManagerPath(keyManager.getDataDirLayout())
                 .resolve("validator-api-bearer"))
         .build();
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -720,11 +720,11 @@ class ValidatorLoaderTest {
 
   private void writeMutableKeystore(final DataDirLayout tempDir) throws Exception {
     final URL resource = Resources.getResource("testKeystore.json");
-    final Path keystore = ValidatorClientService.getAlterableKeystorePath(tempDir);
-    final Path keystorePassword = ValidatorClientService.getAlterableKeystorePasswordPath(tempDir);
-    Files.createDirectory(tempDir.getValidatorDataDirectory());
-    Files.createDirectory(keystore);
-    Files.createDirectory(keystorePassword);
+    final Path keystore = ValidatorClientService.getManagedLocalKeystorePath(tempDir);
+    final Path keystorePassword =
+        ValidatorClientService.getManagedLocalKeystorePasswordPath(tempDir);
+    assertThat(keystore.toFile().mkdirs()).isTrue();
+    assertThat(keystorePassword.toFile().mkdirs()).isTrue();
     Files.copy(Path.of(resource.toURI()), keystore.resolve("key.json"));
     Files.writeString(keystorePassword.resolve("key.txt"), "testpassword");
   }


### PR DESCRIPTION
 - Now that we're going to be storing remote keys, the naming model doesn't fit that well.

 - This should mean we don't have to move anything else when we make the api more publicly available, which would require upgrade scripts etc. for management.

Side issue of #4880

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
