### PR TITLE
Retrieve PendingAttestation schema via SchemaDefinitions

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/PendingAttestation.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/PendingAttestation.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.state.PendingAttestation.PendingAttestationSchema;
 
 public class PendingAttestation {
   @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES_SSZ)
@@ -54,8 +55,8 @@ public class PendingAttestation {
   }
 
   public tech.pegasys.teku.spec.datastructures.state.PendingAttestation
-      asInternalPendingAttestation() {
-    return new tech.pegasys.teku.spec.datastructures.state.PendingAttestation(
+      asInternalPendingAttestation(final PendingAttestationSchema pendingAttestationSchema) {
+    return pendingAttestationSchema.create(
         aggregation_bits, data.asInternalAttestationData(), inclusion_delay, proposer_index);
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/phase0/BeaconStatePhase0.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/phase0/BeaconStatePhase0.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.api.schema.Validator;
 import tech.pegasys.teku.api.schema.interfaces.State;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.state.PendingAttestation.PendingAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 
 public class BeaconStatePhase0 extends BeaconState implements State {
@@ -116,18 +117,26 @@ public class BeaconStatePhase0 extends BeaconState implements State {
     state
         .toMutableVersionPhase0()
         .ifPresent(
-            genesisState -> {
-              genesisState
+            mutableState -> {
+              final PendingAttestationSchema pendingAttestationSchema =
+                  mutableState.getBeaconStateSchema().getPendingAttestationSchema();
+              mutableState
                   .getPrevious_epoch_attestations()
                   .setAll(
                       previous_epoch_attestations.stream()
-                          .map(PendingAttestation::asInternalPendingAttestation)
+                          .map(
+                              pendingAttestation ->
+                                  pendingAttestation.asInternalPendingAttestation(
+                                      pendingAttestationSchema))
                           .collect(Collectors.toList()));
-              genesisState
+              mutableState
                   .getCurrent_epoch_attestations()
                   .setAll(
                       current_epoch_attestations.stream()
-                          .map(PendingAttestation::asInternalPendingAttestation)
+                          .map(
+                              pendingAttestation ->
+                                  pendingAttestation.asInternalPendingAttestation(
+                                      pendingAttestationSchema))
                           .collect(Collectors.toList()));
             });
   }

--- a/data/serializer/src/test/java/tech/pegasys/teku/api/schema/PendingAttestationTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/api/schema/PendingAttestationTest.java
@@ -16,16 +16,20 @@ package tech.pegasys.teku.api.schema;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class PendingAttestationTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final tech.pegasys.teku.spec.datastructures.state.PendingAttestation attestationInternal =
       dataStructureUtil.randomPendingAttestation();
 
   @Test
   public void shouldConvertToInternalObject() {
     final PendingAttestation pendingAttestation = new PendingAttestation(attestationInternal);
-    assertThat(pendingAttestation.asInternalPendingAttestation()).isEqualTo(attestationInternal);
+    assertThat(pendingAttestation.asInternalPendingAttestation(attestationInternal.getSchema()))
+        .isEqualTo(attestationInternal);
   }
 }

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/SszPendingAttestationBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/SszPendingAttestationBenchmark.java
@@ -17,14 +17,19 @@ import org.openjdk.jmh.infra.Blackhole;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
+import tech.pegasys.teku.spec.datastructures.state.PendingAttestation.PendingAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SszPendingAttestationBenchmark
     extends SszAbstractContainerBenchmark<PendingAttestation> {
 
-  private static final DataStructureUtil dataStructureUtil = new DataStructureUtil(1);
+  private static final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private static final DataStructureUtil dataStructureUtil = new DataStructureUtil(1, spec);
   private static final PendingAttestation aPendingAttestation =
       dataStructureUtil.randomPendingAttestation();
 
@@ -32,16 +37,19 @@ public class SszPendingAttestationBenchmark
   private static final AttestationData attestationData = aPendingAttestation.getData();
   private static final UInt64 inclusion_delay = aPendingAttestation.getInclusion_delay();
   private static final UInt64 proposer_index = aPendingAttestation.getProposer_index();
+  private final PendingAttestationSchema schema =
+      BeaconStateSchemaPhase0.required(spec.getGenesisSchemaDefinitions().getBeaconStateSchema())
+          .getPendingAttestationSchema();
 
   @Override
   protected PendingAttestation createContainer() {
     return new PendingAttestation(
-        aggregation_bits, attestationData, inclusion_delay, proposer_index);
+        schema, aggregation_bits, attestationData, inclusion_delay, proposer_index);
   }
 
   @Override
   protected SszSchema<PendingAttestation> getContainerType() {
-    return PendingAttestation.SSZ_SCHEMA;
+    return schema;
   }
 
   @Override

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.reference.phase0.ssz_static;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.tuweni.bytes.Bytes;
@@ -24,6 +25,7 @@ import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.reference.TestDataUtils;
 import tech.pegasys.teku.reference.TestExecutor;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
@@ -49,6 +51,15 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
           .put(
               "ssz_static/HistoricalBatch",
               new SszTestExecutor<>(SchemaDefinitions::getHistoricalBatchSchema))
+          .put(
+              "ssz_static/PendingAttestation",
+              new SszTestExecutor<>(
+                  schemas -> {
+                    assumeThat(schemas.getBeaconStateSchema())
+                        .isInstanceOf(BeaconStateSchemaPhase0.class);
+                    return BeaconStateSchemaPhase0.required(schemas.getBeaconStateSchema())
+                        .getPendingAttestationSchema();
+                  }))
           .put(
               "ssz_static/SyncCommittee",
               new SszTestExecutor<>(

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutorDeprecated.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutorDeprecated.java
@@ -42,7 +42,6 @@ import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkData;
-import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.spec.datastructures.state.SigningData;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 
@@ -78,9 +77,6 @@ public class SszTestExecutorDeprecated<T extends SszData> implements TestExecuto
           .put(
               "ssz_static/IndexedAttestation",
               new SszTestExecutorDeprecated<>(IndexedAttestation.SSZ_SCHEMA))
-          .put(
-              "ssz_static/PendingAttestation",
-              new SszTestExecutorDeprecated<>(PendingAttestation.SSZ_SCHEMA))
           .put(
               "ssz_static/ProposerSlashing",
               new SszTestExecutorDeprecated<>(ProposerSlashing.SSZ_SCHEMA))

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/PendingAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/PendingAttestation.java
@@ -21,7 +21,7 @@ import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitlistSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.config.Constants;
+import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 
 public class PendingAttestation
@@ -31,15 +31,23 @@ public class PendingAttestation
       extends ContainerSchema4<
           PendingAttestation, SszBitlist, AttestationData, SszUInt64, SszUInt64> {
 
-    public PendingAttestationSchema() {
+    public PendingAttestationSchema(final SpecConfig config) {
       super(
           "PendingAttestation",
           namedSchema(
               "aggregation_bitfield",
-              SszBitlistSchema.create(Constants.MAX_VALIDATORS_PER_COMMITTEE)),
+              SszBitlistSchema.create(config.getMaxValidatorsPerCommittee())),
           namedSchema("data", AttestationData.SSZ_SCHEMA),
           namedSchema("inclusion_delay", SszPrimitiveSchemas.UINT64_SCHEMA),
           namedSchema("proposer_index", SszPrimitiveSchemas.UINT64_SCHEMA));
+    }
+
+    public PendingAttestation create(
+        final SszBitlist aggregationBitfield,
+        final AttestationData data,
+        final UInt64 inclusionDelay,
+        final UInt64 proposerIndex) {
+      return new PendingAttestation(this, aggregationBitfield, data, inclusionDelay, proposerIndex);
     }
 
     public SszBitlistSchema<?> getAggregationBitfieldSchema() {
@@ -52,31 +60,27 @@ public class PendingAttestation
     }
   }
 
-  public static final PendingAttestationSchema SSZ_SCHEMA = new PendingAttestationSchema();
-
   private PendingAttestation(PendingAttestationSchema type, TreeNode backingNode) {
     super(type, backingNode);
   }
 
   public PendingAttestation(
-      SszBitlist aggregation_bitfield,
-      AttestationData data,
-      UInt64 inclusion_delay,
-      UInt64 proposer_index) {
+      final PendingAttestationSchema schema,
+      final SszBitlist aggregationBitfield,
+      final AttestationData data,
+      final UInt64 inclusionDelay,
+      final UInt64 proposerIndex) {
     super(
-        SSZ_SCHEMA,
-        aggregation_bitfield,
+        schema,
+        aggregationBitfield,
         data,
-        SszUInt64.of(inclusion_delay),
-        SszUInt64.of(proposer_index));
+        SszUInt64.of(inclusionDelay),
+        SszUInt64.of(proposerIndex));
   }
 
-  public PendingAttestation() {
-    super(SSZ_SCHEMA);
-  }
-
-  public PendingAttestation(PendingAttestation pendingAttestation) {
-    super(SSZ_SCHEMA, pendingAttestation.getBackingNode());
+  @Override
+  public PendingAttestationSchema getSchema() {
+    return (PendingAttestationSchema) super.getSchema();
   }
 
   public SszBitlist getAggregation_bits() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
@@ -71,11 +71,14 @@ public final class BlockProcessorPhase0 extends AbstractBlockProcessor {
     final AttestationData data = attestation.getData();
 
     PendingAttestation pendingAttestation =
-        new PendingAttestation(
-            attestation.getAggregationBits(),
-            data,
-            state.getSlot().minus(data.getSlot()),
-            UInt64.valueOf(beaconStateAccessors.getBeaconProposerIndex(state)));
+        state
+            .getBeaconStateSchema()
+            .getPendingAttestationSchema()
+            .create(
+                attestation.getAggregationBits(),
+                data,
+                state.getSlot().minus(data.getSlot()),
+                UInt64.valueOf(beaconStateAccessors.getBeaconProposerIndex(state)));
 
     if (data.getTarget().getEpoch().equals(beaconStateAccessors.getCurrentEpoch(state))) {
       state.getCurrent_epoch_attestations().append(pendingAttestation);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
@@ -24,7 +24,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
 
 public class SchemaDefinitionsPhase0 extends AbstractSchemaDefinitions {
-  private final BeaconStateSchema<?, ?> beaconStateSchema;
+  private final BeaconStateSchemaPhase0 beaconStateSchema;
   private final BeaconBlockBodySchema<?> beaconBlockBodySchema;
   private final MetadataMessageSchemaPhase0 metadataMessageSchema;
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/sostests/IsVariableTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/sostests/IsVariableTest.java
@@ -36,8 +36,8 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
-import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class IsVariableTest {
@@ -52,7 +52,9 @@ public class IsVariableTest {
         Arguments.of(AttesterSlashing.SSZ_SCHEMA),
         Arguments.of(IndexedAttestation.SSZ_SCHEMA),
         Arguments.of(SCHEMA_DEFINITIONS.getBeaconStateSchema()),
-        Arguments.of(PendingAttestation.SSZ_SCHEMA),
+        Arguments.of(
+            BeaconStateSchemaPhase0.required(SCHEMA_DEFINITIONS.getBeaconStateSchema())
+                .getPendingAttestationSchema()),
         Arguments.of(AggregateAndProof.SSZ_SCHEMA));
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/util/LengthBoundsCalculatorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/util/LengthBoundsCalculatorTest.java
@@ -44,8 +44,8 @@ import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkData;
-import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 /**
@@ -93,7 +93,12 @@ public class LengthBoundsCalculatorTest {
             SszLengthBounds.ofBytes(524288, 524288)),
         Arguments.of(
             getProvider(IndexedAttestation.SSZ_SCHEMA), SszLengthBounds.ofBytes(228, 16612)),
-        Arguments.of(getProvider(PendingAttestation.SSZ_SCHEMA), SszLengthBounds.ofBytes(149, 405)),
+        Arguments.of(
+            (SchemaProvider)
+                definitions ->
+                    BeaconStateSchemaPhase0.required(definitions.getBeaconStateSchema())
+                        .getPendingAttestationSchema(),
+            SszLengthBounds.ofBytes(149, 405)),
         Arguments.of(getProvider(ProposerSlashing.SSZ_SCHEMA), SszLengthBounds.ofBytes(416, 416)),
         Arguments.of(
             getProvider(SignedAggregateAndProof.SSZ_SCHEMA), SszLengthBounds.ofBytes(437, 693)),

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderPhase0.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderPhase0.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.spec.util;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -76,25 +74,11 @@ public class BeaconStateBuilderPhase0
         dataStructureUtil.randomSszList(
             schema.getPreviousEpochAttestationsSchema(),
             defaultItemsInSSZLists,
-            dataStructureUtil::randomPendingAttestation);
+            () -> dataStructureUtil.randomPendingAttestation(schema.getPendingAttestationSchema()));
     currentEpochAttestations =
         dataStructureUtil.randomSszList(
             schema.getCurrentEpochAttestationsSchema(),
             defaultItemsInSSZLists,
-            dataStructureUtil::randomPendingAttestation);
-  }
-
-  public BeaconStateBuilderPhase0 previousEpochAttestations(
-      final SszList<PendingAttestation> previousEpochAttestations) {
-    checkNotNull(previousEpochAttestations);
-    this.previousEpochAttestations = previousEpochAttestations;
-    return this;
-  }
-
-  public BeaconStateBuilderPhase0 currentEpochAttestations(
-      final SszList<PendingAttestation> currentEpochAttestations) {
-    checkNotNull(currentEpochAttestations);
-    this.currentEpochAttestations = currentEpochAttestations;
-    return this;
+            () -> dataStructureUtil.randomPendingAttestation(schema.getPendingAttestationSchema()));
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.util;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.stream.Collectors.toList;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 import static tech.pegasys.teku.spec.constants.NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT;
@@ -106,12 +107,14 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
+import tech.pegasys.teku.spec.datastructures.state.PendingAttestation.PendingAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
 import tech.pegasys.teku.spec.datastructures.state.SyncCommittee.SyncCommitteeSchema;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateSchemaAltair;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 import tech.pegasys.teku.spec.datastructures.util.DepositGenerator;
 import tech.pegasys.teku.spec.executionengine.ForkChoiceState;
@@ -537,7 +540,18 @@ public final class DataStructureUtil {
   }
 
   public PendingAttestation randomPendingAttestation() {
-    return new PendingAttestation(
+    final BeaconStateSchema<?, ?> beaconStateSchema = getBeaconStateSchema();
+    checkState(
+        beaconStateSchema instanceof BeaconStateSchemaPhase0,
+        "Pending attestations only exist in phase0");
+    final PendingAttestationSchema pendingAttestationSchema =
+        ((BeaconStateSchemaPhase0) beaconStateSchema).getPendingAttestationSchema();
+    return randomPendingAttestation(pendingAttestationSchema);
+  }
+
+  public PendingAttestation randomPendingAttestation(
+      final PendingAttestationSchema pendingAttestationSchema) {
+    return pendingAttestationSchema.create(
         randomBitlist(), randomAttestationData(), randomUInt64(), randomUInt64());
   }
 

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStatePhase0;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -517,16 +518,19 @@ class BeaconChainMetricsTest {
     return Stream.of(bitlists)
         .map(
             bitlist1 ->
-                new PendingAttestation(
-                    bitlist1,
-                    new AttestationData(
-                        UInt64.valueOf(slot),
-                        UInt64.valueOf(index),
-                        dataStructureUtil.randomBytes32(),
-                        dataStructureUtil.randomCheckpoint(),
-                        dataStructureUtil.randomCheckpoint()),
-                    dataStructureUtil.randomUInt64(),
-                    dataStructureUtil.randomUInt64()));
+                BeaconStateSchemaPhase0.required(
+                        spec.getGenesisSchemaDefinitions().getBeaconStateSchema())
+                    .getPendingAttestationSchema()
+                    .create(
+                        bitlist1,
+                        new AttestationData(
+                            UInt64.valueOf(slot),
+                            UInt64.valueOf(index),
+                            dataStructureUtil.randomBytes32(),
+                            dataStructureUtil.randomCheckpoint(),
+                            dataStructureUtil.randomCheckpoint()),
+                        dataStructureUtil.randomUInt64(),
+                        dataStructureUtil.randomUInt64()));
   }
 
   private Stream<PendingAttestation> createAttestationsWithTargetCheckpoint(
@@ -534,16 +538,19 @@ class BeaconChainMetricsTest {
     return Stream.of(bitlists)
         .map(
             bitlist1 ->
-                new PendingAttestation(
-                    bitlist1,
-                    new AttestationData(
-                        UInt64.valueOf(slot),
-                        UInt64.valueOf(index),
-                        dataStructureUtil.randomBytes32(),
-                        dataStructureUtil.randomCheckpoint(),
-                        target),
-                    dataStructureUtil.randomUInt64(),
-                    dataStructureUtil.randomUInt64()));
+                BeaconStateSchemaPhase0.required(
+                        spec.getGenesisSchemaDefinitions().getBeaconStateSchema())
+                    .getPendingAttestationSchema()
+                    .create(
+                        bitlist1,
+                        new AttestationData(
+                            UInt64.valueOf(slot),
+                            UInt64.valueOf(index),
+                            dataStructureUtil.randomBytes32(),
+                            dataStructureUtil.randomCheckpoint(),
+                            target),
+                        dataStructureUtil.randomUInt64(),
+                        dataStructureUtil.randomUInt64()));
   }
 
   private SszBitlist bitlistOf(final int... indices) {


### PR DESCRIPTION
## PR Description
Retrieve PendingAttestation schema via SchemaDefinitions.  PendingAttestation is actually only used in Phase0 so is retrieved via the BeaconStatePhase0 schema. Migrating this removes one place where Constants.MAX_VALIDATORS_PER_COMMITTEE is used.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
