### PR TITLE
Fix two mistakes introduced in #4909

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java
@@ -223,7 +223,7 @@ public class DiscoveryConfig {
 
     public Builder minRandomlySelectedPeers(final Integer minRandomlySelectedPeers) {
       checkNotNull(minRandomlySelectedPeers);
-      if (maxPeers < 0) {
+      if (minRandomlySelectedPeers < 0) {
         throw new InvalidConfigurationException(
             String.format("Invalid minRandomlySelectedPeers: %d", minRandomlySelectedPeers));
       }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/InteropConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/InteropConfig.java
@@ -79,7 +79,6 @@ public class InteropConfig {
     private InteropConfigBuilder() {}
 
     public InteropConfigBuilder interopGenesisTime(Integer interopGenesisTime) {
-      checkNotNull(interopGenesisTime);
       if (interopGenesisTime < 0) {
         throw new InvalidConfigurationException(
             String.format("Invalid interopGenesisTime: %d", interopGenesisTime));


### PR DESCRIPTION
## PR Description

The two issues:

1. Replace `maxPeers` with `minRandomlySelectedPeers` the builder function for
   that field. It incorrectly checked the wrong value. This was most likely a
   copy-paste mistake. [PR commit diff for that file.](https://github.com/ConsenSys/teku/commit/540bf51b8407fa80695960dd4d4d778ddf0f4496#diff-31602ae5d50d3048be310b54edd229d10707f5620971b1fb6e50371b98f546a0)

2. Remove new call to `checkNotNull` in `interopGenesisTime`. This was probably
   added because I thought it could not hurt. I have since learned that not all
   builder functions should `checkNotNull`. [PR commit diff for that file.](https://github.com/ConsenSys/teku/commit/540bf51b8407fa80695960dd4d4d778ddf0f4496#diff-8b3fa4c48a2b2f487fc7b37b78399e9a44f76d55e8f0621954e368f94ce92fdf)

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.