### PR TITLE
Use ReadOnlyForkChoiceStrategy whenever possible

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -61,9 +61,9 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.Merkleizable;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.state.CommitteeAssignment;
 import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
 import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
@@ -245,7 +245,7 @@ public class ChainDataProvider {
   public List<Map<String, Object>> getProtoArrayData() {
     return recentChainData
         .getForkChoiceStrategy()
-        .map(ForkChoiceStrategy::getNodeData)
+        .map(ReadOnlyForkChoiceStrategy::getNodeData)
         .orElse(Collections.emptyList());
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.forkchoice;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -25,6 +26,8 @@ public interface ReadOnlyForkChoiceStrategy {
 
   Optional<Bytes32> blockParentRoot(Bytes32 blockRoot);
 
+  Optional<Bytes32> executionBlockHash(Bytes32 blockRoot);
+
   Optional<Bytes32> getAncestor(Bytes32 blockRoot, UInt64 slot);
 
   Set<Bytes32> getBlockRootsAtSlot(UInt64 slot);
@@ -34,5 +37,9 @@ public interface ReadOnlyForkChoiceStrategy {
 
   Map<Bytes32, UInt64> getOptimisticChainHeads();
 
+  List<Map<String, Object>> getNodeData();
+
   boolean contains(Bytes32 blockRoot);
+
+  boolean isOptimistic(Bytes32 blockRoot);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -327,10 +327,7 @@ public class ForkChoice {
                 }
               }
 
-              recentChainData
-                  .getForkChoiceStrategy()
-                  .orElseThrow()
-                  .onExecutionPayloadResult(blockRoot, result);
+              getForkChoiceStrategy().onExecutionPayloadResult(blockRoot, result);
             })
         .reportExceptions();
   }
@@ -484,7 +481,7 @@ public class ForkChoice {
   private ForkChoiceStrategy getForkChoiceStrategy() {
     forkChoiceExecutor.checkOnEventThread();
     return recentChainData
-        .getForkChoiceStrategy()
+        .getUpdatableForkChoiceStrategy()
         .orElseThrow(
             () ->
                 new IllegalStateException(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutor.java
@@ -54,7 +54,7 @@ class ForkChoicePayloadExecutor implements OptimisticExecutionPayloadExecutor {
     if (executionPayload.isDefault()) {
       // We're still pre-merge so no payload to execute
       // Note that the BlockProcessor will have already failed if this is default and shouldn't be
-      // because it check the parentRoot matches
+      // because it checks the parentRoot matches
       return true;
     }
     final BellatrixTransitionHelpers bellatrixTransitionHelpers =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -40,11 +40,11 @@ import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.ssz.type.Bytes20;
 import tech.pegasys.teku.infrastructure.ssz.type.Bytes8;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionengine.ExecutePayloadResult;
@@ -67,7 +67,7 @@ class ForkChoiceNotifierTest {
 
   private StorageSystem storageSystem;
   private RecentChainData recentChainData;
-  private ForkChoiceStrategy forkChoiceStrategy;
+  private ReadOnlyForkChoiceStrategy forkChoiceStrategy;
   private PayloadAttributesCalculator payloadAttributesCalculator;
   private Optional<Bytes20> defaultFeeRecipient =
       Optional.of(Bytes20.fromHexString("0x2Df386eFF130f991321bfC4F8372Ba838b9AB14B"));

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -37,12 +37,12 @@ import tech.pegasys.teku.core.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.protoarray.ForkChoiceStrategy;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
@@ -545,7 +545,7 @@ class ForkChoiceTest {
 
   private void assertForkChoiceUpdateNotification(
       final SignedBlockAndState blockAndState, final boolean optimisticHead) {
-    final ForkChoiceStrategy forkChoiceStrategy =
+    final ReadOnlyForkChoiceStrategy forkChoiceStrategy =
         recentChainData.getForkChoiceStrategy().orElseThrow();
     final Bytes32 headExecutionHash =
         forkChoiceStrategy.executionBlockHash(blockAndState.getRoot()).orElseThrow();

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ForkChoiceStrategy.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ForkChoiceStrategy.java
@@ -284,6 +284,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     }
   }
 
+  @Override
   public boolean isOptimistic(final Bytes32 blockRoot) {
     protoArrayLock.readLock().lock();
     try {
@@ -394,6 +395,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     }
   }
 
+  @Override
   public List<Map<String, Object>> getNodeData() {
     protoArrayLock.readLock().lock();
     try {

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/ForkChoiceStrategyTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/ForkChoiceStrategyTest.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpointEpochs;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.TestStoreFactory;
 import tech.pegasys.teku.spec.datastructures.forkchoice.TestStoreImpl;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
@@ -374,7 +375,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     storageSystem.chainUpdater().saveBlock(block1);
     assertThat(block1.getExecutionBlockHash()).isNotEmpty();
 
-    final ForkChoiceStrategy strategy =
+    final ReadOnlyForkChoiceStrategy strategy =
         storageSystem.recentChainData().getForkChoiceStrategy().orElseThrow();
     assertThat(strategy.executionBlockHash(block1.getRoot()))
         .isEqualTo(block1.getExecutionBlockHash());

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -43,6 +43,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -231,8 +232,12 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     return spec.getAncestorsOnFork(store.getForkChoiceStrategy(), root, startSlot);
   }
 
-  public Optional<ForkChoiceStrategy> getForkChoiceStrategy() {
+  public Optional<ForkChoiceStrategy> getUpdatableForkChoiceStrategy() {
     return Optional.ofNullable(store).map(UpdatableStore::getForkChoiceStrategy);
+  }
+
+  public Optional<ReadOnlyForkChoiceStrategy> getForkChoiceStrategy() {
+    return Optional.ofNullable(store).map(ReadOnlyStore::getForkChoiceStrategy);
   }
 
   public StoreTransaction startStoreTransaction() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -1095,7 +1095,7 @@ class RecentChainDataTest {
   }
 
   private void disableForkChoicePruneThreshold() {
-    recentChainData.getForkChoiceStrategy().orElseThrow().setPruneThreshold(0);
+    recentChainData.getUpdatableForkChoiceStrategy().orElseThrow().setPruneThreshold(0);
   }
 
   private long getReorgCountMetric(final StorageSystem storageSystem) {

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -191,7 +191,7 @@ public class ChainUpdater {
     tx.putBlockAndState(block.getBlock(), block.getState());
     assertThat(tx.commit()).isCompleted();
     recentChainData
-        .getForkChoiceStrategy()
+        .getUpdatableForkChoiceStrategy()
         .orElseThrow()
         .onExecutionPayloadResult(block.getRoot(), ExecutePayloadResult.VALID);
     saveBlockTime(block);


### PR DESCRIPTION
## PR Description
Use `ReadOnlyForkChoiceStrategy` interface whenever possible rather than the full `ForkChoiceStrategy` which allows updates. Mostly this just makes it easier to see when fork choice is being read from vs when it's actually being updated (which has stricter threading considerations).


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
