### PR TITLE
Add ability to use a builder when deserializing objects.

### DIFF
--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/DeserializableFieldDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/DeserializableFieldDefinition.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.infrastructure.restapi.types;
 import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
 
-public interface DeserializableFieldDefinition<TObject>
+public interface DeserializableFieldDefinition<TObject, TBuilder>
     extends SerializableFieldDefinition<TObject> {
-  void readField(TObject target, JsonParser parser) throws IOException;
+  void readField(TBuilder target, JsonParser parser) throws IOException;
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/DeserializableTypeDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/DeserializableTypeDefinition.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.infrastructure.restapi.types;
 import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.restapi.types.StringBasedPrimitiveTypeDefinition.StringTypeBuilder;
 
 public interface DeserializableTypeDefinition<TObject> extends SerializableTypeDefinition<TObject> {
@@ -37,12 +38,19 @@ public interface DeserializableTypeDefinition<TObject> extends SerializableTypeD
     return new EnumTypeDefinition<>(itemType);
   }
 
-  static <TObject> DeserializableObjectTypeDefinitionBuilder<TObject> object(
+  static <TObject> DeserializableObjectTypeDefinitionBuilder<TObject, TObject> object(
       @SuppressWarnings("unused") final Class<TObject> type) {
+    final DeserializableObjectTypeDefinitionBuilder<TObject, TObject> typeBuilder = object();
+    return typeBuilder.finisher(Function.identity());
+  }
+
+  static <TObject, TBuilder> DeserializableObjectTypeDefinitionBuilder<TObject, TBuilder> object(
+      @SuppressWarnings("unused") final Class<TObject> type,
+      @SuppressWarnings("unused") final Class<TBuilder> builderType) {
     return object();
   }
 
-  static <TObject> DeserializableObjectTypeDefinitionBuilder<TObject> object() {
+  static <TObject, TBuilder> DeserializableObjectTypeDefinitionBuilder<TObject, TBuilder> object() {
     return new DeserializableObjectTypeDefinitionBuilder<>();
   }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/OptionalDeserializableFieldDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/OptionalDeserializableFieldDefinition.java
@@ -19,16 +19,16 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-public class OptionalDeserializableFieldDefinition<TObject, TField>
+public class OptionalDeserializableFieldDefinition<TObject, TBuilder, TField>
     extends OptionalSerializableFieldDefinition<TObject, TField>
-    implements DeserializableFieldDefinition<TObject> {
-  private final BiConsumer<TObject, Optional<TField>> setter;
+    implements DeserializableFieldDefinition<TObject, TBuilder> {
+  private final BiConsumer<TBuilder, Optional<TField>> setter;
   private final DeserializableTypeDefinition<TField> deserializableType;
 
   OptionalDeserializableFieldDefinition(
       final String name,
       final Function<TObject, Optional<TField>> getter,
-      final BiConsumer<TObject, Optional<TField>> setter,
+      final BiConsumer<TBuilder, Optional<TField>> setter,
       final DeserializableTypeDefinition<TField> type) {
     super(name, getter, type);
     this.setter = setter;
@@ -36,7 +36,7 @@ public class OptionalDeserializableFieldDefinition<TObject, TField>
   }
 
   @Override
-  public void readField(final TObject target, final JsonParser parser) throws IOException {
+  public void readField(final TBuilder target, final JsonParser parser) throws IOException {
     final Optional<TField> value = Optional.ofNullable(deserializableType.deserialize(parser));
     setter.accept(target, value);
   }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/RequiredDeserializableFieldDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/types/RequiredDeserializableFieldDefinition.java
@@ -18,17 +18,17 @@ import java.io.IOException;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-class RequiredDeserializableFieldDefinition<TObject, TField>
+class RequiredDeserializableFieldDefinition<TObject, TBuilder, TField>
     extends RequiredSerializableFieldDefinition<TObject, TField>
-    implements DeserializableFieldDefinition<TObject> {
+    implements DeserializableFieldDefinition<TObject, TBuilder> {
 
-  private final BiConsumer<TObject, TField> setter;
+  private final BiConsumer<TBuilder, TField> setter;
   private final DeserializableTypeDefinition<TField> deserializableType;
 
   RequiredDeserializableFieldDefinition(
       final String name,
       final Function<TObject, TField> getter,
-      final BiConsumer<TObject, TField> setter,
+      final BiConsumer<TBuilder, TField> setter,
       final DeserializableTypeDefinition<TField> type) {
     super(name, getter, type);
     this.setter = setter;
@@ -36,7 +36,7 @@ class RequiredDeserializableFieldDefinition<TObject, TField>
   }
 
   @Override
-  public void readField(final TObject target, final JsonParser parser) throws IOException {
+  public void readField(final TBuilder target, final JsonParser parser) throws IOException {
     final TField value = deserializableType.deserialize(parser);
     setter.accept(target, value);
   }

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/DeserializableObjectTypeDefinitionTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/types/DeserializableObjectTypeDefinitionTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.types;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.restapi.exceptions.MissingRequiredFieldException;
+import tech.pegasys.teku.infrastructure.restapi.json.JsonUtil;
+
+class DeserializableObjectTypeDefinitionTest {
+
+  public static final DeserializableTypeDefinition<MutableValue> MUTABLE_TYPE_DEFINITION =
+      DeserializableTypeDefinition.object(MutableValue.class)
+          .initializer(MutableValue::new)
+          .withField(
+              "required",
+              CoreTypes.STRING_TYPE,
+              MutableValue::getRequired,
+              MutableValue::setRequired)
+          .withOptionalField(
+              "optional",
+              CoreTypes.STRING_TYPE,
+              MutableValue::getOptional,
+              MutableValue::setOptional)
+          .build();
+
+  public static final DeserializableTypeDefinition<ImmutableValue> IMMUTABLE_TYPE_DEFINITION =
+      DeserializableTypeDefinition.object(ImmutableValue.class, ImmutableValueBuilder.class)
+          .initializer(ImmutableValueBuilder::new)
+          .finisher(ImmutableValueBuilder::build)
+          .withField(
+              "required",
+              CoreTypes.STRING_TYPE,
+              ImmutableValue::getRequired,
+              ImmutableValueBuilder::required)
+          .withOptionalField(
+              "optional",
+              CoreTypes.STRING_TYPE,
+              ImmutableValue::getOptional,
+              ImmutableValueBuilder::optional)
+          .build();
+
+  @Test
+  void shouldDeserializeIntoMutableObject() throws Exception {
+    final MutableValue result =
+        JsonUtil.parse(
+            "{\"required\":\"value1\", \"optional\":\"value2\"}", MUTABLE_TYPE_DEFINITION);
+
+    assertThat(result.required).isEqualTo("value1");
+    assertThat(result.optional).contains("value2");
+  }
+
+  @Test
+  void shouldFailToDeserializeIntoMutableObjectWhenRequiredFieldMissing() {
+    assertThatThrownBy(() -> JsonUtil.parse("{\"optional\":\"value2\"}", MUTABLE_TYPE_DEFINITION))
+        .isInstanceOf(MissingRequiredFieldException.class);
+  }
+
+  @Test
+  void shouldDeserializeIntoMutableObjectWithoutOptionalField() throws Exception {
+    final MutableValue result =
+        JsonUtil.parse("{\"required\":\"value1\"}", MUTABLE_TYPE_DEFINITION);
+
+    assertThat(result.required).isEqualTo("value1");
+    assertThat(result.optional).isEmpty();
+  }
+
+  @Test
+  void shouldDeserializeUsingABuilder() throws Exception {
+    final ImmutableValue result =
+        JsonUtil.parse(
+            "{\"required\":\"value1\", \"optional\":\"value2\"}", IMMUTABLE_TYPE_DEFINITION);
+
+    assertThat(result.required).isEqualTo("value1");
+    assertThat(result.optional).contains("value2");
+  }
+
+  @Test
+  void shouldFailToDeserializeIntoImmutableObjectWhenRequiredFieldMissing() {
+    assertThatThrownBy(() -> JsonUtil.parse("{\"optional\":\"value2\"}", IMMUTABLE_TYPE_DEFINITION))
+        .isInstanceOf(MissingRequiredFieldException.class);
+  }
+
+  @Test
+  void shouldDeserializeUsingABuilderWithoutOptionalField() throws Exception {
+    final ImmutableValue result =
+        JsonUtil.parse("{\"required\":\"value1\"}", IMMUTABLE_TYPE_DEFINITION);
+
+    assertThat(result.required).isEqualTo("value1");
+    assertThat(result.optional).isEmpty();
+  }
+
+  private static class MutableValue {
+    private String required;
+    private Optional<String> optional = Optional.empty();
+
+    public String getRequired() {
+      return required;
+    }
+
+    public void setRequired(final String required) {
+      this.required = required;
+    }
+
+    public Optional<String> getOptional() {
+      return optional;
+    }
+
+    public void setOptional(final Optional<String> optional) {
+      this.optional = optional;
+    }
+  }
+
+  private static class ImmutableValue {
+    private final String required;
+    private final Optional<String> optional;
+
+    private ImmutableValue(final String required, final Optional<String> optional) {
+      this.required = required;
+      this.optional = optional;
+    }
+
+    public String getRequired() {
+      return required;
+    }
+
+    public Optional<String> getOptional() {
+      return optional;
+    }
+  }
+
+  private static class ImmutableValueBuilder {
+    private String required;
+    private Optional<String> optional = Optional.empty();
+
+    public ImmutableValueBuilder required(final String required) {
+      this.required = required;
+      return this;
+    }
+
+    public ImmutableValueBuilder optional(final Optional<String> optional) {
+      this.optional = optional;
+      return this;
+    }
+
+    public ImmutableValue build() {
+      checkNotNull(required);
+      checkNotNull(optional);
+      return new ImmutableValue(required, optional);
+    }
+  }
+}


### PR DESCRIPTION
## PR Description
Adds support for using a separate builder object as part of a deserializable type definition. Avoids the need to make all deserializable objects mutable just to support the framework.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
