### PR TITLE
Update to latest besu and vertx versions

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -68,7 +68,7 @@ dependencyManagement {
       }
     }
 
-    dependencySet(group: 'io.vertx', version: '3.9.9') {
+    dependencySet(group: 'io.vertx', version: '4.2.4') {
       entry 'vertx-codegen'
       entry 'vertx-core'
       entry 'vertx-unit'
@@ -136,13 +136,13 @@ dependencyManagement {
 
     dependency 'io.prometheus:simpleclient:0.9.0'
 
-    dependencySet(group: 'org.hyperledger.besu.internal', version: '21.10.5') {
+    dependencySet(group: 'org.hyperledger.besu.internal', version: '21.10.9') {
       entry('metrics-core') {
         // We include netty-all so omit the separated jars
         exclude 'io.netty:netty-tcnative-boringssl-static'
       }
     }
-    dependency 'org.hyperledger.besu:plugin-api:21.10.3'
+    dependency 'org.hyperledger.besu:plugin-api:21.10.9'
 
     dependencySet(group: 'org.testcontainers', version: '1.16.3') {
       entry "testcontainers"


### PR DESCRIPTION
## PR Description
Update to the latest version of Besu for metrics. That updates to vertx 4 so pull in that update as well.  Fortunately we don't actually use vertx other than to create it, pass it to Besu's metrics and then close it on shutdown so no changes required beyond the version bump.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
