### PR TITLE
Move exception handlers to `:infrastructure:async`

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ExceptionHandlers.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ExceptionHandlers.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.async;
+
+import java.util.function.Consumer;
+
+public class ExceptionHandlers {
+
+  public static Runnable exceptionHandlingRunnable(
+      final Runnable runnable, final SafeFuture<?> target) {
+    return () -> {
+      try {
+        runnable.run();
+      } catch (final Throwable t) {
+        target.completeExceptionally(t);
+      }
+    };
+  }
+
+  public static <T> Consumer<T> exceptionHandlingConsumer(
+      final Consumer<T> consumer, final SafeFuture<?> target) {
+    return value -> {
+      try {
+        consumer.accept(value);
+      } catch (final Throwable t) {
+        target.completeExceptionally(t);
+      }
+    };
+  }
+}

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ExceptionHandlersTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ExceptionHandlersTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+public class ExceptionHandlersTest {
+
+  @Test
+  void exceptionHandlingRunnable_shouldNotCompleteFutureWhenRunnableCompletesNormally() {
+    final SafeFuture<Void> future = new SafeFuture<>();
+    final Runnable delegate = mock(Runnable.class);
+    final Runnable runnable = ExceptionHandlers.exceptionHandlingRunnable(delegate, future);
+    runnable.run();
+
+    verify(delegate).run();
+    assertThat(future).isNotCompleted();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void exceptionHandlingConsumer_shouldPropagateExceptionInConsumer() {
+    final SafeFuture<Void> future = new SafeFuture<>();
+    final RuntimeException exception = new RuntimeException("oops");
+    final String value = "the value";
+    final Consumer<String> delegate = mock(Consumer.class);
+    doThrow(exception).when(delegate).accept(value);
+    final Consumer<String> consumer = ExceptionHandlers.exceptionHandlingConsumer(delegate, future);
+    consumer.accept(value);
+    verify(delegate).accept(value);
+    assertThat(future).isCompletedExceptionally();
+    assertThatThrownBy(future::join).hasRootCause(exception);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void exceptionHandlingConsumer_shouldNotCompleteFutureWhenRunnableCompletesNormally() {
+    final SafeFuture<Void> future = new SafeFuture<>();
+    final String value = "the value";
+    final Consumer<String> delegate = mock(Consumer.class);
+    final Consumer<String> consumer = ExceptionHandlers.exceptionHandlingConsumer(delegate, future);
+    consumer.accept(value);
+
+    verify(delegate).accept(value);
+    assertThat(future).isNotCompleted();
+  }
+}

--- a/infrastructure/exceptions/build.gradle
+++ b/infrastructure/exceptions/build.gradle
@@ -1,5 +1,3 @@
 dependencies {
-  implementation project(':infrastructure:async')
-
   implementation 'org.apache.commons:commons-lang3'
 }

--- a/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/ExceptionUtil.java
+++ b/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/ExceptionUtil.java
@@ -14,9 +14,7 @@
 package tech.pegasys.teku.infrastructure.exceptions;
 
 import java.util.Optional;
-import java.util.function.Consumer;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
 public class ExceptionUtil {
 
@@ -27,27 +25,5 @@ public class ExceptionUtil {
         .filter(targetType::isInstance)
         .map(e -> (T) e)
         .findFirst();
-  }
-
-  public static Runnable exceptionHandlingRunnable(
-      final Runnable runnable, final SafeFuture<?> target) {
-    return () -> {
-      try {
-        runnable.run();
-      } catch (final Throwable t) {
-        target.completeExceptionally(t);
-      }
-    };
-  }
-
-  public static <T> Consumer<T> exceptionHandlingConsumer(
-      final Consumer<T> consumer, final SafeFuture<?> target) {
-    return value -> {
-      try {
-        consumer.accept(value);
-      } catch (final Throwable t) {
-        target.completeExceptionally(t);
-      }
-    };
   }
 }

--- a/infrastructure/exceptions/src/test/java/tech/pegasys/teku/infrastructure/exceptions/ExceptionUtilTest.java
+++ b/infrastructure/exceptions/src/test/java/tech/pegasys/teku/infrastructure/exceptions/ExceptionUtilTest.java
@@ -14,14 +14,8 @@
 package tech.pegasys.teku.infrastructure.exceptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
-import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
 public class ExceptionUtilTest {
 
@@ -66,58 +60,6 @@ public class ExceptionUtilTest {
 
     // Match error
     assertThat(ExceptionUtil.getCause(err, RuntimeException.class)).contains(err);
-  }
-
-  @Test
-  void exceptionHandlingRunnable_shouldPropagateExceptionInRunnable() {
-    final SafeFuture<Void> future = new SafeFuture<>();
-    final RuntimeException exception = new RuntimeException("oops");
-    final Runnable delegate = mock(Runnable.class);
-    doThrow(exception).when(delegate).run();
-    final Runnable runnable = ExceptionUtil.exceptionHandlingRunnable(delegate, future);
-    runnable.run();
-    verify(delegate).run();
-    assertThat(future).isCompletedExceptionally();
-    assertThatThrownBy(future::join).hasRootCause(exception);
-  }
-
-  @Test
-  void exceptionHandlingRunnable_shouldNotCompleteFutureWhenRunnableCompletesNormally() {
-    final SafeFuture<Void> future = new SafeFuture<>();
-    final Runnable delegate = mock(Runnable.class);
-    final Runnable runnable = ExceptionUtil.exceptionHandlingRunnable(delegate, future);
-    runnable.run();
-
-    verify(delegate).run();
-    assertThat(future).isNotCompleted();
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  void exceptionHandlingConsumer_shouldPropagateExceptionInConsumer() {
-    final SafeFuture<Void> future = new SafeFuture<>();
-    final RuntimeException exception = new RuntimeException("oops");
-    final String value = "the value";
-    final Consumer<String> delegate = mock(Consumer.class);
-    doThrow(exception).when(delegate).accept(value);
-    final Consumer<String> consumer = ExceptionUtil.exceptionHandlingConsumer(delegate, future);
-    consumer.accept(value);
-    verify(delegate).accept(value);
-    assertThat(future).isCompletedExceptionally();
-    assertThatThrownBy(future::join).hasRootCause(exception);
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  void exceptionHandlingConsumer_shouldNotCompleteFutureWhenRunnableCompletesNormally() {
-    final SafeFuture<Void> future = new SafeFuture<>();
-    final String value = "the value";
-    final Consumer<String> delegate = mock(Consumer.class);
-    final Consumer<String> consumer = ExceptionUtil.exceptionHandlingConsumer(delegate, future);
-    consumer.accept(value);
-
-    verify(delegate).accept(value);
-    assertThat(future).isNotCompleted();
   }
 
   private static class CustomRuntimeException extends RuntimeException {}

--- a/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/BatchSync.java
+++ b/sync/src/main/java/tech/pegasys/teku/sync/forward/multipeer/BatchSync.java
@@ -15,8 +15,8 @@ package tech.pegasys.teku.sync.forward.multipeer;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.stream.Collectors.joining;
-import static tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil.exceptionHandlingConsumer;
-import static tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil.exceptionHandlingRunnable;
+import static tech.pegasys.teku.infrastructure.async.ExceptionHandlers.exceptionHandlingConsumer;
+import static tech.pegasys.teku.infrastructure.async.ExceptionHandlers.exceptionHandlingRunnable;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Collection;


### PR DESCRIPTION
`:infrastructure:execeptions` had a dependency on `:infrastructure:async` that would cause a circular dependency in some situations. For example, if `:infrastructure:metrics` included `:infrastructure:exceptions`:

```
Circular dependency between the following tasks:
:infrastructure:async:compileJava
\--- :infrastructure:metrics:compileJava
     \--- :infrastructure:exceptions:compileJava
          \--- :infrastructure:async:compileJava (*)
```

To resolve this problem, this commit moves the two exception handlers that used `async.SafeFuture` from `:infrastructure:execeptions:ExceptionUtil` to `:infrastructure:async:ExceptionHandlers`.

Also, the `:infrastructure:async` dependency has been removed from `:infrastructure:execeptions` as it is no longer required.

Related to issue #4906. This PR must be merged before #4909 can be completed.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
